### PR TITLE
Minor security model update

### DIFF
--- a/docs/apache-airflow/security/security_model.rst
+++ b/docs/apache-airflow/security/security_model.rst
@@ -61,7 +61,7 @@ model.
 DAG Authors
 ...........
 
-They can upload, modify, and delete DAG files. The
+They can create, modify, and delete DAG files. The
 code in DAG files is executed on workers and in the DAG File Processor. Note
 that in the simple deployment configuration, parsing DAGs is executed as
 a subprocess of the Scheduler process, but with Standalone DAG File Processor
@@ -69,7 +69,7 @@ deployment managers might separate parsing DAGs from the Scheduler process.
 Therefore, DAG authors can create and change code executed on workers
 and the DAG File Processor and potentially access the credentials that the DAG
 code uses to access external systems. DAG Authors have full access
-to the metadata database and internal audit logs.
+to the metadata database.
 
 Authenticated UI users
 .......................


### PR DESCRIPTION
Users don't "upload" DAGs, and simply state DAG authors have full db access.