### PR TITLE
Gitignore prometheus container volume

### DIFF
--- a/scripts/ci/docker-compose/.gitignore
+++ b/scripts/ci/docker-compose/.gitignore
@@ -1,1 +1,2 @@
 _generated*
+prometheus/volume/*


### PR DESCRIPTION
When you run breeze with the statsd or otel integration grafana and prometheus containers are started to provide the metrics exporting and visualization (it all works and is very cool!).

Prometheus creates a directory to use for it's volume which is mounted into the container, but this volume is not ignored so shows as a untracked in your repository:

![Screenshot from 2024-03-06 14-20-49](https://github.com/apache/airflow/assets/65743084/6be6a7ca-5b47-40f5-9a1e-5c760496b04e)

`volume` is the only directory present in the prometheus directory:
![Screenshot from 2024-03-06 14-39-54](https://github.com/apache/airflow/assets/65743084/5d4c2521-03ed-4267-83c1-2b1022fa99f7)

 
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
