### PR TITLE
Hide upstream dataset edges in dag graph

### DIFF
--- a/airflow/www/static/js/components/Graph/Edge.tsx
+++ b/airflow/www/static/js/components/Graph/Edge.tsx
@@ -32,6 +32,8 @@ const CustomEdge = ({ data }: EdgeProps) => {
   const { colors } = useTheme();
   if (!data) return null;
   const { rest } = data;
+  // We can not actually say a dataset is upstream of a particular task so do not render the edge
+  if (rest.isSourceDataset) return null;
   let strokeWidth = 2;
   if (rest.isSelected) strokeWidth = 3;
   if (rest.isZoomedOut) strokeWidth = 5;

--- a/airflow/www/static/js/dag/details/graph/index.tsx
+++ b/airflow/www/static/js/dag/details/graph/index.tsx
@@ -115,6 +115,7 @@ const Graph = ({
           sourceId: dataset.id.toString(),
           // Point upstream datasets to the first task
           targetId: data.nodes?.children[0].id,
+          isSourceDataset: true,
         });
       }
     }

--- a/airflow/www/static/js/types/index.ts
+++ b/airflow/www/static/js/types/index.ts
@@ -166,6 +166,7 @@ export interface EdgeData {
     isSetupTeardown?: boolean;
     parentNode?: string;
     isZoomedOut?: boolean;
+    isSourceDataset?: boolean;
   };
 }
 
@@ -181,6 +182,7 @@ export interface WebserverEdge {
   targetId: string;
   isSetupTeardown?: boolean;
   parentNode?: string;
+  isSourceDataset?: boolean;
 }
 
 interface DatasetListItem extends API.Dataset {

--- a/airflow/www/static/js/utils/graph.ts
+++ b/airflow/www/static/js/utils/graph.ts
@@ -74,6 +74,7 @@ const formatEdge = (e: WebserverEdge, font: string, node?: DepNode) => ({
   targets: [e.targetId],
   isSetupTeardown: e.isSetupTeardown,
   parentNode: node?.id,
+  isSourceDataset: e.isSourceDataset,
   labels: e.label
     ? [
         {


### PR DESCRIPTION
Datasets were added to the dag graph in https://github.com/apache/airflow/pull/37604. It helps to navigate between connected datasets and dags. But we can't exactly say an individual task is downstream of a dataset and we still want to show the datasets at the start of the graph.

Instead, we keep calculating the edge to place the dataset node towards the start of a dag graph, but do not actually display the edge.


<img width="639" alt="Screenshot 2024-03-20 at 10 42 54 AM" src="https://github.com/apache/airflow/assets/4600967/6e13e353-dfae-40ab-a3ec-ebd46c43a786">

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
