### PR TITLE
Prevent large objects from being stored in the RTIF

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -492,14 +492,14 @@ core:
       type: string
       example: ~
       default: "Disabled"
-    max_templated_field_size:
+    max_templated_field_length:
       description: |
         The maximum length of the rendered template field. If the value to be stored in the
         rendered template field exceeds this size, it's redacted.
       version_added: 2.9.0
       type: integer
       example: ~
-      default: "1024"
+      default: "4096"
 database:
   description: ~
   options:

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -494,7 +494,7 @@ core:
       default: "Disabled"
     max_templated_field_size:
       description: |
-        The maximum size of the rendered template field in bytes. If the value to be stored in the
+        The maximum length of the rendered template field. If the value to be stored in the
         rendered template field exceeds this size, it's redacted.
       version_added: 2.9.0
       type: integer

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -492,6 +492,14 @@ core:
       type: string
       example: ~
       default: "Disabled"
+    max_templated_field_size:
+      description: |
+        The maximum size of the rendered template field. If the value to be stored in the rendered template
+        field exceeds this size, it's redacted.
+      version_added: 2.9.0
+      type: integer
+      example: ~
+      default: "1024"
 database:
   description: ~
   options:

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -494,8 +494,8 @@ core:
       default: "Disabled"
     max_templated_field_size:
       description: |
-        The maximum size of the rendered template field. If the value to be stored in the rendered template
-        field exceeds this size, it's redacted.
+        The maximum size of the rendered template field in bytes. If the value to be stored in the
+        rendered template field exceeds this size, it's redacted.
       version_added: 2.9.0
       type: integer
       example: ~

--- a/airflow/models/renderedtifields.py
+++ b/airflow/models/renderedtifields.py
@@ -121,7 +121,8 @@ class RenderedTaskInstanceFields(TaskInstanceDependencies):
 
             self.k8s_pod_yaml = render_k8s_pod_yaml(ti)
         self.rendered_fields = {
-            field: serialize_template_field(getattr(self.task, field)) for field in self.task.template_fields
+            field: serialize_template_field(getattr(self.task, field), field)
+            for field in self.task.template_fields
         }
 
         self._redact()

--- a/airflow/serialization/helpers.py
+++ b/airflow/serialization/helpers.py
@@ -39,19 +39,14 @@ def serialize_template_field(template_field: Any) -> str | dict | list | int | f
         else:
             return True
 
-    max_size = conf.getint("core", "max_templated_field_size")
+    max_length = conf.getint("core", "max_templated_field_length")
+
+    if template_field and len(str(template_field)) > max_length:
+        return (
+            f"{str(template_field)[:max_length-79]}... truncated. "
+            "You can change this behaviour in [core]max_templated_field_length"
+        )
     if not is_jsonable(template_field):
-        serialized = str(template_field)
-        if len(serialized) > max_size:
-            return (
-                "Value removed due to size. "
-                "You can change this behaviour in [core]max_templated_field_size"
-            )
-        return serialized
+        return str(template_field)
     else:
-        if template_field and len(str(template_field)) > max_size:
-            return (
-                "Value removed due to size. "
-                "You can change this behaviour in [core]max_templated_field_size"
-            )
         return template_field

--- a/airflow/serialization/helpers.py
+++ b/airflow/serialization/helpers.py
@@ -18,7 +18,6 @@
 
 from __future__ import annotations
 
-import sys
 from typing import Any
 
 from airflow.configuration import conf
@@ -43,23 +42,17 @@ def serialize_template_field(template_field: Any) -> str | dict | list | int | f
     max_size = conf.getint("core", "max_templated_field_size")
 
     if not is_jsonable(template_field):
-        if isinstance(template_field, (list, tuple)):
-            if sum(sys.getsizeof(x) for x in template_field) > max_size:
-                return (
-                    "Value redacted as it is too large to be stored in the database. "
-                    "You can change this behaviour in [core]max_templated_field_size"
-                )
-        elif sys.getsizeof(template_field) > max_size:
+        serialized = str(template_field)
+        if len(serialized) > max_size:
             return (
-                "Value redacted as it is too large to be stored in the database. "
+                "Value removed due to size. "
                 "You can change this behaviour in [core]max_templated_field_size"
             )
