### PR TITLE
Improve datasets graph UX

### DIFF
--- a/airflow/www/static/js/api/useDatasetDependencies.ts
+++ b/airflow/www/static/js/api/useDatasetDependencies.ts
@@ -30,11 +30,6 @@ export interface DatasetDependencies {
   edges: DepEdge[];
   nodes: DepNode[];
 }
-
-interface EdgeGroup {
-  edges: DepEdge[];
-}
-
 interface GenerateProps {
   nodes: DepNode[];
   edges: DepEdge[];
@@ -74,115 +69,6 @@ const generateGraph = ({ nodes, edges, font }: GenerateProps) => ({
   })),
 });
 
-interface SeparateGraphsProps {
-  edges: DepEdge[];
-  graphs: EdgeGroup[];
-}
-
-// find the downstream graph of each upstream edge
-const findDownstreamGraph = ({
-  edges,
-  graphs = [],
-}: SeparateGraphsProps): EdgeGroup[] => {
-  let unassignedEdges = [...edges];
-
-  const otherIndexes: number[] = [];
-
-  const mergedGraphs = graphs
-    .reduce((newGraphs, graph) => {
-      // Find all overlapping graphs where at least one edge in each graph has the same target node
-      const otherGroups = newGraphs.filter((otherGroup, i) =>
-        otherGroup.edges.some((otherEdge) => {
-          if (graph.edges.some((edge) => edge.target === otherEdge.target)) {
-            otherIndexes.push(i);
-            return true;
-          }
-          return false;
-        })
-      );
-      if (!otherGroups.length) {
-        return [...newGraphs, graph];
-      }
-
-      // Merge the edges of every overlapping group
-      const mergedEdges = otherGroups
-        .reduce(
-          (totalEdges, group) => [...totalEdges, ...group.edges],
-          [...graph.edges]
-        )
-        .filter(
-          (edge, edgeIndex, otherEdges) =>
-            edgeIndex ===
-            otherEdges.findIndex(
-              (otherEdge) =>
-                otherEdge.source === edge.source &&
-                otherEdge.target === edge.target
-            )
-        );
-      return [
-        // filter out the merged graphs
-        ...newGraphs.filter(
-          (_, newGraphIndex) => !otherIndexes.includes(newGraphIndex)
-        ),
-        { edges: mergedEdges },
-      ];
-    }, [] as EdgeGroup[])
-    .map((graph) => {
-      // find the next set of downstream edges and filter them out of the unassigned edges list
-      const downstreamEdges: DepEdge[] = [];
-      unassignedEdges = unassignedEdges.filter((edge) => {
-        const isDownstream = graph.edges.some(
-          (graphEdge) => graphEdge.target === edge.source
-        );
-        if (isDownstream) downstreamEdges.push(edge);
-        return !isDownstream;
-      });
-
-      return {
-        edges: [...graph.edges, ...downstreamEdges],
-      };
-    });
-
-  // recursively find downstream edges until there are no unassigned edges
-  return unassignedEdges.length
-    ? findDownstreamGraph({ edges: unassignedEdges, graphs: mergedGraphs })
-    : mergedGraphs;
-};
-
-// separate the list of nodes/edges into distinct dataset pipeline graphs
-const separateGraphs = ({
-  edges,
-  nodes,
-}: DatasetDependencies): DatasetDependencies[] => {
-  const separatedGraphs: EdgeGroup[] = [];
-  const remainingEdges: DepEdge[] = [];
-
-  edges.forEach((e) => {
-    // add a separate graph for each edge without an upstream
-    if (!edges.some((ee) => e.source === ee.target)) {
-      separatedGraphs.push({ edges: [e] });
-    } else {
-      remainingEdges.push(e);
-    }
-  });
-
-  const edgeGraphs = findDownstreamGraph({
-    edges: remainingEdges,
-    graphs: separatedGraphs,
-  });
-
-  // once all the edges are found, add the nodes
-  return edgeGraphs.map((eg) => {
-    const graphNodes = nodes.filter((n) =>
-      eg.edges.some((e) => e.target === n.id || e.source === n.id)
-    );
-    return {
-      edges: eg.edges,
-      nodes: graphNodes,
-    };
-  });
-};
-
 const formatDependencies = async ({ edges, nodes }: DatasetDependencies) => {
   const elk = new ELK();
 
@@ -203,47 +89,12 @@ export default function useDatasetDependencies() {
   });
 }
 
