### PR TITLE
Get rid of lowest-direct resolution in no-constraint upgrades with uv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -529,7 +529,7 @@ function common::get_packaging_tool() {
             export EXTRA_UNINSTALL_FLAGS=""
         fi
         export UPGRADE_EAGERLY="--upgrade --resolution highest"
-        export UPGRADE_IF_NEEDED="--upgrade --resolution lowest-direct"
+        export UPGRADE_IF_NEEDED="--upgrade"
     else
         echo
         echo "${COLOR_BLUE}Using 'pip' to install Airflow${COLOR_RESET}"
@@ -906,7 +906,7 @@ function install_airflow() {
             echo
             echo "${COLOR_YELLOW}Likely pyproject.toml has new dependencies conflicting with constraints.${COLOR_RESET}"
             echo
-            echo "${COLOR_BLUE}Falling back to no-constraints, lowest-direct resolution installation.${COLOR_RESET}"
+            echo "${COLOR_BLUE}Falling back to no-constraints installation.${COLOR_RESET}"
             echo
             set -x
             ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} ${UPGRADE_IF_NEEDED} ${ADDITIONAL_PIP_INSTALL_FLAGS} ${installation_command_flags}

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -476,7 +476,7 @@ function common::get_packaging_tool() {
             export EXTRA_UNINSTALL_FLAGS=""
         fi
         export UPGRADE_EAGERLY="--upgrade --resolution highest"
-        export UPGRADE_IF_NEEDED="--upgrade --resolution lowest-direct"
+        export UPGRADE_IF_NEEDED="--upgrade"
     else
         echo
         echo "${COLOR_BLUE}Using 'pip' to install Airflow${COLOR_RESET}"
@@ -710,7 +710,7 @@ function install_airflow() {
             echo
             echo "${COLOR_YELLOW}Likely pyproject.toml has new dependencies conflicting with constraints.${COLOR_RESET}"
             echo
-            echo "${COLOR_BLUE}Falling back to no-constraints, lowest-direct resolution installation.${COLOR_RESET}"
+            echo "${COLOR_BLUE}Falling back to no-constraints installation.${COLOR_RESET}"
             echo
             set -x
             ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} ${UPGRADE_IF_NEEDED} ${ADDITIONAL_PIP_INSTALL_FLAGS} ${installation_command_flags}

--- a/scripts/docker/common.sh
+++ b/scripts/docker/common.sh
@@ -54,7 +54,7 @@ function common::get_packaging_tool() {
             export EXTRA_UNINSTALL_FLAGS=""
         fi
         export UPGRADE_EAGERLY="--upgrade --resolution highest"
-        export UPGRADE_IF_NEEDED="--upgrade --resolution lowest-direct"
+        export UPGRADE_IF_NEEDED="--upgrade"
     else
         echo
         echo "${COLOR_BLUE}Using 'pip' to install Airflow${COLOR_RESET}"

--- a/scripts/docker/install_airflow.sh
+++ b/scripts/docker/install_airflow.sh
@@ -91,7 +91,7 @@ function install_airflow() {
             echo
             echo "${COLOR_YELLOW}Likely pyproject.toml has new dependencies conflicting with constraints.${COLOR_RESET}"
             echo
-            echo "${COLOR_BLUE}Falling back to no-constraints, lowest-direct resolution installation.${COLOR_RESET}"
+            echo "${COLOR_BLUE}Falling back to no-constraints installation.${COLOR_RESET}"
             echo
             set -x
             ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} ${UPGRADE_IF_NEEDED} ${ADDITIONAL_PIP_INSTALL_FLAGS} ${installation_command_flags}

--- a/scripts/in_container/_in_container_utils.sh
+++ b/scripts/in_container/_in_container_utils.sh
@@ -79,7 +79,7 @@ function in_container_get_packaging_tool() {
             export EXTRA_UNINSTALL_FLAGS=""
         fi
         export UPGRADE_EAGERLY="--upgrade --resolution highest"
-        export UPGRADE_IF_NEEDED="--upgrade --resolution lowest-direct"
+        export UPGRADE_IF_NEEDED="--upgrade"
     else
         echo
         echo "${COLOR_BLUE}Using 'pip' to install Airflow${COLOR_RESET}"


### PR DESCRIPTION
When we fall-back to no-constraint mode in uv, we used so far lowest-direct resolution - but it could cause a really old set of versions to be installed with some strange pyproject.toml errors (for example zenpy==2.0.32 had a buggy pyproject.toml and it caused editable local install to fail.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
