### PR TITLE
docs(openlineage): fix quotation around openlineage transport value

### DIFF
--- a/docs/apache-airflow-providers-openlineage/guides/developer.rst
+++ b/docs/apache-airflow-providers-openlineage/guides/developer.rst
@@ -235,7 +235,7 @@ It can be done by using ``extractors`` option in Airflow configuration.
 .. code-block:: ini
 
     [openlineage]
-    transport = '{"type": "http", "url": "http://example.com:5000"}'
+    transport = {"type": "http", "url": "http://example.com:5000"}
     extractors = full.path.to.ExtractorClass;full.path.to.AnotherExtractorClass
 
 ``AIRFLOW__OPENLINEAGE__EXTRACTORS`` environment variable is an equivalent.

--- a/docs/apache-airflow-providers-openlineage/guides/user.rst
+++ b/docs/apache-airflow-providers-openlineage/guides/user.rst
@@ -49,7 +49,7 @@ This example is a basic demonstration of OpenLineage setup.
    .. code-block:: ini
 
       [openlineage]
-      transport = '{"type": "http", "url": "http://example.com:5000", "endpoint": "api/v1/lineage"}'
+      transport = {"type": "http", "url": "http://example.com:5000", "endpoint": "api/v1/lineage"}
 
    or with ``AIRFLOW__OPENLINEAGE__TRANSPORT`` environment variable
 
@@ -87,7 +87,7 @@ The ``transport`` option in Airflow configuration is used for that purpose.
 .. code-block:: ini
 
     [openlineage]
-    transport = '{"type": "http", "url": "http://example.com:5000", "endpoint": "api/v1/lineage"}'
+    transport = {"type": "http", "url": "http://example.com:5000", "endpoint": "api/v1/lineage"}
 
 ``AIRFLOW__OPENLINEAGE__TRANSPORT`` environment variable is an equivalent.
 
@@ -101,7 +101,7 @@ If you want to look at OpenLineage events without sending them anywhere, you can
 .. code-block:: ini
 
     [openlineage]
-    transport = '{"type": "console"}'
+    transport = {"type": "console"}
 
 .. note::
   For full list of built-in transport types, specific transport's options or instructions on how to implement your custom transport, refer to
@@ -180,8 +180,8 @@ If not set, it's using ``default`` namespace. Provide the name of the namespace 
 .. code-block:: ini
 
     [openlineage]
-    transport = '{"type": "http", "url": "http://example.com:5000", "endpoint": "api/v1/lineage"}'
-    namespace = 'my-team-airflow-instance`
+    transport = {"type": "http", "url": "http://example.com:5000", "endpoint": "api/v1/lineage"}
+    namespace = 'my-team-airflow-instance'
 
 ``AIRFLOW__OPENLINEAGE__NAMESPACE`` environment variable is an equivalent.
 
@@ -198,7 +198,7 @@ You can disable sending OpenLineage events without uninstalling OpenLineage prov
 .. code-block:: ini
 
     [openlineage]
-    transport = '{"type": "http", "url": "http://example.com:5000", "endpoint": "api/v1/lineage"}'
+    transport = {"type": "http", "url": "http://example.com:5000", "endpoint": "api/v1/lineage"}
     disabled = true
 
 ``AIRFLOW__OPENLINEAGE__DISABLED`` environment variable is an equivalent.
@@ -217,7 +217,7 @@ To prevent that, set ``disable_source_code`` option to ``true`` in Airflow confi
 .. code-block:: ini
 
     [openlineage]
-    transport = '{"type": "http", "url": "http://example.com:5000", "endpoint": "api/v1/lineage"}'
+    transport = {"type": "http", "url": "http://example.com:5000", "endpoint": "api/v1/lineage"}
     disable_source_code = true
 
 ``AIRFLOW__OPENLINEAGE__DISABLE_SOURCE_CODE`` environment variable is an equivalent.
@@ -236,7 +236,7 @@ full import paths of Airflow Operators to disable as ``disabled_for_operators`` 
 .. code-block:: ini
 
     [openlineage]
-    transport = '{"type": "http", "url": "http://example.com:5000", "endpoint": "api/v1/lineage"}'
+    transport = {"type": "http", "url": "http://example.com:5000", "endpoint": "api/v1/lineage"}
     disabled_for_operators = 'airflow.operators.bash.BashOperator;airflow.operators.python.PythonOperator'
 
 ``AIRFLOW__OPENLINEAGE__DISABLED_FOR_OPERATORS`` environment variable is an equivalent.
@@ -254,7 +254,7 @@ a string of semicolon separated Airflow Operators full import paths to ``extract
 .. code-block:: ini
 
     [openlineage]
-    transport = '{"type": "http", "url": "http://example.com:5000", "endpoint": "api/v1/lineage"}'
+    transport = {"type": "http", "url": "http://example.com:5000", "endpoint": "api/v1/lineage"}
     extractors = full.path.to.ExtractorClass;full.path.to.AnotherExtractorClass
 
 ``AIRFLOW__OPENLINEAGE__EXTRACTORS`` environment variable is an equivalent.


### PR DESCRIPTION
The docs suggests that the transport option should be quoted using `'` in airflow.cfg. Using the described configuration results in `{{utils.py:408}} WARNING - Unable to parse [openlineage] 'transport' as valid json` message. Removing the quotation marks around the transport config entry fixes this.

The generated airflow.cfg shows the correct version of the config:
```
# Pass OpenLineage Client transport configuration as JSON string. It should contain type of the 
# transport and additional options (different for each transport type). For more details see:   
# https://openlineage.io/docs/client/python/#built-in-transport-types                           
#                                                                                               
# Currently supported types are:                                                                
#                                                                                               
#   * HTTP                                                                                      
#   * Kafka                                                                                     
#   * Console                                                                                   
#   * File                                                                                      
#                                                                                               
# Example: transport = {"type": "http", "url": "http://localhost:5000", "endpoint": "api/v1/lineage"}
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
