### PR TITLE
Chart: Enable templating in extraContainers and extraInitContainers

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -50,7 +50,7 @@ spec:
       {{- include "git_sync_container" (dict "Values" .Values "is_init" "true" "Template" .Template) | nindent 4 }}
     {{- end }}
     {{- if .Values.workers.extraInitContainers }}
-      {{- toYaml .Values.workers.extraInitContainers | nindent 4 }}
+      {{- tpl (toYaml .Values.workers.extraInitContainers) . | nindent 4 }}
     {{- end }}
     {{- if and (semverCompare ">=2.8.0" .Values.airflowVersion) .Values.workers.kerberosInitContainer.enabled }}
     - name: kerberos-init
@@ -180,7 +180,7 @@ spec:
         {{- include "standard_airflow_environment" . | indent 6 }}
     {{- end }}
     {{- if .Values.workers.extraContainers }}
-      {{- toYaml .Values.workers.extraContainers | nindent 4 }}
+      {{- tpl (toYaml .Values.workers.extraContainers) . | nindent 4 }}
     {{- end }}
   {{- if .Values.workers.priorityClassName }}
   priorityClassName: {{ .Values.workers.priorityClassName }}

--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -144,7 +144,7 @@ spec:
           {{- include "git_sync_container" (dict "Values" .Values "is_init" "true" "Template" .Template) | nindent 8 }}
         {{- end }}
         {{- if .Values.dagProcessor.extraInitContainers }}
-          {{- toYaml .Values.dagProcessor.extraInitContainers | nindent 8 }}
+          {{- tpl (toYaml .Values.dagProcessor.extraInitContainers) . | nindent 8 }}
         {{- end }}
       containers:
         - name: dag-processor

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -169,7 +169,7 @@ spec:
           {{- include "git_sync_container" (dict "Values" .Values "is_init" "true" "Template" .Template) | nindent 8 }}
         {{- end }}
         {{- if .Values.scheduler.extraInitContainers }}
-          {{- toYaml .Values.scheduler.extraInitContainers | nindent 8 }}
+          {{- tpl (toYaml .Values.scheduler.extraInitContainers) . | nindent 8 }}
         {{- end }}
       containers:
         # Always run the main scheduler container.

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -160,7 +160,7 @@ spec:
           {{- include "git_sync_container" (dict "Values" .Values "is_init" "true" "Template" .Template) | nindent 8 }}
         {{- end }}
         {{- if .Values.triggerer.extraInitContainers }}
-          {{- toYaml .Values.triggerer.extraInitContainers | nindent 8 }}
+          {{- tpl (toYaml .Values.triggerer.extraInitContainers) . | nindent 8 }}
         {{- end }}
       containers:
         - name: triggerer

--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -163,7 +163,7 @@ spec:
           {{- include "git_sync_container" (dict "Values" .Values "is_init" "true" "Template" .Template) | nindent 8 }}
         {{- end }}
         {{- if .Values.webserver.extraInitContainers }}
-          {{- toYaml .Values.webserver.extraInitContainers | nindent 8 }}
+          {{- tpl (toYaml .Values.webserver.extraInitContainers) . | nindent 8 }}
         {{- end }}
       containers:
         - name: webserver

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -220,7 +220,7 @@ spec:
           {{- include "git_sync_container" (dict "Values" .Values "is_init" "true" "Template" .Template) | nindent 8 }}
         {{- end }}
         {{- if .Values.workers.extraInitContainers }}
-          {{- toYaml .Values.workers.extraInitContainers | nindent 8 }}
+          {{- tpl (toYaml .Values.workers.extraInitContainers) . | nindent 8 }}
         {{- end }}
       containers:
         - name: worker

--- a/helm_tests/airflow_aux/test_create_user_job.py
+++ b/helm_tests/airflow_aux/test_create_user_job.py
@@ -166,6 +166,22 @@ class TestCreateUserJob:
             "image": "test-registry/test-repo:test-tag",
         } == jmespath.search("spec.template.spec.containers[-1]", docs[0])
 
