### PR TITLE
NeptuneStopDbClusterOperator - Handle invalid cluster states

### DIFF
--- a/airflow/providers/amazon/aws/hooks/neptune.py
+++ b/airflow/providers/amazon/aws/hooks/neptune.py
@@ -34,6 +34,12 @@ class NeptuneHook(AwsBaseHook):
 
     AVAILABLE_STATES = ["available"]
     STOPPED_STATES = ["stopped"]
+    ERROR_STATES = [
+        "cloning-failed",
+        "inaccessible-encryption-credentials",
+        "inaccessible-encryption-credentials-recoverable",
+        "migration-failed",
+    ]
 
     def __init__(self, *args, **kwargs):
         kwargs["client_type"] = "neptune"
@@ -83,3 +89,32 @@ class NeptuneHook(AwsBaseHook):
         :return: The status of the cluster.
         """
         return self.get_conn().describe_db_clusters(DBClusterIdentifier=cluster_id)["DBClusters"][0]["Status"]
+
+    def get_db_instance_status(self, instance_id: str) -> str:
+        """
+        Get the status of a Neptune instance.
+
+        :param instance_id: The ID of the instance to get the status of.
+        :return: The status of the instance.
+        """
+        return self.get_conn().describe_db_instances(DBInstanceIdentifier=instance_id)["DBInstances"][0][
+            "DBInstanceStatus"
+        ]
+
+    def wait_for_cluster_instance_availability(
+        self, cluster_id: str, delay: int = 30, max_attempts: int = 60
+    ) -> None:
+        """
+        Wait for Neptune instances in a cluster to be available.
+
+        :param cluster_id: The cluster ID of the instances to wait for.
+        :param delay: Time in seconds to delay between polls.
+        :param max_attempts: Maximum number of attempts to poll for completion.
+        :return: The status of the instances.
+        """
+        filters = [{"Name": "db-cluster-id", "Values": [cluster_id]}]
+        self.log.info("Waiting for instances in cluster %s.", cluster_id)
+        self.get_waiter("db_instance_available").wait(
+            Filters=filters, WaiterConfig={"Delay": delay, "MaxAttempts": max_attempts}
+        )
+        self.log.info("Finished waiting for instances in cluster %s.", cluster_id)

--- a/airflow/providers/amazon/aws/hooks/neptune.py
+++ b/airflow/providers/amazon/aws/hooks/neptune.py
@@ -88,7 +88,7 @@ class NeptuneHook(AwsBaseHook):
         :param cluster_id: The ID of the cluster to get the status of.
         :return: The status of the cluster.
         """
-        return self.get_conn().describe_db_clusters(DBClusterIdentifier=cluster_id)["DBClusters"][0]["Status"]
+        return self.conn.describe_db_clusters(DBClusterIdentifier=cluster_id)["DBClusters"][0]["Status"]
 
     def get_db_instance_status(self, instance_id: str) -> str:
         """
@@ -97,7 +97,7 @@ class NeptuneHook(AwsBaseHook):
         :param instance_id: The ID of the instance to get the status of.
         :return: The status of the instance.
         """
