### PR TITLE
Revert CodeCell formatting changes

### DIFF
--- a/airflow/www/static/js/components/NewTable/NewCells.tsx
+++ b/airflow/www/static/js/components/NewTable/NewCells.tsx
@@ -29,6 +29,5 @@ export const TimeCell = ({ getValue }: any) => {
 
 export const CodeCell = ({ getValue }: any) => {
   const value = getValue();
-  const code = typeof value === "string" ? JSON.parse(value) : value;
-  return code ? <Code>{JSON.stringify(code)}</Code> : null;
+  return value ? <Code>{value}</Code> : null;
 };


### PR DESCRIPTION
After we fixed the Audit Log extras. We don't need this change anymore. We also were missing important check to make sure extra actually was json, which older audit log extra wouldn't be.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
