### PR TITLE
Implement wait_until_job_complete parameter for KubernetesJobOperator

### DIFF
--- a/tests/providers/cncf/kubernetes/operators/test_job.py
+++ b/tests/providers/cncf/kubernetes/operators/test_job.py
@@ -17,12 +17,14 @@
 from __future__ import annotations
 
 import re
+from unittest import mock
 from unittest.mock import patch
 
 import pendulum
 import pytest
 from kubernetes.client import ApiClient, models as k8s
 
+from airflow.exceptions import AirflowException
 from airflow.models import DAG, DagModel, DagRun, TaskInstance
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
 from airflow.utils import timezone
@@ -30,7 +32,9 @@ from airflow.utils.session import create_session
 from airflow.utils.types import DagRunType
 
 DEFAULT_DATE = timezone.datetime(2016, 1, 1, 1, 0, 0)
-HOOK_CLASS = "airflow.providers.cncf.kubernetes.operators.job.KubernetesHook"
+JOB_OPERATORS_PATH = "airflow.providers.cncf.kubernetes.operators.job.{}"
+HOOK_CLASS = JOB_OPERATORS_PATH.format("KubernetesHook")
+POLL_INTERVAL = 100
 
 
 def create_context(task, persist_to_db=False, map_index=None):
@@ -450,3 +454,68 @@ class TestKubernetesJobOperator:
         )
         job = k.build_job_request_obj({})
         assert re.match(r"job-a-very-reasonable-task-name-[a-z0-9-]+", job.metadata.name) is not None
+
+    @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.build_job_request_obj"))
+    @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.create_job"))
+    @patch(HOOK_CLASS)
+    def test_execute(self, mock_hook, mock_create_job, mock_build_job_request_obj):
+        mock_hook.return_value.is_job_failed.return_value = False
+        mock_job_request_obj = mock_build_job_request_obj.return_value
+        mock_job_expected = mock_create_job.return_value
+        mock_ti = mock.MagicMock()
+        context = dict(ti=mock_ti)
+
+        op = KubernetesJobOperator(
+            task_id="test_task_id",
+        )
+        execute_result = op.execute(context=context)
+
+        mock_build_job_request_obj.assert_called_once_with(context)
+        mock_create_job.assert_called_once_with(job_request_obj=mock_job_request_obj)
+        mock_ti.xcom_push.assert_has_calls(
+            [
+                mock.call(key="job_name", value=mock_job_expected.metadata.name),
+                mock.call(key="job_namespace", value=mock_job_expected.metadata.namespace),
+            ]
+        )
+
+        assert op.job_request_obj == mock_job_request_obj
+        assert op.job == mock_job_expected
+        assert not op.wait_until_job_complete
+        assert execute_result is None
+        assert not mock_hook.wait_until_job_complete.called
+
+    @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.build_job_request_obj"))
+    @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.create_job"))
+    @patch(HOOK_CLASS)
+    def test_execute_fail(self, mock_hook, mock_create_job, mock_build_job_request_obj):
+        mock_hook.return_value.is_job_failed.return_value = True
+
+        op = KubernetesJobOperator(
+            task_id="test_task_id",
+        )
+
+        with pytest.raises(AirflowException):
+            op.execute(context=dict(ti=mock.MagicMock()))
+
+    @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.build_job_request_obj"))
+    @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.create_job"))
+    @patch(f"{HOOK_CLASS}.wait_until_job_complete")
+    def test_wait_until_job_complete(
+        self, mock_wait_until_job_complete, mock_create_job, mock_build_job_request_obj
+    ):
+        mock_job_expected = mock_create_job.return_value
+        mock_ti = mock.MagicMock()
+
+        op = KubernetesJobOperator(
+            task_id="test_task_id", wait_until_job_complete=True, job_poll_interval=POLL_INTERVAL
+        )
+        op.execute(context=dict(ti=mock_ti))
+
+        assert op.wait_until_job_complete
+        assert op.job_poll_interval == POLL_INTERVAL
+        mock_wait_until_job_complete.assert_called_once_with(
+            job_name=mock_job_expected.metadata.name,
+            namespace=mock_job_expected.metadata.namespace,
+            job_poll_interval=POLL_INTERVAL,
+        )


### PR DESCRIPTION
PR introduces the optional `wait_until_job_complete` parameter for the `KubernetesJobOperator` that blocks execution until the created job is complete.
The default value is `False` thus behavior of existing DAGs won't change.