### PR TITLE
[OpenLineage] fix: Add fallbacks when retrieving Airflow configuration to avoid errors being raised

### DIFF
--- a/airflow/providers/openlineage/extractors/base.py
+++ b/airflow/providers/openlineage/extractors/base.py
@@ -67,7 +67,8 @@ class BaseExtractor(ABC, LoggingMixin):
     @cached_property
     def disabled_operators(self) -> set[str]:
         return set(
-            operator.strip() for operator in conf.get("openlineage", "disabled_for_operators").split(";")
+            operator.strip()
+            for operator in conf.get("openlineage", "disabled_for_operators", fallback="").split(";")
         )
 
     @cached_property

--- a/airflow/providers/openlineage/plugins/adapter.py
+++ b/airflow/providers/openlineage/plugins/adapter.py
@@ -88,13 +88,13 @@ class OpenLineageAdapter(LoggingMixin):
 
     def get_openlineage_config(self) -> dict | None:
         # First, try to read from YAML file
-        openlineage_config_path = conf.get("openlineage", "config_path")
+        openlineage_config_path = conf.get("openlineage", "config_path", fallback="")
         if openlineage_config_path:
             config = self._read_yaml_config(openlineage_config_path)
             if config:
                 return config.get("transport", None)
         # Second, try to get transport config
-        transport = conf.getjson("openlineage", "transport")
+        transport = conf.getjson("openlineage", "transport", fallback="")
         if not transport:
             return None
         elif not isinstance(transport, dict):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

You can encounter `airflow.exceptions.AirflowConfigException` with the following message:
> section/key [openlineage/disabled_for_operators] not found in config

OR / AND

> section/key [openlineage/config_path] not found in config

We should avoid that and treat lack of configuration as empty configuration. This PR adds `fallback` to `conf.get` where missing. This PR has been released in `apache-airflow-providers-openlineage=1.7.0`.

Symptom you can see is only getting OpenLineage DAG start events, as when a task level event is trying to be sent, the above errors are raised.


## Solution
1. If possible, install `apache-airflow-providers-openlineage>=1.7.0`.
2. If you can't upgrade, you must provide the following configuration (they can be empty, but they must be defined to avoid error being raised):

either as environment variables:
> AIRFLOW__OPENLINEAGE__CONFIG_PATH = ""
AIRFLOW__OPENLINEAGE__DISABLED_FOR_OPERATORS = '"

or in airflow.cfg file:
> [openlineage]
disabled_for_operators = ""
config_path = ""


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