-        return str(template_field)
+        return serialized
     else:
-        if template_field and isinstance(template_field, (list, tuple)):
-            if sum(sys.getsizeof(x) for x in template_field) > max_size:
-                return (
-                    "Value redacted as it is too large to be stored in the database. "
-                    "You can change this behaviour in [core]max_templated_field_size"
-                )
+        if template_field and len(str(template_field)) > max_size:
+            return (
+                "Value removed due to size. "
+                "You can change this behaviour in [core]max_templated_field_size"
+            )
         return template_field

--- a/airflow/serialization/helpers.py
+++ b/airflow/serialization/helpers.py
@@ -25,7 +25,7 @@ from airflow.settings import json
 from airflow.utils.log.secrets_masker import redact
 
 
-def serialize_template_field(template_field: Any, name) -> str | dict | list | int | float:
+def serialize_template_field(template_field: Any, name: str) -> str | dict | list | int | float:
     """Return a serializable representation of the templated field.
 
     If ``templated_field`` contains a class or instance that requires recursive

--- a/airflow/serialization/helpers.py
+++ b/airflow/serialization/helpers.py
@@ -40,7 +40,6 @@ def serialize_template_field(template_field: Any) -> str | dict | list | int | f
             return True
 
     max_size = conf.getint("core", "max_templated_field_size")
-
     if not is_jsonable(template_field):
         serialized = str(template_field)
         if len(serialized) > max_size:

--- a/airflow/serialization/helpers.py
+++ b/airflow/serialization/helpers.py
@@ -44,7 +44,7 @@ def serialize_template_field(template_field: Any) -> str | dict | list | int | f
 
     if not is_jsonable(template_field):
         if isinstance(template_field, (list, tuple)):
-            if sys.getsizeof(template_field[0]) > max_size:
+            if sum(sys.getsizeof(x) for x in template_field) > max_size:
                 return (
                     "Value redacted as it is too large to be stored in the database. "
                     "You can change this behaviour in [core]max_templated_field_size"
@@ -57,7 +57,7 @@ def serialize_template_field(template_field: Any) -> str | dict | list | int | f
         return str(template_field)
     else:
         if template_field and isinstance(template_field, (list, tuple)):
-            if len(template_field) and sys.getsizeof(template_field[0]) > max_size:
+            if sum(sys.getsizeof(x) for x in template_field) > max_size:
                 return (
                     "Value redacted as it is too large to be stored in the database. "
                     "You can change this behaviour in [core]max_templated_field_size"

--- a/airflow/serialization/helpers.py
+++ b/airflow/serialization/helpers.py
@@ -43,16 +43,20 @@ def serialize_template_field(template_field: Any, name: str) -> str | dict | lis
     max_length = conf.getint("core", "max_templated_field_length")
 
     if not is_jsonable(template_field):
-        if len(str(template_field)) > max_length:
-            rendered = redact(str(template_field), name)
+        serialized = str(template_field)
+        if len(serialized) > max_length:
+            rendered = redact(serialized, name)
             return (
                 "Truncated. You can change this behaviour in [core]max_templated_field_length. "
                 f"{rendered[:max_length - 79]!r}... "
             )
         return str(template_field)
     else:
-        if template_field and len(str(template_field)) > max_length:
-            rendered = redact(str(template_field), name)
+        if not template_field:
+            return template_field
+        serialized = str(template_field)
+        if len(serialized) > max_length:
+            rendered = redact(serialized, name)
             return (
                 "Truncated. You can change this behaviour in [core]max_templated_field_length. "
                 f"{rendered[:max_length - 79]!r}... "

--- a/airflow/serialization/helpers.py
+++ b/airflow/serialization/helpers.py
@@ -22,9 +22,10 @@ from typing import Any
 
 from airflow.configuration import conf
 from airflow.settings import json
+from airflow.utils.log.secrets_masker import redact
 
 
-def serialize_template_field(template_field: Any) -> str | dict | list | int | float:
+def serialize_template_field(template_field: Any, name) -> str | dict | list | int | float:
     """Return a serializable representation of the templated field.
 
     If ``templated_field`` contains a class or instance that requires recursive
