### PR TITLE
Feature/add log grouping to UI

### DIFF
--- a/airflow/example_dags/example_python_operator.py
+++ b/airflow/example_dags/example_python_operator.py
@@ -51,8 +51,12 @@ with DAG(
     # [START howto_operator_python]
     def print_context(ds=None, **kwargs):
         """Print the Airflow context and ds variable from the context."""
+        print("::group::All kwargs")
         pprint(kwargs)
+        print("::endgroup::")
+        print("::group::Context variable ds")
         print(ds)
+        print("::endgroup::")
         return "Whatever you return gets printed in the logs"
 
     run_this = PythonOperator(task_id="print_the_context", python_callable=print_context)

--- a/airflow/jobs/local_task_job_runner.py
+++ b/airflow/jobs/local_task_job_runner.py
@@ -116,6 +116,9 @@ class LocalTaskJobRunner(BaseJobRunner, LoggingMixin):
 
         self.task_runner = get_task_runner(self)
 
+        # Print a marker post execution for internals of post task processing
+        self.log.info("::group::Pre task execution logs")
+
         def signal_handler(signum, frame):
             """Set kill signal handler."""
             self.log.error("Received SIGTERM. Terminating subprocesses")
@@ -215,6 +218,9 @@ class LocalTaskJobRunner(BaseJobRunner, LoggingMixin):
                     )
             return return_code
         finally:
