### PR TITLE
Remove redundant usage of `importlib_metadata` for distribution versions

### DIFF
--- a/airflow/providers/docker/hooks/docker.py
+++ b/airflow/providers/docker/hooks/docker.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import json
-import sys
 import warnings
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
@@ -105,12 +104,9 @@ class DockerHook(BaseHook):
         :param ssl_version: Version of SSL to use when communicating with docker daemon.
         """
         if ca_cert and client_cert and client_key:
-            from packaging.version import Version
+            from importlib.metadata import version
 
-            if sys.version_info >= (3, 9):
-                from importlib.metadata import version
-            else:
-                from importlib_metadata import version
+            from packaging.version import Version
 
             tls_config = {
                 "ca_cert": ca_cert,

--- a/tests/providers/docker/hooks/test_docker.py
+++ b/tests/providers/docker/hooks/test_docker.py
@@ -19,8 +19,8 @@ from __future__ import annotations
 
 import logging
 import ssl
-import sys
 import warnings
+from importlib.metadata import version
 from unittest import mock
 
 import pytest
@@ -30,12 +30,6 @@ from packaging.version import Version
 
 from airflow.exceptions import AirflowException, AirflowNotFoundException
 from airflow.providers.docker.hooks.docker import DockerHook
-
-if sys.version_info >= (3, 9):
-    from importlib.metadata import version
-else:
-    from importlib_metadata import version
-
 
 DOCKER_PY_7_PLUS = Version(Version(version("docker")).base_version) >= Version("7")
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Was added into the 3.8, https://docs.python.org/3/library/importlib.metadata.html#distribution-versions

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
