### PR TITLE
Do not use cache to install breeze

### DIFF
--- a/.github/actions/breeze/action.yml
+++ b/.github/actions/breeze/action.yml
@@ -38,15 +38,6 @@ runs:
         python-version: ${{ inputs.python-version }}
         cache: 'pip'
         cache-dependency-path: ./dev/breeze/pyproject.toml
-    - name: Cache breeze
-      uses: actions/cache@v4
-      with:
-        path: ~/.local/pipx
-        # README has the latest breeze's hash and python location is used to distinguish between
-        # different minor versions of python
-        key: "breeze-${{inputs.python-version}}-${{env.pythonLocation}}-\
-          ${{hashFiles('dev/breeze/README.md')}}"
-        restore-keys: breeze-${{inputs.python-version}}-${{ env.pythonLocation }}
     - name: "Install Breeze"
       shell: bash
       run: ./scripts/ci/install_breeze.sh

--- a/scripts/ci/install_breeze.sh
+++ b/scripts/ci/install_breeze.sh
@@ -29,5 +29,5 @@ python -m pip install --upgrade pip==24.0
 python -m pip install "pipx>=1.4.1"
 python -m pipx uninstall apache-airflow-breeze >/dev/null 2>&1 || true
 # shellcheck disable=SC2086
-python -m pipx install ${PYTHON_ARG} --editable ./dev/breeze/
+python -m pipx install ${PYTHON_ARG} --force --editable ./dev/breeze/
 echo '/home/runner/.local/bin' >> "${GITHUB_PATH}"


### PR DESCRIPTION
Using cache for breeze might cause various issues and it does not really speed up the installation that significantly (installing breeze is about 20 seconds and restoring cache and checking if breeze is installed there is ~8 seconds, so we are savig some 10 seconds per build.

Removing cache will make breeze always runs in a clean state and also it has less potential for potential cache-poisoning issues. Since cache is shared among multiple workflows and runs, that is also far safer option from security point of view.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
