### PR TITLE
Get rid of deprecated `pytest.warns(None)` usage

### DIFF
--- a/tests/providers/amazon/aws/hooks/test_emr.py
+++ b/tests/providers/amazon/aws/hooks/test_emr.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import re
+import warnings
 from unittest import mock
 
 import boto3
@@ -167,7 +168,9 @@ class TestEmrHook:
         # AmiVersion is really old and almost no one will use it anymore, but
         # it's one of the "optional" request params that moto supports - it's
         # coverage of EMR isn't 100% it turns out.
-        with pytest.warns(None):  # Expected no warnings if ``emr_conn_id`` exists with correct conn_type
+        with warnings.catch_warnings():
+            # Expected no warnings if ``emr_conn_id`` exists with correct conn_type
+            warnings.simplefilter("error")
             cluster = hook.create_job_flow({"Name": "test_cluster", "ReleaseLabel": "", "AmiVersion": "3.2"})
         cluster = client.describe_cluster(ClusterId=cluster["JobFlowId"])["Cluster"]
 

--- a/tests/providers/amazon/aws/utils/test_connection_wrapper.py
+++ b/tests/providers/amazon/aws/utils/test_connection_wrapper.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import os
+import warnings
 from dataclasses import fields
 from unittest import mock
 
@@ -237,7 +238,8 @@ class TestAwsConnectionWrapper:
             expected["profile_name"] = profile_name
         if region_name:
             expected["region_name"] = region_name
-        with pytest.warns(None):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # Not expected any warnings here
             wrap_conn = AwsConnectionWrapper(conn=mock_conn)
         session_kwargs = wrap_conn.session_kwargs
         assert session_kwargs == expected
@@ -354,7 +356,7 @@ class TestAwsConnectionWrapper:
             " Please set extra['endpoint_url'] instead"
         )
 
-        with pytest.warns(None) as records:
+        with warnings.catch_warnings(record=True) as records:
             wrap_conn = AwsConnectionWrapper(conn=mock_conn)
 
         if extra.get("host"):

--- a/tests/www/test_init_views.py
+++ b/tests/www/test_init_views.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import re
+import warnings
 from unittest import mock
 
 import pytest
@@ -37,6 +38,6 @@ class TestInitApiExperimental:
     @conf_vars({("api", "enable_experimental_api"): "false"})
     def test_should_not_raise_deprecation_warning_when_disabled(self):
         app = mock.MagicMock()
-        with pytest.warns(None) as warnings:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # Not expected any warnings here
             init_views.init_api_experimental(app)
-        assert len(warnings) == 0


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This was deprecated/ignored into the pytest 7.0+ (https://github.com/pytest-dev/pytest/issues/8645), and should raise an error in the latest version of pytest (https://github.com/pytest-dev/pytest/issues/10865)

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
