### PR TITLE
Build constraints instead of pulling them for non-main builds

### DIFF
--- a/.github/workflows/prod-image-build.yml
+++ b/.github/workflows/prod-image-build.yml
@@ -239,16 +239,42 @@ ${{ inputs.do-build == 'true' && inputs.image-tag || '' }}"
           name: source-constraints-${{ matrix.python-version }}
           path: ./docker-context-files
         if: inputs.do-build == 'true' && inputs.build-provider-packages == 'true'
-      - name: "Download constraints"
-        uses: actions/download-artifact@v4
-        with:
-          name: constraints
-          path: ./docker-context-files
-        if: inputs.do-build == 'true' && inputs.build-provider-packages != 'true'
       - name: Login to ghcr.io
         shell: bash
         run: echo "${{ env.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
         if: inputs.do-build == 'true'
+      - name: Pull CI images ${{ inputs.python-versions-list-as-string }}:${{ inputs.image-tag }}
+        run: >
+          breeze ci-image pull --tag-as-latest --image-tag "${{ inputs.image-tag }}"
+          --python "${{ matrix.python-version }}"
+        if: inputs.do-build == 'true' && inputs.build-provider-packages != 'true'
+      - name: "Prepare chicken-eggs provider packages"
+        # In case of provider packages which use latest dev0 version of providers, we should prepare them
+        # from the source code, not from the PyPI because they have apache-airflow>=X.Y.Z dependency
+        # And when we prepare them from sources they will have apache-airflow>=X.Y.Z.dev0
+        run: >
+          breeze release-management prepare-provider-packages --include-not-ready-providers
+          --package-format wheel --version-suffix-for-pypi dev0
+          ${{ inputs.chicken-egg-providers }}
+        if: >
+          inputs.do-build == 'true' &&
+          inputs.chicken-egg-providers != '' &&
+          inputs.build-provider-packages != 'true'
+      - name: "PyPI constraints"
+        timeout-minutes: 25
+        run: >
+          breeze release-management generate-constraints --python  "${{ matrix.python-version }}"
+          --airflow-constraints-mode constraints --answer yes
+          --chicken-egg-providers "${{ inputs.chicken-egg-providers }}"
+        if: inputs.do-build == 'true' && inputs.build-provider-packages != 'true'
+      # This cleanup is needed as we will run out of disk space if we keep both CI and PROD images
+      # on public runners.
+      - name: Cleanup docker
+        uses: ./.github/actions/cleanup-docker
+        if: inputs.do-build == 'true' && inputs.build-provider-packages != 'true'
+      - name: "Copy constraints to docker-context-files"
+        run: cp -vr --no-preserve=mode,ownership ./files/constraints-* ./docker-context-files
+        if: inputs.do-build == 'true' && inputs.build-provider-packages != 'true'
       - name: "Build PROD images w/ source providers ${{ matrix.python-version }}:${{ inputs.image-tag }}"
         shell: bash
         run: >


### PR DESCRIPTION
PROD image - when built in non-main branch - needs constraints generated for PyPI builds. Those constraints are generated in "generate-constraints" build but we should not add a dependency for that job, because it will slow-down the regular main builds and PRs. Instead, we should generate the constraints again - this is now rather quick thanks to `uv` so it should not introduce much delay in the non-main builds.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
