### PR TITLE
Fix AWS "Operators and hooks" page so that the text is displayed even if it is not operator.

### DIFF
--- a/docs/exts/templates/operators_and_hooks_ref.rst.jinja2
+++ b/docs/exts/templates/operators_and_hooks_ref.rst.jinja2
@@ -29,7 +29,7 @@
 {%- if "sensors" in item %}
 :Sensors: {% for python_module in item["sensors"]["python-modules"] %}:mod:`{{ python_module }}`{% if not loop.last %}, {% else %}.{% endif %}{%- endfor %}
 {%- endif %}
-{%- if "operators" in item and 'how-to-guide' in item["integration"] %}
+{%- if 'how-to-guide' in item["integration"] %}
 :Guides: {% for guide in item["integration"]['how-to-guide'] %}:doc:`{{ guide }}`{% if not loop.last %}, {% else %}.{% endif %}{%- endfor %}
 {%- endif %}
 :Provider: :provider:`{{ item["integration"]["package-name"] }}`


### PR DESCRIPTION
Fixed so that the "Guides" item is displayed even if it is not operator.
Since the ["Operators and Hooks" page](https://airflow.apache.org/docs/apache-airflow-providers/operators-and-hooks-ref/aws.html#amazon-redshift) contains not only operators but also hooks and sensors, I suggest this change to be able to access to the guide.