### PR TITLE
Fix dynamic allocation specs handling for custom launcher

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/custom_object_launcher.py
+++ b/airflow/providers/cncf/kubernetes/operators/custom_object_launcher.py
@@ -60,9 +60,9 @@ class SparkJobSpec:
         if self.spec.get("dynamicAllocation", {}).get("enabled"):
             if not all(
                 [
-                    self.spec["dynamicAllocation"]["initialExecutors"],
-                    self.spec["dynamicAllocation"]["minExecutors"],
-                    self.spec["dynamicAllocation"]["maxExecutors"],
+                    self.spec["dynamicAllocation"].get("initialExecutors"),
+                    self.spec["dynamicAllocation"].get("minExecutors"),
+                    self.spec["dynamicAllocation"].get("maxExecutors"),
                 ]
             ):
                 raise AirflowException("Make sure initial/min/max value for dynamic allocation is passed")

--- a/tests/providers/cncf/kubernetes/operators/test_custom_object_launcher.py
+++ b/tests/providers/cncf/kubernetes/operators/test_custom_object_launcher.py
@@ -14,3 +14,122 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from unittest.mock import patch
+
+import pytest
+
+from airflow.exceptions import AirflowException
+from airflow.providers.cncf.kubernetes.operators.custom_object_launcher import (
+    SparkJobSpec,
+    SparkResources,
+)
+
+
+class TestSparkJobSpec:
+    @patch("airflow.providers.cncf.kubernetes.operators.custom_object_launcher.SparkJobSpec.update_resources")
+    @patch("airflow.providers.cncf.kubernetes.operators.custom_object_launcher.SparkJobSpec.validate")
+    def test_spark_job_spec_initialization(self, mock_validate, mock_update_resources):
+        entries = {
+            "spec": {
+                "dynamicAllocation": {
+                    "enabled": True,
+                    "initialExecutors": 1,
+                    "minExecutors": 1,
+                    "maxExecutors": 2,
+                },
+                "driver": {},
+                "executor": {},
+            }
+        }
+        SparkJobSpec(**entries)
+        mock_validate.assert_called_once()
+        mock_update_resources.assert_called_once()
+
+    def test_spark_job_spec_dynamicAllocation_enabled(self):
+        entries = {
+            "spec": {
+                "dynamicAllocation": {
+                    "enabled": True,
+                    "initialExecutors": 1,
+                    "minExecutors": 1,
+                    "maxExecutors": 2,
+                },
+                "driver": {},
+                "executor": {},
+            }
+        }
+        spark_job_spec = SparkJobSpec(**entries)
+
+        assert spark_job_spec.spec["dynamicAllocation"]["enabled"]
+
+    def test_spark_job_spec_dynamicAllocation_enabled_with_invalid_config(self):
+        entries = {
+            "spec": {
+                "dynamicAllocation": {
+                    "enabled": True,
+                    "initialExecutors": 1,
+                    "minExecutors": 1,
+                    "maxExecutors": 2,
+                },
+                "driver": {},
+                "executor": {},
+            }
+        }
+        with pytest.raises(
+            AirflowException, match="Make sure initial/min/max value for dynamic allocation is passed"
+        ):
+            entries.copy()["spec"]["dynamicAllocation"]["initialExecutors"] = None
+            SparkJobSpec(**entries)
+
+        with pytest.raises(
+            AirflowException, match="Make sure initial/min/max value for dynamic allocation is passed"
+        ):
+            entries.copy()["spec"]["dynamicAllocation"]["minExecutors"] = None
+            SparkJobSpec(**entries)
+
+        with pytest.raises(
+            AirflowException, match="Make sure initial/min/max value for dynamic allocation is passed"
+        ):
+            entries.copy()["spec"]["dynamicAllocation"]["maxExecutors"] = None
+            SparkJobSpec(**entries)
+
+
+class TestSparkResources:
+    @patch(
+        "airflow.providers.cncf.kubernetes.operators.custom_object_launcher.SparkResources.convert_resources"
+    )
+    def test_spark_resources_initialization(self, mock_convert_resources):
+        driver = {
+            "gpu": {"name": "nvidia", "quantity": 1},
+            "cpu": {"request": "1", "limit": "2"},
+            "memory": {"request": "1Gi", "limit": "2Gi"},
+        }
+        executor = {
+            "gpu": {"name": "nvidia", "quantity": 2},
+            "cpu": {"request": "2", "limit": "4"},
+            "memory": {"request": "2Gi", "limit": "4Gi"},
+        }
+        SparkResources(driver=driver, executor=executor)
+        mock_convert_resources.assert_called_once()
+
+    def test_spark_resources_conversion(self):
+        driver = {
+            "gpu": {"name": "nvidia", "quantity": 1},
+            "cpu": {"request": "1", "limit": "2"},
+            "memory": {"request": "1Gi", "limit": "2Gi"},
+        }
+        executor = {
+            "gpu": {"name": "nvidia", "quantity": 2},
+            "cpu": {"request": "2", "limit": "4"},
+            "memory": {"request": "2Gi", "limit": "4Gi"},
+        }
+        spark_resources = SparkResources(driver=driver, executor=executor)
+
+        assert spark_resources.driver["memory"]["limit"] == "1462m"
+        assert spark_resources.executor["memory"]["limit"] == "2925m"
+        assert spark_resources.driver["cpu"]["request"] == 1
+        assert spark_resources.driver["cpu"]["limit"] == "2"
+        assert spark_resources.executor["cpu"]["request"] == 2
+        assert spark_resources.executor["cpu"]["limit"] == "4"
+        assert spark_resources.driver["gpu"]["quantity"] == 1
+        assert spark_resources.executor["gpu"]["quantity"] == 2

