### PR TITLE
Add padding to prevent grid horizontal scroll overlapping tasks

### DIFF
--- a/airflow/www/static/js/dag/grid/index.tsx
+++ b/airflow/www/static/js/dag/grid/index.tsx
@@ -167,6 +167,7 @@ const Grid = ({
         position="relative"
         mt={8}
         overscrollBehavior="auto"
+        pb={4}
       >
         <Table borderRightWidth="16px" borderColor="transparent">
           <Thead>


### PR DESCRIPTION
Before:
![before](https://github.com/apache/airflow/assets/4600967/23b174ab-ad2a-4e91-8cd1-28a83a20156b)


After:
![after](https://github.com/apache/airflow/assets/4600967/9b687b6f-d0f2-461d-866d-12d217419ca1)



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
