### PR TITLE
Fix graph task state border color

### DIFF
--- a/airflow/www/static/js/dag/details/graph/DagNode.tsx
+++ b/airflow/www/static/js/dag/details/graph/DagNode.tsx
@@ -80,7 +80,7 @@ const DagNode = ({
 
   const nodeBorderColor =
     instance?.state && stateColors[instance.state]
-      ? `${stateColors[instance.state]}.400`
+      ? stateColors[instance.state]
       : "gray.400";
 
   return (


### PR DESCRIPTION
Before:
<img width="703" alt="Screenshot 2024-03-12 at 11 47 39 AM" src="https://github.com/apache/airflow/assets/4600967/8f2e9f57-cd45-4f03-9eec-df134c924fbc">

After:
<img width="672" alt="Screenshot 2024-03-12 at 11 47 20 AM" src="https://github.com/apache/airflow/assets/4600967/3df5bbe4-69f6-42a2-8a3a-249d188901ff">



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
