### PR TITLE
Add `impersonation_scopes` to BigQuery

### DIFF
--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -55,6 +55,7 @@ from sqlalchemy import create_engine
 
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.common.sql.hooks.sql import DbApiHook
+from airflow.providers.google.cloud.utils.credentials_provider import _get_scopes
 from airflow.providers.google.cloud.utils.bigquery import bq_cast
 from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import GoogleBaseAsyncHook, GoogleBaseHook, get_field
@@ -92,6 +93,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         Google BigQuery jobs.
     :param impersonation_chain: This is the optional service account to
         impersonate using short term credentials.
+    :param impersonation_scopes: Optional list of scopes for impersonated account.
+        Will override scopes from connection.
     :param labels: The BigQuery resource label.
     """
 
@@ -108,6 +111,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         priority: str = "INTERACTIVE",
         api_resource_configs: dict | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        impersonation_scopes: str | Sequence[str] | None = None,
         labels: dict | None = None,
         **kwargs,
     ) -> None:
@@ -127,6 +131,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         self.api_resource_configs: dict = api_resource_configs or {}
         self.labels = labels
         self.credentials_path = "bigquery_hook_credentials.json"
+        self.impersonation_scopes = impersonation_scopes
 
     def get_conn(self) -> BigQueryConnection:
         """Get a BigQuery PEP 249 connection object."""
@@ -2734,6 +2739,20 @@ class BigQueryCursor(BigQueryBaseCursor):
     def rowcount(self) -> int:
         """By default, return -1 to indicate that this is not supported."""
         return -1
+    
+    @property
+    def scopes(self) -> Sequence[str]:
+        """
+        Return OAuth 2.0 scopes.
+
+        :return: Returns the scope defined in impersonation_scopes, the connection configuration, or the default scope
+        """
+        scope_value: str | None
+        if self.impersonation_chain and self.impersonation_scopes:
+            scope_value = ",".join(self.impersonation_scopes)
+        else:
+            scope_value = self._get_field("scope", None)
+        return _get_scopes(scope_value)
 
     def execute(self, operation: str, parameters: dict | None = None) -> None:
         """Execute a BigQuery query, and return the job ID.

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -2340,6 +2340,20 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
 
         return project_id, dataset_id, table_id
 
+    @property
+    def scopes(self) -> Sequence[str]:
+        """
+        Return OAuth 2.0 scopes.
+
+        :return: Returns the scope defined in impersonation_scopes, the connection configuration, or the default scope
+        """
+        scope_value: str | None
+        if self.impersonation_chain and self.impersonation_scopes:
+            scope_value = ",".join(self.impersonation_scopes)
+        else:
+            scope_value = self._get_field("scope", None)
+        return _get_scopes(scope_value)
+
 
 class BigQueryConnection:
     """BigQuery connection.
@@ -2739,20 +2753,6 @@ class BigQueryCursor(BigQueryBaseCursor):
     def rowcount(self) -> int:
         """By default, return -1 to indicate that this is not supported."""
         return -1
-    
-    @property
-    def scopes(self) -> Sequence[str]:
-        """
-        Return OAuth 2.0 scopes.
-
-        :return: Returns the scope defined in impersonation_scopes, the connection configuration, or the default scope
-        """
-        scope_value: str | None
-        if self.impersonation_chain and self.impersonation_scopes:
-            scope_value = ",".join(self.impersonation_scopes)
-        else:
-            scope_value = self._get_field("scope", None)
-        return _get_scopes(scope_value)
 
     def execute(self, operation: str, parameters: dict | None = None) -> None:
         """Execute a BigQuery query, and return the job ID.

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -55,8 +55,8 @@ from sqlalchemy import create_engine
 
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.common.sql.hooks.sql import DbApiHook
-from airflow.providers.google.cloud.utils.credentials_provider import _get_scopes
 from airflow.providers.google.cloud.utils.bigquery import bq_cast
+from airflow.providers.google.cloud.utils.credentials_provider import _get_scopes
 from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import GoogleBaseAsyncHook, GoogleBaseHook, get_field
 

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -1213,6 +1213,7 @@ class BigQueryExecuteQueryOperator(GoogleCloudBaseOperator):
         location: str | None = None,
         encryption_configuration: dict | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
+        impersonation_scopes: str | Sequence[str] | None = None,
         job_id: str | list[str] | None = None,
         **kwargs,
     ) -> None:
