### PR TITLE
Check mock assertion methods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1331,6 +1331,7 @@ extend-select = [
     "TID251",  # Specific modules or module members that may not be imported or accessed
     "TID253",  # Ban certain modules from being imported at module level
     "PGH004",  # Use specific rule codes when using noqa
+    "PGH005", # Invalid unittest.mock.Mock methods/attributes/properties
     "B006", # Checks for uses of mutable objects as function argument defaults.
 ]
 ignore = [

--- a/tests/providers/amazon/aws/executors/ecs/test_ecs_executor.py
+++ b/tests/providers/amazon/aws/executors/ecs/test_ecs_executor.py
@@ -1142,7 +1142,7 @@ class TestEcsExecutorConfig:
         task_kwargs = ecs_executor_config.build_task_kwargs()
         assert "launchType" not in task_kwargs
         assert "capacityProviderStrategy" not in task_kwargs
-        assert mock_conn.describe_clusters.called_once()
+        mock_conn.describe_clusters.assert_called_once()
 
     @mock.patch.object(EcsHook, "conn")
     def test_providing_no_capacity_provider_no_lunch_type_no_cluster_default(self, mock_conn, set_env_vars):

--- a/tests/providers/amazon/aws/operators/test_eks.py
+++ b/tests/providers/amazon/aws/operators/test_eks.py
@@ -565,7 +565,7 @@ class TestEksDeleteClusterOperator:
 
         self.delete_cluster_operator.execute({})
 
-        mock_list_nodegroups.assert_called_once
+        mock_list_nodegroups.assert_called_once  # noqa: PGH005 (fixme: called 0 times)
         mock_delete_cluster.assert_called_once_with(name=self.cluster_name)
         mock_waiter.assert_called_with(mock.ANY, name=CLUSTER_NAME)
         assert_expected_waiter_type(mock_waiter, "ClusterDeleted")

--- a/tests/providers/apache/druid/hooks/test_druid.py
+++ b/tests/providers/apache/druid/hooks/test_druid.py
@@ -182,9 +182,9 @@ class TestDruidSubmitHook:
         with pytest.raises(AirflowException):
             self.db_hook.submit_indexing_job("Long json file")
 
+        assert status_check.called
         # PGH005: false positive on ``requests_mock`` argument `called_once`
         assert task_post.call_count == 1
-        assert status_check.call_count == 1
         assert shutdown_post.call_count == 1
 
 

--- a/tests/providers/apache/druid/hooks/test_druid.py
+++ b/tests/providers/apache/druid/hooks/test_druid.py
@@ -59,8 +59,9 @@ class TestDruidSubmitHook:
         with pytest.raises(AirflowException):
             self.db_hook.submit_indexing_job("Long json file")
 
-        assert task_post.called_once
-        assert status_check.called_once
+        # PGH005: false positive on ``requests_mock`` argument `called_once`
+        assert task_post.call_count == 1
+        assert status_check.call_count == 1
 
     def test_submit_ok(self, requests_mock):
         task_post = requests_mock.post(
@@ -76,8 +77,9 @@ class TestDruidSubmitHook:
         # Exists just as it should
         self.db_hook.submit_indexing_job("Long json file")
 
-        assert task_post.called_once
-        assert status_check.called_once
+        # PGH005: false positive on ``requests_mock`` argument `called_once`
+        assert task_post.call_count == 1
+        assert status_check.call_count == 1
 
     def test_submit_sql_based_ingestion_ok(self, requests_mock):
         task_post = requests_mock.post(
@@ -93,8 +95,9 @@ class TestDruidSubmitHook:
         # Exists just as it should
         self.db_hook.submit_indexing_job("Long json file", IngestionType.MSQ)
 
-        assert task_post.called_once
-        assert status_check.called_once
+        # PGH005: false positive on ``requests_mock`` argument `called_once`
+        assert task_post.call_count == 1
+        assert status_check.call_count == 1
 
     def test_submit_with_correct_ssl_arg(self, requests_mock):
         self.db_hook.verify_ssl = False
@@ -109,8 +112,9 @@ class TestDruidSubmitHook:
 
         self.db_hook.submit_indexing_job("Long json file")
 
-        assert task_post.called_once
-        assert status_check.called_once
+        # PGH005: false positive on ``requests_mock`` argument `called_once`
+        assert task_post.call_count == 1
+        assert status_check.call_count == 1
         if task_post.called_once:
             verify_ssl = task_post.request_history[0].verify
             assert False is verify_ssl
@@ -132,8 +136,9 @@ class TestDruidSubmitHook:
         """
         self.db_hook.submit_indexing_job(json_ingestion_string)
 
-        assert task_post.called_once
-        assert status_check.called_once
+        # PGH005: false positive on ``requests_mock`` argument `called_once`
+        assert task_post.call_count == 1
+        assert status_check.call_count == 1
         if task_post.called_once:
             req_body = task_post.request_history[0].json()
             assert req_body["task"] == "9f8a7359-77d4-4612-b0cd-cc2f6a3c28de"
@@ -152,8 +157,9 @@ class TestDruidSubmitHook:
         with pytest.raises(AirflowException):
             self.db_hook.submit_indexing_job("Long json file")
 
-        assert task_post.called_once
-        assert status_check.called_once
+        # PGH005: false positive on requests_mock arguments
+        assert task_post.call_count == 1
+        assert status_check.call_count == 1
 
     def test_submit_timeout(self, requests_mock):
         self.db_hook.timeout = 1
@@ -176,9 +182,10 @@ class TestDruidSubmitHook:
         with pytest.raises(AirflowException):
             self.db_hook.submit_indexing_job("Long json file")
 
-        assert task_post.called_once
-        assert status_check.called
-        assert shutdown_post.called_once
+        # PGH005: false positive on ``requests_mock`` argument `called_once`
+        assert task_post.call_count == 1
+        assert status_check.call_count == 1
+        assert shutdown_post.call_count == 1
 
 
 class TestDruidHook:

--- a/tests/providers/celery/executors/test_celery_executor.py
+++ b/tests/providers/celery/executors/test_celery_executor.py
@@ -258,8 +258,8 @@ class TestCeleryExecutor:
             executor.cleanup_stuck_queued_tasks(tis)
             executor.sync()
         assert executor.tasks == {}
-        assert app.control.revoke.called_with("231")
-        assert mock_fail.called_once()
+        assert app.control.revoke.called_with("231")  # noqa: PGH005 (fixme: called 0 times)
+        mock_fail.assert_called_once()
 
     @conf_vars({("celery", "result_backend_sqlalchemy_engine_options"): '{"pool_recycle": 1800}'})
     @mock.patch("celery.Celery")

--- a/tests/providers/cncf/kubernetes/test_client.py
+++ b/tests/providers/cncf/kubernetes/test_client.py
@@ -34,14 +34,14 @@ class TestClient:
     @mock.patch("airflow.providers.cncf.kubernetes.kube_client.config")
     def test_load_cluster_config(self, config):
         get_kube_client(in_cluster=True)
-        assert config.load_incluster_config.called
-        assert config.load_kube_config.not_called
+        config.load_incluster_config.assert_called()
+        config.load_kube_config.assert_not_called()
 
     @mock.patch("airflow.providers.cncf.kubernetes.kube_client.config")
     def test_load_file_config(self, config):
         get_kube_client(in_cluster=False)
-        assert config.load_incluster_config.not_called
-        assert config.load_kube_config.called
+        config.load_incluster_config.assert_not_called()
+        config.load_kube_config.assert_called()
 
     @mock.patch("airflow.providers.cncf.kubernetes.kube_client.config")
     @mock.patch("airflow.providers.cncf.kubernetes.kube_client.conf")

--- a/tests/providers/fab/auth_manager/test_security.py
+++ b/tests/providers/fab/auth_manager/test_security.py
@@ -1081,7 +1081,7 @@ def test_update_user_auth_stat_first_successful_auth(mock_security_manager, new_
     assert new_user.login_count == 1
     assert new_user.fail_login_count == 0
     assert new_user.last_login == datetime.datetime(1985, 11, 5, 1, 24, 0)
-    assert mock_security_manager.update_user.called_once
+    mock_security_manager.update_user.assert_called_once()
 
 
 @time_machine.travel(datetime.datetime(1985, 11, 5, 1, 24, 0), tick=False)
@@ -1091,7 +1091,7 @@ def test_update_user_auth_stat_subsequent_successful_auth(mock_security_manager,
     assert old_user.login_count == 43
     assert old_user.fail_login_count == 0
     assert old_user.last_login == datetime.datetime(1985, 11, 5, 1, 24, 0)
-    assert mock_security_manager.update_user.called_once
+    mock_security_manager.update_user.assert_called_once()
 
 
 @time_machine.travel(datetime.datetime(1985, 11, 5, 1, 24, 0), tick=False)
@@ -1101,7 +1101,7 @@ def test_update_user_auth_stat_first_unsuccessful_auth(mock_security_manager, ne
     assert new_user.login_count == 0
     assert new_user.fail_login_count == 1
     assert new_user.last_login is None
-    assert mock_security_manager.update_user.called_once
+    mock_security_manager.update_user.assert_called_once()
 
 
 @time_machine.travel(datetime.datetime(1985, 11, 5, 1, 24, 0), tick=False)
@@ -1111,7 +1111,7 @@ def test_update_user_auth_stat_subsequent_unsuccessful_auth(mock_security_manage
     assert old_user.login_count == 42
     assert old_user.fail_login_count == 10
     assert old_user.last_login == datetime.datetime(1984, 12, 1, 0, 0, 0)
-    assert mock_security_manager.update_user.called_once
+    mock_security_manager.update_user.assert_called_once()
 
 
 def test_users_can_be_found(app, security_manager, session, caplog):

--- a/tests/providers/microsoft/azure/hooks/test_adx.py
+++ b/tests/providers/microsoft/azure/hooks/test_adx.py
@@ -270,7 +270,7 @@ class TestAzureDataExplorerHook:
         hook.run_query("Database", "Logs | schema", options={"option1": "option_value"})
         properties = ClientRequestProperties()
         properties.set_option("option1", "option_value")
-        mock_execute.assert_called_with(  # (fixme: expected call not found)
+        assert mock_execute.called_with(  # noqa: PGH005 (fixme: expected call not found)
             "Database", "Logs | schema", properties=properties
         )
 

--- a/tests/providers/microsoft/azure/hooks/test_adx.py
+++ b/tests/providers/microsoft/azure/hooks/test_adx.py
@@ -97,7 +97,7 @@ class TestAzureDataExplorerHook:
     def test_conn_method_aad_creds(self, mock_init, mocked_connection):
         mock_init.return_value = None
         AzureDataExplorerHook(azure_data_explorer_conn_id=mocked_connection.conn_id).get_conn()
-        assert mock_init.called_with(
+        assert mock_init.called_with(  # noqa: PGH005 (fixme: expected call not found)
             KustoConnectionStringBuilder.with_aad_user_password_authentication(
                 "https://help.kusto.windows.net", "client_id", "client secret", "tenant"
             )
@@ -166,7 +166,7 @@ class TestAzureDataExplorerHook:
     def test_conn_method_aad_app(self, mock_init, mocked_connection):
         mock_init.return_value = None
         AzureDataExplorerHook(azure_data_explorer_conn_id=mocked_connection.conn_id).get_conn()
-        assert mock_init.called_with(
+        assert mock_init.called_with(  # noqa: PGH005 (fixme: expected call not found)
             KustoConnectionStringBuilder.with_aad_application_key_authentication(
                 "https://help.kusto.windows.net", "app_id", "app key", "tenant"
             )
@@ -193,7 +193,7 @@ class TestAzureDataExplorerHook:
     def test_conn_method_aad_app_cert(self, mock_init, mocked_connection):
         mock_init.return_value = None
         AzureDataExplorerHook(azure_data_explorer_conn_id=mocked_connection.conn_id).get_conn()
-        assert mock_init.called_with(
+        assert mock_init.called_with(  # noqa: PGH005 (fixme: expected call not found)
             KustoConnectionStringBuilder.with_aad_application_certificate_authentication(
                 "https://help.kusto.windows.net", "client_id", "PEM", "thumbprint", "tenant"
             )
@@ -215,7 +215,7 @@ class TestAzureDataExplorerHook:
     def test_conn_method_aad_device(self, mock_init, mocked_connection):
         mock_init.return_value = None
         AzureDataExplorerHook(azure_data_explorer_conn_id=mocked_connection.conn_id).get_conn()
-        assert mock_init.called_with(
+        assert mock_init.called_with(  # noqa: PGH005 (fixme: expected call not found)
             KustoConnectionStringBuilder.with_aad_device_authentication("https://help.kusto.windows.net")
         )
 
@@ -240,8 +240,11 @@ class TestAzureDataExplorerHook:
     def test_conn_method_azure_token_cred(self, mock_init, mock_default_azure_credential, mocked_connection):
         mock_init.return_value = None
         AzureDataExplorerHook(azure_data_explorer_conn_id=mocked_connection.conn_id).get_conn()
-        assert mock_default_azure_credential.called_with("test_id", "test_tenant_id")
-        assert mock_init.called_with(
+        assert mock_default_azure_credential.called_with(  # noqa: PGH005 (fixme: expected call not found)
+            "test_id",
+            "test_tenant_id",
+        )
+        assert mock_init.called_with(  # noqa: PGH005 (fixme: expected call not found)
             KustoConnectionStringBuilder.with_azure_token_credential(
                 connection_string="https://help.kusto.windows.net",
                 credential=mock_default_azure_credential,
@@ -267,7 +270,9 @@ class TestAzureDataExplorerHook:
         hook.run_query("Database", "Logs | schema", options={"option1": "option_value"})
         properties = ClientRequestProperties()
         properties.set_option("option1", "option_value")
-        assert mock_execute.called_with("Database", "Logs | schema", properties=properties)
+        mock_execute.assert_called_with(  # (fixme: expected call not found)
+            "Database", "Logs | schema", properties=properties
+        )
 
     @pytest.mark.parametrize(
         "mocked_connection",

--- a/tests/providers/microsoft/azure/hooks/test_asb.py
+++ b/tests/providers/microsoft/azure/hooks/test_asb.py
@@ -69,7 +69,7 @@ class TestAdminClientHook:
         mock_connection.return_value = self.mock_conn_without_schema
         hook = AdminClientHook(azure_service_bus_conn_id=self.conn_id)
         assert isinstance(hook.get_conn(), ServiceBusAdministrationClient)
-        assert mock_default_azure_credential.called_with(
+        mock_default_azure_credential.assert_called_with(
             managed_identity_client_id=None, workload_identity_tenant_id=None
         )
 
@@ -182,7 +182,7 @@ class TestMessageHook:
         mock_connection.return_value = self.mock_conn_without_schema
         hook = MessageHook(azure_service_bus_conn_id=self.conn_id)
         assert isinstance(hook.get_conn(), ServiceBusClient)
-        assert mock_default_azure_credential.called_with(
+        mock_default_azure_credential.assert_called_with(
             managed_identity_client_id=None, workload_identity_tenant_id=None
         )
 

--- a/tests/providers/microsoft/azure/hooks/test_container_instance.py
+++ b/tests/providers/microsoft/azure/hooks/test_container_instance.py
@@ -148,7 +148,7 @@ class TestAzureContainerInstanceHookWithoutSetupCredential:
         hook = AzureContainerInstanceHook(azure_conn_id=connection_without_login_password_tenant_id.conn_id)
         conn = hook.get_conn()
 
-        assert mock_default_azure_credential.called_with(
+        mock_default_azure_credential.assert_called_with(
             managed_identity_client_id=None, workload_identity_tenant_id=None
         )
         assert not mock_service_pricipal_credential.called

--- a/tests/providers/microsoft/azure/hooks/test_container_registry.py
+++ b/tests/providers/microsoft/azure/hooks/test_container_registry.py
@@ -82,6 +82,6 @@ class TestAzureContainerRegistryHook:
         assert hook.connection.password == "password"
         assert hook.connection.server == "test.cr"
 
-        assert mocked_default_azure_credential.called_with(
+        mocked_default_azure_credential.assert_called_with(
             managed_identity_client_id=None, workload_identity_tenant_id=None
         )

--- a/tests/providers/microsoft/azure/hooks/test_container_volume.py
+++ b/tests/providers/microsoft/azure/hooks/test_container_volume.py
@@ -112,6 +112,6 @@ class TestAzureContainerVolumeHook:
         assert volume.azure_file.storage_account_name == "storage"
         assert volume.azure_file.read_only is True
 
-        assert mocked_default_azure_credential.called_with(
+        mocked_default_azure_credential.assert_called_with(
             managed_identity_client_id=None, workload_identity_tenant_id=None
         )

--- a/tests/providers/microsoft/azure/hooks/test_cosmos.py
+++ b/tests/providers/microsoft/azure/hooks/test_cosmos.py
@@ -82,7 +82,10 @@ class TestAzureCosmosDbHook:
         hook = AzureCosmosDBHook(azure_cosmos_conn_id="azure_cosmos_test_default_credential")
         hook.get_conn()
 
-        assert mock_default_azure_credential.called_with("test_client_id", "test_tenant_id")
+        assert mock_default_azure_credential.called_with(  # noqa: PGH005 (fixme: expected call not found)
+            "test_client_id",
+            "test_tenant_id",
+        )
 
     @mock.patch(f"{MODULE}.CosmosClient", autospec=True)
     def test_client(self, mock_cosmos):

--- a/tests/providers/microsoft/azure/hooks/test_data_factory.py
+++ b/tests/providers/microsoft/azure/hooks/test_data_factory.py
@@ -190,7 +190,10 @@ def test_get_conn_by_default_azure_credential(mock_credential):
 
         connection = hook.get_conn()
         assert connection is not None
-        assert mock_credential.called_with(None, None)
+        assert mock_credential.called_with(  # noqa: PGH005 (fixme: expected call not found)
+            None,
+            None,
+        )
         mock_create_client.assert_called_with(mock_credential(), "subscriptionId")
 
 
@@ -687,7 +690,7 @@ class TestAzureDataFactoryAsyncHook:
         response = await hook.get_async_conn()
         assert isinstance(response, DataFactoryManagementClient)
 
-        assert mock_default_azure_credential.called_with(
+        mock_default_azure_credential.assert_called_with(
             managed_identity_client_id="test_client_id", workload_identity_tenant_id="test_tenant_id"
         )
 

--- a/tests/providers/microsoft/azure/hooks/test_data_lake.py
+++ b/tests/providers/microsoft/azure/hooks/test_data_lake.py
@@ -101,7 +101,10 @@ class TestAzureDataLakeHook:
         assert hook._conn is None
         assert hook.conn_id == "adl_test_key_without_tenant"
         assert isinstance(hook.get_conn(), core.AzureDLFileSystem)
-        assert mock_azure_identity_credential_adapter.called_with(None, None)
+        assert mock_azure_identity_credential_adapter.called_with(  # noqa: PGH005 (fixme: expected call not found)
+            None,
+            None,
+        )
         assert not mock_datalake_store_lib.auth.called
 
     @pytest.mark.usefixtures("connection")

--- a/tests/providers/microsoft/azure/hooks/test_synapse.py
+++ b/tests/providers/microsoft/azure/hooks/test_synapse.py
@@ -116,7 +116,10 @@ def test_get_conn_by_default_azure_credential(mock_credential):
 
         connection = hook.get_conn()
         assert connection is not None
-        assert mock_credential.called_with(None, None)
+        assert mock_credential.called_with(  # noqa: PGH005 (fixme: expected call not found)
+            None,
+            None,
+        )
         mock_create_client.assert_called_with(
             mock_credential(),
             "https://testsynapse.dev.azuresynapse.net",

--- a/tests/providers/microsoft/azure/hooks/test_wasb.py
+++ b/tests/providers/microsoft/azure/hooks/test_wasb.py
@@ -188,7 +188,10 @@ class TestWasbHook:
         )
 
     def test_managed_identity(self, mocked_default_azure_credential, mocked_blob_service_client):
-        assert mocked_default_azure_credential.called_with(None, None)
+        assert mocked_default_azure_credential.called_with(  # noqa: PGH005 (fixme: expected call not found)
+            None,
+            None,
+        )
         mocked_default_azure_credential.return_value = "foo-bar"
         WasbHook(wasb_conn_id=self.managed_identity_conn_id).get_conn()
         mocked_blob_service_client.assert_called_once_with(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

That is pretty common mistake to use assert on non-existed `unittest.mock.Mock` methods.
PGH005 might help to validate this methods, one downside is that it have false positive in some specific cases, see: https://github.com/astral-sh/ruff/issues/10223 , this PR also cover this case

During the enable rule, I've found that some of the tests broken, maybe even initially or some kind of regression happen during the time.
I've marked this tests with `noqa: PGH005` and have a plan to create a task for fix it

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
