### PR TITLE
Limit `cohere` to <5

### DIFF
--- a/airflow/providers/cohere/hooks/cohere.py
+++ b/airflow/providers/cohere/hooks/cohere.py
@@ -53,7 +53,7 @@ class CohereHook(BaseHook):
         self.max_retries = max_retries
 
     @cached_property
-    def get_conn(self) -> cohere.Client:
+    def get_conn(self) -> cohere.Client:  # type: ignore[override]
         conn = self.get_connection(self.conn_id)
         return cohere.Client(
             api_key=conn.password, timeout=self.timeout, max_retries=self.max_retries, api_url=conn.host

--- a/airflow/providers/cohere/provider.yaml
+++ b/airflow/providers/cohere/provider.yaml
@@ -42,7 +42,7 @@ integrations:
 
 dependencies:
   - apache-airflow>=2.6.0
-  - cohere>=4.37
+  - cohere>=4.37,<5
 
 hooks:
   - integration-name: Cohere

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -330,7 +330,7 @@
   "cohere": {
     "deps": [
       "apache-airflow>=2.6.0",
-      "cohere>=4.37"
+      "cohere>=4.37,<5"
     ],
     "devel-deps": [],
     "cross-providers-deps": [],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -663,7 +663,7 @@ cncf-kubernetes = [ # source: airflow/providers/cncf/kubernetes/provider.yaml
   "kubernetes_asyncio>=28.1.0,<=29.0.0",
 ]
 cohere = [ # source: airflow/providers/cohere/provider.yaml
-  "cohere>=4.37",
+  "cohere>=4.37,<5",
 ]
 common-io = [] # source: airflow/providers/common/io/provider.yaml
 common-sql = [ # source: airflow/providers/common/sql/provider.yaml


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

cohere 5.0.0 [just released](https://pypi.org/project/cohere/#history), and seems breaks mypy and most possible it is also brings some breaking changes

```console
airflow/providers/cohere/hooks/cohere.py:58: error: Unexpected keyword argument
"max_retries" for "Client"  [call-arg]
            return cohere.Client(
                   ^
/usr/local/lib/python3.8/site-packages/cohere/client.py:60: note: "Client" defined here
airflow/providers/cohere/hooks/cohere.py:58: error: Unexpected keyword argument
"api_url" for "Client"  [call-arg]
            return cohere.Client(
                   ^
/usr/local/lib/python3.8/site-packages/cohere/client.py:60: note: "Client" defined here
airflow/providers/cohere/hooks/cohere.py:56: error: Signature of "get_conn"
incompatible with supertype "BaseHook"  [override]
        def get_conn(self) -> cohere.Client:
        ^
airflow/providers/cohere/hooks/cohere.py:56: note:      Superclass:
airflow/providers/cohere/hooks/cohere.py:56: note:          def get_conn(self) -> Any
airflow/providers/cohere/hooks/cohere.py:56: note:      Subclass:
airflow/providers/cohere/hooks/cohere.py:56: note:          Client
airflow/providers/cohere/hooks/cohere.py:67: error: Incompatible return value
type (got "Union[List[List[float]], EmbedByTypeResponseEmbeddings]", expected
"List[List[float]]")  [return-value]
            return embeddings
                   ^~~~~~~~~~
airflow/providers/cohere/hooks/cohere.py:80: error: Too many positional
arguments for "generate" of "BaseCohere"  [misc]
                self.get_conn.generate("Test", max_tokens=10)
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
