### PR TITLE
ECS Executor retry task bug fix

### DIFF
--- a/tests/providers/amazon/aws/executors/ecs/test_ecs_executor.py
+++ b/tests/providers/amazon/aws/executors/ecs/test_ecs_executor.py
@@ -59,6 +59,29 @@ pytestmark = pytest.mark.db_test
 ARN1 = "arn1"
 ARN2 = "arn2"
 ARN3 = "arn3"
+RUN_TASK_KWARGS = {
+    "cluster": "some-cluster",
+    "launchType": "FARGATE",
+    "taskDefinition": "some-task-def",
+    "platformVersion": "LATEST",
+    "count": 1,
+    "overrides": {
+        "containerOverrides": [
+            {
+                "name": "container-name",
+                "command": [""],
+                "environment": [{"name": "AIRFLOW_IS_EXECUTOR_CONTAINER", "value": "true"}],
+            }
+        ]
+    },
+    "networkConfiguration": {
+        "awsvpcConfiguration": {
+            "subnets": ["sub1", "sub2"],
+            "securityGroups": ["sg1", "sg2"],
+            "assignPublicIp": "DISABLED",
+        }
+    },
+}
 
 
 def mock_task(arn=ARN1, state=State.RUNNING):
@@ -428,6 +451,151 @@ class TestAwsEcsExecutor:
             mock_executor.attempt_task_runs()
             # Task is not stored in active workers.
             assert len(mock_executor.active_workers) == 0
