### PR TITLE
Fix bash command formatting in docs

### DIFF
--- a/contributing-docs/03_contributors_quick_start.rst
+++ b/contributing-docs/03_contributors_quick_start.rst
@@ -239,7 +239,7 @@ Setting up Breeze
   The workaround is to downgrade packaging to 23.1 and re-running the ``pipx install`` command, for example
   by running ``pip install "packaging<23.2"``.
 
-  .. code-block::bash
+  .. code-block:: bash
 
      pip install "packaging==23.1"
      pipx install -e ./dev/breeze --force

--- a/contributing-docs/quick-start-ide/contributors_quick_start_gitpod.rst
+++ b/contributing-docs/quick-start-ide/contributors_quick_start_gitpod.rst
@@ -68,7 +68,7 @@ Gitpod default image have all the required packages installed.
   The workaround is to downgrade packaging to 23.1 and re-running the ``pipx install`` command. for example
   by running ``pip install "packaging<23.2"``.
 
-  .. code-block::bash
+  .. code-block:: bash
 
      pip install "packaging==23.1"
      pipx install -e ./dev/breeze --force

--- a/dev/breeze/doc/01_installation.rst
+++ b/dev/breeze/doc/01_installation.rst
@@ -251,7 +251,7 @@ Run this command to install Breeze (make sure to use ``-e`` flag):
 
   The workaround is to downgrade packaging to 23.1 and re-running the ``pipx install`` command.
 
-  .. code-block::bash
+  .. code-block:: bash
 
      pip install "packaging<23.2"
      pipx install -e ./dev/breeze --force

--- a/dev/breeze/doc/05_test_commands.rst
+++ b/dev/breeze/doc/05_test_commands.rst
@@ -427,13 +427,13 @@ for all clusters in parallel.
 
 Run all tests:
 
-.. code-block::bash
+.. code-block:: bash
 
     breeze k8s tests
 
 Run selected tests:
 
-.. code-block::bash
+.. code-block:: bash
 
     breeze k8s tests test_kubernetes_executor.py
 
@@ -449,7 +449,7 @@ shell command directly. In case the shell parameters are the same as the paramet
 can pass them after ``--``. For example this is the way how you can see all available parameters of the shell
 you have:
 
-.. code-block::bash
+.. code-block:: bash
 
     breeze k8s tests -- --help
 
@@ -458,7 +458,7 @@ with the specifications of tests you want to run. For example the command below 
 ``test_kubernetes_executor.py`` and will suppress capturing output from Pytest so that you can see the
 output during test execution.
 
-.. code-block::bash
+.. code-block:: bash
 
     breeze k8s tests -- test_kubernetes_executor.py -s
 
@@ -471,13 +471,13 @@ to run the whole chains in parallel.
 
 Run all tests:
 
-.. code-block::bash
+.. code-block:: bash
 
     breeze k8s run-complete-tests
 
 Run selected tests:
 
-.. code-block::bash
+.. code-block:: bash
 
     breeze k8s run-complete-tests test_kubernetes_executor.py
 
@@ -493,7 +493,7 @@ shell command directly. In case the shell parameters are the same as the paramet
 can pass them after ``--``. For example this is the way how you can see all available parameters of the shell
 you have:
 
-.. code-block::bash
+.. code-block:: bash
 
     breeze k8s run-complete-tests -- --help
 
@@ -502,7 +502,7 @@ with the specifications of tests you want to run. For example the command below 
 ``test_kubernetes_executor.py`` and will suppress capturing output from Pytest so that you can see the
 output during test execution.
 
-.. code-block::bash
+.. code-block:: bash
 
     breeze k8s run-complete-tests -- test_kubernetes_executor.py -s
 
@@ -517,7 +517,7 @@ cluster pre-configured. This is done via ``breeze k8s shell`` command.
 Once you are in the shell, the prompt will indicate which cluster you are interacting with as well
 as executor you use, similar to:
 
-.. code-block::bash
+.. code-block:: bash
 
     (kind-airflow-python-3.9-v1.24.0:KubernetesExecutor)>
 
@@ -526,7 +526,7 @@ The shell automatically activates the virtual environment that has all appropria
 installed and you can interactively run all k8s tests with pytest command (of course the cluster need to
 be created and airflow deployed to it before running the tests):
 
-.. code-block::bash
+.. code-block:: bash
 
     (kind-airflow-python-3.9-v1.24.0:KubernetesExecutor)> pytest test_kubernetes_executor.py
     ================================================= test session starts =================================================
@@ -562,7 +562,7 @@ shell command directly. In case the shell parameters are the same as the paramet
 can pass them after ``--``. For example this is the way how you can see all available parameters of the shell
 you have:
 
-.. code-block::bash
+.. code-block:: bash
 
     breeze k8s shell -- --help
 
@@ -585,7 +585,7 @@ You can also specify any ``k9s`` flags and commands as extra parameters - they w
 can pass them after ``--``. For example this is the way how you can see all available parameters of the
 ``k9s`` you have:
 
-.. code-block::bash
+.. code-block:: bash
 
     breeze k8s k9s -- --help
 


### PR DESCRIPTION
When `.. code-block::bash` is used, the command is not shown in the docs. Example: https://github.com/apache/airflow/blob/main/dev/breeze/doc/05_test_commands.rst#running-k8s-tests

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
