### PR TITLE
make default helm annotations optional on extra cm and secrets

### DIFF
--- a/chart/templates/configmaps/extra-configmaps.yaml
+++ b/chart/templates/configmaps/extra-configmaps.yaml
@@ -43,7 +43,7 @@ metadata:
     {{- $_ := set $annotations "helm.sh/hook-weight" "0" }}
     {{- $_ := set $annotations "helm.sh/hook-delete-policy" "before-hook-creation" }}
   {{- end }}
-  {{- with $annotations := merge $annotations $configMapContent.annotations }}
+  {{- with $annotations := merge $annotations (default dict $configMapContent.annotations) }}
   annotations: {{- $annotations | toYaml | nindent 4 }}
   {{- end }}
 {{- if $configMapContent.data }}

--- a/chart/templates/configmaps/extra-configmaps.yaml
+++ b/chart/templates/configmaps/extra-configmaps.yaml
@@ -37,13 +37,15 @@ metadata:
     {{- if $configMapContent.labels }}
       {{- toYaml $configMapContent.labels | nindent 4 }}
     {{- end }}
-  annotations:
-    "helm.sh/hook": "pre-install,pre-upgrade"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
-    "helm.sh/hook-weight": "0"
-    {{- if $configMapContent.annotations }}
-      {{- toYaml $configMapContent.annotations | nindent 4 }}
-    {{- end }}
+  {{- $annotations := dict }}
+  {{- if $configMapContent.useHelmHooks }}
+    {{- $_ := set $annotations "helm.sh/hook" "pre-install,pre-upgrade" }}
+    {{- $_ := set $annotations "helm.sh/hook-weight" "0" }}
+    {{- $_ := set $annotations "helm.sh/hook-delete-policy" "before-hook-creation" }}
+  {{- end }}
+  {{- with $annotations := merge $annotations $configMapContent.annotations }}
+  annotations: {{- $annotations | toYaml | nindent 4 }}
+  {{- end }}
 {{- if $configMapContent.data }}
 data:
   {{- with $configMapContent.data }}

--- a/chart/templates/secrets/extra-secrets.yaml
+++ b/chart/templates/secrets/extra-secrets.yaml
@@ -43,7 +43,7 @@ metadata:
     {{- $_ := set $annotations "helm.sh/hook-weight" "0" }}
     {{- $_ := set $annotations "helm.sh/hook-delete-policy" "before-hook-creation" }}
   {{- end }}
-  {{- with $annotations := merge $annotations $secretContent.annotations }}
+  {{- with $annotations := merge $annotations (default dict $secretContent.annotations) }}
   annotations: {{- $annotations | toYaml | nindent 4 }}
   {{- end }}
 {{- if $secretContent.type }}

--- a/chart/templates/secrets/extra-secrets.yaml
+++ b/chart/templates/secrets/extra-secrets.yaml
@@ -37,13 +37,15 @@ metadata:
     {{- if $secretContent.labels }}
       {{- toYaml $secretContent.labels | nindent 4 }}
     {{- end }}
-  annotations:
-    "helm.sh/hook": "pre-install,pre-upgrade"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
-    "helm.sh/hook-weight": "0"
-    {{- if $secretContent.annotations }}
-      {{- toYaml $secretContent.annotations | nindent 4 }}
-    {{- end }}
+  {{- $annotations := dict }}
+  {{- if $secretContent.useHelmHooks }}
+    {{- $_ := set $annotations "helm.sh/hook" "pre-install,pre-upgrade" }}
+    {{- $_ := set $annotations "helm.sh/hook-weight" "0" }}
+    {{- $_ := set $annotations "helm.sh/hook-delete-policy" "before-hook-creation" }}
+  {{- end }}
+  {{- with $annotations := merge $annotations $secretContent.annotations }}
+  annotations: {{- $annotations | toYaml | nindent 4 }}
+  {{- end }}
 {{- if $secretContent.type }}
 type: {{ $secretContent.type }}
 {{- end }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1030,6 +1030,11 @@
                     "stringData": {
                         "description": "Content **as string** for the 'stringData' item of the secret (can be templated)",
                         "type": "string"
+                    },
+                    "useHelmHooks": {
+                        "description": "Specify if you want to use the default Helm Hook annotations",
+                        "type": "boolean",
+                        "default": true
                     }
                 }
             },
@@ -1072,6 +1077,11 @@
                     "data": {
                         "description": "Content **as string** for the 'data' item of the configmap (can be templated)",
                         "type": "string"
+                    },
+                    "useHelmHooks": {
+                        "description": "Specify if you want to use the default Helm Hook annotations",
+                        "type": "boolean",
+                        "default": true
                     }
                 }
             },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -329,8 +329,11 @@ extraSecrets: {}
 # extraSecrets:
 #   '{{ .Release.Name }}-airflow-connections':
 #     type: 'Opaque'
