### PR TITLE
Use current time to calculate duration when end date is not present.

### DIFF
--- a/airflow/www/static/js/dag/details/dag/RunDurationChart.tsx
+++ b/airflow/www/static/js/dag/details/dag/RunDurationChart.tsx
@@ -62,9 +62,7 @@ const RunDurationChart = ({ showLandingTimes }: Props) => {
 
     // @ts-ignore
     const runDuration = moment.duration(
-      dagRun.startDate && dagRun.endDate
-        ? getDuration(dagRun.startDate, dagRun?.endDate)
-        : 0
+      dagRun.startDate ? getDuration(dagRun.startDate, dagRun?.endDate) : 0
     );
 
     // @ts-ignore

--- a/airflow/www/static/js/dag/details/task/TaskDuration.tsx
+++ b/airflow/www/static/js/dag/details/task/TaskDuration.tsx
@@ -62,7 +62,7 @@ const TaskDuration = () => {
     if (!instance) return {};
     // @ts-ignore
     const runDuration = moment.duration(
-      instance.startDate && instance.endDate
+      instance.startDate
         ? getDuration(instance.startDate, instance?.endDate)
         : 0
     );


### PR DESCRIPTION
closes: #38215
related: #38215

This also keeps grid bars in sync with the duration chart bars as below.

Before : 

![image](https://github.com/apache/airflow/assets/3972343/b18147ca-0f87-4fe4-b596-ce633eff3bfd)


After : 

![image](https://github.com/apache/airflow/assets/3972343/bc46bfa3-798a-4e3e-bf82-a3345ff3f922)
