### PR TITLE
Fix set deprecated slack operators arguments in `MappedOperator`

### DIFF
--- a/airflow/providers/slack/operators/slack.py
+++ b/airflow/providers/slack/operators/slack.py
@@ -27,6 +27,7 @@ from typing_extensions import Literal
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import BaseOperator
 from airflow.providers.slack.hooks.slack import SlackHook
+from airflow.utils.types import NOTSET, ArgNotSet
 
 if TYPE_CHECKING:
     from slack_sdk.http_retry import RetryHandler
@@ -226,9 +227,10 @@ class SlackAPIFileOperator(SlackAPIOperator):
         content: str | None = None,
         title: str | None = None,
         method_version: Literal["v1", "v2"] = "v1",
+        channel: str | Sequence[str] | None | ArgNotSet = NOTSET,
         **kwargs,
     ) -> None:
-        if channel := kwargs.pop("channel", None):
+        if channel is not NOTSET:
             warnings.warn(
                 "Argument `channel` is deprecated and will removed in a future releases. "
                 "Please use `channels` instead.",
@@ -237,7 +239,7 @@ class SlackAPIFileOperator(SlackAPIOperator):
             )
             if channels:
                 raise ValueError(f"Cannot set both arguments: channel={channel!r} and channels={channels!r}.")
-            channels = channel
+            channels = channel  # type: ignore[assignment]
 
         super().__init__(method="files.upload", **kwargs)
         self.channels = channels

--- a/airflow/providers/slack/transfers/sql_to_slack_webhook.py
+++ b/airflow/providers/slack/transfers/sql_to_slack_webhook.py
@@ -25,6 +25,7 @@ from tabulate import tabulate
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.slack.hooks.slack_webhook import SlackWebhookHook
 from airflow.providers.slack.transfers.base_sql_to_slack import BaseSqlToSlackOperator
+from airflow.utils.types import NOTSET, ArgNotSet
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
@@ -87,9 +88,10 @@ class SqlToSlackWebhookOperator(BaseSqlToSlackOperator):
         slack_message: str,
         results_df_name: str = "results_df",
         parameters: list | tuple | Mapping[str, Any] | None = None,
+        slack_conn_id: str | ArgNotSet = NOTSET,
         **kwargs,
     ) -> None:
-        if slack_conn_id := kwargs.pop("slack_conn_id", None):
+        if slack_conn_id is not NOTSET:
             warnings.warn(
                 "Parameter `slack_conn_id` is deprecated because this attribute initially intend to use with "
                 "Slack API however this operator provided integration with Slack Incoming Webhook. "
@@ -102,7 +104,7 @@ class SqlToSlackWebhookOperator(BaseSqlToSlackOperator):
                     "Conflicting Connection ids provided, "
                     f"slack_webhook_conn_id={slack_webhook_conn_id!r}, slack_conn_id={slack_conn_id!r}."
                 )
-            slack_webhook_conn_id = slack_conn_id
+            slack_webhook_conn_id = slack_conn_id  # type: ignore[assignment]
         if not slack_webhook_conn_id:
             raise ValueError("Got an empty `slack_webhook_conn_id` value.")
         super().__init__(

--- a/tests/providers/slack/operators/test_slack.py
+++ b/tests/providers/slack/operators/test_slack.py
@@ -28,6 +28,7 @@ from airflow.providers.slack.operators.slack import (
     SlackAPIOperator,
     SlackAPIPostOperator,
 )
+from airflow.utils.task_instance_session import set_current_task_instance_session
 
 SLACK_API_TEST_CONNECTION_ID = "test_slack_conn_id"
 DEFAULT_HOOKS_PARAMETERS = {"base_url": None, "timeout": None, "proxy": None, "retry_handlers": None}
@@ -308,3 +309,55 @@ class TestSlackAPIFileOperator:
                 channel="#random",
                 channels="#general",
             )
