### PR TITLE
Adding Task ids in DAG details API endpoint #37564

### DIFF
--- a/docs/apache-airflow/extra-packages-ref.rst
+++ b/docs/apache-airflow/extra-packages-ref.rst
@@ -57,8 +57,6 @@ python dependencies for the provided package.
 +---------------------+-----------------------------------------------------+----------------------------------------------------------------------------+
 | google-auth         | ``pip install 'apache-airflow[google-auth]'``       | Google auth backend                                                        |
 +---------------------+-----------------------------------------------------+----------------------------------------------------------------------------+
-| graphviz            | ``pip install 'apache-airflow[graphvis]'``          | Enables exporting DAGs to .dot graphical output                            |
-+---------------------+-----------------------------------------------------+----------------------------------------------------------------------------+
 | graphviz            | ``pip install 'apache-airflow[graphviz]'``          | Graphviz renderer for converting DAG to graphical output                   |
 +---------------------+-----------------------------------------------------+----------------------------------------------------------------------------+
 | kerberos            | ``pip install 'apache-airflow[kerberos]'``          | Kerberos integration for Kerberized services (Hadoop, Presto, Trino)       |
@@ -333,7 +331,7 @@ pre-installed when Airflow is installed.
 +---------------------+-----------------------------------------------------+--------------------------------------+--------------+
 | openlineage         | ``pip install 'apache-airflow[openlineage]'``       | Sending OpenLineage events           |              |
 +---------------------+-----------------------------------------------------+--------------------------------------+--------------+
-| opensearch         | ``pip install 'apache-airflow[opensearch]'``         | Opensearch hooks and operators       |              |
+| opensearch          | ``pip install 'apache-airflow[opensearch]'``        | Opensearch hooks and operators       |              |
 +---------------------+-----------------------------------------------------+--------------------------------------+--------------+
 | papermill           | ``pip install 'apache-airflow[papermill]'``         | Papermill hooks and operators        |              |
 +---------------------+-----------------------------------------------------+--------------------------------------+--------------+


### PR DESCRIPTION
Description
The absence of task names in the DAG details API necessitates separate calls for task and DAG information, hindering process efficiency.
close #37564

Use case/motivation
Currently, task names are not included in the DAG details API endpoint. Tasks represent the execution component of a DAG also various API endpoints require task names. Therefore, to retrieve task names, one must query the "/dags/{dag_id}/tasks" endpoint. Additionally, to obtain basic DAG details, the "/dags/{dag_id}/details" endpoint is utilized. In my use case, automation of certain processes necessitates both DAG information and task names. Consequently, the need to utilize two separate API endpoints slows down the overall process, particularly considering the multitude of DAGs. It would be advantageous to consolidate this information into a single API call, considering that tasks are integral part of a DAG.

Approach
Added new schema"DAGDetailSchemaWithTasksInfo" to DagSchema.py for task ID information. To include tasks, we have to add a query parameter (include_tasks).

http://localhost:8080/api/v1/dags/example_dag_decorator/details?include_tasks=true
http://localhost:8080/api/v1/dags/example_dag_decorator/details?include_tasks=false
![image](https://github.com/apache/airflow/assets/41102134/e655a65d-146a-4487-a670-cb0f7bb2de69)

![image](https://github.com/apache/airflow/assets/41102134/24b3aaa5-b61e-4afb-b0fb-9ebe6d433907)



