### PR TITLE
Add TaskFail entries to Gantt chart

### DIFF
--- a/airflow/www/static/js/api/index.ts
+++ b/airflow/www/static/js/api/index.ts
@@ -52,6 +52,7 @@ import useHistoricalMetricsData from "./useHistoricalMetricsData";
 import { useTaskXcomEntry, useTaskXcomCollection } from "./useTaskXcom";
 import useEventLogs from "./useEventLogs";
 import useCalendarData from "./useCalendarData";
+import useTaskFails from "./useTaskFails";
 
 axios.interceptors.request.use((config) => {
   config.paramsSerializer = {
@@ -100,4 +101,5 @@ export {
   useTaskXcomCollection,
   useEventLogs,
   useCalendarData,
+  useTaskFails,
 };

--- a/airflow/www/static/js/api/useTaskFails.ts
+++ b/airflow/www/static/js/api/useTaskFails.ts
@@ -1,0 +1,60 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useQuery } from "react-query";
+import axios, { AxiosResponse } from "axios";
+
+import { getMetaValue } from "src/utils";
+
+const DAG_ID_PARAM = "dag_id";
+const RUN_ID_PARAM = "run_id";
+const TASK_ID_PARAM = "task_id";
+
+const dagId = getMetaValue(DAG_ID_PARAM);
+const taskFailsUrl = getMetaValue("task_fails_url");
+
+export interface TaskFail {
+  runId: string;
+  taskId: string;
+  mapIndex?: number;
+  startDate?: string;
+  endDate?: string;
+}
+
+interface Props {
+  runId?: string;
+  taskId?: string;
+  enabled?: boolean;
+}
+
+const useTaskFails = ({ runId, taskId, enabled = true }: Props) =>
+  useQuery(
+    ["taskFails", runId, taskId],
+    async () => {
+      const params = {
+        [DAG_ID_PARAM]: dagId,
+        [RUN_ID_PARAM]: runId,
+        [TASK_ID_PARAM]: taskId,
+      };
+      return axios.get<AxiosResponse, TaskFail[]>(taskFailsUrl, { params });
+    },
+    { enabled }
+  );
+
+export default useTaskFails;

--- a/airflow/www/static/js/api/useTaskFails.ts
+++ b/airflow/www/static/js/api/useTaskFails.ts
@@ -21,6 +21,7 @@ import { useQuery } from "react-query";
 import axios, { AxiosResponse } from "axios";
 
 import { getMetaValue } from "src/utils";
+import { useAutoRefresh } from "src/context/autorefresh";
 
 const DAG_ID_PARAM = "dag_id";
 const RUN_ID_PARAM = "run_id";
@@ -43,8 +44,10 @@ interface Props {
   enabled?: boolean;
 }
 
-const useTaskFails = ({ runId, taskId, enabled = true }: Props) =>
-  useQuery(
+const useTaskFails = ({ runId, taskId, enabled = true }: Props) => {
+  const { isRefreshOn } = useAutoRefresh();
+
+  return useQuery(
     ["taskFails", runId, taskId],
     async () => {
       const params = {
@@ -54,7 +57,11 @@ const useTaskFails = ({ runId, taskId, enabled = true }: Props) =>
       };
       return axios.get<AxiosResponse, TaskFail[]>(taskFailsUrl, { params });
     },
-    { enabled }
+    {
+      enabled,
+      refetchInterval: isRefreshOn && (autoRefreshInterval || 1) * 1000,
+    }
   );
+};
 
 export default useTaskFails;

--- a/airflow/www/static/js/dag/details/gantt/TaskFail.tsx
+++ b/airflow/www/static/js/dag/details/gantt/TaskFail.tsx
@@ -1,0 +1,91 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from "react";
+import { Box, Tooltip, Text } from "@chakra-ui/react";
+
+import { getDuration } from "src/datetime_utils";
+import { SimpleStatus } from "src/dag/StatusBox";
+import { useContainerRef } from "src/context/containerRef";
+import { hoverDelay } from "src/utils";
+import Time from "src/components/Time";
+
+import type { TaskFail as TaskFailType } from "src/api/useTaskFails";
+
+interface Props {
+  taskFail: TaskFailType;
+  runDuration: number;
+  ganttWidth: number;
+  ganttStartDate?: string | null;
+}
+
+const TaskFail = ({
+  taskFail,
+  runDuration,
+  ganttWidth,
+  ganttStartDate,
+}: Props) => {
+  const containerRef = useContainerRef();
+
+  const duration = getDuration(taskFail?.startDate, taskFail?.endDate);
+  const percent = duration / runDuration;
+  const failWidth = ganttWidth * percent;
+
+  const startOffset = getDuration(ganttStartDate, taskFail?.startDate);
+  const offsetLeft = (startOffset / runDuration) * ganttWidth;
+
+  return (
+    <Tooltip
+      label={
+        <Box>
+          <Text mb={2}>Task Fail</Text>
+          {taskFail?.startDate && (
+            <Text>
+              Start: <Time dateTime={taskFail?.startDate} />
+            </Text>
+          )}
+          {taskFail?.endDate && (
+            <Text>
+              End: <Time dateTime={taskFail?.endDate} />
+            </Text>
+          )}
+          <Text mt={2} fontSize="sm">
+            Can only show previous Task Fails, other tries are not yet saved.
+          </Text>
+        </Box>
+      }
+      hasArrow
+      portalProps={{ containerRef }}
+      placement="top"
+      openDelay={hoverDelay}
+      top="4px"
+    >
+      <Box
+        position="absolute"
+        left={`${offsetLeft}px`}
+        cursor="pointer"
+        top="4px"
+      >
+        <SimpleStatus state="failed" width={`${failWidth}px`} />
+      </Box>
+    </Tooltip>
+  );
+};
+
+export default TaskFail;

--- a/airflow/www/static/js/dag/details/task/TaskDuration.tsx
+++ b/airflow/www/static/js/dag/details/task/TaskDuration.tsx
@@ -22,7 +22,7 @@
 import React from "react";
 
 import useSelection from "src/dag/useSelection";
-import { useGridData } from "src/api";
+import { useGridData, useTaskFails } from "src/api";
 import { startCase } from "lodash";
 import { getDuration, formatDateTime, defaultFormat } from "src/datetime_utils";
 import ReactECharts, { ReactEChartsProps } from "src/components/ReactECharts";
@@ -44,6 +44,10 @@ const TaskDuration = () => {
     selected: { taskId },
     onSelect,
   } = useSelection();
+
+  const { data: taskFails } = useTaskFails({ taskId: taskId || undefined });
+
+  console.log(taskFails);
 
   const {
     data: { dagRuns, groups, ordering },

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -57,6 +57,7 @@
   <meta name="grid_data_url" content="{{ url_for('Airflow.grid_data') }}">
   <meta name="graph_data_url" content="{{ url_for('Airflow.graph_data') }}">
   <meta name="calendar_data_url" content="{{ url_for('Airflow.calendar_data') }}">
+  <meta name="task_fails_url" content="{{ url_for('Airflow.task_fails') }}">
   <meta name="next_run_datasets_url" content="{{ url_for('Airflow.next_run_datasets', dag_id=dag.dag_id) }}">
   <meta name="grid_url" content="{{ url_for('Airflow.grid', dag_id=dag.dag_id) }}">
   <meta name="datasets_url" content="{{ url_for('Airflow.datasets') }}">


### PR DESCRIPTION
If we're going to have a `TaskFail` table. Then let's use it. Before it was only used in the old Task Duration table, but that didn't give a user a good sense of their Task Instance. Instead, using it in the Gantt chart can tell more about how a dag run occurred.

Before. Can only see the final task instance try:
<img width="1048" alt="Screenshot 2024-03-05 at 5 20 45 PM" src="https://github.com/apache/airflow/assets/4600967/1369c97c-b1e3-4aa4-a39d-a4cfe1224257">

After. Can see all previous task instances failures. Notice how TryNumber = 6 and there are 6 bars in the chart:
<img width="1051" alt="Screenshot 2024-03-05 at 5 20 25 PM" src="https://github.com/apache/airflow/assets/4600967/ac933c2b-d418-4f7e-92fb-72a3ae5fc613">

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
