### PR TITLE
Exclude Cassandra for Python 3.12

### DIFF
--- a/airflow/providers/apache/cassandra/provider.yaml
+++ b/airflow/providers/apache/cassandra/provider.yaml
@@ -46,6 +46,26 @@ dependencies:
   - apache-airflow>=2.6.0
   - cassandra-driver>=3.13.0
 
+# Cassandra provider is not yet compatible with Python 3.12
+# The main issue is that python cassandra driver by default uses asyncore which has been deprecated since
+# Python 3.6 and removed in Python 3.12 (https://docs.python.org/3.11/library/asyncore.html)
+#
+# Currently the "wheel" package 3.29.0 distributed for manylinux platform is build without libev support (
+# which could be a viable asyncore replacement), and cassandra driver works in Python 3.12 if it is built
+# with libev support (using sdist, having gcc, libev4 and libev-dev installed). But it would be too much to
+# expect our users to build the driver from sources to use it with Python 3.12, so we are waiting for the
+# next release of cassandra-driver which will have libev support in the wheel package.
+# The issue is tracked here https://datastax-oss.atlassian.net/browse/PYTHON-1378
+#
+# Another option to get cassandra drive back is to have asyncio support in the driver instead of asyncore:
+# The issue is tracked here: https://datastax-oss.atlassian.net/browse/PYTHON-1375 and is scheduled
+# to be fixed in cassandra-driver 3.30.0.
+#
+# All Cassandra tests are automatically skipped if cassandra package is not present, so once you remove the
+# exclusion, they will start running for Python 3.12.
+#
+excluded-python-versions: ['3.12']
+
 integrations:
   - integration-name: Apache Cassandra
     external-doc-url: https://cassandra.apache.org/

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -90,7 +90,9 @@
     ],
     "devel-deps": [],
     "cross-providers-deps": [],
-    "excluded-python-versions": [],
+    "excluded-python-versions": [
+      "3.12"
+    ],
     "state": "ready"
   },
   "apache.drill": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -573,7 +573,7 @@ apache-beam = [ # source: airflow/providers/apache/beam/provider.yaml
   "pyarrow>=14.0.1;python_version != \"3.12\"",
 ]
 apache-cassandra = [ # source: airflow/providers/apache/cassandra/provider.yaml
-  "cassandra-driver>=3.13.0",
+  "cassandra-driver>=3.13.0;python_version != \"3.12\"",
 ]
 apache-drill = [ # source: airflow/providers/apache/drill/provider.yaml
   "apache-airflow[common_sql]",


### PR DESCRIPTION
We need to exclude Cassandra separately, in order to make sure that cassandra drivers are not installed in the Python 3.12 image when preparing it from the main branch.

Generally speaking the dependencies are cached from the main branch when image is built, which means that the resulting image will still have cassandra driver even if we remove it in final pyproject.toml.

The way how to get rid of it is two fold:

1) add the exclusion to main
2) after it is merged, increase the EPOCH number in the Dockerfile.ci
   in the PR that adds Python 3.12 compatibility

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
