### PR TITLE
update to latest service bus library

### DIFF
--- a/airflow/providers/microsoft/azure/provider.yaml
+++ b/airflow/providers/microsoft/azure/provider.yaml
@@ -89,7 +89,7 @@ dependencies:
   - azure-storage-blob>=12.14.0
   - azure-mgmt-storage>=16.0.0
   - azure-storage-file-share
-  - azure-servicebus>=7.6.1
+  - azure-servicebus>=7.12.1
   - azure-synapse-spark
   - azure-synapse-artifacts>=0.17.0
   - adal>=1.2.7

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -693,7 +693,7 @@
       "azure-mgmt-datalake-store>=0.5.0",
       "azure-mgmt-resource>=2.2.0",
       "azure-mgmt-storage>=16.0.0",
-      "azure-servicebus>=7.6.1",
+      "azure-servicebus>=7.12.1",
       "azure-storage-blob>=12.14.0",
       "azure-storage-file-datalake>=12.9.1",
       "azure-storage-file-share",


### PR DESCRIPTION
Following #31168.

PR to update the azure-service version to 7.12.1. The new version is using an all python based AMQP stack, which means uamqp is no longer required and opens up the library overall to be run in a wide variety of architectures, OSes etc. There are some performance improvements when receiving messages from queues & topics. It also includes important bug fixes, including for correct behavior on connection drops, more accurate logging, to address misc. errors/warnings, large message sending/settling.

We saw that you hadn't updated the version in a while and this version will help with an old issue that was seen here, so wanted to bump!

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
