### PR TITLE
Add dataset conditions to next run datasets modal

### DIFF
--- a/airflow/www/static/js/datasetUtils.js
+++ b/airflow/www/static/js/datasetUtils.js
@@ -21,19 +21,18 @@
 
 import { getMetaValue } from "./utils";
 
-export function openDatasetModal(
-  dagId,
-  summary = "",
-  nextDatasets = [],
-  error = null
-) {
+export function openDatasetModal(dagId, summary, nextDatasets, error) {
+  const datasetEvents = nextDatasets.events || [];
+  const expression = nextDatasets.dataset_expression;
   const datasetsUrl = getMetaValue("datasets_url");
+  $("#dataset_expression").empty();
   $("#datasets_tbody").empty();
   $("#datasets_error").hide();
   $("#dag_id").text(dagId);
+  $("#dataset_expression").text(JSON.stringify(expression, null, 2));
   $("#datasetNextRunModal").modal({});
-  $("#next_run_summary").text(summary);
-  nextDatasets.forEach((d) => {
+  if (summary) $("#next_run_summary").text(summary);
+  datasetEvents.forEach((d) => {
     const row = document.createElement("tr");
 
     const uriCell = document.createElement("td");
@@ -63,11 +62,12 @@ export function getDatasetTooltipInfo(dagId, run, setNextDatasets) {
       nextRunUrl = nextRunUrl.replace("__DAG_ID__", dagId);
     }
     $.get(nextRunUrl)
-      .done((datasets) => {
+      .done((nextDatasets) => {
+        const datasetEvents = nextDatasets.events;
         let count = 0;
         let title = "<strong>Pending datasets:</strong><br>";
-        setNextDatasets(datasets);
-        datasets.forEach((d) => {
+        setNextDatasets(nextDatasets);
+        datasetEvents.forEach((d) => {
           if (!d.created_at) {
             if (count < 4) title += `${d.uri}<br>`;
             count += 1;

--- a/airflow/www/templates/airflow/dataset_next_run_modal.html
+++ b/airflow/www/templates/airflow/dataset_next_run_modal.html
@@ -30,6 +30,8 @@
           </h4>
         </div>
         <div class="modal-body">
+          <strong>Conditions</strong>
+          <p><pre id="dataset_expression"></pre></p>
           <p id="next_run_summary"></p>
           {{ loading_dots(id='datasets-loading-dots', classes='refresh-loading') }}
           <div id="datasets_error" style="display: none; margin-top: 10px;" class="alert alert-danger" role="alert">

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3693,7 +3693,9 @@ class Airflow(AirflowBaseView):
             return {"error": f"can't find dag {dag_id}"}, 404
 
         with create_session() as session:
-            data = [
+            dag_model = DagModel.get_dagmodel(dag_id, session=session)
+
+            events = [
                 dict(info)
                 for info in session.execute(
                     select(
@@ -3722,6 +3724,7 @@ class Airflow(AirflowBaseView):
                     .order_by(DatasetModel.uri)
                 )
             ]
+            data = {"dataset_expression": dag_model.dataset_expression, "events": events}
         return (
             htmlsafe_json_dumps(data, separators=(",", ":"), dumps=flask.json.dumps),
             {"Content-Type": "application/json; charset=utf-8"},

--- a/tests/www/views/test_views_grid.py
+++ b/tests/www/views/test_views_grid.py
@@ -500,10 +500,13 @@ def test_next_run_datasets(admin_client, dag_maker, session, app, monkeypatch):
         resp = admin_client.get(f"/object/next_run_datasets/{DAG_ID}", follow_redirects=True)
 
     assert resp.status_code == 200, resp.json
-    assert resp.json == [
-        {"id": ds1_id, "uri": "s3://bucket/key/1", "lastUpdate": "2022-08-02T02:00:00+00:00"},
-        {"id": ds2_id, "uri": "s3://bucket/key/2", "lastUpdate": None},
-    ]
+    assert resp.json == {
+        "dataset_expression": {"all": ["s3://bucket/key/1", "s3://bucket/key/2"]},
+        "events": [
+            {"id": ds1_id, "uri": "s3://bucket/key/1", "lastUpdate": "2022-08-02T02:00:00+00:00"},
+            {"id": ds2_id, "uri": "s3://bucket/key/2", "lastUpdate": None},
+        ],
+    }
 
 
 def test_next_run_datasets_404(admin_client):


### PR DESCRIPTION
Add dataset expression to the next run datasets modal:

<img width="612" alt="Screenshot 2024-03-13 at 10 52 29 AM" src="https://github.com/apache/airflow/assets/4600967/6050b06c-8ec9-4437-937c-3de83f2fc1df">

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
