### PR TITLE
Fix bug in validate-operators-init pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -330,6 +330,19 @@ repos:
         pass_filenames: true
         files: ^airflow/providers/.*/(operators|transfers|sensors)/.*\.py$
         additional_dependencies: [ 'rich>=12.4.4' ]
+        # TODO: Handle the provider-specific exclusions and remove them from the list, see:
+        #       https://github.com/apache/airflow/issues/36484
+        exclude: |
+          (?x)^(
+              ^airflow\/providers\/google\/cloud\/operators\/mlengine.py$|
+              ^airflow\/providers\/google\/cloud\/operators\/vertex_ai\/custom_job.py$|
+              ^airflow\/providers\/google\/cloud\/operators\/cloud_storage_transfer_service.py$|
+              ^airflow\/providers\/apache\/spark\/operators\/spark_submit.py\.py$|
+              ^airflow\/providers\/google\/cloud\/operators\/vertex_ai\/auto_ml\.py$|
+              ^airflow\/providers\/apache\/spark\/operators\/spark_submit\.py$|
+              ^airflow\/providers\/apache\/spark\/operators\/spark_sql\.py$|
+              ^airflow\/providers\/databricks\/operators\/databricks_sql\.py$|
+          )$
       - id: ruff
         name: Run 'ruff' for extremely fast Python linting
         description: "Run 'ruff' for extremely fast Python linting"

--- a/scripts/ci/pre_commit/pre_commit_validate_operators_init.py
+++ b/scripts/ci/pre_commit/pre_commit_validate_operators_init.py
@@ -162,7 +162,7 @@ def _handle_assigned_field(
     :param target: The target field.
     :param value: The value of the field.
     """
-    if not isinstance(value, ast.Name):
+    if not isinstance(value, ast.Name) or target.attr != value.id:
         invalid_assignments.append(target.attr)
     else:
         assigned_template_fields.append(target.attr)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

related: #36484,

Unfortunately, in PR #33786, I accidentally missed a condition to check that templated fields' assigned values are parameters with the same name. This PR fixes the pre-commit while ignoring 6 files in `.pre-commit-config` that currently do not comply with this requirement.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