@@ -1239,6 +1240,7 @@ class BigQueryExecuteQueryOperator(GoogleCloudBaseOperator):
         self.encryption_configuration = encryption_configuration
         self.hook: BigQueryHook | None = None
         self.impersonation_chain = impersonation_chain
+        self.impersonation_scopes = impersonation_scopes
         self.job_id = job_id
 
     def execute(self, context: Context):
@@ -1249,6 +1251,7 @@ class BigQueryExecuteQueryOperator(GoogleCloudBaseOperator):
                 use_legacy_sql=self.use_legacy_sql,
                 location=self.location,
                 impersonation_chain=self.impersonation_chain,
+                impersonation_scopes=self.impersonation_scopes,
             )
         if isinstance(self.sql, str):
             self.job_id = self.hook.run_query(

--- a/airflow/providers/google/common/hooks/base_google.py
+++ b/airflow/providers/google/common/hooks/base_google.py
@@ -422,7 +422,7 @@ class GoogleBaseHook(BaseHook):
         """
         scope_value: str | None
         if self.impersonation_chain and self.impersonation_scopes:
-            scope_value = self.impersonation_scopes
+            scope_value = ",".join(self.impersonation_scopes)
         else:
             scope_value = self._get_field("scope", None)
         return _get_scopes(scope_value)

--- a/airflow/providers/google/common/hooks/base_google.py
+++ b/airflow/providers/google/common/hooks/base_google.py
@@ -190,7 +190,6 @@ class GoogleBaseHook(BaseHook):
         If set as a sequence, the identities from the list must grant
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account.
-    :param impersonation_scopes: Optional list of scopes for impersonated account. Will override scopes from connection.
     """
 
     conn_name_attr = "gcp_conn_id"
@@ -244,13 +243,11 @@ class GoogleBaseHook(BaseHook):
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
-        impersonation_scopes: str | Sequence[str] | None = None,
     ) -> None:
         super().__init__()
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
-        self.impersonation_scopes = impersonation_scopes
         self.extras: dict = self.get_connection(self.gcp_conn_id).extra_dejson
         self._cached_credentials: google.auth.credentials.Credentials | None = None
         self._cached_project_id: str | None = None
@@ -418,13 +415,10 @@ class GoogleBaseHook(BaseHook):
         """
         Return OAuth 2.0 scopes.
 
-        :return: Returns the scope defined in impersonation_scopes, the connection configuration, or the default scope
+        :return: Returns the scope defined in the connection configuration, or the default scope
         """
-        scope_value: str | None
-        if self.impersonation_chain and self.impersonation_scopes:
-            scope_value = ",".join(self.impersonation_scopes)
-        else:
-            scope_value = self._get_field("scope", None)
+        scope_value: str | None = self._get_field("scope", None)
+
         return _get_scopes(scope_value)
 
     @staticmethod

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -867,7 +867,12 @@ class TestBigQueryGetDataOperator:
             use_legacy_sql=False,
         )
         operator.execute(None)
-        mock_hook.assert_called_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=None, use_legacy_sql=False)
+        mock_hook.assert_called_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=None,
+            impersonation_scopes=None,
+            use_legacy_sql=False
+        )
         mock_hook.return_value.list_rows.assert_called_once_with(
             dataset_id=TEST_DATASET,
             table_id=TEST_TABLE_ID,

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -867,12 +867,7 @@ class TestBigQueryGetDataOperator:
             use_legacy_sql=False,
         )
         operator.execute(None)
-        mock_hook.assert_called_with(
-            gcp_conn_id=GCP_CONN_ID,
-            impersonation_chain=None,
-            impersonation_scopes=None,
-            use_legacy_sql=False
-        )
+        mock_hook.assert_called_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=None, use_legacy_sql=False)
         mock_hook.return_value.list_rows.assert_called_once_with(
             dataset_id=TEST_DATASET,
             table_id=TEST_TABLE_ID,

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -554,6 +554,7 @@ class TestBigQueryOperator:
         mock_hook.assert_called_with(
             gcp_conn_id="google_cloud_default",
             use_legacy_sql=True,
+            location=None,
             impersonation_chain=["service-account@myproject.iam.gserviceaccount.com"],
             impersonation_scopes=[
                 "https://www.googleapis.com/auth/cloud-platform",

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -543,6 +543,8 @@ class TestBigQueryOperator:
             api_resource_configs=None,
             cluster_fields=None,
             encryption_configuration=encryption_configuration,
+            impersonation_chain=["service-account@myproject.iam.gserviceaccount.com"],
+            impersonation_scopes=["https://www.googleapis.com/auth/cloud-platform", "https://www.googleapis.com/auth/drive"],
         )
 
         operator.execute(MagicMock())
@@ -564,6 +566,8 @@ class TestBigQueryOperator:
             api_resource_configs=None,
             cluster_fields=None,
             encryption_configuration=encryption_configuration,
+            impersonation_chain=["service-account@myproject.iam.gserviceaccount.com"],
+            impersonation_scopes=["https://www.googleapis.com/auth/cloud-platform", "https://www.googleapis.com/auth/drive"],
         )
 
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -544,7 +544,10 @@ class TestBigQueryOperator:
             cluster_fields=None,
             encryption_configuration=encryption_configuration,
             impersonation_chain=["service-account@myproject.iam.gserviceaccount.com"],
-            impersonation_scopes=["https://www.googleapis.com/auth/cloud-platform", "https://www.googleapis.com/auth/drive"],
+            impersonation_scopes=[
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/drive",
+            ],
         )
 
         operator.execute(MagicMock())