+            # Print a marker for log grouping of details before task execution
+            self.log.info("::endgroup::")
+
             self.on_kill()
 
     def handle_task_exit(self, return_code: int) -> None:

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -414,6 +414,9 @@ def _execute_task(task_instance: TaskInstance | TaskInstancePydantic, context: C
 
     def _execute_callable(context, **execute_callable_kwargs):
         try:
+            # Print a marker for log grouping of details before task execution
+            log.info("::endgroup::")
+
             return execute_callable(context=context, **execute_callable_kwargs)
         except SystemExit as e:
             # Handle only successful cases here. Failure cases will be handled upper
@@ -421,6 +424,9 @@ def _execute_task(task_instance: TaskInstance | TaskInstancePydantic, context: C
             if e.code is not None and e.code != 0:
                 raise
             return None
+        finally:
+            # Print a marker post execution for internals of post task processing
+            log.info("::group::Post task execution logs")
 
     # If a timeout is specified for the task, make it fail
     # if it goes beyond

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
@@ -69,8 +69,13 @@ const LogBlock = ({
 
   const onClick = (e: React.MouseEvent<HTMLElement>) => {
     const target = e.target as HTMLElement;
-    if (target.id?.endsWith("_unfold")) {
-      const gId = target.id.substring(0, target.id.length - 7);
+    const unfoldIdSuffix = "_unfold";
+    const foldIdSuffix = "_fold";
+    if (target.id?.endsWith(unfoldIdSuffix)) {
+      const gId = target.id.substring(
+        0,
+        target.id.length - unfoldIdSuffix.length
+      );
       // remember the folding state if logs re-loaded
       unfoldedGroups.push(gId);
       setUnfoldedLogGroup(unfoldedGroups);
@@ -79,9 +84,11 @@ const LogBlock = ({
       if (target.nextElementSibling) {
         (target.nextElementSibling as HTMLElement).style.display = "inline";
       }
-    }
-    if (target.id?.endsWith("_fold")) {
-      const gId = target.id.substring(0, target.id.length - 5);
+    } else if (target.id?.endsWith(foldIdSuffix)) {
+      const gId = target.id.substring(
+        0,
+        target.id.length - foldIdSuffix.length
+      );
       // remember the folding state if logs re-loaded
       if (unfoldedGroups.indexOf(gId) >= 0) {
         unfoldedGroups.splice(unfoldedGroups.indexOf(gId), 1);

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
@@ -69,7 +69,7 @@ const LogBlock = ({
 
   const onClick = (e: React.MouseEvent<HTMLElement>) => {
     const target = e.target as HTMLElement;
-    if (target.id && target.id.endsWith("_unfold")) {
+    if (target.id?.endsWith("_unfold")) {
       const gId = target.id.substring(0, target.id.length - 7);
       // remember the folding state if logs re-loaded
       unfoldedGroups.push(gId);
@@ -80,7 +80,7 @@ const LogBlock = ({
         (target.nextElementSibling as HTMLElement).style.display = "inline";
       }
     }
-    if (target.id && target.id.endsWith("_fold")) {
+    if (target.id?.endsWith("_fold")) {
       const gId = target.id.substring(0, target.id.length - 5);
       // remember the folding state if logs re-loaded
       if (unfoldedGroups.indexOf(gId) >= 0) {
@@ -88,10 +88,10 @@ const LogBlock = ({
       }
       setUnfoldedLogGroup(unfoldedGroups);
       // now do the folding
-      if (target.parentNode) {
-        (target.parentNode as HTMLElement).style.display = "none";
-        if (target.parentNode.previousSibling) {
-          (target.parentNode.previousSibling as HTMLElement).style.display =
+      if (target.parentElement) {
+        target.parentElement.style.display = "none";
+        if (target.parentElement.previousSibling) {
+          (target.parentElement.previousSibling as HTMLElement).style.display =
             "inline";
         }
       }

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
@@ -25,9 +25,17 @@ interface Props {
   parsedLogs: string;
   wrap: boolean;
   tryNumber: number;
+  unfoldedGroups: Array<string>;
+  setUnfoldedLogGroup: React.Dispatch<React.SetStateAction<string[]>>;
 }
 
-const LogBlock = ({ parsedLogs, wrap, tryNumber }: Props) => {
+const LogBlock = ({
+  parsedLogs,
+  wrap,
+  tryNumber,
+  unfoldedGroups,
+  setUnfoldedLogGroup,
+}: Props) => {
   const [autoScroll, setAutoScroll] = useState(true);
 
   const logBoxRef = useRef<HTMLPreElement>(null);
@@ -62,12 +70,24 @@ const LogBlock = ({ parsedLogs, wrap, tryNumber }: Props) => {
   const onClick = (e: React.MouseEvent<HTMLElement>) => {
     const target = e.target as HTMLElement;
     if (target.id && target.id.endsWith("_unfold")) {
+      const gId = target.id.substring(0, target.id.length - 7);
+      // remember the folding state if logs re-loaded
+      unfoldedGroups.push(gId);
+      setUnfoldedLogGroup(unfoldedGroups);
+      // now do the folding
       target.style.display = "none";
       if (target.nextElementSibling) {
         (target.nextElementSibling as HTMLElement).style.display = "inline";
       }
     }
     if (target.id && target.id.endsWith("_fold")) {
+      const gId = target.id.substring(0, target.id.length - 5);
+      // remember the folding state if logs re-loaded
+      if (unfoldedGroups.indexOf(gId) >= 0) {
+        unfoldedGroups.splice(unfoldedGroups.indexOf(gId), 1);
+      }
+      setUnfoldedLogGroup(unfoldedGroups);
+      // now do the folding
       if (target.parentNode) {
         (target.parentNode as HTMLElement).style.display = "none";
         if (target.parentNode.previousSibling) {

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
@@ -59,10 +59,31 @@ const LogBlock = ({ parsedLogs, wrap, tryNumber }: Props) => {
     }
   };
 
+  const onClick = (e: React.MouseEvent<HTMLElement>) => {
+    const target = e.target as HTMLElement;
+    if (target.id && target.id.endsWith("_unfold")) {
+      target.style.display = "none";
+      if (target.nextElementSibling) {
+        (target.nextElementSibling as HTMLElement).style.display = "inline";
+      }
+    }
+    if (target.id && target.id.endsWith("_fold")) {
+      if (target.parentNode) {
+        (target.parentNode as HTMLElement).style.display = "none";
+        if (target.parentNode.previousSibling) {
+          (target.parentNode.previousSibling as HTMLElement).style.display =
+            "inline";
+        }
+      }
+    }
+    return false;
+  };
+
   return (
     <Code
       ref={logBoxRef}
       onScroll={onScroll}
+      onClick={onClick}
       maxHeight={`calc(100% - ${offsetTop}px)`}
       overflowY="auto"
       p={3}

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
@@ -117,6 +117,7 @@ const Logs = ({
   const [fileSourceFilters, setFileSourceFilters] = useState<
     Array<FileSourceOption>
   >([]);
+  const [unfoldedLogGroups, setUnfoldedLogGroup] = useState<Array<string>>([]);
   const { timezone } = useTimezone();
 
   const taskTryNumber = selectedTryNumber || tryNumber || 1;
@@ -148,9 +149,10 @@ const Logs = ({
         data,
         timezone,
         logLevelFilters.map((option) => option.value),
-        fileSourceFilters.map((option) => option.value)
+        fileSourceFilters.map((option) => option.value),
+        unfoldedLogGroups
       ),
-    [data, fileSourceFilters, logLevelFilters, timezone]
+    [data, fileSourceFilters, logLevelFilters, timezone, unfoldedLogGroups]
   );
 
   const logAttemptDropdownLimit = 10;
@@ -315,6 +317,8 @@ const Logs = ({
                 parsedLogs={parsedLogs}
                 wrap={wrap}
                 tryNumber={taskTryNumber}
+                unfoldedGroups={unfoldedLogGroups}
+                setUnfoldedLogGroup={setUnfoldedLogGroup}
               />
             )
           )}

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/utils.test.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/utils.test.tsx
@@ -42,7 +42,13 @@ const mockTaskLog = `
 
 describe("Test Logs Utils.", () => {
   test("parseLogs function replaces datetimes", () => {
-    const { parsedLogs, fileSources } = parseLogs(mockTaskLog, "UTC", [], []);
+    const { parsedLogs, fileSources } = parseLogs(
+      mockTaskLog,
+      "UTC",
+      [],
+      [],
+      []
+    );
 
     expect(parsedLogs).toContain("2022-06-04, 00:00:01 UTC");
     expect(fileSources).toEqual([
@@ -51,7 +57,7 @@ describe("Test Logs Utils.", () => {
       "task_command.py",
       "taskinstance.py",
     ]);
-    const result = parseLogs(mockTaskLog, "America/Los_Angeles", [], []);
+    const result = parseLogs(mockTaskLog, "America/Los_Angeles", [], [], []);
     expect(result.parsedLogs).toContain("2022-06-03, 17:00:01 PDT");
   });
 
@@ -77,6 +83,7 @@ describe("Test Logs Utils.", () => {
         mockTaskLog,
         null,
         logLevelFilters,
+        [],
         []
       );
 
@@ -93,7 +100,8 @@ describe("Test Logs Utils.", () => {
       mockTaskLog,
       null,
       [],
-      ["taskinstance.py"]
+      ["taskinstance.py"],
+      []
     );
 
     expect(fileSources).toEqual([
@@ -112,7 +120,8 @@ describe("Test Logs Utils.", () => {
       mockTaskLog,
       null,
       [LogLevel.INFO, LogLevel.WARNING],
-      ["taskinstance.py"]
+      ["taskinstance.py"],
+      []
     );
 
     expect(fileSources).toEqual([

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
@@ -127,14 +127,14 @@ export const parseLogs = (
           const gId = gName.replace(/\W+/g, "_").toLowerCase();
           const isFolded = unfoldedLogGroups.indexOf(gId) === -1;
           const ufDisplay = isFolded ? "" : "display:none;";
-          const unfold = `<span id="${gId}${unfoldIdSuffix}" style="${ufDisplay}${logGroupStyle}"> &#11208; ${gName}</span>`;
+          const unfold = `<span id="${gId}${unfoldIdSuffix}" style="${ufDisplay}${logGroupStyle}"> &#9654; ${gName}</span>`;
           const fDisplay = isFolded ? "display:none;" : "";
-          const fold = `<span style="${fDisplay}"><span id="${gId}${foldIdSuffix}" style="${logGroupStyle}"> &#11206; ${gName}</span>`;
+          const fold = `<span style="${fDisplay}"><span id="${gId}${foldIdSuffix}" style="${logGroupStyle}"> &#9660; ${gName}</span>`;
           return unfold + fold;
         })
         .replace(
           logGroupEnd,
-          " <span style='color:#0060df;'>&#11205;&#11205;&#11205; Log group end</span></span>"
+          " <span style='color:#0060df;'>&#9650;&#9650;&#9650; Log group end</span></span>"
         );
       parsedLines.push(lineWithHyperlinks);
     }

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
@@ -121,13 +121,15 @@ export const parseLogs = (
           '<a href="$1" target="_blank" style="color: blue; text-decoration: underline;">$1</a>'
         )
         .replace(logGroupStart, (textLine) => {
+          const unfoldIdSuffix = "_unfold";
+          const foldIdSuffix = "_fold";
           const gName = textLine.substring(17);
           const gId = gName.replace(/\W+/g, "_").toLowerCase();
           const isFolded = unfoldedLogGroups.indexOf(gId) === -1;
           const ufDisplay = isFolded ? "" : "display:none;";
-          const unfold = `<span id="${gId}_unfold" style="${ufDisplay}${logGroupStyle}"> &#11208; ${gName}</span>`;
+          const unfold = `<span id="${gId}${unfoldIdSuffix}" style="${ufDisplay}${logGroupStyle}"> &#11208; ${gName}</span>`;
           const fDisplay = isFolded ? "display:none;" : "";
-          const fold = `<span style="${fDisplay}"><span id="${gId}_fold" style="${logGroupStyle}"> &#11206; ${gName}</span>`;
+          const fold = `<span style="${fDisplay}"><span id="${gId}${foldIdSuffix}" style="${logGroupStyle}"> &#11206; ${gName}</span>`;
           return unfold + fold;
         })
         .replace(

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
@@ -42,7 +42,8 @@ export const parseLogs = (
   data: string | undefined,
   timezone: string | null,
   logLevelFilters: Array<LogLevel>,
-  fileSourceFilters: Array<string>
+  fileSourceFilters: Array<string>,
+  unfoldedLogGroups: Array<string>
 ) => {
   if (!data) {
     return {};
@@ -121,8 +122,13 @@ export const parseLogs = (
         .replace(logGroupStart, (textLine) => {
           const gName = textLine.substring(17);
           const gId = gName.replace(/\W+/g, "_").toLowerCase();
-          const unfold = `<span id="${gId}_unfold" style="${logGroupStyle}"> &#11208; ${gName}</span>`;
-          const fold = `<span style="display:none;"><span id="${gId}_fold" style="${logGroupStyle}"> &#11206; ${gName}</span>`;
+          if (unfoldedLogGroups.indexOf(gId) === -1) {
+            const unfold = `<span id="${gId}_unfold" style="${logGroupStyle}"> &#11208; ${gName}</span>`;
+            const fold = `<span style="display:none;"><span id="${gId}_fold" style="${logGroupStyle}"> &#11206; ${gName}</span>`;
+            return unfold + fold;
+          }
+          const unfold = `<span id="${gId}_unfold" style="display:none;${logGroupStyle}"> &#11208; ${gName}</span>`;
+          const fold = `<span><span id="${gId}_fold" style="${logGroupStyle}"> &#11206; ${gName}</span>`;
           return unfold + fold;
         })
         .replace(

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
@@ -71,7 +71,8 @@ export const parseLogs = (
   // see https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=powershell#formatting-commands
   const logGroupStart = / INFO - (::|##\[])group(::|\])([^\n])*/g;
   const logGroupEnd = / INFO - (::|##\[])endgroup(::|\])/g;
-  const logGroupStyle = "color:#0060df;cursor:pointer;font-weight: bold;";
+  // Coloring (blue-60 as chakra style, is #0060df) and style such that log group appears like a link
+  const logGroupStyle = "color:#0060df;cursor:pointer;font-weight:bold;";
 
   lines.forEach((line) => {
     let parsedLine = line;
@@ -122,13 +123,11 @@ export const parseLogs = (
         .replace(logGroupStart, (textLine) => {
           const gName = textLine.substring(17);
           const gId = gName.replace(/\W+/g, "_").toLowerCase();
-          if (unfoldedLogGroups.indexOf(gId) === -1) {
-            const unfold = `<span id="${gId}_unfold" style="${logGroupStyle}"> &#11208; ${gName}</span>`;
-            const fold = `<span style="display:none;"><span id="${gId}_fold" style="${logGroupStyle}"> &#11206; ${gName}</span>`;
-            return unfold + fold;
-          }
-          const unfold = `<span id="${gId}_unfold" style="display:none;${logGroupStyle}"> &#11208; ${gName}</span>`;
-          const fold = `<span><span id="${gId}_fold" style="${logGroupStyle}"> &#11206; ${gName}</span>`;
+          const isFolded = unfoldedLogGroups.indexOf(gId) === -1;
+          const ufDisplay = isFolded ? "" : "display:none;";
+          const unfold = `<span id="${gId}_unfold" style="${ufDisplay}${logGroupStyle}"> &#11208; ${gName}</span>`;
+          const fDisplay = isFolded ? "display:none;" : "";
+          const fold = `<span style="${fDisplay}"><span id="${gId}_fold" style="${logGroupStyle}"> &#11206; ${gName}</span>`;
           return unfold + fold;
         })
         .replace(

--- a/airflow/www/static/js/ti_log.js
+++ b/airflow/www/static/js/ti_log.js
@@ -165,13 +165,13 @@ function autoTailingLog(tryNumber, metadata = null, autoTailing = false) {
           .replaceAll(logGroupStart, (line) => {
             const gName = line.substring(17);
             const gId = gName.replaceAll(/\W+/g, "_").toLowerCase();
-            const unfold = `<span id="${gId}${unfoldIdSuffix}" style="${logGroupStyle}"> &#11208; ${gName}</span>`;
-            const fold = `<span style="display:none;"><span id="${gId}${foldIdSuffix}" style="${logGroupStyle}"> &#11206; ${gName}</span>`;
+            const unfold = `<span id="${gId}${unfoldIdSuffix}" style="${logGroupStyle}"> &#9654; ${gName}</span>`;
+            const fold = `<span style="display:none;"><span id="${gId}${foldIdSuffix}" style="${logGroupStyle}"> &#9660; ${gName}</span>`;
             return unfold + fold;
           })
           .replaceAll(
             logGroupEnd,
-            " <span style='color:#0060df;'>&#11205;&#11205;&#11205; Log group end</span></span>"
+            " <span style='color:#0060df;'>&#9650;&#9650;&#9650; Log group end</span></span>"
           );
         logBlock.innerHTML += `${linkifiedMessage}`;
       });

--- a/airflow/www/static/js/ti_log.js
+++ b/airflow/www/static/js/ti_log.js
@@ -31,6 +31,8 @@ const DELAY = parseInt(getMetaValue("delay"), 10);
 const AUTO_TAILING_OFFSET = parseInt(getMetaValue("auto_tailing_offset"), 10);
 const ANIMATION_SPEED = parseInt(getMetaValue("animation_speed"), 10);
 const TOTAL_ATTEMPTS = parseInt(getMetaValue("total_attempts"), 10);
+const unfoldIdSuffix = "_unfold";
+const foldIdSuffix = "_fold";
 
 function recurse(delay = DELAY) {
   return new Promise((resolve) => {
@@ -163,8 +165,8 @@ function autoTailingLog(tryNumber, metadata = null, autoTailing = false) {
           .replaceAll(logGroupStart, (line) => {
             const gName = line.substring(17);
             const gId = gName.replaceAll(/\W+/g, "_").toLowerCase();
-            const unfold = `<span id="${gId}_unfold" style="${logGroupStyle}"> &#11208; ${gName}</span>`;
-            const fold = `<span style="display:none;"><span id="${gId}_fold" style="${logGroupStyle}"> &#11206; ${gName}</span>`;
+            const unfold = `<span id="${gId}${unfoldIdSuffix}" style="${logGroupStyle}"> &#11208; ${gName}</span>`;
+            const fold = `<span style="display:none;"><span id="${gId}${foldIdSuffix}" style="${logGroupStyle}"> &#11206; ${gName}</span>`;
             return unfold + fold;
           })
           .replaceAll(
@@ -189,11 +191,10 @@ function autoTailingLog(tryNumber, metadata = null, autoTailing = false) {
 }
 
 function handleLogGroupClick(e) {
-  if (e.target.id && e.target.id.endsWith("_unfold")) {
+  if (e.target.id?.endsWith(unfoldIdSuffix)) {
     e.target.style.display = "none";
     e.target.nextSibling.style.display = "inline";
-  }
-  if (e.target.id && e.target.id.endsWith("_fold")) {
+  } else if (e.target.id?.endsWith(foldIdSuffix)) {
     e.target.parentNode.style.display = "none";
     e.target.parentNode.previousSibling.style.display = "inline";
   }

--- a/docs/apache-airflow/administration-and-deployment/logging-monitoring/logging-tasks.rst
+++ b/docs/apache-airflow/administration-and-deployment/logging-monitoring/logging-tasks.rst
@@ -82,6 +82,47 @@ This is the usual way loggers are used directly in Python code:
   logger = logging.getLogger(__name__)
   logger.info("This is a log message")
 
+Grouping of log lines
+---------------------
+
+.. versionadded:: 2.9.0
+
+Like CI pipelines also Airflow logs can be quite large and become hard to read. Sometimes therefore it is useful to group sections of log areas
+and provide folding of text areas to hide unrelevant content. Airflow therefore implements a compatible log message grouping like
+`Github <https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines>`_ and
+`Azure DevOps <https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=powershell#formatting-commands>`_
+such that areas of text can be folded. The implemented scheme is compatible such that tools making output in CI can leverage the same experience
+in Airflow directly.
+
+By adding log markers with the starting and ending positions like for example below log messages can be grouped:
+
+.. code-block:: python
+
+   print("Here is some standard text.")
+   print("::group::Non important details")
+   print("bla")
+   print("debug messages...")
+   print("::endgroup::")
+   print("Here is again some standard text.")
+
+When displaying the logs in web UI, the display of logs will be condensed:
+
+.. code-block:: text
+
+   [2024-03-08, 23:30:18 CET] {logging_mixin.py:188} INFO - Here is some standard text.
+   [2024-03-08, 23:30:18 CET] {logging_mixin.py:188} ⯈ Non important details
+   [2024-03-08, 23:30:18 CET] {logging_mixin.py:188} INFO - Here is again some standard text.
+
+If you click on the log text label, the detailed log lies will be displayed.
+
+.. code-block:: text
+
+   [2024-03-08, 23:30:18 CET] {logging_mixin.py:188} INFO - Here is some standard text.
+   [2024-03-08, 23:30:18 CET] {logging_mixin.py:188} ⯆ Non important details
+   [2024-03-08, 23:30:18 CET] {logging_mixin.py:188} INFO - bla
+   [2024-03-08, 23:30:18 CET] {logging_mixin.py:188} INFO - debug messages...
+   [2024-03-08, 23:30:18 CET] {logging_mixin.py:188} ⯅⯅⯅ Log group end
+   [2024-03-08, 23:30:18 CET] {logging_mixin.py:188} INFO - Here is again some standard text.
 
 Interleaving of logs
 --------------------

--- a/docs/apache-airflow/administration-and-deployment/logging-monitoring/logging-tasks.rst
+++ b/docs/apache-airflow/administration-and-deployment/logging-monitoring/logging-tasks.rst
@@ -88,7 +88,7 @@ Grouping of log lines
 .. versionadded:: 2.9.0
 
 Like CI pipelines also Airflow logs can be quite large and become hard to read. Sometimes therefore it is useful to group sections of log areas
-and provide folding of text areas to hide unrelevant content. Airflow therefore implements a compatible log message grouping like
+and provide folding of text areas to hide non relevant content. Airflow therefore implements a compatible log message grouping like
 `Github <https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines>`_ and
 `Azure DevOps <https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=powershell#formatting-commands>`_
 such that areas of text can be folded. The implemented scheme is compatible such that tools making output in CI can leverage the same experience


### PR DESCRIPTION
This PR is another "eye candy" for upcoming 2.9.0 release - and I hope I pass the review and merge if before release cut-off.

Logging is usually a mass of text. Tasks/Operators generate a lot of text and it is hard to read and understand what is going on. Expertise need to be built-up. In our departments users are mostly over-whelmed with the logs in Airflow.

A bit of filtering had been introduced but what I personally always was missing was a kind of log grouping which is existing in [Github](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines) or also [Azure DevOps Pipelines](https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=powershell#formatting-commands).

This PR adds Log Grouping also to Airflow with the following effects:
- Log grouping can be made with the same keywords like in Github or AzureDevOps - means that if users have scripts from these systems, they could be used in Airflow as well. Start a group with `::group::Some Headline` and end it with `::endgroup::`
- Task instance runs automatically "fold" log details of task execution prior and post `execute()` method, making logs clean per default (showing only real business logic)
- If a user un-folds a section, un-folding state is remembered in Grid view
- Grouping is also working in old/legacy log view as well as Grid if the log is updated (auto-tail when task is running)

Example, how do logs look like for the `example_params_trigger_ui` DAG:
![image](https://github.com/apache/airflow/assets/95105677/5718a2d1-70e6-4316-83bb-1c0ab104f47a)

If you click on the blue colored log group header, the section un-folds:
![image](https://github.com/apache/airflow/assets/95105677/75f00c74-d9dc-453b-9a71-340e9afd44e3)

One example added to `example_python_operator` DAG, prints are grouped giving the following results in the task logs:
![image](https://github.com/apache/airflow/assets/95105677/ad5d83dd-42c5-40fc-b23c-49fe3146b1a2)

FYI @clellmann @wolfdn @AutomationDev85 