### PR TITLE
Fix side-effect of default options in Beam Operators

### DIFF
--- a/airflow/providers/apache/beam/operators/beam.py
+++ b/airflow/providers/apache/beam/operators/beam.py
@@ -333,6 +333,7 @@ class BeamRunPythonPipelineOperator(BeamBasePipelineOperator):
         self.py_interpreter = py_interpreter
         self.py_requirements = py_requirements
         self.py_system_site_packages = py_system_site_packages
+        self.pipeline_options = copy.deepcopy(self.pipeline_options)
         self.pipeline_options.setdefault("labels", {}).update(
             {"airflow-version": "v" + version.replace(".", "-").replace("+", "-")}
         )
@@ -740,7 +741,7 @@ class BeamRunGoPipelineOperator(BeamBasePipelineOperator):
         self.go_file = go_file
         self.launcher_binary = launcher_binary
         self.worker_binary = worker_binary or launcher_binary
-
+        self.pipeline_options = copy.deepcopy(self.pipeline_options)
         self.pipeline_options.setdefault("labels", {}).update(
             {"airflow-version": "v" + version.replace(".", "-").replace("+", "-")}
         )

--- a/tests/providers/apache/beam/operators/test_beam.py
+++ b/tests/providers/apache/beam/operators/test_beam.py
@@ -60,6 +60,7 @@ EXPECTED_ADDITIONAL_OPTIONS = {
     "output": "gs://test/output",
     "labels": {"foo": "bar", "airflow-version": TEST_VERSION},
 }
+
 TEST_IMPERSONATION_ACCOUNT = "test@impersonation.com"
 BEAM_OPERATOR_PATH = "airflow.providers.apache.beam.operators.beam.{}"
 
@@ -286,7 +287,7 @@ class TestBeamRunJavaPipelineOperator:
             "jobName": job_name,
             "stagingLocation": "gs://test/staging",
             "region": "us-central1",
-            "labels": {"foo": "bar", "airflow-version": TEST_VERSION},
+            "labels": {"foo": "bar"},
             "output": "gs://test/output",
             "impersonateServiceAccount": TEST_IMPERSONATION_ACCOUNT,
         }
@@ -926,7 +927,7 @@ class TestBeamRunJavaPipelineOperatorAsync:
             "job_name": job_name,
             "staging_location": "gs://test/staging",
             "output": "gs://test/output",
-            "labels": {"foo": "bar", "airflow-version": TEST_VERSION},
+            "labels": {"foo": "bar"},
             "region": "us-central1",
             "impersonate_service_account": TEST_IMPERSONATION_ACCOUNT,
         }


### PR DESCRIPTION
Some of the operators in Apache Beam had side effect that they modified detault options passed to it in constructor, and in case of xdist tests it had side effect that they could impact other test results (this happened recently in main). The default options are already set by the Dataflow mixin in execute method in all Beam operators, but in Python and Go operator the defaults are also set in the constructor.

Setting the defaults in mixin uses deepcopy to avoid such side effects.

This might  be intended, so this PR rather than removing default settings in the constructor, also adds deepcopy in them and fixes resulting tests - removing the defaults in tests that do not have the defaults set in the constructor.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
