### PR TITLE
`@task.bash` warn only if `multiple_outputs=True`

### DIFF
--- a/airflow/decorators/bash.py
+++ b/airflow/decorators/bash.py
@@ -53,12 +53,11 @@ class _BashDecoratedOperator(DecoratedOperator, BashOperator):
         op_kwargs: Mapping[str, Any] | None = None,
         **kwargs,
     ) -> None:
-        if kwargs.get("multiple_outputs") is not None:
+        if kwargs.pop("multiple_outputs", None) is True:
             warnings.warn(
-                f"`multiple_outputs` is not supported in {self.custom_operator_name} tasks. Ignoring.",
-                stacklevel=1,
+                f"`multiple_outputs=True` is not supported in {self.custom_operator_name} tasks. Ignoring.",
+                stacklevel=3,
             )
-        kwargs.pop("multiple_outputs")
 
         super().__init__(
             python_callable=python_callable,

--- a/airflow/decorators/bash.py
+++ b/airflow/decorators/bash.py
@@ -53,7 +53,7 @@ class _BashDecoratedOperator(DecoratedOperator, BashOperator):
         op_kwargs: Mapping[str, Any] | None = None,
         **kwargs,
     ) -> None:
-        if kwargs.pop("multiple_outputs", None) is True:
+        if kwargs.pop("multiple_outputs", None):
             warnings.warn(
                 f"`multiple_outputs=True` is not supported in {self.custom_operator_name} tasks. Ignoring.",
                 stacklevel=3,

--- a/airflow/decorators/bash.py
+++ b/airflow/decorators/bash.py
@@ -64,6 +64,7 @@ class _BashDecoratedOperator(DecoratedOperator, BashOperator):
             op_args=op_args,
             op_kwargs=op_kwargs,
             bash_command=NOTSET,
+            multiple_outputs=False,
             **kwargs,
         )
 

--- a/airflow/decorators/bash.py
+++ b/airflow/decorators/bash.py
@@ -56,6 +56,7 @@ class _BashDecoratedOperator(DecoratedOperator, BashOperator):
         if kwargs.pop("multiple_outputs", None):
             warnings.warn(
                 f"`multiple_outputs=True` is not supported in {self.custom_operator_name} tasks. Ignoring.",
+                UserWarning,
                 stacklevel=3,
             )
 

--- a/tests/decorators/test_bash.py
+++ b/tests/decorators/test_bash.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import os
 import stat
+import warnings
 from contextlib import nullcontext as no_raise
 from unittest import mock
 
@@ -382,19 +383,46 @@ class TestBashDecorator:
             ti, _ = self.execute_task(bash_task)
             self.validate_bash_command_rtif(ti, "set -e; something-that-isnt-on-path")
 
-    @pytest.mark.parametrize(argnames="multiple_outputs", argvalues=[True, False])
-    def test_multiple_outputs(self, multiple_outputs):
+    def test_multiple_outputs_true(self):
         """Verify setting `multiple_outputs` for a @task.bash-decorated function is ignored."""
 
         with self.dag:
 
-            @task.bash(multiple_outputs=multiple_outputs)
+            @task.bash(multiple_outputs=True)
             def bash():
                 return "echo"
 
             with pytest.warns(
-                UserWarning, match="`multiple_outputs` is not supported in @task.bash tasks. Ignoring."
+                UserWarning, match="`multiple_outputs=True` is not supported in @task.bash tasks. Ignoring."
             ):
+                bash_task = bash()
+
+                assert bash_task.operator.bash_command == NOTSET
+
+                ti, _ = self.execute_task(bash_task)
+
+        assert bash_task.operator.multiple_outputs is False
+        self.validate_bash_command_rtif(ti, "echo")
+
+    @pytest.mark.parametrize(
+        "multiple_outputs", [False, pytest.param(None, id="none"), pytest.param(NOTSET, id="not-set")]
+    )
+    def test_multiple_outputs(self, multiple_outputs):
+        """Verify setting `multiple_outputs` for a @task.bash-decorated function is ignored."""
+
+        decorator_kwargs = {}
+        if multiple_outputs is not NOTSET:
+            decorator_kwargs["multiple_outputs"] = multiple_outputs
+
+        with self.dag:
+
+            @task.bash(**decorator_kwargs)
+            def bash():
+                return "echo"
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", category=UserWarning)
+
                 bash_task = bash()
 
                 assert bash_task.operator.bash_command == NOTSET


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Some small side effect with warnings after https://github.com/apache/airflow/pull/37297.
`@task.bash` constantly warns even if `multiple_outputs` doesn't set

In addition change stack level to show in which file this decorator use

stacklevel=1
```console
/opt/airflow/airflow/models/baseoperator.py:445 UserWarning: `multiple_outputs=True` is not supported in @task.bash tasks. Ignoring.
```

stacklevel=3
```console
/files/dags/sample_bash.py:14 UserWarning: `multiple_outputs=True` is not supported in @task.bash tasks. Ignoring.
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
