### PR TITLE
Override chakra styles to keep dropdowns in filter bar

### DIFF
--- a/airflow/www/static/js/dag/Main.tsx
+++ b/airflow/www/static/js/dag/Main.tsx
@@ -236,7 +236,14 @@ const MainInContext = () => {
         transition="all 0.2s"
       />
       <Accordion allowToggle index={accordionIndexes} borderTopWidth={0}>
-        <AccordionItem>
+        <AccordionItem
+          sx={{
+            // Override chakra-collapse so our dropdowns still work
+            ".chakra-collapse": {
+              overflow: "visible !important",
+            },
+          }}
+        >
           <AccordionButton display="none" />
           <AccordionPanel p={0}>
             <FilterBar />


### PR DESCRIPTION
Fixes: https://github.com/apache/airflow/issues/38455

<img width="1083" alt="Screenshot 2024-03-25 at 7 24 05 AM" src="https://github.com/apache/airflow/assets/4600967/5994d4cc-9aee-4982-952f-5d8a441cbfc5">


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