+
+    @pytest.mark.db_test
+    @pytest.mark.parametrize(
+        "channel",
+        [
+            pytest.param("#contributors", id="single-channel"),
+            pytest.param(["#random", "#general"], id="multiple-channels"),
+        ],
+    )
+    def test_partial_deprecated_channel(self, channel, dag_maker, session):
+        with dag_maker(dag_id="test_partial_deprecated_channel", session=session):
+            SlackAPIFileOperator.partial(
+                task_id="fake-task-id",
+                slack_conn_id="fake-conn-id",
+                channel=channel,
+            ).expand(filename=["/dev/zero", "/dev/urandom"])
+
+        dr = dag_maker.create_dagrun()
+        tis = dr.get_task_instances(session=session)
+        with set_current_task_instance_session(session=session):
+            warning_match = r"Argument `channel` is deprecated.*use `channels` instead"
+            for ti in tis:
+                with pytest.warns(AirflowProviderDeprecationWarning, match=warning_match):
+                    ti.render_templates()
+                assert ti.task.channels == channel
+
+    @pytest.mark.db_test
+    @pytest.mark.parametrize(
+        "channel, channels",
+        [
+            pytest.param("#contributors", "#user-troubleshooting", id="ambiguous-channel-params"),
+            pytest.param(["#random", "#general"], ["#random", "#general"], id="non-ambiguous-channel-params"),
+        ],
+    )
+    def test_partial_both_channel_parameters(self, channel, channels, dag_maker, session):
+        with dag_maker("test_partial_both_channel_parameters", session=session):
+            SlackAPIFileOperator.partial(
+                task_id="fake-task-id",
+                slack_conn_id="fake-conn-id",
+                channel=channel,
+                channels=channels,
+            ).expand(filename=["/dev/zero", "/dev/urandom"])
+
+        dr = dag_maker.create_dagrun(session=session)
+        tis = dr.get_task_instances(session=session)
+        with set_current_task_instance_session(session=session):
+            warning_match = r"Argument `channel` is deprecated.*use `channels` instead"
+            for ti in tis:
+                with pytest.warns(AirflowProviderDeprecationWarning, match=warning_match), pytest.raises(
+                    ValueError, match="Cannot set both arguments"
+                ):
+                    ti.render_templates()

--- a/tests/providers/slack/transfers/test_sql_to_slack_webhook.py
+++ b/tests/providers/slack/transfers/test_sql_to_slack_webhook.py
@@ -27,6 +27,7 @@ from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import Connection
 from airflow.providers.slack.transfers.sql_to_slack_webhook import SqlToSlackWebhookOperator
 from airflow.utils import timezone
+from airflow.utils.task_instance_session import set_current_task_instance_session
 
 TEST_DAG_ID = "sql_to_slack_unit_test"
 TEST_TASK_ID = "sql_to_slack_unit_test_task"
@@ -269,3 +270,49 @@ class TestSqlToSlackWebhookOperator:
         assert hook.database == "database"
         assert hook.role == "role"
         assert hook.schema == "schema"
+
+    @pytest.mark.parametrize(
+        "slack_conn_id, slack_webhook_conn_id",
+        [
+            pytest.param("slack_conn_id", None, id="slack-conn-id-only"),
+            pytest.param("slack_conn_id", "slack_conn_id", id="non-ambiguous-params"),
+        ],
+    )
+    def test_partial_deprecated_slack_conn_id(self, slack_conn_id, slack_webhook_conn_id, dag_maker, session):
+        with dag_maker(dag_id="test_partial_deprecated_slack_conn_id", session=session):
+            SqlToSlackWebhookOperator.partial(
+                task_id="fake-task-id",
+                slack_conn_id=slack_conn_id,
+                slack_webhook_conn_id=slack_webhook_conn_id,
+                sql_conn_id="fake-sql-conn-id",
+                slack_message="<https://github.com/apache/airflow|Apache Airflow™>",
+            ).expand(sql=["SELECT 1", "SELECT 2"])
+
+        dr = dag_maker.create_dagrun()
+        tis = dr.get_task_instances(session=session)
+        with set_current_task_instance_session(session=session):
+            warning_match = r"Parameter `slack_conn_id` is deprecated"
+            for ti in tis:
+                with pytest.warns(AirflowProviderDeprecationWarning, match=warning_match):
+                    ti.render_templates()
+                assert ti.task.slack_webhook_conn_id == slack_conn_id
+
+    def test_partial_ambiguous_slack_connections(self, dag_maker, session):
+        with dag_maker("test_partial_ambiguous_slack_connections", session=session):
+            SqlToSlackWebhookOperator.partial(
+                task_id="fake-task-id",
+                slack_conn_id="slack_conn_id",
+                slack_webhook_conn_id="slack_webhook_conn_id",
+                sql_conn_id="fake-sql-conn-id",
+                slack_message="<https://github.com/apache/airflow|Apache Airflow™>",
+            ).expand(sql=["SELECT 1", "SELECT 2"])
+
+        dr = dag_maker.create_dagrun(session=session)
+        tis = dr.get_task_instances(session=session)
+        with set_current_task_instance_session(session=session):
+            warning_match = r"Parameter `slack_conn_id` is deprecated"
+            for ti in tis:
+                with pytest.warns(AirflowProviderDeprecationWarning, match=warning_match), pytest.raises(
+                    ValueError, match="Conflicting Connection ids provided"
+                ):
+                    ti.render_templates()


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

similar to: https://github.com/apache/airflow/pull/38178

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
