### PR TITLE
Properly exclude providers from serialization tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1416,6 +1416,7 @@ combine-as-imports = true
 "tests/providers/openai/operators/test_openai.py" = ["E402"]
 "tests/providers/qdrant/hooks/test_qdrant.py" = ["E402"]
 "tests/providers/qdrant/operators/test_qdrant.py" = ["E402"]
+"tests/providers/snowflake/operators/test_snowflake_sql.py" = ["E402"]
 
 # All the modules which do not follow D105 yet, please remove as soon as it becomes compatible
 "airflow/callbacks/callback_requests.py" = ["D105"]

--- a/tests/providers/snowflake/operators/test_snowflake_sql.py
+++ b/tests/providers/snowflake/operators/test_snowflake_sql.py
@@ -20,7 +20,19 @@ from __future__ import annotations
 from unittest.mock import MagicMock, call, patch
 
 import pytest
-from databricks.sql.types import Row
+from _pytest.outcomes import importorskip
+
+databricks = importorskip("databricks")
+
+try:
+    from databricks.sql.types import Row
+except ImportError:
+    # Row is used in the parametrize so it's parsed during collection and we need to have a viable
+    # replacement for the collection time when databricks is not installed (Python 3.12 for now)
+    def Row(*args, **kwargs):
+        return MagicMock()
+
+
 from openlineage.client.facet import (
     ColumnLineageDatasetFacet,
     ColumnLineageDatasetFacetFieldsAdditional,

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -336,10 +336,10 @@ def collect_dags(dag_folder=None):
             "tests/system/providers/*/",
             "tests/system/providers/*/*/",
         ]
-    excluded_patterns = list(get_excluded_patterns())
+    excluded_patterns = [f"{ROOT_FOLDER}/{excluded_pattern}" for excluded_pattern in get_excluded_patterns()]
     for pattern in patterns:
         for directory in glob(f"{ROOT_FOLDER}/{pattern}"):
-            if any([directory.startswith(pattern) for pattern in excluded_patterns]):
+            if any([directory.startswith(excluded_pattern) for excluded_pattern in excluded_patterns]):
                 continue
             dags.update(make_example_dags(directory))
 

--- a/tests/serialization/test_serde.py
+++ b/tests/serialization/test_serde.py
@@ -367,6 +367,11 @@ class TestSerDe:
                     import pyiceberg  # noqa: F401
                 except ImportError:
                     continue
+            if name == "airflow.serialization.serializers.deltalake":
+                try:
+                    import deltalake  # noqa: F401
+                except ImportError:
+                    continue
             mod = import_module(name)
             for s in getattr(mod, "serializers", list()):
                 if not isinstance(s, str):


### PR DESCRIPTION
The serialization test imports example dags from providers and when providers are excluded in a certain Python version, they should be excluded. The previous exclusion had a bug, that did not properly checked exclusions (it missed adding ROOT_FOLDER to exclusion patterns)

This PR fixes it.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
