### PR TITLE
Make postgresql default engine args comply with SA 2.0

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -273,7 +273,7 @@ def configure_orm(disable_connection_pool=False, pool_class=None):
 
 DEFAULT_ENGINE_ARGS = {
     "postgresql": {
-        "executemany_mode": "values",
+        "executemany_mode": "values_plus_batch",
         "executemany_values_page_size": 10000,
         "executemany_batch_page_size": 2000,
     },

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -274,7 +274,7 @@ def configure_orm(disable_connection_pool=False, pool_class=None):
 DEFAULT_ENGINE_ARGS = {
     "postgresql": {
         "executemany_mode": "values_plus_batch",
-        "executemany_values_page_size": 10000,
+        "executemany_values_page_size" if is_sqlalchemy_v1() else "insertmanyvalues_page_size": 10000,
         "executemany_batch_page_size": 2000,
     },
 }


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

'values' is old mode from SQLAlchemy <= 1.3
SA 1.3: https://docs.sqlalchemy.org/en/13/dialects/postgresql.html#psycopg2-fast-execution-helpers
SA 1.4: https://docs.sqlalchemy.org/en/14/dialects/postgresql.html#psycopg2-fast-execution-helpers
SA 2.0: https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#psycopg2-fast-execution-helpers

It still work with 1.4 hover it presumably fail in 2.0

As far as I understand `values_plus_batch` it is the same as `values` in 1.4: https://github.com/sqlalchemy/sqlalchemy/issues/5401

This one is continuation of: https://github.com/apache/airflow/pull/38066

closes: #38064 ?

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
