### PR TITLE
Disable coverage for Python 3.12

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/run_tests.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_tests.py
@@ -364,7 +364,12 @@ def generate_args_for_pytest(
     args.extend(get_excluded_provider_args(python_version))
     if use_xdist:
         args.extend(["-n", str(parallelism) if parallelism else "auto"])
-    if enable_coverage:
+    # We have to disabke coverage for Python 3.12 because of the issue with coverage that takes too long, despite
+    # Using experimental support for Python 3.12 PEP 669. The coverage.py is not yet fully compatible with the
+    # full scope of PEP-669. That will be fully done when https://github.com/nedbat/coveragepy/issues/1746 is
+    # resolve for now we are disabling coverage for Python 3.12, and it causes slower execution and occasional
+    # timeouts
+    if enable_coverage and python_version != "3.12":
         args.extend(
             [
                 "--cov=airflow",

--- a/scripts/in_container/run_ci_tests.sh
+++ b/scripts/in_container/run_ci_tests.sh
@@ -23,18 +23,6 @@ echo "Starting the tests with those pytest arguments:" "${@}"
 echo
 set +e
 
-# We have to tweak coverage for Python 3.12 because of the issue with coverage that takes too long, despite
-# Using experimental support for Python 3.12 PEP 669. The coverage.py is not yet fully compatible with the
-# full scope of PEP-669. That will be fully done when https://github.com/nedbat/coveragepy/issues/1746 is
-# resolve for now we are disabling coverage for Python 3.12, but possibly it is enough for now.
-PYTHON_3_12_OR_ABOVE=$(python -c "import sys; print(sys.version_info >= (3,12))")
-
-if [[ ${PYTHON_3_12_OR_ABOVE} == "True" ]]; then
-    echo
-    echo "${COLOR_BLUE}Enabling experimental PEP-669 support in coverage.py for Python 3.12 and above.${COLOR_RESET}"
-    echo
-    export COVERAGE_CORE=sysmon
-fi
 
 pytest "${@}"
 RES=$?


### PR DESCRIPTION
Finally we have to disable coverage for Python 3.12 because with coverage enabled it runs slower and occasionally timeouts in coverage methods.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
