### PR TITLE
Update AWS auth manager CLI command to not disable AVP schema validation

### DIFF
--- a/airflow/providers/amazon/aws/auth_manager/cli/avp_commands.py
+++ b/airflow/providers/amazon/aws/auth_manager/cli/avp_commands.py
@@ -120,7 +120,7 @@ def _create_policy_store(client: BaseClient, args) -> tuple[str | None, bool]:
 
         response = client.create_policy_store(
             validationSettings={
-                "mode": "OFF",
+                "mode": "STRICT",
             },
             description=args.policy_store_description,
         )
@@ -138,30 +138,6 @@ def _set_schema(client: BaseClient, policy_store_id: str, args) -> None:
         print(f"Dry run, not updating the schema of the policy store with ID '{policy_store_id}'.")
         return
 
-    if args.verbose:
-        log.debug("Getting the policy store details")
-
-    details = client.get_policy_store(
-        policyStoreId=policy_store_id,
-    )
-
-    if args.verbose:
-        log.debug("Response from get_policy_store: %s", details)
-
-    if args.verbose:
-        log.debug("Disabling schema validation before updating schema")
-
-    response = client.update_policy_store(
-        policyStoreId=policy_store_id,
-        validationSettings={
-            "mode": "OFF",
-        },
-        description=details["description"],
-    )
-
-    if args.verbose:
-        log.debug("Response from update_policy_store: %s", response)
-
     schema_path = Path(__file__).parents[0].joinpath("schema.json").resolve()
     with open(schema_path) as schema_file:
         response = client.put_schema(
@@ -175,17 +151,3 @@ def _set_schema(client: BaseClient, policy_store_id: str, args) -> None:
             log.debug("Response from put_schema: %s", response)
 
     print("Policy store schema updated.")
-
-    if args.verbose:
-        log.debug("Enabling schema validation after updating schema")
-
-    response = client.update_policy_store(
-        policyStoreId=policy_store_id,
-        validationSettings={
-            "mode": "STRICT",
-        },
-        description=details["description"],
-    )
-
-    if args.verbose:
-        log.debug("Response from update_policy_store: %s", response)

--- a/tests/providers/amazon/aws/auth_manager/cli/test_avp_commands.py
+++ b/tests/providers/amazon/aws/auth_manager/cli/test_avp_commands.py
@@ -65,7 +65,6 @@ class TestAvpCommands:
 
         mock_boto3.get_paginator.return_value = paginator
         mock_boto3.create_policy_store.return_value = {"policyStoreId": policy_store_id}
-        mock_boto3.get_policy_store.return_value = {"description": policy_store_description}
 
         with conf_vars({("database", "check_migrations"): "False"}):
             params = [
@@ -82,16 +81,14 @@ class TestAvpCommands:
 
         if dry_run:
             mock_boto3.create_policy_store.assert_not_called()
-            mock_boto3.update_policy_store.assert_not_called()
             mock_boto3.put_schema.assert_not_called()
         else:
             mock_boto3.create_policy_store.assert_called_once_with(
                 validationSettings={
-                    "mode": "OFF",
+                    "mode": "STRICT",
                 },
                 description=policy_store_description,
             )
-            assert mock_boto3.update_policy_store.call_count == 2
             mock_boto3.put_schema.assert_called_once_with(
                 policyStoreId=policy_store_id,
                 definition={
@@ -164,10 +161,8 @@ class TestAvpCommands:
             update_schema(self.arg_parser.parse_args(params))
 
         if dry_run:
-            mock_boto3.update_policy_store.assert_not_called()
             mock_boto3.put_schema.assert_not_called()
         else:
-            assert mock_boto3.update_policy_store.call_count == 2
             mock_boto3.put_schema.assert_called_once_with(
                 policyStoreId=policy_store_id,
                 definition={


### PR DESCRIPTION
Amazon Verified Permissions schema validation should never be disabled. It could be pretty destructive for user defined policies. 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
