### PR TITLE
Allow sort by on all fields in MappedInstances.tsx

### DIFF
--- a/airflow/api_connexion/endpoints/task_instance_endpoint.py
+++ b/airflow/api_connexion/endpoints/task_instance_endpoint.py
@@ -239,33 +239,28 @@ def get_mapped_task_instances(
         .options(joinedload(TI.rendered_task_instance_fields))
     )
 
-    if order_by is not None:
-        if order_by == "state":
-            entry_query = entry_query.order_by(TI.state.asc(), TI.map_index.asc())
-        elif order_by == "-state":
-            entry_query = entry_query.order_by(TI.state.desc(), TI.map_index.asc())
-        elif order_by == "duration":
-            print("duration")
-            entry_query = entry_query.order_by(TI.duration.asc(), TI.map_index.asc())
-        elif order_by == "-duration":
-            print("-duration")
-            entry_query = entry_query.order_by(TI.duration.desc(), TI.map_index.asc())
-        elif order_by == "start_date":
-            entry_query = entry_query.order_by(TI.start_date.asc(), TI.map_index.asc())
-        elif order_by == "-start_date":
-            entry_query = entry_query.order_by(TI.start_date.desc(), TI.map_index.asc())
-        elif order_by == "end_date":
-            entry_query = entry_query.order_by(TI.end_date.asc(), TI.map_index.asc())
-        elif order_by == "-end_date":
-            entry_query = entry_query.order_by(TI.end_date.desc(), TI.map_index.asc())
-        elif order_by == "-map_index":
-            print("map index!!")
-            entry_query = entry_query.order_by(TI.map_index.desc())
-        else:
-            raise BadRequest(detail=f"Ordering with '{order_by}' is not supported")
-    else:
-        print("map inde ascx!!")
+    if order_by is None:
         entry_query = entry_query.order_by(TI.map_index.asc())
+    elif order_by == "state":
+        entry_query = entry_query.order_by(TI.state.asc(), TI.map_index.asc())
+    elif order_by == "-state":
+        entry_query = entry_query.order_by(TI.state.desc(), TI.map_index.asc())
+    elif order_by == "duration":
+        entry_query = entry_query.order_by(TI.duration.asc(), TI.map_index.asc())
+    elif order_by == "-duration":
+        entry_query = entry_query.order_by(TI.duration.desc(), TI.map_index.asc())
+    elif order_by == "start_date":
+        entry_query = entry_query.order_by(TI.start_date.asc(), TI.map_index.asc())
+    elif order_by == "-start_date":
+        entry_query = entry_query.order_by(TI.start_date.desc(), TI.map_index.asc())
+    elif order_by == "end_date":
+        entry_query = entry_query.order_by(TI.end_date.asc(), TI.map_index.asc())
+    elif order_by == "-end_date":
+        entry_query = entry_query.order_by(TI.end_date.desc(), TI.map_index.asc())
+    elif order_by == "-map_index":
+        entry_query = entry_query.order_by(TI.map_index.desc())
+    else:
+        raise BadRequest(detail=f"Ordering with '{order_by}' is not supported")
 
     # using execute because we want the SlaMiss entity. Scalars don't return None for missing entities
     task_instances = session.execute(entry_query.offset(offset).limit(limit)).all()

--- a/airflow/api_connexion/endpoints/task_instance_endpoint.py
+++ b/airflow/api_connexion/endpoints/task_instance_endpoint.py
@@ -239,16 +239,32 @@ def get_mapped_task_instances(
         .options(joinedload(TI.rendered_task_instance_fields))
     )
 
-    if order_by:
+    if order_by is not None:
         if order_by == "state":
             entry_query = entry_query.order_by(TI.state.asc(), TI.map_index.asc())
         elif order_by == "-state":
             entry_query = entry_query.order_by(TI.state.desc(), TI.map_index.asc())
