### PR TITLE
Add messages to task log about moving to queued

### DIFF
--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1570,9 +1570,9 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             for ti in tasks_stuck_in_queued:
                 if repr(ti) in cleaned_up_task_instances:
                     self._task_context_logger.warning(
-                        "Marking task instance %s stuck in queued as failed. "
+                        "Marking task instance %s stuck in queued for {} seconds as failed. "
                         "If the task instance has available retries, it will be retried.",
-                        ti,
+                        self._task_queued_timeout,
                         ti=ti,
                     )
         except NotImplementedError:

--- a/airflow/providers/celery/executors/celery_executor.py
+++ b/airflow/providers/celery/executors/celery_executor.py
@@ -34,6 +34,8 @@ from typing import TYPE_CHECKING, Any, Optional, Sequence, Tuple
 
 from celery import states as celery_states
 
+from airflow.utils.log.task_context_logger import TaskContextLogger
+
 try:
     from airflow.cli.cli_config import (
         ARG_DAEMON,
@@ -77,9 +79,7 @@ from airflow.utils.state import TaskInstanceState
 
 log = logging.getLogger(__name__)
 
-
 CELERY_SEND_ERR_MSG_HEADER = "Error sending Celery task"
-
 
 if TYPE_CHECKING:
     import argparse
@@ -111,7 +111,6 @@ def __getattr__(name):
 To start the celery worker, run the command:
 airflow celery worker
 """
-
 
 # flower cli args
 ARG_BROKER_API = Arg(("-a", "--broker-api"), help="Broker API")
@@ -256,6 +255,7 @@ class CeleryExecutor(BaseExecutor):
         self.tasks = {}
         self.task_publish_retries: Counter[TaskInstanceKey] = Counter()
         self.task_publish_max_retries = conf.getint("celery", "task_publish_max_retries")
+        self._task_context_logger = TaskContextLogger("celery_executor", self.log)
 
     def start(self) -> None:
         self.log.debug("Starting Celery Executor using %s processes for syncing", self._sync_parallelism)
@@ -432,6 +432,9 @@ class CeleryExecutor(BaseExecutor):
             self.running.add(ti.key)
             self.update_task_state(ti.key, state, info)
             adopted.append(f"{ti} in state {state}")
+            self._task_context_logger.info(
+                "Adopted in state %s after previous executor died", state, ti=ti, suppress_in_call_site=True
+            )
 
         if adopted:
             task_instance_str = "\n\t".join(adopted)

--- a/airflow/utils/log/task_context_logger.py
+++ b/airflow/utils/log/task_context_logger.py
@@ -78,15 +78,20 @@ class TaskContextLogger:
             assert isinstance(h, FileTaskHandler)
         return h
 
-    def _log(self, level: int, msg: str, *args, ti: TaskInstance):
+    def _log(self, level: int, msg: str, *args, ti: TaskInstance, suppress_in_call_site=False):
         """
         Emit a log message to the task instance logs.
 
         :param level: the log level
         :param msg: the message to relay to task context log
         :param ti: the task instance
+        :param suppress_in_call_site: if True, only write to task log not call site log
         """
-        if self.call_site_logger and self.call_site_logger.isEnabledFor(level=level):
+        if (
+            self.call_site_logger
+            and self.call_site_logger.isEnabledFor(level=level)
+            and not suppress_in_call_site
+        ):
             with suppress(Exception):
                 self.call_site_logger.log(level, msg, *args)
 
@@ -109,74 +114,82 @@ class TaskContextLogger:
         finally:
             task_handler.close()
 
-    def critical(self, msg: str, *args, ti: TaskInstance):
+    def critical(self, msg: str, *args, ti: TaskInstance, suppress_in_call_site=False):
         """
         Emit a log message with level CRITICAL to the task instance logs.
 
         :param msg: the message to relay to task context log
         :param ti: the task instance
+        :param suppress_in_call_site: if True, only write to task log not call site log
         """
-        self._log(logging.CRITICAL, msg, *args, ti=ti)
+        self._log(logging.CRITICAL, msg, *args, ti=ti, suppress_in_call_site=suppress_in_call_site)
 
-    def fatal(self, msg: str, *args, ti: TaskInstance):
+    def fatal(self, msg: str, *args, ti: TaskInstance, suppress_in_call_site=False):
         """
         Emit a log message with level FATAL to the task instance logs.
 
         :param msg: the message to relay to task context log
         :param ti: the task instance
+        :param suppress_in_call_site: if True, only write to task log not call site log
         """
-        self._log(logging.FATAL, msg, *args, ti=ti)
+        self._log(logging.FATAL, msg, *args, ti=ti, suppress_in_call_site=suppress_in_call_site)
 
-    def error(self, msg: str, *args, ti: TaskInstance):
+    def error(self, msg: str, *args, ti: TaskInstance, suppress_in_call_site=False):
         """
         Emit a log message with level ERROR to the task instance logs.
 
         :param msg: the message to relay to task context log
         :param ti: the task instance
+        :param suppress_in_call_site: if True, only write to task log not call site log
         """
-        self._log(logging.ERROR, msg, *args, ti=ti)
+        self._log(logging.ERROR, msg, *args, ti=ti, suppress_in_call_site=suppress_in_call_site)
 
-    def warn(self, msg: str, *args, ti: TaskInstance):
+    def warn(self, msg: str, *args, ti: TaskInstance, suppress_in_call_site=False):
         """
         Emit a log message with level WARN to the task instance logs.
 
         :param msg: the message to relay to task context log
         :param ti: the task instance
+        :param suppress_in_call_site: if True, only write to task log not call site log
         """
-        self._log(logging.WARNING, msg, *args, ti=ti)
+        self._log(logging.WARNING, msg, *args, ti=ti, suppress_in_call_site=suppress_in_call_site)
 
-    def warning(self, msg: str, *args, ti: TaskInstance):
+    def warning(self, msg: str, *args, ti: TaskInstance, suppress_in_call_site=False):
         """
         Emit a log message with level WARNING to the task instance logs.
 
         :param msg: the message to relay to task context log
         :param ti: the task instance
+        :param suppress_in_call_site: if True, only write to task log not call site log
         """
-        self._log(logging.WARNING, msg, *args, ti=ti)
+        self._log(logging.WARNING, msg, *args, ti=ti, suppress_in_call_site=suppress_in_call_site)
 
-    def info(self, msg: str, *args, ti: TaskInstance):
+    def info(self, msg: str, *args, ti: TaskInstance, suppress_in_call_site=False):
         """
         Emit a log message with level INFO to the task instance logs.
 
         :param msg: the message to relay to task context log
         :param ti: the task instance
+        :param suppress_in_call_site: if True, only write to task log not call site log
         """
-        self._log(logging.INFO, msg, *args, ti=ti)
+        self._log(logging.INFO, msg, *args, ti=ti, suppress_in_call_site=suppress_in_call_site)
 
-    def debug(self, msg: str, *args, ti: TaskInstance):
+    def debug(self, msg: str, *args, ti: TaskInstance, suppress_in_call_site=False):
         """
         Emit a log message with level DEBUG to the task instance logs.
 
         :param msg: the message to relay to task context log
         :param ti: the task instance
+        :param suppress_in_call_site: if True, only write to task log not call site log
         """
-        self._log(logging.DEBUG, msg, *args, ti=ti)
+        self._log(logging.DEBUG, msg, *args, ti=ti, suppress_in_call_site=suppress_in_call_site)
 
-    def notset(self, msg: str, *args, ti: TaskInstance):
+    def notset(self, msg: str, *args, ti: TaskInstance, suppress_in_call_site=False):
         """
         Emit a log message with level NOTSET to the task instance logs.
 
         :param msg: the message to relay to task context log
         :param ti: the task instance
+        :param suppress_in_call_site: if True, only write to task log not call site log
         """
-        self._log(logging.NOTSET, msg, *args, ti=ti)
+        self._log(logging.NOTSET, msg, *args, ti=ti, suppress_in_call_site=suppress_in_call_site)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

When troubleshooting a task that failed somewhere other than the main execute function, it is necessary to look across multiple logs and amidst many unrelated messages in the scheduler. This change adds the messages relevant to a particular task to the task log so that the full history of relevant actions across Airflow can be seen from the task log. This is still in its initial stages, and I need to get a better understanding of the performance impact of this logging.
