### PR TITLE
Add guard checks to dataset expressions

### DIFF
--- a/airflow/datasets/__init__.py
+++ b/airflow/datasets/__init__.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import os
 import urllib.parse
 import warnings
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Iterable, Iterator, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Iterable, Iterator
 
 import attr
 
@@ -82,17 +82,20 @@ def _sanitize_uri(uri: str) -> str:
     return urllib.parse.urlunsplit(parsed)
 
 
-@runtime_checkable
-class BaseDatasetEventInput(Protocol):
+class BaseDatasetEventInput:
     """Protocol for all dataset triggers to use in ``DAG(schedule=...)``.
 
     :meta private:
     """
 
     def __or__(self, other: BaseDatasetEventInput) -> DatasetAny:
+        if not isinstance(other, BaseDatasetEventInput):
+            return NotImplemented
         return DatasetAny(self, other)
 
     def __and__(self, other: BaseDatasetEventInput) -> DatasetAll:
+        if not isinstance(other, BaseDatasetEventInput):
+            return NotImplemented
         return DatasetAll(self, other)
 
     def evaluate(self, statuses: dict[str, bool]) -> bool:
@@ -120,8 +123,7 @@ class Dataset(os.PathLike, BaseDatasetEventInput):
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, self.__class__):
             return self.uri == other.uri
-        else:
-            return NotImplemented
+        return NotImplemented
 
     def __hash__(self) -> int:
         return hash(self.uri)
@@ -139,6 +141,8 @@ class _DatasetBooleanCondition(BaseDatasetEventInput):
     agg_func: Callable[[Iterable], bool]
 
     def __init__(self, *objects: BaseDatasetEventInput) -> None:
+        if not all(isinstance(o, BaseDatasetEventInput) for o in objects):
+            raise TypeError("expect dataset expressions in condition")
         self.objects = objects
 
     def evaluate(self, statuses: dict[str, bool]) -> bool:
@@ -160,6 +164,8 @@ class DatasetAny(_DatasetBooleanCondition):
     agg_func = any
 
     def __or__(self, other: BaseDatasetEventInput) -> DatasetAny:
+        if not isinstance(other, BaseDatasetEventInput):
+            return NotImplemented
         # Optimization: X | (Y | Z) is equivalent to X | Y | Z.
         return DatasetAny(*self.objects, other)
 
@@ -173,6 +179,8 @@ class DatasetAll(_DatasetBooleanCondition):
     agg_func = all
 
     def __and__(self, other: BaseDatasetEventInput) -> DatasetAll:
+        if not isinstance(other, BaseDatasetEventInput):
+            return NotImplemented
         # Optimization: X & (Y & Z) is equivalent to X & Y & Z.
         return DatasetAll(*self.objects, other)
 

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import os
 from collections import defaultdict
+from typing import Callable
 
 import pytest
 from sqlalchemy.sql import select
@@ -408,3 +409,34 @@ test_cases = [
 def test_evaluate_datasets_expression(expression, expected):
     expr = expression()
     assert datasets_equal(expr, expected)
+
+
+@pytest.mark.parametrize(
+    "expression, error",
+    [
+        pytest.param(
+            lambda: dataset1 & 1,  # type: ignore[operator]
+            "unsupported operand type(s) for &: 'Dataset' and 'int'",
+            id="&",
+        ),
+        pytest.param(
+            lambda: dataset1 | 1,  # type: ignore[operator]
+            "unsupported operand type(s) for |: 'Dataset' and 'int'",
+            id="|",
+        ),
+        pytest.param(
+            lambda: DatasetAll(1, dataset1),  # type: ignore[arg-type]
+            "expect dataset expressions in condition",
+            id="DatasetAll",
+        ),
+        pytest.param(
+            lambda: DatasetAny(1, dataset1),  # type: ignore[arg-type]
+            "expect dataset expressions in condition",
+            id="DatasetAny",
+        ),
+    ],
+)
+def test_datasets_expression_error(expression: Callable[[], None], error: str) -> None:
+    with pytest.raises(TypeError) as info:
+        expression()
+    assert str(info.value) == error


### PR DESCRIPTION
Just some guard rails for users who don't use static type checks to not do things crazy and take things to weird directions.