### PR TITLE
Handling edge case for generate-issue-content for providers

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -1862,11 +1862,6 @@ def get_prs_for_package(provider_id: str) -> list[int]:
     changelog_lines = provider_details.changelog_path.read_text().splitlines()
     extract_prs = False
     skip_line = False
-
-    version_line_index = -1
-    exclusion_line_index = -1
-    line_number = 0
-
     for line in changelog_lines:
         if skip_line:
             # Skip first "....." header
@@ -1874,26 +1869,16 @@ def get_prs_for_package(provider_id: str) -> list[int]:
         elif line.strip() == current_release_version:
             extract_prs = True
             skip_line = True
-            version_line_index = line_number
         elif extract_prs:
             if len(line) > 1 and all(c == "." for c in line.strip()):
                 # Header for next version reached
                 break
             if line.startswith(".. Below changes are excluded from the changelog"):
                 # The reminder of PRs is not important skipping it
-                exclusion_line_index = line_number
-                changelog_lines_sublist = changelog_lines[version_line_index:exclusion_line_index]
-                valid_format = False
-                for sublist_line in changelog_lines_sublist:
-                    if sublist_line.startswith("*"):
-                        valid_format = True
-                if not valid_format:
-                    prs = [-1]
                 break
             match_result = pr_matcher.match(line.strip())
             if match_result:
                 prs.append(int(match_result.group(1)))
-        line_number += 1
     return prs
 
 
@@ -1978,7 +1963,7 @@ def generate_issue_content_providers(
                 )
                 continue
             prs = get_prs_for_package(provider_id)
-            if prs == [-1]:
+            if not prs:
                 get_console().print(
                     f"[warning]Skipping provider {provider_id}. "
                     "The changelog file doesn't contain any PRs for the release.\n"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

@eladkal realised an edge case while generating the issue content for FAB. The issue is that if there are no PRs above: `.. Below changes are excluded from the changelog`, the issue generation generates empty content for issue with no users. Instead this part shouldn't happen and we should early exit, with a warning.

Example:
```
➜  airflow git:(fixingEdgeCaseFab) ✗ breeze release-management generate-issue-content-providers --only-available-in-dist
/Users/adesai/.local/pipx/venvs/apache-airflow-breeze/lib/python3.9/site-packages/urllib3/__init__.py:34: NotOpenSSLWarning: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 2.8.3'. See: https://github.com/urllib3/urllib3/issues/3020
  warnings.warn(

Generates GitHub issue content with people who can test it

Skipping extracting PRs for provider airbyte as it is missing in dist
Skipping extracting PRs for provider alibaba as it is missing in dist
Skipping extracting PRs for provider amazon as it is missing in dist
Skipping extracting PRs for provider apache.beam as it is missing in dist
Skipping extracting PRs for provider apache.cassandra as it is missing in dist
Skipping extracting PRs for provider apache.drill as it is missing in dist
Skipping extracting PRs for provider apache.druid as it is missing in dist
Skipping extracting PRs for provider apache.flink as it is missing in dist
Skipping extracting PRs for provider apache.hdfs as it is missing in dist
Skipping extracting PRs for provider apache.hive as it is missing in dist
Skipping extracting PRs for provider apache.impala as it is missing in dist
Skipping extracting PRs for provider apache.kafka as it is missing in dist
Skipping extracting PRs for provider apache.kylin as it is missing in dist
Skipping extracting PRs for provider apache.livy as it is missing in dist
Skipping extracting PRs for provider apache.pig as it is missing in dist
Skipping extracting PRs for provider apache.pinot as it is missing in dist
Skipping extracting PRs for provider apache.spark as it is missing in dist
Skipping extracting PRs for provider apprise as it is missing in dist
Skipping extracting PRs for provider arangodb as it is missing in dist
Skipping extracting PRs for provider asana as it is missing in dist
Skipping extracting PRs for provider atlassian.jira as it is missing in dist
Skipping extracting PRs for provider celery as it is missing in dist
Skipping extracting PRs for provider cloudant as it is missing in dist
Skipping extracting PRs for provider cncf.kubernetes as it is missing in dist
Skipping extracting PRs for provider cohere as it is missing in dist
Skipping extracting PRs for provider common.io as it is missing in dist
Skipping extracting PRs for provider common.sql as it is missing in dist
Skipping extracting PRs for provider databricks as it is missing in dist
Skipping extracting PRs for provider datadog as it is missing in dist
Skipping extracting PRs for provider dbt.cloud as it is missing in dist
Skipping extracting PRs for provider dingding as it is missing in dist
Skipping extracting PRs for provider discord as it is missing in dist
Skipping extracting PRs for provider docker as it is missing in dist
Skipping extracting PRs for provider elasticsearch as it is missing in dist
Skipping extracting PRs for provider exasol as it is missing in dist
Extracting PRs for provider fab
Skipping provider fab. The changelog file doesn't contain any PRs for the release.
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
