### PR TITLE
Suppress error if no tests collected in pydantic special Tests

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/testing_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/testing_commands.py
@@ -679,6 +679,11 @@ def _run_test_command(
     fix_ownership_using_docker()
     cleanup_python_generated_files()
     perform_environment_checks()
+    if pydantic:
+        # Avoid edge cases when there are no available tests, e.g. No-Pydantic for Weaviate provider.
+        # https://docs.pytest.org/en/stable/reference/exit-codes.html
+        # https://github.com/apache/airflow/pull/38402#issuecomment-2014938950
+        extra_pytest_args = (*extra_pytest_args, "--suppress-no-test-exit-code")
     if run_in_parallel:
         if test_type != "Default":
             get_console().print(

--- a/dev/breeze/src/airflow_breeze/commands/testing_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/testing_commands.py
@@ -679,7 +679,7 @@ def _run_test_command(
     fix_ownership_using_docker()
     cleanup_python_generated_files()
     perform_environment_checks()
-    if pydantic:
+    if pydantic != "v2":
         # Avoid edge cases when there are no available tests, e.g. No-Pydantic for Weaviate provider.
         # https://docs.pytest.org/en/stable/reference/exit-codes.html
         # https://github.com/apache/airflow/pull/38402#issuecomment-2014938950

--- a/dev/breeze/src/airflow_breeze/utils/run_tests.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_tests.py
@@ -394,10 +394,6 @@ def generate_args_for_pytest(
                 "--disable-warnings",
             ]
         )
-    else:
-        # Avoid edge cases when there are no available tests, e.g. No-Pydantic for Weaviate provider.
-        # https://docs.pytest.org/en/stable/reference/exit-codes.html
-        args.append("--suppress-no-test-exit-code")
     return args
 
 

--- a/dev/breeze/src/airflow_breeze/utils/run_tests.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_tests.py
@@ -394,6 +394,10 @@ def generate_args_for_pytest(
                 "--disable-warnings",
             ]
         )
+    else:
+        # Avoid edge cases when there are no available tests, e.g. No-Pydantic for Weaviate provider.
+        # https://docs.pytest.org/en/stable/reference/exit-codes.html
+        args.append("--suppress-no-test-exit-code")
     return args
 
 

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -255,6 +255,7 @@ DEVEL_EXTRAS: dict[str, list[str]] = {
         "coverage>=7.4.0",
         "pytest-asyncio>=0.23.3",
         "pytest-cov>=4.1.0",
+        "pytest-custom-exit-code>=0.3.0",
         "pytest-icdiff>=0.9",
         "pytest-instafail>=0.5.0",
         "pytest-mock>=3.12.0",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

https://github.com/apache/airflow/pull/38402#issuecomment-2014938950

Without changes
```console
❯ breeze testing db-tests --pydantic none --parallelism 2 --parallel-test-types "Always Providers[weaviate]"

...

airflow-test-providers_weaviate_default
airflow-test-always_default

Completed 2 out of 2 (100%).


OK  for Test: Always.
NOK for Test: Providers[weaviate]: Return code: 5.

Always OK
Providers[weaviate]

```

With changes (without pydantic)
```console
❯ breeze testing db-tests --pydantic none --parallelism 2 --parallel-test-types "Always Providers[weaviate]"

...
Extra pytest args: ('--suppress-no-test-exit-code',)
...

────────────────────────────────────────
Progress: Always                        tests/always/test_connection.py ssssssssssssssssssssssssssssssssssssssss [ 18%]
Progress: Providers[weaviate]           ============================== 2 skipped in 0.93s ==============================
───────────────────────────────────────────────────────────────────────────────────────── Time passed: 00:00:42 ──────────────────────────────────────────────────────────────────────────────────────────
airflow-test-always_default

Completed 2 out of 2 (100%).


OK  for Test: Always.
OK  for Test: Providers[weaviate].

Always OK
Providers[weaviate] OK

Tests Always Providers[weaviate] completed successfully
```

With changes (with pydantic v2)
```
❯ breeze testing db-tests --parallelism 2 --parallel-test-types "Always Providers[weaviate]"

...
Extra pytest args: ()
...
Completed 2 out of 2 (100%).


OK  for Test: Always.
OK  for Test: Providers[weaviate].

Always OK
Providers[weaviate] OK

Tests Always Providers[weaviate] completed successfully
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
