### PR TITLE
Add CLI support for bulk pause and resume of DAGs

### DIFF
--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -382,10 +382,10 @@ ARG_RUN_BACKWARDS = Arg(
     ),
     action="store_true",
 )
-# TODO: Deprecate in backfill command in favor of --treat-dag-id-as-regex
+
 ARG_TREAT_DAG_AS_REGEX = Arg(
     ("--treat-dag-as-regex",),
-    help=("if set, dag_id will be treated as regex instead of an exact string"),
+    help=("Deprecated -- use `--treat-dag-id-as-regex` instead"),
     action="store_true",
 )
 
@@ -1240,6 +1240,7 @@ DAGS_COMMANDS = (
             ARG_RERUN_FAILED_TASKS,
             ARG_RUN_BACKWARDS,
             ARG_TREAT_DAG_AS_REGEX,
+            ARG_TREAT_DAG_ID_AS_REGEX,
         ),
     ),
     ActionCommand(

--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -1098,15 +1098,25 @@ DAGS_COMMANDS = (
     ),
     ActionCommand(
         name="pause",
-        help="Pause a DAG",
+        help="Pause DAG(s)",
+        description=(
+            "Pause one or more DAGs. This command allows to halt the execution of specified DAGs, "
+            "disabling further task scheduling. Use `--treat-dag-as-regex` to target multiple DAGs by "
+            "treating the `--dag-id` as a regex pattern."
+        ),
         func=lazy_load_command("airflow.cli.commands.dag_command.dag_pause"),
-        args=(ARG_DAG_ID, ARG_SUBDIR, ARG_TREAT_DAG_AS_REGEX, ARG_YES, ARG_VERBOSE),
+        args=(ARG_DAG_ID, ARG_SUBDIR, ARG_TREAT_DAG_AS_REGEX, ARG_YES, ARG_OUTPUT, ARG_VERBOSE),
     ),
     ActionCommand(
         name="unpause",
-        help="Resume a paused DAG",
+        help="Resume paused DAG(s)",
+        description=(
+            "Resume one or more DAGs. This command allows to restore the execution of specified "
+            "DAGs, enabling further task scheduling. Use `--treat-dag-as-regex` to target multiple DAGs "
+            "treating the `--dag-id` as a regex pattern."
+        ),
         func=lazy_load_command("airflow.cli.commands.dag_command.dag_unpause"),
-        args=(ARG_DAG_ID, ARG_SUBDIR, ARG_TREAT_DAG_AS_REGEX, ARG_YES, ARG_VERBOSE),
+        args=(ARG_DAG_ID, ARG_SUBDIR, ARG_TREAT_DAG_AS_REGEX, ARG_YES, ARG_OUTPUT, ARG_VERBOSE),
     ),
     ActionCommand(
         name="trigger",

--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -382,11 +382,19 @@ ARG_RUN_BACKWARDS = Arg(
     ),
     action="store_true",
 )
+# TODO: Deprecate in backfill command in favor of --treat-dag-id-as-regex
 ARG_TREAT_DAG_AS_REGEX = Arg(
     ("--treat-dag-as-regex",),
     help=("if set, dag_id will be treated as regex instead of an exact string"),
     action="store_true",
 )
+
+ARG_TREAT_DAG_ID_AS_REGEX = Arg(
+    ("--treat-dag-id-as-regex",),
+    help=("if set, dag_id will be treated as regex instead of an exact string"),
+    action="store_true",
+)
+
 # test_dag
 ARG_SHOW_DAGRUN = Arg(
     ("--show-dagrun",),
@@ -1101,22 +1109,22 @@ DAGS_COMMANDS = (
         help="Pause DAG(s)",
         description=(
             "Pause one or more DAGs. This command allows to halt the execution of specified DAGs, "
-            "disabling further task scheduling. Use `--treat-dag-as-regex` to target multiple DAGs by "
+            "disabling further task scheduling. Use `--treat-dag-id-as-regex` to target multiple DAGs by "
             "treating the `--dag-id` as a regex pattern."
         ),
         func=lazy_load_command("airflow.cli.commands.dag_command.dag_pause"),
-        args=(ARG_DAG_ID, ARG_SUBDIR, ARG_TREAT_DAG_AS_REGEX, ARG_YES, ARG_OUTPUT, ARG_VERBOSE),
+        args=(ARG_DAG_ID, ARG_SUBDIR, ARG_TREAT_DAG_ID_AS_REGEX, ARG_YES, ARG_OUTPUT, ARG_VERBOSE),
     ),
     ActionCommand(
         name="unpause",
         help="Resume paused DAG(s)",
         description=(
             "Resume one or more DAGs. This command allows to restore the execution of specified "
-            "DAGs, enabling further task scheduling. Use `--treat-dag-as-regex` to target multiple DAGs "
+            "DAGs, enabling further task scheduling. Use `--treat-dag-id-as-regex` to target multiple DAGs "
             "treating the `--dag-id` as a regex pattern."
         ),
         func=lazy_load_command("airflow.cli.commands.dag_command.dag_unpause"),
-        args=(ARG_DAG_ID, ARG_SUBDIR, ARG_TREAT_DAG_AS_REGEX, ARG_YES, ARG_OUTPUT, ARG_VERBOSE),
+        args=(ARG_DAG_ID, ARG_SUBDIR, ARG_TREAT_DAG_ID_AS_REGEX, ARG_YES, ARG_OUTPUT, ARG_VERBOSE),
     ),
     ActionCommand(
         name="trigger",

--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -1100,13 +1100,13 @@ DAGS_COMMANDS = (
         name="pause",
         help="Pause a DAG",
         func=lazy_load_command("airflow.cli.commands.dag_command.dag_pause"),
-        args=(ARG_DAG_ID, ARG_SUBDIR, ARG_VERBOSE),
+        args=(ARG_DAG_ID, ARG_SUBDIR, ARG_TREAT_DAG_AS_REGEX, ARG_YES, ARG_VERBOSE),
     ),
     ActionCommand(
         name="unpause",
         help="Resume a paused DAG",
         func=lazy_load_command("airflow.cli.commands.dag_command.dag_unpause"),
-        args=(ARG_DAG_ID, ARG_SUBDIR, ARG_VERBOSE),
+        args=(ARG_DAG_ID, ARG_SUBDIR, ARG_TREAT_DAG_AS_REGEX, ARG_YES, ARG_VERBOSE),
     ),
     ActionCommand(
         name="trigger",

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -218,14 +218,14 @@ def set_is_paused(is_paused: bool, args) -> None:
     should_apply = True
     dags = [
         dag
-        for dag in get_dags(args.subdir, dag_id=args.dag_id, use_regex=args.treat_dag_as_regex)
+        for dag in get_dags(args.subdir, dag_id=args.dag_id, use_regex=args.treat_dag_id_as_regex)
         if is_paused != dag.get_is_paused()
     ]
 
     if not dags:
         raise AirflowException(f"No {'un' if is_paused else ''}paused DAGs were found")
 
-    if not args.yes and args.treat_dag_as_regex:
+    if not args.yes and args.treat_dag_id_as_regex:
         dags_ids = [dag.dag_id for dag in dags]
         question = (
             f"You are about to {'un' if not is_paused else ''}pause {len(dags_ids)} DAGs:\n"

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -138,6 +138,13 @@ def dag_backfill(args, dag: list[DAG] | DAG | None = None) -> None:
         category=RemovedInAirflow3Warning,
     )
 
+    if not args.treat_dag_id_as_regex and args.treat_dag_as_regex:
+        warnings.warn(
+            "--treat-dag-as-regex is deprecated, use --treat-dag-id-as-regex instead",
+            category=RemovedInAirflow3Warning,
+        )
+        args.treat_dag_id_as_regex = args.treat_dag_as_regex
+
     if args.ignore_first_depends_on_past is False:
         args.ignore_first_depends_on_past = True
 
@@ -145,7 +152,7 @@ def dag_backfill(args, dag: list[DAG] | DAG | None = None) -> None:
         raise AirflowException("Provide a start_date and/or end_date")
 
     if not dag:
-        dags = get_dags(args.subdir, dag_id=args.dag_id, use_regex=args.treat_dag_as_regex)
+        dags = get_dags(args.subdir, dag_id=args.dag_id, use_regex=args.treat_dag_id_as_regex)
     elif isinstance(dag, list):
         dags = dag
     else:

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -650,11 +650,41 @@ class TestCliDags:
     def test_pause(self):
         args = self.parser.parse_args(["dags", "pause", "example_bash_operator"])
         dag_command.dag_pause(args)
-        assert self.dagbag.dags["example_bash_operator"].get_is_paused() in [True, 1]
+        assert self.dagbag.dags["example_bash_operator"].get_is_paused()
 
         args = self.parser.parse_args(["dags", "unpause", "example_bash_operator"])
         dag_command.dag_unpause(args)
-        assert self.dagbag.dags["example_bash_operator"].get_is_paused() in [False, 0]
+        assert not self.dagbag.dags["example_bash_operator"].get_is_paused()
+
+    def test_pause_regex(self):
+        args = self.parser.parse_args(["dags", "pause", "^example_.*$", "--treat-dag-as-regex"])
+        dag_command.dag_pause(args)
+        assert self.dagbag.dags["example_bash_decorator"].get_is_paused()
+        assert self.dagbag.dags["example_kubernetes_executor"].get_is_paused()
+        assert self.dagbag.dags["example_xcom_args"].get_is_paused()
+
+        args = self.parser.parse_args(["dags", "pause", "^example_.*$", "--treat-dag-as-regex"])
+        dag_command.dag_unpause(args)
+        assert not self.dagbag.dags["example_bash_decorator"].get_is_paused()
+        assert not self.dagbag.dags["example_kubernetes_executor"].get_is_paused()
+        assert not self.dagbag.dags["example_xcom_args"].get_is_paused()
+
+    @mock.patch("airflow.cli.commands.dag_command.ask_yesno")
+    def test_pause_regex_all_dags_confirmation(self, mock_yesno):
+        args = self.parser.parse_args(["dags", "pause", ".*", "--treat-dag-as-regex"])
+        dag_command.dag_pause(args)
+        mock_yesno.assert_called_once()
+
+    @mock.patch("airflow.cli.commands.dag_command.ask_yesno")
+    def test_pause_regex_all_dags_yes(self, mock_yesno):
+        args = self.parser.parse_args(["dags", "pause", ".*", "--treat-dag-as-regex", "--yes"])
+        dag_command.dag_pause(args)
+        mock_yesno.assert_not_called()
+
+    def test_pause_non_existing_dag_error(self):
+        args = self.parser.parse_args(["dags", "pause", "non_existing_dag"])
+        with pytest.raises(AirflowException):
+            dag_command.dag_pause(args)
 
     def test_trigger_dag(self):
         dag_command.dag_trigger(

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -651,40 +651,48 @@ class TestCliDags:
         args = self.parser.parse_args(["dags", "pause", "example_bash_operator"])
         dag_command.dag_pause(args)
         assert self.dagbag.dags["example_bash_operator"].get_is_paused()
-
-        args = self.parser.parse_args(["dags", "unpause", "example_bash_operator"])
         dag_command.dag_unpause(args)
         assert not self.dagbag.dags["example_bash_operator"].get_is_paused()
 
-    def test_pause_regex(self):
+    @mock.patch("airflow.cli.commands.dag_command.ask_yesno")
+    def test_pause_regex(self, mock_yesno):
         args = self.parser.parse_args(["dags", "pause", "^example_.*$", "--treat-dag-as-regex"])
         dag_command.dag_pause(args)
+        mock_yesno.assert_called_once()
         assert self.dagbag.dags["example_bash_decorator"].get_is_paused()
         assert self.dagbag.dags["example_kubernetes_executor"].get_is_paused()
         assert self.dagbag.dags["example_xcom_args"].get_is_paused()
 
-        args = self.parser.parse_args(["dags", "pause", "^example_.*$", "--treat-dag-as-regex"])
+        args = self.parser.parse_args(["dags", "unpause", "^example_.*$", "--treat-dag-as-regex"])
         dag_command.dag_unpause(args)
         assert not self.dagbag.dags["example_bash_decorator"].get_is_paused()
         assert not self.dagbag.dags["example_kubernetes_executor"].get_is_paused()
         assert not self.dagbag.dags["example_xcom_args"].get_is_paused()
 
     @mock.patch("airflow.cli.commands.dag_command.ask_yesno")
-    def test_pause_regex_all_dags_confirmation(self, mock_yesno):
-        args = self.parser.parse_args(["dags", "pause", ".*", "--treat-dag-as-regex"])
+    def test_pause_regex_operation_cancelled(self, ask_yesno, capsys):
+        args = self.parser.parse_args(["dags", "pause", "example_bash_operator", "--treat-dag-as-regex"])
+        ask_yesno.return_value = False
         dag_command.dag_pause(args)
-        mock_yesno.assert_called_once()
+        stdout = capsys.readouterr().out
+        assert "Operation cancelled by user" in stdout
 
     @mock.patch("airflow.cli.commands.dag_command.ask_yesno")
-    def test_pause_regex_all_dags_yes(self, mock_yesno):
+    def test_pause_regex_yes(self, mock_yesno):
         args = self.parser.parse_args(["dags", "pause", ".*", "--treat-dag-as-regex", "--yes"])
         dag_command.dag_pause(args)
         mock_yesno.assert_not_called()
+        dag_command.dag_unpause(args)
 
     def test_pause_non_existing_dag_error(self):
         args = self.parser.parse_args(["dags", "pause", "non_existing_dag"])
         with pytest.raises(AirflowException):
             dag_command.dag_pause(args)
+
+    def test_unpause_already_unpaused_dag_error(self):
+        args = self.parser.parse_args(["dags", "unpause", "example_bash_operator", "--yes"])
+        with pytest.raises(AirflowException, match="No paused DAGs were found"):
+            dag_command.dag_unpause(args)
 
     def test_trigger_dag(self):
         dag_command.dag_trigger(

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -656,14 +656,14 @@ class TestCliDags:
 
     @mock.patch("airflow.cli.commands.dag_command.ask_yesno")
     def test_pause_regex(self, mock_yesno):
-        args = self.parser.parse_args(["dags", "pause", "^example_.*$", "--treat-dag-as-regex"])
+        args = self.parser.parse_args(["dags", "pause", "^example_.*$", "--treat-dag-id-as-regex"])
         dag_command.dag_pause(args)
         mock_yesno.assert_called_once()
         assert self.dagbag.dags["example_bash_decorator"].get_is_paused()
         assert self.dagbag.dags["example_kubernetes_executor"].get_is_paused()
         assert self.dagbag.dags["example_xcom_args"].get_is_paused()
 
-        args = self.parser.parse_args(["dags", "unpause", "^example_.*$", "--treat-dag-as-regex"])
+        args = self.parser.parse_args(["dags", "unpause", "^example_.*$", "--treat-dag-id-as-regex"])
         dag_command.dag_unpause(args)
         assert not self.dagbag.dags["example_bash_decorator"].get_is_paused()
         assert not self.dagbag.dags["example_kubernetes_executor"].get_is_paused()
@@ -671,7 +671,7 @@ class TestCliDags:
 
     @mock.patch("airflow.cli.commands.dag_command.ask_yesno")
     def test_pause_regex_operation_cancelled(self, ask_yesno, capsys):
-        args = self.parser.parse_args(["dags", "pause", "example_bash_operator", "--treat-dag-as-regex"])
+        args = self.parser.parse_args(["dags", "pause", "example_bash_operator", "--treat-dag-id-as-regex"])
         ask_yesno.return_value = False
         dag_command.dag_pause(args)
         stdout = capsys.readouterr().out
@@ -679,7 +679,7 @@ class TestCliDags:
 
     @mock.patch("airflow.cli.commands.dag_command.ask_yesno")
     def test_pause_regex_yes(self, mock_yesno):
-        args = self.parser.parse_args(["dags", "pause", ".*", "--treat-dag-as-regex", "--yes"])
+        args = self.parser.parse_args(["dags", "pause", ".*", "--treat-dag-id-as-regex", "--yes"])
         dag_command.dag_pause(args)
         mock_yesno.assert_not_called()
         dag_command.dag_unpause(args)

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -230,7 +230,7 @@ class TestCliDags:
                         "--task-regex",
                         "run_this_first",
                         "--dry-run",
-                        "--treat-dag-as-regex",
+                        "--treat-dag-id-as-regex",
                         "--start-date",
                         DEFAULT_DATE.isoformat(),
                     ]
@@ -243,6 +243,24 @@ class TestCliDags:
         assert "Task run_this_first located in DAG example_branch_python_operator_decorator\n" in output
         assert f"Dry run of DAG example_branch_operator on {DEFAULT_DATE_REPR}\n" in output
         assert "Task run_this_first located in DAG example_branch_operator\n" in output
+
+    @mock.patch("airflow.cli.commands.dag_command._run_dag_backfill")
+    def test_backfill_treat_dag_as_regex_deprecation(self, _):
+        run_date = DEFAULT_DATE + timedelta(days=1)
+        cli_args = self.parser.parse_args(
+            [
+                "dags",
+                "backfill",
+                "example_bash_operator",
+                "--treat-dag-as-regex",
+                "--start-date",
+                run_date.isoformat(),
+            ]
+        )
+
+        with pytest.warns(DeprecationWarning, match="--treat-dag-as-regex is deprecated"):
+            dag_command.dag_backfill(cli_args)
+        assert cli_args.treat_dag_id_as_regex == cli_args.treat_dag_as_regex
 
     @mock.patch("airflow.cli.commands.dag_command.get_dag")
     def test_backfill_fails_without_loading_dags(self, mock_get_dag):


### PR DESCRIPTION
closes: #36956

This PR adds the ability for `airflow dags (un)pause` commands to treat `dag_id` as a regex (similar to `backfill`), so we could apply it to multiple DAGs.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
