### PR TITLE
Adding max consecutive failed dag runs info in UI

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -130,12 +130,7 @@
           <span class="text-muted">DAG:</span> {{ dag.dag_id }}
           <small class="text-muted">{{ dag.description[0:150] + '…' if dag.description and dag.description|length > 150 else dag.description|default('', true) }}</small>
           {% if dag_model is defined and dag_model.max_consecutive_failed_dag_runs is defined and  dag_model.max_consecutive_failed_dag_runs > 0  %}
-<!--           <span class="material-icons text-muted js-tooltip" aria-hidden="true" style="color: #365f84;" data-original-title="auto-pause: After {{ dag_model.max_consecutive_failed_dag_runs|string }} consecutive failures">-->
-<!--            motion_photos_paused-->
-<!--           </span>-->
-           <span class="material-icons text-muted js-tooltip" aria-hidden="true" style="color: #365f84;" data-original-title="auto-pause: After {{ dag_model.max_consecutive_failed_dag_runs|string }} consecutive failures">
-            pause_circle_outline
-           </span>
+           <span class="material-icons text-muted js-tooltip" aria-hidden="true" style="color: #017cee;" data-original-title="auto-pause: After {{ dag_model.max_consecutive_failed_dag_runs|string }} consecutive failures">motion_photos_paused</span>
           {% endif %}
         {% endif %}
         {% if root %}

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -129,6 +129,14 @@
           </label>
           <span class="text-muted">DAG:</span> {{ dag.dag_id }}
           <small class="text-muted">{{ dag.description[0:150] + '…' if dag.description and dag.description|length > 150 else dag.description|default('', true) }}</small>
+          {% if dag_model is defined and dag_model.max_consecutive_failed_dag_runs is defined and  dag_model.max_consecutive_failed_dag_runs > 0  %}
+<!--           <span class="material-icons text-muted js-tooltip" aria-hidden="true" style="color: #365f84;" data-original-title="auto-pause: After {{ dag_model.max_consecutive_failed_dag_runs|string }} consecutive failures">-->
+<!--            motion_photos_paused-->
+<!--           </span>-->
+           <span class="material-icons text-muted js-tooltip" aria-hidden="true" style="color: #365f84;" data-original-title="auto-pause: After {{ dag_model.max_consecutive_failed_dag_runs|string }} consecutive failures">
+            pause_circle_outline
+           </span>
+          {% endif %}
         {% endif %}
         {% if root %}
           <span class="text-muted">ROOT:</span> {{ root }}

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -130,8 +130,8 @@
           <span class="text-muted">DAG:</span> {{ dag.dag_id }}
           <small class="text-muted">{{ dag.description[0:150] + '…' if dag.description and dag.description|length > 150 else dag.description|default('', true) }}</small>
           {% if dag_model is defined and dag_model.max_consecutive_failed_dag_runs is defined and  dag_model.max_consecutive_failed_dag_runs > 0  %}
-           <span class="material-icons text-muted js-tooltip" aria-hidden="true" data-original-title="auto-pause: After {{ dag_model.max_consecutive_failed_dag_runs|string }} consecutive failures">motion_photos_paused</span>
-          {% endif %}
+           <span class="material-icons text-muted js-tooltip" aria-hidden="true" data-original-title="Auto Pauses: After {{ dag_model.max_consecutive_failed_dag_runs|string }} consecutive failures">motion_photos_paused</span>
+            {% endif %}
         {% endif %}
         {% if root %}
           <span class="text-muted">ROOT:</span> {{ root }}

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -130,7 +130,7 @@
           <span class="text-muted">DAG:</span> {{ dag.dag_id }}
           <small class="text-muted">{{ dag.description[0:150] + '…' if dag.description and dag.description|length > 150 else dag.description|default('', true) }}</small>
           {% if dag_model is defined and dag_model.max_consecutive_failed_dag_runs is defined and  dag_model.max_consecutive_failed_dag_runs > 0  %}
-           <span class="material-icons text-muted js-tooltip" aria-hidden="true" style="color: #017cee;" data-original-title="auto-pause: After {{ dag_model.max_consecutive_failed_dag_runs|string }} consecutive failures">motion_photos_paused</span>
+           <span class="material-icons text-muted js-tooltip" aria-hidden="true" data-original-title="auto-pause: After {{ dag_model.max_consecutive_failed_dag_runs|string }} consecutive failures">motion_photos_paused</span>
           {% endif %}
         {% endif %}
         {% if root %}


### PR DESCRIPTION
closes: #38171
related: #36935

**Description**
We have added ability to automatically turn off DAG after X number of consecutive failures.

We should also highlight/show this information to user as this will affect their DAG runs,
I am adding information in DAG in UI,
this will only be shown in the DAGs which have this feature enabled.

### Before the Change
<img width="906" alt="image" src="https://github.com/apache/airflow/assets/16856802/b38b3e7a-9f9e-4f11-9540-61330ebdce71">

### After the Change
<img width="1048" alt="image" src="https://github.com/apache/airflow/assets/16856802/5eb1f684-00be-444c-b33f-52e2e9f78554">
