### PR TITLE
Add task failed dependencies to details page.

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3557,6 +3557,14 @@ components:
           type: integer
           nullable: true
 
+    TaskFailedDependency:
+      type: object
+      properties:
+        name:
+          type: string
+        reason:
+          type: string
+
     Job:
       type: object
       nullable: true
@@ -3683,6 +3691,14 @@ components:
           $ref: "#/components/schemas/Trigger"
         triggerer_job:
           $ref: "#/components/schemas/Job"
+        task_failed_deps:
+          description: |
+            Array of failed dependencies blocking task from getting scheduled.
+
+            *New in version 2.9.0*
+          type: array
+          items:
+            $ref: "#/components/schemas/TaskFailedDependency"
         note:
           type: string
           description: |

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -679,6 +679,71 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}/dependencies:
+    parameters:
+      - $ref: "#/components/parameters/DAGID"
+      - $ref: "#/components/parameters/DAGRunID"
+      - $ref: "#/components/parameters/TaskID"
+
+    get:
+      summary: Get task dependencies blocking task from getting scheduled.
+      description: |
+        Get task dependencies blocking task from getting scheduled.
+
+        *New in version 2.9.0*
+      x-openapi-router-controller: airflow.api_connexion.endpoints.task_instance_endpoint
+      operationId: get_task_instance_dependencies
+      tags: [TaskInstance]
+
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TaskInstanceDependencyCollection"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "403":
+          $ref: "#/components/responses/PermissionDenied"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  ? /dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}/{map_index}/dependencies
+  : parameters:
+      - $ref: "#/components/parameters/DAGID"
+      - $ref: "#/components/parameters/DAGRunID"
+      - $ref: "#/components/parameters/TaskID"
+      - $ref: "#/components/parameters/MapIndex"
+
+    get:
+      summary: Get task dependencies blocking task from getting scheduled.
+      description: |
+        Get task dependencies blocking task from getting scheduled.
+
+        *New in version 2.9.0*
+      x-openapi-router-controller: airflow.api_connexion.endpoints.task_instance_endpoint
+      operationId: get_mapped_task_instance_dependencies
+      tags: [TaskInstance]
+
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TaskInstanceDependencyCollection"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "403":
+          $ref: "#/components/responses/PermissionDenied"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
   /dags/{dag_id}/updateTaskInstancesState:
     parameters:
       - $ref: "#/components/parameters/DAGID"
@@ -3565,6 +3630,14 @@ components:
         reason:
           type: string
 
+    TaskInstanceDependencyCollection:
+      type: object
+      properties:
+        dependencies:
+          type: array
+          items:
+            $ref: "#/components/schemas/TaskFailedDependency"
+
     Job:
       type: object
       nullable: true
@@ -3691,14 +3764,6 @@ components:
           $ref: "#/components/schemas/Trigger"
         triggerer_job:
           $ref: "#/components/schemas/Job"
-        task_failed_deps:
-          description: |
-            Array of failed dependencies blocking task from getting scheduled.
-
-            *New in version 2.9.0*
-          type: array
-          items:
-            $ref: "#/components/schemas/TaskFailedDependency"
         note:
           type: string
           description: |

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -690,7 +690,7 @@ paths:
       description: |
         Get task dependencies blocking task from getting scheduled.
 
-        *New in version 2.9.0*
+        *New in version 2.10.0*
       x-openapi-router-controller: airflow.api_connexion.endpoints.task_instance_endpoint
       operationId: get_task_instance_dependencies
       tags: [TaskInstance]
@@ -723,7 +723,7 @@ paths:
       description: |
         Get task dependencies blocking task from getting scheduled.
 
-        *New in version 2.9.0*
+        *New in version 2.10.0*
       x-openapi-router-controller: airflow.api_connexion.endpoints.task_instance_endpoint
       operationId: get_mapped_task_instance_dependencies
       tags: [TaskInstance]

--- a/airflow/api_connexion/schemas/task_instance_schema.py
+++ b/airflow/api_connexion/schemas/task_instance_schema.py
@@ -28,7 +28,11 @@ from airflow.api_connexion.schemas.enum_schemas import TaskInstanceStateField
 from airflow.api_connexion.schemas.job_schema import JobSchema
 from airflow.api_connexion.schemas.sla_miss_schema import SlaMissSchema
 from airflow.api_connexion.schemas.trigger_schema import TriggerSchema
+from airflow.exceptions import TaskNotFound
 from airflow.models import TaskInstance
+from airflow.ti_deps.dep_context import DepContext
+from airflow.ti_deps.dependencies_deps import SCHEDULER_QUEUED_DEPS
+from airflow.utils.airflow_flask_app import get_airflow_app
 from airflow.utils.helpers import exactly_one
 from airflow.utils.state import TaskInstanceState
 
@@ -72,6 +76,7 @@ class TaskInstanceSchema(SQLAlchemySchema):
     rendered_fields = JsonObjectField(dump_default={})
     trigger = fields.Nested(TriggerSchema)
     triggerer_job = fields.Nested(JobSchema)
