### PR TITLE
Fix Scheduler in daemon mode doesn't create PID at the specified location

### DIFF
--- a/airflow/cli/commands/daemon_utils.py
+++ b/airflow/cli/commands/daemon_utils.py
@@ -48,11 +48,10 @@ def run_command_with_daemon_option(
         If not specified, a file path is generated with the default pattern.
     """
     if args.daemon:
+        pid = pid_file or args.pid if pid_file is not None or args.pid is not None else None
         pid, stdout, stderr, log_file = setup_locations(
-            process=process_name, stdout=args.stdout, stderr=args.stderr, log=args.log_file
+            process=process_name, pid=pid, stdout=args.stdout, stderr=args.stderr, log=args.log_file
         )
-        if pid_file or args.pid:
-            pid = pid_file or args.pid
 
         # Check if the process is already running; if not but a pidfile exists, clean it up
         check_if_pidfile_process_is_running(pid_file=pid, process_name=process_name)

--- a/airflow/cli/commands/daemon_utils.py
+++ b/airflow/cli/commands/daemon_utils.py
@@ -51,8 +51,8 @@ def run_command_with_daemon_option(
         pid, stdout, stderr, log_file = setup_locations(
             process=process_name, stdout=args.stdout, stderr=args.stderr, log=args.log_file
         )
-        if pid_file:
-            pid = pid_file
+        if pid_file or args.pid:
+            pid = pid_file or args.pid
 
         # Check if the process is already running; if not but a pidfile exists, clean it up
         check_if_pidfile_process_is_running(pid_file=pid, process_name=process_name)

--- a/tests/cli/commands/test_celery_command.py
+++ b/tests/cli/commands/test_celery_command.py
@@ -340,6 +340,7 @@ class TestFlowerCommand:
         assert mock_setup_locations.mock_calls == [
             mock.call(
                 process="flower",
+                pid="/tmp/flower.pid",
                 stdout="/tmp/flower-stdout.log",
                 stderr="/tmp/flower-stderr.log",
                 log="/tmp/flower.log",

--- a/tests/cli/commands/test_kerberos_command.py
+++ b/tests/cli/commands/test_kerberos_command.py
@@ -93,6 +93,7 @@ class TestKerberosCommand:
 
         assert mock_setup_locations.mock_calls[0] == mock.call(
             process="kerberos",
+            pid="/tmp/kerberos.pid",
             stdout="/tmp/kerberos-stdout.log",
             stderr="/tmp/kerberos-stderr.log",
             log="/tmp/kerberos.log",


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/38108
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