@@ -42,9 +43,10 @@ def serialize_template_field(template_field: Any) -> str | dict | list | int | f
     max_length = conf.getint("core", "max_templated_field_length")
 
     if template_field and len(str(template_field)) > max_length:
+        rendered = redact(str(template_field), name)
         return (
             "Truncated. You can change this behaviour in [core]max_templated_field_length. "
-            f"{str(template_field)[:max_length-79]}... "
+            f"{rendered[:max_length-79]!r}... "
         )
     if not is_jsonable(template_field):
         return str(template_field)

--- a/airflow/serialization/helpers.py
+++ b/airflow/serialization/helpers.py
@@ -42,13 +42,19 @@ def serialize_template_field(template_field: Any, name: str) -> str | dict | lis
 
     max_length = conf.getint("core", "max_templated_field_length")
 
-    if template_field and len(str(template_field)) > max_length:
-        rendered = redact(str(template_field), name)
-        return (
-            "Truncated. You can change this behaviour in [core]max_templated_field_length. "
-            f"{rendered[:max_length-79]!r}... "
-        )
     if not is_jsonable(template_field):
+        if len(str(template_field)) > max_length:
+            rendered = redact(str(template_field), name)
+            return (
+                "Truncated. You can change this behaviour in [core]max_templated_field_length. "
+                f"{rendered[:max_length - 79]!r}... "
+            )
         return str(template_field)
     else:
+        if template_field and len(str(template_field)) > max_length:
+            rendered = redact(str(template_field), name)
+            return (
+                "Truncated. You can change this behaviour in [core]max_templated_field_length. "
+                f"{rendered[:max_length - 79]!r}... "
+            )
         return template_field

--- a/airflow/serialization/helpers.py
+++ b/airflow/serialization/helpers.py
@@ -43,8 +43,8 @@ def serialize_template_field(template_field: Any) -> str | dict | list | int | f
 
     if template_field and len(str(template_field)) > max_length:
         return (
-            f"{str(template_field)[:max_length-79]}... truncated. "
-            "You can change this behaviour in [core]max_templated_field_length"
+            "Truncated. You can change this behaviour in [core]max_templated_field_length. "
+            f"{str(template_field)[:max_length-79]}... "
         )
     if not is_jsonable(template_field):
         return str(template_field)

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -993,7 +993,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                     )
                 value = getattr(op, template_field, None)
                 if not cls._is_excluded(value, template_field, op):
-                    serialize_op[template_field] = serialize_template_field(value)
+                    serialize_op[template_field] = serialize_template_field(value, template_field)
 
         if op.params:
             serialize_op["params"] = cls._serialize_params_dict(op.params)

--- a/newsfragments/38094.significant.rst
+++ b/newsfragments/38094.significant.rst
@@ -1,0 +1,5 @@
+Prevent large string objects from being stored in the Rendered Template Fields
+
+There's now a limit to the length of data that can be stored in the Rendered Template Fields.
+The limit is set to 4096 characters. If the data exceeds this limit, it will be truncated. You can change this limit
+by setting the ``[core]max_template_field_length`` configuration option in your airflow config.

