### PR TITLE
Add config to avoid one DAG run when unpausing a DAG with catchup=False

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2270,6 +2270,20 @@ scheduler:
       type: boolean
       example: ~
       default: "True"
+    catchup_false_no_dagrun_airflow_2_fix:
+      description: |
+        Prevent built-in timetables from immediately running one DAG run when first unpausing a DAG with
+        ``catchup=False``. This is a temporary fix introduced in Airflow 2.9.0 which will be removed in
+        Airflow 3.0.0, where this will become the default behaviour.
+      version_added: 2.9.0
+      version_deprecated: 2.9.0
+      deprecation_reason: |
+        This option is a temporary solution to enable Timetables where ``catchup=False`` does *not* run one
+        DAG run when first unpausing a DAG. This option will be removed in Airflow 3.0.0, where it will become
+        the default behaviour.
+      type: boolean
+      example: ~
+      default: "False"
     ignore_first_depends_on_past_by_default:
       description: |
         Setting this to True will make first task instance of a task

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -114,12 +114,7 @@ from airflow.settings import json
 from airflow.stats import Stats
 from airflow.timetables.base import DagRunInfo, DataInterval, TimeRestriction, Timetable
 from airflow.timetables.datasets import DatasetOrTimeSchedule
-from airflow.timetables.interval import (
-    CronDataIntervalFixCatchupTimetable,
-    CronDataIntervalTimetable,
-    DeltaDataIntervalFixCatchupTimetable,
-    DeltaDataIntervalTimetable,
-)
+from airflow.timetables.interval import CronDataIntervalTimetable, DeltaDataIntervalTimetable
 from airflow.timetables.simple import (
     ContinuousTimetable,
     DatasetTriggeredTimetable,
@@ -225,10 +220,7 @@ def _get_model_data_interval(
 def create_timetable(interval: ScheduleIntervalArg, timezone: Timezone | FixedTimezone) -> Timetable:
     """Create a Timetable instance from a ``schedule_interval`` argument."""
     if interval is NOTSET:
-        if airflow_conf.getboolean("scheduler", "catchup_false_no_dagrun_airflow_2_fix"):
-            return DeltaDataIntervalFixCatchupTimetable(DEFAULT_SCHEDULE_INTERVAL)
-        else:
-            return DeltaDataIntervalTimetable(DEFAULT_SCHEDULE_INTERVAL)
+        return DeltaDataIntervalTimetable(DEFAULT_SCHEDULE_INTERVAL)
     if interval is None:
         return NullTimetable()
     if interval == "@once":
@@ -236,16 +228,10 @@ def create_timetable(interval: ScheduleIntervalArg, timezone: Timezone | FixedTi
     if interval == "@continuous":
         return ContinuousTimetable()
     if isinstance(interval, (timedelta, relativedelta)):
-        if airflow_conf.getboolean("scheduler", "catchup_false_no_dagrun_airflow_2_fix"):
-            return DeltaDataIntervalFixCatchupTimetable(interval)
-        else:
-            return DeltaDataIntervalTimetable(interval)
+        return DeltaDataIntervalTimetable(interval)
     if isinstance(interval, str):
         if airflow_conf.getboolean("scheduler", "create_cron_data_intervals"):
-            if airflow_conf.getboolean("scheduler", "catchup_false_no_dagrun_airflow_2_fix"):
-                return CronDataIntervalFixCatchupTimetable(interval, timezone)
-            else:
-                return CronDataIntervalTimetable(interval, timezone)
+            return CronDataIntervalTimetable(interval, timezone)
         else:
             return CronTriggerTimetable(interval, timezone=timezone)
     raise ValueError(f"{interval!r} is not a valid schedule_interval.")

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -117,6 +117,7 @@ from airflow.timetables.datasets import DatasetOrTimeSchedule
 from airflow.timetables.interval import (
     CronDataIntervalFixCatchupTimetable,
     CronDataIntervalTimetable,
+    DeltaDataIntervalFixCatchupTimetable,
     DeltaDataIntervalTimetable,
 )
 from airflow.timetables.simple import (
@@ -232,7 +233,10 @@ def create_timetable(interval: ScheduleIntervalArg, timezone: Timezone | FixedTi
     if interval == "@continuous":
         return ContinuousTimetable()
     if isinstance(interval, (timedelta, relativedelta)):
-        return DeltaDataIntervalTimetable(interval)
+        if airflow_conf.getboolean("scheduler", "catchup_false_no_dagrun_airflow_2_fix"):
+            return DeltaDataIntervalFixCatchupTimetable(interval)
+        else:
+            return DeltaDataIntervalTimetable(interval)
     if isinstance(interval, str):
         if airflow_conf.getboolean("scheduler", "create_cron_data_intervals"):
             if airflow_conf.getboolean("scheduler", "catchup_false_no_dagrun_airflow_2_fix"):

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -225,7 +225,10 @@ def _get_model_data_interval(
 def create_timetable(interval: ScheduleIntervalArg, timezone: Timezone | FixedTimezone) -> Timetable:
     """Create a Timetable instance from a ``schedule_interval`` argument."""
     if interval is NOTSET:
-        return DeltaDataIntervalTimetable(DEFAULT_SCHEDULE_INTERVAL)
+        if airflow_conf.getboolean("scheduler", "catchup_false_no_dagrun_airflow_2_fix"):
+            return DeltaDataIntervalFixCatchupTimetable(DEFAULT_SCHEDULE_INTERVAL)
+        else:
+            return DeltaDataIntervalTimetable(DEFAULT_SCHEDULE_INTERVAL)
     if interval is None:
         return NullTimetable()
     if interval == "@once":

--- a/airflow/timetables/interval.py
+++ b/airflow/timetables/interval.py
@@ -283,3 +283,20 @@ class DeltaDataIntervalTimetable(_DataIntervalTimetable):
 
     def infer_manual_data_interval(self, run_after: DateTime) -> DataInterval:
         return DataInterval(start=self._get_prev(run_after), end=run_after)
+
+
+class DeltaDataIntervalFixCatchupTimetable(DeltaDataIntervalTimetable):
+    """Temporary solution to avoid one DAG run when first unpausing a DAG with catchup=False.
+
+    This timetable exists as a temporary solution to avoid running *one* DAG run when first unpausing a DAG
+    with ``catchup=False``. We aim to make this behaviour the default in Airflow 3.0, but have this as a
+    separate configurable Timetable to avoid breaking changes in Airflow 2.*.
+    """
+
+    def _skip_to_latest(self, earliest: DateTime | None) -> DateTime:
+        next_start = self._round(coerce_datetime(utcnow()))
+
+        if earliest is None:
+            return next_start
+        else:
+            return max(next_start, earliest)


### PR DESCRIPTION
This PR adds a config to avoid immediately running a DAG run when first unpausing a DAG with `catchup=False`.

This is a common issue during e.g. migrations, where people expect that unpausing a DAG with `catchup=False` will wait for the next interval to complete, and only then run the first interval. However, it currently immediately executes the first DAG runs.

Since this would be a breaking change, I suggest this behaviour should be fixed in Airflow 3.0.0. To support this temporarily in Airflow 2.*, I suggest introducing a config `AIRFLOW__SCHEDULER__CATCHUP_FALSE_NO_DAGRUN_AIRFLOW_2_FIX`, which is default `False`, but can be set to `True` to enable this fix.

Creating a draft for feedback. TODOs are add tests, docs, and support all timetables (currently only cron-based timetable supported).

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
