### PR TITLE
Fix spark operator log retrieval from driver

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
@@ -72,6 +72,8 @@ class SparkKubernetesOperator(KubernetesPodOperator):
     template_ext = ("yaml", "yml", "json")
     ui_color = "#f4a460"
 
+    BASE_CONTAINER_NAME = "spark-kubernetes-driver"
+
     def __init__(
         self,
         *,
@@ -108,6 +110,18 @@ class SparkKubernetesOperator(KubernetesPodOperator):
         self.get_logs = get_logs
         self.log_events_on_failure = log_events_on_failure
         self.success_run_history_limit = success_run_history_limit
+
+        if self.base_container_name != self.BASE_CONTAINER_NAME:
+            self.log.warning(
+                "base_container_name is not supported and will be overridden to %s", self.BASE_CONTAINER_NAME
+            )
+            self.base_container_name = self.BASE_CONTAINER_NAME
+
+        if self.get_logs and self.container_logs != self.BASE_CONTAINER_NAME:
+            self.log.warning(
+                "container_logs is not supported and will be overridden to %s", self.BASE_CONTAINER_NAME
+            )
+            self.container_logs = [self.BASE_CONTAINER_NAME]
 
     def _render_nested_template_fields(
         self,
@@ -273,7 +287,6 @@ class SparkKubernetesOperator(KubernetesPodOperator):
             template_body=self.template_body,
         )
         self.pod = self.get_or_create_spark_crd(self.launcher, context)
-        self.BASE_CONTAINER_NAME = "spark-kubernetes-driver"
         self.pod_request_obj = self.launcher.pod_spec
 
         return super().execute(context=context)

--- a/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
@@ -27,6 +27,7 @@ from kubernetes.client import CoreV1Api, CustomObjectsApi, models as k8s
 from airflow.exceptions import AirflowException
 from airflow.providers.cncf.kubernetes import pod_generator
 from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook, _load_body_to_dict
+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import add_unique_suffix
 from airflow.providers.cncf.kubernetes.operators.custom_object_launcher import CustomObjectLauncher
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.pod_generator import MAX_LABEL_LEN, PodGenerator
@@ -158,7 +159,7 @@ class SparkKubernetesOperator(KubernetesPodOperator):
         return template_body
 
     def create_job_name(self):
-        initial_name = PodGenerator.make_unique_pod_id(self.task_id)[:MAX_LABEL_LEN]
+        initial_name = add_unique_suffix(name=self.task_id, max_len=MAX_LABEL_LEN)
         return re.sub(r"[^a-z0-9-]+", "-", initial_name.lower())
 
     @staticmethod

--- a/tests/providers/cncf/kubernetes/operators/test_spark_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/operators/test_spark_kubernetes.py
@@ -51,10 +51,10 @@ def test_spark_kubernetes_operator(mock_kubernetes_hook, data_file):
     assert "hook" not in operator.__dict__  # Cached property has not been accessed as part of construction.
 
 
-def test_init_spark_kubernetes_operator():
+def test_init_spark_kubernetes_operator(data_file):
     operator = SparkKubernetesOperator(
         task_id="task_id",
-        application_file=join(Path(__file__).parent, "spark_application_test.yaml"),
+        application_file=data_file("spark/application_test.yaml").as_posix(),
         kubernetes_conn_id="kubernetes_conn_id",
         in_cluster=True,
         cluster_context="cluster_context",
@@ -535,9 +535,10 @@ class TestSparkKubernetesOperator:
         mock_await_pod_start,
         mock_await_pod_completion,
         mock_fetch_requested_container_logs,
+        data_file,
     ):
         task_name = "test_get_logs_from_driver"
-        job_spec = yaml.safe_load(open(join(Path(__file__).parent, "spark_application_template.yaml")))
+        job_spec = yaml.safe_load(data_file("spark/application_template.yaml").read_text())
         op = self.execute_operator(task_name, mock_create_job_name, job_spec=job_spec)
 
         mock_fetch_requested_container_logs.assert_called_once_with(

--- a/tests/providers/cncf/kubernetes/operators/test_spark_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/operators/test_spark_kubernetes.py
@@ -51,6 +51,21 @@ def test_spark_kubernetes_operator(mock_kubernetes_hook, data_file):
     assert "hook" not in operator.__dict__  # Cached property has not been accessed as part of construction.
 
 
+def test_init_spark_kubernetes_operator():
+    operator = SparkKubernetesOperator(
+        task_id="task_id",
+        application_file=join(Path(__file__).parent, "spark_application_test.yaml"),
+        kubernetes_conn_id="kubernetes_conn_id",
+        in_cluster=True,
+        cluster_context="cluster_context",
+        config_file="config_file",
+        base_container_name="base",
+        get_logs=True,
+    )
+    assert operator.base_container_name == "spark-kubernetes-driver"
+    assert operator.container_logs == ["spark-kubernetes-driver"]
+
+
 @patch("airflow.providers.cncf.kubernetes.operators.spark_kubernetes.KubernetesHook")
 def test_spark_kubernetes_operator_hook(mock_kubernetes_hook, data_file):
     operator = SparkKubernetesOperator(
@@ -172,6 +187,7 @@ def create_context(task):
     }
 
 
+@patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.fetch_requested_container_logs")
 @patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.await_pod_completion")
 @patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.await_pod_start")
 @patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.create_pod")
@@ -203,6 +219,7 @@ class TestSparkKubernetesOperator:
             template_spec=job_spec,
             kubernetes_conn_id="kubernetes_default_kube_config",
             task_id=task_name,
+            get_logs=True,
         )
         context = create_context(op)
         op.execute(context)
@@ -218,6 +235,7 @@ class TestSparkKubernetesOperator:
         mock_create_pod,
         mock_await_pod_start,
         mock_await_pod_completion,
+        mock_fetch_requested_container_logs,
         data_file,
     ):
         task_name = "default_yaml"
