### PR TITLE
Update SqlToSlackApiFileOperator with new param to check empty output

### DIFF
--- a/airflow/providers/slack/transfers/sql_to_slack.py
+++ b/airflow/providers/slack/transfers/sql_to_slack.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Any, Mapping, Sequence
 from deprecated import deprecated
 from typing_extensions import Literal
 
-from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning, AirflowSkipException
 from airflow.providers.slack.hooks.slack import SlackHook
 from airflow.providers.slack.transfers.base_sql_to_slack import BaseSqlToSlackOperator
 from airflow.providers.slack.transfers.sql_to_slack_webhook import SqlToSlackWebhookOperator
@@ -58,7 +58,11 @@ class SqlToSlackApiFileOperator(BaseSqlToSlackOperator):
     :param slack_base_url: A string representing the Slack API base URL. Optional
     :param slack_method_version: The version of the Slack SDK Client method to be used, either "v1" or "v2".
     :param df_kwargs: Keyword arguments forwarded to ``pandas.DataFrame.to_{format}()`` method.
-    :param send_file_if_empty: Keyword argument to allow sending an empty file, as a result of null sql output.
+    :param action_on_empty_df: Specifying how to handle an empty sql output df. Possible values:
+
+        - ``send``: (default) send the slack with an empty file.
+        - ``skip``: skip sending the slack message. Task state set to "skipped".
+        - ``error``: raise an error to fail the task. Task state set to "failed".
     """
 
     template_fields: Sequence[str] = (
@@ -88,7 +92,7 @@ class SqlToSlackApiFileOperator(BaseSqlToSlackOperator):
         slack_base_url: str | None = None,
         slack_method_version: Literal["v1", "v2"] = "v1",
         df_kwargs: dict | None = None,
-        send_file_if_empty: bool = True,
+        action_on_empty_df: Literal["send", "skip", "error"] = "send",
         **kwargs,
     ):
         super().__init__(
@@ -102,7 +106,9 @@ class SqlToSlackApiFileOperator(BaseSqlToSlackOperator):
         self.slack_base_url = slack_base_url
         self.slack_method_version = slack_method_version
         self.df_kwargs = df_kwargs or {}
-        self.send_file_if_empty = send_file_if_empty
+        if not action_on_empty_df or action_on_empty_df not in ("send", "skip", "error"):
+            raise ValueError(f"Invalid `action_on_empty_df` value {action_on_empty_df!r}")
+        self.action_on_empty_df = action_on_empty_df
 
     @cached_property
     def slack_hook(self):
@@ -137,9 +143,15 @@ class SqlToSlackApiFileOperator(BaseSqlToSlackOperator):
             output_file_name = fp.name
             output_file_format = output_file_format.upper()
             df_result = self._get_query_results()
-            if not self.send_file_if_empty and df_result.empty:
-                self.log.info("Sql output is empty. Skipping sending the slack with an empty file.")
-                return
+            if df_result.empty:
+                if self.action_on_empty_df == "skip":
+                    raise AirflowSkipException("Sql output df is empty. Skipping.")
+                elif self.action_on_empty_df == "error":
+                    raise ValueError("Sql output df must be non-empty. Failing.")
+                elif self.action_on_empty_df == "send":
+                    pass
+                else:
+                    raise ValueError(f"Invalid `action_on_empty_df` value {self.action_on_empty_df!r}")
             if output_file_format == "CSV":
                 df_result.to_csv(output_file_name, **self.df_kwargs)
             elif output_file_format == "JSON":

--- a/airflow/providers/slack/transfers/sql_to_slack.py
+++ b/airflow/providers/slack/transfers/sql_to_slack.py
@@ -33,10 +33,6 @@ if TYPE_CHECKING:
     from airflow.utils.context import Context
 
 
-class SqlToSlackNullOutputException(AirflowException):
-    """An exception that indicates the sql output is empty and hence should not be sent with slack message."""
-
-
 class SqlToSlackApiFileOperator(BaseSqlToSlackOperator):
     """
     Executes an SQL statement in a given SQL connection and sends the results to Slack API as file.
@@ -62,7 +58,7 @@ class SqlToSlackApiFileOperator(BaseSqlToSlackOperator):
     :param slack_base_url: A string representing the Slack API base URL. Optional
     :param slack_method_version: The version of the Slack SDK Client method to be used, either "v1" or "v2".
     :param df_kwargs: Keyword arguments forwarded to ``pandas.DataFrame.to_{format}()`` method.
