### PR TITLE
Limit prod-image extra checks to default python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1908,7 +1908,7 @@ jobs:
     needs: [build-info, build-ci-images]
     uses: ./.github/workflows/prod-image-extra-checks.yml
     with:
-      python-versions: ${{ needs.build-info.outputs.python-versions }}
+      python-versions: "[ '${{ needs.build-info.outputs.default-python-version }}' ]"
       branch: ${{ needs.build-info.outputs.default-branch }}
       image-tag: ${{ needs.build-info.outputs.image-tag }}
       build-provider-packages: ${{ needs.build-info.outputs.default-branch == 'main' }}
@@ -1926,7 +1926,7 @@ jobs:
     needs: [build-info, generate-constraints]
     uses: ./.github/workflows/prod-image-extra-checks.yml
     with:
-      python-versions: ${{ needs.build-info.outputs.python-versions }}
+      python-versions: "[ '${{ needs.build-info.outputs.default-python-version }}' ]"
       branch: ${{ needs.build-info.outputs.default-branch }}
       image-tag: ${{ needs.build-info.outputs.image-tag }}
       build-provider-packages: ${{ needs.build-info.outputs.default-branch == 'main' }}

--- a/.github/workflows/prod-image-extra-checks.yml
+++ b/.github/workflows/prod-image-extra-checks.yml
@@ -104,7 +104,7 @@ jobs:
   pip-image:
     uses: ./.github/workflows/prod-image-build.yml
     with:
-      build-type: "MySQL Client"
+      build-type: "pip"
       image-tag: mysql-${{ inputs.image-tag }}
       install-mysql-client-type: "mysql"
       python-versions: ${{ inputs.python-versions }}


### PR DESCRIPTION
The extra checks for prod image are only to check is the variants we have for prod image can be built. There is no need to run it for all python versions - default python version is enough

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