+
+    @mock.patch.object(ecs_executor, "calculate_next_attempt_delay", return_value=dt.timedelta(seconds=0))
+    def test_attempt_task_runs_attempts_when_tasks_fail(self, _, mock_executor, caplog):
+        """
+        Test case when all tasks fail to run.
+
+        The executor should attempt each task exactly once per sync() iteration.
+        It should preserve the order of tasks, and attempt each task up to
+        `MAX_RUN_TASK_ATTEMPTS` times before dropping the task.
+        """
+        airflow_keys = [mock.Mock(spec=tuple), mock.Mock(spec=tuple)]
+        airflow_cmd1 = mock.Mock(spec=list)
+        airflow_cmd2 = mock.Mock(spec=list)
+        caplog.set_level("ERROR")
+        commands = [airflow_cmd1, airflow_cmd2]
+
+        failures = [Exception("Failure 1"), Exception("Failure 2")]
+
+        mock_executor.execute_async(airflow_keys[0], commands[0])
+        mock_executor.execute_async(airflow_keys[1], commands[1])
+
+        assert len(mock_executor.pending_tasks) == 2
+        assert len(mock_executor.active_workers.get_all_arns()) == 0
+
+        mock_executor.ecs.run_task.side_effect = failures
+        mock_executor.attempt_task_runs()
+
+        for i in range(2):
+            RUN_TASK_KWARGS["overrides"]["containerOverrides"][0]["command"] = commands[i]
+            assert mock_executor.ecs.run_task.call_args_list[i].kwargs == RUN_TASK_KWARGS
+        assert "Pending ECS tasks failed to launch for the following reasons: " in caplog.messages[0]
+        assert len(mock_executor.pending_tasks) == 2
+        assert len(mock_executor.active_workers.get_all_arns()) == 0
+
+        caplog.clear()
+        mock_executor.ecs.run_task.call_args_list.clear()
+
+        mock_executor.ecs.run_task.side_effect = failures
+        mock_executor.attempt_task_runs()
+
+        for i in range(2):
+            RUN_TASK_KWARGS["overrides"]["containerOverrides"][0]["command"] = commands[i]
+            assert mock_executor.ecs.run_task.call_args_list[i].kwargs == RUN_TASK_KWARGS
+        assert "Pending ECS tasks failed to launch for the following reasons: " in caplog.messages[0]
+        assert len(mock_executor.pending_tasks) == 2
+        assert len(mock_executor.active_workers.get_all_arns()) == 0
+
+        caplog.clear()
+        mock_executor.ecs.run_task.call_args_list.clear()
+
+        mock_executor.ecs.run_task.side_effect = failures
+        mock_executor.attempt_task_runs()
+
+        assert len(mock_executor.active_workers.get_all_arns()) == 0
+        assert len(mock_executor.pending_tasks) == 0
+
+        assert len(caplog.messages) == 3
+        for i in range(2):
+            assert (
+                f"ECS task {airflow_keys[i]} has failed a maximum of 3 times. Marking as failed"
+                == caplog.messages[i]
+            )
+
+    @mock.patch.object(ecs_executor, "calculate_next_attempt_delay", return_value=dt.timedelta(seconds=0))
+    def test_attempt_task_runs_attempts_when_some_tasks_fal(self, _, mock_executor, caplog):
+        """
+        Test case when one task fail to run, and a new task gets queued.
+
+        The executor should attempt each task exactly once per sync() iteration.
+        It should preserve the order of tasks, and attempt each task up to
+        `MAX_RUN_TASK_ATTEMPTS` times before dropping the task. If a task succeeds, the task
+        should be removed from pending_jobs and into active_workers.
+        """
+        airflow_keys = [mock.Mock(spec=tuple), mock.Mock(spec=tuple)]
+        airflow_cmd1 = mock.Mock(spec=list)
+        airflow_cmd2 = mock.Mock(spec=list)
+        caplog.set_level("ERROR")
+        airflow_commands = [airflow_cmd1, airflow_cmd2]
+        task = {
+            "taskArn": ARN1,
+            "lastStatus": "",
+            "desiredStatus": "",
+            "containers": [{"name": "some-ecs-container"}],
+        }
+        success_response = {"tasks": [task], "failures": []}
+
+        responses = [Exception("Failure 1"), success_response]
+
+        mock_executor.execute_async(airflow_keys[0], airflow_commands[0])
+        mock_executor.execute_async(airflow_keys[1], airflow_commands[1])
+
+        assert len(mock_executor.pending_tasks) == 2
+
+        mock_executor.ecs.run_task.side_effect = responses
+        mock_executor.attempt_task_runs()
+
+        for i in range(2):
+            RUN_TASK_KWARGS["overrides"]["containerOverrides"][0]["command"] = airflow_commands[i]
+            assert mock_executor.ecs.run_task.call_args_list[i].kwargs == RUN_TASK_KWARGS
+
+        assert len(mock_executor.pending_tasks) == 1
+        assert len(mock_executor.active_workers.get_all_arns()) == 1
+
+        caplog.clear()
+        mock_executor.ecs.run_task.call_args_list.clear()
+
+        # queue new task
+        airflow_keys[1] = mock.Mock(spec=tuple)
+        airflow_commands[1] = mock.Mock(spec=list)
+        mock_executor.execute_async(airflow_keys[1], airflow_commands[1])
+
+        assert len(mock_executor.pending_tasks) == 2
+        # assert that the order of pending tasks is preserved i.e. the first task is 1st etc.
+        assert mock_executor.pending_tasks[0].key == airflow_keys[0]
+        assert mock_executor.pending_tasks[0].command == airflow_commands[0]
+
+        task["taskArn"] = ARN2
+        success_response = {"tasks": [task], "failures": []}
+        responses = [Exception("Failure 1"), success_response]
+        mock_executor.ecs.run_task.side_effect = responses
+        mock_executor.attempt_task_runs()
+
+        for i in range(2):
+            RUN_TASK_KWARGS["overrides"]["containerOverrides"][0]["command"] = airflow_commands[i]
+            assert mock_executor.ecs.run_task.call_args_list[i].kwargs == RUN_TASK_KWARGS
+
+        assert len(mock_executor.pending_tasks) == 1
+        assert len(mock_executor.active_workers.get_all_arns()) == 2
+
+        caplog.clear()
+        mock_executor.ecs.run_task.call_args_list.clear()
+
+        responses = [Exception("Failure 1")]
+        mock_executor.ecs.run_task.side_effect = responses
+        mock_executor.attempt_task_runs()
+
+        RUN_TASK_KWARGS["overrides"]["containerOverrides"][0]["command"] = airflow_commands[0]
+        assert mock_executor.ecs.run_task.call_args_list[0].kwargs == RUN_TASK_KWARGS
+
+        assert len(caplog.messages) == 2
+
+        assert (
+            f"ECS task {airflow_keys[0]} has failed a maximum of 3 times. Marking as failed"
+            == caplog.messages[0]
+        )
 
     @mock.patch.object(BaseExecutor, "fail")
     @mock.patch.object(BaseExecutor, "success")


### PR DESCRIPTION
This PR addresses a bug in the ECS Executor where the executor did not attempt all queued tasks in one `sync` cycle if a task failed. This PR fixes the behaviour, and the ECS Executor now attempts all queued tasks exactly once per iteration, regardless of the state of the task. If a task fails to run (i.e. some `Exception` is thrown when calling `run_task`), it gets put back on the queued tasks list, and gets attempted in the next `sync` iteration. This continues until the maximum number of attempts for a task has been reached. 


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
