### PR TITLE
Replace "Role" by "Group" in AWS auth manager

### DIFF
--- a/airflow/providers/amazon/aws/auth_manager/avp/entities.py
+++ b/airflow/providers/amazon/aws/auth_manager/avp/entities.py
@@ -29,7 +29,7 @@ class AvpEntities(Enum):
     """Enum of Amazon Verified Permissions entities."""
 
     ACTION = "Action"
-    ROLE = "Role"
+    GROUP = "Group"
     USER = "User"
 
     # Resource types
@@ -48,7 +48,7 @@ def get_entity_type(resource_type: AvpEntities) -> str:
 
     :param resource_type: Resource type.
 
-    Example: Airflow::Action, Airflow::Role, Airflow::Variable, Airflow::User.
+    Example: Airflow::Action, Airflow::Group, Airflow::Variable, Airflow::User.
     """
     return AVP_PREFIX_ENTITIES + resource_type.value
 

--- a/airflow/providers/amazon/aws/auth_manager/avp/facade.py
+++ b/airflow/providers/amazon/aws/auth_manager/avp/facade.py
@@ -94,7 +94,7 @@ class AwsAuthManagerAmazonVerifiedPermissionsFacade(LoggingMixin):
         if user is None:
             return False
 
-        entity_list = self._get_user_role_entities(user)
+        entity_list = self._get_user_group_entities(user)
 
         self.log.debug(
             "Making authorization request for user=%s, method=%s, entity_type=%s, entity_id=%s",
@@ -144,7 +144,7 @@ class AwsAuthManagerAmazonVerifiedPermissionsFacade(LoggingMixin):
         :param requests: the list of requests containing the method, the entity_type and the entity ID
         :param user: the user
         """
-        entity_list = self._get_user_role_entities(user)
+        entity_list = self._get_user_group_entities(user)
 
         self.log.debug("Making batch authorization request for user=%s, requests=%s", user.get_id(), requests)
 
@@ -223,19 +223,19 @@ class AwsAuthManagerAmazonVerifiedPermissionsFacade(LoggingMixin):
         raise AirflowException("Could not find the authorization result.")
 
     @staticmethod
-    def _get_user_role_entities(user: AwsAuthManagerUser) -> list[dict]:
+    def _get_user_group_entities(user: AwsAuthManagerUser) -> list[dict]:
         user_entity = {
             "identifier": {"entityType": get_entity_type(AvpEntities.USER), "entityId": user.get_id()},
             "parents": [
-                {"entityType": get_entity_type(AvpEntities.ROLE), "entityId": group}
+                {"entityType": get_entity_type(AvpEntities.GROUP), "entityId": group}
                 for group in user.get_groups()
             ],
         }
-        role_entities = [
-            {"identifier": {"entityType": get_entity_type(AvpEntities.ROLE), "entityId": group}}
+        group_entities = [
+            {"identifier": {"entityType": get_entity_type(AvpEntities.GROUP), "entityId": group}}
             for group in user.get_groups()
         ]
-        return [user_entity, *role_entities]
+        return [user_entity, *group_entities]
 
     @staticmethod
     def _build_context(context: dict | None) -> dict | None:

--- a/airflow/providers/amazon/aws/auth_manager/cli/schema.json
+++ b/airflow/providers/amazon/aws/auth_manager/cli/schema.json
@@ -158,10 +158,10 @@
             "Dag": {},
             "Dataset": {},
             "Pool": {},
-            "Role": {},
+            "Group": {},
             "User": {
                 "memberOfTypes": [
-                    "Role"
+                    "Group"
                 ]
             },
             "Variable": {},

--- a/tests/providers/amazon/aws/auth_manager/avp/test_facade.py
+++ b/tests/providers/amazon/aws/auth_manager/avp/test_facade.py
@@ -89,15 +89,15 @@ class TestAwsAuthManagerAmazonVerifiedPermissionsFacade:
                     {
                         "identifier": {"entityType": "Airflow::User", "entityId": "test_user"},
                         "parents": [
-                            {"entityType": "Airflow::Role", "entityId": "group1"},
-                            {"entityType": "Airflow::Role", "entityId": "group2"},
+                            {"entityType": "Airflow::Group", "entityId": "group1"},
+                            {"entityType": "Airflow::Group", "entityId": "group2"},
                         ],
                     },
                     {
-                        "identifier": {"entityType": "Airflow::Role", "entityId": "group1"},
+                        "identifier": {"entityType": "Airflow::Group", "entityId": "group1"},
                     },
                     {
-                        "identifier": {"entityType": "Airflow::Role", "entityId": "group2"},
+                        "identifier": {"entityType": "Airflow::Group", "entityId": "group2"},
                     },
                 ],
                 None,
@@ -113,15 +113,15 @@ class TestAwsAuthManagerAmazonVerifiedPermissionsFacade:
                     {
                         "identifier": {"entityType": "Airflow::User", "entityId": "test_user"},
                         "parents": [
-                            {"entityType": "Airflow::Role", "entityId": "group1"},
-                            {"entityType": "Airflow::Role", "entityId": "group2"},
+                            {"entityType": "Airflow::Group", "entityId": "group1"},
+                            {"entityType": "Airflow::Group", "entityId": "group2"},
                         ],
                     },
                     {
-                        "identifier": {"entityType": "Airflow::Role", "entityId": "group1"},
+                        "identifier": {"entityType": "Airflow::Group", "entityId": "group1"},
                     },
                     {
-                        "identifier": {"entityType": "Airflow::Role", "entityId": "group2"},
+                        "identifier": {"entityType": "Airflow::Group", "entityId": "group2"},
                     },
                 ],
                 None,
@@ -152,15 +152,15 @@ class TestAwsAuthManagerAmazonVerifiedPermissionsFacade:
                     {
                         "identifier": {"entityType": "Airflow::User", "entityId": "test_user"},
                         "parents": [
-                            {"entityType": "Airflow::Role", "entityId": "group1"},
-                            {"entityType": "Airflow::Role", "entityId": "group2"},
+                            {"entityType": "Airflow::Group", "entityId": "group1"},
+                            {"entityType": "Airflow::Group", "entityId": "group2"},
                         ],
                     },
                     {
-                        "identifier": {"entityType": "Airflow::Role", "entityId": "group1"},
+                        "identifier": {"entityType": "Airflow::Group", "entityId": "group1"},
                     },
                     {
-                        "identifier": {"entityType": "Airflow::Role", "entityId": "group2"},
+                        "identifier": {"entityType": "Airflow::Group", "entityId": "group2"},
                     },
                 ],
                 {"contextMap": {"context_param": {"string": "value"}}},

--- a/tests/system/providers/amazon/aws/tests/test_aws_auth_manager.py
+++ b/tests/system/providers/amazon/aws/tests/test_aws_auth_manager.py
@@ -49,7 +49,7 @@ SAML_METADATA_PARSED = {
 
 AVP_POLICY_ADMIN = """
 permit (
-    principal in Airflow::Role::"Admin",
+    principal in Airflow::Group::"Admin",
     action,
     resource
 );


### PR DESCRIPTION
In AWS Identity center there is no notion of role but notion of groups. We used to make a translation role -> group but I think it makes it easier for users to use the same concept across the different services (AWS Identity center and Amazon Verified Permissions).

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
