### PR TITLE
Add average duration markline in task and dagrun duration charts.

### DIFF
--- a/airflow/www/static/js/dag/details/dag/RunDurationChart.tsx
+++ b/airflow/www/static/js/dag/details/dag/RunDurationChart.tsx
@@ -178,6 +178,10 @@ const RunDurationChart = ({ showLandingTimes }: Props) => {
                 opacity: 0.6,
               },
               stack: "x",
+              markLine: {
+                silent: true,
+                data: [{ type: "average" }],
+              },
             } as SeriesOption,
           ]
         : []),
@@ -189,6 +193,10 @@ const RunDurationChart = ({ showLandingTimes }: Props) => {
           opacity: 0.6,
         },
         stack: "x",
+        markLine: {
+          silent: true,
+          data: [{ type: "average" }],
+        },
       },
       {
         type: "bar",
@@ -199,6 +207,10 @@ const RunDurationChart = ({ showLandingTimes }: Props) => {
           color: (params) => stateColors[params.data.state],
         },
         stack: "x",
+        markLine: {
+          silent: true,
+          data: [{ type: "average" }],
+        },
       },
     ],
     // @ts-ignore

--- a/airflow/www/static/js/dag/details/dag/RunDurationChart.tsx
+++ b/airflow/www/static/js/dag/details/dag/RunDurationChart.tsx
@@ -180,7 +180,7 @@ const RunDurationChart = ({ showLandingTimes }: Props) => {
               stack: "x",
               markLine: {
                 silent: true,
-                data: [{ type: "average" }],
+                data: [{ type: "median" }],
               },
             } as SeriesOption,
           ]
@@ -195,7 +195,7 @@ const RunDurationChart = ({ showLandingTimes }: Props) => {
         stack: "x",
         markLine: {
           silent: true,
-          data: [{ type: "average" }],
+          data: [{ type: "median" }],
         },
       },
       {
@@ -209,7 +209,7 @@ const RunDurationChart = ({ showLandingTimes }: Props) => {
         stack: "x",
         markLine: {
           silent: true,
-          data: [{ type: "average" }],
+          data: [{ type: "median" }],
         },
       },
     ],

--- a/airflow/www/static/js/dag/details/task/TaskDuration.tsx
+++ b/airflow/www/static/js/dag/details/task/TaskDuration.tsx
@@ -165,6 +165,10 @@ const TaskDuration = () => {
           opacity: 0.6,
         },
         stack: "x",
+        markLine: {
+          silent: true,
+          data: [{ type: "average" }],
+        },
       },
       {
         type: "bar",
@@ -174,6 +178,10 @@ const TaskDuration = () => {
           color: (params) => stateColors[params.data.state],
         },
         stack: "x",
+        markLine: {
+          silent: true,
+          data: [{ type: "average" }],
+        },
       },
     ],
     // @ts-ignore

--- a/airflow/www/static/js/dag/details/task/TaskDuration.tsx
+++ b/airflow/www/static/js/dag/details/task/TaskDuration.tsx
@@ -167,7 +167,7 @@ const TaskDuration = () => {
         stack: "x",
         markLine: {
           silent: true,
-          data: [{ type: "average" }],
+          data: [{ type: "median" }],
         },
       },
       {
@@ -180,7 +180,7 @@ const TaskDuration = () => {
         stack: "x",
         markLine: {
           silent: true,
-          data: [{ type: "average" }],
+          data: [{ type: "median" }],
         },
       },
     ],


### PR DESCRIPTION
Add average duration for run and queued time in task duration and dag run duration. This can help in visualizing potential delays in runs like below dag for one month where there is more sleep time in the last 5 days compared to previous days.

Related: #22132
Ref comment in PR review : https://github.com/apache/airflow/pull/35863#issuecomment-1894981925

![image](https://github.com/apache/airflow/assets/3972343/ff79d5b0-e205-4c88-8483-c2b52c314dc1)

![image](https://github.com/apache/airflow/assets/3972343/a7ef78b8-a44a-4270-8ae3-94aa24ed05ed)


```python
from datetime import datetime, timedelta

from airflow import DAG
from airflow.decorators import task
from airflow.operators.empty import EmptyOperator

from datetime import timedelta


with DAG(
    dag_id="task_duration_average",
    start_date=datetime(2024, 1, 1),
    end_date=datetime(2024, 1, 31),
    catchup=True,
    schedule_interval="@daily",
) as dag:

    @task
    def sleeper(ds=None):
        import random, time, pendulum

        end_term = pendulum.datetime(2024, 1, 25)
        execution_date = pendulum.parse(ds)

        if execution_date < end_term:
            duration = random.randint(1, 5)
        else:
            duration = random.randint(10, 20)

        time.sleep(duration)

    sleeper()
```