### PR TITLE
Fix parameters propagation in `build-k8s-image --rebuild-base-image`

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
@@ -562,7 +562,11 @@ def _rebuild_k8s_image(
 ) -> tuple[int, str]:
     params = BuildProdParams(python=python, image_tag=image_tag, use_uv=use_uv)
     if rebuild_base_image:
-        run_build_production_image(prod_image_params=params, output=output)
+        run_build_production_image(
+            prod_image_params=params,
+            param_description=f"Python: {params.python}, Platform: {params.platform}",
+            output=output,
+        )
     else:
         if not check_if_base_image_exists(params):
             get_console(output=output).print(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Found during follow https://github.com/apache/airflow/blob/main/contributing-docs/testing/k8s_tests.rst 

```console
❯ breeze k8s build-k8s-image --rebuild-base-image
K8S Virtualenv is initialized in /home/taragolis/Projects/common/airflow/.build/.k8s-env
Good version of kind installed: 0.22.0 in /home/taragolis/Projects/common/airflow/.build/.k8s-env/bin
Good version of kubectl installed: 1.29.3 in /home/taragolis/Projects/common/airflow/.build/.k8s-env/bin
Good version of helm installed: 3.14.0 in /home/taragolis/Projects/common/airflow/.build/.k8s-env/bin
Stable repo is already added
Traceback (most recent call last):
  File "/home/taragolis/.local/bin/breeze", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/taragolis/.local/pipx/venvs/apache-airflow-breeze/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/taragolis/.local/pipx/venvs/apache-airflow-breeze/lib/python3.11/site-packages/rich_click/rich_command.py", line 126, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/taragolis/.local/pipx/venvs/apache-airflow-breeze/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/taragolis/.local/pipx/venvs/apache-airflow-breeze/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/taragolis/.local/pipx/venvs/apache-airflow-breeze/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/taragolis/.local/pipx/venvs/apache-airflow-breeze/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/taragolis/Projects/common/airflow/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py", line 693, in build_k8s_image
    return_code, _ = _rebuild_k8s_image(
                     ^^^^^^^^^^^^^^^^^^^
  File "/home/taragolis/Projects/common/airflow/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py", line 565, in _rebuild_k8s_image
    run_build_production_image(prod_image_params=params, output=output)
TypeError: run_build_production_image() missing 1 required positional argument: 'param_description'
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
