### PR TITLE
Exit with error in case dependencies are not synchronized in CI

### DIFF
--- a/.github/workflows/ci-image-build.yml
+++ b/.github/workflows/ci-image-build.yml
@@ -177,7 +177,7 @@ ${{ inputs.do-build == 'true' && inputs.image-tag || '' }}"
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
         if: inputs.do-build == 'true'
-      - name: "Regenerate dependencies in case they was modified manually so that we can build an image"
+      - name: "Regenerate dependencies in case they were modified manually so that we can build an image"
         shell: bash
         run: |
           pip install rich>=12.4.4 pyyaml

--- a/scripts/ci/pre_commit/pre_commit_update_providers_dependencies.py
+++ b/scripts/ci/pre_commit/pre_commit_update_providers_dependencies.py
@@ -384,6 +384,9 @@ if __name__ == "__main__":
             )
             console.print("breeze static-checks --type update-providers-dependencies --all-files")
             console.print()
+            console.print("[yellow]Make sure to rebase your changes on the latest main branch!")
+            console.print()
+            sys.exit(1)
         else:
             console.print()
             console.print(
@@ -401,6 +404,10 @@ if __name__ == "__main__":
             )
             console.print("breeze static-checks --type update-providers-dependencies --all-files")
             console.print()
+            console.print()
+            console.print("[yellow]Make sure to rebase your changes on the latest main branch!")
+            console.print()
+            sys.exit(1)
         else:
             console.print(f"Written {PYPROJECT_TOML_FILE_PATH}")
     console.print()


### PR DESCRIPTION
In case dependencies are not synchronized between provider.yaml and pyproject.toml, they got regenerated in CI, just to prevent the case we are using old dependencies - using pre-commit script.

Normally pre-commit fails when it make changes to files, but in case we are building CI image we run the pre-commit manually as we do not want to initialize all pre-commit environments and in this case we should also sys.exit(1) to fail the image build in this case.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
