### PR TITLE
Add option to clear only failed tasks in a graph view

### DIFF
--- a/airflow/www/static/js/api/useClearRun.ts
+++ b/airflow/www/static/js/api/useClearRun.ts
@@ -34,10 +34,17 @@ export default function useClearRun(dagId: string, runId: string) {
   const { startRefresh } = useAutoRefresh();
   return useMutation(
     ["dagRunClear", dagId, runId],
-    ({ confirmed = false }: { confirmed: boolean }) => {
+    ({
+      confirmed = false,
+      only_failed = false,
+    }: {
+      confirmed: boolean;
+      only_failed?: boolean;
+    }) => {
       const params = new URLSearchParamsWrapper({
         csrf_token: csrfToken,
         confirmed,
+        only_failed,
         dag_id: dagId,
         dag_run_id: runId,
       }).toString();

--- a/airflow/www/static/js/dag/details/dagRun/ClearRun.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/ClearRun.tsx
@@ -56,6 +56,10 @@ const ClearRun = ({ runId, ...otherProps }: Props) => {
     onClear({ confirmed: true });
   };
 
+  const clearFailedTasks = () => {
+    onClear({ confirmed: true, only_failed: true });
+  };
+
   const queueNewTasks = () => {
     onQueue({ confirmed: true });
   };
@@ -103,6 +107,9 @@ const ClearRun = ({ runId, ...otherProps }: Props) => {
         </MenuButton>
         <MenuList>
           <MenuItem onClick={clearExistingTasks}>Clear existing tasks</MenuItem>
+          <MenuItem onClick={clearFailedTasks}>
+            Clear only failed tasks
+          </MenuItem>
           <MenuItem onClick={queueNewTasks}>Queue up new tasks</MenuItem>
         </MenuList>
       </Menu>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2324,6 +2324,7 @@ class Airflow(AirflowBaseView):
         dag_id = request.form.get("dag_id")
         dag_run_id = request.form.get("dag_run_id")
         confirmed = request.form.get("confirmed") == "true"
+        only_failed = request.form.get("only_failed") == "true"
 
         dag = get_airflow_app().dag_bag.get_dag(dag_id)
         dr = dag.get_dagrun(run_id=dag_run_id)
@@ -2337,6 +2338,7 @@ class Airflow(AirflowBaseView):
             origin=None,
             recursive=True,
             confirmed=confirmed,
+            only_failed=only_failed,
             session=session,
         )
 


### PR DESCRIPTION
This PR adds a new option to clear only failed tasks in a dag run. The backend API will accept a new parameter only_failed which by default is False for backwards compatibility. 

closes: #38031
related: #38031

![image](https://github.com/apache/airflow/assets/3972343/6dd5869c-ed3e-41ea-b2a0-0bb4fb473baf)