+        elif order_by == "duration":
+            print("duration")
+            entry_query = entry_query.order_by(TI.duration.asc(), TI.map_index.asc())
+        elif order_by == "-duration":
+            print("-duration")
+            entry_query = entry_query.order_by(TI.duration.desc(), TI.map_index.asc())
+        elif order_by == "start_date":
+            entry_query = entry_query.order_by(TI.start_date.asc(), TI.map_index.asc())
+        elif order_by == "-start_date":
+            entry_query = entry_query.order_by(TI.start_date.desc(), TI.map_index.asc())
+        elif order_by == "end_date":
+            entry_query = entry_query.order_by(TI.end_date.asc(), TI.map_index.asc())
+        elif order_by == "-end_date":
+            entry_query = entry_query.order_by(TI.end_date.desc(), TI.map_index.asc())
         elif order_by == "-map_index":
+            print("map index!!")
             entry_query = entry_query.order_by(TI.map_index.desc())
         else:
             raise BadRequest(detail=f"Ordering with '{order_by}' is not supported")
     else:
+        print("map inde ascx!!")
         entry_query = entry_query.order_by(TI.map_index.asc())
 
     # using execute because we want the SlaMiss entity. Scalars don't return None for missing entities

--- a/airflow/www/static/js/dag/details/taskInstance/MappedInstances.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/MappedInstances.tsx
@@ -106,17 +106,14 @@ const MappedInstances = ({ dagId, runId, taskId, onRowClicked }: Props) => {
       {
         Header: "Duration",
         accessor: "duration",
-        disableSortBy: true,
       },
       {
         Header: "Start Date",
         accessor: "startDate",
-        disableSortBy: true,
       },
       {
         Header: "End Date",
         accessor: "endDate",
-        disableSortBy: true,
       },
       {
         Header: "Try Number",

--- a/airflow/www/static/js/dag/details/taskInstance/MappedInstances.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/MappedInstances.tsx
@@ -47,7 +47,12 @@ const MappedInstances = ({ dagId, runId, taskId, onRowClicked }: Props) => {
   const sort = sortBy[0];
 
   const orderBy =
-    sort && (sort.id === "state" || sort.id === "mapIndex")
+    sort &&
+    (sort.id === "state" ||
+      sort.id === "mapIndex" ||
+      sort.id === "duration" ||
+      sort.id === "startDate" ||
+      sort.id === "endDate")
       ? `${sort.desc ? "-" : ""}${snakeCase(sort.id)}`
       : "";
 

--- a/airflow/www/static/js/dag/details/taskInstance/MappedInstances.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/MappedInstances.tsx
@@ -47,9 +47,7 @@ const MappedInstances = ({ dagId, runId, taskId, onRowClicked }: Props) => {
   const sort = sortBy[0];
 
   const orderBy =
-    sort && sort.id
-      ? `${sort.desc ? "-" : ""}${snakeCase(sort.id)}`
-      : "";
+    sort && sort.id ? `${sort.desc ? "-" : ""}${snakeCase(sort.id)}` : "";
 
   const {
     data: { taskInstances = [], totalEntries = 0 } = {

--- a/airflow/www/static/js/dag/details/taskInstance/MappedInstances.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/MappedInstances.tsx
@@ -47,12 +47,7 @@ const MappedInstances = ({ dagId, runId, taskId, onRowClicked }: Props) => {
   const sort = sortBy[0];
 
   const orderBy =
-    sort &&
-    (sort.id === "state" ||
-      sort.id === "mapIndex" ||
-      sort.id === "duration" ||
-      sort.id === "startDate" ||
-      sort.id === "endDate")
+    sort && sort.id
       ? `${sort.desc ? "-" : ""}${snakeCase(sort.id)}`
       : "";
 


### PR DESCRIPTION
It's difficult to find problematic TIs when attempting to debug tasks that have dozens or hundreds of mapped TIs. For example, imagine 99 mapped instances completed in 10 seconds but 1 mapped instance took 10 minutes. It's like finding a needle in a haystack to find that one. 

This will allow users to sort by each field in the grid view.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
