### PR TITLE
Support multiple Docker hosts in `docker_url` attribute.

### DIFF
--- a/airflow/providers/docker/hooks/docker.py
+++ b/airflow/providers/docker/hooks/docker.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Any
 
 from docker import APIClient, TLSConfig
 from docker.constants import DEFAULT_TIMEOUT_SECONDS
-from docker.errors import APIError
+from docker.errors import APIError, DockerException
 
 from airflow.exceptions import AirflowException, AirflowNotFoundException
 from airflow.hooks.base import BaseHook
@@ -46,7 +46,7 @@ class DockerHook(BaseHook):
 
     :param docker_conn_id: :ref:`Docker connection id <howto/connection:docker>` where stored credentials
          to Docker Registry. If set to ``None`` or empty then hook does not login to Container Registry.
-    :param base_url: URL to the Docker server.
+    :param base_url: URL or list of URLs to the Docker server.
     :param version: The version of the API to use. Use ``auto`` or ``None`` for automatically detect
         the server's version.
     :param tls: Is connection required TLS, for enable pass ``True`` for use with default options,
@@ -62,7 +62,7 @@ class DockerHook(BaseHook):
     def __init__(
         self,
         docker_conn_id: str | None = default_conn_name,
-        base_url: str | None = None,
+        base_url: str | list[str] | None = None,
         version: str | None = None,
         tls: TLSConfig | bool | None = None,
         timeout: int = DEFAULT_TIMEOUT_SECONDS,
@@ -70,12 +70,10 @@ class DockerHook(BaseHook):
         super().__init__()
         if not base_url:
             raise AirflowException("URL to the Docker server not provided.")
-        elif tls:
-            if base_url.startswith("tcp://"):
-                base_url = base_url.replace("tcp://", "https://")
-                self.log.debug("Change `base_url` schema from 'tcp://' to 'https://'.")
-            if not base_url.startswith("https://"):
-                self.log.warning("When `tls` specified then `base_url` expected 'https://' schema.")
+        if isinstance(base_url, str):
+            base_url = [base_url]
+        if tls:
+            base_url = list(map(self._redact_tls_schema, base_url))
 
         self.docker_conn_id = docker_conn_id
         self.__base_url = base_url
@@ -146,15 +144,25 @@ class DockerHook(BaseHook):
     @cached_property
     def api_client(self) -> APIClient:
         """Create connection to docker host and return ``docker.APIClient`` (cached)."""
-        client = APIClient(
-            base_url=self.__base_url, version=self.__version, tls=self.__tls, timeout=self.__timeout
-        )
-        if self.docker_conn_id:
-            # Obtain connection and try to login to Container Registry only if ``docker_conn_id`` set.
-            self.__login(client, self.get_connection(self.docker_conn_id))
-
-        self._client_created = True
-        return client
+        for url in self.__base_url:
+            try:
+                client = APIClient(
+                    base_url=url, version=self.__version, tls=self.__tls, timeout=self.__timeout
+                )
+                if not client.ping():
+                    msg = f"Failed to ping host {url}."
+                    raise AirflowException(msg)
+                if self.docker_conn_id:
+                    # Obtain connection and try to login to Container Registry only if ``docker_conn_id`` set.
+                    self.__login(client, self.get_connection(self.docker_conn_id))
+            except APIError:
+                raise
+            except DockerException as e:
+                self.log.error("Failed to establish connection to Docker host %s: %s", url, e)
+            else:
+                self._client_created = True
+                return client
+        raise AirflowException("Failed to establish connection to any given Docker hosts.")
 
     @property
     def client_created(self) -> bool:
@@ -228,3 +236,11 @@ class DockerHook(BaseHook):
                 )
             },
         }
+
+    def _redact_tls_schema(self, url: str) -> str:
+        if url.startswith("tcp://"):
+            url = url.replace("tcp://", "https://")
+            self.log.debug("Change `base_url` schema from 'tcp://' to 'https://'.")
+        if not url.startswith("https://"):
+            self.log.warning("When `tls` specified then `base_url` expected 'https://' schema.")
+        return url

--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -95,7 +95,7 @@ class DockerOperator(BaseOperator):
     :param cpus: Number of CPUs to assign to the container.
         This value gets multiplied with 1024. See
         https://docs.docker.com/engine/reference/run/#cpu-share-constraint
-    :param docker_url: URL of the host running the docker daemon.
+    :param docker_url: URL or list of URLs of the host(s) running the docker daemon.
         Default is the value of the ``DOCKER_HOST`` environment variable or unix://var/run/docker.sock
         if it is unset.
     :param environment: Environment variables to set in the container. (templated)
@@ -200,7 +200,7 @@ class DockerOperator(BaseOperator):
         command: str | list[str] | None = None,
         container_name: str | None = None,
         cpus: float = 1.0,
-        docker_url: str | None = None,
+        docker_url: str | list[str] | None = None,
         environment: dict | None = None,
         private_environment: dict | None = None,
         env_file: str | None = None,

--- a/tests/providers/docker/hooks/test_docker.py
+++ b/tests/providers/docker/hooks/test_docker.py
@@ -296,3 +296,12 @@ def test_construct_tls_config(assert_hostname, ssl_version):
             mock_tls_config.assert_called_once_with(
                 **expected_call_args, assert_hostname=assert_hostname, ssl_version=ssl_version
             )
+
+
+@pytest.mark.parametrize(
+    "base_url", [["tcp://foo.bar.spam.egg", "unix:///foo/bar/spam.egg", "unix:///var/run/docker.sock"]]
+)
+def test_connect_to_valid_host(base_url):
+    """Test connect to valid host from a given list of hosts."""
+    hook = DockerHook(base_url=base_url, docker_conn_id=None)
+    assert hook.api_client.base_url == "http+docker://localhost"


### PR DESCRIPTION
This PR improves `DockerOperator` to support multiple Docker hosts, enabling high availability.

Changes include:
- Allowing the `docker_url` parameter to accept a list of str.
- Iterating over multiple host URLs to create and attempt connection.