### PR TITLE
Add tryNumber to grid task instance tooltip

### DIFF
--- a/airflow/www/static/js/dag/InstanceTooltip.tsx
+++ b/airflow/www/static/js/dag/InstanceTooltip.tsx
@@ -33,7 +33,16 @@ interface Props {
 
 const InstanceTooltip = ({
   group,
-  instance: { taskId, startDate, endDate, state, runId, mappedStates, note },
+  instance: {
+    taskId,
+    startDate,
+    endDate,
+    state,
+    runId,
+    mappedStates,
+    note,
+    tryNumber,
+  },
 }: Props) => {
   if (!group) return null;
   const isGroup = !!group.children;
@@ -88,6 +97,7 @@ const InstanceTooltip = ({
           </Text>
         </>
       )}
+      {tryNumber && tryNumber > 1 && <Text>Try Number: {tryNumber}</Text>}
       {group.triggerRule && <Text>Trigger Rule: {group.triggerRule}</Text>}
       {note && <Text>Contains a note</Text>}
     </Box>


### PR DESCRIPTION
When try number is important (More than 1 try on a task instance). Show it in the tooltip of the grid view.


If we have `try_number` displayed in a few more place. Then we should be able to get rid of the `task_tries` page entirely.


<img width="312" alt="Screenshot 2024-03-05 at 2 01 31 PM" src="https://github.com/apache/airflow/assets/4600967/c42486fb-9c24-408a-83eb-7194838bea5e">


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
