### PR TITLE
Use AwsLogsHook when fetching Glue job logs

### DIFF
--- a/airflow/providers/amazon/aws/hooks/glue.py
+++ b/airflow/providers/amazon/aws/hooks/glue.py
@@ -218,7 +218,9 @@ class GlueJobHook(AwsBaseHook):
         """
         Returns an AwsLogsHook instantiated with the parameters of the GlueJobHook
         """
-        return AwsLogsHook(aws_conn_id=self.aws_conn_id, region_name=self.region_name, verify=self.verify, config=self.config)
+        return AwsLogsHook(
+            aws_conn_id=self.aws_conn_id, region_name=self.region_name, verify=self.verify, config=self.config
+        )
 
     def print_job_logs(
         self,
@@ -232,7 +234,6 @@ class GlueJobHook(AwsBaseHook):
         :param continuation_tokens: the tokens where to resume from when reading logs.
             The object gets updated with the new tokens by this method.
         """
-        
         log_client = self.logs_hook.get_conn()
         paginator = log_client.get_paginator("filter_log_events")
 

--- a/airflow/providers/amazon/aws/hooks/glue.py
+++ b/airflow/providers/amazon/aws/hooks/glue.py
@@ -226,7 +226,6 @@ class GlueJobHook(AwsBaseHook):
         :param continuation_tokens: the tokens where to resume from when reading logs.
             The object gets updated with the new tokens by this method.
         """
-        #  log_client = boto3.client("logs") # replace with log hook
         log_client = self.logs_hook.get_conn()
         paginator = log_client.get_paginator("filter_log_events")
 
@@ -235,13 +234,11 @@ class GlueJobHook(AwsBaseHook):
             fetched_logs = []
             next_token = continuation_token
             try:
-                print("before pagination")
                 for response in paginator.paginate(
                     logGroupName=log_group,
                     logStreamNames=[run_id],
                     PaginationConfig={"StartingToken": continuation_token},
                 ):
-                    print(f"RESPONSE HEHEHE {response}")
                     fetched_logs.extend([event["message"] for event in response["events"]])
                     # if the response is empty there is no nextToken in it
                     next_token = response.get("nextToken") or next_token
@@ -266,7 +263,6 @@ class GlueJobHook(AwsBaseHook):
             return next_token
 
         log_group_prefix = self.conn.get_job_run(JobName=job_name, RunId=run_id)["JobRun"]["LogGroupName"]
-        print(log_group_prefix)
         log_group_default = f"{log_group_prefix}/{DEFAULT_LOG_SUFFIX}"
         log_group_error = f"{log_group_prefix}/{ERROR_LOG_SUFFIX}"
         # one would think that the error log group would contain only errors, but it actually contains

--- a/airflow/providers/amazon/aws/hooks/glue.py
+++ b/airflow/providers/amazon/aws/hooks/glue.py
@@ -215,9 +215,7 @@ class GlueJobHook(AwsBaseHook):
 
     @property
     def logs_hook(self):
-        """
-        Returns an AwsLogsHook instantiated with the parameters of the GlueJobHook
-        """
+        """Returns an AwsLogsHook instantiated with the parameters of the GlueJobHook."""
         return AwsLogsHook(
             aws_conn_id=self.aws_conn_id, region_name=self.region_name, verify=self.verify, config=self.config
         )

--- a/airflow/providers/amazon/aws/hooks/glue.py
+++ b/airflow/providers/amazon/aws/hooks/glue.py
@@ -112,7 +112,6 @@ class GlueJobHook(AwsBaseHook):
 
         kwargs["client_type"] = "glue"
         super().__init__(*args, **kwargs)
-        self.logs_hook = AwsLogsHook(aws_conn_id=self.aws_conn_id)
 
     def create_glue_job_config(self) -> dict:
         default_command = {
@@ -214,6 +213,13 @@ class GlueJobHook(AwsBaseHook):
             job_run = await client.get_job_run(JobName=job_name, RunId=run_id)
         return job_run["JobRun"]["JobRunState"]
 
+    @property
+    def logs_hook(self):
+        """
+        Returns an AwsLogsHook instantiated with the parameters of the GlueJobHook
+        """
+        return AwsLogsHook(aws_conn_id=self.aws_conn_id, region_name=self.region_name, verify=self.verify, config=self.config)
+
     def print_job_logs(
         self,
         job_name: str,
@@ -226,6 +232,7 @@ class GlueJobHook(AwsBaseHook):
         :param continuation_tokens: the tokens where to resume from when reading logs.
             The object gets updated with the new tokens by this method.
         """
+        
         log_client = self.logs_hook.get_conn()
         paginator = log_client.get_paginator("filter_log_events")
 

--- a/airflow/providers/amazon/aws/hooks/glue.py
+++ b/airflow/providers/amazon/aws/hooks/glue.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from functools import cached_property
 
 from botocore.exceptions import ClientError
 
@@ -213,7 +214,7 @@ class GlueJobHook(AwsBaseHook):
             job_run = await client.get_job_run(JobName=job_name, RunId=run_id)
         return job_run["JobRun"]["JobRunState"]
 
-    @property
+    @cached_property
     def logs_hook(self):
         """Returns an AwsLogsHook instantiated with the parameters of the GlueJobHook."""
         return AwsLogsHook(

--- a/airflow/providers/amazon/aws/hooks/glue.py
+++ b/airflow/providers/amazon/aws/hooks/glue.py
@@ -20,11 +20,11 @@ from __future__ import annotations
 import asyncio
 import time
 
-import boto3
 from botocore.exceptions import ClientError
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
+from airflow.providers.amazon.aws.hooks.logs import AwsLogsHook
 
 DEFAULT_LOG_SUFFIX = "output"
 ERROR_LOG_SUFFIX = "error"
@@ -112,6 +112,7 @@ class GlueJobHook(AwsBaseHook):
 
         kwargs["client_type"] = "glue"
         super().__init__(*args, **kwargs)
+        self.logs_hook = AwsLogsHook(aws_conn_id=self.aws_conn_id)
 
     def create_glue_job_config(self) -> dict:
         default_command = {
@@ -225,7 +226,8 @@ class GlueJobHook(AwsBaseHook):
         :param continuation_tokens: the tokens where to resume from when reading logs.
             The object gets updated with the new tokens by this method.
         """
-        log_client = boto3.client("logs")
+        #  log_client = boto3.client("logs") # replace with log hook
+        log_client = self.logs_hook.get_conn()
         paginator = log_client.get_paginator("filter_log_events")
 
         def display_logs_from(log_group: str, continuation_token: str | None) -> str | None:
@@ -233,11 +235,13 @@ class GlueJobHook(AwsBaseHook):
             fetched_logs = []
             next_token = continuation_token
             try:
+                print("before pagination")
                 for response in paginator.paginate(
                     logGroupName=log_group,
                     logStreamNames=[run_id],
                     PaginationConfig={"StartingToken": continuation_token},
                 ):
+                    print(f"RESPONSE HEHEHE {response}")
                     fetched_logs.extend([event["message"] for event in response["events"]])
                     # if the response is empty there is no nextToken in it
                     next_token = response.get("nextToken") or next_token
@@ -262,9 +266,9 @@ class GlueJobHook(AwsBaseHook):
             return next_token
 
         log_group_prefix = self.conn.get_job_run(JobName=job_name, RunId=run_id)["JobRun"]["LogGroupName"]
+        print(log_group_prefix)
         log_group_default = f"{log_group_prefix}/{DEFAULT_LOG_SUFFIX}"
         log_group_error = f"{log_group_prefix}/{ERROR_LOG_SUFFIX}"
-
         # one would think that the error log group would contain only errors, but it actually contains
         # a lot of interesting logs too, so it's valuable to have both
         continuation_tokens.output_stream_continuation = display_logs_from(


### PR DESCRIPTION
This PR aim to fix a bug in the GlueJobHook that occurs when setting the `verbose` parameter of GlueJobOperator to True.
The `print_job_logs` method is instantiating a new boto3 client instead of using an AwsLogsHook.

https://github.com/apache/airflow/blob/main/airflow/providers/amazon/aws/hooks/glue.py#L228

If the `GlueJobOperator` is instantiated with an Airflow Connection with a `role_arn` different than the one used by the Airflow Workers, it result in a `AccessDeniedException` (because the boto3 client is using the default credentials)

To fix this bug I've deleted the boto3 client instantiated in the `print_job_logs` method and instead, created a new `AwsLogsHook` using the `aws_conn_id` attribute.

Close  #37976
