### PR TITLE
Fix `region` argument in `MappedOperator` based on `AwsBaseOperator` / `AwsBaseSensor`

### DIFF
--- a/airflow/providers/amazon/aws/operators/base_aws.py
+++ b/airflow/providers/amazon/aws/operators/base_aws.py
@@ -26,6 +26,7 @@ from airflow.providers.amazon.aws.utils.mixins import (
     AwsHookType,
     aws_template_fields,
 )
+from airflow.utils.types import NOTSET, ArgNotSet
 
 
 class AwsBaseOperator(BaseOperator, AwsBaseHookMixin[AwsHookType]):
@@ -85,10 +86,12 @@ class AwsBaseOperator(BaseOperator, AwsBaseHookMixin[AwsHookType]):
         region_name: str | None = None,
         verify: bool | str | None = None,
         botocore_config: dict | None = None,
+        region: str | None | ArgNotSet = NOTSET,  # Required for `.partial` signature check
         **kwargs,
     ):
+        additional_params = {} if region is NOTSET else {"region": region}
         hook_params = AwsHookParams.from_constructor(
-            aws_conn_id, region_name, verify, botocore_config, additional_params=kwargs
+            aws_conn_id, region_name, verify, botocore_config, additional_params=additional_params
         )
         super().__init__(**kwargs)
         self.aws_conn_id = hook_params.aws_conn_id

--- a/airflow/providers/amazon/aws/sensors/base_aws.py
+++ b/airflow/providers/amazon/aws/sensors/base_aws.py
@@ -26,6 +26,7 @@ from airflow.providers.amazon.aws.utils.mixins import (
     aws_template_fields,
 )
 from airflow.sensors.base import BaseSensorOperator
+from airflow.utils.types import NOTSET, ArgNotSet
 
 
 class AwsBaseSensor(BaseSensorOperator, AwsBaseHookMixin[AwsHookType]):
@@ -84,10 +85,12 @@ class AwsBaseSensor(BaseSensorOperator, AwsBaseHookMixin[AwsHookType]):
         region_name: str | None = None,
         verify: bool | str | None = None,
         botocore_config: dict | None = None,
+        region: str | None | ArgNotSet = NOTSET,  # Required for `.partial` signature check
         **kwargs,
     ):
+        additional_params = {} if region is NOTSET else {"region": region}
         hook_params = AwsHookParams.from_constructor(
-            aws_conn_id, region_name, verify, botocore_config, additional_params=kwargs
+            aws_conn_id, region_name, verify, botocore_config, additional_params=additional_params
         )
         super().__init__(**kwargs)
         self.aws_conn_id = hook_params.aws_conn_id

--- a/tests/providers/amazon/aws/operators/test_base_aws.py
+++ b/tests/providers/amazon/aws/operators/test_base_aws.py
@@ -16,6 +16,8 @@
 # under the License.
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
@@ -37,6 +39,10 @@ class FakeS3Hook(AwsBaseHook):
 
 class FakeS3Operator(AwsBaseOperator):
     aws_hook_class = FakeS3Hook
+
+    def __init__(self, *, value: Any = None, **kwargs):
+        super().__init__(**kwargs)
+        self.value = value
 
     def execute(self, context):
         """For test purpose"""
@@ -170,3 +176,40 @@ class TestAwsBaseOperator:
         error_match = r"Class attribute 'SoWrongOperator.aws_hook_class' is not a subclass of AwsGenericHook"
         with pytest.raises(AttributeError, match=error_match):
             SoWrongOperator(task_id="fake-task-id")