--- a/tests/providers/cncf/kubernetes/operators/test_custom_object_launcher.py
+++ b/tests/providers/cncf/kubernetes/operators/test_custom_object_launcher.py
@@ -77,28 +77,29 @@ class TestSparkJobSpec:
                 "executor": {},
             }
         }
+
+        cloned_entries = entries.copy()
+        cloned_entries["spec"]["dynamicAllocation"]["initialExecutors"] = None
         with pytest.raises(
             AirflowException,
             match="Make sure initial/min/max value for dynamic allocation is passed",
         ):
-            cloned_entries = entries.copy()
-            cloned_entries["spec"]["dynamicAllocation"]["initialExecutors"] = None
             SparkJobSpec(**cloned_entries)
 
+        cloned_entries = entries.copy()
+        cloned_entries["spec"]["dynamicAllocation"]["minExecutors"] = None
         with pytest.raises(
             AirflowException,
             match="Make sure initial/min/max value for dynamic allocation is passed",
         ):
-            cloned_entries = entries.copy()
-            cloned_entries["spec"]["dynamicAllocation"]["minExecutors"] = None
             SparkJobSpec(**cloned_entries)
 
+        cloned_entries = entries.copy()
+        cloned_entries["spec"]["dynamicAllocation"]["maxExecutors"] = None
         with pytest.raises(
             AirflowException,
             match="Make sure initial/min/max value for dynamic allocation is passed",
         ):
-            cloned_entries = entries.copy()
-            cloned_entries["spec"]["dynamicAllocation"]["maxExecutors"] = None
             SparkJobSpec(**cloned_entries)
 
 

--- a/tests/providers/cncf/kubernetes/operators/test_custom_object_launcher.py
+++ b/tests/providers/cncf/kubernetes/operators/test_custom_object_launcher.py
@@ -76,22 +76,28 @@ class TestSparkJobSpec:
             }
         }
         with pytest.raises(
-            AirflowException, match="Make sure initial/min/max value for dynamic allocation is passed"
+            AirflowException,
+            match="Make sure initial/min/max value for dynamic allocation is passed",
         ):
-            entries.copy()["spec"]["dynamicAllocation"]["initialExecutors"] = None
-            SparkJobSpec(**entries)
+            cloned_entries = entries.copy()
+            cloned_entries["spec"]["dynamicAllocation"]["initialExecutors"] = None
+            SparkJobSpec(**cloned_entries)
 
         with pytest.raises(
-            AirflowException, match="Make sure initial/min/max value for dynamic allocation is passed"
+            AirflowException,
+            match="Make sure initial/min/max value for dynamic allocation is passed",
         ):
-            entries.copy()["spec"]["dynamicAllocation"]["minExecutors"] = None
-            SparkJobSpec(**entries)
+            cloned_entries = entries.copy()
+            cloned_entries["spec"]["dynamicAllocation"]["minExecutors"] = None
+            SparkJobSpec(**cloned_entries)
 
         with pytest.raises(
-            AirflowException, match="Make sure initial/min/max value for dynamic allocation is passed"
+            AirflowException,
+            match="Make sure initial/min/max value for dynamic allocation is passed",
         ):
-            entries.copy()["spec"]["dynamicAllocation"]["maxExecutors"] = None
-            SparkJobSpec(**entries)
+            cloned_entries = entries.copy()
+            cloned_entries["spec"]["dynamicAllocation"]["maxExecutors"] = None
+            SparkJobSpec(**cloned_entries)
 
 
 class TestSparkResources:

--- a/tests/providers/cncf/kubernetes/operators/test_custom_object_launcher.py
+++ b/tests/providers/cncf/kubernetes/operators/test_custom_object_launcher.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
+
 from unittest.mock import patch
 
 import pytest


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Primarily about a fix to handle dynamicAllocation specs gracefully and adding unit test for custom object launcher.

**Context:**
When defining dynamic allocation specs, if users accidentally miss any required fields, currently we throw a `KeyError` exception which looks confused. So that I've put a minor change to make the exception thrown should be `AirflowException` with a more meaningful error message.

On the other hand, we also don't have unit test to cover some helper classes in `custom_object_launcher.py`, this PR also includes a few simple test cases.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
