### PR TITLE
Fix a bug where scheduler heartrate parameter were not used

### DIFF
--- a/airflow/jobs/job.py
+++ b/airflow/jobs/job.py
@@ -265,6 +265,8 @@ class Job(Base, LoggingMixin):
     def _heartrate(job_type: str) -> float:
         if job_type == "TriggererJob":
             return conf.getfloat("triggerer", "JOB_HEARTBEAT_SEC")
+        elif job_type == "SchedulerJob":
+            return conf.getfloat("scheduler", "SCHEDULER_HEARTBEAT_SEC")
         else:
             # Heartrate used to be hardcoded to scheduler, so in all other
             # cases continue to use that value for back compat

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -150,7 +150,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
     """
 
     job_type = "SchedulerJob"
-    heartrate: int = conf.getint("scheduler", "SCHEDULER_HEARTBEAT_SEC")
 
     def __init__(
         self,

--- a/tests/jobs/test_base_job.py
+++ b/tests/jobs/test_base_job.py
@@ -97,9 +97,12 @@ class TestJob:
     )
     def test_heart_rate_after_fetched_from_db(self, job_runner, job_type, job_heartbeat_sec):
         """Ensure heartrate is set correctly after jobs are queried from the DB"""
-        with create_session() as session, conf_vars(
-            {(job_type.lower(), "job_heartbeat_sec"): job_heartbeat_sec}
-        ):
+        if job_type == "scheduler":
+            config_name = "scheduler_heartbeat_sec"
+        else:
+            config_name = "job_heartbeat_sec"
+
+        with create_session() as session, conf_vars({(job_type.lower(), config_name): job_heartbeat_sec}):
             job = Job()
             job_runner(job=job)
             session.add(job)

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -193,6 +193,16 @@ class TestSchedulerJob:
                 not scheduler_job.is_alive()
             ), "Completed jobs even with recent heartbeat should not be alive"
 
+    @pytest.mark.parametrize(
+        "heartrate",
+        [10, 5],
+    )
+    def test_heartrate(self, heartrate):
+        with conf_vars({("scheduler", "scheduler_heartbeat_sec"): str(heartrate)}):
+            scheduler_job = Job(executor=self.null_exec)
+            _ = SchedulerJobRunner(job=scheduler_job)
+            assert scheduler_job.heartrate == heartrate
+
     def run_single_scheduler_loop_with_no_dags(self, dags_folder):
         """
         Utility function that runs a single scheduler loop without actually


### PR DESCRIPTION
Since #30255 scheduler heartrate has not been properly calculated. We missed the check for SchedulerJob type and setting heartrate value from `scheduler_health_check_threshold`.

This PR fixes it.

Fix: #37971

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
