### PR TITLE
Add exclude/include events filters to audit log

### DIFF
--- a/airflow/www/extensions/init_jinja_globals.py
+++ b/airflow/www/extensions/init_jinja_globals.py
@@ -76,6 +76,8 @@ def init_jinja_globals(app):
             "k8s_or_k8scelery_executor": IS_K8S_OR_K8SCELERY_EXECUTOR,
             "rest_api_enabled": False,
             "config_test_connection": conf.get("core", "test_connection", fallback="Disabled"),
+            "included_events_raw": conf.get("webserver", "audit_view_included_events", fallback=""),
+            "excluded_events_raw": conf.get("webserver", "audit_view_excluded_events", fallback=""),
         }
 
         # Extra global specific to auth manager

--- a/airflow/www/static/js/api/useEventLogs.tsx
+++ b/airflow/www/static/js/api/useEventLogs.tsx
@@ -34,6 +34,8 @@ export default function useEventLogs({
   after,
   before,
   owner,
+  includedEvents,
+  excludedEvents,
 }: API.GetEventLogsVariables) {
   const { isRefreshOn } = useAutoRefresh();
   return useQuery(
@@ -48,10 +50,18 @@ export default function useEventLogs({
       after,
       before,
       owner,
+      excludedEvents,
+      includedEvents,
     ],
     () => {
       const eventsLogUrl = getMetaValue("event_logs_api");
       const orderParam = orderBy ? { order_by: orderBy } : {};
+      const excludedParam = excludedEvents
+        ? { excluded_events: excludedEvents }
+        : {};
+      const includedParam = includedEvents
+        ? { included_events: includedEvents }
+        : {};
       return axios.get<AxiosResponse, API.EventLogCollection>(eventsLogUrl, {
         params: {
           offset,
@@ -60,6 +70,8 @@ export default function useEventLogs({
           ...{ task_id: taskId },
           ...{ run_id: runId },
           ...orderParam,
+          ...excludedParam,
+          ...includedParam,
           after,
           before,
         },

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -89,6 +89,8 @@
   <meta name="is_paused" content="{{ dag_is_paused }}">
   <meta name="csrf_token" content="{{ csrf_token() }}">
   <meta name="k8s_or_k8scelery_executor" content="{{ k8s_or_k8scelery_executor }}">
+  <meta name="excluded_audit_log_events" content="{{ excluded_events_raw }}">
+  <meta name="included_audit_log_events" content="{{ included_events_raw }}">
   {% if dag_model is defined and dag_model.next_dagrun_create_after is defined and dag_model.next_dagrun_create_after is not none %}
     <meta name="next_dagrun_create_after" content="{{ dag_model.next_dagrun_create_after }}">
     <meta name="next_dagrun_data_interval_start" content="{{ dag_model.next_dagrun_data_interval_start }}">

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2796,6 +2796,9 @@ class Airflow(AirflowBaseView):
         wwwutils.check_import_errors(dag.fileloc, session)
         wwwutils.check_dag_warnings(dag.dag_id, session)
 
+        included_events_raw = conf.get("webserver", "audit_view_included_events", fallback="")
+        excluded_events_raw = conf.get("webserver", "audit_view_excluded_events", fallback="")
+
         root = request.args.get("root")
         if root:
             dag = dag.partial_subset(task_ids_or_regex=root, include_downstream=False, include_upstream=True)
@@ -2840,6 +2843,8 @@ class Airflow(AirflowBaseView):
                     "numRuns": num_runs_options,
                 }
             ),
+            included_events_raw=included_events_raw,
+            excluded_events_raw=excluded_events_raw,
         )
 
     @expose("/calendar")

--- a/tests/www/views/test_views.py
+++ b/tests/www/views/test_views.py
@@ -94,6 +94,8 @@ def test_redoc_should_render_template(capture_templates, admin_client):
         "openapi_spec_url": "/api/v1/openapi.yaml",
         "rest_api_enabled": True,
         "get_docs_url": get_docs_url,
+        "excluded_events_raw": "",
+        "included_events_raw": "",
     }
 
 


### PR DESCRIPTION
Add the ability to filter the audit logs by events to include/exclude. Send the config values to the UI to act as the default value.

Also, some fixes to the react-select option in the dataset searchbar

<img width="1046" alt="Screenshot 2024-03-26 at 12 16 49 PM" src="https://github.com/apache/airflow/assets/4600967/d724426d-00df-4f15-89d8-27ecfe2bcdfc">


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
