### PR TITLE
Fix post-test failure conditions

### DIFF
--- a/.github/actions/post_tests_failure/action.yml
+++ b/.github/actions/post_tests_failure/action.yml
@@ -27,15 +27,18 @@ runs:
         name: airflow-logs-${{env.JOB_ID}}
         path: './files/airflow_logs*'
         retention-days: 7
+        if-no-files-found: ignore
     - name: "Upload container logs"
       uses: actions/upload-artifact@v4
       with:
         name: container-logs-${{env.JOB_ID}}
         path: "./files/container_logs*"
         retention-days: 7
+        if-no-files-found: ignore
     - name: "Upload other logs"
       uses: actions/upload-artifact@v4
       with:
         name: container-logs-${{env.JOB_ID}}
         path: "./files/other_logs*"
         retention-days: 7
+        if-no-files-found: ignore

--- a/.github/actions/post_tests_success/action.yml
+++ b/.github/actions/post_tests_success/action.yml
@@ -27,6 +27,7 @@ runs:
         name: test-warnings-${{env.JOB_ID}}
         path: ./files/warnings-*.txt
         retention-days: 7
+        if-no-files-found: ignore
     - name: "Move coverage artifacts in separate directory"
       if: env.ENABLE_COVERAGE == 'true' && env.TEST_TYPES != 'Helm'
       shell: bash

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -148,7 +148,7 @@ jobs:
         if: inputs.is-airflow-runner == 'true'
       - name: "Post Tests success: Integration"
         uses: ./.github/actions/post_tests_success
-        if: success() && inputs.is-airflow-runner == 'true' || matrix.backend == 'postgres'
+        if: success() && (inputs.is-airflow-runner == 'true' || matrix.backend == 'postgres')
       - name: "Post Tests failure: Integration"
         uses: ./.github/actions/post_tests_failure
-        if: failure() && inputs.is-airflow-runner == 'true' || matrix.backend == 'postgres'
+        if: failure() && (inputs.is-airflow-runner == 'true' || matrix.backend == 'postgres')


### PR DESCRIPTION
Integration tests are run either when we run tests on airflow runners (then we run them all as a single step) or when we run integration tests on public runners, we run each of the integration tests separately. However, success/failure conditions on the post-test actions were wrong - the || condition caused both success and failure post actions to be executed on postgres.

This caused warnings on CI workflow runs as the artifacts to upload were missing.

This PR fixes the condition and ignores warning on missing log files to upload - as there might still be cases when the test fail.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
