### PR TITLE
fix: EmrServerlessStartJobOperator not serializing DAGs correctly whe…

### DIFF
--- a/tests/providers/amazon/aws/operators/test_emr_serverless.py
+++ b/tests/providers/amazon/aws/operators/test_emr_serverless.py
@@ -25,11 +25,20 @@ from botocore.exceptions import WaiterError
 
 from airflow.exceptions import AirflowException, TaskDeferred
 from airflow.providers.amazon.aws.hooks.emr import EmrServerlessHook
+from airflow.providers.amazon.aws.links.emr import (
+    EmrServerlessCloudWatchLogsLink,
+    EmrServerlessDashboardLink,
+    EmrServerlessLogsLink,
+    EmrServerlessS3LogsLink,
+)
 from airflow.providers.amazon.aws.operators.emr import (
     EmrServerlessCreateApplicationOperator,
     EmrServerlessDeleteApplicationOperator,
     EmrServerlessStartJobOperator,
     EmrServerlessStopApplicationOperator,
+)
+from airflow.serialization.serialized_objects import (
+    SerializedBaseOperator,
 )
 from airflow.utils.types import NOTSET
 
@@ -1095,6 +1104,52 @@ class TestEmrServerlessStartJobOperator:
             application_id=application_id,
             job_run_id=job_run_id,
         )
+
+    def test_operator_extra_links_mapped_without_applicationui_enabled(
+        self,
+    ):
+        operator = EmrServerlessStartJobOperator.partial(
+            task_id=task_id,
+            application_id=application_id,
+            execution_role_arn=execution_role_arn,
+            job_driver=spark_job_driver,
+            enable_application_ui_links=False,
+        ).expand(
+            configuration_overrides=[s3_configuration_overrides, cloudwatch_configuration_overrides],
+        )
+
+        serialize = SerializedBaseOperator.serialize
+        deserialize = SerializedBaseOperator.deserialize_operator
+        deserialized_operator = deserialize(serialize(operator))
+
+        assert deserialized_operator.operator_extra_links == [
+            EmrServerlessS3LogsLink(),
+            EmrServerlessCloudWatchLogsLink(),
+        ]
+
+    def test_operator_extra_links_mapped_with_applicationui_enabled_at_partial(
+        self,
+    ):
+        operator = EmrServerlessStartJobOperator.partial(
+            task_id=task_id,
+            application_id=application_id,
+            execution_role_arn=execution_role_arn,
+            job_driver=spark_job_driver,
+            enable_application_ui_links=True,
+        ).expand(
+            configuration_overrides=[s3_configuration_overrides, cloudwatch_configuration_overrides],
+        )
+
+        serialize = SerializedBaseOperator.serialize
+        deserialize = SerializedBaseOperator.deserialize_operator
+        deserialized_operator = deserialize(serialize(operator))
+
+        assert deserialized_operator.operator_extra_links == [
+            EmrServerlessS3LogsLink(),
+            EmrServerlessCloudWatchLogsLink(),
+            EmrServerlessDashboardLink(),
+            EmrServerlessLogsLink(),
+        ]
 
 
 class TestEmrServerlessDeleteOperator:


### PR DESCRIPTION
This fixes: https://github.com/apache/airflow/issues/38005

Result: Now EMRServerlessStartJobOperator is able to utilize partial/expand functionality of Airflow.

Previously, the following DAG code will fail to serialize in the webserver:

```python
from datetime import datetime
from airflow.models.dag import DAG
from airflow.providers.amazon.aws.operators.emr import (
    EmrServerlessStartJobOperator,
)

DAG_ID = "example_emr_serverless"
emr_serverless_app_id = "01234abcd"
role_arn = "arn:test"


with DAG(
    dag_id=DAG_ID,
    schedule="@once",
    start_date=datetime(2021, 1, 1),
    tags=["example"],
    catchup=False,
):
    start_job = EmrServerlessStartJobOperator.partial(
        task_id="start_emr_serverless_job",
        application_id=emr_serverless_app_id,
        execution_role_arn=role_arn,
        configuration_overrides={
            "monitoringConfiguration": {"s3MonitoringConfiguration": {"logUri": f"s3://test/logs"}}
        },
    ).expand(
        job_driver=[{
            "sparkSubmit": {
                "entryPoint": "test.jar",
                "entryPointArguments": ["--arg", "1"],
                "sparkSubmitParameters": "--conf sample",
            }
        },{
            "sparkSubmit": {
                "entryPoint": "test.jar",
                "entryPointArguments": ["--arg", "2"],
                "sparkSubmitParameters": "--conf sample",
            }
        }]
    )
```

After this PR, the above DAG should be serialized successfully.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #38005
related: #38005

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->