### PR TITLE
Fix unhandled exceptions in the Triggerer tests

### DIFF
--- a/tests/jobs/test_triggerer_job.py
+++ b/tests/jobs/test_triggerer_job.py
@@ -52,20 +52,20 @@ from tests.test_utils.db import clear_db_dags, clear_db_runs
 pytestmark = pytest.mark.db_test
 
 
-@pytest.fixture(autouse=True)
+class QueueListener_(logging.handlers.QueueListener):
+    def __init__(self, queue, *handlers, respect_handler_level):
+        no_console_handlers = []
+        for h in handlers:
+            if h.name != "console":
+                no_console_handlers.append(h)
+        super().__init__(queue, *no_console_handlers, respect_handler_level=respect_handler_level)
+
+
+@pytest.fixture(scope="module", autouse=True)
 def disable_console_handler():
     """
     Prevent console handler from getting bound to the trigger_job_runner when setup_queue_listener is called during tests
     """
-
-    class QueueListener_(logging.handlers.QueueListener):
-        def __init__(self, queue, *handlers, respect_handler_level):
-            no_console_handlers = []
-            for h in handlers:
-                if h.name != "console":
-                    no_console_handlers.append(h)
-            super().__init__(queue, *no_console_handlers, respect_handler_level=respect_handler_level)
-
     with patch("logging.handlers.QueueListener", QueueListener_):
         yield
 

--- a/tests/jobs/test_triggerer_job.py
+++ b/tests/jobs/test_triggerer_job.py
@@ -54,10 +54,7 @@ pytestmark = pytest.mark.db_test
 
 class QueueListener_(logging.handlers.QueueListener):
     def __init__(self, queue, *handlers, respect_handler_level):
-        no_console_handlers = []
-        for h in handlers:
-            if h.name != "console":
-                no_console_handlers.append(h)
+        no_console_handlers = (h for h in handlers if h.name != "console")
         super().__init__(queue, *no_console_handlers, respect_handler_level=respect_handler_level)
 
 
@@ -152,8 +149,6 @@ def test_trigger_logging_sensitive_info(session, caplog):
     triggerer_job_runner.load_triggers()
     # Now, start TriggerRunner up (and set it as a daemon thread during tests)
     triggerer_job_runner.daemon = True
-    # set job_id so that it can be used by FileTaskHandler.add_triggerer_suffix
-    triggerer_job_runner.trigger_runner.job_id = triggerer_job.id
     triggerer_job_runner.trigger_runner.start()
     try:
         # Wait for up to 3 seconds for it to fire and appear in the event queue
@@ -260,8 +255,6 @@ def test_trigger_lifecycle(session):
     assert [x for x, y in job_runner.trigger_runner.to_create] == [1]
     # Now, start TriggerRunner up (and set it as a daemon thread during tests)
     job_runner.daemon = True
-    # set job_id so that it can be used by FileTaskHandler.add_triggerer_suffix
-    job_runner.trigger_runner.job_id = job.id
     job_runner.trigger_runner.start()
     try:
         # Wait for up to 3 seconds for it to appear in the TriggerRunner's storage
@@ -430,8 +423,6 @@ def test_trigger_create_race_condition_18392(session, tmp_path):
     job.prepare_for_execution()
     job_runner = TriggererJob_(job)
     job_runner.trigger_runner = TriggerRunner_()
-    # set job_id so that it can be used by FileTaskHandler.add_triggerer_suffix
-    job_runner.trigger_runner.job_id = job.id
     thread = Thread(target=job_runner._execute)
     thread.start()
     try:
@@ -570,8 +561,6 @@ def test_trigger_firing(session):
     job.prepare_for_execution()
     job_runner = TriggererJobRunner(job)
     job_runner.load_triggers()
-    # set job_id so that it can be used by FileTaskHandler.add_triggerer_suffix
-    job_runner.trigger_runner.job_id = job.id
     # Now, start TriggerRunner up (and set it as a daemon thread during tests)
     job_runner.daemon = True
     job_runner.trigger_runner.start()

--- a/tests/models/test_trigger.py
+++ b/tests/models/test_trigger.py
@@ -142,10 +142,12 @@ def test_submit_failure(session, create_task_instance):
     assert updated_task_instance.next_method == "__fail__"
 
 
-def test_assign_unassigned(session, create_task_instance):
+def test_assign_unassigned(session, create_task_instance, monkeypatch):
     """
     Tests that unassigned triggers of all appropriate states are assigned.
     """