@@ -567,7 +570,10 @@ class TestBigQueryOperator:
             cluster_fields=None,
             encryption_configuration=encryption_configuration,
             impersonation_chain=["service-account@myproject.iam.gserviceaccount.com"],
-            impersonation_scopes=["https://www.googleapis.com/auth/cloud-platform", "https://www.googleapis.com/auth/drive"],
+            impersonation_scopes=[
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/drive",
+            ],
         )
 
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -551,6 +551,15 @@ class TestBigQueryOperator:
         )
 
         operator.execute(MagicMock())
+        mock_hook.assert_called_with(
+            gcp_conn_id="google_cloud_default",
+            use_legacy_sql=True,
+            impersonation_chain=["service-account@myproject.iam.gserviceaccount.com"],
+            impersonation_scopes=[
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/drive",
+            ],
+        )
         mock_hook.return_value.run_query.assert_called_once_with(
             sql="Select * from test_table",
             destination_dataset_table=None,
@@ -569,11 +578,6 @@ class TestBigQueryOperator:
             api_resource_configs=None,
             cluster_fields=None,
             encryption_configuration=encryption_configuration,
-            impersonation_chain=["service-account@myproject.iam.gserviceaccount.com"],
-            impersonation_scopes=[
-                "https://www.googleapis.com/auth/cloud-platform",
-                "https://www.googleapis.com/auth/drive",
-            ],
         )
 
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/33400

Currently `scopes` for google libraries are taken from connection parameters, this PR creates an additional parameter `impersonation_scopes` that will be used in situations when `impersonation_chain` is being used.

The flow to get credentials for gcp providers goes something like this

1. A library like bigquery will call get_credentials() https://github.com/apache/airflow/blob/00cd44e4ccb4a7d6406e75d3cf8f80277545d5d2/airflow/providers/google/cloud/hooks/bigquery.py#L163
2. This is provided by GoogleBaseHook https://github.com/apache/airflow/blob/00cd44e4ccb4a7d6406e75d3cf8f80277545d5d2/airflow/providers/google/common/hooks/base_google.py#L307
3. This then makes a call to `self.scopes()` https://github.com/apache/airflow/blob/00cd44e4ccb4a7d6406e75d3cf8f80277545d5d2/airflow/providers/google/common/hooks/base_google.py#L290 
4. scopes will then return scopes from connection extras or default (in `_get_scopes()`) https://github.com/apache/airflow/blob/00cd44e4ccb4a7d6406e75d3cf8f80277545d5d2/airflow/providers/google/common/hooks/base_google.py#L414

Possible alternative solutions

1. Override `scopes()` definition in custom hook - as detailed in above issue https://github.com/apache/airflow/issues/33400#issuecomment-1678606598
2. Introduce a parameter called `scopes` - it would be confusing what takes precedence if there is scopes in parameter and connection
3. Create a class for impersonation https://google-auth.readthedocs.io/en/master/reference/google.auth.impersonated_credentials.html 

I would need some help testing and bringing this over the finish line

Should be able to do something like

```py
bq_hook = BigQueryHook(
    gcp_conn_id="my_con",
    impersonation_chain="service-account@myproject.iam.gserviceaccount.com",
    use_legacy_sql=False,
    location="us",
    api_resource_configs={"query": {"useQueryCache": False, "priority": "BATCH"}},
    scopes = (
    "https://www.googleapis.com/auth/cloud-platform",
    "https://www.googleapis.com/auth/drive",
    ),
)
bq_hook.scopes  # check that it got set
```