### PR TITLE
Show abandoned tasks in Grid View

### DIFF
--- a/airflow/www/static/js/dag/details/Header.tsx
+++ b/airflow/www/static/js/dag/details/Header.tsx
@@ -64,8 +64,6 @@ const Header = () => {
       clearSelection();
     } else if (runId && !dagRun) {
       onSelect({ taskId });
-    } else if (taskId && !group) {
-      onSelect({ runId });
     }
   }, [dagRun, taskId, group, runId, onSelect, clearSelection]);
 
@@ -99,7 +97,7 @@ const Header = () => {
   const isMappedTaskDetails = runId && taskId && mapIndex !== undefined;
 
   return (
-    <Breadcrumb ml={3} separator={<Text color="gray.300">/</Text>}>
+    <Breadcrumb ml={3} pt={2} separator={<Text color="gray.300">/</Text>}>
       <BreadcrumbItem isCurrentPage={isDagDetails} mt={4}>
         <BreadcrumbLink
           onClick={clearSelection}

--- a/airflow/www/static/js/dag/details/NotesAccordion.tsx
+++ b/airflow/www/static/js/dag/details/NotesAccordion.tsx
@@ -46,6 +46,7 @@ interface Props {
   taskId?: string;
   mapIndex?: number;
   initialValue?: string | null;
+  isAbandonedTask?: boolean;
 }
 
 const NotesAccordion = ({
@@ -54,8 +55,9 @@ const NotesAccordion = ({
   taskId,
   mapIndex,
   initialValue,
+  isAbandonedTask,
 }: Props) => {
-  const canEdit = getMetaValue("can_edit") === "True";
+  const canEdit = getMetaValue("can_edit") === "True" && !isAbandonedTask;
   const [note, setNote] = useState(initialValue ?? "");
   const [editMode, setEditMode] = useState(false);
   const [accordionIndexes, setAccordionIndexes] = useState<Array<number>>(

--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -283,9 +283,7 @@ const Details = ({
               />
             </>
           )}
-          {taskId && runId && !isAbandonedTask && (
-            <FilterTasks taskId={taskId} />
-          )}
+          {taskId && runId && <FilterTasks taskId={taskId} />}
         </Flex>
       </Flex>
       <Divider my={2} />

--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -255,7 +255,7 @@ const Details = ({
               <MarkRunAs runId={runId} state={run?.state} />
             </>
           )}
-          {runId && taskId && (
+          {runId && taskId && !isAbandonedTask && (
             <>
               <ClearInstance
                 taskId={taskId}
@@ -283,7 +283,9 @@ const Details = ({
               />
             </>
           )}
-          {taskId && runId && <FilterTasks taskId={taskId} />}
+          {taskId && runId && !isAbandonedTask && (
+            <FilterTasks taskId={taskId} />
+          )}
         </Flex>
       </Flex>
       <Divider my={2} />

--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -185,6 +185,8 @@ const Details = ({
 
   const showTaskDetails = !!taskId && !runId;
 
+  const isAbandonedTask = !!taskId && !group;
+
   const [searchParams, setSearchParams] = useSearchParams();
   const tab = searchParams.get(TAB_PARAM) || undefined;
   const tabIndex = tabToIndex(tab);
@@ -379,6 +381,7 @@ const Details = ({
                 onChangeTab(0);
                 onSelect({ taskId });
               }}
+              isDisabled={isAbandonedTask}
             >
               <MdHourglassBottom size={16} />
               <Text as="strong" ml={1}>

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
@@ -201,146 +201,142 @@ const Logs = ({
           </Flex>
         </Box>
       )}
-      {tryNumber !== undefined && (
-        <>
+      <Box>
+        {!showDropdown && (
           <Box>
-            {!showDropdown && (
-              <Box>
-                <Text as="span"> (by attempts)</Text>
-                <Flex my={1} justifyContent="space-between">
-                  <Flex flexWrap="wrap">
-                    {internalIndexes.map((index) => (
-                      <Button
-                        key={index}
-                        variant={taskTryNumber === index ? "solid" : "ghost"}
-                        colorScheme="blue"
-                        onClick={() => setSelectedTryNumber(index)}
-                        data-testid={`log-attempt-select-button-${index}`}
-                      >
-                        {index}
-                      </Button>
-                    ))}
-                  </Flex>
-                </Flex>
-              </Box>
-            )}
-            <Flex my={1} justifyContent="space-between" flexWrap="wrap">
-              <Flex alignItems="center" flexGrow={1} mr={10}>
-                {showDropdown && (
-                  <Box width="100%" mr={2}>
-                    <Select
-                      size="sm"
-                      placeholder="Select log attempt"
-                      onChange={(e) => {
-                        setSelectedTryNumber(Number(e.target.value));
-                      }}
-                    >
-                      {internalIndexes.map((index) => (
-                        <option key={index} value={index}>
-                          {index}
-                        </option>
-                      ))}
-                    </Select>
-                  </Box>
-                )}
-                <Box width="100%" mr={2}>
-                  <MultiSelect
-                    size="sm"
-                    isMulti
-                    options={logLevelOptions}
-                    placeholder="All Levels"
-                    value={logLevelFilters}
-                    onChange={(options) => setLogLevelFilters([...options])}
-                    chakraStyles={{
-                      multiValue: (provided, ...rest) => ({
-                        ...provided,
-                        backgroundColor: rest[0].data.color,
-                      }),
-                      option: (provided, ...rest) => ({
-                        ...provided,
-                        borderLeft: "solid 4px black",
-                        borderColor: rest[0].data.color,
-                        mt: 2,
-                      }),
-                    }}
-                  />
-                </Box>
-                <Box width="100%">
-                  <MultiSelect
-                    size="sm"
-                    isMulti
-                    options={fileSources.map((fileSource) => ({
-                      label: fileSource,
-                      value: fileSource,
-                    }))}
-                    placeholder="All File Sources"
-                    value={fileSourceFilters}
-                    onChange={(options) => setFileSourceFilters([...options])}
-                  />
-                </Box>
-              </Flex>
-              <Flex alignItems="center" flexWrap="wrap">
-                <Checkbox
-                  isChecked={wrap}
-                  onChange={() => setWrap((previousState) => !previousState)}
-                  px={4}
-                  data-testid="wrap-checkbox"
-                >
-                  <Text as="strong">Wrap</Text>
-                </Checkbox>
-                <LogLink
-                  dagId={dagId}
-                  taskId={taskId}
-                  executionDate={executionDate}
-                  isInternal
-                  tryNumber={tryNumber}
-                  mapIndex={mapIndex}
-                />
-                <LinkButton href={`${logUrl}&${params.toString()}`}>
-                  See More
-                </LinkButton>
-                <IconButton
-                  variant="ghost"
-                  aria-label="Toggle full screen"
-                  title="Toggle full screen"
-                  onClick={toggleFullScreen}
-                  icon={
-                    isFullScreen ? (
-                      <BiCollapse height="24px" />
-                    ) : (
-                      <BiExpand height="24px" />
-                    )
-                  }
-                />
+            <Text as="span"> (by attempts)</Text>
+            <Flex my={1} justifyContent="space-between">
+              <Flex flexWrap="wrap">
+                {internalIndexes.map((index) => (
+                  <Button
+                    key={index}
+                    variant={taskTryNumber === index ? "solid" : "ghost"}
+                    colorScheme="blue"
+                    onClick={() => setSelectedTryNumber(index)}
+                    data-testid={`log-attempt-select-button-${index}`}
+                  >
+                    {index}
+                  </Button>
+                ))}
               </Flex>
             </Flex>
           </Box>
-          {!!warning && (
-            <Flex
-              bg="yellow.200"
-              borderRadius={2}
-              borderColor="gray.400"
-              alignItems="center"
-              p={2}
-            >
-              <Icon as={MdWarning} color="yellow.500" mr={2} />
-              <Text fontSize="sm">{warning}</Text>
-            </Flex>
-          )}
-          {isLoading ? (
-            <Spinner />
-          ) : (
-            !!parsedLogs && (
-              <LogBlock
-                parsedLogs={parsedLogs}
-                wrap={wrap}
-                tryNumber={taskTryNumber}
-                unfoldedGroups={unfoldedLogGroups}
-                setUnfoldedLogGroup={setUnfoldedLogGroup}
+        )}
+        <Flex my={1} justifyContent="space-between" flexWrap="wrap">
+          <Flex alignItems="center" flexGrow={1} mr={10}>
+            {showDropdown && (
+              <Box width="100%" mr={2}>
+                <Select
+                  size="sm"
+                  placeholder="Select log attempt"
+                  onChange={(e) => {
+                    setSelectedTryNumber(Number(e.target.value));
+                  }}
+                >
+                  {internalIndexes.map((index) => (
+                    <option key={index} value={index}>
+                      {index}
+                    </option>
+                  ))}
+                </Select>
+              </Box>
+            )}
+            <Box width="100%" mr={2}>
+              <MultiSelect
+                size="sm"
+                isMulti
+                options={logLevelOptions}
+                placeholder="All Levels"
+                value={logLevelFilters}
+                onChange={(options) => setLogLevelFilters([...options])}
+                chakraStyles={{
+                  multiValue: (provided, ...rest) => ({
+                    ...provided,
+                    backgroundColor: rest[0].data.color,
+                  }),
+                  option: (provided, ...rest) => ({
+                    ...provided,
+                    borderLeft: "solid 4px black",
+                    borderColor: rest[0].data.color,
+                    mt: 2,
+                  }),
+                }}
               />
-            )
-          )}
-        </>
+            </Box>
+            <Box width="100%">
+              <MultiSelect
+                size="sm"
+                isMulti
+                options={fileSources.map((fileSource) => ({
+                  label: fileSource,
+                  value: fileSource,
+                }))}
+                placeholder="All File Sources"
+                value={fileSourceFilters}
+                onChange={(options) => setFileSourceFilters([...options])}
+              />
+            </Box>
+          </Flex>
+          <Flex alignItems="center" flexWrap="wrap">
+            <Checkbox
+              isChecked={wrap}
+              onChange={() => setWrap((previousState) => !previousState)}
+              px={4}
+              data-testid="wrap-checkbox"
+            >
+              <Text as="strong">Wrap</Text>
+            </Checkbox>
+            <LogLink
+              dagId={dagId}
+              taskId={taskId}
+              executionDate={executionDate}
+              isInternal
+              tryNumber={tryNumber}
+              mapIndex={mapIndex}
+            />
+            <LinkButton href={`${logUrl}&${params.toString()}`}>
+              See More
+            </LinkButton>
+            <IconButton
+              variant="ghost"
+              aria-label="Toggle full screen"
+              title="Toggle full screen"
+              onClick={toggleFullScreen}
+              icon={
+                isFullScreen ? (
+                  <BiCollapse height="24px" />
+                ) : (
+                  <BiExpand height="24px" />
+                )
+              }
+            />
+          </Flex>
+        </Flex>
+      </Box>
+      {!!warning && (
+        <Flex
+          bg="yellow.200"
+          borderRadius={2}
+          borderColor="gray.400"
+          alignItems="center"
+          p={2}
+        >
+          <Icon as={MdWarning} color="yellow.500" mr={2} />
+          <Text fontSize="sm">{warning}</Text>
+        </Flex>
+      )}
+      {isLoading ? (
+        <Spinner />
+      ) : (
+        !!parsedLogs && (
+          <LogBlock
+            parsedLogs={parsedLogs}
+            wrap={wrap}
+            tryNumber={taskTryNumber}
+            unfoldedGroups={unfoldedLogGroups}
+            setUnfoldedLogGroup={setUnfoldedLogGroup}
+          />
+        )
       )}
     </>
   );

--- a/airflow/www/static/js/dag/details/taskInstance/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/index.tsx
@@ -65,11 +65,8 @@ const TaskInstance = ({ taskId, runId, mapIndex }: Props) => {
     mapIndex,
     enabled: (!isGroup && !isMapped) || isMapIndexDefined,
   });
+
   const gridInstance = group?.instances.find((ti) => ti.runId === runId);
-
-  if (!group || !run || !gridInstance) return null;
-
-  const { executionDate } = run;
 
   return (
     <Box
@@ -79,12 +76,12 @@ const TaskInstance = ({ taskId, runId, mapIndex }: Props) => {
       ref={taskInstanceRef}
       overflowY="auto"
     >
-      {!isGroup && (
+      {!isGroup && run?.executionDate && (
         <TaskNav
           taskId={taskId}
           isMapped={isMapped}
           mapIndex={mapIndex}
-          executionDate={executionDate}
+          executionDate={run?.executionDate}
           operator={operator}
         />
       )}
@@ -93,22 +90,24 @@ const TaskInstance = ({ taskId, runId, mapIndex }: Props) => {
           dagId={dagId}
           runId={runId}
           taskId={taskId}
-          mapIndex={gridInstance.mapIndex}
-          initialValue={gridInstance.note}
-          key={dagId + runId + taskId + gridInstance.mapIndex}
+          mapIndex={mapIndex}
+          initialValue={gridInstance?.note || taskInstance?.note}
+          key={dagId + runId + taskId + mapIndex}
         />
       )}
-      {!!group.extraLinks?.length && !isGroupOrMappedTaskSummary && (
-        <ExtraLinks
-          taskId={taskId}
-          dagId={dagId}
-          mapIndex={isMapped && isMapIndexDefined ? mapIndex : undefined}
-          executionDate={executionDate}
-          extraLinks={group?.extraLinks}
-          tryNumber={taskInstance?.tryNumber || gridInstance.tryNumber}
-        />
-      )}
-      {group.hasOutletDatasets && (
+      {!!group?.extraLinks?.length &&
+        !isGroupOrMappedTaskSummary &&
+        run?.executionDate && (
+          <ExtraLinks
+            taskId={taskId}
+            dagId={dagId}
+            mapIndex={isMapped && isMapIndexDefined ? mapIndex : undefined}
+            executionDate={run.executionDate}
+            extraLinks={group.extraLinks}
+            tryNumber={taskInstance?.tryNumber || gridInstance?.tryNumber || 1}
+          />
+        )}
+      {group?.hasOutletDatasets && (
         <DatasetUpdateEvents taskId={taskId} runId={runId} />
       )}
       <TriggererInfo taskInstance={taskInstance} />

--- a/airflow/www/static/js/dag/details/taskInstance/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/index.tsx
@@ -93,6 +93,7 @@ const TaskInstance = ({ taskId, runId, mapIndex }: Props) => {
           mapIndex={mapIndex}
           initialValue={gridInstance?.note || taskInstance?.note}
           key={dagId + runId + taskId + mapIndex}
+          isAbandonedTask={!!taskId && !group}
         />
       )}
       {!!group?.extraLinks?.length &&

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -423,13 +423,17 @@ def task_instance_link(attr):
     dag_id = attr.get("dag_id")
     task_id = attr.get("task_id")
     run_id = attr.get("run_id")
-    execution_date = attr.get("dag_run.execution_date") or attr.get("execution_date") or timezone.utcnow()
+    map_index = attr.get("map_index", None)
+    if map_index == -1:
+        map_index = None
+
     url = url_for(
-        "Airflow.task",
+        "Airflow.grid",
         dag_id=dag_id,
         task_id=task_id,
-        execution_date=execution_date.isoformat(),
-        map_index=attr.get("map_index", -1),
+        dag_run_id=run_id,
+        map_index=map_index,
+        tab="graph",
     )
     url_root = url_for(
         "Airflow.grid",
@@ -437,8 +441,8 @@ def task_instance_link(attr):
         task_id=task_id,
         root=task_id,
         dag_run_id=run_id,
+        map_index=map_index,
         tab="graph",
-        map_index=attr.get("map_index", -1),
     )
     return Markup(
         """

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -5187,10 +5187,24 @@ class TaskInstanceModelView(AirflowModelView):
 
     def log_url_formatter(self):
         """Format log URL."""
-        log_url = self.get("log_url")
+        dag_id = self.get("dag_id")
+        task_id = self.get("task_id")
+        run_id = self.get("run_id")
+        map_index = self.get("map_index", None)
+        if map_index == -1:
+            map_index = None
+
+        url = url_for(
+            "Airflow.grid",
+            dag_id=dag_id,
+            task_id=task_id,
+            dag_run_id=run_id,
+            map_index=map_index,
+            tab="logs",
+        )
         return Markup(
             '<a href="{log_url}"><span class="material-icons" aria-hidden="true">reorder</span></a>'
-        ).format(log_url=log_url)
+        ).format(log_url=url)
 
     def duration_f(self):
         """Format duration."""


### PR DESCRIPTION
Fixes: https://github.com/apache/airflow/issues/38329

Even if a task no longer exists in a DAG, we can still allow a user to see the information in the grid view if the task_id is specified in the url such as the links in `/taskinstance/list`

See Task Instance details, audit log and logs all show up for the abandoned task:
<img width="1152" alt="Screenshot 2024-03-26 at 1 57 31 PM" src="https://github.com/apache/airflow/assets/4600967/19d5d64a-2e01-4aa2-8183-f8ca125cbef7">
<img width="1156" alt="Screenshot 2024-03-26 at 1 57 26 PM" src="https://github.com/apache/airflow/assets/4600967/696a7f8d-aa83-4b96-acbf-dd968dce9a24">
<img width="1155" alt="Screenshot 2024-03-26 at 1 57 21 PM" src="https://github.com/apache/airflow/assets/4600967/ac0be712-2190-43a7-823d-31d806d2595b">



---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
