### PR TITLE
Fix deprecated `DockerOperator` operator arguments in `MappedOperator`

### DIFF
--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -44,6 +44,7 @@ from airflow.providers.docker.exceptions import (
     DockerContainerFailedSkipException,
 )
 from airflow.providers.docker.hooks.docker import DockerHook
+from airflow.utils.types import NOTSET, ArgNotSet
 
 if TYPE_CHECKING:
     from docker import APIClient
@@ -240,9 +241,11 @@ class DockerOperator(BaseOperator):
         skip_on_exit_code: int | Container[int] | None = None,
         port_bindings: dict | None = None,
         ulimits: list[Ulimit] | None = None,
+        # deprecated, no need to include into docstring
+        skip_exit_code: int | Container[int] | ArgNotSet = NOTSET,
         **kwargs,
     ) -> None:
-        if skip_exit_code := kwargs.pop("skip_exit_code", None):
+        if skip_exit_code is not NOTSET:
             warnings.warn(
                 "`skip_exit_code` is deprecated and will be removed in the future. "
                 "Please use `skip_on_exit_code` instead.",
@@ -255,7 +258,7 @@ class DockerOperator(BaseOperator):
                     f"skip_on_exit_code={skip_on_exit_code!r}, skip_exit_code={skip_exit_code!r}."
                 )
                 raise ValueError(msg)
-            skip_on_exit_code = skip_exit_code
+            skip_on_exit_code = skip_exit_code  # type: ignore[assignment]
         if isinstance(auto_remove, bool):
             warnings.warn(
                 "bool value for `auto_remove` is deprecated and will be removed in the future. "

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -29,6 +29,7 @@ from docker.types import DeviceRequest, LogConfig, Mount, Ulimit
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning, AirflowSkipException
 from airflow.providers.docker.exceptions import DockerContainerFailedException
 from airflow.providers.docker.operators.docker import DockerOperator
+from airflow.utils.task_instance_session import set_current_task_instance_session
 
 TEST_CONN_ID = "docker_test_connection"
 TEST_DOCKER_URL = "unix://var/run/docker.test.sock"
@@ -807,3 +808,58 @@ class TestDockerOperator:
         monkeypatch.delenv("DOCKER_HOST", raising=False)
         operator = DockerOperator(task_id="test", image="test")
         assert operator.docker_url == "unix://var/run/docker.sock"
+
+    @pytest.mark.db_test
+    @pytest.mark.parametrize(
+        "skip_exit_code, skip_on_exit_code, expected",
+        [
+            pytest.param(101, None, [101], id="skip-on-exit-code-not-set"),
+            pytest.param(102, 102, [102], id="skip-on-exit-code-same"),
+        ],
+    )
+    def test_partial_deprecated_skip_exit_code(
+        self, skip_exit_code, skip_on_exit_code, expected, dag_maker, session
+    ):
+        with dag_maker(dag_id="test_partial_deprecated_skip_exit_code", session=session):
+            DockerOperator.partial(
+                task_id="fake-task-id",
+                skip_exit_code=skip_exit_code,
+                skip_on_exit_code=skip_on_exit_code,
+            ).expand(image=["test", "apache/airflow"])
+
+        dr = dag_maker.create_dagrun()
+        tis = dr.get_task_instances(session=session)
+        with set_current_task_instance_session(session=session):
+            warning_match = r"`skip_exit_code` is deprecated and will be removed"
+            for ti in tis:
+                with pytest.warns(AirflowProviderDeprecationWarning, match=warning_match):
+                    ti.render_templates()
+                assert ti.task.skip_on_exit_code == expected
+
+    @pytest.mark.db_test
+    @pytest.mark.parametrize(
+        "skip_exit_code, skip_on_exit_code",
+        [
+            pytest.param(103, 0, id="skip-on-exit-code-zero"),
+            pytest.param(104, 105, id="skip-on-exit-code-not-same"),
+        ],
+    )
+    def test_partial_deprecated_skip_exit_code_ambiguous(
+        self, skip_exit_code, skip_on_exit_code, dag_maker, session
+    ):
+        with dag_maker("test_partial_deprecated_skip_exit_code_ambiguous", session=session):
+            DockerOperator.partial(
+                task_id="fake-task-id",
+                skip_exit_code=skip_exit_code,
+                skip_on_exit_code=skip_on_exit_code,
+            ).expand(image=["test", "apache/airflow"])
+
+        dr = dag_maker.create_dagrun(session=session)
+        tis = dr.get_task_instances(session=session)
+        with set_current_task_instance_session(session=session):
+            warning_match = r"`skip_exit_code` is deprecated and will be removed"
+            for ti in tis:
+                with pytest.warns(AirflowProviderDeprecationWarning, match=warning_match), pytest.raises(
+                    ValueError, match="Conflicting `skip_on_exit_code` provided"
+                ):
+                    ti.render_templates()


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

similar to: https://github.com/apache/airflow/pull/38178

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
