### PR TITLE
Add refetch button to audit log, format extra

### DIFF
--- a/airflow/www/static/js/components/NewTable/NewCells.tsx
+++ b/airflow/www/static/js/components/NewTable/NewCells.tsx
@@ -29,5 +29,6 @@ export const TimeCell = ({ getValue }: any) => {
 
 export const CodeCell = ({ getValue }: any) => {
   const value = getValue();
-  return value ? <Code>{JSON.stringify(value)}</Code> : null;
+  const code = typeof value === "string" ? JSON.parse(value) : value;
+  return code ? <Code>{JSON.stringify(code)}</Code> : null;
 };

--- a/airflow/www/static/js/dag/details/AuditLog.tsx
+++ b/airflow/www/static/js/dag/details/AuditLog.tsx
@@ -28,6 +28,7 @@ import {
   FormLabel,
   Input,
   HStack,
+  Button,
 } from "@chakra-ui/react";
 import { createColumnHelper } from "@tanstack/react-table";
 import { snakeCase } from "lodash";
@@ -40,6 +41,7 @@ import type { EventLog } from "src/types/api-generated";
 import { NewTable } from "src/components/NewTable/NewTable";
 import { useTableURLState } from "src/components/NewTable/useTableUrlState";
 import { CodeCell, TimeCell } from "src/components/NewTable/NewCells";
+import { MdRefresh } from "react-icons/md";
 
 interface Props {
   taskId?: string;
@@ -60,7 +62,7 @@ const AuditLog = ({ taskId, run }: Props) => {
   const sort = tableURLState.sorting[0];
   const orderBy = sort ? `${sort.desc ? "-" : ""}${snakeCase(sort.id)}` : "";
 
-  const { data, isLoading, isFetching } = useEventLogs({
+  const { data, isLoading, isFetching, refetch } = useEventLogs({
     dagId,
     taskId,
     runId: run?.runId || undefined,
@@ -121,7 +123,16 @@ const AuditLog = ({ taskId, run }: Props) => {
       ref={logRef}
       overflowY="auto"
     >
-      <Flex justifyContent="right">
+      <Flex justifyContent="right" mb={2}>
+        <Button
+          leftIcon={<MdRefresh />}
+          onClick={() => refetch()}
+          variant="outline"
+          colorScheme="blue"
+          mr={2}
+        >
+          Refresh
+        </Button>
         <LinkButton href={getMetaValue("audit_log_url")}>
           View full cluster Audit Log
         </LinkButton>


### PR DESCRIPTION
Once we switch the audit log extra to json we should format it correctly. Also, it is nice to have a manual refetch button.

Before:
<img width="1049" alt="Screenshot 2024-03-18 at 4 10 47 PM" src="https://github.com/apache/airflow/assets/4600967/30f47dd4-d5cf-488d-a6b2-65b6ec9ffda2">


After:
<img width="1058" alt="Screenshot 2024-03-18 at 4 08 30 PM" src="https://github.com/apache/airflow/assets/4600967/2eb5ac89-4fc8-4672-a05a-480370bd5c81">




---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
