### PR TITLE
Add method to get metadata from GCS blob in GCSHook

### DIFF
--- a/airflow/providers/google/cloud/hooks/gcs.py
+++ b/airflow/providers/google/cloud/hooks/gcs.py
@@ -1015,20 +1015,20 @@ class GCSHook(GoogleBaseHook):
         Get the metadata of an object in Google Cloud Storage.
 
         :param bucket_name: Name of the Google Cloud Storage bucket where the object is.
-        :param object_name: The name of the object that posseses the desired metadata
+        :param object_name: The name of the object containing the desired metadata
         :return: The metadata associated with the object
         """
-        self.log.info(f"Retrieving the metadata dict of object ({object_name}) in bucket ({bucket_name})")
+        self.log.info("Retrieving the metadata dict of object (%s) in bucket (%s)", object_name, bucket_name)
         client = self.get_conn()
         bucket = client.bucket(bucket_name)
         blob = bucket.get_blob(blob_name=object_name)
         if blob is None:
-            raise ValueError(f"Object ({object_name}) not found in bucket ({bucket_name})")
+            raise ValueError("Object (%s) not found in bucket (%s)", object_name, bucket_name)
         blob_metadata = blob.metadata
         if blob_metadata:
-            self.log.info(f"Retrieved metadata of {object_name} with {len(blob_metadata)} fields")
+            self.log.info("Retrieved metadata of object (%s) with %s fields", object_name, len(blob_metadata))
         else:
-            self.log.info(f"Metadata of {object_name} is empty or it does not exist")
+            self.log.info("Metadata of object (%s) is empty or it does not exist", object_name)
         return blob_metadata
 
     @GoogleBaseHook.fallback_to_default_project_id

--- a/airflow/providers/google/cloud/hooks/gcs.py
+++ b/airflow/providers/google/cloud/hooks/gcs.py
@@ -1010,6 +1010,27 @@ class GCSHook(GoogleBaseHook):
         self.log.info("The md5Hash of %s is %s", object_name, blob_md5hash)
         return blob_md5hash
 
+    def get_metadata(self, bucket_name: str, object_name: str) -> dict | None:
+        """
+        Get the metadata of an object in Google Cloud Storage.
+
+        :param bucket_name: Name of the Google Cloud Storage bucket where the object is.
+        :param object_name: The name of the object that posseses the desired metadata
+        :return: The metadata associated with the object
+        """
+        self.log.info(f"Retrieving the metadata dict of object ({object_name}) in bucket ({bucket_name})")
+        client = self.get_conn()
+        bucket = client.bucket(bucket_name)
+        blob = bucket.get_blob(blob_name=object_name)
+        if blob is None:
+            raise ValueError(f"Object ({object_name}) not found in bucket ({bucket_name})")
+        blob_metadata = blob.metadata
+        if blob_metadata:
+            self.log.info(f"Retrieved metadata of {object_name} with {len(blob_metadata)} fields")
+        else:
+            self.log.info(f"Metadata of {object_name} is empty or it does not exist")
+        return blob_metadata
+
     @GoogleBaseHook.fallback_to_default_project_id
     def create_bucket(
         self,

--- a/tests/providers/google/cloud/hooks/test_gcs.py
+++ b/tests/providers/google/cloud/hooks/test_gcs.py
@@ -579,6 +579,18 @@ class TestGCSHook:
 
         assert response == returned_file_metadata
 
+    @mock.patch(GCS_STRING.format("GCSHook.get_conn"))
+    def test_nonexisting_object_get_metadata(self, mock_service):
+        test_bucket = "test_bucket"
+        test_object = "test_object"
+
+        bucket_method = mock_service.return_value.bucket
+        get_blob_method = bucket_method.return_value.get_blob
+        get_blob_method.return_value = None
+
+        with pytest.raises(exceptions.ValueError):
+            self.gcs_hook.get_metadata(bucket_name=test_bucket, object_name=test_object)
+
     @mock.patch("google.cloud.storage.Bucket")
     @mock.patch(GCS_STRING.format("GCSHook.get_conn"))
     def test_create_bucket(self, mock_service, mock_bucket):

--- a/tests/providers/google/cloud/hooks/test_gcs.py
+++ b/tests/providers/google/cloud/hooks/test_gcs.py
@@ -565,6 +565,20 @@ class TestGCSHook:
 
         assert response == returned_file_md5hash
 
+    @mock.patch(GCS_STRING.format("GCSHook.get_conn"))
+    def test_object_get_metadata(self, mock_service):
+        test_bucket = "test_bucket"
+        test_object = "test_object"
+        returned_file_metadata = {"test_metadata_key": "test_metadata_val"}
+
+        bucket_method = mock_service.return_value.bucket
+        get_blob_method = bucket_method.return_value.get_blob
+        get_blob_method.return_value.metadata = returned_file_metadata
+
+        response = self.gcs_hook.get_metadata(bucket_name=test_bucket, object_name=test_object)
+
+        assert response == returned_file_metadata
+
     @mock.patch("google.cloud.storage.Bucket")
     @mock.patch(GCS_STRING.format("GCSHook.get_conn"))
     def test_create_bucket(self, mock_service, mock_bucket):

--- a/tests/providers/google/cloud/hooks/test_gcs.py
+++ b/tests/providers/google/cloud/hooks/test_gcs.py
@@ -588,7 +588,7 @@ class TestGCSHook:
         get_blob_method = bucket_method.return_value.get_blob
         get_blob_method.return_value = None
 
-        with pytest.raises(exceptions.ValueError):
+        with pytest.raises(ValueError, match=r"Object \((.*?)\) not found in bucket \((.*?)\)"):
             self.gcs_hook.get_metadata(bucket_name=test_bucket, object_name=test_object)
 
     @mock.patch("google.cloud.storage.Bucket")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
- Background: GCS blobs can be associated with metadata to make tracking and validating data easier. The `GCSHook` doesn't yet allow for the metadata attribute to be exposed, although it supports uploading of blobs and associating metadata with them.
- Add `get_metadata` method to `GCSHook`
- The `get_metadata` function would retrieve metadata from blobs which already reside in a GCS bucket.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