+    task_failed_deps = fields.Method("get_task_failed_deps", dump_default=[])
 
     def get_attribute(self, obj, attr, default):
         if attr == "sla_miss":
@@ -83,6 +88,30 @@ class TaskInstanceSchema(SQLAlchemySchema):
         elif attr == "rendered_fields":
             return get_value(obj[0], "rendered_task_instance_fields.rendered_fields", default)
         return get_value(obj[0], attr, default)
+
+    @staticmethod
+    def get_task_failed_deps(obj):
+        # Get failed deps only for tasks in None or scheduled state
+        if obj and (obj[0].state in [None, TaskInstanceState.SCHEDULED]):
+            ti = obj[0]
+            dag = get_airflow_app().dag_bag.get_dag(ti.dag_id)
+
+            if dag:
+                try:
+                    ti.task = dag.get_task(ti.task_id)
+                except TaskNotFound:
+                    return []
+
+            dep_context = DepContext(SCHEDULER_QUEUED_DEPS)
+            return sorted(
+                [
+                    {"name": dep.dep_name, "reason": dep.reason}
+                    for dep in ti.get_failed_dep_statuses(dep_context=dep_context)
+                ],
+                key=lambda x: x["name"],
+            )
+        else:
+            return []
 
 
 class TaskInstanceCollection(NamedTuple):

--- a/airflow/www/static/js/api/index.ts
+++ b/airflow/www/static/js/api/index.ts
@@ -41,6 +41,7 @@ import useSetDagRunNote from "./useSetDagRunNote";
 import useSetTaskInstanceNote from "./useSetTaskInstanceNote";
 import useUpstreamDatasetEvents from "./useUpstreamDatasetEvents";
 import useTaskInstance from "./useTaskInstance";
+import useTaskFailedDependency from "./useTaskFailedDependency";
 import useDag from "./useDag";
 import useDagCode from "./useDagCode";
 import useDagDetails from "./useDagDetails";
