### PR TITLE
Add upper limit to planned calendar events calculation

### DIFF
--- a/airflow/www/static/js/dag/details/dag/Calendar.tsx
+++ b/airflow/www/static/js/dag/details/dag/Calendar.tsx
@@ -21,11 +21,12 @@
 
 import React from "react";
 import type { EChartsOption } from "echarts";
-import { Spinner } from "@chakra-ui/react";
+import { Box, Spinner, Flex } from "@chakra-ui/react";
 
 import ReactECharts from "src/components/ReactECharts";
 import { useCalendarData } from "src/api";
 import useFilters from "src/dag/useFilters";
+import InfoTooltip from "src/components/InfoTooltip";
 
 const Calendar = () => {
   const { onBaseDateChange } = useFilters();
@@ -189,7 +190,18 @@ const Calendar = () => {
     },
   };
 
-  return <ReactECharts option={option} events={events} />;
+  return (
+    <Box height="100%">
+      <Flex>
+        <InfoTooltip
+          label="        Only showing the next year of planned DAG runs or the next 2000 runs,
+          whichever comes first."
+          size={16}
+        />
+      </Flex>
+      <ReactECharts option={option} events={events} />
+    </Box>
+  );
 };
 
 export default Calendar;

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2976,6 +2976,10 @@ class Airflow(AirflowBaseView):
             for dr in dag_states
         ]
 
+        # Upper limit of how many planned runs we should iterate through
+        max_planned_runs = 2000
+        total_planned = 0
+
         # Interpret the schedule and show planned dag runs in calendar
         if (
             dag_states
@@ -3023,6 +3027,9 @@ class Airflow(AirflowBaseView):
                     last_automated_data_interval = curr_info.data_interval
                     dates[curr_info.logical_date.date()] += 1
                     prev_logical_date = curr_info.logical_date
+                    total_planned += 1
+                    if total_planned > max_planned_runs:
+                        break
 
             data_dag_states.extend(
                 {"date": date.isoformat(), "state": "planned", "count": count}


### PR DESCRIPTION
If you had a Dag that ran extremely often, like every minute, it would take a long time to fetch the data for the calendar view. And seeing that many planned events isn't too useful anyways. The easy fix is to put a max count we are willing to calculate and then include an info tooltip for the user explaining the issue.

<img width="903" alt="Screenshot 2024-03-19 at 5 09 56 PM" src="https://github.com/apache/airflow/assets/4600967/cbc18d3d-0d72-44d6-be65-5cb0efd70bd8">



---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
