### PR TITLE
Fix D105 for mongo provider

### DIFF
--- a/airflow/providers/mongo/hooks/mongo.py
+++ b/airflow/providers/mongo/hooks/mongo.py
@@ -118,6 +118,7 @@ class MongoHook(BaseHook):
             self.allow_insecure = False
 
     def __enter__(self):
+        """Return the object when a context manager is created."""
         return self
 
     def __exit__(
@@ -126,6 +127,7 @@ class MongoHook(BaseHook):
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
+        """Close mongo connection when exiting the context manager."""
         if self.client is not None:
             self.client.close()
             self.client = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1475,7 +1475,6 @@ combine-as-imports = true
 "airflow/providers/google/cloud/links/dataproc.py" = ["D105"]
 "airflow/providers/imap/hooks/imap.py" = ["D105"]
 "airflow/providers/microsoft/psrp/hooks/psrp.py" = ["D105"]
-"airflow/providers/mongo/hooks/mongo.py" = ["D105"]
 "airflow/providers/samba/hooks/samba.py" = ["D105"]
 "airflow/providers/smtp/hooks/smtp.py" = ["D105"]
 "airflow/providers/ssh/hooks/ssh.py" = ["D105"]


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

related: https://github.com/apache/airflow/issues/37523

Fixing the D105 pre commit hook for mongo provider


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
