### PR TITLE
Restore delegate_to for Google Transfer Operators retrieving from Google Cloud.

### DIFF
--- a/airflow/providers/google/suite/transfers/gcs_to_gdrive.py
+++ b/airflow/providers/google/suite/transfers/gcs_to_gdrive.py
@@ -79,6 +79,9 @@ class GCSToGoogleDriveOperator(BaseOperator):
         If set as a sequence, the identities from the list must grant
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account (templated).
+    :param delegate_to: (Optional) The account to impersonate using domain-wide delegation
+        of authority, if any. For this to work, the service account making the
+        request must have domain-wide delegation enabled. This only applies to the Google Drive connection.
     """
 
     template_fields: Sequence[str] = (
@@ -99,6 +102,7 @@ class GCSToGoogleDriveOperator(BaseOperator):
         move_object: bool = False,
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
+        delegate_to: str | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -110,6 +114,7 @@ class GCSToGoogleDriveOperator(BaseOperator):
         self.move_object = move_object
         self.gcp_conn_id = gcp_conn_id
         self.impersonation_chain = impersonation_chain
+        self.delegate_to = delegate_to
         self.gcs_hook: GCSHook | None = None
         self.gdrive_hook: GoogleDriveHook | None = None
 
@@ -121,6 +126,7 @@ class GCSToGoogleDriveOperator(BaseOperator):
         self.gdrive_hook = GoogleDriveHook(
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.impersonation_chain,
+            delegate_to=self.delegate_to,
         )
 
         if WILDCARD in self.source_object:

--- a/airflow/providers/google/suite/transfers/gcs_to_sheets.py
+++ b/airflow/providers/google/suite/transfers/gcs_to_sheets.py
@@ -40,7 +40,7 @@ class GCSToGoogleSheetsOperator(BaseOperator):
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :param delegate_to: The account to impersonate using domain-wide delegation of authority,
         if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
+        domain-wide delegation enabled. This only applies to the Google Sheet Connection
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -68,6 +68,7 @@ class GCSToGoogleSheetsOperator(BaseOperator):
         spreadsheet_range: str = "Sheet1",
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
+        delegate_to: str | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -78,11 +79,13 @@ class GCSToGoogleSheetsOperator(BaseOperator):
         self.bucket_name = bucket_name
         self.object_name = object_name
         self.impersonation_chain = impersonation_chain
+        self.delegate_to = delegate_to
 
     def execute(self, context: Any) -> None:
         sheet_hook = GSheetsHook(
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.impersonation_chain,
+            delegate_to=self.delegate_to,
         )
         gcs_hook = GCSHook(
             gcp_conn_id=self.gcp_conn_id,

--- a/newsfragments/37925.bugfix
+++ b/newsfragments/37925.bugfix
@@ -1,0 +1,1 @@
+Restores `delegate_to` argument of Google Cloud to Google Drive Transfer Operators, to only be used in the Drive Hook

--- a/tests/providers/google/suite/transfers/test_gcs_to_gdrive.py
+++ b/tests/providers/google/suite/transfers/test_gcs_to_gdrive.py
@@ -26,6 +26,7 @@ from airflow.providers.google.suite.transfers.gcs_to_gdrive import GCSToGoogleDr
 
 MODULE = "airflow.providers.google.suite.transfers.gcs_to_gdrive"
 IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
+DELEGATE_TO = "test_account@xxx.zzz"
 
 
 class TestGcsToGDriveOperator:
@@ -41,6 +42,8 @@ class TestGcsToGDriveOperator:
             source_bucket="data",
             source_object="sales/sales-2017/january.avro",
             destination_object="copied_sales/2017/january-backup.avro",
+            impersonation_chain=None,
+            delegate_to=DELEGATE_TO,
         )
 
         task.execute(mock.MagicMock())
@@ -60,6 +63,7 @@ class TestGcsToGDriveOperator:
         mock_gdrive.assert_has_calls(
             [
                 mock.call(
+                    delegate_to=DELEGATE_TO,
                     gcp_conn_id="google_cloud_default",
                     impersonation_chain=None,
                 ),
@@ -84,6 +88,7 @@ class TestGcsToGDriveOperator:
             source_object="sales/sales-2017/january.avro",
             destination_object="copied_sales/2017/january-backup.avro",
             destination_folder_id="aAopls6bE4tUllZVGJvRUU",
+            delegate_to=DELEGATE_TO,
         )
 
         task.execute(mock.MagicMock())
@@ -104,6 +109,7 @@ class TestGcsToGDriveOperator:
             [
                 mock.call(
                     gcp_conn_id="google_cloud_default",
+                    delegate_to=DELEGATE_TO,
                     impersonation_chain=None,
                 ),
                 mock.call().upload_file(
@@ -130,6 +136,7 @@ class TestGcsToGDriveOperator:
             source_object="sales/sales-2017/*.avro",
             destination_object="copied_sales/2017/",
             impersonation_chain=IMPERSONATION_CHAIN,
+            delegate_to=DELEGATE_TO,
         )
 
         task.execute(mock.MagicMock())
@@ -152,6 +159,7 @@ class TestGcsToGDriveOperator:
         mock_gdrive.assert_has_calls(
             [
                 mock.call(
+                    delegate_to=DELEGATE_TO,
                     gcp_conn_id="google_cloud_default",
                     impersonation_chain=IMPERSONATION_CHAIN,
                 ),
@@ -181,6 +189,7 @@ class TestGcsToGDriveOperator:
             source_object="sales/sales-2017/*.avro",
             move_object=True,
             impersonation_chain=IMPERSONATION_CHAIN,
+            delegate_to=DELEGATE_TO,
         )
 
         task.execute(mock.MagicMock())
@@ -206,6 +215,7 @@ class TestGcsToGDriveOperator:
         mock_gdrive.assert_has_calls(
             [
                 mock.call(
+                    delegate_to=DELEGATE_TO,
                     gcp_conn_id="google_cloud_default",
                     impersonation_chain=IMPERSONATION_CHAIN,
                 ),

--- a/tests/providers/google/suite/transfers/test_gcs_to_sheets.py
+++ b/tests/providers/google/suite/transfers/test_gcs_to_sheets.py
@@ -26,6 +26,7 @@ SPREADSHEET_ID = "1234567890"
 VALUES = [[1, 2, 3]]
 BUCKET = "destination_bucket"
 PATH = "path/to/reports"
+DELEGATE_TO = "test_account@xxx.zzz"
 
 
 class TestGCSToGoogleSheets:
@@ -47,11 +48,13 @@ class TestGCSToGoogleSheets:
             object_name=PATH,
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
+            delegate_to=DELEGATE_TO,
         )
         op.execute(None)
 
         mock_sheet_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
+            delegate_to=DELEGATE_TO,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
         mock_gcs_hook.assert_called_once_with(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
This PR restores the `delegate_to` parameter to Transfer Operators moving Google Cloud data to Google Drive removed when addressing #29088 via #30748. 

The `delgate_to` parameter provides Google Suite Hooks a method of interacting with user spaces, as service accounts are not able to interact with user owned spaces with implicit permissions. While it makes sense that `delegate_to` has been deprecated in favour of `impersonation_chain` for the Google Cloud Hooks, I suspect this was removed in error from GoogleDriveHooks in Transfer Operators that also include Google Cloud Hooks. Google Drive Hooks and Transfer Operators that do not involve Google Cloud still supports the `delegate_to` parameter, so it make sense that the Transfer operators copying from Google Cloud into Google Drive do as well.

This PR contains the following changes:
- Adds delegate_to as constructor arguments and instance variables for GCSToGoogleDrive and GCSToGoogleSheets Transfer operators.
- Adds appropriate unittest coverage.
- Updates inline documentation for these classes to explicitly note that the `delegate_to` argument only applies to the GoogleDrive hooks.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
