### PR TITLE
Fix deprecated apache.hive operators arguments in `MappedOperator`

### DIFF
--- a/tests/providers/apache/hive/operators/test_hive_stats.py
+++ b/tests/providers/apache/hive/operators/test_hive_stats.py
@@ -23,9 +23,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.apache.hive.operators.hive_stats import HiveStatsCollectionOperator
 from airflow.providers.presto.hooks.presto import PrestoHook
+from airflow.utils import timezone
+from airflow.utils.task_instance_session import set_current_task_instance_session
 from tests.providers.apache.hive import (
     DEFAULT_DATE,
     DEFAULT_DATE_DS,
@@ -370,3 +372,41 @@ class TestHiveStatsCollectionOperator(TestHiveEnvironment):
                 "value",
             ],
         )
+
+    def test_col_blacklist_deprecation(self):
+        warn_message = "col_blacklist kwarg passed to.*task_id: fake-task-id.*is deprecated"
+        with pytest.warns(AirflowProviderDeprecationWarning, match=warn_message):
+            HiveStatsCollectionOperator(
+                task_id="fake-task-id",
+                table="airflow.static_babynames_partitioned",
+                partition={"ds": DEFAULT_DATE_DS},
+                col_blacklist=["foo", "bar"],
+            )
+
+    @pytest.mark.db_test
+    @pytest.mark.parametrize(
+        "col_blacklist",
+        [pytest.param(None, id="none"), pytest.param(["foo", "bar"], id="list")],
+    )
+    def test_partial_col_blacklist_deprecation(self, col_blacklist, dag_maker, session):
+        with dag_maker(
+            dag_id="test_partial_col_blacklist_deprecation",
+            start_date=timezone.datetime(2024, 1, 1),
+            session=session,
+        ):
+            HiveStatsCollectionOperator.partial(
+                task_id="fake-task-id",
+                partition={"ds": DEFAULT_DATE_DS},
+                col_blacklist=col_blacklist,
+                excluded_columns=["spam", "egg"],
+            ).expand(table=["airflow.table1", "airflow.table2"])
+
+        dr = dag_maker.create_dagrun(execution_date=None)
+        tis = dr.get_task_instances(session=session)
+        with set_current_task_instance_session(session=session):
+            warn_message = "col_blacklist kwarg passed to.*task_id: fake-task-id.*is deprecated"
+            for ti in tis:
+                with pytest.warns(AirflowProviderDeprecationWarning, match=warn_message):
+                    ti.render_templates()
+                expected = col_blacklist or []
+                assert ti.task.excluded_columns == expected


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

similar to: https://github.com/apache/airflow/pull/38178

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
