### PR TITLE
Fix cursor unique name surpasses Postgres identifier limit in `PostgresToGCSOperator`

### DIFF
--- a/airflow/providers/google/cloud/transfers/postgres_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/postgres_to_gcs.py
@@ -113,7 +113,13 @@ class PostgresToGCSOperator(BaseSQLToGCSOperator):
         self.cursor_itersize = cursor_itersize
 
     def _unique_name(self):
-        return f"{self.dag_id}__{self.task_id}__{uuid.uuid4()}" if self.use_server_side_cursor else None
+        """
+        Generates a deterministic UUID for the cursor name,
+        using the combination of DAG ID and task ID.
+        """
+        if self.use_server_side_cursor:
+            return str(uuid5(uuid5(NAMESPACE_OID, self.dag_id), self.task_id))
+        return None
 
     def query(self):
         """Query Postgres and returns a cursor to the results."""

--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -159,6 +159,7 @@ dependencies:
   - PyOpenSSL
   - sqlalchemy-bigquery>=1.2.1
   - sqlalchemy-spanner>=1.6.2
+  - python-slugify>=5.0
 
 additional-extras:
   - name: apache.beam

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -570,6 +570,7 @@
       "pandas-gbq",
       "pandas>=1.2.5,<2.2",
       "proto-plus>=1.19.6",
+      "python-slugify>=5.0",
       "sqlalchemy-bigquery>=1.2.1",
       "sqlalchemy-spanner>=1.6.2"
     ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -770,6 +770,7 @@ google = [ # source: airflow/providers/google/provider.yaml
   "pandas-gbq",
   "pandas>=1.2.5,<2.2",
   "proto-plus>=1.19.6",
+  "python-slugify>=5.0",
   "sqlalchemy-bigquery>=1.2.1",
   "sqlalchemy-spanner>=1.6.2",
 ]

--- a/tests/providers/google/cloud/transfers/test_postgres_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_postgres_to_gcs.py
@@ -28,6 +28,7 @@ from airflow.providers.postgres.hooks.postgres import PostgresHook
 TABLES = {"postgres_to_gcs_operator", "postgres_to_gcs_operator_empty"}
 
 TASK_ID = "test-postgres-to-gcs"
+LONG_TASK_ID = "t" * 100
 POSTGRES_CONN_ID = "postgres_default"
 SQL = "SELECT * FROM postgres_to_gcs_operator"
 BUCKET = "gs://test"
@@ -138,6 +139,25 @@ class TestPostgresToGoogleCloudStorageOperator:
         """Test the execute in case where the run is successful while using server side cursor."""
         op = PostgresToGCSOperator(
             task_id=TASK_ID,
+            postgres_conn_id=POSTGRES_CONN_ID,
+            sql=SQL,
+            bucket=BUCKET,
+            filename=FILENAME,
+            use_server_side_cursor=True,
+            cursor_itersize=100,
+        )
+        gcs_hook_mock = gcs_hook_mock_class.return_value
+        gcs_hook_mock.upload.side_effect = self._assert_uploaded_file_content
+        op.execute(None)
+
+    @patch("airflow.providers.google.cloud.transfers.sql_to_gcs.GCSHook")
+    def test_exec_success_server_side_cursor_unique_name(self, gcs_hook_mock_class):
+        """
+        Test that the server side cursor unique name generator is sucessfull
+        with a task id that surpasses postgres identifier limit.
+        """
+        op = PostgresToGCSOperator(
+            task_id= LONG_TASK_ID,
             postgres_conn_id=POSTGRES_CONN_ID,
             sql=SQL,
             bucket=BUCKET,

--- a/tests/providers/google/cloud/transfers/test_postgres_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_postgres_to_gcs.py
@@ -153,11 +153,11 @@ class TestPostgresToGoogleCloudStorageOperator:
     @patch("airflow.providers.google.cloud.transfers.sql_to_gcs.GCSHook")
     def test_exec_success_server_side_cursor_unique_name(self, gcs_hook_mock_class):
         """
-        Test that the server side cursor unique name generator is sucessfull
+        Test that the server side cursor unique name generator is successful
         with a task id that surpasses postgres identifier limit.
         """
         op = PostgresToGCSOperator(
-            task_id= LONG_TASK_ID,
+            task_id=LONG_TASK_ID,
             postgres_conn_id=POSTGRES_CONN_ID,
             sql=SQL,
             bucket=BUCKET,


### PR DESCRIPTION
closes: #37654

The function unique_name now generates UUID from the SHA-1 hash using the dag id and the task id. The previous version of the function throwed unterminated quoted identifier error when the operator was used with a task_id greater than 24 bytes as the name generated surpassed the postgres identifier limit.