### PR TITLE
Add dataset_expression to grid dag details

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3830,6 +3830,10 @@ components:
             dag_run_timeout:
               $ref: "#/components/schemas/TimeDelta"
               nullable: true
+            dataset_expression:
+              type: object
+              description: Nested dataset any/all conditions
+              nullable: true
             doc_md:
               type: string
               readOnly: true

--- a/airflow/www/static/js/dag/details/dag/Dag.tsx
+++ b/airflow/www/static/js/dag/details/dag/Dag.tsx
@@ -242,6 +242,22 @@ const Dag = () => {
                 </Td>
                 <Td />
               </Tr>
+              {!!dagDetailsData.datasetExpression && (
+                <Tr>
+                  <Td>Dataset Conditions</Td>
+                  <Td>
+                    <Code>
+                      <pre>
+                        {JSON.stringify(
+                          dagDetailsData.datasetExpression,
+                          null,
+                          2
+                        )}
+                      </pre>
+                    </Code>
+                  </Td>
+                </Tr>
+              )}
               {renderDagDetailsData(dagDetailsData, dagDataExcludeFields)}
               <Tr>
                 <Td>Owners</Td>

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1536,6 +1536,8 @@ export interface components {
        */
       start_date?: string | null;
       dag_run_timeout?: components["schemas"]["TimeDelta"] | null;
+      /** @description Nested dataset any/all conditions */
+      dataset_expression?: { [key: string]: unknown } | null;
       doc_md?: string | null;
       default_view?: string | null;
       /**


### PR DESCRIPTION
Add dataset_expression to API schema and use it in the DAG Details page:


Later on, we can actually parse the expression and link to the datasets.

<img width="557" alt="Screenshot 2024-03-13 at 10 30 48 AM" src="https://github.com/apache/airflow/assets/4600967/9d8914aa-2b59-4f5f-815c-a4900a34c2a3">





---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
