### PR TITLE
DockerOperator: use DOCKER_HOST as default for docker_url

### DIFF
--- a/airflow/providers/docker/CHANGELOG.rst
+++ b/airflow/providers/docker/CHANGELOG.rst
@@ -27,6 +27,13 @@
 Changelog
 ---------
 
+.. note::
+  The standard ``DOCKER_HOST`` environment variable now overrides the default value
+  of the ``docker_url`` parameter when set. If ``DOCKER_HOST`` is set but you want to
+  use the previous default value, then you must explicitly set
+  ``docker_url="unix://var/run/docker.sock"`` in the ``DockerOperator`` constructor
+  or ``@task.docker`` decorator.
+
 3.9.2
 .....
 

--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -20,6 +20,7 @@
 from __future__ import annotations
 
 import ast
+import os
 import pickle
 import tarfile
 import warnings
@@ -94,7 +95,8 @@ class DockerOperator(BaseOperator):
         This value gets multiplied with 1024. See
         https://docs.docker.com/engine/reference/run/#cpu-share-constraint
     :param docker_url: URL of the host running the docker daemon.
-        Default is unix://var/run/docker.sock
+        Default is the value of the ``DOCKER_HOST`` environment variable or unix://var/run/docker.sock
+        if it is unset.
     :param environment: Environment variables to set in the container. (templated)
     :param private_environment: Private environment variables to set in the container.
         These are not templated, and hidden from the website.
@@ -197,7 +199,7 @@ class DockerOperator(BaseOperator):
         command: str | list[str] | None = None,
         container_name: str | None = None,
         cpus: float = 1.0,
-        docker_url: str = "unix://var/run/docker.sock",
+        docker_url: str | None = None,
         environment: dict | None = None,
         private_environment: dict | None = None,
         env_file: str | None = None,
@@ -277,7 +279,7 @@ class DockerOperator(BaseOperator):
         self.cpus = cpus
         self.dns = dns
         self.dns_search = dns_search
-        self.docker_url = docker_url
+        self.docker_url = docker_url or os.environ.get("DOCKER_HOST") or "unix://var/run/docker.sock"
         self.environment = environment or {}
         self._private_environment = private_environment or {}
         self.env_file = env_file

--- a/airflow/providers/docker/operators/docker_swarm.py
+++ b/airflow/providers/docker/operators/docker_swarm.py
@@ -59,7 +59,8 @@ class DockerSwarmOperator(DockerOperator):
         The default is False.
     :param command: Command to be run in the container. (templated)
     :param docker_url: URL of the host running the docker daemon.
-        Default is unix://var/run/docker.sock
+        Default is the value of the ``DOCKER_HOST`` environment variable or unix://var/run/docker.sock
+        if it is unset.
     :param environment: Environment variables to set in the container. (templated)
     :param force_pull: Pull the docker image on every run. Default is False.
     :param mem_limit: Maximum amount of memory the container can use.

--- a/docs/apache-airflow-providers-docker/decorators/docker.rst
+++ b/docs/apache-airflow-providers-docker/decorators/docker.rst
@@ -48,7 +48,8 @@ cpus
     Number of CPUs to assign to the container. This value gets multiplied with 1024.
 docker_url
     URL of the host running the docker daemon.
-    Default is unix://var/run/docker.sock
+    Default is the value of the ``DOCKER_HOST`` environment variable or unix://var/run/docker.sock
+    if it is unset.
 environment
     Environment variables to set in the container. (templated)
 private_environment

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -790,3 +790,20 @@ class TestDockerOperator:
                     skip_exit_code=skip_exit_code,
                     skip_on_exit_code=skip_on_exit_code,
                 )
+
+    def test_respect_docker_host_env(self, monkeypatch):
+        monkeypatch.setenv("DOCKER_HOST", "tcp://docker-host-from-env:2375")
+        operator = DockerOperator(task_id="test", image="test")
+        assert operator.docker_url == "tcp://docker-host-from-env:2375"
+
+    def test_docker_host_env_empty(self, monkeypatch):
+        monkeypatch.setenv("DOCKER_HOST", "")
+        operator = DockerOperator(task_id="test", image="test")
+        # The docker CLI ignores the empty string and defaults to unix://var/run/docker.sock
+        # We want to ensure the same behavior.
+        assert operator.docker_url == "unix://var/run/docker.sock"
+
+    def test_docker_host_env_unset(self, monkeypatch):
+        monkeypatch.delenv("DOCKER_HOST", raising=False)
+        operator = DockerOperator(task_id="test", image="test")
+        assert operator.docker_url == "unix://var/run/docker.sock"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Respect the `DOCKER_HOST` environment variable with the DockerOperator.

<!-- Please keep an empty line above the dashes. -->
---

I was really surprised that the `DOCKER_HOST` environment variable is ignored. I was also surprised that I didn't find any proposal to add it, so apologies in case I missed a previous discussion. Might this be an acceptable change?

Of course this will break in situations where  `DOCKER_HOST` is set, but the user is relying on the default value of `docker_url` to override this setting. Having such a setup is really begging for trouble, so I wouldn't feel so guilty about breaking those cases.

TODO if I get :+1: to proceed:

- [x] Add tests (any suggestions?)
- [x] In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
- [x] Anything else?
