### PR TITLE
Add legend for duration markline.

### DIFF
--- a/airflow/www/static/js/dag/details/dag/RunDurationChart.tsx
+++ b/airflow/www/static/js/dag/details/dag/RunDurationChart.tsx
@@ -164,43 +164,7 @@ const RunDurationChart = ({ showLandingTimes }: Props) => {
     `;
   }
 
-  function formatMarkLineLegendName(name: string) {
-    switch (name) {
-      case "runDurationUnit":
-        return "Mean run duration";
-      case "queuedDurationUnit":
-        return "Mean queued duration";
-      case "landingDurationUnit":
-        return "Mean landing duration";
-      default:
-        return name;
-    }
-  }
-
   const option: ReactEChartsProps["option"] = {
-    legend: {
-      orient: "horizontal",
-      icon: "circle",
-      formatter: formatMarkLineLegendName,
-      data: [
-        ...(showLandingTimes
-          ? [
-              {
-                name: "landingDurationUnit",
-                itemStyle: { color: stateColors.scheduled },
-              },
-            ]
-          : []),
-        {
-          name: "runDurationUnit",
-          itemStyle: { color: "blue" },
-        },
-        {
-          name: "queuedDurationUnit",
-          itemStyle: { color: stateColors.queued },
-        },
-      ],
-    },
     series: [
       ...(showLandingTimes
         ? [
@@ -212,15 +176,6 @@ const RunDurationChart = ({ showLandingTimes }: Props) => {
                 opacity: 0.6,
               },
               stack: "x",
-              markLine: {
-                silent: true,
-                data: [
-                  {
-                    type: "median",
-                    lineStyle: { color: stateColors.scheduled },
-                  },
-                ],
-              },
             } as SeriesOption,
           ]
         : []),
@@ -232,10 +187,6 @@ const RunDurationChart = ({ showLandingTimes }: Props) => {
           opacity: 0.6,
         },
         stack: "x",
-        markLine: {
-          silent: true,
-          data: [{ type: "median", lineStyle: { color: stateColors.queued } }],
-        },
       },
       {
         type: "bar",
@@ -246,10 +197,6 @@ const RunDurationChart = ({ showLandingTimes }: Props) => {
           color: (params) => stateColors[params.data.state],
         },
         stack: "x",
-        markLine: {
-          silent: true,
-          data: [{ type: "median", lineStyle: { color: "blue" } }],
-        },
       },
     ],
     // @ts-ignore

--- a/airflow/www/static/js/dag/details/dag/RunDurationChart.tsx
+++ b/airflow/www/static/js/dag/details/dag/RunDurationChart.tsx
@@ -164,7 +164,43 @@ const RunDurationChart = ({ showLandingTimes }: Props) => {
     `;
   }
 
+  function formatMarkLineLegendName(name: string) {
+    switch (name) {
+      case "runDurationUnit":
+        return "Mean run duration";
+      case "queuedDurationUnit":
+        return "Mean queued duration";
+      case "landingDurationUnit":
+        return "Mean landing duration";
+      default:
+        return name;
+    }
+  }
+
   const option: ReactEChartsProps["option"] = {
+    legend: {
+      orient: "horizontal",
+      icon: "circle",
+      formatter: formatMarkLineLegendName,
+      data: [
+        ...(showLandingTimes
+          ? [
+              {
+                name: "landingDurationUnit",
+                itemStyle: { color: stateColors.scheduled },
+              },
+            ]
+          : []),
+        {
+          name: "runDurationUnit",
+          itemStyle: { color: "blue" },
+        },
+        {
+          name: "queuedDurationUnit",
+          itemStyle: { color: stateColors.queued },
+        },
+      ],
+    },
     series: [
       ...(showLandingTimes
         ? [
@@ -178,7 +214,12 @@ const RunDurationChart = ({ showLandingTimes }: Props) => {
               stack: "x",
               markLine: {
                 silent: true,
-                data: [{ type: "median" }],
+                data: [
+                  {
+                    type: "median",
+                    lineStyle: { color: stateColors.scheduled },
+                  },
+                ],
               },
             } as SeriesOption,
           ]
@@ -193,7 +234,7 @@ const RunDurationChart = ({ showLandingTimes }: Props) => {
         stack: "x",
         markLine: {
           silent: true,
-          data: [{ type: "median" }],
+          data: [{ type: "median", lineStyle: { color: stateColors.queued } }],
         },
       },
       {
@@ -207,7 +248,7 @@ const RunDurationChart = ({ showLandingTimes }: Props) => {
         stack: "x",
         markLine: {
           silent: true,
-          data: [{ type: "median" }],
+          data: [{ type: "median", lineStyle: { color: "blue" } }],
         },
       },
     ],

--- a/airflow/www/static/js/dag/details/task/TaskDuration.tsx
+++ b/airflow/www/static/js/dag/details/task/TaskDuration.tsx
@@ -155,7 +155,33 @@ const TaskDuration = () => {
     `;
   }
 
+  function formatMarkLineLegendName(name: string) {
+    switch (name) {
+      case "runDurationUnit":
+        return "Mean run duration";
+      case "queuedDurationUnit":
+        return "Mean queued duration";
+      default:
+        return name;
+    }
+  }
+
   const option: ReactEChartsProps["option"] = {
+    legend: {
+      orient: "horizontal",
+      icon: "circle",
+      formatter: formatMarkLineLegendName,
+      data: [
+        {
+          name: "runDurationUnit",
+          itemStyle: { color: "blue" },
+        },
+        {
+          name: "queuedDurationUnit",
+          itemStyle: { color: stateColors.queued },
+        },
+      ],
+    },
     series: [
       {
         type: "bar",
@@ -167,7 +193,7 @@ const TaskDuration = () => {
         stack: "x",
         markLine: {
           silent: true,
-          data: [{ type: "median" }],
+          data: [{ type: "median", lineStyle: { color: stateColors.queued } }],
         },
       },
       {
@@ -180,7 +206,7 @@ const TaskDuration = () => {
         stack: "x",
         markLine: {
           silent: true,
-          data: [{ type: "median" }],
+          data: [{ type: "median", lineStyle: { color: "blue" } }],
         },
       },
     ],

--- a/airflow/www/static/js/dag/details/task/TaskDuration.tsx
+++ b/airflow/www/static/js/dag/details/task/TaskDuration.tsx
@@ -158,9 +158,9 @@ const TaskDuration = () => {
   function formatMarkLineLegendName(name: string) {
     switch (name) {
       case "runDurationUnit":
-        return "Mean run duration";
+        return "Median total duration";
       case "queuedDurationUnit":
-        return "Mean queued duration";
+        return "Median queued duration";
       default:
         return name;
     }


### PR DESCRIPTION
closes: #38420 
related: #38420 

I am facing two issues and not able to debug why.

1. When show landing times is not selected and on page refresh even upon checking it the legend is not added. But when show landing times is selected and on refresh it adds it to legend along with unchecking it removes it from legend.
2. On show landing times selected blue color still seems to be used for landing time though the legend says color of scheduled state to be used.

Task run duration : 

![image](https://github.com/apache/airflow/assets/3972343/b7dd23c9-b376-4c48-99ef-124b803e009d)

Dag run duration : 

![image](https://github.com/apache/airflow/assets/3972343/39055bad-5be2-4453-b4b4-e9f4a1d6b869)

Dag run duration blue color is selected for landing time too : 

![image](https://github.com/apache/airflow/assets/3972343/29e57309-71ef-4c6e-96ad-0fbd7484d344)
