### PR TITLE
Refactor: Directly pass HttpOperator `data` and `json` arguments to requests and aiohttp params

### DIFF
--- a/airflow/providers/http/operators/http.py
+++ b/airflow/providers/http/operators/http.py
@@ -107,6 +107,7 @@ class HttpOperator(BaseOperator):
         endpoint: str | None = None,
         method: str = "POST",
         data: dict[str, Any] | str | None = None,
+        json: dict[str, Any] | str | None = None,
         headers: dict[str, str] | None = None,
         pagination_function: Callable[..., Any] | None = None,
         response_check: Callable[..., bool] | None = None,
@@ -128,6 +129,7 @@ class HttpOperator(BaseOperator):
         self.endpoint = endpoint
         self.headers = headers or {}
         self.data = data or {}
+        self.json = json or {}
         self.pagination_function = pagination_function
         self.response_check = response_check
         self.response_filter = response_filter
@@ -167,7 +169,7 @@ class HttpOperator(BaseOperator):
 
     def execute_sync(self, context: Context) -> Any:
         self.log.info("Calling HTTP method")
-        response = self.hook.run(self.endpoint, self.data, self.headers, self.extra_options)
+        response = self.hook.run(self.endpoint, self.data, self.json, self.headers, self.extra_options)
         response = self.paginate_sync(response=response)
         return self.process_response(context=context, response=response)
 
@@ -193,6 +195,7 @@ class HttpOperator(BaseOperator):
                 endpoint=self.endpoint,
                 headers=self.headers,
                 data=self.data,
+                json=self.json,
                 extra_options=self.extra_options,
             ),
             method_name="execute_complete",

--- a/airflow/providers/http/triggers/http.py
+++ b/airflow/providers/http/triggers/http.py
@@ -59,6 +59,7 @@ class HttpTrigger(BaseTrigger):
         endpoint: str | None = None,
         headers: dict[str, str] | None = None,
         data: dict[str, Any] | str | None = None,
+        json: dict[str, Any] | str | None = None,
         extra_options: dict[str, Any] | None = None,
     ):
         super().__init__()
@@ -68,6 +69,7 @@ class HttpTrigger(BaseTrigger):
         self.endpoint = endpoint
         self.headers = headers
         self.data = data
+        self.json = json
         self.extra_options = extra_options
 
     def serialize(self) -> tuple[str, dict[str, Any]]:
@@ -81,6 +83,7 @@ class HttpTrigger(BaseTrigger):
                 "endpoint": self.endpoint,
                 "headers": self.headers,
                 "data": self.data,
+                "json": self.json,
                 "extra_options": self.extra_options,
             },
         )
@@ -96,6 +99,7 @@ class HttpTrigger(BaseTrigger):
             client_response = await hook.run(
                 endpoint=self.endpoint,
                 data=self.data,
+                json=self.json,
                 headers=self.headers,
                 extra_options=self.extra_options,
             )

--- a/tests/providers/http/hooks/test_http.py
+++ b/tests/providers/http/hooks/test_http.py
@@ -332,7 +332,7 @@ class TestHttpHook:
         hook.get_conn({})
         assert hook.base_url == "http://"
 
-    @pytest.mark.parametrize("method", ["GET", "POST"])
+    @pytest.mark.parametrize("method", ["POST"])
     def test_json_request(self, method, requests_mock):
         obj1 = {"a": 1, "b": "abc", "c": [1, 2, {"d": 10}]}
 

--- a/tests/providers/http/triggers/test_http.py
+++ b/tests/providers/http/triggers/test_http.py
@@ -40,6 +40,7 @@ TEST_METHOD = "POST"
 TEST_ENDPOINT = "endpoint"
 TEST_HEADERS = {"Authorization": "Bearer test"}
 TEST_DATA = ""
+TEST_JSON = {"key": "value"}
 TEST_EXTRA_OPTIONS: dict[str, Any] = {}
 
 
@@ -52,6 +53,7 @@ def trigger():
         endpoint=TEST_ENDPOINT,
         headers=TEST_HEADERS,
         data=TEST_DATA,
+        json=TEST_JSON,
         extra_options=TEST_EXTRA_OPTIONS,
     )
 
@@ -91,6 +93,7 @@ class TestHttpTrigger:
             "endpoint": TEST_ENDPOINT,
             "headers": TEST_HEADERS,
             "data": TEST_DATA,
+            "json": TEST_JSON,
             "extra_options": TEST_EXTRA_OPTIONS,
         }
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/

-->

<!-- Please keep an empty line above the dashes. -->

related: #37291

Both `requests` and `aiohttp` deal with json and data arguments in the same 
manner (https://requests.readthedocs.io/en/latest/api/#requests.post and https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientSession.request), so it would be more transparent to simply pass these arguments 
directly. I believe it is also a good choice to be transparent in this 
direct usage because requests is a very popular HTTP library so most 
people already know how these arguments are expected. 

The `params` argument could also be introduced in the HttpOperator with the same goal.

This PR was meant to address #37291 after seeing the discussion started here https://github.com/apache/airflow/pull/37293#discussion_r1529377720
The PR includes a breaking change.