### PR TITLE
Neptune system test tweaks

### DIFF
--- a/tests/system/providers/amazon/aws/example_neptune.py
+++ b/tests/system/providers/amazon/aws/example_neptune.py
@@ -16,10 +16,12 @@
 # under the License.
 from __future__ import annotations
 
-import pendulum
+from datetime import datetime
 
+from airflow.decorators import task
 from airflow.models.baseoperator import chain
 from airflow.models.dag import DAG
+from airflow.providers.amazon.aws.hooks.neptune import NeptuneHook
 from airflow.providers.amazon.aws.operators.neptune import (
     NeptuneStartDbClusterOperator,
     NeptuneStopDbClusterOperator,
@@ -27,34 +29,53 @@ from airflow.providers.amazon.aws.operators.neptune import (
 from tests.system.providers.amazon.aws.utils import SystemTestContextBuilder
 
 DAG_ID = "example_neptune"
-# This test requires an existing Neptune cluster.
-CLUSTER_ID = "CLUSTER_ID"
 
-sys_test_context_task = SystemTestContextBuilder().add_variable(CLUSTER_ID).build()
+sys_test_context_task = SystemTestContextBuilder().build()
 
-with DAG(DAG_ID, schedule="@once", start_date=pendulum.datetime(2024, 1, 1, tz="UTC"), catchup=False) as dag:
+
+@task
+def create_cluster(cluster_id):
+    hook = NeptuneHook()
+    hook.conn.create_db_cluster(DBClusterIdentifier=cluster_id, Engine="neptune", DeletionProtection=False)
+
+    hook.wait_for_cluster_availability(cluster_id=cluster_id)
+
+
+@task
+def delete_cluster(cluster_id):
+    hook = NeptuneHook()
+    hook.conn.delete_db_cluster(DBClusterIdentifier=cluster_id, SkipFinalSnapshot=True)
+
+
+with DAG(
+    dag_id=DAG_ID,
+    start_date=datetime(2021, 1, 1),
+    schedule="@once",
+    catchup=False,
+    tags=["example"],
+) as dag:
     test_context = sys_test_context_task()
+
     env_id = test_context["ENV_ID"]
-    cluster_id = test_context["CLUSTER_ID"]
+    cluster_id = f"{env_id}-cluster"
 
     # [START howto_operator_start_neptune_cluster]
-    start_cluster = NeptuneStartDbClusterOperator(
-        task_id="start_task", db_cluster_id=cluster_id, deferrable=True
-    )
+    start_cluster = NeptuneStartDbClusterOperator(task_id="start_task", db_cluster_id=cluster_id)
     # [END howto_operator_start_neptune_cluster]
 
     # [START howto_operator_stop_neptune_cluster]
-    stop_cluster = NeptuneStopDbClusterOperator(
-        task_id="stop_task", db_cluster_id=cluster_id, deferrable=True
-    )
+    stop_cluster = NeptuneStopDbClusterOperator(task_id="stop_task", db_cluster_id=cluster_id)
     # [END howto_operator_stop_neptune_cluster]
 
     chain(
         # TEST SETUP
         test_context,
+        create_cluster(cluster_id),
         # TEST BODY
         start_cluster,
         stop_cluster,
+        # TEST TEARDOWN
+        delete_cluster(cluster_id),
     )
     from tests.system.utils.watcher import watcher
 

--- a/tests/system/providers/amazon/aws/example_neptune.py
+++ b/tests/system/providers/amazon/aws/example_neptune.py
@@ -37,7 +37,6 @@ sys_test_context_task = SystemTestContextBuilder().build()
 def create_cluster(cluster_id):
     hook = NeptuneHook()
     hook.conn.create_db_cluster(DBClusterIdentifier=cluster_id, Engine="neptune", DeletionProtection=False)
-
     hook.wait_for_cluster_availability(cluster_id=cluster_id)
 
 


### PR DESCRIPTION
Some small adjustments were needed to make this run for our dashboard.

- System Tests should be self-contained; rather than accepting a cluster-id passed in, the test now creates and tears down the cluster
- Only one of our system tests uses `pendulum.datetime`, the rest all use `datetime.datetime`
- Trivial adjustments to the DAG parameters to match the other tests (added an "example" tag and set the same start date) 
- Our system test runners do not yet support deferrable mode, removed that for now

Local run results: 
![image](https://github.com/apache/airflow/assets/1920178/31b04330-efe4-4c8d-b324-2f1988dc8a9a)



(tagging @ellisms since the test is his contribution)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
