### PR TITLE
Fix SparkKubernetesOperator when using initContainers

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/custom_object_launcher.py
+++ b/airflow/providers/cncf/kubernetes/operators/custom_object_launcher.py
@@ -344,7 +344,7 @@ class CustomObjectLauncher(LoggingMixin):
             waiting_message = waiting_status.message
         except Exception:
             return
-        if waiting_reason != "ContainerCreating":
+        if waiting_reason not in ("ContainerCreating", "PodInitializing"):
             raise AirflowException(f"Spark Job Failed. Status: {waiting_reason}, Error: {waiting_message}")
 
     def delete_spark_job(self, spark_job_name=None):

--- a/tests/providers/cncf/kubernetes/operators/test_custom_object_launcher.py
+++ b/tests/providers/cncf/kubernetes/operators/test_custom_object_launcher.py
@@ -38,24 +38,25 @@ from airflow.providers.cncf.kubernetes.operators.custom_object_launcher import (
 @pytest.fixture
 def mock_launcher():
     launcher = CustomObjectLauncher(
-        name='test-spark-job',
-        namespace='default',
+        name="test-spark-job",
+        namespace="default",
         kube_client=MagicMock(),
         custom_obj_api=MagicMock(),
         template_body={
-            'spark': {
-                'spec': {
-                    'image': 'gcr.io/spark-operator/spark-py:v3.0.0',
-                    'driver': {},
-                    'executor': {},
+            "spark": {
+                "spec": {
+                    "image": "gcr.io/spark-operator/spark-py:v3.0.0",
+                    "driver": {},
+                    "executor": {},
                 },
-                'apiVersion': 'sparkoperator.k8s.io/v1beta2',
-                'kind': 'SparkApplication',
+                "apiVersion": "sparkoperator.k8s.io/v1beta2",
+                "kind": "SparkApplication",
             },
         },
     )
     launcher.pod_spec = V1Pod()
     return launcher
+
 
 class TestSparkJobSpec:
     @patch("airflow.providers.cncf.kubernetes.operators.custom_object_launcher.SparkJobSpec.update_resources")
@@ -181,14 +182,15 @@ class TestSparkResources:
         assert spark_resources.driver["gpu"]["quantity"] == 1
         assert spark_resources.executor["gpu"]["quantity"] == 2
 
+
 class TestCustomObjectLauncher:
     def get_pod_status(self, reason: str, message: str | None = None):
         return V1PodStatus(
             container_statuses=[
                 V1ContainerStatus(
-                    image='test',
-                    image_id='test',
-                    name='test',
+                    image="test",
+                    image_id="test",
+                    name="test",
                     ready=False,
                     restart_count=0,
                     state=V1ContainerState(
@@ -201,26 +203,18 @@ class TestCustomObjectLauncher:
             ]
         )
 
-    @patch(
-        'airflow.providers.cncf.kubernetes.operators.custom_object_launcher.PodManager'
-    )
+    @patch("airflow.providers.cncf.kubernetes.operators.custom_object_launcher.PodManager")
     def test_check_pod_start_failure_no_error(self, mock_pod_manager, mock_launcher):
-        mock_pod_manager.return_value.read_pod.return_value.status = self.get_pod_status(
-            'ContainerCreating'
-        )
+        mock_pod_manager.return_value.read_pod.return_value.status = self.get_pod_status("ContainerCreating")
         mock_launcher.check_pod_start_failure()
 
-        mock_pod_manager.return_value.read_pod.return_value.status = self.get_pod_status(
-            'PodInitializing'
-        )
+        mock_pod_manager.return_value.read_pod.return_value.status = self.get_pod_status("PodInitializing")
         mock_launcher.check_pod_start_failure()
 
-    @patch(
-        'airflow.providers.cncf.kubernetes.operators.custom_object_launcher.PodManager'
-    )
+    @patch("airflow.providers.cncf.kubernetes.operators.custom_object_launcher.PodManager")
     def test_check_pod_start_failure_with_error(self, mock_pod_manager, mock_launcher):
         mock_pod_manager.return_value.read_pod.return_value.status = self.get_pod_status(
-            'CrashLoopBackOff', 'Error message'
+            "CrashLoopBackOff", "Error message"
         )
         with pytest.raises(AirflowException):
             mock_launcher.check_pod_start_failure()

--- a/tests/providers/cncf/kubernetes/operators/test_custom_object_launcher.py
+++ b/tests/providers/cncf/kubernetes/operators/test_custom_object_launcher.py
@@ -16,16 +16,46 @@
 # under the License.
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+from kubernetes.client import (
+    V1ContainerState,
+    V1ContainerStateWaiting,
+    V1ContainerStatus,
+    V1Pod,
+    V1PodStatus,
+)
 
 from airflow.exceptions import AirflowException
 from airflow.providers.cncf.kubernetes.operators.custom_object_launcher import (
+    CustomObjectLauncher,
     SparkJobSpec,
     SparkResources,
 )
 
+
+@pytest.fixture
+def mock_launcher():
+    launcher = CustomObjectLauncher(
+        name='test-spark-job',
+        namespace='default',
+        kube_client=MagicMock(),
+        custom_obj_api=MagicMock(),
+        template_body={
+            'spark': {
+                'spec': {
+                    'image': 'gcr.io/spark-operator/spark-py:v3.0.0',
+                    'driver': {},
+                    'executor': {},
+                },
+                'apiVersion': 'sparkoperator.k8s.io/v1beta2',
+                'kind': 'SparkApplication',
+            },
+        },
+    )
+    launcher.pod_spec = V1Pod()
+    return launcher
 
 class TestSparkJobSpec:
     @patch("airflow.providers.cncf.kubernetes.operators.custom_object_launcher.SparkJobSpec.update_resources")
@@ -150,3 +180,47 @@ class TestSparkResources:
         assert spark_resources.executor["cpu"]["limit"] == "4"
         assert spark_resources.driver["gpu"]["quantity"] == 1
         assert spark_resources.executor["gpu"]["quantity"] == 2
+
+class TestCustomObjectLauncher:
+    def get_pod_status(self, reason: str, message: str | None = None):
+        return V1PodStatus(
+            container_statuses=[
+                V1ContainerStatus(
+                    image='test',
+                    image_id='test',
+                    name='test',
+                    ready=False,
+                    restart_count=0,
+                    state=V1ContainerState(
+                        waiting=V1ContainerStateWaiting(
+                            reason=reason,
+                            message=message,
+                        ),
+                    ),
+                ),
+            ]
+        )
+
+    @patch(
+        'airflow.providers.cncf.kubernetes.operators.custom_object_launcher.PodManager'
+    )
+    def test_check_pod_start_failure_no_error(self, mock_pod_manager, mock_launcher):
+        mock_pod_manager.return_value.read_pod.return_value.status = self.get_pod_status(
+            'ContainerCreating'
+        )
+        mock_launcher.check_pod_start_failure()
+
+        mock_pod_manager.return_value.read_pod.return_value.status = self.get_pod_status(
+            'PodInitializing'
+        )
+        mock_launcher.check_pod_start_failure()
+
+    @patch(
+        'airflow.providers.cncf.kubernetes.operators.custom_object_launcher.PodManager'
+    )
+    def test_check_pod_start_failure_with_error(self, mock_pod_manager, mock_launcher):
+        mock_pod_manager.return_value.read_pod.return_value.status = self.get_pod_status(
+            'CrashLoopBackOff', 'Error message'
+        )
+        with pytest.raises(AirflowException):
+            mock_launcher.check_pod_start_failure()


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
I found this error while trying to use `initContainers` with spark job after upgrading `apache-airflow-providers-cncf-kubernetes`  to `8.0.1` (reproducible on `8.0.0` as well).
```
[2024-03-13, 11:36:49 UTC] {custom_object_launcher.py:312} ERROR - Exception when attempting to create spark job
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.11/site-packages/airflow/providers/cncf/kubernetes/operators/custom_object_launcher.py", line 305, in start_spark_job
    self.check_pod_start_failure()
  File "/home/airflow/.local/lib/python3.11/site-packages/airflow/providers/cncf/kubernetes/operators/custom_object_launcher.py", line 348, in check_pod_start_failure
    raise AirflowException(f"Spark Job Failed. Status: {waiting_reason}, Error: {waiting_message}")
airflow.exceptions.AirflowException: Spark Job Failed. Status: PodInitializing, Error: None
[2024-03-13, 11:36:49 UTC] {taskinstance.py:2728} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.11/site-packages/airflow/models/taskinstance.py", line 439, in _execute_task
    result = _execute_callable(context=context, **execute_callable_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.11/site-packages/airflow/models/taskinstance.py", line 414, in _execute_callable
    return execute_callable(context=context, **execute_callable_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.11/site-packages/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py", line 265, in execute
    self.pod = self.get_or_create_spark_crd(self.launcher, context)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.11/site-packages/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py", line 223, in get_or_create_spark_crd
    driver_pod, spark_obj_spec = launcher.start_spark_job(
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.11/site-packages/tenacity/__init__.py", line 289, in wrapped_f
    return self(f, *args, **kw)
           ^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.11/site-packages/tenacity/__init__.py", line 379, in __call__
    do = self.iter(retry_state=retry_state)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.11/site-packages/tenacity/__init__.py", line 314, in iter
    return fut.result()
           ^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/home/airflow/.local/lib/python3.11/site-packages/tenacity/__init__.py", line 382, in __call__
    result = fn(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.11/site-packages/airflow/providers/cncf/kubernetes/operators/custom_object_launcher.py", line 313, in start_spark_job
    raise e
  File "/home/airflow/.local/lib/python3.11/site-packages/airflow/providers/cncf/kubernetes/operators/custom_object_launcher.py", line 305, in start_spark_job
    self.check_pod_start_failure()
  File "/home/airflow/.local/lib/python3.11/site-packages/airflow/providers/cncf/kubernetes/operators/custom_object_launcher.py", line 348, in check_pod_start_failure
    raise AirflowException(f"Spark Job Failed. Status: {waiting_reason}, Error: {waiting_message}")
airflow.exceptions.AirflowException: Spark Job Failed. Status: PodInitializing, Error: None
```
Using a patched operator with these changes helped to overcome the issue.
There might be other statutes to be included in this check.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
