### PR TITLE
Fix GCSObjectExistenceSensor xcom push

### DIFF
--- a/tests/providers/google/cloud/sensors/test_gcs.py
+++ b/tests/providers/google/cloud/sensors/test_gcs.py
@@ -184,7 +184,6 @@ class TestGoogleCloudStorageObjectSensor:
         mock_log_info.assert_called_with("File %s was found in bucket %s.", TEST_OBJECT, TEST_BUCKET)
 
     @mock.patch("airflow.providers.google.cloud.sensors.gcs.GCSHook")
-    # @mock.patch("airflow.providers.google.cloud.sensors.gcs.GCSObjectExistenceSensor")
     def test_xcom_value_when_poke_success(self, mock_hook):
         mock_hook.return_value.exists.return_value = True
         task = GCSObjectExistenceSensor(
@@ -194,8 +193,7 @@ class TestGoogleCloudStorageObjectSensor:
             google_cloud_conn_id=TEST_GCP_CONN_ID,
             deferrable=True,
         )
-        # repsonses = task.execute(mock.MagicMock())
-        responses = task.execute(None)  # oh wait ma
+        responses = task.execute(None)
         assert responses == "success"
 
 

--- a/tests/providers/google/cloud/sensors/test_gcs.py
+++ b/tests/providers/google/cloud/sensors/test_gcs.py
@@ -183,6 +183,21 @@ class TestGoogleCloudStorageObjectSensor:
             task.execute_complete(context=None, event={"status": "success", "message": "Job completed"})
         mock_log_info.assert_called_with("File %s was found in bucket %s.", TEST_OBJECT, TEST_BUCKET)
 
+    @mock.patch("airflow.providers.google.cloud.sensors.gcs.GCSHook")
+    # @mock.patch("airflow.providers.google.cloud.sensors.gcs.GCSObjectExistenceSensor")
+    def test_xcom_value_when_poke_success(self, mock_hook):
+        mock_hook.return_value.exists.return_value = True
+        task = GCSObjectExistenceSensor(
+            task_id="task-id",
+            bucket=TEST_BUCKET,
+            object=TEST_OBJECT,
+            google_cloud_conn_id=TEST_GCP_CONN_ID,
+            deferrable=True,
+        )
+        # repsonses = task.execute(mock.MagicMock())
+        responses = task.execute(None)  # oh wait ma
+        assert responses == "success"
+
 
 class TestGoogleCloudStorageObjectAsyncSensor:
     depcrecation_message = (


### PR DESCRIPTION
Fix GCSObjectExistenceSensor to return the xcom value if the object already exists upon first run. At present, if the object already exists before the DAG runs, the xcom value is not populated.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
