### PR TITLE
Add Matomo as an option for analytics_tool.

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1775,7 +1775,7 @@ webserver:
     analytics_tool:
       description: |
         Send anonymous user activity to your analytics tool
-        choose from google_analytics, segment, or metarouter
+        choose from google_analytics, segment, metarouter, or matomo
       version_added: ~
       type: string
       example: ~
@@ -1786,6 +1786,13 @@ webserver:
       version_added: 1.10.5
       type: string
       example: ~
+      default: ~
+    analytics_url:
+      description: |
+        Your instances url, only applicable to Matomo.
+      version_added: 2.9.0
+      type: string
+      example: https://your.matomo.instance.com/
       default: ~
     show_recent_stats_for_completed_runs:
       description: |

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -471,7 +471,7 @@ class AirflowConfigParser(ConfigParser):
         ("logging", "fab_logging_level"): _available_logging_levels,
         # celery_logging_level can be empty, which uses logging_level as fallback
         ("logging", "celery_logging_level"): [*_available_logging_levels, ""],
-        ("webserver", "analytical_tool"): ["google_analytics", "metarouter", "segment", ""],
+        ("webserver", "analytical_tool"): ["google_analytics", "metarouter", "segment", "matomo", ""],
     }
 
     upgraded_values: dict[tuple[str, str], str]

--- a/airflow/www/extensions/init_jinja_globals.py
+++ b/airflow/www/extensions/init_jinja_globals.py
@@ -90,6 +90,7 @@ def init_jinja_globals(app):
                 {
                     "analytics_tool": conf.get("webserver", "ANALYTICS_TOOL"),
                     "analytics_id": conf.get("webserver", "ANALYTICS_ID"),
+                    "analytics_url": conf.get("webserver", "ANALYTICS_URL"),
                 }
             )
 

--- a/airflow/www/templates/analytics/matomo.html
+++ b/airflow/www/templates/analytics/matomo.html
@@ -1,0 +1,34 @@
+{#
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+#}
+
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="{{ analytics_url }}";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '{{ analytics_id }}']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->

--- a/docs/apache-airflow/administration-and-deployment/logging-monitoring/tracking-user-activity.rst
+++ b/docs/apache-airflow/administration-and-deployment/logging-monitoring/tracking-user-activity.rst
@@ -22,14 +22,15 @@ You can configure Airflow to route anonymous data to
 `Google Analytics <https://analytics.google.com/>`_,
 `Segment <https://segment.com/>`_, or `Metarouter <https://www.metarouter.io/>`_.
 
-Edit ``airflow.cfg`` and set the ``webserver`` block to have an ``analytics_tool`` and ``analytics_id``:
+Edit ``airflow.cfg`` and set the ``webserver`` block to have an ``analytics_tool`` and ``analytics_id`` and ``analytics_url`` if you're using ``matomo``:
 
 .. code-block:: ini
 
   [webserver]
   # Send anonymous user activity to Google Analytics, Segment, or Metarouter
-  analytics_tool = google_analytics # valid options: google_analytics, segment, metarouter
+  analytics_tool = google_analytics # valid options: google_analytics, segment, metarouter, matomo
   analytics_id = XXXXXXXXXXX
+  analytics_url = https://your-matomo-instance.example.com # only required for Matomo
 
 .. note:: You can see view injected tracker html within Airflow's source code at
   ``airflow/www/templates/airflow/main.html``. The related global

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -982,6 +982,8 @@ MarketingTeam
 MarkupSafe
 Masternode
 masterType
+Matomo
+matomo
 Maxime
 mb
 md


### PR DESCRIPTION
Matomo is a Google Analytics alternative for use-cases that require all tracking data be kept internally, and is set up the same way as the existing supported analytics tools.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->