+
+    @pytest.mark.parametrize(
+        "region, region_name, expected_region_name",
+        [
+            pytest.param("ca-west-1", None, "ca-west-1", id="region-only"),
+            pytest.param("us-west-1", "us-west-1", "us-west-1", id="non-ambiguous-params"),
+        ],
+    )
+    @pytest.mark.db_test
+    def test_region_in_partial_operator(self, region, region_name, expected_region_name, dag_maker):
+        with dag_maker("test_region_in_partial_operator"):
+            FakeS3Operator.partial(
+                task_id="fake-task-id",
+                region=region,
+                region_name=region_name,
+            ).expand(value=[1, 2, 3])
+
+        dr = dag_maker.create_dagrun(execution_date=timezone.utcnow())
+        warning_match = r"`region` is deprecated and will be removed"
+        for ti in dr.task_instances:
+            with pytest.warns(AirflowProviderDeprecationWarning, match=warning_match):
+                ti.run()
+            assert ti.task.region_name == expected_region_name
+
+    @pytest.mark.db_test
+    def test_ambiguous_region_in_partial_operator(self, dag_maker):
+        with dag_maker("test_ambiguous_region_in_partial_operator"):
+            FakeS3Operator.partial(
+                task_id="fake-task-id",
+                region="eu-west-1",
+                region_name="us-east-1",
+            ).expand(value=[1, 2, 3])
+
+        dr = dag_maker.create_dagrun(execution_date=timezone.utcnow())
+        for ti in dr.task_instances:
+            with pytest.raises(ValueError, match="Conflicting `region_name` provided"):
+                ti.run()

--- a/tests/providers/amazon/aws/operators/test_base_aws.py
+++ b/tests/providers/amazon/aws/operators/test_base_aws.py
@@ -210,6 +210,9 @@ class TestAwsBaseOperator:
             ).expand(value=[1, 2, 3])
 
         dr = dag_maker.create_dagrun(execution_date=timezone.utcnow())
+        warning_match = r"`region` is deprecated and will be removed"
         for ti in dr.task_instances:
-            with pytest.raises(ValueError, match="Conflicting `region_name` provided"):
+            with pytest.warns(AirflowProviderDeprecationWarning, match=warning_match), pytest.raises(
+                ValueError, match="Conflicting `region_name` provided"
+            ):
                 ti.run()

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -710,7 +710,7 @@ class TestEcsRunTaskOperator(EcsBaseTestCase):
 
     @pytest.mark.db_test
     def test_partial_ambiguous_region(self, dag_maker, session):
