### PR TITLE
feat: update SnowflakeSqlApiHook to support OAuth

### DIFF
--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -256,6 +256,15 @@ class SnowflakeHook(DbApiHook):
             conn_config["private_key"] = pkb
             conn_config.pop("password", None)
 
+        refresh_token = self._get_field(extra_dict, "refresh_token") or ""
+        if refresh_token:
+            conn_config["refresh_token"] = refresh_token
+            conn_config["authenticator"] = "oauth"
+            conn_config["client_id"] = conn.login
+            conn_config["client_secret"] = conn.password
+            conn_config.pop("login", None)
+            conn_config.pop("password", None)
+
         return conn_config
 
     def get_uri(self) -> str:

--- a/docs/apache-airflow-providers-snowflake/connections/snowflake.rst
+++ b/docs/apache-airflow-providers-snowflake/connections/snowflake.rst
@@ -56,7 +56,8 @@ Extra (optional)
     * ``region``: Warehouse region.
     * ``warehouse``: Snowflake warehouse name.
     * ``role``: Snowflake role.
-    * ``authenticator``: To connect using OAuth set this parameter ``oath``.
+    * ``authenticator``: To connect using OAuth set this parameter ``oauth``.
+    * ``refresh_token``: Specify refresh_token for OAuth connection.
     * ``private_key_file``: Specify the path to the private key file.
     * ``private_key_content``: Specify the content of the private key file.
     * ``session_parameters``: Specify `session level parameters <https://docs.snowflake.com/en/user-guide/python-connector-example.html#setting-session-parameters>`_.

--- a/docs/apache-airflow-providers-snowflake/operators/snowflake.rst
+++ b/docs/apache-airflow-providers-snowflake/operators/snowflake.rst
@@ -82,13 +82,13 @@ the connection metadata is structured as follows:
    * - Parameter
      - Input
    * - Login: string
-     - Snowflake user name
+     - Snowflake user name. If using `OAuth connection <https://docs.snowflake.com/en/developer-guide/sql-api/authenticating#using-oauth>`__ this is the ``client_id``
    * - Password: string
-     - Password for Snowflake user
+     - Password for Snowflake user. If using OAuth this is the ``client_secret``
    * - Schema: string
      - Set schema to execute SQL operations on by default
    * - Extra: dictionary
-     - ``warehouse``, ``account``, ``database``, ``region``, ``role``, ``authenticator``
+     - ``warehouse``, ``account``, ``database``, ``region``, ``role``, ``authenticator``, ``refresh_token``. If using OAuth must specify ``refresh_token`` (`obtained here <https://community.snowflake.com/s/article/HOW-TO-OAUTH-TOKEN-GENERATION-USING-SNOWFLAKE-CUSTOM-OAUTH>`__)
 
 An example usage of the SnowflakeSqlApiHook is as follows:
 

--- a/tests/providers/snowflake/hooks/test_snowflake_sql_api.py
+++ b/tests/providers/snowflake/hooks/test_snowflake_sql_api.py
@@ -58,6 +58,7 @@ BASE_CONNECTION_KWARGS: dict = {
         "role": "af_role",
     },
 }
