### PR TITLE
Optimize skipping building images for not "in-workflow" builds

### DIFF
--- a/.github/workflows/ci-image-build.yml
+++ b/.github/workflows/ci-image-build.yml
@@ -87,11 +87,14 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ${{fromJson(inputs.python-versions)}}
+        # yamllint disable-line rule:line-length
+        python-version: ${{ inputs.do-build == 'true' && fromJson(inputs.python-versions) || fromJson('[""]') }}
     timeout-minutes: 110
-    name: >
-      ${{ inputs.do-build == 'true' && 'Build' || 'Skip build' }}
-      CI ${{inputs.build-type}} image ${{matrix.python-version}}:${{inputs.image-tag}}
+    name: "\
+${{ inputs.do-build == 'true' && 'Build' || 'Skip building' }} \
+CI ${{inputs.build-type}} image\
+${{matrix.python-version}}${{ inputs.do-build == 'true' && ':' || '' }}\
+${{ inputs.do-build == 'true' && inputs.image-tag || '' }}"
     runs-on: ${{fromJson(inputs.runs-on)}}
     env:
       BACKEND: sqlite

--- a/.github/workflows/prod-image-build.yml
+++ b/.github/workflows/prod-image-build.yml
@@ -91,11 +91,14 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ${{fromJson(inputs.python-versions)}}
+        # yamllint disable-line rule:line-length
+        python-version: ${{ inputs.do-build == 'true' && fromJson(inputs.python-versions) || fromJson('[""]') }}
     timeout-minutes: 80
-    name: >
-      ${{ inputs.do-build == 'true' && 'Build' || 'Skip build' }}
-      PROD ${{inputs.build-type}} image ${{matrix.python-version}}:${{inputs.image-tag}}
+    name: "\
+${{ inputs.do-build == 'true' && 'Build' || 'Skip building' }} \
+PROD ${{inputs.build-type}} image\
+${{matrix.python-version}}${{ inputs.do-build == 'true' && ':' || '' }}\
+${{ inputs.do-build == 'true' && inputs.image-tag || '' }}"
     runs-on: ["ubuntu-22.04"]
     env:
       BACKEND: sqlite


### PR DESCRIPTION
In case images are built in the "pull-request-target" workflow, we should skip the builds "in-workflow" - but just "skipping" them is no good because skip state propagates to downstream jobs - but this leads - in naive implementation of build matrix to a number of jobs that start and end immediately.

Instead we can simply use empty matrix for the builds - this will make it much better optimized.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