@@ -266,6 +284,7 @@ class TestSparkKubernetesOperator:
         mock_create_pod,
         mock_await_pod_start,
         mock_await_pod_completion,
+        mock_fetch_requested_container_logs,
         data_file,
     ):
         task_name = "default_yaml_template"
@@ -296,6 +315,7 @@ class TestSparkKubernetesOperator:
         mock_create_pod,
         mock_await_pod_start,
         mock_await_pod_completion,
+        mock_fetch_requested_container_logs,
         data_file,
     ):
         task_name = "default_yaml_template"
@@ -322,6 +342,7 @@ class TestSparkKubernetesOperator:
         mock_create_pod,
         mock_await_pod_start,
         mock_await_pod_completion,
+        mock_fetch_requested_container_logs,
         data_file,
     ):
         task_name = "default_env"
@@ -365,6 +386,7 @@ class TestSparkKubernetesOperator:
         mock_create_pod,
         mock_await_pod_start,
         mock_await_pod_completion,
+        mock_fetch_requested_container_logs,
         data_file,
     ):
         task_name = "default_volume"
@@ -410,6 +432,7 @@ class TestSparkKubernetesOperator:
         mock_create_pod,
         mock_await_pod_start,
         mock_await_pod_completion,
+        mock_fetch_requested_container_logs,
         data_file,
     ):
         task_name = "test_pull_secret"
@@ -430,6 +453,7 @@ class TestSparkKubernetesOperator:
         mock_create_pod,
         mock_await_pod_start,
         mock_await_pod_completion,
+        mock_fetch_requested_container_logs,
         data_file,
     ):
         task_name = "test_affinity"
@@ -483,6 +507,7 @@ class TestSparkKubernetesOperator:
         mock_create_pod,
         mock_await_pod_start,
         mock_await_pod_completion,
+        mock_fetch_requested_container_logs,
         data_file,
     ):
         toleration = k8s.V1Toleration(
@@ -498,6 +523,28 @@ class TestSparkKubernetesOperator:
 
         assert op.launcher.body["spec"]["driver"]["tolerations"] == [toleration]
         assert op.launcher.body["spec"]["executor"]["tolerations"] == [toleration]
+
+    def test_get_logs_from_driver(
+        self,
+        mock_create_namespaced_crd,
+        mock_get_namespaced_custom_object_status,
+        mock_cleanup,
+        mock_create_job_name,
+        mock_get_kube_client,
+        mock_create_pod,
+        mock_await_pod_start,
+        mock_await_pod_completion,
+        mock_fetch_requested_container_logs,
+    ):
+        task_name = "test_get_logs_from_driver"
+        job_spec = yaml.safe_load(open(join(Path(__file__).parent, "spark_application_template.yaml")))
+        op = self.execute_operator(task_name, mock_create_job_name, job_spec=job_spec)
+
+        mock_fetch_requested_container_logs.assert_called_once_with(
+            pod=op.pod,
+            containers="spark-kubernetes-driver",
+            follow_logs=True,
+        )
 
 
 @pytest.mark.db_test


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #37681 
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Related logs:
<img width="1036" alt="image" src="https://github.com/apache/airflow/assets/22145541/25cb1e79-7d96-4cbf-ae40-b9cef512ead5">


closes: #37681 

Overriding default BASE_CONTAINER_NAME assigns the `container_logs` attribute correctly in further steps, so that in execution airflow can get logs from the correct container.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
