### PR TITLE
Run special tests only in canary-runs and when we upgrade deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -456,6 +456,7 @@ jobs:
       run-coverage: ${{ needs.build-info.outputs.run-coverage }}
       default-python-version: ${{ needs.build-info.outputs.default-python-version }}
       default-postgres-version: ${{ needs.build-info.outputs.default-postgres-version }}
+      canary-run: ${{ needs.build-info.outputs.canary-run }}
       debug-resources: ${{ needs.build-info.outputs.debug-resources }}
     if: needs.build-info.outputs.run-tests == 'true'
 

--- a/.github/workflows/special-tests.yml
+++ b/.github/workflows/special-tests.yml
@@ -45,6 +45,14 @@ on:  # yamllint disable-line rule:truthy
         description: "The default version of the postgres to use"
         required: true
         type: string
+      canary-run:
+        description: "Whether to run canary tests or not (true/false)"
+        required: true
+        type: string
+      upgrade-to-newer-dependencies:
+        description: "Whether to upgrade to newer dependencies or not (true/false)"
+        required: true
+        type: string
       debug-resources:
         description: "Whether to debug resources or not (true/false)"
         required: true
@@ -57,6 +65,7 @@ jobs:
       contents: read
       packages: read
     secrets: inherit
+    if: inputs.canary-run == 'true'
     with:
       runs-on: ${{ inputs.runs-on }}
       downgrade-sqlalchemy: "true"
@@ -79,6 +88,7 @@ jobs:
       contents: read
       packages: read
     secrets: inherit
+    if: inputs.canary-run == 'true' || inputs.upgrade-to-newer-dependencies == 'true'
     with:
       runs-on: ${{ inputs.runs-on }}
       upgrade-boto: "true"
@@ -101,6 +111,7 @@ jobs:
       contents: read
       packages: read
     secrets: inherit
+    if: inputs.canary-run == 'true' || inputs.upgrade-to-newer-dependencies == 'true'
     with:
       runs-on: ${{ inputs.runs-on }}
       pydantic: "v1"
@@ -123,6 +134,7 @@ jobs:
       contents: read
       packages: read
     secrets: inherit
+    if: inputs.canary-run == 'true' || inputs.upgrade-to-newer-dependencies == 'true'
     with:
       runs-on: ${{ inputs.runs-on }}
       pydantic: "none"
@@ -145,6 +157,7 @@ jobs:
       contents: read
       packages: read
     secrets: inherit
+    if: inputs.canary-run == 'true' || inputs.upgrade-to-newer-dependencies == 'true'
     with:
       runs-on: ${{ inputs.runs-on }}
       downgrade-pendulum: "true"
@@ -167,6 +180,7 @@ jobs:
       contents: read
       packages: read
     secrets: inherit
+    if: inputs.canary-run == 'true' || inputs.upgrade-to-newer-dependencies == 'true'
     with:
       runs-on: ${{ inputs.runs-on }}
       enable-aip-44: "false"
@@ -189,6 +203,7 @@ jobs:
       contents: read
       packages: read
     secrets: inherit
+    if: inputs.canary-run == 'true' || inputs.upgrade-to-newer-dependencies == 'true'
     with:
       runs-on: ${{ inputs.runs-on }}
       test-name: "Postgres"
@@ -210,6 +225,7 @@ jobs:
       contents: read
       packages: read
     secrets: inherit
+    if: inputs.canary-run == 'true' || inputs.upgrade-to-newer-dependencies == 'true'
     with:
       runs-on: ${{ inputs.runs-on }}
       test-name: "Postgres"


### PR DESCRIPTION
The "special" tests that test pendulum/sqlalchemy etc are rather difficult to break and running them for regular PRs adds quite an overhaead on every single PR we run.

It's likely better to run those tests only when canary-runs are run and when upgrade-to-newer-dependencies is set - that will be enough to flag errors here - frequently enough after any merge of such a change happens to be able to quickly find out the culprit and either fix it or revert it.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
