### PR TITLE
Store duration in seconds and scale to handle case when a value in the series has a larger unit than the preceding durations

### DIFF
--- a/airflow/www/static/js/dag/details/dag/RunDurationChart.tsx
+++ b/airflow/www/static/js/dag/details/dag/RunDurationChart.tsx
@@ -51,6 +51,7 @@ const RunDurationChart = ({ showLandingTimes }: Props) => {
 
   let maxDuration = 0;
   let unit = "seconds";
+  let unitDivisor = 1;
 
   const orderingLabel = ordering[0] || ordering[1] || "startDate";
 
@@ -84,35 +85,21 @@ const RunDurationChart = ({ showLandingTimes }: Props) => {
 
     if (maxDuration <= 60 * 2) {
       unit = "seconds";
+      unitDivisor = 1;
     } else if (maxDuration <= 60 * 60 * 2) {
       unit = "minutes";
+      unitDivisor = 60;
     } else if (maxDuration <= 24 * 60 * 60 * 2) {
       unit = "hours";
+      unitDivisor = 60 * 60;
     } else {
       unit = "days";
+      unitDivisor = 60 * 60 * 24;
     }
 
-    let landingDurationUnit;
-    let queuedDurationUnit;
-    let runDurationUnit;
-
-    if (unit === "seconds") {
-      landingDurationUnit = landingDuration.asSeconds();
-      queuedDurationUnit = queuedDuration.asSeconds();
-      runDurationUnit = runDuration.asSeconds();
-    } else if (unit === "minutes") {
-      landingDurationUnit = landingDuration.asMinutes();
-      queuedDurationUnit = queuedDuration.asMinutes();
-      runDurationUnit = runDuration.asMinutes();
-    } else if (unit === "hours") {
-      landingDurationUnit = landingDuration.asHours();
-      queuedDurationUnit = queuedDuration.asHours();
-      runDurationUnit = runDuration.asHours();
-    } else {
-      landingDurationUnit = landingDuration.asDays();
-      queuedDurationUnit = queuedDuration.asDays();
-      runDurationUnit = runDuration.asDays();
-    }
+    const landingDurationUnit = landingDuration.asSeconds();
+    const queuedDurationUnit = queuedDuration.asSeconds();
+    const runDurationUnit = runDuration.asSeconds();
 
     return {
       ...dagRun,
@@ -209,7 +196,20 @@ const RunDurationChart = ({ showLandingTimes }: Props) => {
         "queuedDurationUnit",
         "runDurationUnit",
       ],
-      source: durations,
+      source: durations.map((duration) => {
+        if (duration) {
+          const durationInSeconds = duration as RunDuration;
+          return {
+            ...durationInSeconds,
+            landingDurationUnit:
+              durationInSeconds.landingDurationUnit / unitDivisor,
+            queuedDurationUnit:
+              durationInSeconds.queuedDurationUnit / unitDivisor,
+            runDurationUnit: durationInSeconds.runDurationUnit / unitDivisor,
+          };
+        }
+        return duration;
+      }),
     },
     tooltip: {
       trigger: "axis",

--- a/airflow/www/static/js/dag/details/task/TaskDuration.tsx
+++ b/airflow/www/static/js/dag/details/task/TaskDuration.tsx
@@ -50,6 +50,7 @@ const TaskDuration = () => {
   } = useGridData();
   let maxDuration = 0;
   let unit = "seconds";
+  let unitDivisor = 1;
 
   const task = getTask({ taskId, task: groups });
 
@@ -82,30 +83,20 @@ const TaskDuration = () => {
 
     if (maxDuration <= 60 * 2) {
       unit = "seconds";
+      unitDivisor = 1;
     } else if (maxDuration <= 60 * 60 * 2) {
       unit = "minutes";
+      unitDivisor = 60;
     } else if (maxDuration <= 24 * 60 * 60 * 2) {
       unit = "hours";
+      unitDivisor = 60 * 60;
     } else {
       unit = "days";
+      unitDivisor = 60 * 60 * 24;
     }
 
-    let runDurationUnit;
-    let queuedDurationUnit;
-
-    if (unit === "seconds") {
-      runDurationUnit = runDuration.asSeconds();
-      queuedDurationUnit = queuedDuration.asSeconds();
-    } else if (unit === "minutes") {
-      runDurationUnit = runDuration.asMinutes();
-      queuedDurationUnit = queuedDuration.asMinutes();
-    } else if (unit === "hours") {
-      runDurationUnit = runDuration.asHours();
-      queuedDurationUnit = queuedDuration.asHours();
-    } else {
-      runDurationUnit = runDuration.asDays();
-      queuedDurationUnit = queuedDuration.asDays();
-    }
+    const runDurationUnit = runDuration.asSeconds();
+    const queuedDurationUnit = queuedDuration.asSeconds();
 
     return {
       ...instance,
@@ -179,7 +170,18 @@ const TaskDuration = () => {
     // @ts-ignore
     dataset: {
       dimensions: ["runId", "queuedDurationUnit", "runDurationUnit"],
-      source: durations,
+      source: durations.map((duration) => {
+        if (duration) {
+          const durationInSeconds = duration as TaskInstanceDuration;
+          return {
+            ...durationInSeconds,
+            queuedDurationUnit:
+              durationInSeconds.queuedDurationUnit / unitDivisor,
+            runDurationUnit: durationInSeconds.runDurationUnit / unitDivisor,
+          };
+        }
+        return duration;
+      }),
     },
     tooltip: {
       trigger: "axis",


### PR DESCRIPTION
closes: #38371
related: #38371

Store all durations in seconds and have unitDivisor which is the scale factor selected based on the maximum duration seen. During chart construction scale down the values with unitDivisor.

Before : 

![image](https://github.com/apache/airflow/assets/3972343/9c222ee8-c418-4975-9d25-acfb68c6a395)

After :

![image](https://github.com/apache/airflow/assets/3972343/880ec3a5-ffc9-4cc4-a4b7-31a01e9def45)
