### PR TITLE
Use `next` when redirecting

### DIFF
--- a/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -350,7 +350,7 @@ class FabAuthManager(BaseAuthManager):
         if not self.security_manager.auth_view:
             raise AirflowException("`auth_view` not defined in the security manager.")
         if "next_url" in kwargs and kwargs["next_url"]:
-            return url_for(f"{self.security_manager.auth_view.endpoint}.login", next_url=kwargs["next_url"])
+            return url_for(f"{self.security_manager.auth_view.endpoint}.login", next=kwargs["next_url"])
         else:
             return url_for(f"{self.security_manager.auth_view.endpoint}.login")
 

--- a/tests/providers/fab/auth_manager/test_fab_auth_manager.py
+++ b/tests/providers/fab/auth_manager/test_fab_auth_manager.py
@@ -399,7 +399,7 @@ class TestFabAuthManager:
         auth_manager_with_appbuilder.security_manager.auth_view = Mock()
         auth_manager_with_appbuilder.security_manager.auth_view.endpoint = "test_endpoint"
         auth_manager_with_appbuilder.get_url_login(next_url="next_url")
-        mock_url_for.assert_called_once_with("test_endpoint.login", next_url="next_url")
+        mock_url_for.assert_called_once_with("test_endpoint.login", next="next_url")
 
     @pytest.mark.db_test
     def test_get_url_logout_when_auth_view_not_defined(self, auth_manager_with_appbuilder):

--- a/tests/www/views/test_anonymous_as_admin_role.py
+++ b/tests/www/views/test_anonymous_as_admin_role.py
@@ -56,10 +56,7 @@ def test_delete_pool_anonymous_user_no_role(anonymous_client, pool_factory):
     pool = pool_factory()
     resp = anonymous_client.post(f"pool/delete/{pool.id}")
     assert 302 == resp.status_code
-    assert (
-        f"/login/?next_url={quote_plus(f'http://localhost/pool/delete/{pool.id}')}"
-        == resp.headers["Location"]
-    )
+    assert f"/login/?next={quote_plus(f'http://localhost/pool/delete/{pool.id}')}" == resp.headers["Location"]
 
 
 def test_delete_pool_anonymous_user_as_admin(anonymous_client_as_admin, pool_factory):

--- a/tests/www/views/test_views_tasks.py
+++ b/tests/www/views/test_views_tasks.py
@@ -680,13 +680,13 @@ def one_dag_perm_user_client(app):
 
 def test_delete_just_dag_per_dag_permissions(new_dag_to_delete, per_dag_perm_user_client):
     resp = per_dag_perm_user_client.post(
-        f"delete?dag_id={new_dag_to_delete.dag_id}&next_url=/home", follow_redirects=True
+        f"delete?dag_id={new_dag_to_delete.dag_id}&next=/home", follow_redirects=True
     )
     check_content_in_response(f"Deleting DAG with id {new_dag_to_delete.dag_id}.", resp)
 
 
 def test_delete_just_dag_resource_permissions(new_dag_to_delete, user_client):
-    resp = user_client.post(f"delete?dag_id={new_dag_to_delete.dag_id}&next_url=/home", follow_redirects=True)
+    resp = user_client.post(f"delete?dag_id={new_dag_to_delete.dag_id}&next=/home", follow_redirects=True)
     check_content_in_response(f"Deleting DAG with id {new_dag_to_delete.dag_id}.", resp)
 
 


### PR DESCRIPTION
See comment [here](https://github.com/apache/airflow/pull/37225#issuecomment-1978267614). `next` should be used with `url_for` function.

cc @csp33.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
