### PR TITLE
Validate tasks total priority weight in DagBag

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -481,6 +481,18 @@ core:
       type: string
       example: ~
       default: "Disabled"
+    priority_weight_check_rule:
+      description: |
+        Which rule use for validar task's **priority_weight_total**.
+
+        * ``strict`` - Validate that task's **priority_weight_total**
+          in range **[-2147483648..2147483647]** (int32).
+        * ``ignore`` - Do not validate **priority_weight_total**. It might leads to the scheduler failure
+          in case if it cannot be written into the Airflow Database.
+      version_added: 2.9.0
+      type: string
+      example: ~
+      default: "strict"
 database:
   description: ~
   options:

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -483,7 +483,7 @@ core:
       default: "Disabled"
     priority_weight_check_rule:
       description: |
-        Which rule use for validar task's **priority_weight_total**.
+        Which rule use for validate task's **priority_weight_total**.
 
         * ``strict`` - Validate that task's **priority_weight_total**
           in range **[-2147483648..2147483647]** (int32).

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -464,6 +464,7 @@ class AirflowConfigParser(ConfigParser):
     _available_logging_levels = ["CRITICAL", "FATAL", "ERROR", "WARN", "WARNING", "INFO", "DEBUG"]
     enums_options = {
         ("core", "default_task_weight_rule"): sorted(WeightRule.all_weight_rules()),
+        ("core", "priority_weight_check_rule"): ["strict", "ignore"],
         ("core", "dag_ignore_file_syntax"): ["regexp", "glob"],
         ("core", "mp_start_method"): multiprocessing.get_all_start_methods(),
         ("scheduler", "file_parsing_sort_mode"): ["modified_time", "random_seeded_by_host", "alphabetical"],

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -432,3 +432,7 @@ class DeserializingResultError(ValueError):
             "Error deserializing result. Note that result deserialization "
             "is not supported across major Python versions. Cause: " + str(self.__cause__)
         )
