### PR TITLE
Only show latest dataset event timestamp after last run

### DIFF
--- a/airflow/www/templates/airflow/dataset_next_run_modal.html
+++ b/airflow/www/templates/airflow/dataset_next_run_modal.html
@@ -42,7 +42,7 @@
             <thead>
               <tr>
                 <th>Dataset URI</th>
-                <th>Latest Update</th>
+                <th>Latest Update since last Dag Run</th>
               </tr>
             </thead>
             <tbody id="datasets_tbody">

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3677,7 +3677,7 @@ class Airflow(AirflowBaseView):
         with create_session() as session:
             dag_model = DagModel.get_dagmodel(dag_id, session=session)
 
-            latest_run = dag_model.get_last_dagrun()
+            latest_run = dag_model.get_last_dagrun(session=session)
 
             events = [
                 dict(info)

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3677,8 +3677,16 @@ class Airflow(AirflowBaseView):
         with create_session() as session:
             dag_model = DagModel.get_dagmodel(dag_id, session=session)
 
+            latest_run = dag_model.get_last_dagrun()
+
             events = [
-                dict(info)
+                {
+                    "id": info.id,
+                    "uri": info.uri,
+                    "lastUpdate": info.lastUpdate
+                    if not latest_run or (info.lastUpdate and info.lastUpdate > latest_run.execution_date)
+                    else None,
+                }
                 for info in session.execute(
                     select(
                         DatasetModel.id,


### PR DESCRIPTION
In the next run dataset modal, "Last Update" can be confusing since the dataset update events could be irrelevant to the next dag run. Therefore, we should only show the last update event that has happened since the previous dag run.

Before: (Looks like 2 of 2 datasets are updated and its hard to see what we're waiting on)
<img width="650" alt="Screenshot 2024-03-20 at 11 06 42 AM" src="https://github.com/apache/airflow/assets/4600967/98d822b2-23db-4ade-a6d2-70c71613754b">


After: (1 of 2 datasets is a lot more straightforward to see)
<img width="657" alt="Screenshot 2024-03-20 at 11 06 29 AM" src="https://github.com/apache/airflow/assets/4600967/acdf604b-89a6-48ad-b1d7-8ab6e1898c03">


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