+#     useHelmHooks: true
 #     labels:
 #       my.custom.label/v1: my_custom_label_value_1
+#     annotations:
+#       my.custom.annotation: my_custom_annotation_value
 #     data: |
 #       AIRFLOW_CONN_GCP: 'base64_encoded_gcp_conn_string'
 #       AIRFLOW_CONN_AWS: 'base64_encoded_aws_conn_string'
@@ -350,8 +353,11 @@ extraConfigMaps: {}
 # eg:
 # extraConfigMaps:
 #   '{{ .Release.Name }}-airflow-variables':
+#     useHelmHooks: true
 #     labels:
 #       my.custom.label/v2: my_custom_label_value_2
+#     annotations:
+#       my.custom.annotation: my_custom_annotation_value
 #     data: |
 #       AIRFLOW_VAR_HELLO_MESSAGE: "Hi!"
 #       AIRFLOW_VAR_KUBERNETES_NAMESPACE: "{{ .Release.Namespace }}"

--- a/helm_tests/security/test_extra_configmaps_secrets.py
+++ b/helm_tests/security/test_extra_configmaps_secrets.py
@@ -194,12 +194,14 @@ class TestExtraConfigMapsSecrets:
             values={
                 "extraSecrets": {
                     "{{ .Release.Name }}-extra-secret-1": {
+                        "useHelmHooks": True,
                         "annotations": {"test_annotation": "test_annotation_value"},
                         "stringData": "data: secretData",
                     }
                 },
                 "extraConfigMaps": {
                     "{{ .Release.Name }}-extra-configmap-1": {
+                        "useHelmHooks": True,
                         "annotations": {"test_annotation": "test_annotation_value"},
                         "data": "data: configData",
                     }

--- a/helm_tests/security/test_extra_configmaps_secrets.py
+++ b/helm_tests/security/test_extra_configmaps_secrets.py
@@ -217,3 +217,26 @@ class TestExtraConfigMapsSecrets:
 
         for k8s_object in k8s_objects:
             assert k8s_object["metadata"]["annotations"] == expected_annotations
+
+    def test_extra_configmaps_secrets_disable_default_helm_hooks(self):
+        k8s_objects = render_chart(
+            name=RELEASE_NAME,
+            values={
+                "extraSecrets": {
+                    "{{ .Release.Name }}-extra-secret-1": {
+                        "useHelmHooks": False,
+                        "stringData": "data: secretData",
+                    }
+                },
+                "extraConfigMaps": {
+                    "{{ .Release.Name }}-extra-configmap-1": {
+                        "useHelmHooks": False,
+                        "data": "data: configData",
+                    }
+                },
+            },
+            show_only=["templates/configmaps/extra-configmaps.yaml", "templates/secrets/extra-secrets.yaml"],
+        )
+
+        for k8s_object in k8s_objects:
+            assert k8s_object["metadata"]["annotations"] is None

--- a/helm_tests/security/test_extra_configmaps_secrets.py
+++ b/helm_tests/security/test_extra_configmaps_secrets.py
@@ -228,17 +228,23 @@ class TestExtraConfigMapsSecrets:
                     "{{ .Release.Name }}-extra-secret-1": {
                         "useHelmHooks": False,
                         "stringData": "data: secretData",
+                        "annotations": {"test_annotation": "test_annotation_value"}
                     }
                 },
                 "extraConfigMaps": {
                     "{{ .Release.Name }}-extra-configmap-1": {
                         "useHelmHooks": False,
                         "data": "data: configData",
+                        "annotations": {"test_annotation": "test_annotation_value"},
                     }
                 },
             },
             show_only=["templates/configmaps/extra-configmaps.yaml", "templates/secrets/extra-secrets.yaml"],
         )
 
+        expected_annotations = {
+            "test_annotation": "test_annotation_value"
+        }
+
         for k8s_object in k8s_objects:
-            assert k8s_object["metadata"]["annotations"] is None
+            assert k8s_object["metadata"]["annotations"] == expected_annotations


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Make default helm hook annotations on extra configmaps and secrets to be optional. Currently, they are always enabled, and there's no way to turn them off. This aligns the chart with similar pattern as observed in the `db-migrations` and `create-user` job. The user however will now have to specify explicitly if they want add the hooks or not with the `useHelmHooks` in the manifest as boolean values can not be defaulted


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
