### PR TITLE
Introducing linked issue support for generate-issue-content-providers

### DIFF
--- a/dev/breeze/src/airflow_breeze/provider_issue_TEMPLATE.md.jinja2
+++ b/dev/breeze/src/airflow_breeze/provider_issue_TEMPLATE.md.jinja2
@@ -13,6 +13,12 @@ Those are providers that require testing as there were some substantial changes 
 ## Provider [{{ provider_id }}: {{ provider_info.version }}{{ provider_info.suffix }}](https://pypi.org/project/{{ provider_info.pypi_package_name }}/{{ provider_info.version }}{{ provider_info.suffix }})
 {%- for pr in provider_info.pr_list %}
    - [ ] [{{ pr.title }} (#{{ pr.number }})]({{ pr.html_url }}): @{{ pr.user.login }}
+   {%- if pr.number in linked_issues %}
+     Linked issues:
+     {%- for linked_issue in linked_issues[pr.number] %}
+       - [ ] [Linked Issue #{{ linked_issue.number }}]({{ linked_issue.html_url }}): @{{ linked_issue.user.login }}
+     {%- endfor %}
+   {%- endif %}
 {%- endfor %}
 {%- endfor %}
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


The issue generation for providers doesnt work the same like helm or airflow
In helm/airflow if there is linked issue it shows it and request issue author to also verify the fix. In providers we dont have that.

Adding that support to `breeze release-management generate-issue-content-providers`

Sample output:
```
I have a kind request for all the contributors to the latest provider packages release.
Could you please help us to test the RC versions of the providers?

The guidelines on how to test providers can be found in

[Verify providers by contributors](https://github.com/apache/airflow/blob/main/dev/README_RELEASE_PROVIDER_PACKAGES.md#verify-the-release-candidate-by-contributors)

Let us know in the comment, whether the issue is addressed.

Those are providers that require testing as there were some substantial changes introduced:


## Provider [amazon: 8.18.0](https://pypi.org/project/apache-airflow-providers-amazon/8.18.0)
   - [ ] [ECS Executor - Add backoff on failed task retry (#37109)](https://github.com/apache/airflow/pull/37109): @ferruzzi
   - [ ] [SqlToS3Operator: feat/ add max_rows_per_file parameter (#37055)](https://github.com/apache/airflow/pull/37055): @selimchergui
   - [ ] [Adding Amazon Neptune Hook and Operators (#37000)](https://github.com/apache/airflow/pull/37000): @ellisms
     Linked issues:
       - [ ] [Linked Issue #28289](https://github.com/apache/airflow/issues/28289): @eladkal
   - [ ] [Add retry configuration in `EmrContainerOperator` (#37426)](https://github.com/apache/airflow/pull/37426): @vincbeck
   - [ ] [Create CLI commands for AWS auth manager to create AWS Identity Center related resources (#37407)](https://github.com/apache/airflow/pull/37407): @vincbeck
   - [ ] [Add extra operator links for EMR Serverless (#34225)](https://github.com/apache/airflow/pull/34225): @dacort
     Linked issues:
       - [ ] [Linked Issue #31620](https://github.com/apache/airflow/issues/31620): @dacort
   - [ ] [Fix `log_query` to format SQL statement correctly in `AthenaOperator` (#36962)](https://github.com/apache/airflow/pull/36962): @ferruzzi
   - [ ] [check sagemaker training job status before deferring SageMakerTrainingOperator (#36685)](https://github.com/apache/airflow/pull/36685): @Lee-W
   - [ ] [Merge all ECS executor configs following recursive python dict update (#37137)](https://github.com/apache/airflow/pull/37137): @o-nikolas
     Linked issues:
       - [ ] [Linked Issue #35490](https://github.com/apache/airflow/issues/35490): @o-nikolas
   - [ ] [Update default value for `BatchSensor` (#37234)](https://github.com/apache/airflow/pull/37234): @vincbeck
     Linked issues:
       - [ ] [Linked Issue #37120](https://github.com/apache/airflow/issues/37120): @0x26res
   - [ ] [Remove info log from amazon provider-> S3 Hook -> download_file (#37211)](https://github.com/apache/airflow/pull/37211): @rawwar
     Linked issues:
       - [ ] [Linked Issue #37204](https://github.com/apache/airflow/issues/37204): @Bartket
   - [ ] [feature: S3ToRedshiftOperator templating aws_conn_id (#37195)](https://github.com/apache/airflow/pull/37195): @raphaelauv
   - [ ] [Updates to ECS Executor Docs (#37125)](https://github.com/apache/airflow/pull/37125): @o-nikolas
   - [ ] [Standardize deprecations in providers [part1] (#36876)](https://github.com/apache/airflow/pull/36876): @kacpermuda
   - [ ] [Replace usage of `datetime.utcnow` and `datetime.utcfromtimestamp` in providers (#37138)](https://github.com/apache/airflow/pull/37138): @Taragolis
   - [ ] [add type annotations to Amazon provider "execute_coplete" methods (#36330)](https://github.com/apache/airflow/pull/36330): @Lee-W

<!--

NOTE TO RELEASE MANAGER:

You can move here the providers that have doc-only changes or for which changes are trivial, and
you could assess that they are OK.

-->
All users involved in the PRs:
@selimchergui @ferruzzi @dacort @kacpermuda @vincbeck @o-nikolas @Lee-W @rawwar @raphaelauv @ellisms @Taragolis
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