+
+
+class AirflowDagTaskOutOfBoundsValue(AirflowException):
+    """Raise when a parameter in DAG task can cause out-of-bounds on mapping insertion."""

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -122,6 +122,7 @@ from airflow.timetables.simple import (
 from airflow.timetables.trigger import CronTriggerTimetable
 from airflow.utils import timezone
 from airflow.utils.dag_cycle_tester import check_cycle
+from airflow.utils.dag_parameters_overflow import check_values_overflow
 from airflow.utils.dates import cron_presets, date_range as utils_date_range
 from airflow.utils.decorators import fixup_decorator_warning_stack
 from airflow.utils.helpers import at_most_one, exactly_one, validate_key
@@ -2798,6 +2799,7 @@ class DAG(LoggingMixin):
     def cli(self):
         """Exposes a CLI specific to this DAG."""
         check_cycle(self)
+        check_values_overflow(self)
 
         from airflow.cli import cli_parser
 

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -41,11 +41,13 @@ from airflow.exceptions import (
     AirflowClusterPolicyViolation,
     AirflowDagCycleException,
     AirflowDagDuplicatedIdException,
+    AirflowDagTaskOutOfBoundsValue,
     RemovedInAirflow3Warning,
 )
 from airflow.stats import Stats
 from airflow.utils import timezone
 from airflow.utils.dag_cycle_tester import check_cycle
+from airflow.utils.dag_parameters_overflow import check_values_overflow
 from airflow.utils.docs import get_docs_url
 from airflow.utils.file import (
     correct_maybe_zipped,
@@ -468,6 +470,7 @@ class DagBag(LoggingMixin):
         intended to only be used by the ``_bag_dag()`` implementation.
         """
         check_cycle(dag)  # throws if a task cycle is found
+        check_values_overflow(dag)
 
         dag.resolve_template_files()
         dag.last_loaded = timezone.utcnow()
@@ -504,7 +507,7 @@ class DagBag(LoggingMixin):
                 )
             self.dags[dag.dag_id] = dag
             self.log.debug("Loaded DAG %s", dag)
-        except (AirflowDagCycleException, AirflowDagDuplicatedIdException):
+        except (AirflowDagCycleException, AirflowDagDuplicatedIdException, AirflowDagTaskOutOfBoundsValue):
             # There was an error in bagging the dag. Remove it from the list of dags
             self.log.exception("Exception bagging dag: %s", dag.dag_id)
             # Only necessary at the root level since DAG.subdags automatically

--- a/airflow/utils/dag_parameters_overflow.py
+++ b/airflow/utils/dag_parameters_overflow.py
@@ -1,0 +1,56 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""DAG parameters overflow validator."""
+from __future__ import annotations
+
+import functools
+from typing import TYPE_CHECKING
+
+from airflow import settings
+from airflow.exceptions import AirflowDagTaskOutOfBoundsValue, AirflowException
+
+if TYPE_CHECKING:
+    from airflow.models.dag import DAG
+
+
+_POSTGRES_PRIORITY_WEIGHT_UPPER_BOUND = 2147483647
+_POSTGRES_PRIORITY_WEIGHT_LOWER_BOUND = -2147483648
+
+
+@functools.lru_cache(maxsize=None)
+def _is_metadatabase_postgres() -> bool:
+    if settings.engine is None:
+        raise AirflowException("Must initialize ORM first")
+    return settings.engine.url.get_backend_name() == "postgresql"
+
+
+def check_values_overflow(dag: DAG) -> None:
+    """Validate priority weight values overflow."""
+    if _is_metadatabase_postgres():
+        task_dict = dag.task_dict
+
+        for task in task_dict.values():
+            task_priority_weight_total = task.priority_weight_total
+
+            if (task_priority_weight_total > _POSTGRES_PRIORITY_WEIGHT_UPPER_BOUND) or (
+                task_priority_weight_total < _POSTGRES_PRIORITY_WEIGHT_LOWER_BOUND
+            ):
+                msg = (
+                    f"Faulty DAG/Task: [{dag.dag_id}/{task.task_id}] with total "
+                    f"priority weight {task_priority_weight_total} exceeds max/min DB value"
+                )
+                raise AirflowDagTaskOutOfBoundsValue(msg)

--- a/tests/utils/test_dag_task_param_overflow.py
+++ b/tests/utils/test_dag_task_param_overflow.py
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from airflow import DAG
+from airflow.exceptions import AirflowDagTaskOutOfBoundsValue
+from airflow.operators.empty import EmptyOperator
+from airflow.utils.dag_parameters_overflow import check_values_overflow
+from tests.models import DEFAULT_DATE
+
+
+class TestDagTaskParameterOverflow:
+    def test_priority_weight_empty(self):
+        # test empty DAG no overflow
+        dag = DAG("dag", start_date=DEFAULT_DATE, default_args={"owner": "owner1"})
+
+        assert not check_values_overflow(dag)
+
+    def test_priority_weight_single_task(self):
+        # test single task with no specific priority weight (no overflow)
+        dag = DAG("dag", start_date=DEFAULT_DATE, default_args={"owner": "owner1"})
+
+        with dag:
+            EmptyOperator(task_id="stage1")
+
+        assert not check_values_overflow(dag)
+
+    @pytest.mark.backend("postgres")
+    def test_priority_weight_sum_up_overflow(self):
+        # Test that priority_weight_total sum up overflows
+        dag = DAG("dag", start_date=DEFAULT_DATE, default_args={"owner": "owner1"})
+        with dag:
+            op1 = EmptyOperator(task_id="stage1", priority_weight=10)
+            op2 = EmptyOperator(task_id="stage2", priority_weight=2147483647)
+            op1.set_downstream(op2)
+        with pytest.raises(AirflowDagTaskOutOfBoundsValue):
+            assert check_values_overflow(dag)
+
+    @pytest.mark.backend("postgres")
+    def test_priority_weight_negative_overflow(self):
+        # Test that priority_weight_total overflows
+        dag = DAG("dag", start_date=DEFAULT_DATE, default_args={"owner": "owner1"})
+        with dag:
+            EmptyOperator(task_id="stage1", priority_weight=-3147483648)
+        with pytest.raises(AirflowDagTaskOutOfBoundsValue):
+            assert check_values_overflow(dag)
+
+    @pytest.mark.backend("postgres")
+    def test_priority_weight_positive_overflow(self):
+        # Test that priority_weight_total overflows
+        dag = DAG("dag", start_date=DEFAULT_DATE, default_args={"owner": "owner1"})
+        with dag:
+            EmptyOperator(task_id="stage1", priority_weight=2147483648)
+        with pytest.raises(AirflowDagTaskOutOfBoundsValue):
+            assert check_values_overflow(dag)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This one is continuation of https://github.com/apache/airflow/pull/34168.
Validation happen independently of the Database Type and expects that the task's priority_weight_total in int32 range which suits for all databases (Postgres, MySQL, SQLite).

I've also thought to add ability to replace to max allowed value, e.g. `lax` mode, however it required to workaround tasks Weight Rules and maybe it is better to do it after https://github.com/apache/airflow/pull/36029 completed

``ignore`` - options exists for compatibility with previous behaviour, however it might work only in SQLite which are not suits for the production usage.

---

```console
ERROR [airflow.models.dagbag.DagBag] Failed to bag_dag: /files/dags/pr_37990.py
Traceback (most recent call last):
  File "/opt/airflow/airflow/models/dagbag.py", line 445, in _process_modules
    self.bag_dag(dag=dag, root_dag=dag)
  File "/opt/airflow/airflow/models/dagbag.py", line 464, in bag_dag
    self._bag_dag(dag=dag, root_dag=root_dag, recursive=True)
  File "/opt/airflow/airflow/models/dagbag.py", line 473, in _bag_dag
    check_values_overflow(dag)
  File "/opt/airflow/airflow/utils/dag_parameters_overflow.py", line 50, in check_values_overflow
    raise AirflowDagTaskOutOfBoundsValue(error_msg)
airflow.exceptions.AirflowDagTaskOutOfBoundsValue: Tasks in dag 'pr_37990' exceeds allowed priority weight [-2147483648..2147483647] range: 
 * Task 'stage1' has priority weight 2147483649.
 * Task 'stage2' has priority weight 2147483648.
```

![image](https://github.com/apache/airflow/assets/3998685/ad7b396e-489d-4488-9130-6ad8f804b64d)


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
