### PR TITLE
AWS auth manager CLI: persist the policy store description when doing updates

### DIFF
--- a/airflow/providers/amazon/aws/auth_manager/cli/avp_commands.py
+++ b/airflow/providers/amazon/aws/auth_manager/cli/avp_commands.py
@@ -63,8 +63,9 @@ def init_avp(args):
         _set_schema(client, policy_store_id, args)
 
     if not args.dry_run:
-        print("Amazon Verified Permissions resources created successfully.")
-        print("Please set them in Airflow configuration under AIRFLOW__AWS_AUTH_MANAGER__<config name>.")
+        print(
+            "Please set configs below in Airflow configuration under AIRFLOW__AWS_AUTH_MANAGER__<config name>."
+        )
         print(json.dumps({"avp_policy_store_id": policy_store_id}, indent=4))
 
 
@@ -74,9 +75,6 @@ def update_schema(args):
     """Update Amazon Verified Permissions policy store schema."""
     client = _get_client()
     _set_schema(client, args.policy_store_id, args)
-
-    if not args.dry_run:
-        print("Amazon Verified Permissions policy store schema updated successfully.")
 
 
 def _get_client():
@@ -140,6 +138,16 @@ def _set_schema(client: BaseClient, policy_store_id: str, args) -> None:
         return
 
     if args.verbose:
+        log.debug("Getting the policy store details")
+
+    details = client.get_policy_store(
+        policyStoreId=policy_store_id,
+    )
+
+    if args.verbose:
+        log.debug("Response from get_policy_store: %s", details)
+
+    if args.verbose:
         log.debug("Disabling schema validation before updating schema")
 
     response = client.update_policy_store(
@@ -147,6 +155,7 @@ def _set_schema(client: BaseClient, policy_store_id: str, args) -> None:
         validationSettings={
             "mode": "OFF",
         },
+        description=details["description"],
     )
 
     if args.verbose:
@@ -164,6 +173,8 @@ def _set_schema(client: BaseClient, policy_store_id: str, args) -> None:
         if args.verbose:
             log.debug("Response from put_schema: %s", response)
 
+    print("Policy store schema updated.")
+
     if args.verbose:
         log.debug("Enabling schema validation after updating schema")
 
@@ -172,6 +183,7 @@ def _set_schema(client: BaseClient, policy_store_id: str, args) -> None:
         validationSettings={
             "mode": "STRICT",
         },
+        description=details["description"],
     )
 
     if args.verbose:

--- a/tests/providers/amazon/aws/auth_manager/cli/test_avp_commands.py
+++ b/tests/providers/amazon/aws/auth_manager/cli/test_avp_commands.py
@@ -65,6 +65,7 @@ class TestAvpCommands:
 
         mock_boto3.get_paginator.return_value = paginator
         mock_boto3.create_policy_store.return_value = {"policyStoreId": policy_store_id}
+        mock_boto3.get_policy_store.return_value = {"description": policy_store_description}
 
         with conf_vars({("database", "check_migrations"): "False"}):
             params = [


### PR DESCRIPTION
When calling the API `update_policy_store` from the service Amazon Verified Permissions, if the description is not provided, it erases it. This PR fixes that.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
