### PR TITLE
Disable `uv` upgrade checks temporarily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -641,6 +641,8 @@ jobs:
           --hook-stage manual
           update-installers
         if: always()
+        env:
+          UPGRADE_UV: "false"
       - name: "Run automated upgrade for chart dependencies"
         run: >
           pre-commit run

--- a/scripts/ci/pre_commit/pre_commit_update_installers.py
+++ b/scripts/ci/pre_commit/pre_commit_update_installers.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import os
 import re
 import sys
 from pathlib import Path
@@ -46,6 +47,13 @@ PIP_PATTERN = re.compile(r"AIRFLOW_PIP_VERSION=[0-9.]+")
 UV_PATTERN = re.compile(r"AIRFLOW_UV_VERSION=[0-9.]+")
 UV_GREATER_PATTERN = re.compile(r'"uv>=[0-9]+[0-9.]+"')
 
+# For now we temporarily disable upgrading uv in the pre-commit hook because the latest version (0.1.16)
+# is not compatible with our pyproject.toml using Draft https://peps.python.org/pep-0639/
+# licence-files key (which hatchling backend already supports nicely)
+# We will re-enable it once the problem is addressed:
+# Issue: https://github.com/astral-sh/uv/issues/2302
+UPGRADE_UV: bool = os.environ.get("UPGRADE_UV", "true").lower() == "true"
+
 if __name__ == "__main__":
     pip_version = get_latest_pypi_version("pip")
     console.print(f"[bright_blue]Latest pip version: {pip_version}")
@@ -58,8 +66,9 @@ if __name__ == "__main__":
         file_content = file.read_text()
         new_content = file_content
         new_content = re.sub(PIP_PATTERN, f"AIRFLOW_PIP_VERSION={pip_version}", new_content, re.MULTILINE)
-        new_content = re.sub(UV_PATTERN, f"AIRFLOW_UV_VERSION={uv_version}", new_content, re.MULTILINE)
-        new_content = re.sub(UV_GREATER_PATTERN, f'"uv>={uv_version}"', new_content, re.MULTILINE)
+        if UPGRADE_UV:
+            new_content = re.sub(UV_PATTERN, f"AIRFLOW_UV_VERSION={uv_version}", new_content, re.MULTILINE)
+            new_content = re.sub(UV_GREATER_PATTERN, f'"uv>={uv_version}"', new_content, re.MULTILINE)
         if new_content != file_content:
             file.write_text(new_content)
             console.print(f"[bright_blue]Updated {file}")


### PR DESCRIPTION
Until https://github.com/astral-sh/uv/issues/2302 is solved we should disable UV upgrade check as 0.1.16 version of `uv` does not properly validate our pyproject.toml with Draft PEP-0639 extension (licence-files).

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
