### PR TITLE
Fix PT012 checks for celery provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1514,7 +1514,6 @@ combine-as-imports = true
 "tests/providers/amazon/aws/waiters/test_neptune.py" = ["PT012"]
 "tests/providers/apache/hive/hooks/test_hive.py" = ["PT012"]
 "tests/providers/apache/hive/sensors/test_named_hive_partition.py" = ["PT012"]
-"tests/providers/celery/sensors/test_celery_queue.py" = ["PT012"]
 "tests/providers/cncf/kubernetes/executors/test_kubernetes_executor.py" = ["PT012"]
 "tests/providers/cncf/kubernetes/hooks/test_kubernetes.py" = ["PT012"]
 "tests/providers/cncf/kubernetes/operators/test_pod.py" = ["PT012"]

--- a/tests/providers/celery/sensors/test_celery_queue.py
+++ b/tests/providers/celery/sensors/test_celery_queue.py
@@ -66,9 +66,9 @@ class TestCeleryQueueSensor:
         mock_inspect_result.reserved.return_value = {}
         mock_inspect_result.scheduled.return_value = {}
         mock_inspect_result.active.return_value = {}
-
+        test_sensor = self.sensor(celery_queue="test_queue", task_id="test-task", soft_fail=soft_fail)
+        
         with pytest.raises(expected_exception):
-            test_sensor = self.sensor(celery_queue="test_queue", task_id="test-task", soft_fail=soft_fail)
             test_sensor.poke(None)
 
     @patch("celery.app.control.Inspect")

--- a/tests/providers/celery/sensors/test_celery_queue.py
+++ b/tests/providers/celery/sensors/test_celery_queue.py
@@ -67,7 +67,7 @@ class TestCeleryQueueSensor:
         mock_inspect_result.scheduled.return_value = {}
         mock_inspect_result.active.return_value = {}
         test_sensor = self.sensor(celery_queue="test_queue", task_id="test-task", soft_fail=soft_fail)
-        
+
         with pytest.raises(expected_exception):
             test_sensor.poke(None)
 


### PR DESCRIPTION
## Related issue:

#38270

fix PT012 checks for celery provider.

## Checks:

- [x] tests/providers/celery/sensors/test_celery_queue.py