-interface GraphsProps {
-  dagIds?: string[];
-  selectedUri: string | null;
-}
-
-export const useDatasetGraphs = ({ dagIds, selectedUri }: GraphsProps) => {
+export const useDatasetGraphs = () => {
   const { data: datasetDependencies } = useDatasetDependencies();
-  return useQuery(
-    ["datasetGraphs", datasetDependencies, dagIds, selectedUri],
-    () => {
-      if (datasetDependencies) {
-        let graph = datasetDependencies;
-        const subGraphs = datasetDependencies
-          ? separateGraphs(datasetDependencies)
-          : [];
-
-        // Filter by dataset URI takes precedence
-        if (selectedUri) {
-          graph =
-            subGraphs.find((g) =>
-              g.nodes.some((n) => n.value.label === selectedUri)
-            ) || graph;
-        } else if (dagIds?.length) {
-          const filteredSubGraphs = subGraphs.filter((sg) =>
-            dagIds.some((dagId) =>
-              sg.nodes.some((c) => c.value.label === dagId)
-            )
-          );
-
-          graph = filteredSubGraphs.reduce(
-            (graphs, subGraph) => ({
-              edges: [...graphs.edges, ...subGraph.edges],
-              nodes: [...graphs.nodes, ...subGraph.nodes],
-            }),
-            { edges: [], nodes: [] }
-          );
-        }
-
-        return formatDependencies(graph);
-      }
-      return undefined;
+  return useQuery(["datasetGraphs", datasetDependencies], () => {
+    if (datasetDependencies) {
+      return formatDependencies(datasetDependencies);
     }
-  );
+    return undefined;
+  });
 };

--- a/airflow/www/static/js/datasets/Graph/DagNode.tsx
+++ b/airflow/www/static/js/datasets/Graph/DagNode.tsx
@@ -54,7 +54,7 @@ const DagNode = ({
 
   const gridUrl = getMetaValue("grid_url").replace("__DAG_ID__", dagId);
   return (
-    <Popover>
+    <Popover trigger="hover">
       <PopoverTrigger>
         <Flex
           borderColor={
@@ -70,6 +70,11 @@ const DagNode = ({
           fontSize={16}
           justifyContent="space-between"
           alignItems="center"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            if (onSelect) onSelect(dagId, "dag");
+          }}
         >
           <MdOutlineAccountTree size="16px" />
           <Text ml={2}>{dagId}</Text>
@@ -81,16 +86,6 @@ const DagNode = ({
           <PopoverCloseButton />
           <PopoverHeader>{dagId}</PopoverHeader>
           <PopoverFooter as={Flex} justifyContent="space-between">
-            <Button
-              variant="outline"
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                if (onSelect) onSelect(dagId, "dag");
-              }}
-            >
-              Filter by DAG
-            </Button>
             <Button
               as={Link}
               href={gridUrl}

--- a/airflow/www/static/js/datasets/Graph/index.tsx
+++ b/airflow/www/static/js/datasets/Graph/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, { useEffect } from "react";
+import React, { useCallback, useEffect } from "react";
 import ReactFlow, {
   ReactFlowProvider,
   Controls,
@@ -27,6 +27,7 @@ import ReactFlow, {
   useReactFlow,
   ControlButton,
   Panel,
+  useNodesInitialized,
 } from "reactflow";
 import { Box, Tooltip, useTheme } from "@chakra-ui/react";
 import { RiFocus3Line } from "react-icons/ri";
@@ -39,30 +40,19 @@ import Node, { CustomNodeProps } from "./Node";
 import Legend from "./Legend";
 
 interface Props {
-  onSelect: (datasetId: string) => void;
-  selectedUri: string | null;
-  filteredDagIds: string[];
-  onFilterDags: (dagIds: string[]) => void;
+  selectedNodeId: string | null;
+  onSelectNode: (id: string, type: string) => void;
 }
 
 const nodeTypes = { custom: Node };
 const edgeTypes = { custom: Edge };
 
-const Graph = ({
-  onSelect,
-  selectedUri,
-  filteredDagIds,
-  onFilterDags,
-}: Props) => {
+const Graph = ({ selectedNodeId, onSelectNode }: Props) => {
   const { colors } = useTheme();
-  const { setCenter, setViewport } = useReactFlow();
+  const { setCenter } = useReactFlow();
   const containerRef = useContainerRef();
 
   const { data: graph } = useDatasetGraphs();
-
-  useEffect(() => {
-    setViewport({ x: 0, y: 0, zoom: 1 });
-  }, [selectedUri, setViewport]);
 
   const nodeColor = ({
     data: { isSelected },
@@ -78,19 +68,13 @@ const Graph = ({
       data: {
         rest: {
           ...e,
-          isSelected: selectedUri && e.id.includes(selectedUri),
+          isSelected:
+            selectedNodeId &&
+            (e.id.includes(`dataset:${selectedNodeId}`) ||
+              e.id.includes(`dag:${selectedNodeId}`)),
         },
       },
     })) || [];
-
-  const handleSelect = (id: string, type: string) => {
-    if (type === "dataset") onSelect(id);
-    if (type === "dag") {
-      if (filteredDagIds.includes(id))
-        onFilterDags(filteredDagIds.filter((dagId) => dagId !== id));
-      else onFilterDags([...filteredDagIds, id]);
-    }
-  };
 
   const nodes: ReactFlowNode<CustomNodeProps>[] =
     graph?.children?.map((c) => ({
@@ -100,10 +84,8 @@ const Graph = ({
         type: c.value.class,
         width: c.width,
         height: c.height,
-        onSelect: handleSelect,
-        isSelected:
-          selectedUri === c.value.label ||
-          (c.value.class === "dag" && filteredDagIds.includes(c.value.label)),
+        onSelect: onSelectNode,
+        isSelected: selectedNodeId === c.value.label,
         isHighlighted: edges.some(
           (e) => e.data.rest.isSelected && e.id.includes(c.id)
         ),
@@ -115,10 +97,10 @@ const Graph = ({
       },
     })) || [];
 
-  const focusNode = () => {
-    if (selectedUri) {
-      const node = nodes.find((n) => n.data.label === selectedUri);
-      if (!node || !node.position) return;
+  const node = nodes.find((n) => n.data.label === selectedNodeId);
+
+  const focusNode = useCallback(() => {
+    if (node && node.position) {
       const { x, y } = node.position;
       setCenter(
         x + (node.data.width || 0) / 2,
@@ -128,7 +110,13 @@ const Graph = ({
         }
       );
     }
-  };
+  }, [setCenter, node]);
+
+  const nodesInitialized = useNodesInitialized();
+
+  useEffect(() => {
+    if (nodesInitialized) focusNode();
+  }, [selectedNodeId, nodesInitialized, focusNode]);
 
   return (
     <ReactFlow
@@ -144,7 +132,7 @@ const Graph = ({
     >
       <Background />
       <Controls showInteractive={false}>
-        <ControlButton onClick={focusNode} disabled={!selectedUri}>
+        <ControlButton onClick={focusNode} disabled={!selectedNodeId}>
           <Tooltip
             portalProps={{ containerRef }}
             label="Center selected dataset"

--- a/airflow/www/static/js/datasets/Graph/index.tsx
+++ b/airflow/www/static/js/datasets/Graph/index.tsx
@@ -58,10 +58,7 @@ const Graph = ({
   const { setCenter, setViewport } = useReactFlow();
   const containerRef = useContainerRef();
 
-  const { data: graph } = useDatasetGraphs({
-    dagIds: filteredDagIds,
-    selectedUri,
-  });
+  const { data: graph } = useDatasetGraphs();
 
   useEffect(() => {
     setViewport({ x: 0, y: 0, zoom: 1 });

--- a/airflow/www/static/js/datasets/List.test.tsx
+++ b/airflow/www/static/js/datasets/List.test.tsx
@@ -87,11 +87,7 @@ describe("Test Datasets List", () => {
       .mockImplementation(() => returnValue);
 
     const { getByText, queryAllByTestId } = render(
-      <DatasetsList
-        onSelect={() => {}}
-        filteredDagIds={[]}
-        onFilterDags={() => {}}
-      />,
+      <DatasetsList onSelectNode={() => {}} />,
       { wrapper: Wrapper }
     );
 
@@ -115,11 +111,7 @@ describe("Test Datasets List", () => {
       .mockImplementation(() => emptyReturnValue);
 
     const { getByText, queryAllByTestId, getByTestId } = render(
-      <DatasetsList
-        onSelect={() => {}}
-        filteredDagIds={[]}
-        onFilterDags={() => {}}
-      />,
+      <DatasetsList onSelectNode={() => {}} />,
       { wrapper: Wrapper }
     );
 
@@ -129,23 +121,5 @@ describe("Test Datasets List", () => {
 
     expect(getByTestId("no-datasets-msg")).toBeInTheDocument();
     expect(getByText("No Data found.")).toBeInTheDocument();
-  });
-
-  test("Correctly decodes search param and applies it to the input", () => {
-    jest
-      .spyOn(useDatasetsModule, "default")
-      .mockImplementation(() => returnValue);
-
-    const { getByDisplayValue } = render(
-      <Wrapper initialEntries={["/datasets?search=s3%253A%252F%252F"]}>
-        <DatasetsList
-          onSelect={() => {}}
-          filteredDagIds={[]}
-          onFilterDags={() => {}}
-        />
-      </Wrapper>
-    );
-
-    expect(getByDisplayValue("s3://")).toBeInTheDocument();
   });
 });

--- a/airflow/www/static/js/datasets/Main.tsx
+++ b/airflow/www/static/js/datasets/Main.tsx
@@ -19,7 +19,7 @@
 
 import React, { useCallback, useEffect, useRef } from "react";
 import { useSearchParams } from "react-router-dom";
-import { Flex, Box } from "@chakra-ui/react";
+import { Flex, Box, Spinner } from "@chakra-ui/react";
 
 import { useOffsetTop } from "src/utils";
 import { useDatasetDependencies } from "src/api";
@@ -51,7 +51,7 @@ const Datasets = () => {
     .map((param) => decodeURIComponent(param));
 
   // We need to load in the raw dependencies in order to generate the list of dagIds
-  const { data: datasetDependencies } = useDatasetDependencies();
+  const { data: datasetDependencies, isLoading } = useDatasetDependencies();
 
   const onBack = () => {
     searchParams.delete(DATASET_URI_PARAM);
@@ -116,6 +116,7 @@ const Datasets = () => {
     >
       <Box
         minWidth={minPanelWidth}
+        width={500}
         height={height}
         overflowY="auto"
         ref={listRef}
@@ -146,7 +147,9 @@ const Datasets = () => {
         height={height}
         borderColor="gray.200"
         borderWidth={1}
+        position="relative"
       >
+        {isLoading && <Spinner position="absolute" top="50%" left="50%" />}
         <Graph
           selectedUri={datasetUriSearch}
           onSelect={onSelect}

--- a/airflow/www/static/js/datasets/SearchBar.tsx
+++ b/airflow/www/static/js/datasets/SearchBar.tsx
@@ -117,7 +117,7 @@ const SearchBar = ({
         { label: "DAGs", options: dagOptions },
         { label: "Datasets", options: datasetOptions },
       ]}
-      placeholder="Search by DAG Id or Dataset Uri"
+      placeholder="Search by DAG ID or Dataset URI"
     />
   );
 };


### PR DESCRIPTION
We had a bunch of complicated logic trying to separate out unconnected dataset "graphs" from each other in the UI. It was buggy and could cause the UI to crash if there were too many datasets. So I decided to refactor a few things wih the tools I have available:

- Always render the full datasets dependencies graph
- Merge the Dataset and DAG search bars into one, with a single selection vs multiselect
- Can click to select a DAG
- Hover on a DAG shows popover to link to it's page
- Add loading indicator to the graph
- Zoom the graph to the node upon selection
- Highlight edges connected to a DAG
- Don't have the list/details left panel changing width when changing dataset selection

<img width="544" alt="Screenshot 2024-03-25 at 6 56 02 PM" src="https://github.com/apache/airflow/assets/4600967/3e2ea7f6-3fd8-4fb5-932e-23b459b8a669">

![Mar-25-2024 19-03-17](https://github.com/apache/airflow/assets/4600967/5b172900-32a7-448f-ad43-f46baadeba40)


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