-        with dag_maker("test_partial_ambiguous_region_ecs"):
+        with dag_maker("test_partial_ambiguous_region_ecs", session=session):
             EcsRunTaskOperator.partial(
                 task_id="fake-task-id",
                 region="eu-west-1",

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -37,6 +37,7 @@ from airflow.providers.amazon.aws.operators.ecs import (
 )
 from airflow.providers.amazon.aws.triggers.ecs import TaskDoneTrigger
 from airflow.providers.amazon.aws.utils.task_log_fetcher import AwsTaskLogFetcher
+from airflow.utils.task_instance_session import set_current_task_instance_session
 from airflow.utils.types import NOTSET
 
 CLUSTER_NAME = "test_cluster"
@@ -679,6 +680,54 @@ class TestEcsRunTaskOperator(EcsBaseTestCase):
 
         # task gets described to assert its success
         client_mock().describe_tasks.assert_called_once_with(cluster="c", tasks=["my_arn"])
+
+    @pytest.mark.db_test
+    @pytest.mark.parametrize(
+        "region, region_name, expected_region_name",
+        [
+            pytest.param("ca-west-1", None, "ca-west-1", id="region-only"),
+            pytest.param("us-west-1", "us-west-1", "us-west-1", id="non-ambiguous-params"),
+        ],
+    )
+    def test_partial_deprecated_region(self, region, region_name, expected_region_name, dag_maker, session):
+        with dag_maker(dag_id="test_partial_deprecated_region_ecs", session=session):
+            EcsRunTaskOperator.partial(
+                task_id="fake-task-id",
+                region=region,
+                region_name=region_name,
+                cluster="foo",
+                task_definition="bar",
+            ).expand(overrides=[{}, {}, {}])
+
+        dr = dag_maker.create_dagrun()
+        tis = dr.get_task_instances(session=session)
+        with set_current_task_instance_session(session=session):
+            warning_match = r"`region` is deprecated and will be removed"
+            for ti in tis:
+                with pytest.warns(AirflowProviderDeprecationWarning, match=warning_match):
+                    ti.render_templates()
+                assert ti.task.region_name == expected_region_name
+
+    @pytest.mark.db_test
+    def test_partial_ambiguous_region(self, dag_maker, session):
+        with dag_maker("test_partial_ambiguous_region_ecs"):
+            EcsRunTaskOperator.partial(
+                task_id="fake-task-id",
+                region="eu-west-1",
+                region_name="us-west-1",
+                cluster="foo",
+                task_definition="bar",
+            ).expand(overrides=[{}, {}, {}])
+
+        dr = dag_maker.create_dagrun(session=session)
+        tis = dr.get_task_instances(session=session)
+        with set_current_task_instance_session(session=session):
+            warning_match = r"`region` is deprecated and will be removed"
+            for ti in tis:
+                with pytest.warns(AirflowProviderDeprecationWarning, match=warning_match), pytest.raises(
+                    ValueError, match="Conflicting `region_name` provided"
+                ):
+                    ti.render_templates()
 
 
 class TestEcsCreateClusterOperator(EcsBaseTestCase):

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -37,7 +37,6 @@ from airflow.providers.amazon.aws.operators.ecs import (
 )
 from airflow.providers.amazon.aws.triggers.ecs import TaskDoneTrigger
 from airflow.providers.amazon.aws.utils.task_log_fetcher import AwsTaskLogFetcher
-from airflow.utils import timezone
 from airflow.utils.types import NOTSET
 
 CLUSTER_NAME = "test_cluster"
@@ -680,23 +679,6 @@ class TestEcsRunTaskOperator(EcsBaseTestCase):
 
         # task gets described to assert its success
         client_mock().describe_tasks.assert_called_once_with(cluster="c", tasks=["my_arn"])
-
-    @pytest.mark.db_test
-    def test_partial_deprecated_region(self, dag_maker):
-        with dag_maker("test_partial_deprecated_region_esc_run_task"):
-            EcsRunTaskOperator.partial(
-                task_id="fake-task-id",
-                region="ca-west-1",
-                cluster="foo",
-                task_definition="bar",
-            ).expand(overrides=[{}, {}, {}])
-
-        dr = dag_maker.create_dagrun(execution_date=timezone.utcnow())
-        warning_match = r"`region` is deprecated and will be removed"
-        for ti in dr.task_instances:
-            with pytest.warns(AirflowProviderDeprecationWarning, match=warning_match):
-                ti.render_templates()
-            assert ti.task.region_name == "ca-west-1"
 
 
 class TestEcsCreateClusterOperator(EcsBaseTestCase):

--- a/tests/providers/amazon/aws/sensors/test_base_aws.py
+++ b/tests/providers/amazon/aws/sensors/test_base_aws.py
@@ -16,6 +16,8 @@
 # under the License.
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
@@ -37,6 +39,10 @@ class FakeDynamoDbHook(AwsBaseHook):
 
 class FakeDynamoDBSensor(AwsBaseSensor):
     aws_hook_class = FakeDynamoDbHook
+
+    def __init__(self, *, value: Any = None, **kwargs):
+        super().__init__(**kwargs)
+        self.value = value
 
     def poke(self, context):
         """For test purpose"""
@@ -170,3 +176,40 @@ class TestAwsBaseSensor:
         error_match = r"Class attribute 'SoWrongSensor.aws_hook_class' is not a subclass of AwsGenericHook"
         with pytest.raises(AttributeError, match=error_match):
             SoWrongSensor(task_id="fake-task-id")
+
+    @pytest.mark.parametrize(
+        "region, region_name, expected_region_name",
+        [
+            pytest.param("ca-west-1", None, "ca-west-1", id="region-only"),
+            pytest.param("us-west-1", "us-west-1", "us-west-1", id="non-ambiguous-params"),
+        ],
+    )
+    @pytest.mark.db_test
+    def test_region_in_partial_sensor(self, region, region_name, expected_region_name, dag_maker):
+        with dag_maker("test_region_in_partial_sensor"):
+            FakeDynamoDBSensor.partial(
+                task_id="fake-task-id",
+                region=region,
+                region_name=region_name,
+            ).expand(value=[1, 2, 3])
+
+        dr = dag_maker.create_dagrun(execution_date=timezone.utcnow())
+        warning_match = r"`region` is deprecated and will be removed"
+        for ti in dr.task_instances:
+            with pytest.warns(AirflowProviderDeprecationWarning, match=warning_match):
+                ti.run()
+            assert ti.task.region_name == expected_region_name
+
+    @pytest.mark.db_test
+    def test_ambiguous_region_in_partial_sensor(self, dag_maker):
+        with dag_maker("test_ambiguous_region_in_partial_sensor"):
+            FakeDynamoDBSensor.partial(
+                task_id="fake-task-id",
+                region="eu-west-1",
+                region_name="us-east-1",
+            ).expand(value=[1, 2, 3])
+
+        dr = dag_maker.create_dagrun(execution_date=timezone.utcnow())
+        for ti in dr.task_instances:
+            with pytest.raises(ValueError, match="Conflicting `region_name` provided"):
+                ti.run()

--- a/tests/providers/amazon/aws/sensors/test_base_aws.py
+++ b/tests/providers/amazon/aws/sensors/test_base_aws.py
@@ -210,6 +210,9 @@ class TestAwsBaseSensor:
             ).expand(value=[1, 2, 3])
 
         dr = dag_maker.create_dagrun(execution_date=timezone.utcnow())
