### PR TITLE
Don't allow defaults other than None in context parameters, and improve error message

### DIFF
--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -223,21 +223,20 @@ class DecoratedOperator(BaseOperator):
         try:
             signature = signature.replace(parameters=parameters)
         except ValueError as err:
-            raise ValueError(
-                textwrap.dedent(
-                    f"""
-                    The function signature broke while assigning defaults to context key parameters.
+            message = textwrap.dedent(
+                f"""
+                The function signature broke while assigning defaults to context key parameters.
 
-                    The decorator is replacing the signature
-                    > {python_callable.__name__}({', '.join(str(param) for param in signature.parameters.values())})
+                The decorator is replacing the signature
+                > {python_callable.__name__}({', '.join(str(param) for param in signature.parameters.values())})
 
-                    with
-                    > {python_callable.__name__}({', '.join(str(param) for param in parameters)})
+                with
+                > {python_callable.__name__}({', '.join(str(param) for param in parameters)})
 
-                    which isn't valid: {err}
-                    """
-                )
+                which isn't valid: {err}
+                """
             )
+            raise ValueError(message)
 
         # Check that arguments can be binded. There's a slight difference when
         # we do validation for task-mapping: Since there's no guarantee we can

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -222,10 +222,21 @@ class DecoratedOperator(BaseOperator):
         ]
         try:
             signature = signature.replace(parameters=parameters)
-        except ValueError:
+        except ValueError as err:
             raise ValueError(
-                "The function signature broke while assigning defaults to context key parameters. "
-                "You need to change their position in the parameter list"
+                textwrap.dedent(
+                    f"""
+                    The function signature broke while assigning defaults to context key parameters.
+
+                    The decorator is replacing the signature
+                    > {python_callable.__name__}({', '.join(str(param) for param in signature.parameters.values())})
+
+                    with
+                    > {python_callable.__name__}({', '.join(str(param) for param in parameters)})
+
+                    which isn't valid: {err}
+                    """
+                )
             )
 
         # Check that arguments can be binded. There's a slight difference when

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -208,6 +208,14 @@ class DecoratedOperator(BaseOperator):
         # since values for those will be provided when the task is run. Since
         # we're not actually running the function, None is good enough here.
         signature = inspect.signature(python_callable)
+
+        # Don't allow context argument defaults other than None to avoid ambiguities.
+        if any(
+            param.name in KNOWN_CONTEXT_KEYS and param.default not in (None, inspect.Parameter.empty)
+            for param in signature.parameters.values()
+        ):
+            raise ValueError("Context key parameters can't have a default other than None")
+
         parameters = [
             param.replace(default=None) if param.name in KNOWN_CONTEXT_KEYS else param
             for param in signature.parameters.values()

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -220,7 +220,13 @@ class DecoratedOperator(BaseOperator):
             param.replace(default=None) if param.name in KNOWN_CONTEXT_KEYS else param
             for param in signature.parameters.values()
         ]
-        signature = signature.replace(parameters=parameters)
+        try:
+            signature = signature.replace(parameters=parameters)
+        except ValueError:
+            raise ValueError(
+                "The function signature broke while assigning defaults to context key parameters. "
+                "You need to change their position in the parameter list"
+            )
 
         # Check that arguments can be binded. There's a slight difference when
         # we do validation for task-mapping: Since there's no guarantee we can

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -256,6 +256,16 @@ class TestAirflowTaskDecorator(BasePythonTest):
             add_number()
         add_number("test")
 
+    def test_fails_context_parameter_other_than_none(self):
+        """Fail if a context parameter has a default and it's not None."""
+        with pytest.raises(ValueError):
+
+            @task_decorator
+            def add_number_to_try_number(num: int, try_number: int = 0):
+                return num + try_number
+
+            add_number_to_try_number(1)
+
     def test_fail_method(self):
         """Tests that @task will fail if signature is not binding."""
 

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -259,12 +259,12 @@ class TestAirflowTaskDecorator(BasePythonTest):
     def test_fails_context_parameter_other_than_none(self):
         """Fail if a context parameter has a default and it's not None."""
         error_message = "Context key parameter try_number can't have a default other than None"
+
+        @task_decorator
+        def add_number_to_try_number(num: int, try_number: int = 0):
+            return num + try_number
+
         with pytest.raises(ValueError, match=error_message):
-
-            @task_decorator
-            def add_number_to_try_number(num: int, try_number: int = 0):
-                return num + try_number
-
             add_number_to_try_number(1)
 
     def test_fail_method(self):

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -258,7 +258,8 @@ class TestAirflowTaskDecorator(BasePythonTest):
 
     def test_fails_context_parameter_other_than_none(self):
         """Fail if a context parameter has a default and it's not None."""
-        with pytest.raises(ValueError):
+        error_message = "Context key parameter try_number can't have a default other than None"
+        with pytest.raises(ValueError, match=error_message):
 
             @task_decorator
             def add_number_to_try_number(num: int, try_number: int = 0):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This PR does two things for the Python task decorator:

1. Don't allow a default parameter other than None for context parameters, since this is always replaced by None in 2.8. Keeping this behavior allowed would only bring confusion as it's ambiguous. Suggested by @potiuk in https://github.com/apache/airflow/pull/38007#pullrequestreview-1926201627.
2. Improve the error message for cases where the replacement of default values breaks the function signature. For this I opted for a simple try-catch where we let the Python traceback provide the exact nature of the failure.

Closes: #38006


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
