### PR TITLE
Fix XComObjectStoreBackend config var in docs and bug when xcom_objectstore_compression is empty

### DIFF
--- a/airflow/providers/common/io/provider.yaml
+++ b/airflow/providers/common/io/provider.yaml
@@ -53,14 +53,14 @@ config:
   common.io:
     description: Common IO configuration section
     options:
-      xcom_objectstorage_path:
+      xcom_objectstore_path:
         description: |
           Path to a location on object storage where XComs can be stored in url format.
         version_added: 1.3.0
         type: string
         example: "s3://conn_id@bucket/path"
         default: ""
-      xcom_objectstorage_threshold:
+      xcom_objectstore_threshold:
         description: |
           Threshold in bytes for storing XComs in object storage. -1 means always store in the
           database. 0 means always store in object storage. Any positive number means
@@ -69,7 +69,7 @@ config:
         type: integer
         example: "1000000"
         default: "-1"
-      xcom_objectstorage_compression:
+      xcom_objectstore_compression:
         description: |
           Compression algorithm to use when storing XComs in object storage. Supported algorithms
           are a.o.: snappy, zip, gzip, bz2, and lzma. If not specified, no compression will be used.

--- a/airflow/providers/common/io/xcom/backend.py
+++ b/airflow/providers/common/io/xcom/backend.py
@@ -122,6 +122,7 @@ class XComObjectStoreBackend(BaseXCom):
             suffix = "." + _get_compression_suffix(compression)
         else:
             suffix = ""
+            compression = None
 
         threshold = conf.getint(SECTION, "xcom_objectstore_threshold", fallback=-1)
 

--- a/docs/apache-airflow-providers-common-io/xcom_backend.rst
+++ b/docs/apache-airflow-providers-common-io/xcom_backend.rst
@@ -20,11 +20,11 @@ Object Storage XCom Backend
 
 The default XCom backend is the :class:`~airflow.models.xcom.BaseXCom` class, which stores XComs in the Airflow database. This is fine for small values, but can be problematic for large values, or for large numbers of XComs.
 
-To enable storing XComs in an object store, you can set the ``xcom_backend`` configuration option to ``airflow.providers.common.io.xcom.backend.XComObjectStoreBackend``. You will also need to set ``xcom_objectstorage_path`` to the desired location. The connection
-id is obtained from the user part of the url the you will provide, e.g. ``xcom_objectstorage_path = s3://conn_id@mybucket/key``. Furthermore, ``xcom_objectstorage_threshold`` is required
+To enable storing XComs in an object store, you can set the ``xcom_backend`` configuration option to ``airflow.providers.common.io.xcom.backend.XComObjectStoreBackend``. You will also need to set ``xcom_objectstore_path`` to the desired location. The connection
+id is obtained from the user part of the url the you will provide, e.g. ``xcom_objectstore_path = s3://conn_id@mybucket/key``. Furthermore, ``xcom_objectstore_threshold`` is required
 to be something larger than -1. Any object smaller than the threshold in bytes will be stored in the database and anything larger will be be
 put in object storage. This will allow a hybrid setup. If an xcom is stored on object storage a reference will be
-saved in the database. Finally, you can set ``xcom_objectstorage_compression`` to fsspec supported compression methods like ``zip`` or ``snappy`` to
+saved in the database. Finally, you can set ``xcom_objectstore_compression`` to fsspec supported compression methods like ``zip`` or ``snappy`` to
 compress the data before storing it in object storage.
 
 So for example the following configuration will store anything above 1MB in S3 and will compress it using gzip::
@@ -33,9 +33,9 @@ So for example the following configuration will store anything above 1MB in S3 a
       xcom_backend = airflow.providers.common.io.xcom.backend.XComObjectStoreBackend
 
       [common.io]
-      xcom_objectstorage_path = s3://conn_id@mybucket/key
-      xcom_objectstorage_threshold = 1048576
-      xcom_objectstorage_compression = gzip
+      xcom_objectstore_path = s3://conn_id@mybucket/key
+      xcom_objectstore_threshold = 1048576
+      xcom_objectstore_compression = gzip
 
 .. note::
 

--- a/docs/apache-airflow/core-concepts/xcoms.rst
+++ b/docs/apache-airflow/core-concepts/xcoms.rst
@@ -64,11 +64,11 @@ Object Storage XCom Backend
 
 The default XCom backend is the :class:`~airflow.models.xcom.BaseXCom` class, which stores XComs in the Airflow database. This is fine for small values, but can be problematic for large values, or for large numbers of XComs.
 
-To enable storing XComs in an object store, you can set the ``xcom_backend`` configuration option to ``airflow.providers.common.io.xcom.backend.XComObjectStoreBackend``. You will also need to set ``xcom_objectstorage_path`` to the desired location. The connection
-id is obtained from the user part of the url the you will provide, e.g. ``xcom_objectstorage_path = s3://conn_id@mybucket/key``. Furthermore, ``xcom_objectstorage_threshold`` is required
+To enable storing XComs in an object store, you can set the ``xcom_backend`` configuration option to ``airflow.providers.common.io.xcom.backend.XComObjectStoreBackend``. You will also need to set ``xcom_objectstore_path`` to the desired location. The connection
+id is obtained from the user part of the url the you will provide, e.g. ``xcom_objectstorage_path = s3://conn_id@mybucket/key``. Furthermore, ``xcom_objectstore_threshold`` is required
 to be something larger than -1. Any object smaller than the threshold in bytes will be stored in the database and anything larger will be be
 put in object storage. This will allow a hybrid setup. If an xcom is stored on object storage a reference will be
-saved in the database. Finally, you can set ``xcom_objectstorage_compression`` to fsspec supported compression methods like ``zip`` or ``snappy`` to
+saved in the database. Finally, you can set ``xcom_objectstore_compression`` to fsspec supported compression methods like ``zip`` or ``snappy`` to
 compress the data before storing it in object storage.
 
 So for example the following configuration will store anything above 1MB in S3 and will compress it using gzip::
@@ -77,9 +77,9 @@ So for example the following configuration will store anything above 1MB in S3 a
       xcom_backend = airflow.providers.common.io.xcom.backend.XComObjectStoreBackend
 
       [common.io]
-      xcom_objectstorage_path = s3://conn_id@mybucket/key
-      xcom_objectstorage_threshold = 1048576
-      xcom_objectstorage_compression = gzip
+      xcom_objectstore_path = s3://conn_id@mybucket/key
+      xcom_objectstore_threshold = 1048576
+      xcom_objectstore_compression = gzip
 
 
 .. note::

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1092,6 +1092,7 @@ oauth
 Oauthlib
 objectORfile
 objectstorage
+objectstore
 observability
 od
 odbc


### PR DESCRIPTION
Look like the XComObjectStoreBackend config
variables are incorrect in docs or updated but 
the docs still have old names. The  implementation
code `*store*` but docs has `*storage*` 

https://github.com/apache/airflow/blob/191b5c30e68566a75f67aefc860f59573b79bed6/airflow/providers/common/io/xcom/backend.py#L106-L143

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

Also, tests are when xcom_objectstore_compression an empty string so I have set it to None if it empty string 



<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
