### PR TITLE
Show if dag page filters are active

### DIFF
--- a/airflow/www/static/js/dag/nav/FilterBar.tsx
+++ b/airflow/www/static/js/dag/nav/FilterBar.tsx
@@ -31,8 +31,6 @@ import { useTimezone } from "src/context/timezone";
 import { isoFormatWithoutTZ } from "src/datetime_utils";
 import useFilters from "src/dag/useFilters";
 
-declare const defaultDagRunDisplayNumber: number;
-
 declare const filtersOptions: {
   dagStates: RunState[];
   numRuns: number[];
@@ -47,9 +45,6 @@ const FilterBar = () => {
     filters: {
       baseDate,
       numRuns,
-      root,
-      filterUpstream,
-      filterDownstream,
       runState,
       runStateOptions,
       runType,
@@ -65,17 +60,10 @@ const FilterBar = () => {
 
   // @ts-ignore
   const isBaseDateDefault = moment(now).isSame(baseDate, "minute");
-  const isNumRunsDefault = numRuns === defaultDagRunDisplayNumber.toString();
   const isRunStateDefault = !runState || !runState.length;
   const isRunTypeDefault = !runType || !runType.length;
   const areFiltersDefault =
-    isBaseDateDefault &&
-    isNumRunsDefault &&
-    !root &&
-    !filterUpstream &&
-    !filterDownstream &&
-    isRunTypeDefault &&
-    isRunStateDefault;
+    isBaseDateDefault && isRunTypeDefault && isRunStateDefault;
 
   const { timezone } = useTimezone();
   // @ts-ignore
@@ -155,7 +143,6 @@ const FilterBar = () => {
             placeholder="Runs"
             value={numRuns || ""}
             onChange={(e) => onNumRunsChange(e.target.value)}
-            {...(isNumRunsDefault ? {} : filteredStyles)}
           >
             {filtersOptions.numRuns.map((value) => (
               <option value={value} key={value}>

--- a/airflow/www/static/js/dag/nav/FilterBar.tsx
+++ b/airflow/www/static/js/dag/nav/FilterBar.tsx
@@ -66,8 +66,8 @@ const FilterBar = () => {
   // @ts-ignore
   const isBaseDateDefault = moment(now).isSame(baseDate, "minute");
   const isNumRunsDefault = numRuns === defaultDagRunDisplayNumber.toString();
-  const isRunTypeDefault = !runState || !runState.length;
-  const isRunStateDefault = !runType || !runType.length;
+  const isRunStateDefault = !runState || !runState.length;
+  const isRunTypeDefault = !runType || !runType.length;
   const areFiltersDefault =
     isBaseDateDefault &&
     isNumRunsDefault &&
@@ -111,6 +111,9 @@ const FilterBar = () => {
         ...provided,
         bg: "white",
         ...(isRunTypeDefault ? {} : filteredStyles),
+        _hover: {
+          ...(isRunTypeDefault ? {} : filteredStyles),
+        },
       }),
     },
   });
@@ -122,6 +125,9 @@ const FilterBar = () => {
         ...provided,
         bg: "white",
         ...(isRunStateDefault ? {} : filteredStyles),
+        _hover: {
+          ...(isRunStateDefault ? {} : filteredStyles),
+        },
       }),
     },
   });

--- a/airflow/www/static/js/dag/nav/FilterBar.tsx
+++ b/airflow/www/static/js/dag/nav/FilterBar.tsx
@@ -137,20 +137,6 @@ const FilterBar = () => {
             {...(isBaseDateDefault ? {} : filteredStyles)}
           />
         </Box>
-        <Box px={2}>
-          <Select
-            {...inputStyles}
-            placeholder="Runs"
-            value={numRuns || ""}
-            onChange={(e) => onNumRunsChange(e.target.value)}
-          >
-            {filtersOptions.numRuns.map((value) => (
-              <option value={value} key={value}>
-                {value}
-              </option>
-            ))}
-          </Select>
-        </Box>
         <Box px={2} style={multiSelectBoxStyle}>
           <MultiSelect
             {...runTypeStyles}
@@ -202,7 +188,24 @@ const FilterBar = () => {
           </Button>
         </Box>
       </Flex>
-      <AutoRefresh />
+      <Flex>
+        <AutoRefresh />
+        <Box px={2}>
+          <Select
+            {...inputStyles}
+            placeholder="Runs"
+            value={numRuns || ""}
+            onChange={(e) => onNumRunsChange(e.target.value)}
+            aria-label="Number of runs to display in grid"
+          >
+            {filtersOptions.numRuns.map((value) => (
+              <option value={value} key={value}>
+                {value}
+              </option>
+            ))}
+          </Select>
+        </Box>
+      </Flex>
     </Flex>
   );
 };

--- a/airflow/www/static/js/dag/useFilters.test.tsx
+++ b/airflow/www/static/js/dag/useFilters.test.tsx
@@ -128,9 +128,8 @@ describe("Test useFilters hook", () => {
     if (paramName === "baseDate") {
       expect(result.current.filters[paramName]).toBe(date.toISOString());
     } else if (paramName === "numRuns") {
-      expect(result.current.filters[paramName]).toBe(
-        global.defaultDagRunDisplayNumber.toString()
-      );
+      // Number of runs isn't a filter so it should persist
+      expect(result.current.filters[paramName]).toBe("10");
     } else {
       expect(result.current.filters[paramName]).toEqual([]);
     }

--- a/airflow/www/static/js/dag/useFilters.tsx
+++ b/airflow/www/static/js/dag/useFilters.tsx
@@ -180,7 +180,6 @@ const useFilters = (): FilterHookReturn => {
 
   const clearFilters = () => {
     searchParams.delete(BASE_DATE_PARAM);
-    searchParams.delete(NUM_RUNS_PARAM);
     searchParams.delete(RUN_TYPE_PARAM);
     searchParams.delete(RUN_STATE_PARAM);
     setSearchParams(searchParams);


### PR DESCRIPTION
It is not always obvious that we have active filters on the DAG page. We should make it more obvious so users are less confused.

Clear button is disabled if no filters:
<img width="822" alt="Screenshot 2024-03-12 at 9 56 53 AM" src="https://github.com/apache/airflow/assets/4600967/3c191d7e-c070-4df6-8ad3-97e60f566c30">

Clear button is active and the active filter has a blue border color:
<img width="811" alt="Screenshot 2024-03-12 at 9 56 58 AM" src="https://github.com/apache/airflow/assets/4600967/745aaf61-72b4-4614-befb-89d69b77955e">

Also a minor styling fix (before and after):
<img width="477" alt="Screenshot 2024-03-12 at 9 57 18 AM" src="https://github.com/apache/airflow/assets/4600967/903ce782-9dec-46f5-983e-8100d6c3d7e3">
<img width="475" alt="Screenshot 2024-03-12 at 9 57 07 AM" src="https://github.com/apache/airflow/assets/4600967/37c85eeb-31fc-43fd-8937-d8674f184f06">


---


**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
