### PR TITLE
Fix filtered TI links

### DIFF
--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -435,6 +435,7 @@ def task_instance_link(attr):
         "Airflow.grid",
         dag_id=dag_id,
         task_id=task_id,
+        root=task_id,
         dag_run_id=run_id,
         tab="graph",
         map_index=attr.get("map_index", -1),


### PR DESCRIPTION
We have links to the graph, filtered down to a specific TI. This was accidentally broken in #38096.

See https://github.com/apache/airflow/pull/38096#issuecomment-1996734180.