+
 CONN_PARAMS = {
     "account": "airflow",
     "application": "AIRFLOW",
@@ -71,6 +72,22 @@ CONN_PARAMS = {
     "user": "user",
     "warehouse": "af_wh",
 }
+
+CONN_PARAMS_OAUTH = {
+    "account": "airflow",
+    "application": "AIRFLOW",
+    "authenticator": "oauth",
+    "database": "db",
+    "client_id": "test_client_id",
+    "client_secret": "test_client_pw",
+    "refresh_token": "secrettoken",
+    "region": "af_region",
+    "role": "af_role",
+    "schema": "public",
+    "session_parameters": None,
+    "warehouse": "af_wh",
+}
+
 HEADERS = {
     "Content-Type": "application/json",
     "Authorization": "Bearer newT0k3n",
@@ -78,6 +95,15 @@ HEADERS = {
     "User-Agent": "snowflakeSQLAPI/1.0",
     "X-Snowflake-Authorization-Token-Type": "KEYPAIR_JWT",
 }
+
+HEADERS_OAUTH = {
+    "Content-Type": "application/json",
+    "Authorization": "Bearer newT0k3n",
+    "Accept": "application/json",
+    "User-Agent": "snowflakeSQLAPI/1.0",
+    "X-Snowflake-Authorization-Token-Type": "OAUTH",
+}
+
 
 GET_RESPONSE = {
     "resultSetMetaData": {
@@ -173,7 +199,7 @@ class TestSnowflakeSqlApiHook:
     @mock.patch("airflow.providers.snowflake.hooks.snowflake_sql_api.requests")
     @mock.patch("airflow.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHook._get_conn_params")
     @mock.patch("airflow.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHook.get_headers")
-    def test_execute_query_exception_without_statement_handel(
+    def test_execute_query_exception_without_statement_handle(
         self,
         mock_get_header,
         mock_conn_param,
@@ -250,13 +276,45 @@ class TestSnowflakeSqlApiHook:
     @mock.patch("airflow.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHook.get_private_key")
     @mock.patch("airflow.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHook._get_conn_params")
     @mock.patch("airflow.providers.snowflake.utils.sql_api_generate_jwt.JWTGenerator.get_token")
-    def test_get_headers(self, mock_get_token, mock_conn_param, mock_private_key):
+    def test_get_headers_should_support_private_key(self, mock_get_token, mock_conn_param, mock_private_key):
         """Test get_headers method by mocking get_private_key and _get_conn_params method"""
         mock_get_token.return_value = "newT0k3n"
         mock_conn_param.return_value = CONN_PARAMS
         hook = SnowflakeSqlApiHook(snowflake_conn_id="mock_conn_id")
         result = hook.get_headers()
         assert result == HEADERS
+
+    @mock.patch("airflow.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHook.get_oauth_token")
+    @mock.patch("airflow.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHook._get_conn_params")
+    def test_get_headers_should_support_oauth(self, mock_conn_param, mock_oauth_token):
+        """Test get_headers method by mocking get_oauth_token and _get_conn_params method"""
+        mock_conn_param.return_value = CONN_PARAMS_OAUTH
+        mock_oauth_token.return_value = "newT0k3n"
+        hook = SnowflakeSqlApiHook(snowflake_conn_id="mock_conn_id")
+        result = hook.get_headers()
+        assert result == HEADERS_OAUTH
+
+    @mock.patch("airflow.providers.snowflake.hooks.snowflake_sql_api.HTTPBasicAuth")
+    @mock.patch("requests.post")
+    @mock.patch("airflow.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHook._get_conn_params")
+    def test_get_oauth_token(self, mock_conn_param, requests_post, mock_auth):
+        """Test get_oauth_token method makes the right http request"""
+        BASIC_AUTH = {"Authorization": "Basic usernamepassword"}
+        mock_conn_param.return_value = CONN_PARAMS_OAUTH
+        requests_post.return_value.status_code = 200
+        mock_auth.return_value = BASIC_AUTH
+        hook = SnowflakeSqlApiHook(snowflake_conn_id="mock_conn_id")
+        hook.get_oauth_token()
+        requests_post.assert_called_once_with(
+            f"https://{CONN_PARAMS_OAUTH['account']}.{CONN_PARAMS_OAUTH['region']}.snowflakecomputing.com/oauth/token-request",
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": CONN_PARAMS_OAUTH["refresh_token"],
+                "redirect_uri": "https://localhost.com",
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            auth=BASIC_AUTH,
+        )
 
     @pytest.fixture
     def non_encrypted_temporary_private_key(self, tmp_path: Path) -> Path:


### PR DESCRIPTION
This PR updates SnowflakeSqlApiHook to support [OAuth](https://docs.snowflake.com/en/developer-guide/sql-api/authenticating#using-oauth).

In order to update this hook have to update the `SnowflakeHook` to parse the refresh token and client credentials.

The OAuth workflow assumes the user already obtained the `refresh_token`, `client_id`, and `client_secret`. In particular the `refresh_token` should be obtained outside of airflow. 

The PR also fixes the snowflake `account_identifier` used in the hook which used to force a region, but region should be [optional](https://docs.snowflake.com/en/user-guide/admin-account-identifier) in the identifier. 

Also tested locally by running the `SnowflakeSqlApiOperator` operator in example DAG.

closes: https://github.com/apache/airflow/issues/36621



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
