### PR TITLE
Print selective-check traceback on stdout rather than stderr

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/ci_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_commands.py
@@ -248,26 +248,30 @@ def selective_check(
     github_actor: str,
     github_context: str,
 ):
-    from airflow_breeze.utils.selective_checks import SelectiveChecks
+    try:
+        from airflow_breeze.utils.selective_checks import SelectiveChecks
 
-    github_context_dict = json.loads(github_context) if github_context else {}
-    github_event = GithubEvents(github_event_name)
-    if commit_ref is not None:
-        changed_files = get_changed_files(commit_ref=commit_ref)
-    else:
-        changed_files = ()
-    sc = SelectiveChecks(
-        commit_ref=commit_ref,
-        files=changed_files,
-        default_branch=default_branch,
-        default_constraints_branch=default_constraints_branch,
-        pr_labels=tuple(ast.literal_eval(pr_labels)) if pr_labels else (),
-        github_event=github_event,
-        github_repository=github_repository,
-        github_actor=github_actor,
-        github_context_dict=github_context_dict,
-    )
-    print(str(sc), file=sys.stderr)
+        github_context_dict = json.loads(github_context) if github_context else {}
+        github_event = GithubEvents(github_event_name)
+        if commit_ref is not None:
+            changed_files = get_changed_files(commit_ref=commit_ref)
+        else:
+            changed_files = ()
+        sc = SelectiveChecks(
+            commit_ref=commit_ref,
+            files=changed_files,
+            default_branch=default_branch,
+            default_constraints_branch=default_constraints_branch,
+            pr_labels=tuple(ast.literal_eval(pr_labels)) if pr_labels else (),
+            github_event=github_event,
+            github_repository=github_repository,
+            github_actor=github_actor,
+            github_context_dict=github_context_dict,
+        )
+        print(str(sc), file=sys.stderr)
+    except Exception:
+        get_console().print_exception(show_locals=True)
+        sys.exit(1)
 
 
 TEST_BRANCH_MATCHER = re.compile(r"^v.*test$")


### PR DESCRIPTION
We are using stdout of selective-check to print diagnostic information and stderr is redirected to produce outputs for GIHUB_OUTPUTS special variable in GitHub Actions. However this means that when there is an error when running selective-checks, the traceback goes to stderr and we cannot see it, plus it makes Github Actions to fail with crypttic errors.

This PR catches uncaught exception and uses rich mechanism to print the traceback to the diagnostic (stdout) console instead so that we can see it - in colour as well as with local variables, which might become handy.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