-    :param allow_null: Keyword argument to allow null sql output which implies allowing sending an empty file.
+    :param send_file_if_empty: Keyword argument to allow sending an empty file, as a result of null sql output.
     """
 
     template_fields: Sequence[str] = (
@@ -92,7 +88,7 @@ class SqlToSlackApiFileOperator(BaseSqlToSlackOperator):
         slack_base_url: str | None = None,
         slack_method_version: Literal["v1", "v2"] = "v1",
         df_kwargs: dict | None = None,
-        allow_null: bool = True,
+        send_file_if_empty: bool = True,
         **kwargs,
     ):
         super().__init__(
@@ -106,7 +102,7 @@ class SqlToSlackApiFileOperator(BaseSqlToSlackOperator):
         self.slack_base_url = slack_base_url
         self.slack_method_version = slack_method_version
         self.df_kwargs = df_kwargs or {}
-        self.allow_null = allow_null
+        self.send_file_if_empty = send_file_if_empty
 
     @cached_property
     def slack_hook(self):
@@ -141,8 +137,9 @@ class SqlToSlackApiFileOperator(BaseSqlToSlackOperator):
             output_file_name = fp.name
             output_file_format = output_file_format.upper()
             df_result = self._get_query_results()
-            if not self.allow_null and df_result.empty:
-                raise SqlToSlackNullOutputException("Sql output is empty.")
+            if not self.send_file_if_empty and df_result.empty:
+                self.log.info("Sql output is empty. Skipping sending the slack with an empty file.")
+                return
             if output_file_format == "CSV":
                 df_result.to_csv(output_file_name, **self.df_kwargs)
             elif output_file_format == "JSON":

--- a/airflow/providers/slack/transfers/sql_to_slack.py
+++ b/airflow/providers/slack/transfers/sql_to_slack.py
@@ -145,12 +145,10 @@ class SqlToSlackApiFileOperator(BaseSqlToSlackOperator):
             df_result = self._get_query_results()
             if df_result.empty:
                 if self.action_on_empty_df == "skip":
-                    raise AirflowSkipException("Sql output df is empty. Skipping.")
+                    raise AirflowSkipException("SQL output df is empty. Skipping.")
                 elif self.action_on_empty_df == "error":
-                    raise ValueError("Sql output df must be non-empty. Failing.")
-                elif self.action_on_empty_df == "send":
-                    pass
-                else:
+                    raise ValueError("SQL output df must be non-empty. Failing.")
+                elif self.action_on_empty_df != "send":
                     raise ValueError(f"Invalid `action_on_empty_df` value {self.action_on_empty_df!r}")
             if output_file_format == "CSV":
                 df_result.to_csv(output_file_name, **self.df_kwargs)

--- a/tests/providers/slack/transfers/test_sql_to_slack.py
+++ b/tests/providers/slack/transfers/test_sql_to_slack.py
@@ -199,7 +199,7 @@ class TestSqlToSlackApiFileOperator:
 
         with pytest.raises(AirflowSkipException):
             op.execute(mock.MagicMock())
-            mock_slack_hook_cls.assert_not_called()
+        mock_slack_hook_cls.assert_not_called()
 
     @mock.patch("airflow.providers.slack.transfers.sql_to_slack.SlackHook")
     @mock.patch("airflow.providers.slack.transfers.sql_to_slack.BaseSqlToSlackOperator._get_query_results")
@@ -220,9 +220,9 @@ class TestSqlToSlackApiFileOperator:
         mock_df.configure_mock(**{"empty.return_value": True})
         mock_get_query_results.return_value = mock_df
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="output df must be non-empty\. Failing"):
             op.execute(mock.MagicMock())
-            mock_slack_hook_cls.assert_not_called()
+        mock_slack_hook_cls.assert_not_called()
 
 
 def test_deprecated_sql_to_slack_operator():

--- a/tests/providers/slack/transfers/test_sql_to_slack.py
+++ b/tests/providers/slack/transfers/test_sql_to_slack.py
@@ -20,7 +20,7 @@ from unittest import mock
 
 import pytest
 
-from airflow.exceptions import AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowProviderDeprecationWarning, AirflowSkipException
 from airflow.providers.slack.transfers.sql_to_slack import SqlToSlackApiFileOperator, SqlToSlackOperator
 from airflow.utils import timezone
 
@@ -188,7 +188,7 @@ class TestSqlToSlackApiFileOperator:
             "slack_channels": ["#random"],
             "slack_initial_comment": "test_comment",
             "slack_title": "test_title",
-            "send_file_if_empty": False,
+            "action_on_empty_df": "skip",
         }
         op = SqlToSlackApiFileOperator(task_id="test_send_file", **op_kwargs)
 
@@ -197,8 +197,32 @@ class TestSqlToSlackApiFileOperator:
         mock_df.configure_mock(**{"empty.return_value": True})
         mock_get_query_results.return_value = mock_df
 
-        op.execute(mock.MagicMock)
-        mock_slack_hook_cls.assert_not_called()
+        with pytest.raises(AirflowSkipException):
+            op.execute(mock.MagicMock())
+            mock_slack_hook_cls.assert_not_called()
+
+    @mock.patch("airflow.providers.slack.transfers.sql_to_slack.SlackHook")
+    @mock.patch("airflow.providers.slack.transfers.sql_to_slack.BaseSqlToSlackOperator._get_query_results")
+    def test_null_output_raise_error(self, mock_get_query_results, mock_slack_hook_cls):
+        op_kwargs = {
+            **self.default_op_kwargs,
+            "slack_conn_id": "expected-test-slack-conn-id",
+            "slack_filename": "test_filename.csv",
+            "slack_channels": ["#random"],
+            "slack_initial_comment": "test_comment",
+            "slack_title": "test_title",
+            "action_on_empty_df": "error",
+        }
+        op = SqlToSlackApiFileOperator(task_id="test_send_file", **op_kwargs)
+
+        # Mock empty query results
+        mock_df = mock.MagicMock()
+        mock_df.configure_mock(**{"empty.return_value": True})
+        mock_get_query_results.return_value = mock_df
+
+        with pytest.raises(ValueError):
+            op.execute(mock.MagicMock())
+            mock_slack_hook_cls.assert_not_called()
 
 
 def test_deprecated_sql_to_slack_operator():


### PR DESCRIPTION
This PR adds a new param to the SqlToSlackApiFileOperator to optionally allow skipping sending an empty file. 

closes: https://github.com/apache/airflow/issues/37191


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
