### PR TITLE
Resolve PT015: assertion always fails, replace with `pytest.fail()`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1353,7 +1353,6 @@ ignore = [
     "PT008", # Use return_value= instead of patching with lambda
     "PT011", # pytest.raises() is too broad, set the match parameter
     "PT012", # [controversial rule] pytest.raises() block should contain a single simple statement.
-    "PT015", # assertion always fails, replace with pytest.fail()
     "PT018", # assertion should be broken down into multiple parts
     "PT019", # fixture without value is injected as parameter, use @pytest.mark.usefixtures instead
 ]

--- a/tests/cli/commands/test_webserver_command.py
+++ b/tests/cli/commands/test_webserver_command.py
@@ -278,8 +278,7 @@ class TestCliWebServer(_ComonCLIGunicornTestClass):
                     console.print("[blue]Waiting for gunicorn to start ...")
                     time.sleep(1)
                 else:
-                    console.print("[red]Gunicorn processes not found after 120 seconds")
-                    assert False
+                    pytest.fail("Gunicorn processes not found after 120 seconds")
                 console.print("[blue]Running gunicorn processes:")
                 assert self._find_all_processes("^gunicorn", print_found_process=True)
                 console.print("[magenta]Webserver process started successfully.")

--- a/tests/dags/test_mark_state.py
+++ b/tests/dags/test_mark_state.py
@@ -73,9 +73,9 @@ def test_mark_failure_externally(ti):
         session.merge(ti)
         session.commit()
 
-    # This should not happen -- the state change should be noticed and the task should get killed
     sleep(10)
-    assert False
+    msg = "This should not happen -- the state change should be noticed and the task should get killed"
+    raise RuntimeError(msg)
 
 
 PythonOperator(
@@ -95,9 +95,9 @@ def test_mark_skipped_externally(ti):
         session.merge(ti)
         session.commit()
 
-    # This should not happen -- the state change should be noticed and the task should get killed
     sleep(10)
-    assert False
+    msg = "This should not happen -- the state change should be noticed and the task should get killed"
+    raise RuntimeError(msg)
 
 
 PythonOperator(task_id="test_mark_skipped_externally", python_callable=test_mark_skipped_externally, dag=dag)

--- a/tests/operators/test_bash.py
+++ b/tests/operators/test_bash.py
@@ -243,8 +243,7 @@ class TestBashOperator:
         for proc in psutil.process_iter():
             if proc.cmdline() == ["sleep", sleep_time]:
                 os.kill(proc.pid, signal.SIGTERM)
-                assert False, "BashOperator's subprocess still running after stopping on timeout!"
-                break
+                pytest.fail("BashOperator's subprocess still running after stopping on timeout!")
 
     @pytest.mark.db_test
     def test_templated_fields(self, create_task_instance_of_operator):

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -224,7 +224,7 @@ class TestPythonOperator(BasePythonTest):
 
     def test_python_operator_shallow_copy_attr(self):
         def not_callable(x):
-            assert False, "Should not be triggered"
+            raise RuntimeError("Should not be triggered")
 
         original_task = PythonOperator(
             python_callable=not_callable,

--- a/tests/providers/cncf/kubernetes/utils/test_k8s_resource_iterator.py
+++ b/tests/providers/cncf/kubernetes/utils/test_k8s_resource_iterator.py
@@ -58,8 +58,4 @@ def test_k8s_resource_iterator():
     def callback_success(yml_doc: dict) -> None:
         return
 
-    try:
-        k8s_resource_iterator(callback_success, resources=yaml.safe_load_all(TEST_VALID_LIST_RESOURCE_YAML))
-
-    except FailToCreateError:
-        assert False
+    k8s_resource_iterator(callback_success, resources=yaml.safe_load_all(TEST_VALID_LIST_RESOURCE_YAML))


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Yet another `flake8-pytest-style` rule: [PT015](https://docs.astral.sh/ruff/rules/pytest-assert-always-false/)

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
