### PR TITLE
Refactor GKE hooks

### DIFF
--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import json
 import tempfile
@@ -582,13 +583,15 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
         return False
 
     @staticmethod
-    def is_job_failed(job: V1Job) -> bool:
+    def is_job_failed(job: V1Job) -> str | bool:
         """Check whether the given job is failed.
 
-        :return: Boolean indicating that the given job is failed.
+        :return: Error message if the job is failed, and False otherwise.
         """
         conditions = job.status.conditions or []
-        return bool(next((c for c in conditions if c.type == "Failed" and c.status), None))
+        if fail_condition := next((c for c in conditions if c.type == "Failed" and c.status), None):
+            return fail_condition.reason
+        return False
 
     def patch_namespaced_job(self, job_name: str, namespace: str, body: object) -> V1Job:
         """
@@ -769,3 +772,34 @@ class AsyncKubernetesHook(KubernetesHook):
             except HTTPError:
                 self.log.exception("There was an error reading the kubernetes API.")
                 raise
+
+    async def get_job_status(self, name: str, namespace: str) -> V1Job:
+        """
+        Get job's status object.
+
+        :param name: Name of the pod.
+        :param namespace: Name of the pod's namespace.
+        """
+        async with self.get_conn() as connection:
+            v1_api = async_client.BatchV1Api(connection)
+            job: V1Job = await v1_api.read_namespaced_job_status(
+                name=name,
+                namespace=namespace,
+            )
+        return job
+
+    async def wait_until_job_complete(self, name: str, namespace: str, poll_interval: float = 10) -> V1Job:
+        """Block job of specified name and namespace until it is complete or failed.
+
+        :param name: Name of Job to fetch.
+        :param namespace: Namespace of the Job.
+        :param poll_interval: Interval in seconds between polling the job status
+        :return: Job object
+        """
+        while True:
+            self.log.info("Requesting status for the job '%s' ", name)
+            job: V1Job = await self.get_job_status(name=name, namespace=namespace)
+            if self.is_job_complete(job=job):
+                return job
+            self.log.info("The job '%s' is incomplete. Sleeping for %i sec.", name, poll_interval)
+            await asyncio.sleep(poll_interval)

--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -771,7 +771,7 @@ class KubernetesPodOperator(BaseOperator):
 
     @deprecated(reason="use `trigger_reentry` instead.", category=AirflowProviderDeprecationWarning)
     def execute_complete(self, context: Context, event: dict, **kwargs):
-        self.trigger_reentry(context=context, event=event)
+        return self.trigger_reentry(context=context, event=event)
 
     def write_logs(self, pod: k8s.V1Pod):
         try:

--- a/airflow/providers/cncf/kubernetes/provider.yaml
+++ b/airflow/providers/cncf/kubernetes/provider.yaml
@@ -136,6 +136,7 @@ triggers:
   - integration-name: Kubernetes
     python-modules:
       - airflow.providers.cncf.kubernetes.triggers.pod
+      - airflow.providers.cncf.kubernetes.triggers.job
 
 
 connection-types:

--- a/airflow/providers/cncf/kubernetes/triggers/job.py
+++ b/airflow/providers/cncf/kubernetes/triggers/job.py
@@ -1,0 +1,101 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from functools import cached_property
+from typing import TYPE_CHECKING, Any, AsyncIterator
+
+from airflow.providers.cncf.kubernetes.hooks.kubernetes import AsyncKubernetesHook
+from airflow.triggers.base import BaseTrigger, TriggerEvent
+
+if TYPE_CHECKING:
+    from kubernetes.client import V1Job
+
+
+class KubernetesJobTrigger(BaseTrigger):
+    """
+    KubernetesJobTrigger run on the trigger worker to check the state of Job.
+
+    :param job_name: The name of the job.
+    :param job_namespace: The namespace of the job.
+    :param kubernetes_conn_id: The :ref:`kubernetes connection id <howto/connection:kubernetes>`
+        for the Kubernetes cluster.
+    :param cluster_context: Context that points to kubernetes cluster.
+    :param config_file: Path to kubeconfig file.
+    :param poll_interval: Polling period in seconds to check for the status.
+    :param in_cluster: run kubernetes client with in_cluster configuration.
+    """
+
+    def __init__(
+        self,
+        job_name: str,
+        job_namespace: str,
+        kubernetes_conn_id: str | None = None,
+        poll_interval: float = 2,
+        cluster_context: str | None = None,
+        config_file: str | None = None,
+        in_cluster: bool | None = None,
+    ):
+        super().__init__()
+        self.job_name = job_name
+        self.job_namespace = job_namespace
+        self.kubernetes_conn_id = kubernetes_conn_id
+        self.poll_interval = poll_interval
+        self.cluster_context = cluster_context
+        self.config_file = config_file
+        self.in_cluster = in_cluster
+
+    def serialize(self) -> tuple[str, dict[str, Any]]:
+        """Serialize KubernetesCreateJobTrigger arguments and classpath."""
+        return (
+            "airflow.providers.cncf.kubernetes.triggers.job.KubernetesJobTrigger",
+            {
+                "job_name": self.job_name,
+                "job_namespace": self.job_namespace,
+                "kubernetes_conn_id": self.kubernetes_conn_id,
+                "poll_interval": self.poll_interval,
+                "cluster_context": self.cluster_context,
+                "config_file": self.config_file,
+                "in_cluster": self.in_cluster,
+            },
+        )
+
+    async def run(self) -> AsyncIterator[TriggerEvent]:  # type: ignore[override]
+        """Get current job status and yield a TriggerEvent."""
+        job: V1Job = await self.hook.wait_until_job_complete(name=self.job_name, namespace=self.job_namespace)
+        job_dict = job.to_dict()
+        error_message = self.hook.is_job_failed(job=job)
+        yield TriggerEvent(
+            {
+                "name": job.metadata.name,
+                "namespace": job.metadata.namespace,
+                "status": "error" if error_message else "success",
+                "message": f"Job failed with error: {error_message}"
+                if error_message
+                else "Job completed successfully",
+                "job": job_dict,
+            }
+        )
+
+    @cached_property
+    def hook(self) -> AsyncKubernetesHook:
+        return AsyncKubernetesHook(
+            conn_id=self.kubernetes_conn_id,
+            in_cluster=self.in_cluster,
+            config_file=self.config_file,
+            cluster_context=self.cluster_context,
+        )

--- a/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -541,6 +541,7 @@ class GKEStartKueueInsideClusterOperator(GoogleCloudBaseOperator):
             impersonation_chain=self.impersonation_chain,
             cluster_url=self._cluster_url,
             ssl_ca_cert=self._ssl_ca_cert,
+            enable_tcp_keepalive=True,
         )
 
     @staticmethod
@@ -743,6 +744,7 @@ class GKEStartPodOperator(KubernetesPodOperator):
             cluster_url=self._cluster_url,
             ssl_ca_cert=self._ssl_ca_cert,
             impersonation_chain=self.impersonation_chain,
+            enable_tcp_keepalive=True,
         )
         return hook
 

--- a/airflow/providers/google/cloud/triggers/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/triggers/kubernetes_engine.py
@@ -147,6 +147,7 @@ class GKEStartPodTrigger(KubernetesPodTrigger):
             ssl_ca_cert=self._ssl_ca_cert,
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.impersonation_chain,
+            enable_tcp_keepalive=True,
         )
 
 

--- a/docs/apache-airflow-providers-cncf-kubernetes/operators.rst
+++ b/docs/apache-airflow-providers-cncf-kubernetes/operators.rst
@@ -618,6 +618,15 @@ to ``~/.kube/config``. It also allows users to supply a template YAML file using
     :start-after: [START howto_operator_k8s_job]
     :end-before: [END howto_operator_k8s_job]
 
+The :class:`~airflow.providers.cncf.kubernetes.operators.job.KubernetesJobOperator` also supports deferrable mode:
+
+.. exampleinclude:: /../../tests/system/providers/cncf/kubernetes/example_kubernetes_job.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_k8s_job_deferrable]
+    :end-before: [END howto_operator_k8s_job_deferrable]
+
+
 Difference between ``KubernetesPodOperator`` and ``KubernetesJobOperator``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The :class:`~airflow.providers.cncf.kubernetes.operators.job.KubernetesJobOperator` is operator for creating Job.

--- a/tests/providers/cncf/kubernetes/operators/test_job.py
+++ b/tests/providers/cncf/kubernetes/operators/test_job.py
@@ -39,6 +39,9 @@ DEFAULT_DATE = timezone.datetime(2016, 1, 1, 1, 0, 0)
 JOB_OPERATORS_PATH = "airflow.providers.cncf.kubernetes.operators.job.{}"
 HOOK_CLASS = JOB_OPERATORS_PATH.format("KubernetesHook")
 POLL_INTERVAL = 100
+JOB_NAME = "test-job"
+JOB_NAMESPACE = "test-namespace"
+KUBERNETES_CONN_ID = "test-conn_id"
 
 
 def create_context(task, persist_to_db=False, map_index=None):
@@ -480,6 +483,7 @@ class TestKubernetesJobOperator:
             [
                 mock.call(key="job_name", value=mock_job_expected.metadata.name),
                 mock.call(key="job_namespace", value=mock_job_expected.metadata.namespace),
+                mock.call(key="job", value=mock_job_expected.to_dict.return_value),
             ]
         )
 
@@ -491,16 +495,94 @@ class TestKubernetesJobOperator:
 
     @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.build_job_request_obj"))
     @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.create_job"))
+    @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.execute_deferrable"))
     @patch(HOOK_CLASS)
-    def test_execute_fail(self, mock_hook, mock_create_job, mock_build_job_request_obj):
-        mock_hook.return_value.is_job_failed.return_value = True
+    def test_execute_in_deferrable(
+        self, mock_hook, mock_execute_deferrable, mock_create_job, mock_build_job_request_obj
+    ):
+        mock_hook.return_value.is_job_failed.return_value = False
+        mock_job_request_obj = mock_build_job_request_obj.return_value
+        mock_job_expected = mock_create_job.return_value
+        mock_ti = mock.MagicMock()
+        context = dict(ti=mock_ti)
 
         op = KubernetesJobOperator(
             task_id="test_task_id",
+            wait_until_job_complete=True,
+            deferrable=True,
+        )
+        actual_result = op.execute(context=context)
+
+        mock_build_job_request_obj.assert_called_once_with(context)
+        mock_create_job.assert_called_once_with(job_request_obj=mock_job_request_obj)
+        mock_ti.xcom_push.assert_has_calls(
+            [
+                mock.call(key="job_name", value=mock_job_expected.metadata.name),
+                mock.call(key="job_namespace", value=mock_job_expected.metadata.namespace),
+            ]
+        )
+        mock_execute_deferrable.assert_called_once()
+
+        assert op.job_request_obj == mock_job_request_obj
+        assert op.job == mock_job_expected
+        assert actual_result is None
+        assert not mock_hook.wait_until_job_complete.called
+
+    @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.build_job_request_obj"))
+    @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.create_job"))
+    @patch(HOOK_CLASS)
+    def test_execute_fail(self, mock_hook, mock_create_job, mock_build_job_request_obj):
+        mock_hook.return_value.is_job_failed.return_value = "Error"
+
+        op = KubernetesJobOperator(
+            task_id="test_task_id",
+            wait_until_job_complete=True,
         )
 
         with pytest.raises(AirflowException):
             op.execute(context=dict(ti=mock.MagicMock()))
+
+    @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.defer"))
+    @patch(JOB_OPERATORS_PATH.format("KubernetesJobTrigger"))
+    def test_execute_deferrable(self, mock_trigger, mock_execute_deferrable):
+        mock_cluster_context = mock.MagicMock()
+        mock_config_file = mock.MagicMock()
+        mock_in_cluster = mock.MagicMock()
+
+        mock_job = mock.MagicMock()
+        mock_job.metadata.name = JOB_NAME
+        mock_job.metadata.namespace = JOB_NAMESPACE
+
+        mock_trigger_instance = mock_trigger.return_value
+
+        op = KubernetesJobOperator(
+            task_id="test_task_id",
+            kubernetes_conn_id=KUBERNETES_CONN_ID,
+            cluster_context=mock_cluster_context,
+            config_file=mock_config_file,
+            in_cluster=mock_in_cluster,
+            job_poll_interval=POLL_INTERVAL,
+            wait_until_job_complete=True,
+            deferrable=True,
+        )
+        op.job = mock_job
+
+        actual_result = op.execute_deferrable()
+
+        mock_execute_deferrable.assert_called_once_with(
+            trigger=mock_trigger_instance,
+            method_name="execute_complete",
+        )
+        mock_trigger.assert_called_once_with(
+            job_name=JOB_NAME,
+            job_namespace=JOB_NAMESPACE,
+            kubernetes_conn_id=KUBERNETES_CONN_ID,
+            cluster_context=mock_cluster_context,
+            config_file=mock_config_file,
+            in_cluster=mock_in_cluster,
+            poll_interval=POLL_INTERVAL,
+        )
+        assert actual_result is None
 
     @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.build_job_request_obj"))
     @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.create_job"))
@@ -523,6 +605,82 @@ class TestKubernetesJobOperator:
             namespace=mock_job_expected.metadata.namespace,
             job_poll_interval=POLL_INTERVAL,
         )
+
+    def test_execute_complete(self):
+        mock_ti = mock.MagicMock()
+        context = {"ti": mock_ti}
+        mock_job = mock.MagicMock()
+        event = {"job": mock_job, "status": "success"}
+
+        KubernetesJobOperator(task_id="test_task_id").execute_complete(context=context, event=event)
+
+        mock_ti.xcom_push.assert_called_once_with(key="job", value=mock_job)
+
+    def test_execute_complete_fail(self):
+        mock_ti = mock.MagicMock()
+        context = {"ti": mock_ti}
+        mock_job = mock.MagicMock()
+        event = {"job": mock_job, "status": "error", "message": "error message"}
+
+        with pytest.raises(AirflowException):
+            KubernetesJobOperator(task_id="test_task_id").execute_complete(context=context, event=event)
+
+        mock_ti.xcom_push.assert_called_once_with(key="job", value=mock_job)
+
+    @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.client"))
+    @patch(HOOK_CLASS)
+    def test_on_kill(self, mock_hook, mock_client):
+        mock_job = mock.MagicMock()
+        mock_job.metadata.name = JOB_NAME
+        mock_job.metadata.namespace = JOB_NAMESPACE
+        mock_serialize = mock_hook.return_value.batch_v1_client.api_client.sanitize_for_serialization
+        mock_serialized_job = mock_serialize.return_value
+
+        op = KubernetesJobOperator(task_id="test_task_id")
+        op.job = mock_job
+        op.on_kill()
+
+        mock_client.delete_namespaced_job.assert_called_once_with(
+            name=JOB_NAME,
+            namespace=JOB_NAMESPACE,
+            job=mock_serialized_job,
+        )
+        mock_serialize.assert_called_once_with(mock_job)
+
+    @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.client"))
+    @patch(HOOK_CLASS)
+    def test_on_kill_termination_grace_period(self, mock_hook, mock_client):
+        mock_job = mock.MagicMock()
+        mock_job.metadata.name = JOB_NAME
+        mock_job.metadata.namespace = JOB_NAMESPACE
+        mock_serialize = mock_hook.return_value.batch_v1_client.api_client.sanitize_for_serialization
+        mock_serialized_job = mock_serialize.return_value
+        mock_termination_grace_period = mock.MagicMock()
+
+        op = KubernetesJobOperator(
+            task_id="test_task_id", termination_grace_period=mock_termination_grace_period
+        )
+        op.job = mock_job
+        op.on_kill()
+
+        mock_client.delete_namespaced_job.assert_called_once_with(
+            name=JOB_NAME,
+            namespace=JOB_NAMESPACE,
+            job=mock_serialized_job,
+            grace_period_seconds=mock_termination_grace_period,
+        )
+        mock_serialize.assert_called_once_with(mock_job)
+
+    @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.client"))
+    @patch(HOOK_CLASS)
+    def test_on_kill_none_job(self, mock_hook, mock_client):
+        mock_serialize = mock_hook.return_value.batch_v1_client.api_client.sanitize_for_serialization
+
+        op = KubernetesJobOperator(task_id="test_task_id")
+        op.on_kill()
+
+        mock_client.delete_namespaced_job.assert_not_called()
+        mock_serialize.assert_not_called()
 
 
 @pytest.mark.execution_timeout(300)

--- a/tests/providers/cncf/kubernetes/triggers/test_job.py
+++ b/tests/providers/cncf/kubernetes/triggers/test_job.py
@@ -1,0 +1,135 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from airflow.providers.cncf.kubernetes.triggers.job import KubernetesJobTrigger
+from airflow.triggers.base import TriggerEvent
+
+TRIGGER_PATH = "airflow.providers.cncf.kubernetes.triggers.job.{}"
+TRIGGER_CLASS = TRIGGER_PATH.format("KubernetesJobTrigger")
+HOOK_PATH = "airflow.providers.cncf.kubernetes.hooks.kubernetes.AsyncKubernetesHook"
+JOB_NAME = "test-job-name"
+NAMESPACE = "default"
+CONN_ID = "test_kubernetes_conn_id"
+POLL_INTERVAL = 2
+CLUSTER_CONTEXT = "test-context"
+CONFIG_FILE = "/path/to/config/file"
+IN_CLUSTER = False
+
+
+@pytest.fixture
+def trigger():
+    return KubernetesJobTrigger(
+        job_name=JOB_NAME,
+        job_namespace=NAMESPACE,
+        kubernetes_conn_id=CONN_ID,
+        poll_interval=POLL_INTERVAL,
+        cluster_context=CLUSTER_CONTEXT,
+        config_file=CONFIG_FILE,
+        in_cluster=IN_CLUSTER,
+    )
+
+
+class TestKubernetesJobTrigger:
+    def test_serialize(self, trigger):
+        classpath, kwargs_dict = trigger.serialize()
+
+        assert classpath == TRIGGER_CLASS
+        assert kwargs_dict == {
+            "job_name": JOB_NAME,
+            "job_namespace": NAMESPACE,
+            "kubernetes_conn_id": CONN_ID,
+            "poll_interval": POLL_INTERVAL,
+            "cluster_context": CLUSTER_CONTEXT,
+            "config_file": CONFIG_FILE,
+            "in_cluster": IN_CLUSTER,
+        }
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{TRIGGER_CLASS}.hook")
+    async def test_run_success(self, mock_hook, trigger):
+        mock_job = mock.MagicMock()
+        mock_job.metadata.name = JOB_NAME
+        mock_job.metadata.namespace = NAMESPACE
+        mock_hook.wait_until_job_complete.side_effect = mock.AsyncMock(return_value=mock_job)
+
+        mock_is_job_failed = mock_hook.is_job_failed
+        mock_is_job_failed.return_value = False
+
+        mock_job_dict = mock_job.to_dict.return_value
+
+        event_actual = await trigger.run().asend(None)
+
+        mock_hook.wait_until_job_complete.assert_called_once_with(name=JOB_NAME, namespace=NAMESPACE)
+        mock_job.to_dict.assert_called_once()
+        mock_is_job_failed.assert_called_once_with(job=mock_job)
+        assert event_actual == TriggerEvent(
+            {
+                "name": JOB_NAME,
+                "namespace": NAMESPACE,
+                "status": "success",
+                "message": "Job completed successfully",
+                "job": mock_job_dict,
+            }
+        )
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{TRIGGER_CLASS}.hook")
+    async def test_run_fail(self, mock_hook, trigger):
+        mock_job = mock.MagicMock()
+        mock_job.metadata.name = JOB_NAME
+        mock_job.metadata.namespace = NAMESPACE
+        mock_hook.wait_until_job_complete.side_effect = mock.AsyncMock(return_value=mock_job)
+
+        mock_is_job_failed = mock_hook.is_job_failed
+        mock_is_job_failed.return_value = "Error"
+
+        mock_job_dict = mock_job.to_dict.return_value
+
+        event_actual = await trigger.run().asend(None)
+
+        mock_hook.wait_until_job_complete.assert_called_once_with(name=JOB_NAME, namespace=NAMESPACE)
+        mock_job.to_dict.assert_called_once()
+        mock_is_job_failed.assert_called_once_with(job=mock_job)
+        assert event_actual == TriggerEvent(
+            {
+                "name": JOB_NAME,
+                "namespace": NAMESPACE,
+                "status": "error",
+                "message": "Job failed with error: Error",
+                "job": mock_job_dict,
+            }
+        )
+
+    @mock.patch(TRIGGER_PATH.format("AsyncKubernetesHook"))
+    def test_hook(self, mock_hook, trigger):
+        hook_expected = mock_hook.return_value
+
+        hook_actual = trigger.hook
+
+        mock_hook.assert_called_once_with(
+            conn_id=CONN_ID,
+            in_cluster=IN_CLUSTER,
+            config_file=CONFIG_FILE,
+            cluster_context=CLUSTER_CONTEXT,
+        )
+        assert hook_actual == hook_expected

--- a/tests/providers/google/cloud/hooks/test_kubernetes_engine.py
+++ b/tests/providers/google/cloud/hooks/test_kubernetes_engine.py
@@ -508,38 +508,28 @@ class TestGKEPodAsyncHook:
         )
 
     @pytest.mark.asyncio
-    @mock.patch(BASE_STRING.format("_CredentialsToken"))
     @mock.patch(GKE_STRING.format("GKEPodAsyncHook.get_conn"))
     @mock.patch(GKE_STRING.format("async_client.CoreV1Api.read_namespaced_pod"))
-    async def test_get_pod(self, read_namespace_pod_mock, get_conn_mock, mock_token, async_hook):
-        async_hook.get_token = mock.AsyncMock()
-        async_hook.get_token.return_value = mock_token
-
+    async def test_get_pod(self, read_namespace_pod_mock, get_conn_mock, async_hook):
         self.make_mock_awaitable(read_namespace_pod_mock)
 
         await async_hook.get_pod(name=POD_NAME, namespace=POD_NAMESPACE)
 
-        async_hook.get_token.assert_called_once()
-        get_conn_mock.assert_called_once_with(mock_token)
+        get_conn_mock.assert_called_once_with()
         read_namespace_pod_mock.assert_called_with(
             name=POD_NAME,
             namespace=POD_NAMESPACE,
         )
 
     @pytest.mark.asyncio
-    @mock.patch(BASE_STRING.format("_CredentialsToken"))
     @mock.patch(GKE_STRING.format("GKEPodAsyncHook.get_conn"))
     @mock.patch(GKE_STRING.format("async_client.CoreV1Api.delete_namespaced_pod"))
-    async def test_delete_pod(self, delete_namespaced_pod, get_conn_mock, mock_token, async_hook):
-        async_hook.get_token = mock.AsyncMock()
-        async_hook.get_token.return_value = mock_token
-
+    async def test_delete_pod(self, delete_namespaced_pod, get_conn_mock, async_hook):
         self.make_mock_awaitable(delete_namespaced_pod)
 
         await async_hook.delete_pod(name=POD_NAME, namespace=POD_NAMESPACE)
 
-        async_hook.get_token.assert_called_once()
-        get_conn_mock.assert_called_once_with(mock_token)
+        get_conn_mock.assert_called_once_with()
         delete_namespaced_pod.assert_called_with(
             name=POD_NAME,
             namespace=POD_NAMESPACE,
@@ -547,19 +537,14 @@ class TestGKEPodAsyncHook:
         )
 
     @pytest.mark.asyncio
-    @mock.patch(BASE_STRING.format("_CredentialsToken"))
     @mock.patch(GKE_STRING.format("GKEPodAsyncHook.get_conn"))
     @mock.patch(GKE_STRING.format("async_client.CoreV1Api.read_namespaced_pod_log"))
-    async def test_read_logs(self, read_namespaced_pod_log, get_conn_mock, mock_token, async_hook, caplog):
-        async_hook.get_token = mock.AsyncMock()
-        async_hook.get_token.return_value = mock_token
-
+    async def test_read_logs(self, read_namespaced_pod_log, get_conn_mock, async_hook, caplog):
         self.make_mock_awaitable(read_namespaced_pod_log, result="Test string #1\nTest string #2\n")
 
         await async_hook.read_logs(name=POD_NAME, namespace=POD_NAMESPACE)
 
-        async_hook.get_token.assert_called_once()
-        get_conn_mock.assert_called_once_with(mock_token)
+        get_conn_mock.assert_called_once_with()
         read_namespaced_pod_log.assert_called_with(
             name=POD_NAME,
             namespace=POD_NAMESPACE,

--- a/tests/system/providers/cncf/kubernetes/example_kubernetes_job.py
+++ b/tests/system/providers/cncf/kubernetes/example_kubernetes_job.py
@@ -57,10 +57,22 @@ with DAG(
     update_job = KubernetesPatchJobOperator(
         task_id="update-job-task",
         namespace="default",
-        name="test-pi",
+        name=JOB_NAME,
         body={"spec": {"suspend": False}},
     )
     # [END howto_operator_update_job]
+
+    # [START howto_operator_k8s_job_deferrable]
+    k8s_job_def = KubernetesJobOperator(
+        task_id="job-task-def",
+        namespace="default",
+        image="perl:5.34.0",
+        cmds=["perl", "-Mbignum=bpi", "-wle", "print bpi(2000)"],
+        name=JOB_NAME + "-def",
+        wait_until_job_complete=True,
+        deferrable=True,
+    )
+    # [END howto_operator_k8s_job_deferrable]
 
     # [START howto_operator_delete_k8s_job]
     delete_job_task = KubernetesDeleteJobOperator(
@@ -70,7 +82,14 @@ with DAG(
     )
     # [END howto_operator_delete_k8s_job]
 
+    delete_job_task_def = KubernetesDeleteJobOperator(
+        task_id="delete_job_task_def",
+        name=JOB_NAME + "-def",
+        namespace=JOB_NAMESPACE,
+    )
+
     k8s_job >> update_job >> delete_job_task
+    k8s_job_def >> delete_job_task_def
 
     from tests.system.utils.watcher import watcher
 

--- a/tests/system/providers/google/cloud/kubernetes_engine/example_kubernetes_engine.py
+++ b/tests/system/providers/google/cloud/kubernetes_engine/example_kubernetes_engine.py
@@ -31,17 +31,19 @@ from airflow.providers.google.cloud.operators.kubernetes_engine import (
     GKEDeleteClusterOperator,
     GKEStartPodOperator,
 )
+from airflow.utils.trigger_rule import TriggerRule
 
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID")
 DAG_ID = "kubernetes_engine"
 GCP_PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT", "default")
 
 GCP_LOCATION = "europe-north1-a"
-CLUSTER_NAME = f"cluster-name-test-build-{ENV_ID}"
+CLUSTER_NAME = f"gke-{ENV_ID}".replace("_", "-")
 
 # [START howto_operator_gcp_gke_create_cluster_definition]
 CLUSTER = {"name": CLUSTER_NAME, "initial_node_count": 1}
 # [END howto_operator_gcp_gke_create_cluster_definition]
+
 
 with DAG(
     DAG_ID,
@@ -102,9 +104,9 @@ with DAG(
         location=GCP_LOCATION,
     )
     # [END howto_operator_gke_delete_cluster]
+    delete_cluster.trigger_rule = TriggerRule.ALL_DONE
 
-    create_cluster >> pod_task >> delete_cluster
-    create_cluster >> pod_task_xcom >> delete_cluster
+    create_cluster >> [pod_task, pod_task_xcom] >> delete_cluster
     pod_task_xcom >> pod_task_xcom_result
 
     from tests.system.utils.watcher import watcher

--- a/tests/system/providers/google/cloud/kubernetes_engine/example_kubernetes_engine_async.py
+++ b/tests/system/providers/google/cloud/kubernetes_engine/example_kubernetes_engine_async.py
@@ -31,13 +31,14 @@ from airflow.providers.google.cloud.operators.kubernetes_engine import (
     GKEDeleteClusterOperator,
     GKEStartPodOperator,
 )
+from airflow.utils.trigger_rule import TriggerRule
 
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID")
 DAG_ID = "kubernetes_engine_async"
 GCP_PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT", "default")
 
 GCP_LOCATION = "europe-north1-a"
-CLUSTER_NAME = f"example-cluster-defer-{ENV_ID}".replace("_", "-")
+CLUSTER_NAME = f"gke-async-{ENV_ID}".replace("_", "-")
 
 CLUSTER = {"name": CLUSTER_NAME, "initial_node_count": 1}
 
@@ -92,7 +93,7 @@ with DAG(
 
     # [START howto_operator_gke_xcom_result_async]
     pod_task_xcom_result = BashOperator(
-        bash_command="echo \"{{ task_instance.xcom_pull('pod_task_xcom')[0] }}\"",
+        bash_command="echo \"{{ task_instance.xcom_pull('pod_task_xcom_async')[0] }}\"",
         task_id="pod_task_xcom_result",
     )
     # [END howto_operator_gke_xcom_result_async]
@@ -106,9 +107,9 @@ with DAG(
         deferrable=True,
     )
     # [END howto_operator_gke_delete_cluster_async]
+    delete_cluster.trigger_rule = TriggerRule.ALL_DONE
 
-    create_cluster >> pod_task >> delete_cluster
-    create_cluster >> pod_task_xcom_async >> delete_cluster
+    create_cluster >> [pod_task, pod_task_xcom_async] >> delete_cluster
     pod_task_xcom_async >> pod_task_xcom_result
 
     from tests.system.utils.watcher import watcher

--- a/tests/system/providers/google/cloud/kubernetes_engine/example_kubernetes_engine_resource.py
+++ b/tests/system/providers/google/cloud/kubernetes_engine/example_kubernetes_engine_resource.py
@@ -31,13 +31,14 @@ from airflow.providers.google.cloud.operators.kubernetes_engine import (
     GKEDeleteClusterOperator,
     GKEDeleteCustomResourceOperator,
 )
+from airflow.utils.trigger_rule import TriggerRule
 
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID", "default")
 DAG_ID = "kubernetes_engine_resource"
 GCP_PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT", "default")
 
 GCP_LOCATION = "europe-north1-a"
-CLUSTER_NAME = f"cluster-name-test-build-{ENV_ID}"
+CLUSTER_NAME = f"gke-resource-{ENV_ID}".replace("_", "-")
 CLUSTER = {"name": CLUSTER_NAME, "initial_node_count": 1}
 
 PVC_NAME = "test-pvc-name"
@@ -95,6 +96,7 @@ with DAG(
         name=CLUSTER_NAME,
         project_id=GCP_PROJECT_ID,
         location=GCP_LOCATION,
+        trigger_rule=TriggerRule.ALL_DONE,
     )
 
     create_cluster >> create_resource_task >> delete_resource_task >> delete_cluster


### PR DESCRIPTION
In order to reduce code duplication and high complexity of the implementation, GKE hooks were refactored in this PR:
1. Existing `GKEHook` and `GKEAsyncHook` provide interface to GKE API remain unchanged.
2. The new `GKEKubernetesHook(GoogleBaseHook, KubernetesHook)` was introduced as a replacement for redundant hooks that used to contain duplicated methods that now are simply inherited from `GoogleBaseHook` and `KubernetesHook`:
- GKEDeploymentHook (deprecated)
- GKECustomResourceHook (deprecated)
- GKEPodHook (deprecated)
- GKEJobHook (deprecated)
3. By following the same pattern, the new `GKEKubernetesAsyncHook(GoogleBaseAsyncHook, AsyncKubernetesHook)` was introduced as a replacement for redundant hooks that used to contain duplicated methods that now are simply inherited from `GoogleBaseAsyncHook` and `AsyncKubernetesHook`:
- GKEPodAsyncHook (deprecated)
4. New hooks (GKEKubernetesHook, GKEKubernetesAsyncHook) provide access to the standard Kubernetes API with a GKE authentication.
5. Slightly adjusted system tests (they are all green now).
![system tests](https://github.com/VladaZakharova/airflow/assets/42827971/bf8807a8-43f5-4792-b8bd-8050df722984)
6. Except tiny changes, unit tests remain the same in order to prove stability of the code after refactoring. In the following PR we will disconnect GKE operators from the deprecated hooks, so it will be easy to remove them in the future.