### PR TITLE
Bump apache-airflow-providers-cncf-kubernetes version up to 8.0.0

### DIFF
--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -166,7 +166,7 @@ additional-extras:
       - apache-beam[gcp]
   - name: cncf.kubernetes
     dependencies:
-      - apache-airflow-providers-cncf-kubernetes>=7.2.0
+      - apache-airflow-providers-cncf-kubernetes>=8.0.0
   - name: leveldb
     dependencies:
       - plyvel

--- a/dev/breeze/tests/test_packages.py
+++ b/dev/breeze/tests/test_packages.py
@@ -173,7 +173,7 @@ def test_get_package_extras():
         "amazon": ["apache-airflow-providers-amazon>=2.6.0"],
         "apache.beam": ["apache-airflow-providers-apache-beam", "apache-beam[gcp]"],
         "apache.cassandra": ["apache-airflow-providers-apache-cassandra"],
-        "cncf.kubernetes": ["apache-airflow-providers-cncf-kubernetes>=7.2.0"],
+        "cncf.kubernetes": ["apache-airflow-providers-cncf-kubernetes>=8.0.0"],
         "common.sql": ["apache-airflow-providers-common-sql"],
         "facebook": ["apache-airflow-providers-facebook>=2.2.0"],
         "leveldb": ["plyvel"],


### PR DESCRIPTION
Bump missing version for `apache-airflow-providers-cncf-kubernetes` up to 8.0.0 required for the #36847.

related: #36847, #37890