### PR TITLE
Use `importlib_metadata` with compat to Python 3.10/3.12 stdlib

### DIFF
--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -924,16 +924,15 @@ class ExternalPythonOperator(_BasePythonVirtualenvOperator):
         On the other hand, `importlib.metadata.version` will retrieve the package version pretty fast
         something below 100ms; this includes new subprocess overhead.
 
-        Possible side effect: it might be a situation that backport package is not available
-        in Python 3.8 and below, which indicates that venv doesn't contain an `apache-airflow`
+        Possible side effect: It might be a situation that `importlib.metadata` is not available (Python < 3.8),
+        as well as backport `importlib_metadata` which might indicate that venv doesn't contain an `apache-airflow`
         or something wrong with the environment.
         """
         return textwrap.dedent(
             """
-            import sys
-            if sys.version_info >= (3, 9):
+            try:
                 from importlib.metadata import version
-            else:
+            except ImportError:
                 from importlib_metadata import version
             print(version("apache-airflow"))
             """

--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -41,9 +41,9 @@ from airflow.utils.module_loading import import_string, qualname
 
 if TYPE_CHECKING:
     try:
-        import importlib_metadata
+        import importlib_metadata as metadata
     except ImportError:
-        from importlib import metadata as importlib_metadata  # type: ignore[no-redef]
+        from importlib import metadata  # type: ignore[no-redef]
     from types import ModuleType
 
     from airflow.hooks.base import BaseHook
@@ -125,7 +125,7 @@ class PluginsDirectorySource(AirflowPluginSource):
 class EntryPointSource(AirflowPluginSource):
     """Class used to define Plugins loaded from entrypoint."""
 
-    def __init__(self, entrypoint: importlib_metadata.EntryPoint, dist: importlib_metadata.Distribution):
+    def __init__(self, entrypoint: metadata.EntryPoint, dist: metadata.Distribution):
         self.dist = dist.metadata["Name"]
         self.version = dist.version
         self.entrypoint = str(entrypoint)

--- a/airflow/utils/docs.py
+++ b/airflow/utils/docs.py
@@ -16,10 +16,12 @@
 # under the License.
 from __future__ import annotations
 
-try:
-    import importlib_metadata
-except ImportError:
-    from importlib import metadata as importlib_metadata  # type: ignore[no-redef]
+import sys
+
+if sys.version_info >= (3, 10):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata  # type: ignore[no-redef]
 
 
 def get_docs_url(page: str | None = None) -> str:
@@ -40,7 +42,7 @@ def get_docs_url(page: str | None = None) -> str:
 def get_doc_url_for_provider(provider_name: str, provider_version: str) -> str:
     """Prepare link to Airflow Provider documentation."""
     try:
-        metadata_items = importlib_metadata.metadata(provider_name).get_all("Project-URL")
+        metadata_items = metadata.metadata(provider_name).get_all("Project-URL")
         if isinstance(metadata_items, str):
             metadata_items = [metadata_items]
         if metadata_items:
@@ -49,7 +51,7 @@ def get_doc_url_for_provider(provider_name: str, provider_version: str) -> str:
                     _, _, url = item.partition(",")
                     if url:
                         return url.strip()
-    except importlib_metadata.PackageNotFoundError:
+    except metadata.PackageNotFoundError:
         pass
     # Fallback if provider is apache one
     if provider_name.startswith("apache-airflow"):

--- a/airflow/utils/entry_points.py
+++ b/airflow/utils/entry_points.py
@@ -18,13 +18,14 @@ from __future__ import annotations
 
 import functools
 import logging
+import sys
 from collections import defaultdict
 from typing import Iterator, Tuple
 
-try:
-    import importlib_metadata as metadata
-except ImportError:
-    from importlib import metadata  # type: ignore[no-redef]
+if sys.version_info >= (3, 12):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata  # type: ignore[no-redef]
 
 log = logging.getLogger(__name__)
 

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -447,7 +447,7 @@ DEPENDENCIES = [
     "google-re2>=1.0",
     "gunicorn>=20.1.0",
     "httpx",
-    'importlib_metadata>=1.7;python_version<"3.9"',
+    'importlib_metadata>=6.5;python_version<"3.12"',
     # Importib_resources 6.2.0-6.3.1 break pytest_rewrite
     # see https://github.com/python/importlib_resources/issues/299
     'importlib_resources>=5.2,!=6.2.0,!=6.3.0,!=6.3.1;python_version<"3.9"',


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

That what I've accidentally found, that we install `importlib_metadata` only for Python 3.8 however in some places we might use in more modern versions of the Python when we use

```python
try:
    import importlib_metadata as metadata
except ImportError:
   from importlib import metadata  
```

Right now `importlib_metadata` as well as (`importlib_resources`) presented into the Docker Image (2.8.4rc1), more like it comes from one of the dependency. 
So this could be a situation that we unintendedly use some features from the backported packages and it works as expected, because this package also provide new feature which will added into the `stdlib` in the future, see [compat table](https://github.com/python/importlib_metadata/?tab=readme-ov-file#compatibility)

| **importlib_metadata** | **stdlib** |
|------------------------|------------|
| 7.0                    | 3.13       |
| 6.5                    | 3.12       |
| 4.13                   | 3.11       |
| 4.6                    | 3.10       |
| 1.4                    | 3.8        |

I've tried to found places where the behavior in stdlib changed (https://docs.python.org/3/library/importlib.metadata.html), and only found two places which we use in Airflow code base
- Entrypoints: in 3.6 (not relevant), 3.10 and 3.12
- Distribution metadata: In 3.10 (maybe also not our case)

This PR is attempt to prevent that something work just because some dependency install `importlib_metadata` and our code just always  use `importlib_metadata` if it installed. This might help to detect some minor/major incompatabilities

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
