### PR TITLE
Don't log "403" from worker serve-logs as "Unknown error".

### DIFF
--- a/airflow/utils/serve_logs.py
+++ b/airflow/utils/serve_logs.py
@@ -32,6 +32,7 @@ from jwt.exceptions import (
     InvalidSignatureError,
 )
 from setproctitle import setproctitle
+from werkzeug.exceptions import HTTPException
 
 from airflow.configuration import conf
 from airflow.utils.docs import get_docs_url
@@ -96,6 +97,8 @@ def create_app():
                     token_filename,
                 )
                 abort(403)
+        except HTTPException:
+            raise
         except InvalidAudienceError:
             logger.warning("Invalid audience for the request", exc_info=True)
             abort(403)


### PR DESCRIPTION
If you make a request to `http://localhost:8793/` it would get denied from this block on L82:

```python
            auth = request.headers.get("Authorization")
            if auth is None:
                logger.warning("The Authorization header is missing: %s.", request.headers)
                abort(403)
```

abort is internally implemented to raise an exception. However since that `abort()` call was inside a try/except block, it was getting caught under the `execpt Exception:` fallback and running this:

```python
        except Exception:
            logger.warning("Unknown error", exc_info=True)
            abort(403)
```

So nothing was wrong with the behaviour (it still 403d the request), it's just the logs were slightly confusing.
