### PR TITLE
Fix TaskHandlerWithCustomFormatter now adds prefix only once

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -848,7 +848,7 @@ logging:
         Specify prefix pattern like mentioned below with stream handler TaskHandlerWithCustomFormatter
       version_added: 2.0.0
       type: string
-      example: "{ti.dag_id}-{ti.task_id}-{execution_date}-{try_number}"
+      example: "{{ti.dag_id}}-{{ti.task_id}}-{{execution_date}}-{{ti.try_number}}"
       is_template: true
       default: ""
     log_filename_template:

--- a/airflow/utils/log/task_handler_with_custom_formatter.py
+++ b/airflow/utils/log/task_handler_with_custom_formatter.py
@@ -45,6 +45,7 @@ class TaskHandlerWithCustomFormatter(logging.StreamHandler):
         :param ti:
         :return:
         """
+        # Returns if there is no formatter or if the prefix has already been set
         if ti.raw or self.formatter is None or self.prefix_jinja_template is not None:
             return
         prefix = conf.get("logging", "task_log_prefix_template")

--- a/airflow/utils/log/task_handler_with_custom_formatter.py
+++ b/airflow/utils/log/task_handler_with_custom_formatter.py
@@ -45,7 +45,7 @@ class TaskHandlerWithCustomFormatter(logging.StreamHandler):
         :param ti:
         :return:
         """
-        if ti.raw or self.formatter is None:
+        if ti.raw or self.formatter is None or self.prefix_jinja_template is not None:
             return
         prefix = conf.get("logging", "task_log_prefix_template")
 

--- a/tests/utils/test_task_handler_with_custom_formatter.py
+++ b/tests/utils/test_task_handler_with_custom_formatter.py
@@ -74,20 +74,36 @@ def task_instance():
     clear_db_runs()
 
 
-def assert_prefix(task_instance: TaskInstance, prefix: str) -> None:
+def assert_prefix_once(task_instance: TaskInstance, prefix: str) -> None:
     handler = next((h for h in task_instance.log.handlers if h.name == TASK_HANDLER), None)
     assert handler is not None, "custom task log handler not set up correctly"
     assert handler.formatter is not None, "custom task log formatter not set up correctly"
+    previous_formatter = handler.formatter
     expected_format = f"{prefix}:{handler.formatter._fmt}"
     set_context(task_instance.log, task_instance)
     assert expected_format == handler.formatter._fmt
+    handler.setFormatter(previous_formatter)
+
+
+def assert_prefix_multiple(task_instance: TaskInstance, prefix: str) -> None:
+    handler = next((h for h in task_instance.log.handlers if h.name == TASK_HANDLER), None)
+    assert handler is not None, "custom task log handler not set up correctly"
+    assert handler.formatter is not None, "custom task log formatter not set up correctly"
+    previous_formatter = handler.formatter
+    expected_format = f"{prefix}:{handler.formatter._fmt}"
+    set_context(task_instance.log, task_instance)
+    set_context(task_instance.log, task_instance)
+    set_context(task_instance.log, task_instance)
+    assert expected_format == handler.formatter._fmt
+    handler.setFormatter(previous_formatter)
 
 
 def test_custom_formatter_default_format(task_instance):
     """The default format provides no prefix."""
-    assert_prefix(task_instance, "")
+    assert_prefix_once(task_instance, "")
 
 
-@conf_vars({("logging", "task_log_prefix_template"): "{{ti.dag_id }}-{{ ti.task_id }}"})
+@conf_vars({("logging", "task_log_prefix_template"): "{{ ti.dag_id }}-{{ ti.task_id }}"})
 def test_custom_formatter_custom_format_not_affected_by_config(task_instance):
-    assert_prefix(task_instance, f"{DAG_ID}-{TASK_ID}")
+    """Certifies that the prefix is only added once, even after repeated calls"""
+    assert_prefix_multiple(task_instance, f"{DAG_ID}-{TASK_ID}")


### PR DESCRIPTION
When using the [TaskHandlerWithCustomFormatter](https://github.com/apache/airflow/blob/main/airflow/utils/log/task_handler_with_custom_formatter.py) to add a prefix to logs, it was previously adding the prefix multiple times. This happened because its `set_context` method was being called multiple times from [logging_mixin.py](https://github.com/apache/airflow/blob/main/airflow/utils/log/logging_mixin.py#L256)'s `set_context`, and worsened because even when the handler's formatter was a [TimezoneAware](https://github.com/apache/airflow/blob/main/airflow/utils/log/timezone_aware.py) formatter (to include UTC offset), it was still adding an additional prefix. Because of this, I felt that any solution outside of the TaskHandlerWithCustomFormatter itself would either require a restructuring of the handlers' structure or slow down execution for all other handlers. And so, the solution I settled on was to add to [TaskHandlerWithCustomFormatter's initial 'if' statement](https://github.com/apache/airflow/blob/main/airflow/utils/log/task_handler_with_custom_formatter.py#L48) a simple "`or self.prefix_jinja_template is not None`", so that it returns if the prefix has already been set. This is similar to what is done by the ElasticSearch handler [es_task_handler.py](https://github.com/apache/airflow/blob/main/airflow/providers/elasticsearch/log/es_task_handler.py#L443).

Note: also fixed the documentation's example for the handler, as the previous one was incorrect and didn't work.

closes: #35622

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
