### PR TITLE
Ignore `datetime.datetime.utcnow` deprecated warning from `botocore.auth`

### DIFF
--- a/tests/providers/amazon/aws/hooks/test_emr.py
+++ b/tests/providers/amazon/aws/hooks/test_emr.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import re
+import sys
 import warnings
 from unittest import mock
 
@@ -171,6 +172,13 @@ class TestEmrHook:
         with warnings.catch_warnings():
             # Expected no warnings if ``emr_conn_id`` exists with correct conn_type
             warnings.simplefilter("error")
+            if sys.version_info >= (3, 12):
+                # Ignore some modules' warnings in Python 3.12
+                warnings.filterwarnings(
+                    "ignore",
+                    module="botocore.auth",
+                    message=r"datetime.datetime.utcnow\(\) is deprecated*",
+                )
             cluster = hook.create_job_flow({"Name": "test_cluster", "ReleaseLabel": "", "AmiVersion": "3.2"})
         cluster = client.describe_cluster(ClusterId=cluster["JobFlowId"])["Cluster"]
 

--- a/tests/providers/amazon/conftest.py
+++ b/tests/providers/amazon/conftest.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import warnings
 
 try:
@@ -58,6 +59,13 @@ def filter_botocore_warnings(botocore_version):
                 category=FutureWarning,
                 module="botocore.client",
                 message="The .* client is currently using a deprecated endpoint.*",
+            )
+        if sys.version_info >= (3, 12):
+            # Ignore some modules' warnings in Python 3.12
+            warnings.filterwarnings(
+                "ignore",
+                module="botocore.auth",
+                message=r"datetime.datetime.utcnow\(\) is deprecated*",
             )
         yield
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

cc: @potiuk 

Tested it locally should fix the problem in python 3.12

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
