### PR TITLE
Add missing containers to helm chart resources docs

### DIFF
--- a/docs/helm-chart/setting-resources-for-containers.rst
+++ b/docs/helm-chart/setting-resources-for-containers.rst
@@ -30,13 +30,16 @@ Possible Containers where resources can be configured include:
    * ``workers.resources``
    * ``workers.logGroomerSidecar.resources``
    * ``workers.kerberosSidecar.resources``
+   * ``workers.kerberosInitContainer.resources``
    * ``scheduler.resources``
    * ``scheduler.logGroomerSidecar.resources``
    * ``dags.gitSync.resources``
    * ``webserver.resources``
    * ``flower.resources``
    * ``dagProcessor.resources``
+   * ``dagProcessor.logGroomerSidecar.resources``
    * ``triggerer.resources``
+   * ``triggerer.logGroomerSidecar.resources``
 
 * Containers used for Airflow k8s jobs or cron jobs. You can add the resources for these Containers through the following parameters:
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This is minor PR that adds missing containers to helm chart `how to set resources per airflow container` docs

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
