### PR TITLE
Add the possibility of custom probes in flower helm deployment

### DIFF
--- a/chart/templates/flower/flower-deployment.yaml
+++ b/chart/templates/flower/flower-deployment.yaml
@@ -115,6 +115,9 @@ spec:
           ports:
             - name: flower-ui
               containerPort: {{ .Values.ports.flowerUI }}
+          {{- if .Values.flower.customLivenessProbe }}
+          livenessProbe: {{- toYaml .Values.flower.customLivenessProbe | nindent 12 }}
+          {{- else if .Values.flower.livenessProbe.enabled }}
           livenessProbe:
             failureThreshold: {{ .Values.flower.livenessProbe.failureThreshold }}
             exec:
@@ -128,6 +131,10 @@ spec:
             initialDelaySeconds: {{ .Values.flower.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.flower.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.flower.livenessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.flower.customReadinessProbe }}
+          readinessProbe: {{- toYaml .Values.flower.customReadinessProbe | nindent 12 }}
+          {{- else if .Values.flower.readinessProbe.enabled }}
           readinessProbe:
             failureThreshold: {{ .Values.flower.readinessProbe.failureThreshold }}
             exec:
@@ -141,6 +148,7 @@ spec:
             initialDelaySeconds: {{ .Values.flower.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.flower.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.flower.readinessProbe.timeoutSeconds }}
+          {{- end }}
           envFrom:
           {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 10 }}
           env:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -4968,6 +4968,11 @@
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
+                        "enabled": {
+                            "description": "Enable livenessProbe on flower container.",
+                            "type": "boolean",
+                            "default": true
+                        },
                         "initialDelaySeconds": {
                             "description": "Flower Liveness probe initial delay.",
                             "type": "integer",
@@ -4990,11 +4995,36 @@
                         }
                     }
                 },
+                "customLivenessProbe": {
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "type": "object",
+                    "default": {},
+                    "examples": [
+                        {
+                            "failureThreshold": 5,
+                            "httpGet": {
+                                "path": "/flower/",
+                                "port": 5555,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 5,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 5
+                        }
+                    ],
+                    "$ref": "#/definitions/io.k8s.api.core.v1.Probe"
+                },
                 "readinessProbe": {
                     "description": "Readiness probe configuration.",
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
+                        "enabled": {
+                            "description": "Enable readinessProbe on flower container.",
+                            "type": "boolean",
+                            "default": true
+                        },
                         "initialDelaySeconds": {
                             "description": "Flower Readiness probe initial delay.",
                             "type": "integer",
@@ -5016,6 +5046,26 @@
                             "default": 5
                         }
                     }
+                },
+                "customReadinessProbe": {
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "type": "object",
+                    "default": {},
+                    "examples": [
+                        {
+                            "failureThreshold": 5,
+                            "httpGet": {
+                                "path": "/flower/",
+                                "port": 5555,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 5,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 5
+                        }
+                    ],
+                    "$ref": "#/definitions/io.k8s.api.core.v1.Probe"
                 },
                 "revisionHistoryLimit": {
                     "description": "Number of old replicasets to retain.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1713,16 +1713,22 @@ flower:
   enabled: false
 
   livenessProbe:
+    enabled: true
     initialDelaySeconds: 10
     timeoutSeconds: 5
     failureThreshold: 10
     periodSeconds: 5
 
+  customLivenessProbe: {}
+
   readinessProbe:
+    enabled: true
     initialDelaySeconds: 10
     timeoutSeconds: 5
     failureThreshold: 10
     periodSeconds: 5
+
+  customReadinessProbe: {}
 
   # Max number of old replicasets to retain
   revisionHistoryLimit: ~


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This PR adds the possibility to configure custom probes for the flower deployment in the airflow helm chart. It also add the possibility to fully disable probes.

I would like to be able to use `httpGet` probe rather than the `exec` one configured at the moment, I figured out that it would be simpler to be able to fully customize the probe rather that to add many variables. 

Example of the probe I would like to use 

```yaml
    readinessProbe:                  
      failureThreshold: 10
      httpGet:                                
        path: /flower/
        port: 5555                     
        scheme: HTTP   
      initialDelaySeconds: 10                 
      periodSeconds: 5
      successThreshold: 1
      timeoutSeconds: 1
```

I want a probe like this because I use `FLOWER_URL_PREFIX=/flower` and I need the probe to be able to query the right path.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
