### PR TITLE
Move operator color back to a badge vs node background

### DIFF
--- a/airflow/www/static/js/dag/details/graph/DagNode.tsx
+++ b/airflow/www/static/js/dag/details/graph/DagNode.tsx
@@ -80,7 +80,7 @@ const DagNode = ({
 
   const nodeBorderColor =
     instance?.state && stateColors[instance.state]
-      ? `${stateColors[instance.state]}.400`
+      ? `${stateColors[instance.state]}`
       : "gray.400";
 
   return (
@@ -99,12 +99,7 @@ const DagNode = ({
         borderRadius={isZoomedOut ? 10 : 5}
         borderWidth={(isSelected ? 4 : 2) * (isZoomedOut ? 3 : 1)}
         borderColor={nodeBorderColor}
-        bg={
-          !task.children?.length && operatorBG
-            ? // Fade the operator color to clash less with the task instance status
-              `color-mix(in srgb, ${operatorBG.replace(";", "")} 80%, white)`
-            : bg
-        }
+        bg={bg}
         height={`${height}px`}
         width={`${width}px`}
         cursor={latestDagRunId ? "cursor" : "default"}
@@ -152,7 +147,11 @@ const DagNode = ({
                 maxWidth={`calc(${width}px - 12px)`}
                 fontWeight={400}
                 fontSize="md"
-                color={operatorTextColor}
+                bg={operatorBG}
+                width="fit-content"
+                color={operatorTextColor || "gray.500"}
+                borderRadius={5}
+                px={2}
               >
                 {task.operator}
               </Text>


### PR DESCRIPTION
Some operator colors are too similar to task state colors leading to confusion. Moving it back to just the operator badge. Also fixed a bug with the border color not showing up for some task states

Also, I'm open to feedback on if we should mix what the border of a task means in the graph vs the minimap. In the graph its the state, in the minimap its the selection.

Before. See how `run_this_last` might look like it was successful
<img width="771" alt="Screenshot 2024-03-06 at 2 49 52 PM" src="https://github.com/apache/airflow/assets/4600967/c48b3a8e-e4bc-4612-b5f1-dea4103870c8">


After:
<img width="754" alt="Screenshot 2024-03-06 at 12 52 28 PM" src="https://github.com/apache/airflow/assets/4600967/463eb5f8-906b-4721-9d75-055142063678">


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