@@ -100,6 +101,7 @@ export {
   useHistoricalMetricsData,
   useTaskXcomEntry,
   useTaskXcomCollection,
+  useTaskFailedDependency,
   useEventLogs,
   useCalendarData,
   useCreateDatasetEvent,

--- a/airflow/www/static/js/api/useTaskFailedDependency.ts
+++ b/airflow/www/static/js/api/useTaskFailedDependency.ts
@@ -39,8 +39,9 @@ export default function useTaskFailedDependency({
   return useQuery(
     ["taskFailedDependencies", dagId, taskId, runId, mapIndex],
     async () => {
+      const definedMapIndex = mapIndex ?? -1;
       const url = (
-        mapIndex && mapIndex >= 0 ? mappedTaskDependencyURI : taskDependencyURI
+        definedMapIndex >= 0 ? mappedTaskDependencyURI : taskDependencyURI
       )
         .replace("_DAG_RUN_ID_", runId)
         .replace(

--- a/airflow/www/static/js/api/useTaskFailedDependency.ts
+++ b/airflow/www/static/js/api/useTaskFailedDependency.ts
@@ -50,17 +50,11 @@ export default function useTaskFailedDependency({
         )
         .replace("_TASK_ID_", taskId);
 
-      try {
-        const datum = await axios.get<
-          AxiosResponse,
-          API.TaskInstanceDependencyCollection
-        >(url);
-        return datum;
-      } catch (e) {
-        // eslint-disable-next-line no-console
-        console.error(e);
-        return { dependencies: [] };
-      }
+      const datum = await axios.get<
+        AxiosResponse,
+        API.TaskInstanceDependencyCollection
+      >(url);
+      return datum;
     }
   );
 }

--- a/airflow/www/static/js/api/useTaskFailedDependency.ts
+++ b/airflow/www/static/js/api/useTaskFailedDependency.ts
@@ -1,0 +1,65 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import axios, { AxiosResponse } from "axios";
+import type { API } from "src/types";
+import { useQuery } from "react-query";
+import { getMetaValue } from "../utils";
+
+const taskDependencyURI = getMetaValue("task_dependency_api");
+const mappedTaskDependencyURI = getMetaValue("mapped_task_dependency_api");
+
+export default function useTaskFailedDependency({
+  dagId,
+  taskId,
+  runId,
+  mapIndex,
+}: {
+  dagId: string;
+  taskId: string;
+  runId: string;
+  mapIndex?: number | undefined;
+}) {
+  return useQuery(
+    ["taskFailedDependencies", dagId, taskId, runId, mapIndex],
+    async () => {
+      const url = (
+        mapIndex && mapIndex >= 0 ? mappedTaskDependencyURI : taskDependencyURI
+      )
+        .replace("_DAG_RUN_ID_", runId)
+        .replace(
+          "_TASK_ID_/0/dependencies",
+          `_TASK_ID_/${mapIndex}/dependencies`
+        )
+        .replace("_TASK_ID_", taskId);
+
+      try {
+        const datum = await axios.get<
+          AxiosResponse,
+          API.TaskInstanceDependencyCollection
+        >(url);
+        return datum;
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error(e);
+        return { dependencies: [] };
+      }
+    }
+  );
+}

--- a/airflow/www/static/js/api/useTaskFailedDependency.ts
+++ b/airflow/www/static/js/api/useTaskFailedDependency.ts
@@ -18,6 +18,7 @@
  */
 
 import axios, { AxiosResponse } from "axios";
+import { useAutoRefresh } from "src/context/autorefresh";
 import type { API } from "src/types";
 import { useQuery } from "react-query";
 import { getMetaValue } from "../utils";
@@ -36,6 +37,7 @@ export default function useTaskFailedDependency({
   runId: string;
   mapIndex?: number | undefined;
 }) {
+  const { isRefreshOn } = useAutoRefresh();
   return useQuery(
     ["taskFailedDependencies", dagId, taskId, runId, mapIndex],
     async () => {
@@ -55,6 +57,7 @@ export default function useTaskFailedDependency({
         API.TaskInstanceDependencyCollection
       >(url);
       return datum;
-    }
+    },
+    { refetchInterval: isRefreshOn && (autoRefreshInterval || 1) * 1000 }
   );
 }

--- a/airflow/www/static/js/dag/details/taskInstance/Details.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Details.tsx
@@ -18,7 +18,17 @@
  */
 
 import React from "react";
-import { Text, Flex, Table, Tbody, Tr, Td, Code, Box } from "@chakra-ui/react";
+import {
+  Text,
+  Flex,
+  Table,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Code,
+  Box,
+} from "@chakra-ui/react";
 import { snakeCase } from "lodash";
 
 import { getGroupAndMapSummary } from "src/utils";
@@ -95,10 +105,36 @@ const Details = ({ gridInstance, taskInstance, group }: Props) => {
   const isStateFinal =
     state &&
     ["success", "failed", "upstream_failed", "skipped"].includes(state);
+  const isStateScheduled = !state || (state && ["scheduled"].includes(state));
   const isOverall = (isMapped || isGroup) && "Overall ";
 
   return (
     <Box mt={3} flexGrow={1}>
+      {isStateScheduled && (
+        <Box>
+          <Text as="strong" mb={3}>
+            Task Failed Dependencies
+          </Text>
+          <br />
+          <br />
+          <Text>Dependencies Blocking Task From Getting Scheduled</Text>
+          <Table variant="striped">
+            <Tbody>
+              <Tr>
+                <Th>Dependency</Th>
+                <Th>Reason</Th>
+              </Tr>
+              {taskInstance?.taskFailedDeps &&
+                taskInstance.taskFailedDeps.map((dep) => (
+                  <Tr key={dep.name}>
+                    <Td>{dep.name}</Td>
+                    <Td>{dep.reason}</Td>
+                  </Tr>
+                ))}
+            </Tbody>
+          </Table>
+        </Box>
+      )}
       <Text as="strong" mb={3}>
         Task Instance Details
       </Text>

--- a/airflow/www/static/js/dag/details/taskInstance/Details.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Details.tsx
@@ -18,17 +18,7 @@
  */
 
 import React from "react";
-import {
-  Text,
-  Flex,
-  Table,
-  Tbody,
-  Tr,
-  Th,
-  Td,
-  Code,
-  Box,
-} from "@chakra-ui/react";
+import { Text, Flex, Table, Tbody, Tr, Td, Code, Box } from "@chakra-ui/react";
 import { snakeCase } from "lodash";
 
 import { getGroupAndMapSummary } from "src/utils";
@@ -105,36 +95,10 @@ const Details = ({ gridInstance, taskInstance, group }: Props) => {
   const isStateFinal =
     state &&
     ["success", "failed", "upstream_failed", "skipped"].includes(state);
-  const isStateScheduled = !state || (state && ["scheduled"].includes(state));
   const isOverall = (isMapped || isGroup) && "Overall ";
 
   return (
     <Box mt={3} flexGrow={1}>
-      {isStateScheduled && (
-        <Box>
-          <Text as="strong" mb={3}>
-            Task Failed Dependencies
-          </Text>
-          <br />
-          <br />
-          <Text>Dependencies Blocking Task From Getting Scheduled</Text>
-          <Table variant="striped">
-            <Tbody>
-              <Tr>
-                <Th>Dependency</Th>
-                <Th>Reason</Th>
-              </Tr>
-              {taskInstance?.taskFailedDeps &&
-                taskInstance.taskFailedDeps.map((dep) => (
-                  <Tr key={dep.name}>
-                    <Td>{dep.name}</Td>
-                    <Td>{dep.reason}</Td>
-                  </Tr>
-                ))}
-            </Tbody>
-          </Table>
-        </Box>
-      )}
       <Text as="strong" mb={3}>
         Task Instance Details
       </Text>

--- a/airflow/www/static/js/dag/details/taskInstance/TaskFailedDependency.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/TaskFailedDependency.tsx
@@ -18,7 +18,18 @@
  */
 
 import React from "react";
-import { Text, Table, Tbody, Tr, Th, Td, Box } from "@chakra-ui/react";
+import {
+  Alert,
+  AlertIcon,
+  Box,
+  Spinner,
+  Text,
+  Table,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+} from "@chakra-ui/react";
 
 import { useTaskFailedDependency } from "src/api";
 
@@ -30,16 +41,16 @@ interface Props {
 }
 
 const TaskFailedDependency = ({ dagId, runId, taskId, mapIndex }: Props) => {
-  const { data: dependencies, isLoading } = useTaskFailedDependency({
+  const {
+    data: dependencies,
+    isLoading,
+    error,
+  } = useTaskFailedDependency({
     dagId,
     taskId,
     runId,
     mapIndex,
   });
-
-  if (isLoading) {
-    return null;
-  }
 
   return (
     <Box mt={3} flexGrow={1}>
@@ -47,22 +58,34 @@ const TaskFailedDependency = ({ dagId, runId, taskId, mapIndex }: Props) => {
         Task Failed Dependencies
       </Text>
       <br />
-      <br />
-      <Text>Dependencies Blocking Task From Getting Scheduled</Text>
-      <Table variant="striped">
-        <Tbody>
-          <Tr>
-            <Th>Dependency</Th>
-            <Th>Reason</Th>
-          </Tr>
-          {dependencies?.dependencies?.map((dep) => (
-            <Tr key={dep.name}>
-              <Td>{dep.name}</Td>
-              <Td>{dep.reason}</Td>
-            </Tr>
-          ))}
-        </Tbody>
-      </Table>
+
+      {isLoading && <Spinner size="md" thickness="4px" speed="0.65s" />}
+      {!!error && (
+        <Alert status="error" marginBottom="10px">
+          <AlertIcon />
+          An error occurred while fetching task dependencies.
+        </Alert>
+      )}
+
+      {dependencies && (
+        <Box mt={3}>
+          <Text>Dependencies Blocking Task From Getting Scheduled</Text>
+          <Table variant="striped">
+            <Tbody>
+              <Tr>
+                <Th>Dependency</Th>
+                <Th>Reason</Th>
+              </Tr>
+              {dependencies.dependencies?.map((dep) => (
+                <Tr key={dep.name}>
+                  <Td>{dep.name}</Td>
+                  <Td>{dep.reason}</Td>
+                </Tr>
+              ))}
+            </Tbody>
+          </Table>
+        </Box>
+      )}
     </Box>
   );
 };

--- a/airflow/www/static/js/dag/details/taskInstance/TaskFailedDependency.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/TaskFailedDependency.tsx
@@ -1,0 +1,70 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from "react";
+import { Text, Table, Tbody, Tr, Th, Td, Box } from "@chakra-ui/react";
+
+import { useTaskFailedDependency } from "src/api";
+
+interface Props {
+  dagId: string;
+  runId: string;
+  taskId: string;
+  mapIndex?: number;
+}
+
+const TaskFailedDependency = ({ dagId, runId, taskId, mapIndex }: Props) => {
+  const { data: dependencies, isLoading } = useTaskFailedDependency({
+    dagId,
+    taskId,
+    runId,
+    mapIndex,
+  });
+
+  if (isLoading) {
+    return null;
+  }
+
+  return (
+    <Box mt={3} flexGrow={1}>
+      <Text as="strong" mb={3}>
+        Task Failed Dependencies
+      </Text>
+      <br />
+      <br />
+      <Text>Dependencies Blocking Task From Getting Scheduled</Text>
+      <Table variant="striped">
+        <Tbody>
+          <Tr>
+            <Th>Dependency</Th>
+            <Th>Reason</Th>
+          </Tr>
+          {dependencies?.dependencies?.map((dep) => (
+            <Tr key={dep.name}>
+              <Td>{dep.name}</Td>
+              <Td>{dep.reason}</Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </Box>
+  );
+};
+
+export default TaskFailedDependency;

--- a/airflow/www/static/js/dag/details/taskInstance/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/index.tsx
@@ -30,6 +30,7 @@ import ExtraLinks from "./ExtraLinks";
 import Details from "./Details";
 import DatasetUpdateEvents from "./DatasetUpdateEvents";
 import TriggererInfo from "./TriggererInfo";
+import TaskFailedDependency from "./TaskFailedDependency";
 
 const dagId = getMetaValue("dag_id")!;
 
@@ -65,6 +66,10 @@ const TaskInstance = ({ taskId, runId, mapIndex }: Props) => {
     mapIndex,
     enabled: (!isGroup && !isMapped) || isMapIndexDefined,
   });
+
+  const showTaskSchedulingDependencies =
+    !isGroupOrMappedTaskSummary &&
+    (!taskInstance?.state || taskInstance?.state === "scheduled");
 
   const gridInstance = group?.instances.find((ti) => ti.runId === runId);
 
@@ -112,6 +117,14 @@ const TaskInstance = ({ taskId, runId, mapIndex }: Props) => {
         <DatasetUpdateEvents taskId={taskId} runId={runId} />
       )}
       <TriggererInfo taskInstance={taskInstance} />
+      {showTaskSchedulingDependencies && (
+        <TaskFailedDependency
+          dagId={dagId}
+          runId={runId}
+          taskId={taskId}
+          mapIndex={isMapped && isMapIndexDefined ? mapIndex : undefined}
+        />
+      )}
       <Details
         gridInstance={gridInstance}
         taskInstance={taskInstance}

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -139,6 +139,44 @@ export interface paths {
       };
     };
   };
+  "/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}/dependencies": {
+    /**
+     * Get task dependencies blocking task from getting scheduled.
+     *
+     * *New in version 2.9.0*
+     */
+    get: operations["get_task_instance_dependencies"];
+    parameters: {
+      path: {
+        /** The DAG ID. */
+        dag_id: components["parameters"]["DAGID"];
+        /** The DAG run ID. */
+        dag_run_id: components["parameters"]["DAGRunID"];
+        /** The task ID. */
+        task_id: components["parameters"]["TaskID"];
+      };
+    };
+  };
+  "/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}/{map_index}/dependencies": {
+    /**
+     * Get task dependencies blocking task from getting scheduled.
+     *
+     * *New in version 2.9.0*
+     */
+    get: operations["get_mapped_task_instance_dependencies"];
+    parameters: {
+      path: {
+        /** The DAG ID. */
+        dag_id: components["parameters"]["DAGID"];
+        /** The DAG run ID. */
+        dag_run_id: components["parameters"]["DAGRunID"];
+        /** The task ID. */
+        task_id: components["parameters"]["TaskID"];
+        /** The map index. */
+        map_index: components["parameters"]["MapIndex"];
+      };
+    };
+  };
   "/dags/{dag_id}/updateTaskInstancesState": {
     /** Updates the state for multiple task instances simultaneously. */
     post: operations["post_set_task_instances_state"];
@@ -1398,6 +1436,9 @@ export interface components {
       name?: string;
       reason?: string;
     };
+    TaskInstanceDependencyCollection: {
+      dependencies?: components["schemas"]["TaskFailedDependency"][];
+    };
     Job: {
       id?: number;
       dag_id?: string | null;
@@ -1466,12 +1507,6 @@ export interface components {
       rendered_fields?: { [key: string]: unknown };
       trigger?: components["schemas"]["Trigger"];
       triggerer_job?: components["schemas"]["Job"];
-      /**
-       * @description Array of failed dependencies blocking task from getting scheduled.
-       *
-       * *New in version 2.9.0*
-       */
-      task_failed_deps?: components["schemas"]["TaskFailedDependency"][];
       /**
        * @description Contains manually entered notes by the user about the TaskInstance.
        *
@@ -3024,6 +3059,66 @@ export interface operations {
       content: {
         "application/json": components["schemas"]["SetTaskInstanceNote"];
       };
+    };
+  };
+  /**
+   * Get task dependencies blocking task from getting scheduled.
+   *
+   * *New in version 2.9.0*
+   */
+  get_task_instance_dependencies: {
+    parameters: {
+      path: {
+        /** The DAG ID. */
+        dag_id: components["parameters"]["DAGID"];
+        /** The DAG run ID. */
+        dag_run_id: components["parameters"]["DAGRunID"];
+        /** The task ID. */
+        task_id: components["parameters"]["TaskID"];
+      };
+    };
+    responses: {
+      /** Success. */
+      200: {
+        content: {
+          "application/json": components["schemas"]["TaskInstanceDependencyCollection"];
+        };
+      };
+      400: components["responses"]["BadRequest"];
+      401: components["responses"]["Unauthenticated"];
+      403: components["responses"]["PermissionDenied"];
+      404: components["responses"]["NotFound"];
+    };
+  };
+  /**
+   * Get task dependencies blocking task from getting scheduled.
+   *
+   * *New in version 2.9.0*
+   */
+  get_mapped_task_instance_dependencies: {
+    parameters: {
+      path: {
+        /** The DAG ID. */
+        dag_id: components["parameters"]["DAGID"];
+        /** The DAG run ID. */
+        dag_run_id: components["parameters"]["DAGRunID"];
+        /** The task ID. */
+        task_id: components["parameters"]["TaskID"];
+        /** The map index. */
+        map_index: components["parameters"]["MapIndex"];
+      };
+    };
+    responses: {
+      /** Success. */
+      200: {
+        content: {
+          "application/json": components["schemas"]["TaskInstanceDependencyCollection"];
+        };
+      };
+      400: components["responses"]["BadRequest"];
+      401: components["responses"]["Unauthenticated"];
+      403: components["responses"]["PermissionDenied"];
+      404: components["responses"]["NotFound"];
     };
   };
   /** Updates the state for multiple task instances simultaneously. */
@@ -5161,6 +5256,9 @@ export type Trigger = CamelCasedPropertiesDeep<
 export type TaskFailedDependency = CamelCasedPropertiesDeep<
   components["schemas"]["TaskFailedDependency"]
 >;
+export type TaskInstanceDependencyCollection = CamelCasedPropertiesDeep<
+  components["schemas"]["TaskInstanceDependencyCollection"]
+>;
 export type Job = CamelCasedPropertiesDeep<components["schemas"]["Job"]>;
 export type TaskInstance = CamelCasedPropertiesDeep<
   components["schemas"]["TaskInstance"]
@@ -5382,6 +5480,13 @@ export type SetMappedTaskInstanceNoteVariables = CamelCasedPropertiesDeep<
   operations["set_mapped_task_instance_note"]["parameters"]["path"] &
     operations["set_mapped_task_instance_note"]["requestBody"]["content"]["application/json"]
 >;
+export type GetTaskInstanceDependenciesVariables = CamelCasedPropertiesDeep<
+  operations["get_task_instance_dependencies"]["parameters"]["path"]
+>;
+export type GetMappedTaskInstanceDependenciesVariables =
+  CamelCasedPropertiesDeep<
+    operations["get_mapped_task_instance_dependencies"]["parameters"]["path"]
+  >;
 export type PostSetTaskInstancesStateVariables = CamelCasedPropertiesDeep<
   operations["post_set_task_instances_state"]["parameters"]["path"] &
     operations["post_set_task_instances_state"]["requestBody"]["content"]["application/json"]

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1394,6 +1394,10 @@ export interface components {
       created_date?: string;
       triggerer_id?: number | null;
     } | null;
+    TaskFailedDependency: {
+      name?: string;
+      reason?: string;
+    };
     Job: {
       id?: number;
       dag_id?: string | null;
@@ -1462,6 +1466,12 @@ export interface components {
       rendered_fields?: { [key: string]: unknown };
       trigger?: components["schemas"]["Trigger"];
       triggerer_job?: components["schemas"]["Job"];
+      /**
+       * @description Array of failed dependencies blocking task from getting scheduled.
+       *
+       * *New in version 2.9.0*
+       */
+      task_failed_deps?: components["schemas"]["TaskFailedDependency"][];
       /**
        * @description Contains manually entered notes by the user about the TaskInstance.
        *
@@ -5147,6 +5157,9 @@ export type SLAMiss = CamelCasedPropertiesDeep<
 >;
 export type Trigger = CamelCasedPropertiesDeep<
   components["schemas"]["Trigger"]
+>;
+export type TaskFailedDependency = CamelCasedPropertiesDeep<
+  components["schemas"]["TaskFailedDependency"]
 >;
 export type Job = CamelCasedPropertiesDeep<components["schemas"]["Job"]>;
 export type TaskInstance = CamelCasedPropertiesDeep<

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -143,7 +143,7 @@ export interface paths {
     /**
      * Get task dependencies blocking task from getting scheduled.
      *
-     * *New in version 2.9.0*
+     * *New in version 2.10.0*
      */
     get: operations["get_task_instance_dependencies"];
     parameters: {
@@ -161,7 +161,7 @@ export interface paths {
     /**
      * Get task dependencies blocking task from getting scheduled.
      *
-     * *New in version 2.9.0*
+     * *New in version 2.10.0*
      */
     get: operations["get_mapped_task_instance_dependencies"];
     parameters: {
@@ -3064,7 +3064,7 @@ export interface operations {
   /**
    * Get task dependencies blocking task from getting scheduled.
    *
-   * *New in version 2.9.0*
+   * *New in version 2.10.0*
    */
   get_task_instance_dependencies: {
     parameters: {
@@ -3093,7 +3093,7 @@ export interface operations {
   /**
    * Get task dependencies blocking task from getting scheduled.
    *
-   * *New in version 2.9.0*
+   * *New in version 2.10.0*
    */
   get_mapped_task_instance_dependencies: {
     parameters: {

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -84,6 +84,9 @@
   <meta name="event_logs_api" content="{{ url_for('/api/v1.airflow_api_connexion_endpoints_event_log_endpoint_get_event_logs') }}">
   <meta name="audit_log_url" content="{{ url_for('LogModelView.list') }}">
   <meta name="dag_run_url" content="{{ url_for('/api/v1.airflow_api_connexion_endpoints_dag_run_endpoint_get_dag_run', dag_id='__DAG_ID__', dag_run_id='__DAG_RUN_ID__') }}">
+  <meta name="task_dependency_api" content="{{ url_for('/api/v1.airflow_api_connexion_endpoints_task_instance_endpoint_get_task_instance_dependencies', dag_id=dag.dag_id, dag_run_id='_DAG_RUN_ID_', task_id='_TASK_ID_') }}">
+    <meta name="mapped_task_dependency_api" content="{{ url_for('/api/v1.airflow_api_connexion_endpoints_task_instance_endpoint_get_mapped_task_instance_dependencies', dag_id=dag.dag_id, dag_run_id='_DAG_RUN_ID_', task_id='_TASK_ID_', map_index=0) }}">
+
 
   <!-- End Urls -->
   <meta name="is_paused" content="{{ dag_is_paused }}">

--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -251,7 +251,6 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "rendered_map_index": None,
             "trigger": None,
             "triggerer_job": None,
-            "task_failed_deps": [],
         }
 
     def test_should_respond_200_with_task_state_in_deferred(self, session):
@@ -319,7 +318,6 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
                 "state": "running",
                 "unixname": getuser(),
             },
-            "task_failed_deps": [],
         }
 
     def test_should_respond_200_with_task_state_in_removed(self, session):
@@ -358,7 +356,6 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "rendered_map_index": None,
             "trigger": None,
             "triggerer_job": None,
-            "task_failed_deps": [],
         }
 
     def test_should_respond_200_task_instance_with_sla_and_rendered(self, session):
@@ -417,7 +414,6 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "rendered_map_index": None,
             "trigger": None,
             "triggerer_job": None,
-            "task_failed_deps": [],
         }
 
     def test_should_respond_200_mapped_task_instance_with_rtif(self, session):
@@ -470,7 +466,6 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
                 "rendered_map_index": None,
                 "trigger": None,
                 "triggerer_job": None,
-                "task_failed_deps": [],
             }
 
     def test_should_raises_401_unauthenticated(self):
@@ -2396,7 +2391,6 @@ class TestSetTaskInstanceNote(TestTaskInstanceEndpoint):
             "rendered_map_index": None,
             "trigger": None,
             "triggerer_job": None,
-            "task_failed_deps": [],
         }
         ti = session.scalars(select(TaskInstance).where(TaskInstance.task_id == "print_the_context")).one()
         assert ti.task_instance_note.user_id is not None
@@ -2456,7 +2450,6 @@ class TestSetTaskInstanceNote(TestTaskInstanceEndpoint):
                 "rendered_map_index": None,
                 "trigger": None,
                 "triggerer_job": None,
-                "task_failed_deps": [],
             }
 
     def test_should_respond_200_when_note_is_empty(self, session):
@@ -2515,6 +2508,122 @@ class TestSetTaskInstanceNote(TestTaskInstanceEndpoint):
                 f"api/v1/dags/INVALID_DAG_ID/dagRuns/TEST_DAG_RUN_ID/taskInstances/print_the_context"
                 f"{map_index}/setNote",
                 json={"note": "I am setting a note on a DAG that doesn't exist."},
+                environ_overrides={"REMOTE_USER": "test"},
+            )
+            assert response.status_code == 404
+
+
+class TestGetTaskDependencies(TestTaskInstanceEndpoint):
+    def setup_method(self):
+        clear_db_runs()
+
+    def teardown_method(self):
+        clear_db_runs()
+
+    @provide_session
+    def test_should_respond_empty_non_scheduled(self, session):
+        self.create_task_instances(session)
+        response = self.client.get(
+            "api/v1/dags/example_python_operator/dagRuns/TEST_DAG_RUN_ID/taskInstances/"
+            "print_the_context/dependencies",
+            environ_overrides={"REMOTE_USER": "test"},
+        )
+        assert response.status_code == 200, response.text
+        assert response.json == {"dependencies": []}
+
+    @pytest.mark.parametrize(
+        "state, dependencies",
+        [
+            (
+                State.SCHEDULED,
+                {
+                    "dependencies": [
+                        {
+                            "name": "Execution Date",
+                            "reason": "The execution date is 2020-01-01T00:00:00+00:00 but this is "
+                            "before the task's start date 2021-01-01T00:00:00+00:00.",
+                        },
+                        {
+                            "name": "Execution Date",
+                            "reason": "The execution date is 2020-01-01T00:00:00+00:00 but this is "
+                            "before the task's DAG's start date 2021-01-01T00:00:00+00:00.",
+                        },
+                    ],
+                },
+            ),
+            (
+                State.NONE,
+                {
+                    "dependencies": [
+                        {
+                            "name": "Execution Date",
+                            "reason": "The execution date is 2020-01-01T00:00:00+00:00 but this is before the task's start date 2021-01-01T00:00:00+00:00.",
+                        },
+                        {
+                            "name": "Execution Date",
+                            "reason": "The execution date is 2020-01-01T00:00:00+00:00 but this is before the task's DAG's start date 2021-01-01T00:00:00+00:00.",
+                        },
+                        {"name": "Task Instance State", "reason": "Task is in the 'None' state."},
+                    ]
+                },
+            ),
+        ],
+    )
+    @provide_session
+    def test_should_respond_dependencies(self, session, state, dependencies):
+        self.create_task_instances(session, task_instances=[{"state": state}], update_extras=True)
+
+        response = self.client.get(
+            "api/v1/dags/example_python_operator/dagRuns/TEST_DAG_RUN_ID/taskInstances/"
+            "print_the_context/dependencies",
+            environ_overrides={"REMOTE_USER": "test"},
+        )
+        assert response.status_code == 200, response.text
+        assert response.json == dependencies
+
+    def test_should_respond_dependencies_mapped(self, session):
+        tis = self.create_task_instances(
+            session, task_instances=[{"state": State.SCHEDULED}], update_extras=True
+        )
+        old_ti = tis[0]
+
+        ti = TaskInstance(task=old_ti.task, run_id=old_ti.run_id, map_index=0, state=old_ti.state)
+        session.add(ti)
+        session.commit()
+
+        response = self.client.get(
+            "api/v1/dags/example_python_operator/dagRuns/TEST_DAG_RUN_ID/taskInstances/"
+            "print_the_context/0/dependencies",
+            environ_overrides={"REMOTE_USER": "test"},
+        )
+        assert response.status_code == 200, response.text
+
+    def test_should_raises_401_unauthenticated(self):
+        for map_index in ["", "/0"]:
+            url = (
+                "api/v1/dags/example_python_operator/dagRuns/TEST_DAG_RUN_ID/taskInstances/"
+                f"print_the_context{map_index}/dependencies"
+            )
+            response = self.client.get(
+                url,
+            )
+            assert_401(response)
+
+    def test_should_raise_403_forbidden(self):
+        for map_index in ["", "/0"]:
+            response = self.client.get(
+                "api/v1/dags/example_python_operator/dagRuns/TEST_DAG_RUN_ID/taskInstances/"
+                f"print_the_context{map_index}/dependencies",
+                environ_overrides={"REMOTE_USER": "test_no_permissions"},
+            )
+            assert response.status_code == 403
+
+    def test_should_respond_404(self, session):
+        self.create_task_instances(session)
+        for map_index in ["", "/0"]:
+            response = self.client.get(
+                f"api/v1/dags/INVALID_DAG_ID/dagRuns/TEST_DAG_RUN_ID/taskInstances/print_the_context"
+                f"{map_index}/dependencies",
                 environ_overrides={"REMOTE_USER": "test"},
             )
             assert response.status_code == 404

--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -251,6 +251,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "rendered_map_index": None,
             "trigger": None,
             "triggerer_job": None,
+            "task_failed_deps": [],
         }
 
     def test_should_respond_200_with_task_state_in_deferred(self, session):
@@ -318,6 +319,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
                 "state": "running",
                 "unixname": getuser(),
             },
+            "task_failed_deps": [],
         }
 
     def test_should_respond_200_with_task_state_in_removed(self, session):
@@ -356,6 +358,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "rendered_map_index": None,
             "trigger": None,
             "triggerer_job": None,
+            "task_failed_deps": [],
         }
 
     def test_should_respond_200_task_instance_with_sla_and_rendered(self, session):
@@ -414,6 +417,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "rendered_map_index": None,
             "trigger": None,
             "triggerer_job": None,
+            "task_failed_deps": [],
         }
 
     def test_should_respond_200_mapped_task_instance_with_rtif(self, session):
@@ -466,6 +470,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
                 "rendered_map_index": None,
                 "trigger": None,
                 "triggerer_job": None,
+                "task_failed_deps": [],
             }
 
     def test_should_raises_401_unauthenticated(self):
@@ -2391,6 +2396,7 @@ class TestSetTaskInstanceNote(TestTaskInstanceEndpoint):
             "rendered_map_index": None,
             "trigger": None,
             "triggerer_job": None,
+            "task_failed_deps": [],
         }
         ti = session.scalars(select(TaskInstance).where(TaskInstance.task_id == "print_the_context")).one()
         assert ti.task_instance_note.user_id is not None
@@ -2450,6 +2456,7 @@ class TestSetTaskInstanceNote(TestTaskInstanceEndpoint):
                 "rendered_map_index": None,
                 "trigger": None,
                 "triggerer_job": None,
+                "task_failed_deps": [],
             }
 
     def test_should_respond_200_when_note_is_empty(self, session):


### PR DESCRIPTION
Show task failed dependencies when task is in scheduled or none state. None state helps to capture issues when the execution date is in future, depends_on_past fails with past task instance a failure etc.

closes: #38189
related: #38189

Scheduled state : 

![image](https://github.com/apache/airflow/assets/3972343/8a4c8d95-56f3-4512-af46-8ed6cfb0f77c)

None state : 

![image](https://github.com/apache/airflow/assets/3972343/114e76f3-082d-4442-8985-8a4455049cc3)