### PR TITLE
Cleans up runs-on in workflows 

### DIFF
--- a/.github/workflows/additional-ci-image-checks.yml
+++ b/.github/workflows/additional-ci-image-checks.yml
@@ -171,7 +171,7 @@ jobs:
   test-airflow-release-commands:
     timeout-minutes: 80
     name: "Test Airflow release commands"
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    runs-on: ["ubuntu-22.0.4"]
     env:
       PYTHON_MAJOR_MINOR_VERSION: "${{ inputs.default-python-version }}"
       IMAGE_TAG: ${{ inputs.image-tag }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -51,7 +51,7 @@ jobs:
   build-info:
     timeout-minutes: 10
     name: "Build Info"
-    runs-on: ['ubuntu-22.04']
+    runs-on: ["ubuntu-22.04"]
     env:
       TARGET_BRANCH: ${{ github.event.pull_request.base.ref }}
     outputs:
@@ -171,7 +171,7 @@ jobs:
       needs.build-info.outputs.ci-image-build == 'true' &&
       github.event.pull_request.head.repo.full_name != 'apache/airflow'
     with:
-      runs-on: ${{ needs.build-info.outputs.runs-on }}
+      runs-on: '["ubuntu-22.04"]'
       do-build: ${{ needs.build-info.outputs.ci-image-build }}
       target-commit-sha: ${{ needs.build-info.outputs.target-commit-sha }}
       pull-request-target: "true"
@@ -200,7 +200,7 @@ jobs:
       needs.build-info.outputs.prod-image-build == 'true' &&
       github.event.pull_request.head.repo.full_name != 'apache/airflow'
     with:
-      runs-on: ${{ needs.build-info.outputs.runs-on }}
+      runs-on: '["ubuntu-22.04"]'
       build-type: "Regular"
       do-build: ${{ needs.build-info.outputs.ci-image-build }}
       target-commit-sha: ${{ needs.build-info.outputs.target-commit-sha }}

--- a/.github/workflows/check-providers.yml
+++ b/.github/workflows/check-providers.yml
@@ -61,7 +61,6 @@ jobs:
     name: "Provider packages wheel build and verify"
     runs-on: ${{fromJSON(inputs.runs-on)}}
     env:
-      RUNS_ON: "${{ inputs.runs-on }}"
       PYTHON_MAJOR_MINOR_VERSION: "${{ inputs.default-python-version }}"
       IMAGE_TAG: "${{ inputs.image-tag }}"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -127,7 +126,6 @@ jobs:
     name: "Provider packages sdist build and install"
     runs-on: ${{fromJSON(inputs.runs-on)}}
     env:
-      RUNS_ON: "${{ inputs.runs-on }}"
       PYTHON_MAJOR_MINOR_VERSION: "${{ inputs.default-python-version }}"
       IMAGE_TAG: "${{ inputs.image-tag }}"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -196,7 +194,6 @@ jobs:
       matrix:
         include: ${{fromJson(inputs.providers-compatibility-checks)}}
     env:
-      RUNS_ON: "${{ inputs.runs-on }}"
       IMAGE_TAG: "${{ inputs.image-tag }}"
       PYTHON_MAJOR_MINOR_VERSION: "${{matrix.python-version}}"
       VERSION_SUFFIX_FOR_PYPI: "dev0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,7 @@ jobs:
       packages: write
     secrets: inherit
     with:
+      runs-on: '["ubuntu-22.04"]'
       do-build: ${{ needs.build-info.outputs.in-workflow-build }}
       image-tag: ${{ needs.build-info.outputs.image-tag }}
       python-versions: ${{ needs.build-info.outputs.python-versions }}
@@ -247,7 +248,7 @@ jobs:
     needs: [build-info, wait-for-ci-images]
     uses: ./.github/workflows/additional-ci-image-checks.yml
     with:
-      runs-on: ${{needs.build-info.outputs.runs-on}}
+      runs-on: ${{ needs.build-info.outputs.runs-on }}
       image-tag: ${{ needs.build-info.outputs.image-tag }}
       python-versions: ${{ needs.build-info.outputs.python-versions }}
       branch: ${{ needs.build-info.outputs.default-branch }}
@@ -268,7 +269,7 @@ jobs:
     needs: [build-info, wait-for-ci-images]
     uses: ./.github/workflows/static-checks-mypy-and-constraints-generation.yml
     with:
-      runs-on: ${{needs.build-info.outputs.runs-on}}
+      runs-on: ${{ needs.build-info.outputs.runs-on }}
       image-tag: ${{ needs.build-info.outputs.image-tag }}
       python-versions-list-as-string: ${{ needs.build-info.outputs.python-versions-list-as-string }}
       branch: ${{ needs.build-info.outputs.default-branch }}
@@ -493,6 +494,7 @@ jobs:
       packages: write
     secrets: inherit
     with:
+      runs-on: '["ubuntu-22.04"]'
       build-type: "Regular"
       do-build: ${{ needs.build-info.outputs.in-workflow-build }}
       image-tag: ${{ needs.build-info.outputs.image-tag }}

--- a/.github/workflows/helm-tests.yml
+++ b/.github/workflows/helm-tests.yml
@@ -47,7 +47,6 @@ jobs:
       matrix:
         helm-test-package: ${{ fromJson(inputs.helm-test-packages) }}
     env:
-      RUNS_ON: "${{ inputs.runs-on }}"
       # Always use default Python version of CI image for preparing packages
       PYTHON_MAJOR_MINOR_VERSION: "${{ inputs.default-python-version }}"
       PARALLEL_TEST_TYPES: "Helm"
@@ -75,9 +74,8 @@ jobs:
   tests-helm-release:
     timeout-minutes: 80
     name: "Release Helm"
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    runs-on: ["ubuntu-22.04"]
     env:
-      RUNS_ON: "${{inputs.runs-on}}"
       PYTHON_MAJOR_MINOR_VERSION: "${{inputs.default-python-version}}"
     steps:
       - name: "Cleanup repo"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -75,7 +75,6 @@ jobs:
           - backend: mysql
             backend-version: ${{ inputs.default-mysql-version }}
     env:
-      RUNS_ON: "${{ inputs.runs-on }}"
       IMAGE_TAG: "${{ inputs.image-tag }}"
       PARALLEL_TEST_TYPES: "${{ inputs.parallel-test-types-list-as-string }}"
       BACKEND: "${{ matrix.backend }}"

--- a/.github/workflows/k8s-tests.yml
+++ b/.github/workflows/k8s-tests.yml
@@ -62,7 +62,6 @@ jobs:
         use-standard-naming: [true, false]
       fail-fast: false
     env:
-      RUNS_ON: ${{ inputs.outputs.runs-on }}
       DEBUG_RESOURCES: ${{ inputs.debug-resources }}
       INCLUDE_SUCCESS_OUTPUTS: ${{ inputs.include-success-outputs }}
       IMAGE_TAG: ${{ inputs.image-tag }}

--- a/.github/workflows/release_dockerhub_image.yml
+++ b/.github/workflows/release_dockerhub_image.yml
@@ -42,7 +42,7 @@ jobs:
     name: "Build Info"
     # TODO: when we have it properly set-up with labels we should check for
     #       "airflow-runner" presence in runs_on
-    runs-on: ["self-hosted", "Linux", "X64"]
+    runs-on: ["ubuntu-22.04"]
     outputs:
       pythonVersions: ${{ steps.selective-checks.outputs.python-versions }}
       allPythonVersions: ${{ steps.selective-checks.outputs.all-python-versions }}
@@ -81,8 +81,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ${{ fromJson(needs.build-info.outputs.pythonVersions) }}
-    env:
-      RUNS_ON: '["self-hosted", "Linux", "X64"]'
     if: contains(fromJSON('[
       "ashb",
       "eladkal",

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -136,7 +136,6 @@ jobs:
       PARALLEL_TEST_TYPES: "${{ inputs.parallel-test-types-list-as-string }}"
       PYDANTIC: "${{ inputs.pydantic }}"
       PYTHON_MAJOR_MINOR_VERSION: "${{ matrix.python-version }}"
-      RUNS_ON: "${{inputs.runs-on}}"
       UPGRADE_BOTO: "${{ inputs.upgrade-boto }}"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
The RUNS_ON has been used in the past as env variable in the workflows
but it's not used any more. Also several of the runs-om directive are
using passed `runs-on` but they are small/fast jobs that can be
easily run on small, public runners, so this PR revieved and updated
all those places.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