-        return self.get_conn().describe_db_instances(DBInstanceIdentifier=instance_id)["DBInstances"][0][
+        return self.conn.describe_db_instances(DBInstanceIdentifier=instance_id)["DBInstances"][0][
             "DBInstanceStatus"
         ]
 

--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -1363,6 +1363,10 @@ class S3Hook(AwsBaseHook):
         """
         Download a file from the S3 location to the local file system.
 
+        Note:
+            This function shadows the 'download_file' method of S3 API, but it is not the same.
+            If you want to use the original method from S3 API, please use 'S3Hook.get_conn().download_file()'
+
         .. seealso::
             - :external+boto3:py:meth:`S3.Object.download_fileobj`
 
@@ -1380,12 +1384,6 @@ class S3Hook(AwsBaseHook):
             Default: True.
         :return: the file name.
         """
-        self.log.info(
-            "This function shadows the 'download_file' method of S3 API, but it is not the same. If you "
-            "want to use the original method from S3 API, please call "
-            "'S3Hook.get_conn().download_file()'"
-        )
-
         self.log.info("Downloading source S3 file from Bucket %s with path %s", bucket_name, key)
 
         try:

--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -1363,10 +1363,6 @@ class S3Hook(AwsBaseHook):
         """
         Download a file from the S3 location to the local file system.
 
-        Note:
-            This function shadows the 'download_file' method of S3 API, but it is not the same.
-            If you want to use the original method from S3 API, please use 'S3Hook.get_conn().download_file()'
-
         .. seealso::
             - :external+boto3:py:meth:`S3.Object.download_fileobj`
 
@@ -1384,6 +1380,12 @@ class S3Hook(AwsBaseHook):
             Default: True.
         :return: the file name.
         """
+        self.log.info(
+            "This function shadows the 'download_file' method of S3 API, but it is not the same. If you "
+            "want to use the original method from S3 API, please call "
+            "'S3Hook.get_conn().download_file()'"
+        )
+
         self.log.info("Downloading source S3 file from Bucket %s with path %s", bucket_name, key)
 
         try:

--- a/airflow/providers/amazon/aws/operators/neptune.py
+++ b/airflow/providers/amazon/aws/operators/neptune.py
@@ -79,7 +79,6 @@ def handle_waitable_exception(
             operator.hook.wait_for_cluster_availability(operator.cluster_id)
 
 
-
 class NeptuneStartDbClusterOperator(AwsBaseOperator[NeptuneHook]):
     """Starts an Amazon Neptune DB cluster.
 

--- a/airflow/providers/amazon/aws/operators/neptune.py
+++ b/airflow/providers/amazon/aws/operators/neptune.py
@@ -39,7 +39,8 @@ if TYPE_CHECKING:
 def handle_waitable_exception(
     operator: NeptuneStartDbClusterOperator | NeptuneStopDbClusterOperator, err: str
 ):
-    """Handle client exceptions for invalid cluster or invalid instance status that are temporary.
+    """
+    Handle client exceptions for invalid cluster or invalid instance status that are temporary.
 
     After status change, it's possible to retry. Waiter will handle terminal status.
     """

--- a/airflow/providers/amazon/aws/operators/neptune.py
+++ b/airflow/providers/amazon/aws/operators/neptune.py
@@ -337,7 +337,7 @@ class NeptuneStopDbClusterOperator(AwsBaseOperator[NeptuneHook]):
                     self.hook.wait_for_cluster_instance_availability(cluster_id=self.cluster_id)
             else:
                 # re raise for any other type of client error
-                raise ex
+                raise
 
         if self.deferrable:
             self.log.info("Deferring for cluster stop: %s", self.cluster_id)

--- a/airflow/providers/amazon/aws/operators/neptune.py
+++ b/airflow/providers/amazon/aws/operators/neptune.py
@@ -78,7 +78,6 @@ def handle_waitable_exception(
             operator.log.info("Need to wait for cluster to become available: %s", operator.cluster_id)
             operator.hook.wait_for_cluster_availability(operator.cluster_id)
 
-    return
 
 
 class NeptuneStartDbClusterOperator(AwsBaseOperator[NeptuneHook]):

--- a/airflow/providers/amazon/aws/operators/neptune.py
+++ b/airflow/providers/amazon/aws/operators/neptune.py
@@ -141,6 +141,9 @@ class NeptuneStartDbClusterOperator(AwsBaseOperator[NeptuneHook]):
                             trigger=NeptuneClusterInstancesAvailableTrigger(
                                 aws_conn_id=self.aws_conn_id,
                                 db_cluster_id=self.cluster_id,
+                                region_name=self.region_name,
+                                botocore_config=self.botocore_config,
+                                verify=self.verify,
                             ),
                             method_name="execute",
                             kwargs=defer_args,
@@ -151,6 +154,9 @@ class NeptuneStartDbClusterOperator(AwsBaseOperator[NeptuneHook]):
                             trigger=NeptuneClusterAvailableTrigger(
                                 aws_conn_id=self.aws_conn_id,
                                 db_cluster_id=self.cluster_id,
+                                region_name=self.region_name,
+                                botocore_config=self.botocore_config,
+                                verify=self.verify,
                             ),
                             method_name="execute",
                             kwargs=defer_args,
@@ -164,7 +170,7 @@ class NeptuneStartDbClusterOperator(AwsBaseOperator[NeptuneHook]):
                     self.hook.wait_for_cluster_instance_availability(cluster_id=self.cluster_id)
             else:
                 # re raise for any other type of client error
-                raise ex
+                raise
 
         if self.deferrable:
             self.log.info("Deferring for cluster start: %s", self.cluster_id)

--- a/airflow/providers/amazon/aws/operators/neptune.py
+++ b/airflow/providers/amazon/aws/operators/neptune.py
@@ -41,7 +41,7 @@ def handle_waitable_exception(
 ):
     """Handle client exceptions for invalid cluster or invalid instance status that are temporary.
 
-    After status change, its possible to retry. Waiter will handle terminal status.
+    After status change, it's possible to retry. Waiter will handle terminal status.
     """
     code = err
 

--- a/airflow/providers/amazon/aws/triggers/neptune.py
+++ b/airflow/providers/amazon/aws/triggers/neptune.py
@@ -113,3 +113,48 @@ class NeptuneClusterStoppedTrigger(AwsBaseWaiterTrigger):
             verify=self.verify,
             config=self.botocore_config,
         )
+
+
+class NeptuneClusterInstancesAvailableTrigger(AwsBaseWaiterTrigger):
+    """
+    Triggers when a Neptune Cluster Instances available.
+
+    :param db_cluster_id: Cluster ID to wait on instances from
+    :param waiter_delay: The amount of time in seconds to wait between attempts.
+    :param waiter_max_attempts: The maximum number of attempts to be made.
+    :param aws_conn_id: The Airflow connection used for AWS credentials.
+    :param region_name: AWS region name (example: us-east-1)
+    """
+
+    def __init__(
+        self,
+        *,
+        db_cluster_id: str,
+        waiter_delay: int = 30,
+        waiter_max_attempts: int = 60,
+        aws_conn_id: str | None = None,
+        region_name: str | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            serialized_fields={"db_cluster_id": db_cluster_id},
+            waiter_name="cluster_instances_available",
+            waiter_args={"Filters": [{"Name": "db-cluster-id", "Value": db_cluster_id}]},
+            failure_message="Failed to start Neptune instances",
+            status_message="Status of Neptune instances are",
+            status_queries=["DBInstances[].Status"],
+            return_key="db_cluster_id",
+            return_value=db_cluster_id,
+            waiter_delay=waiter_delay,
+            waiter_max_attempts=waiter_max_attempts,
+            aws_conn_id=aws_conn_id,
+            **kwargs,
+        )
+
+    def hook(self) -> AwsGenericHook:
+        return NeptuneHook(
+            aws_conn_id=self.aws_conn_id,
+            region_name=self.region_name,
+            verify=self.verify,
+            config=self.botocore_config,
+        )

--- a/airflow/providers/amazon/aws/triggers/neptune.py
+++ b/airflow/providers/amazon/aws/triggers/neptune.py
@@ -117,7 +117,7 @@ class NeptuneClusterStoppedTrigger(AwsBaseWaiterTrigger):
 
 class NeptuneClusterInstancesAvailableTrigger(AwsBaseWaiterTrigger):
     """
-    Triggers when a Neptune Cluster Instances available.
+    Triggers when a Neptune Cluster Instance is available.
 
     :param db_cluster_id: Cluster ID to wait on instances from
     :param waiter_delay: The amount of time in seconds to wait between attempts.

--- a/airflow/providers/amazon/aws/triggers/neptune.py
+++ b/airflow/providers/amazon/aws/triggers/neptune.py
@@ -138,8 +138,8 @@ class NeptuneClusterInstancesAvailableTrigger(AwsBaseWaiterTrigger):
     ) -> None:
         super().__init__(
             serialized_fields={"db_cluster_id": db_cluster_id},
-            waiter_name="cluster_instances_available",
-            waiter_args={"Filters": [{"Name": "db-cluster-id", "Value": db_cluster_id}]},
+            waiter_name="db_instance_available",
+            waiter_args={"Filters": [{"Name": "db-cluster-id", "Values": [db_cluster_id]}]},
             failure_message="Failed to start Neptune instances",
             status_message="Status of Neptune instances are",
             status_queries=["DBInstances[].Status"],

--- a/tests/providers/amazon/aws/hooks/test_neptune.py
+++ b/tests/providers/amazon/aws/hooks/test_neptune.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 from typing import Generator
+from unittest import mock
 
 import pytest
 from moto import mock_aws
@@ -50,3 +51,10 @@ class TestNeptuneHook:
 
     def test_get_cluster_status(self, neptune_hook: NeptuneHook, neptune_cluster_id):
         assert neptune_hook.get_cluster_status(neptune_cluster_id) is not None
+
+    @mock.patch.object(NeptuneHook, "get_waiter")
+    def test_wait_for_cluster_instance_availability(
+        self, mock_get_waiter, neptune_hook: NeptuneHook, neptune_cluster_id
+    ):
+        neptune_hook.wait_for_cluster_instance_availability(neptune_cluster_id)
+        mock_get_waiter.assert_called_once_with("db_instance_available")

--- a/tests/providers/amazon/aws/operators/test_neptune.py
+++ b/tests/providers/amazon/aws/operators/test_neptune.py
@@ -19,10 +19,13 @@ from __future__ import annotations
 
 from typing import Generator
 from unittest import mock
+from unittest.mock import ANY, call
 
 import pytest
+from boto3 import client
 from moto import mock_aws
 
+from airflow.exceptions import AirflowException, TaskDeferred
 from airflow.providers.amazon.aws.hooks.neptune import NeptuneHook
 from airflow.providers.amazon.aws.operators.neptune import (
     NeptuneStartDbClusterOperator,
@@ -100,11 +103,152 @@ class TestNeptuneStartClusterOperator:
         mock_waiter.assert_not_called()
         assert resp == {"db_cluster_id": CLUSTER_ID}
 
+    @mock.patch.object(NeptuneHook, "conn")
+    def test_start_cluster_deferrable(self, mock_conn):
+        operator = NeptuneStartDbClusterOperator(
+            task_id="task_test",
+            db_cluster_id=CLUSTER_ID,
+            deferrable=True,
+            wait_for_completion=False,
+            aws_conn_id="aws_default",
+        )
+
+        with pytest.raises(TaskDeferred):
+            operator.execute(None)
+
+    @mock.patch.object(NeptuneHook, "conn")
+    @mock.patch.object(NeptuneHook, "get_cluster_status")
+    @mock.patch.object(NeptuneHook, "get_waiter")
+    def test_start_cluster_cluster_error(self, mock_waiter, mock_get_cluster_status, mock_conn):
+        mock_get_cluster_status.return_value = "migration-failed"
+        operator = NeptuneStartDbClusterOperator(
+            task_id="task_test",
+            db_cluster_id=CLUSTER_ID,
+            deferrable=False,
+            wait_for_completion=True,
+            aws_conn_id="aws_default",
+        )
+
+        with pytest.raises(AirflowException):
+            operator.execute(None)
+
+    @mock.patch("airflow.providers.amazon.aws.operators.neptune.NeptuneStartDbClusterOperator.defer")
+    @mock.patch.object(NeptuneHook, "conn")
+    def test_start_cluster_not_ready_defer(self, mock_conn, mock_defer):
+        err_response = {"Error": {"Code": "InvalidClusterStateFault", "Message": "Test message"}}
+        exception = client("neptune").exceptions.ClientError(err_response, "test")
+        returned_exception = type(exception)
+
+        mock_conn.exceptions.InvalidClusterStateFault = returned_exception
+        mock_conn.start_db_cluster.side_effect = exception
+        operator = NeptuneStartDbClusterOperator(
+            task_id="task_test",
+            db_cluster_id=CLUSTER_ID,
+            deferrable=True,
+            wait_for_completion=False,
+            aws_conn_id="aws_default",
+        )
+
+        operator.execute(None)
+        # setting the trigger to ANY because an actual trigger doesn't seem to pass the test, even though
+        # the output (strings) are exactly the same. Suspect it may be an issue in the trigger's __eq__ function
+        calls = [
+            call(
+                trigger=ANY,
+                method_name="execute",
+                kwargs={
+                    "cluster_id": CLUSTER_ID,
+                    "defer": True,
+                    "wait_for_completion": False,
+                    "waiter_delay": 30,
+                    "waiter_max_attempts": 60,
+                    "aws_conn_id": "aws_default",
+                },
+            ),
+            call(
+                trigger=ANY,
+                method_name="execute_complete",
+            ),
+        ]
+
+        mock_defer.assert_has_calls(calls)
+        assert mock_defer.call_count == 2
+
+    @mock.patch.object(NeptuneHook, "conn")
+    @mock.patch.object(NeptuneHook, "get_cluster_status")
+    @mock.patch.object(NeptuneHook, "get_waiter")
+    def test_start_cluster_instances_not_ready(self, mock_get_waiter, mock_get_cluster_status, mock_conn):
+        """Tests both waiters are called if an instance exception is raised"""
+        err_response = {"Error": {"Code": "InvalidDBInstanceStateFault", "Message": "Test message"}}
+        exception = client("neptune").exceptions.ClientError(err_response, "test")
+        returned_exception = type(exception)
+
+        mock_conn.exceptions.InvalidClusterStateFault = returned_exception
+        mock_conn.start_db_cluster.side_effect = exception
+
+        operator = NeptuneStartDbClusterOperator(
+            task_id="task_test",
+            db_cluster_id=CLUSTER_ID,
+            deferrable=False,
+            wait_for_completion=False,
+            aws_conn_id="aws_default",
+        )
+        operator.execute(None)
+        mock_get_waiter.assert_any_call("cluster_available")
+        mock_get_waiter.assert_any_call("db_instance_available")
+
+    @mock.patch("airflow.providers.amazon.aws.operators.neptune.NeptuneStartDbClusterOperator.defer")
+    @mock.patch.object(NeptuneHook, "conn")
+    def test_start_cluster_instances_not_ready_defer(self, mock_conn, mock_defer):
+        """Tests both waiters are called if an instance exception is raised"""
+
+        err_response = {"Error": {"Code": "InvalidDBInstanceStateFault", "Message": "Test message"}}
+        exception = client("neptune").exceptions.ClientError(err_response, "test")
+        returned_exception = type(exception)
+
+        mock_conn.exceptions.InvalidClusterStateFault = returned_exception
+        mock_conn.start_db_cluster.side_effect = exception
+        operator = NeptuneStartDbClusterOperator(
+            task_id="task_test",
+            db_cluster_id=CLUSTER_ID,
+            deferrable=True,
+            wait_for_completion=False,
+            aws_conn_id="aws_default",
+        )
+
+        operator.execute(None)
+        # setting the trigger to ANY because an actual trigger doesn't seem to pass the test, even though
+        # the output (strings) are exactly the same. Suspect it may be an issue in the trigger's __eq__ function
+        calls = [
+            call(
+                trigger=ANY,
+                method_name="execute",
+                kwargs={
+                    "cluster_id": CLUSTER_ID,
+                    "defer": True,
+                    "wait_for_completion": False,
+                    "waiter_delay": 30,
+                    "waiter_max_attempts": 60,
+                    "aws_conn_id": "aws_default",
+                },
+            ),
+            call(
+                trigger=ANY,
+                method_name="execute_complete",
+            ),
+        ]
+
+        mock_defer.assert_has_calls(calls)
+        assert mock_defer.call_count == 2
+
 
 class TestNeptuneStopClusterOperator:
     @mock.patch.object(NeptuneHook, "conn")
+    @mock.patch.object(NeptuneHook, "get_cluster_status")
     @mock.patch.object(NeptuneHook, "get_waiter")
-    def test_stop_cluster_wait_for_completion(self, mock_hook_get_waiter, mock_conn):
+    def test_stop_cluster_wait_for_completion(self, mock_hook_get_waiter, mock_get_cluster_status, mock_conn):
+        '''Test the waiter is only once when the cluster is "available"'''
+        mock_get_cluster_status.return_value = "available"
         operator = NeptuneStopDbClusterOperator(
             task_id="task_test",
             db_cluster_id=CLUSTER_ID,
@@ -118,8 +262,11 @@ class TestNeptuneStopClusterOperator:
         assert resp == EXPECTED_RESPONSE
 
     @mock.patch.object(NeptuneHook, "conn")
+    @mock.patch.object(NeptuneHook, "get_cluster_status")
     @mock.patch.object(NeptuneHook, "get_waiter")
-    def test_stop_cluster_no_wait(self, mock_hook_get_waiter, mock_conn):
+    def test_stop_cluster_no_wait(self, mock_hook_get_waiter, mock_get_cluster_status, mock_conn):
+        mock_get_cluster_status.return_value = "available"
+
         operator = NeptuneStopDbClusterOperator(
             task_id="task_test",
             db_cluster_id=CLUSTER_ID,
@@ -150,3 +297,157 @@ class TestNeptuneStopClusterOperator:
         mock_conn.stop_db_cluster.assert_not_called()
         mock_waiter.assert_not_called()
         assert resp == {"db_cluster_id": CLUSTER_ID}
+
+    @mock.patch.object(NeptuneHook, "conn")
+    @mock.patch.object(NeptuneHook, "get_cluster_status")
+    @mock.patch.object(NeptuneHook, "get_waiter")
+    def test_stop_cluster_cluster_error(self, mock_waiter, mock_get_cluster_status, mock_conn):
+        mock_get_cluster_status.return_value = "migration-failed"
+        operator = NeptuneStopDbClusterOperator(
+            task_id="task_test",
+            db_cluster_id=CLUSTER_ID,
+            deferrable=False,
+            wait_for_completion=True,
+            aws_conn_id="aws_default",
+        )
+
+        with pytest.raises(AirflowException):
+            operator.execute(None)
+
+    @mock.patch.object(NeptuneHook, "conn")
+    @mock.patch.object(NeptuneHook, "get_cluster_status")
+    @mock.patch.object(NeptuneHook, "get_waiter")
+    def test_stop_cluster_not_in_available(self, mock_waiter, mock_get_cluster_status, mock_conn):
+        mock_get_cluster_status.return_value = "backing-up"
+        operator = NeptuneStopDbClusterOperator(
+            task_id="task_test",
+            db_cluster_id=CLUSTER_ID,
+            deferrable=False,
+            wait_for_completion=True,
+            aws_conn_id="aws_default",
+        )
+
+        operator.execute(None)
+        mock_waiter.assert_called_with("cluster_stopped")
+
+    @mock.patch("airflow.providers.amazon.aws.operators.neptune.NeptuneStopDbClusterOperator.defer")
+    @mock.patch.object(NeptuneHook, "conn")
+    def test_stop_cluster_not_ready_defer(self, mock_conn, mock_defer):
+        err_response = {"Error": {"Code": "InvalidClusterStateFault", "Message": "Test message"}}
+        exception = client("neptune").exceptions.ClientError(err_response, "test")
+        returned_exception = type(exception)
+
+        mock_conn.exceptions.InvalidClusterStateFault = returned_exception
+        mock_conn.stop_db_cluster.side_effect = exception
+        operator = NeptuneStopDbClusterOperator(
+            task_id="task_test",
+            db_cluster_id=CLUSTER_ID,
+            deferrable=True,
+            wait_for_completion=False,
+            aws_conn_id="aws_default",
+        )
+
+        operator.execute(None)
+        # setting the trigger to ANY because an actual trigger doesn't seem to pass the test, even though
+        # the output (strings) are exactly the same. Suspect it may be an issue in the trigger's __eq__ function
+        calls = [
+            call(
+                trigger=ANY,
+                method_name="execute",
+                kwargs={
+                    "cluster_id": CLUSTER_ID,
+                    "defer": True,
+                    "wait_for_completion": False,
+                    "waiter_delay": 30,
+                    "waiter_max_attempts": 60,
+                    "aws_conn_id": "aws_default",
+                },
+            ),
+            call(
+                trigger=ANY,
+                method_name="execute_complete",
+            ),
+        ]
+
+        mock_defer.assert_has_calls(calls)
+        assert mock_defer.call_count == 2
+
+    @mock.patch.object(NeptuneHook, "conn")
+    @mock.patch.object(NeptuneHook, "get_cluster_status")
+    @mock.patch.object(NeptuneHook, "get_waiter")
+    def test_stop_cluster_instances_not_ready(self, mock_get_waiter, mock_get_cluster_status, mock_conn):
+        """Tests both waiters are called if an instance exception is raised"""
+        err_response = {"Error": {"Code": "InvalidDBInstanceStateFault", "Message": "Test message"}}
+        exception = client("neptune").exceptions.ClientError(err_response, "test")
+        returned_exception = type(exception)
+
+        mock_conn.exceptions.InvalidClusterStateFault = returned_exception
+        mock_conn.stop_db_cluster.side_effect = exception
+
+        operator = NeptuneStopDbClusterOperator(
+            task_id="task_test",
+            db_cluster_id=CLUSTER_ID,
+            deferrable=False,
+            wait_for_completion=False,
+            aws_conn_id="aws_default",
+        )
+        operator.execute(None)
+        mock_get_waiter.assert_any_call("cluster_available")
+        mock_get_waiter.assert_any_call("db_instance_available")
+
+    @mock.patch("airflow.providers.amazon.aws.operators.neptune.NeptuneStopDbClusterOperator.defer")
+    @mock.patch.object(NeptuneHook, "conn")
+    def test_stop_cluster_instances_not_ready_defer(self, mock_conn, mock_defer):
+        """Tests both waiters are called if an instance exception is raised"""
+
+        err_response = {"Error": {"Code": "InvalidDBInstanceStateFault", "Message": "Test message"}}
+        exception = client("neptune").exceptions.ClientError(err_response, "test")
+        returned_exception = type(exception)
+
+        mock_conn.exceptions.InvalidClusterStateFault = returned_exception
+        mock_conn.stop_db_cluster.side_effect = exception
+        operator = NeptuneStopDbClusterOperator(
+            task_id="task_test",
+            db_cluster_id=CLUSTER_ID,
+            deferrable=True,
+            wait_for_completion=False,
+            aws_conn_id="aws_default",
+        )
+
+        operator.execute(None)
+        # setting the trigger to ANY because an actual trigger doesn't seem to pass the test, even though
+        # the output (strings) are exactly the same. Suspect it may be an issue in the trigger's __eq__ function
+        calls = [
+            call(
+                trigger=ANY,
+                method_name="execute",
+                kwargs={
+                    "cluster_id": CLUSTER_ID,
+                    "defer": True,
+                    "wait_for_completion": False,
+                    "waiter_delay": 30,
+                    "waiter_max_attempts": 60,
+                    "aws_conn_id": "aws_default",
+                },
+            ),
+            call(
+                trigger=ANY,
+                method_name="execute_complete",
+            ),
+        ]
+
+        mock_defer.assert_has_calls(calls)
+        assert mock_defer.call_count == 2
+
+    @mock.patch.object(NeptuneHook, "conn")
+    def test_stop_cluster_deferrable(self, mock_conn):
+        operator = NeptuneStopDbClusterOperator(
+            task_id="task_test",
+            db_cluster_id=CLUSTER_ID,
+            deferrable=True,
+            wait_for_completion=False,
+            aws_conn_id="aws_default",
+        )
+
+        with pytest.raises(TaskDeferred):
+            operator.execute(None)

--- a/tests/providers/amazon/aws/operators/test_neptune.py
+++ b/tests/providers/amazon/aws/operators/test_neptune.py
@@ -290,7 +290,7 @@ class TestNeptuneStopClusterOperator:
         operator.execute(None)
         mock_waiter.assert_called_with("cluster_stopped")
 
-    @mock.patch("airflow.providers.amazon.aws.operators.neptune.NeptuneStopDbClusterOperator.defer")
+    @mock.patch.object(NeptuneStopDbClusterOperator, "defer")
     @mock.patch.object(NeptuneHook, "conn")
     def test_stop_cluster_not_ready_defer(self, mock_conn, mock_defer):
         err_response = {"Error": {"Code": "InvalidClusterState", "Message": "Test message"}}


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!-- Please keep an empty line above the dashes. -->
---
closes #38120 

Handles case where the stop cluster api returns either InvalidClusterState or InvalidDBInstanceState exceptions. The operator now uses the waiter to wait for the cluster to be available. Also updated the start cluster operator to do the same.