--- a/tests/models/test_renderedtifields.py
+++ b/tests/models/test_renderedtifields.py
@@ -174,24 +174,20 @@ class TestRenderedTaskInstanceFields:
         Test that secrets are masked when the templated field is a large string
         """
         Variable.set(
-            key="api_key",
-            value="Api key secret should be masked as before"
-            * 5000,
+            key="name",
+            value="A field exceeding the max length of the templated field length" * 5000,
         )
         with dag_maker("test_serialized_rendered_fields"):
-            task = BashOperator(task_id="test", bash_command="echo {{ var.value.api_key }}")
+            task = BashOperator(task_id="test", bash_command="echo {{ var.value.name }}")
         dr = dag_maker.create_dagrun()
         ti = dr.task_instances[0]
         ti.task = task
         rtif = RTIF(ti=ti)
-
-        assert ti.dag_id == rtif.dag_id
-        assert ti.task_id == rtif.task_id
-        assert ti.run_id == rtif.run_id
         assert "***" in rtif.rendered_fields.get("bash_command")
 
     @mock.patch("airflow.models.BaseOperator.render_template")
     def test_pandas_dataframes_works_with_the_string_compare(self, render_mock, dag_maker):
+        """Test that rendered dataframe gets passed through the serialized template fields."""
         import pandas
 
         render_mock.return_value = pandas.DataFrame({"a": [1, 2, 3]})

--- a/tests/models/test_renderedtifields.py
+++ b/tests/models/test_renderedtifields.py
@@ -73,7 +73,6 @@ class LargeStrObject:
 
 
 max_length = conf.getint("core", "max_templated_field_length")
-LargeStr = "a" * 5000
 
 
 class TestRenderedTaskInstanceFields:
@@ -176,7 +175,7 @@ class TestRenderedTaskInstanceFields:
         """
         Variable.set(
             key="api_key",
-            value="Some very long secret with private information that asserts private is not in the rendered field"
+            value="Api key secret should be masked as before"
             * 5000,
         )
         with dag_maker("test_serialized_rendered_fields"):

--- a/tests/models/test_renderedtifields.py
+++ b/tests/models/test_renderedtifields.py
@@ -125,11 +125,11 @@ class TestRenderedTaskInstanceFields:
             ),
             (
                 "a" * 5000,
-                f"{('a'*5000)[:max_length-79]}... truncated. You can change this behaviour in [core]max_templated_field_length",
+                f"Truncated. You can change this behaviour in [core]max_templated_field_length. {('a'*5000)[:max_length-79]}... ",
             ),
             (
                 LargeStrObject(),
-                f"{str(LargeStrObject())[:max_length-79]}... truncated. You can change this behaviour in [core]max_templated_field_length",
+                f"Truncated. You can change this behaviour in [core]max_templated_field_length. {str(LargeStrObject())[:max_length-79]}... ",
             ),
         ],
     )

--- a/tests/models/test_renderedtifields.py
+++ b/tests/models/test_renderedtifields.py
@@ -72,6 +72,7 @@ class LargeStrObject:
 
 
 max_length = conf.getint("core", "max_templated_field_length")
+LargeStr = "a" * 5000
 
 
 class TestRenderedTaskInstanceFields:
@@ -125,11 +126,11 @@ class TestRenderedTaskInstanceFields:
             ),
             (
                 "a" * 5000,
-                f"Truncated. You can change this behaviour in [core]max_templated_field_length. {('a'*5000)[:max_length-79]}... ",
+                f"Truncated. You can change this behaviour in [core]max_templated_field_length. {('a'*5000)[:max_length-79]!r}... ",
             ),
             (
                 LargeStrObject(),
-                f"Truncated. You can change this behaviour in [core]max_templated_field_length. {str(LargeStrObject())[:max_length-79]}... ",
+                f"Truncated. You can change this behaviour in [core]max_templated_field_length. {str(LargeStrObject())[:max_length-79]!r}... ",
             ),
         ],
     )
@@ -168,24 +169,18 @@ class TestRenderedTaskInstanceFields:
         # Fetching them will return None
         assert RTIF.get_templated_fields(ti=ti2) is None
 
-    @mock.patch("airflow.utils.log.secrets_masker.redact", autospec=True)
-    def test_secrets_are_masked_when_large_string(self, redact, dag_maker):
+    def test_secrets_are_masked_when_large_string(self, dag_maker):
         """
         Test that secrets are masked when the templated field is a large string
         """
         Variable.set(
-            key="test_key",
+            key="api_key",
             value="Some very long secret with private information that asserts private is not in the rendered field"
             * 5000,
         )
         with dag_maker("test_serialized_rendered_fields"):
-            task = BashOperator(task_id="test", bash_command="echo {{ var.value.test_key }}")
+            task = BashOperator(task_id="test", bash_command="echo {{ var.value.api_key }}")
         dr = dag_maker.create_dagrun()