+    # disable QueueListener to prevent logging during tests
+    monkeypatch.setattr("airflow.jobs.triggerer_job_runner.DISABLE_LISTENER", True)
     time_now = timezone.utcnow()
     triggerer_heartrate = 10
     finished_triggerer = Job(heartrate=triggerer_heartrate, state=State.SUCCESS)


### PR DESCRIPTION
Created a new PR based on #37927 where the feature branch merge got messed up...

Fix for unhandled exceptions raised in the triggerer tests on the queue listener thread.

The queue listener was being killed due to missing a reference to the triggerer_job. Fixing this resulted in console logging during tests. So changes also include disabling the console logging handler / queue listener during tests.

Also fixed a bug in tests/jobs/test_triggerer_job.py::test_trigger_create_race_condition_18392 which caused another unhandled exception.

---

```
tests/jobs/test_triggerer_job.py::test_trigger_logging_sensitive_info                                                                                                               
  /usr/local/lib/python3.8/site-packages/_pytest/threadexception.py:73: PytestUnhandledThreadExceptionWarning: Exception in thread Thread-3                                         
                                                                                                                                                                                    
  Traceback (most recent call last):                                                                                                                                                
    File "/usr/local/lib/python3.8/threading.py", line 932, in _bootstrap_inner                                                                                                     
      self.run()                                                                                                                                                                    
    File "/usr/local/lib/python3.8/threading.py", line 870, in run                                                                                                                  
      self._target(*self._args, **self._kwargs)                                                                                                                                     
    File "/usr/local/lib/python3.8/logging/handlers.py", line 1487, in _monitor                                                                                                     
      self.handle(record)                                                                                                                                                           
    File "/usr/local/lib/python3.8/logging/handlers.py", line 1468, in handle                                                                                                       
      handler.handle(record)                                                                                                                                                        
    File "/opt/airflow/airflow/utils/log/trigger_handler.py", line 107, in handle                                                                                                   
      self.emit(record)                                                                                                                                                             
    File "/opt/airflow/airflow/utils/log/trigger_handler.py", line 96, in emit                                                                                                      
      h = self._get_or_create_handler(record.trigger_id, record.task_instance)                                                                                                      
    File "/opt/airflow/airflow/utils/log/trigger_handler.py", line 92, in _get_or_create_handler                                                                                    
      self.handlers[trigger_id] = self._make_handler(ti)                                                                                                                            
    File "/opt/airflow/airflow/utils/log/trigger_handler.py", line 87, in _make_handler                                                                                             
      h.set_context(ti=ti)                                                                                                                                                          
    File "/opt/airflow/airflow/utils/log/file_task_handler.py", line 243, in set_context                                                                                            
      local_loc = self._init_file(ti, identifier=identifier)                                                                                                                        
    File "/opt/airflow/airflow/utils/log/file_task_handler.py", line 533, in _init_file                                                                                             
      full_path = self.add_triggerer_suffix(full_path=full_path, job_id=ti.triggerer_job.id)                                                                                        
  AttributeError: 'NoneType' object has no attribute 'id'                                                                                                                           
                                                                                                                                                                                    
    warnings.warn(pytest.PytestUnhandledThreadExceptionWarning(msg))                                                                                                                
                                                                                                                                                                                    
tests/jobs/test_triggerer_job.py::test_trigger_lifecycle                                                                                                                            
  /usr/local/lib/python3.8/site-packages/_pytest/threadexception.py:73: PytestUnhandledThreadExceptionWarning: Exception in thread Thread-11                                        
                                                                                                                                                                                    
  Traceback (most recent call last):                                                                                                                                                
    File "/usr/local/lib/python3.8/threading.py", line 932, in _bootstrap_inner                                                                                                     
      self.run()                                                                                                                                                                    
    File "/usr/local/lib/python3.8/threading.py", line 870, in run
      self._target(*self._args, **self._kwargs)
    File "/usr/local/lib/python3.8/logging/handlers.py", line 1487, in _monitor
      self.handle(record)
    File "/usr/local/lib/python3.8/logging/handlers.py", line 1468, in handle
      handler.handle(record)
    File "/opt/airflow/airflow/utils/log/trigger_handler.py", line 107, in handle
      self.emit(record)
    File "/opt/airflow/airflow/utils/log/trigger_handler.py", line 96, in emit
      h = self._get_or_create_handler(record.trigger_id, record.task_instance)
    File "/opt/airflow/airflow/utils/log/trigger_handler.py", line 92, in _get_or_create_handler
      self.handlers[trigger_id] = self._make_handler(ti)
    File "/opt/airflow/airflow/utils/log/trigger_handler.py", line 87, in _make_handler
      h.set_context(ti=ti)
    File "/opt/airflow/airflow/utils/log/file_task_handler.py", line 243, in set_context
      local_loc = self._init_file(ti, identifier=identifier)
    File "/opt/airflow/airflow/utils/log/file_task_handler.py", line 533, in _init_file
      full_path = self.add_triggerer_suffix(full_path=full_path, job_id=ti.triggerer_job.id)
  AttributeError: 'NoneType' object has no attribute 'id'


tests/jobs/test_triggerer_job.py::test_trigger_create_race_condition_18392
  /usr/local/lib/python3.8/site-packages/_pytest/threadexception.py:73: PytestUnhandledThreadExceptionWarning: Exception in thread Thread-19
   
  Traceback (most recent call last):
    File "/usr/local/lib/python3.8/threading.py", line 932, in _bootstrap_inner
      self.run()
    File "/usr/local/lib/python3.8/threading.py", line 870, in run
      self._target(*self._args, **self._kwargs)
    File "/opt/airflow/airflow/jobs/triggerer_job_runner.py", line 341, in _execute
      self._run_trigger_loop()
    File "/opt/airflow/airflow/jobs/triggerer_job_runner.py", line 364, in _run_trigger_loop
      self.load_triggers()
    File "/opt/airflow/tests/jobs/test_triggerer_job.py", line 376, in load_triggers
      self.wait_for_runner_loop(runner_loop_count=2)
    File "/opt/airflow/tests/jobs/test_triggerer_job.py", line 367, in wait_for_runner_loop
      pytest.fail("did not observe 2 loops in the runner thread")
    File "/usr/local/lib/python3.8/site-packages/_pytest/outcomes.py", line 198, in fail
      raise Failed(msg=reason, pytrace=pytrace)
  Failed: did not observe 2 loops in the runner thread
   
    warnings.warn(pytest.PytestUnhandledThreadExceptionWarning(msg))
                                                                                                              
                                                                                                                                                                         
tests/jobs/test_triggerer_job.py::test_trigger_firing                                                                                                                               
  /usr/local/lib/python3.8/site-packages/_pytest/threadexception.py:73: PytestUnhandledThreadExceptionWarning: Exception in thread Thread-28                                        
                                                                                                                                                                                    
  Traceback (most recent call last):                                                                                                                                                
    File "/usr/local/lib/python3.8/threading.py", line 932, in _bootstrap_inner                                                                                                     
      self.run()                                                                                                                                                                    
    File "/usr/local/lib/python3.8/threading.py", line 870, in run                                                                                                                  
      self._target(*self._args, **self._kwargs)                                                                                                                                     
    File "/usr/local/lib/python3.8/logging/handlers.py", line 1487, in _monitor                                                                                                     
      self.handle(record)                                                                                                                                                           
    File "/usr/local/lib/python3.8/logging/handlers.py", line 1468, in handle                                                                                                       
      handler.handle(record)                                                                                                                                                        
    File "/opt/airflow/airflow/utils/log/trigger_handler.py", line 107, in handle                                                                                                   
      self.emit(record)                                                                                                                                                             
    File "/opt/airflow/airflow/utils/log/trigger_handler.py", line 96, in emit                                                                                                      
      h = self._get_or_create_handler(record.trigger_id, record.task_instance)                                                                                                      
    File "/opt/airflow/airflow/utils/log/trigger_handler.py", line 92, in _get_or_create_handler                                                                                    
      self.handlers[trigger_id] = self._make_handler(ti)                                                                                                                            
    File "/opt/airflow/airflow/utils/log/trigger_handler.py", line 87, in _make_handler                                                                                             
      h.set_context(ti=ti)                                                                                                                                                          
    File "/opt/airflow/airflow/utils/log/file_task_handler.py", line 243, in set_context                                                                                            
      local_loc = self._init_file(ti, identifier=identifier)
    File "/opt/airflow/airflow/utils/log/file_task_handler.py", line 533, in _init_file
      full_path = self.add_triggerer_suffix(full_path=full_path, job_id=ti.triggerer_job.id)
  AttributeError: 'NoneType' object has no attribute 'id'
   
    warnings.warn(pytest.PytestUnhandledThreadExceptionWarning(msg))

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```