### PR TITLE
Fix skip Apache Beam pipeline options if value is set to false

### DIFF
--- a/airflow/providers/apache/beam/hooks/beam.py
+++ b/airflow/providers/apache/beam/hooks/beam.py
@@ -81,6 +81,8 @@ def beam_options_to_args(options: dict) -> list[str]:
     for attr, value in options.items():
         if value is None or (isinstance(value, bool) and value):
             args.append(f"--{attr}")
+        elif isinstance(value, bool) and not value:
+            continue
         elif isinstance(value, list):
             args.extend([f"--{attr}={v}" for v in value])
         else:

--- a/tests/providers/apache/beam/hooks/test_beam.py
+++ b/tests/providers/apache/beam/hooks/test_beam.py
@@ -443,7 +443,7 @@ class TestBeamOptionsToArgs:
             ({"key": "val"}, ["--key=val"]),
             ({"key": None}, ["--key"]),
             ({"key": True}, ["--key"]),
-            ({"key": False}, ["--key=False"]),
+            ({"key": False}, []),
             ({"key": ["a", "b", "c"]}, ["--key=a", "--key=b", "--key=c"]),
         ],
     )


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #38457 
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Apache Beam pipeline options should skip options where their value is False to be consistent with the Apache Beam pipeline options behaviour and with the Apache Airflow [doc](https://github.com/apache/airflow/blob/b402f8a35633beb4a41e09365a57008c67d377e8/airflow/providers/apache/beam/operators/beam.py#L156)

closes: #38457 

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