+    def test_should_template_extra_containers(self):
+        docs = render_chart(
+            values={
+                "createUserJob": {
+                    "extraContainers": [
+                        {"name": "{{ .Release.Name }}-test-container"}
+                    ],
+                },
+            },
+            show_only=["templates/jobs/create-user-job.yaml"],
+        )
+
+        assert {
+            "name": "release-name-test-container"
+        } == jmespath.search("spec.template.spec.containers[-1]", docs[0])
+
     def test_should_add_extra_volumes(self):
         docs = render_chart(
             values={

--- a/helm_tests/airflow_aux/test_create_user_job.py
+++ b/helm_tests/airflow_aux/test_create_user_job.py
@@ -170,17 +170,15 @@ class TestCreateUserJob:
         docs = render_chart(
             values={
                 "createUserJob": {
-                    "extraContainers": [
-                        {"name": "{{ .Release.Name }}-test-container"}
-                    ],
+                    "extraContainers": [{"name": "{{ .Release.Name }}-test-container"}],
                 },
             },
             show_only=["templates/jobs/create-user-job.yaml"],
         )
 
-        assert {
-            "name": "release-name-test-container"
-        } == jmespath.search("spec.template.spec.containers[-1]", docs[0])
+        assert {"name": "release-name-test-container"} == jmespath.search(
+            "spec.template.spec.containers[-1]", docs[0]
+        )
 
     def test_should_add_extra_volumes(self):
         docs = render_chart(

--- a/helm_tests/airflow_aux/test_migrate_database_job.py
+++ b/helm_tests/airflow_aux/test_migrate_database_job.py
@@ -194,17 +194,15 @@ class TestMigrateDatabaseJob:
         docs = render_chart(
             values={
                 "migrateDatabaseJob": {
-                    "extraContainers": [
-                        {"name": "{{ .Release.Name }}-test-container"}
-                    ],
+                    "extraContainers": [{"name": "{{ .Release.Name }}-test-container"}],
                 },
             },
             show_only=["templates/jobs/migrate-database-job.yaml"],
         )
 
-        assert {
-            "name": "release-name-test-container"
-        } == jmespath.search("spec.template.spec.containers[-1]", docs[0])
+        assert {"name": "release-name-test-container"} == jmespath.search(
+            "spec.template.spec.containers[-1]", docs[0]
+        )
 
     def test_set_resources(self):
         docs = render_chart(

--- a/helm_tests/airflow_aux/test_migrate_database_job.py
+++ b/helm_tests/airflow_aux/test_migrate_database_job.py
@@ -190,6 +190,22 @@ class TestMigrateDatabaseJob:
             "image": "test-registry/test-repo:test-tag",
         } == jmespath.search("spec.template.spec.containers[-1]", docs[0])
 
+    def test_should_template_extra_containers(self):
+        docs = render_chart(
+            values={
+                "migrateDatabaseJob": {
+                    "extraContainers": [
+                        {"name": "{{ .Release.Name }}-test-container"}
+                    ],
+                },
+            },
+            show_only=["templates/jobs/migrate-database-job.yaml"],
+        )
+
+        assert {
+            "name": "release-name-test-container"
+        } == jmespath.search("spec.template.spec.containers[-1]", docs[0])
+
     def test_set_resources(self):
         docs = render_chart(
             values={

--- a/helm_tests/airflow_aux/test_pod_template_file.py
+++ b/helm_tests/airflow_aux/test_pod_template_file.py
@@ -702,6 +702,24 @@ class TestPodTemplateFile:
             "image": "test-registry/test-repo:test-tag",
         } == jmespath.search("spec.initContainers[-1]", docs[0])
 
+    def test_should_template_extra_init_containers(self):
+        docs = render_chart(
+            values={
+                "workers": {
+                    "extraInitContainers": [
+                        {"name": "{{ .Release.Name }}-test-init-container"}
+                    ],
+                },
+            },
+            show_only=["templates/pod-template-file.yaml"],
+            chart_dir=self.temp_chart_dir,
+        )
+
+        assert {
+            "name": "release-name-test-init-container",
+        } == jmespath.search("spec.initContainers[-1]", docs[0])
+
+
     def test_should_add_extra_containers(self):
         docs = render_chart(
             values={
@@ -718,6 +736,23 @@ class TestPodTemplateFile:
         assert {
             "name": "test-container",
             "image": "test-registry/test-repo:test-tag",
+        } == jmespath.search("spec.containers[-1]", docs[0])
+
+    def test_should_template_extra_containers(self):
+        docs = render_chart(
+            values={
+                "workers": {
+                    "extraContainers": [
+                        {"name": "{{ .Release.Name }}-test-container"}
+                    ],
+                },
+            },
+            show_only=["templates/pod-template-file.yaml"],
+            chart_dir=self.temp_chart_dir,
+        )
+
+        assert {
+            "name": "release-name-test-container",
         } == jmespath.search("spec.containers[-1]", docs[0])
 
     def test_should_add_pod_labels(self):

--- a/helm_tests/airflow_aux/test_pod_template_file.py
+++ b/helm_tests/airflow_aux/test_pod_template_file.py
@@ -706,9 +706,7 @@ class TestPodTemplateFile:
         docs = render_chart(
             values={
                 "workers": {
-                    "extraInitContainers": [
-                        {"name": "{{ .Release.Name }}-test-init-container"}
-                    ],
+                    "extraInitContainers": [{"name": "{{ .Release.Name }}-test-init-container"}],
                 },
             },
             show_only=["templates/pod-template-file.yaml"],
@@ -718,7 +716,6 @@ class TestPodTemplateFile:
         assert {
             "name": "release-name-test-init-container",
         } == jmespath.search("spec.initContainers[-1]", docs[0])
-
 
     def test_should_add_extra_containers(self):
         docs = render_chart(
@@ -742,9 +739,7 @@ class TestPodTemplateFile:
         docs = render_chart(
             values={
                 "workers": {
-                    "extraContainers": [
-                        {"name": "{{ .Release.Name }}-test-container"}
-                    ],
+                    "extraContainers": [{"name": "{{ .Release.Name }}-test-container"}],
                 },
             },
             show_only=["templates/pod-template-file.yaml"],

--- a/helm_tests/airflow_core/test_dag_processor.py
+++ b/helm_tests/airflow_core/test_dag_processor.py
@@ -115,17 +115,15 @@ class TestDagProcessor:
             values={
                 "dagProcessor": {
                     "enabled": True,
-                    "extraContainers": [
-                        {"name": "{{ .Release.Name }}-test-container"}
-                    ],
+                    "extraContainers": [{"name": "{{ .Release.Name }}-test-container"}],
                 },
             },
             show_only=["templates/dag-processor/dag-processor-deployment.yaml"],
         )
 
-        assert {
-            "name": "release-name-test-container"
-        } == jmespath.search("spec.template.spec.containers[-1]", docs[0])
+        assert {"name": "release-name-test-container"} == jmespath.search(
+            "spec.template.spec.containers[-1]", docs[0]
+        )
 
     def test_should_add_extra_init_containers(self):
         docs = render_chart(
@@ -150,17 +148,15 @@ class TestDagProcessor:
             values={
                 "dagProcessor": {
                     "enabled": True,
-                    "extraInitContainers": [
-                        {"name": "{{ .Release.Name }}-test-init-container"}
-                    ],
+                    "extraInitContainers": [{"name": "{{ .Release.Name }}-test-init-container"}],
                 },
             },
             show_only=["templates/dag-processor/dag-processor-deployment.yaml"],
         )
 
-        assert {
-            "name": "release-name-test-init-container"
-        } == jmespath.search("spec.template.spec.initContainers[-1]", docs[0])
+        assert {"name": "release-name-test-init-container"} == jmespath.search(
+            "spec.template.spec.initContainers[-1]", docs[0]
+        )
 
     def test_should_add_extra_volume_and_extra_volume_mount(self):
         docs = render_chart(

--- a/helm_tests/airflow_core/test_dag_processor.py
+++ b/helm_tests/airflow_core/test_dag_processor.py
@@ -110,6 +110,23 @@ class TestDagProcessor:
             "image": "test-registry/test-repo:test-tag",
         } == jmespath.search("spec.template.spec.containers[-1]", docs[0])
 
+    def test_should_template_extra_containers(self):
+        docs = render_chart(
+            values={
+                "dagProcessor": {
+                    "enabled": True,
+                    "extraContainers": [
+                        {"name": "{{ .Release.Name }}-test-container"}
+                    ],
+                },
+            },
+            show_only=["templates/dag-processor/dag-processor-deployment.yaml"],
+        )
+
+        assert {
+            "name": "release-name-test-container"
+        } == jmespath.search("spec.template.spec.containers[-1]", docs[0])
+
     def test_should_add_extra_init_containers(self):
         docs = render_chart(
             values={
@@ -126,6 +143,23 @@ class TestDagProcessor:
         assert {
             "name": "test-init-container",
             "image": "test-registry/test-repo:test-tag",
+        } == jmespath.search("spec.template.spec.initContainers[-1]", docs[0])
+
+    def test_should_template_extra_init_containers(self):
+        docs = render_chart(
+            values={
+                "dagProcessor": {
+                    "enabled": True,
+                    "extraInitContainers": [
+                        {"name": "{{ .Release.Name }}-test-init-container"}
+                    ],
+                },
+            },
+            show_only=["templates/dag-processor/dag-processor-deployment.yaml"],
+        )
+
+        assert {
+            "name": "release-name-test-init-container"
         } == jmespath.search("spec.template.spec.initContainers[-1]", docs[0])
 
     def test_should_add_extra_volume_and_extra_volume_mount(self):

--- a/helm_tests/airflow_core/test_scheduler.py
+++ b/helm_tests/airflow_core/test_scheduler.py
@@ -69,6 +69,23 @@ class TestScheduler:
             "image": "test-registry/test-repo:test-tag",
         } == jmespath.search("spec.template.spec.containers[-1]", docs[0])
 
+    def test_should_template_extra_containers(self):
+        docs = render_chart(
+            values={
+                "executor": "CeleryExecutor",
+                "scheduler": {
+                    "extraContainers": [
+                        {"name": "{{ .Release.Name }}-test-container"}
+                    ],
+                },
+            },
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+
+        assert {
+            "name": "release-name-test-container"
+        } == jmespath.search("spec.template.spec.containers[-1]", docs[0])
+
     def test_disable_wait_for_migration(self):
         docs = render_chart(
             values={
@@ -98,6 +115,22 @@ class TestScheduler:
         assert {
             "name": "test-init-container",
             "image": "test-registry/test-repo:test-tag",
+        } == jmespath.search("spec.template.spec.initContainers[-1]", docs[0])
+
+    def test_should_template_extra_init_containers(self):
+        docs = render_chart(
+            values={
+                "scheduler": {
+                    "extraInitContainers": [
+                        {"name": "{{ .Release.Name }}-test-init-container"}
+                    ],
+                },
+            },
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+
+        assert {
+            "name": "release-name-test-init-container"
         } == jmespath.search("spec.template.spec.initContainers[-1]", docs[0])
 
     def test_should_add_extra_volume_and_extra_volume_mount(self):

--- a/helm_tests/airflow_core/test_scheduler.py
+++ b/helm_tests/airflow_core/test_scheduler.py
@@ -74,17 +74,15 @@ class TestScheduler:
             values={
                 "executor": "CeleryExecutor",
                 "scheduler": {
-                    "extraContainers": [
-                        {"name": "{{ .Release.Name }}-test-container"}
-                    ],
+                    "extraContainers": [{"name": "{{ .Release.Name }}-test-container"}],
                 },
             },
             show_only=["templates/scheduler/scheduler-deployment.yaml"],
         )
 
-        assert {
-            "name": "release-name-test-container"
-        } == jmespath.search("spec.template.spec.containers[-1]", docs[0])
+        assert {"name": "release-name-test-container"} == jmespath.search(
+            "spec.template.spec.containers[-1]", docs[0]
+        )
 
     def test_disable_wait_for_migration(self):
         docs = render_chart(
@@ -121,17 +119,15 @@ class TestScheduler:
         docs = render_chart(
             values={
                 "scheduler": {
-                    "extraInitContainers": [
-                        {"name": "{{ .Release.Name }}-test-init-container"}
-                    ],
+                    "extraInitContainers": [{"name": "{{ .Release.Name }}-test-init-container"}],
                 },
             },
             show_only=["templates/scheduler/scheduler-deployment.yaml"],
         )
 
-        assert {
-            "name": "release-name-test-init-container"
-        } == jmespath.search("spec.template.spec.initContainers[-1]", docs[0])
+        assert {"name": "release-name-test-init-container"} == jmespath.search(
+            "spec.template.spec.initContainers[-1]", docs[0]
+        )
 
     def test_should_add_extra_volume_and_extra_volume_mount(self):
         docs = render_chart(

--- a/helm_tests/airflow_core/test_triggerer.py
+++ b/helm_tests/airflow_core/test_triggerer.py
@@ -111,17 +111,15 @@ class TestTriggerer:
         docs = render_chart(
             values={
                 "triggerer": {
-                    "extraContainers": [
-                        {"name": "{{ .Release.Name }}-test-container"}
-                    ],
+                    "extraContainers": [{"name": "{{ .Release.Name }}-test-container"}],
                 },
             },
             show_only=["templates/triggerer/triggerer-deployment.yaml"],
         )
 
-        assert {
-            "name": "release-name-test-container"
-        } == jmespath.search("spec.template.spec.containers[-1]", docs[0])
+        assert {"name": "release-name-test-container"} == jmespath.search(
+            "spec.template.spec.containers[-1]", docs[0]
+        )
 
     def test_should_add_extra_init_containers(self):
         docs = render_chart(
@@ -144,17 +142,15 @@ class TestTriggerer:
         docs = render_chart(
             values={
                 "triggerer": {
-                    "extraInitContainers": [
-                        {"name": "{{ .Release.Name }}-test-init-container"}
-                    ],
+                    "extraInitContainers": [{"name": "{{ .Release.Name }}-test-init-container"}],
                 },
             },
             show_only=["templates/triggerer/triggerer-deployment.yaml"],
         )
 
-        assert {
-            "name": "release-name-test-init-container"
-        } == jmespath.search("spec.template.spec.initContainers[-1]", docs[0])
+        assert {"name": "release-name-test-init-container"} == jmespath.search(
+            "spec.template.spec.initContainers[-1]", docs[0]
+        )
 
     def test_should_add_extra_volume_and_extra_volume_mount(self):
         docs = render_chart(

--- a/helm_tests/airflow_core/test_triggerer.py
+++ b/helm_tests/airflow_core/test_triggerer.py
@@ -107,6 +107,22 @@ class TestTriggerer:
             "image": "test-registry/test-repo:test-tag",
         } == jmespath.search("spec.template.spec.containers[-1]", docs[0])
 
+    def test_should_template_extra_containers(self):
+        docs = render_chart(
+            values={
+                "triggerer": {
+                    "extraContainers": [
+                        {"name": "{{ .Release.Name }}-test-container"}
+                    ],
+                },
+            },
+            show_only=["templates/triggerer/triggerer-deployment.yaml"],
+        )
+
+        assert {
+            "name": "release-name-test-container"
+        } == jmespath.search("spec.template.spec.containers[-1]", docs[0])
+
     def test_should_add_extra_init_containers(self):
         docs = render_chart(
             values={
@@ -122,6 +138,22 @@ class TestTriggerer:
         assert {
             "name": "test-init-container",
             "image": "test-registry/test-repo:test-tag",
+        } == jmespath.search("spec.template.spec.initContainers[-1]", docs[0])
+
+    def test_should_template_extra_init_containers(self):
+        docs = render_chart(
+            values={
+                "triggerer": {
+                    "extraInitContainers": [
+                        {"name": "{{ .Release.Name }}-test-init-container"}
+                    ],
+                },
+            },
+            show_only=["templates/triggerer/triggerer-deployment.yaml"],
+        )
+
+        assert {
+            "name": "release-name-test-init-container"
         } == jmespath.search("spec.template.spec.initContainers[-1]", docs[0])
 
     def test_should_add_extra_volume_and_extra_volume_mount(self):

--- a/helm_tests/airflow_core/test_worker.py
+++ b/helm_tests/airflow_core/test_worker.py
@@ -87,17 +87,15 @@ class TestWorker:
             values={
                 "executor": "CeleryExecutor",
                 "workers": {
-                    "extraContainers": [
-                        {"name": "{{ .Release.Name }}-test-container"}
-                    ],
+                    "extraContainers": [{"name": "{{ .Release.Name }}-test-container"}],
                 },
             },
             show_only=["templates/workers/worker-deployment.yaml"],
         )
 
-        assert {
-            "name": "release-name-test-container"
-        } == jmespath.search("spec.template.spec.containers[-1]", docs[0])
+        assert {"name": "release-name-test-container"} == jmespath.search(
+            "spec.template.spec.containers[-1]", docs[0]
+        )
 
     def test_disable_wait_for_migration(self):
         docs = render_chart(
@@ -134,17 +132,15 @@ class TestWorker:
         docs = render_chart(
             values={
                 "workers": {
-                    "extraInitContainers": [
-                        {"name": "{{ .Release.Name }}-test-init-container"}
-                    ],
+                    "extraInitContainers": [{"name": "{{ .Release.Name }}-test-init-container"}],
                 },
             },
             show_only=["templates/workers/worker-deployment.yaml"],
         )
 
-        assert {
-            "name": "release-name-test-init-container"
-        } == jmespath.search("spec.template.spec.initContainers[-1]", docs[0])
+        assert {"name": "release-name-test-init-container"} == jmespath.search(
+            "spec.template.spec.initContainers[-1]", docs[0]
+        )
 
     def test_should_add_extra_volume_and_extra_volume_mount(self):
         docs = render_chart(

--- a/helm_tests/airflow_core/test_worker.py
+++ b/helm_tests/airflow_core/test_worker.py
@@ -82,6 +82,23 @@ class TestWorker:
             "image": "test-registry/test-repo:test-tag",
         } == jmespath.search("spec.template.spec.containers[-1]", docs[0])
 
+    def test_should_template_extra_containers(self):
+        docs = render_chart(
+            values={
+                "executor": "CeleryExecutor",
+                "workers": {
+                    "extraContainers": [
+                        {"name": "{{ .Release.Name }}-test-container"}
+                    ],
+                },
+            },
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+
+        assert {
+            "name": "release-name-test-container"
+        } == jmespath.search("spec.template.spec.containers[-1]", docs[0])
+
     def test_disable_wait_for_migration(self):
         docs = render_chart(
             values={
@@ -111,6 +128,22 @@ class TestWorker:
         assert {
             "name": "test-init-container",
             "image": "test-registry/test-repo:test-tag",
+        } == jmespath.search("spec.template.spec.initContainers[-1]", docs[0])
+
+    def test_should_template_extra_init_containers(self):
+        docs = render_chart(
+            values={
+                "workers": {
+                    "extraInitContainers": [
+                        {"name": "{{ .Release.Name }}-test-init-container"}
+                    ],
+                },
+            },
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+
+        assert {
+            "name": "release-name-test-init-container"
         } == jmespath.search("spec.template.spec.initContainers[-1]", docs[0])
 
     def test_should_add_extra_volume_and_extra_volume_mount(self):

--- a/helm_tests/webserver/test_webserver.py
+++ b/helm_tests/webserver/test_webserver.py
@@ -205,9 +205,7 @@ class TestWebserverDeployment:
             values={
                 "executor": "CeleryExecutor",
                 "webserver": {
-                    "extraContainers": [
-                        {"name": "{{ .Release.Name }}-test-container"}
-                    ],
+                    "extraContainers": [{"name": "{{ .Release.Name }}-test-container"}],
                 },
             },
             show_only=["templates/webserver/webserver-deployment.yaml"],
@@ -216,7 +214,6 @@ class TestWebserverDeployment:
         assert {
             "name": "release-name-test-container",
         } == jmespath.search("spec.template.spec.containers[-1]", docs[0])
-
 
     def test_should_add_extraEnvs(self):
         docs = render_chart(
@@ -337,9 +334,7 @@ class TestWebserverDeployment:
         docs = render_chart(
             values={
                 "webserver": {
-                    "extraInitContainers": [
-                        {"name": "{{ .Release.Name }}-init-container"}
-                    ],
+                    "extraInitContainers": [{"name": "{{ .Release.Name }}-init-container"}],
                 },
             },
             show_only=["templates/webserver/webserver-deployment.yaml"],
@@ -348,7 +343,6 @@ class TestWebserverDeployment:
         assert {
             "name": "release-name-init-container",
         } == jmespath.search("spec.template.spec.initContainers[-1]", docs[0])
-
 
     def test_should_add_component_specific_labels(self):
         docs = render_chart(

--- a/helm_tests/webserver/test_webserver.py
+++ b/helm_tests/webserver/test_webserver.py
@@ -200,6 +200,24 @@ class TestWebserverDeployment:
             "image": "test-registry/test-repo:test-tag",
         } == jmespath.search("spec.template.spec.containers[-1]", docs[0])
 
+    def test_should_template_extra_containers(self):
+        docs = render_chart(
+            values={
+                "executor": "CeleryExecutor",
+                "webserver": {
+                    "extraContainers": [
+                        {"name": "{{ .Release.Name }}-test-container"}
+                    ],
+                },
+            },
+            show_only=["templates/webserver/webserver-deployment.yaml"],
+        )
+
+        assert {
+            "name": "release-name-test-container",
+        } == jmespath.search("spec.template.spec.containers[-1]", docs[0])
+
+
     def test_should_add_extraEnvs(self):
         docs = render_chart(
             values={
@@ -314,6 +332,23 @@ class TestWebserverDeployment:
             "name": "test-init-container",
             "image": "test-registry/test-repo:test-tag",
         } == jmespath.search("spec.template.spec.initContainers[-1]", docs[0])
+
+    def test_should_template_extra_init_containers(self):
+        docs = render_chart(
+            values={
+                "webserver": {
+                    "extraInitContainers": [
+                        {"name": "{{ .Release.Name }}-init-container"}
+                    ],
+                },
+            },
+            show_only=["templates/webserver/webserver-deployment.yaml"],
+        )
+
+        assert {
+            "name": "release-name-init-container",
+        } == jmespath.search("spec.template.spec.initContainers[-1]", docs[0])
+
 
     def test_should_add_component_specific_labels(self):
         docs = render_chart(


### PR DESCRIPTION
Currently, the `extraContainers` and `extraInitContainers` are passed on an "as-is" basis. What this means in practice is that if you depend on a release-specific resource you have to manually provide the names rather than use templating.

---

Example: mounting a release-specific `ConfigMap` into an `extraContainer`

The following config will not work, since it produces an init container which references `{{ .Release.Name }}-stuff-config` copied verbatim, rather than the templated value including the actual release name as you would expect.

```yaml
workers:
  extraInitContainers:
    - name: init-stuff
      image: does/stuff:1.0.0
      envFrom:
        - configMapRef:
            name: "{{ .Release.Name }}-stuff-config"

extraConfigMaps:
  '{{ .Release.Name }}-stuff-config':
    data: |-
      STUFF_ENV_VAR1: one
      STUFF_ENV_VAR2: two
```

---

This PR enables templating for `extraContainers` and `extraInitContainers` fields to fix this issue and improve the reusability of the chart.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
