### PR TITLE
Temporarily disable cache pushing from CI

### DIFF
--- a/.github/workflows/early-image-checks.yml
+++ b/.github/workflows/early-image-checks.yml
@@ -81,30 +81,30 @@ jobs:
   # delay cache refresh. It does not attempt to upgrade to newer dependencies.
   # We only push CI cache as PROD cache usually does not gain as much from fresh cache because
   # it uses prepared airflow and provider packages that invalidate the cache anyway most of the time
-  push-early-buildx-cache-to-github-registry:
-    name: Push Early Image Cache
-    uses: ./.github/workflows/push-image-cache.yml
-    permissions:
-      contents: read
-      # This write is only given here for `push` events from "apache/airflow" repo. It is not given for PRs
-      # from forks. This is to prevent malicious PRs from creating images in the "apache/airflow" repo.
-      # For regular build for PRS this "build-prod-images" workflow will be skipped anyway by the
-      # "in-workflow-build" condition
-      packages: write
-    secrets: inherit
-    with:
-      runs-on: ${{ inputs.runs-on }}
-      cache-type: "Early"
-      include-prod-images: "false"
-      push-latest-images: "false"
-      image-tag: ${{ inputs.image-tag }}
-      python-versions: ${{ inputs.python-versions }}
-      branch: ${{ inputs.branch }}
-      use-uv: "true"
-      include-success-outputs: ${{ inputs.include-success-outputs }}
-      constraints-branch: ${{ inputs.constraints-branch }}
-      docker-cache: ${{ inputs.docker-cache }}
-    if: inputs.canary-run == 'true' && inputs.branch == 'main'
+  # push-early-buildx-cache-to-github-registry:
+  #   name: Push Early Image Cache
+  #   uses: ./.github/workflows/push-image-cache.yml
+  #   permissions:
+  #     contents: read
+  #     # This write is only given here for `push` events from "apache/airflow" repo. It is not given for PRs
+  #     # from forks. This is to prevent malicious PRs from creating images in the "apache/airflow" repo.
+  #     # For regular build for PRS this "build-prod-images" workflow will be skipped anyway by the
+  #     # "in-workflow-build" condition
+  #     packages: write
+  #   secrets: inherit
+  #   with:
+  #     runs-on: ${{ inputs.runs-on }}
+  #     cache-type: "Early"
+  #     include-prod-images: "false"
+  #     push-latest-images: "false"
+  #     image-tag: ${{ inputs.image-tag }}
+  #     python-versions: ${{ inputs.python-versions }}
+  #     branch: ${{ inputs.branch }}
+  #     use-uv: "true"
+  #     include-success-outputs: ${{ inputs.include-success-outputs }}
+  #     constraints-branch: ${{ inputs.constraints-branch }}
+  #     docker-cache: ${{ inputs.docker-cache }}
+  #   if: inputs.canary-run == 'true' && inputs.branch == 'main'
 
   # Check that after earlier cache push, breeze command will build quickly
   check-that-image-builds-quickly:

--- a/.github/workflows/finalize-tests.yml
+++ b/.github/workflows/finalize-tests.yml
@@ -124,27 +124,27 @@ jobs:
   # is executed as result of direct push to "main" or one of the "vX-Y-test" branches
   # It rebuilds all images using just-pushed constraints using buildx and pushes them to registry
   # It will automatically check if a new python image was released and will pull the latest one if needed
-  push-buildx-cache-to-github-registry:
-    name: Push Regular Image Cache
-    needs: [update-constraints]
-    uses: ./.github/workflows/push-image-cache.yml
-    permissions:
-      contents: read
-      packages: write
-    secrets: inherit
-    with:
-      runs-on: ${{ inputs.runs-on }}
-      cache-type: "Regular"
-      include-prod-images: "true"
-      push-latest-images: "true"
-      use-uv: "true"
-      image-tag: ${{ inputs.image-tag }}
-      python-versions: ${{ inputs.python-versions }}
-      branch: ${{ inputs.branch }}
-      constraints-branch: ${{ inputs.constraints-branch }}
-      include-success-outputs: ${{ inputs.include-success-outputs }}
-      docker-cache: ${{ inputs.docker-cache }}
-    if: inputs.canary-run == 'true'
+  #  push-buildx-cache-to-github-registry:
+  #    name: Push Regular Image Cache
+  #    needs: [update-constraints]
+  #    uses: ./.github/workflows/push-image-cache.yml
+  #    permissions:
+  #      contents: read
+  #      packages: write
+  #    secrets: inherit
+  #    with:
+  #      runs-on: ${{ inputs.runs-on }}
+  #      cache-type: "Regular"
+  #      include-prod-images: "true"
+  #      push-latest-images: "true"
+  #      use-uv: "true"
+  #      image-tag: ${{ inputs.image-tag }}
+  #      python-versions: ${{ inputs.python-versions }}
+  #      branch: ${{ inputs.branch }}
+  #      constraints-branch: ${{ inputs.constraints-branch }}
+  #      include-success-outputs: ${{ inputs.include-success-outputs }}
+  #      docker-cache: ${{ inputs.docker-cache }}
+  #    if: inputs.canary-run == 'true'
 
   summarize-warnings:
     timeout-minutes: 15


### PR DESCRIPTION
There are some issue with pushing and invalidating cache from CI, until this gets investigated we should disable it.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
