### PR TITLE
Remove unnecessary cache for MyPy jobs

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -79,15 +79,6 @@ jobs:
         with:
           python-version: ${{ inputs.breeze-python-version }}
         if: inputs.needs-mypy == 'true'
-      - name: Cache pre-commit envs
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pre-commit
-          # yamllint disable-line rule:line-length
-          key: "pre-commit-${{steps.breeze.outputs.host-python-version}}-${{ hashFiles('.pre-commit-config.yaml') }}"
-          restore-keys: |
-            pre-commit-${{steps.breeze.outputs.host-python-version}}-
-        if: inputs.needs-mypy == 'true'
       - name: "MyPy checks for ${{ matrix.mypy-folder }}"
         run: |
           pip install pre-commit
@@ -98,4 +89,5 @@ jobs:
           SKIP_GROUP_OUTPUT: "true"
           DEFAULT_BRANCH: ${{ inputs.default-branch }}
           RUFF_FORMAT: "github"
+          INCLUDE_MYPY_VOLUME: "false"
         if: inputs.needs-mypy == 'true'

--- a/scripts/ci/pre_commit/pre_commit_mypy_folder.py
+++ b/scripts/ci/pre_commit/pre_commit_mypy_folder.py
@@ -53,7 +53,7 @@ res = run_command_via_breeze_shell(
     ],
     warn_image_upgrade_needed=True,
     extra_env={
-        "INCLUDE_MYPY_VOLUME": "true",
+        "INCLUDE_MYPY_VOLUME": os.environ.get("INCLUDE_MYPY_VOLUME", "true"),
         # Need to mount local sources when running it - to not have to rebuild the image
         # and to let CI work on it when running on PRs from forks - because mypy-dev uses files
         # that are not available at the time when image is built in CI


### PR DESCRIPTION
The MyPy jobs started to fail pretty randomly in docs and dev builds and the main suspect for that is cache - either pre-commit cache or docker cache stored locally in docker volume.

We can actually disable the cache, because a) pre-commit cache is not really needed for this job as we only one venv to create and b) the docker volume cache in case of CI job is at most harmless as we exect to start all jobs from a clean state.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
