### PR TITLE
Allow to use redis>=5

### DIFF
--- a/airflow/providers/celery/provider.yaml
+++ b/airflow/providers/celery/provider.yaml
@@ -57,7 +57,7 @@ dependencies:
   # (https://docs.celeryq.dev/en/stable/contributing.html?highlight=semver#versions).
   # Make sure that the limit here is synchronized with [celery] extra in the airflow core
   # The 5.3.3/5.3.2 limit comes from https://github.com/celery/celery/issues/8470
-  - celery>=5.3.0,<6,!=5.3.3,!=5.3.2
+  - celery[redis]>=5.3.0,<6,!=5.3.3,!=5.3.2
   - flower>=1.0.0
   - google-re2>=1.0
 

--- a/airflow/providers/redis/provider.yaml
+++ b/airflow/providers/redis/provider.yaml
@@ -46,11 +46,8 @@ versions:
 
 dependencies:
   - apache-airflow>=2.6.0
-  # We limit redis to <5.0.0 because of incompatibility with celery. Both Celery and Kombu limited it
-  # and deferred fixing it for later, we should bump the limit once they do. Also !=4.5.5 matches celery
-  # limits and prevents installing 4.5.5 which is broken.
-  # https://github.com/celery/celery/pull/8442, https://github.com/celery/kombu/pull/1776
-  - redis>=4.5.2,<5.0.0,!=4.5.5
+  # 5.0.2 excluded due to breaking changes which fixed in https://github.com/redis/redis-py/pull/3176
+  - redis>=4.5.2,!=4.5.5,!=5.0.2
 
 integrations:
   - integration-name: Redis

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -291,7 +291,7 @@
   "celery": {
     "deps": [
       "apache-airflow>=2.6.0",
-      "celery>=5.3.0,<6,!=5.3.3,!=5.3.2",
+      "celery[redis]>=5.3.0,<6,!=5.3.3,!=5.3.2",
       "flower>=1.0.0",
       "google-re2>=1.0"
     ],
@@ -957,7 +957,7 @@
   "redis": {
     "deps": [
       "apache-airflow>=2.6.0",
-      "redis>=4.5.2,<5.0.0,!=4.5.5"
+      "redis>=4.5.2,!=4.5.5,!=5.0.2"
     ],
     "devel-deps": [],
     "cross-providers-deps": [],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -647,7 +647,7 @@ atlassian-jira = [ # source: airflow/providers/atlassian/jira/provider.yaml
   "beautifulsoup4",
 ]
 celery = [ # source: airflow/providers/celery/provider.yaml
-  "celery>=5.3.0,<6,!=5.3.3,!=5.3.2",
+  "celery[redis]>=5.3.0,<6,!=5.3.3,!=5.3.2",
   "flower>=1.0.0",
   "google-re2>=1.0",
 ]
@@ -906,7 +906,7 @@ qdrant = [ # source: airflow/providers/qdrant/provider.yaml
   "qdrant_client>=1.7.0",
 ]
 redis = [ # source: airflow/providers/redis/provider.yaml
-  "redis>=4.5.2,<5.0.0,!=4.5.5",
+  "redis>=4.5.2,!=4.5.5,!=5.0.2",
 ]
 salesforce = [ # source: airflow/providers/salesforce/provider.yaml
   "pandas>=1.2.5,<2.2",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Originally [`redis-py`](https://github.com/redis/redis-py) limited to <5 by the problem in Celery https://github.com/celery/celery/pull/8442 and Kombu https://github.com/celery/kombu/pull/1776

Seems like the limitation is gone into the latest version of celery:
- https://github.com/celery/celery/pull/8504
- https://github.com/celery/kombu/pull/1969

Also add "redis" extras into the Celery provider, so it might limited independently of Redis Provider

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
