### PR TITLE
WIP/Idea: Pass task output as outlet to dataset trigger params

### DIFF
--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1283,9 +1283,17 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     events=dataset_events,
                 )
 
+                run_conf = {}
+                for item in dataset_events:
+                    event: DatasetEvent = item
+                    extra: dict | None = event.extra
+                    if extra:
+                        run_conf.update(extra)
+
                 dag_run = dag.create_dagrun(
                     run_id=run_id,
                     run_type=DagRunType.DATASET_TRIGGERED,
+                    conf=run_conf,
                     execution_date=exec_date,
                     data_interval=data_interval,
                     state=DagRunState.QUEUED,


### PR DESCRIPTION
This PR is a WIP proposal to fix/resolve the request for feature #37810 

NOTE: It is just a code preview, therefore WIP.

Idea:
- Use XCom / task result as `extra` (if not provided in Dataset reference)
  - If dataset defines `extra` use this as params
  - If task returns a dict, pass this as params
  - If task does not return a dict, provide the task name as key, return as value
- Pass the `extra` to the data triggered DAG as `params`
  - If multiple events trigger a DAG, params are merged

Open items:
- Agree on "this is a good idea"
- Documentation
  - Is this a noteworthy change? Then add a newsfragment
- Polishing of example(s)

closes: #37810