### PR TITLE
Remove constraint caching from image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -552,10 +552,6 @@ function common::get_airflow_version_specification() {
 }
 
 function common::get_constraints_location() {
-    if [[ -f "${HOME}/constraints.txt" ]]; then
-        # constraints are already downloaded, do not calculate/override again
-        return
-    fi
     # auto-detect Airflow-constraint reference and location
     if [[ -z "${AIRFLOW_CONSTRAINTS_REFERENCE=}" ]]; then
         if  [[ ${AIRFLOW_VERSION} =~ v?2.* && ! ${AIRFLOW_VERSION} =~ .*dev.* ]]; then

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -499,10 +499,6 @@ function common::get_airflow_version_specification() {
 }
 
 function common::get_constraints_location() {
-    if [[ -f "${HOME}/constraints.txt" ]]; then
-        # constraints are already downloaded, do not calculate/override again
-        return
-    fi
     # auto-detect Airflow-constraint reference and location
     if [[ -z "${AIRFLOW_CONSTRAINTS_REFERENCE=}" ]]; then
         if  [[ ${AIRFLOW_VERSION} =~ v?2.* && ! ${AIRFLOW_VERSION} =~ .*dev.* ]]; then

--- a/scripts/docker/common.sh
+++ b/scripts/docker/common.sh
@@ -77,10 +77,6 @@ function common::get_airflow_version_specification() {
 }
 
 function common::get_constraints_location() {
-    if [[ -f "${HOME}/constraints.txt" ]]; then
-        # constraints are already downloaded, do not calculate/override again
-        return
-    fi
     # auto-detect Airflow-constraint reference and location
     if [[ -z "${AIRFLOW_CONSTRAINTS_REFERENCE=}" ]]; then
         if  [[ ${AIRFLOW_VERSION} =~ v?2.* && ! ${AIRFLOW_VERSION} =~ .*dev.* ]]; then


### PR DESCRIPTION
Constraint caching added recently to the image caused some unexpected side effects when conflicting constraints were added - as old constraints cached in the image were not replaced even if main has been updated. This PR removes caching from the image - so that building the image will always use constraints from main.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