+        warning_match = r"`region` is deprecated and will be removed"
         for ti in dr.task_instances:
-            with pytest.raises(ValueError, match="Conflicting `region_name` provided"):
+            with pytest.warns(AirflowProviderDeprecationWarning, match=warning_match), pytest.raises(
+                ValueError, match="Conflicting `region_name` provided"
+            ):
                 ti.run()


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Originally reported in [Slack](https://apache-airflow.slack.com/archives/CCQ7EGB1P/p1710437655032589)
---

Hi everyone! :nyanparrot:
I just upgraded the airflow packages versions:

```console
apache-airflow==2.8.3
apache-airflow-providers-amazon==8.19.0
```

And now I have a broken DAG:
```console
Broken DAG: [/opt/airflow/dags/distributor_catalogue.py]
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.11/site-packages/airflow/models/baseoperator.py", line 265, in partial
    validate_mapping_kwargs(operator_class, "partial", kwargs)
  File "/home/airflow/.local/lib/python3.11/site-packages/airflow/models/mappedoperator.py", line 117, in validate_mapping_kwargs
    raise TypeError(f"{op.__name__}.{func}() got {error}")
TypeError: EcsRunTaskOperator.partial() got an unexpected keyword argument 'region'
```

The use of region is this one:
```python
EcsRunTaskOperator.partial(
    task_id="task_id",
    aws_conn_id="aws_manual_test",
    cluster="tf_ecs_airflow",
    task_definition="tf_ecs_airflow",
    launch_type="FARGATE",
    region="eu-west-3",
    network_configuration={
        "awsvpcConfiguration": {
            "securityGroups": [Variable.get("ecs_securitygroup")],
            "subnets": [Variable.get("ecs_subnet1"), Variable.get("ecs_subnet2"), Variable.get("ecs_subnet3")],
            "assignPublicIp": "ENABLED",
        },
    },
    trigger_rule="all_done",
    waiter_delay=60,
    waiter_max_attempts=3000,
).expand(overrides=generate_params_list)
```
Does someone know why it is broken?
Thanks a lot :face_holding_back_tears: (edited) 

---

This happen because partial check signature, and if argument not exists in any MRO references it will failed.
We grab `region` directly from kwargs and remove it, for avoid provide it into the BaseOperator.

Fix pretty simple, add `region` into `AwsBaseOperator` / `AwsBaseSensor` signatures, it should fix all operators which migrated to this helper operators and use deprecated `region` attribute over Dynamic Task Mapping 

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