-        redact.side_effect = [
-            "val 1",  # bash_command
-            "val 2",
-            "val 3",
-        ]
         ti = dr.task_instances[0]
         ti.task = task
         rtif = RTIF(ti=ti)
@@ -193,7 +188,7 @@ class TestRenderedTaskInstanceFields:
         assert ti.dag_id == rtif.dag_id
         assert ti.task_id == rtif.task_id
         assert ti.run_id == rtif.run_id
-        assert "val 1" == rtif.rendered_fields.get("bash_command")
+        assert "***" in rtif.rendered_fields.get("bash_command")
 
     @pytest.mark.parametrize(
         "rtif_num, num_to_keep, remaining_rtifs, expected_query_count",

--- a/tests/models/test_renderedtifields.py
+++ b/tests/models/test_renderedtifields.py
@@ -27,6 +27,7 @@ from unittest import mock
 import pytest
 
 from airflow import settings
+from airflow.configuration import conf
 from airflow.models import Variable
 from airflow.models.renderedtifields import RenderedTaskInstanceFields as RTIF
 from airflow.operators.bash import BashOperator
@@ -64,10 +65,13 @@ class ClassWithCustomAttributes:
 
 class LargeStrObject:
     def __init__(self):
-        self.a = "a" * 2560
+        self.a = "a" * 5000
 
     def __str__(self):
         return self.a
+
+
+max_length = conf.getint("core", "max_templated_field_length")
 
 
 class TestRenderedTaskInstanceFields:
@@ -120,12 +124,12 @@ class TestRenderedTaskInstanceFields:
                 "'template_fields': ['nested1']})",
             ),
             (
-                "a" * 2560,
-                "Value removed due to size. You can change this behaviour in [core]max_templated_field_size",
+                "a" * 5000,
+                f"{('a'*5000)[:max_length-79]}... truncated. You can change this behaviour in [core]max_templated_field_length",
             ),
             (
                 LargeStrObject(),
-                "Value removed due to size. You can change this behaviour in [core]max_templated_field_size",
+                f"{str(LargeStrObject())[:max_length-79]}... truncated. You can change this behaviour in [core]max_templated_field_length",
             ),
         ],
     )

--- a/tests/models/test_renderedtifields.py
+++ b/tests/models/test_renderedtifields.py
@@ -33,7 +33,7 @@ from airflow.operators.bash import BashOperator
 from airflow.utils.task_instance_session import set_current_task_instance_session
 from airflow.utils.timezone import datetime
 from tests.test_utils.asserts import assert_queries_count
-from tests.test_utils.db import clear_db_dags, clear_db_runs, clear_db_xcom, clear_rendered_ti_fields
+from tests.test_utils.db import clear_db_dags, clear_db_runs, clear_rendered_ti_fields
 
 pytestmark = pytest.mark.db_test
 
@@ -78,7 +78,6 @@ class TestRenderedTaskInstanceFields:
         clear_db_runs()
         clear_db_dags()
         clear_rendered_ti_fields()
-        clear_db_xcom()
 
     def setup_method(self):
         self.clean_db()

--- a/tests/models/test_renderedtifields.py
+++ b/tests/models/test_renderedtifields.py
@@ -174,11 +174,11 @@ class TestRenderedTaskInstanceFields:
         Test that secrets are masked when the templated field is a large string
         """
         Variable.set(
-            key="name",
-            value="A field exceeding the max length of the templated field length" * 5000,
+            key="api_key",
+            value="test api key are still masked" * 5000,
         )
         with dag_maker("test_serialized_rendered_fields"):
-            task = BashOperator(task_id="test", bash_command="echo {{ var.value.name }}")
+            task = BashOperator(task_id="test", bash_command="echo {{ var.value.api_key }}")
         dr = dag_maker.create_dagrun()
         ti = dr.task_instances[0]
         ti.task = task


### PR DESCRIPTION
There's no control over the size of objects stored in the rendered taskinstance field. This PR adds control and enable users to be able to customize the size of data that can be stored in this field

closes: #28199

