### PR TITLE
Implement the dataset_dags API endpoint for retrieving DAGs related to a specific dataset

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1122,6 +1122,11 @@ class Airflow(AirflowBaseView):
                 for dag in session.query(DagModel).filter(DagModel.dag_id.in_(all_dag_ids)).all()
             }
 
+            # Validate if all dag_ids found
+            missing_dags = all_dag_ids - dag_status.keys()
+            if missing_dags:
+                raise ValueError(f"Missing DAGs in DagModel: {missing_dags}")
+
             consuming_dags = [
                 {
                     "dag_id": dag_ref.dag_id,

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1130,8 +1130,7 @@ class Airflow(AirflowBaseView):
             consuming_dags = [
                 {
                     "dag_id": dag_ref.dag_id,
-                    "is_paused": dag_status.get(dag_ref.dag_id, False),
-                    # Default to False if dag_id not found
+                    "is_paused": dag_status[dag_ref.dag_id],
                 }
                 for dag_ref in consuming_dags_refs
             ]
@@ -1139,8 +1138,7 @@ class Airflow(AirflowBaseView):
             producing_tasks = [
                 {
                     "dag_id": task_ref.dag_id,
-                    "is_paused": dag_status.get(task_ref.dag_id, False),
-                    # Default to False if dag_id not found
+                    "is_paused": dag_status[task_ref.dag_id],
                     "source_task_instance": {"task_id": task_ref.task_id},
                 }
                 for task_ref in producing_tasks_refs


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
This PR adds a new API endpoint `GET /dataset_dags/{dataset_id}` , allowing users to retrieve a list of DAGs that are upstream or downstream of a dataset. This feature aids in understanding which DAGs are producing or consuming a specific dataset.

**Changes:**
- Implemented `GET /dataset_dags/{dataset_id}` in the webserver.
- Added tests covering different scenarios for the endpoint.

**Example API Response:**
```json
[
  {
    "dag_id": "conditional_dataset_and_time_based_timetable",
    "is_paused": false
  },
  {
    "dag_id": "consume_1_and_2_with_dataset_expressions",
    "is_paused": false
  },
  {
    "dag_id": "consume_1_or_2_with_dataset_expressions",
    "is_paused": false
  },
  {
    "dag_id": "consume_1_or_both_2_and_3_with_dataset_expressions",
    "is_paused": false
  },
  {
    "dag_id": "dataset_consumes_1",
    "is_paused": false
  },
  {
    "dag_id": "dataset_consumes_1_and_2",
    "is_paused": false
  },
  {
    "dag_id": "dataset_consumes_1_never_scheduled",
    "is_paused": false
  },
  {
    "dag_id": "dataset_produces_1",
    "is_paused": false,
    "source_task_instance": {
      "task_id": "producing_task_1"
    }
  }
]
```
![Screenshot 2024-03-21 at 7 02 56 PM](https://github.com/apache/airflow/assets/8670962/de6d9025-e5f3-49a9-aaf9-75c94ef31258)


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
