### PR TITLE
Exclude Python 3.12 for Databricks provider

### DIFF
--- a/airflow/providers/databricks/provider.yaml
+++ b/airflow/providers/databricks/provider.yaml
@@ -60,6 +60,12 @@ versions:
   - 1.0.1
   - 1.0.0
 
+
+# Databricks is excluded for Python 3.12 because running databricks-sql-python imports on Python 3.12
+# Cause extremely long import times  https://github.com/databricks/databricks-sql-python/issues/369
+# and until the problem is fixed, we exclude Python 3.12 for Databricks provider
+excluded-python-versions: ['3.12']
+
 dependencies:
   - apache-airflow>=2.6.0
   - apache-airflow-providers-common-sql>=1.10.0

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -377,7 +377,9 @@
     "cross-providers-deps": [
       "common.sql"
     ],
-    "excluded-python-versions": [],
+    "excluded-python-versions": [
+      "3.12"
+    ],
     "state": "ready"
   },
   "datadog": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -662,12 +662,12 @@ common-sql = [ # source: airflow/providers/common/sql/provider.yaml
   "sqlparse>=0.4.2",
 ]
 databricks = [ # source: airflow/providers/databricks/provider.yaml
-  "aiohttp>=3.9.2, <4",
-  "apache-airflow[common_sql]",
-  "databricks-sql-connector>=2.0.0, <3.0.0, !=2.9.0",
-  "requests>=2.27.0,<3",
+  "aiohttp>=3.9.2, <4;python_version != \"3.12\"",
+  "apache-airflow[common_sql];python_version != \"3.12\"",
+  "databricks-sql-connector>=2.0.0, <3.0.0, !=2.9.0;python_version != \"3.12\"",
+  "requests>=2.27.0,<3;python_version != \"3.12\"",
   # Devel dependencies for the databricks provider
-  "deltalake>=0.12.0",
+  "deltalake>=0.12.0;python_version != \"3.12\"",
 ]
 datadog = [ # source: airflow/providers/datadog/provider.yaml
   "datadog>=0.14.0",


### PR DESCRIPTION
Databricks is excluded for Python 3.12 because running databricks-sql-python imports on Python 3.12 Cause extremely long import times: https://github.com/databricks/databricks-sql-python/issues/369 and until the problem is fixed, we exclude Python 3.12 for Databricks provider

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
