### PR TITLE
Fix failure of additional prod image builds in non-main build

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -209,6 +209,7 @@ jobs:
       push-image: "true"
       use-uv: "true"
       image-tag: ${{ needs.build-info.outputs.image-tag }}
+      ci-image-tag: ${{ needs.build-info.outputs.image-tag }}
       platform: "linux/amd64"
       python-versions: ${{ needs.build-info.outputs.python-versions }}
       branch: ${{ needs.build-info.outputs.default-branch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,6 +490,7 @@ jobs:
       build-type: "Regular"
       do-build: ${{ needs.build-info.outputs.in-workflow-build }}
       image-tag: ${{ needs.build-info.outputs.image-tag }}
+      ci-image-tag: ${{ needs.build-info.outputs.image-tag }}
       platform: "linux/amd64"
       python-versions: ${{ needs.build-info.outputs.python-versions }}
       branch: ${{ needs.build-info.outputs.default-branch }}

--- a/.github/workflows/prod-image-build.yml
+++ b/.github/workflows/prod-image-build.yml
@@ -73,6 +73,10 @@ on:  # yamllint disable-line rule:truthy
         description: "Tag to set for the image"
         required: true
         type: string
+      ci-image-tag:
+        description: "Tag to use for the CI image used during the build"
+        required: true
+        type: string
       python-versions:
         description: "JSON-formatted array of Python versions to build images from"
         required: true
@@ -243,23 +247,11 @@ ${{ inputs.do-build == 'true' && inputs.image-tag || '' }}"
         shell: bash
         run: echo "${{ env.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
         if: inputs.do-build == 'true'
-      - name: Pull CI images ${{ inputs.python-versions-list-as-string }}:${{ inputs.image-tag }}
+      - name: Pull CI images ${{ matrix.python-version }}:${{ inputs.ci-image-tag }}
         run: >
-          breeze ci-image pull --tag-as-latest --image-tag "${{ inputs.image-tag }}"
+          breeze ci-image pull --tag-as-latest --image-tag "${{ inputs.ci-image-tag }}"
           --python "${{ matrix.python-version }}"
         if: inputs.do-build == 'true' && inputs.build-provider-packages != 'true'
-      - name: "Prepare chicken-eggs provider packages"
-        # In case of provider packages which use latest dev0 version of providers, we should prepare them
-        # from the source code, not from the PyPI because they have apache-airflow>=X.Y.Z dependency
-        # And when we prepare them from sources they will have apache-airflow>=X.Y.Z.dev0
-        run: >
-          breeze release-management prepare-provider-packages --include-not-ready-providers
-          --package-format wheel --version-suffix-for-pypi dev0
-          ${{ inputs.chicken-egg-providers }}
-        if: >
-          inputs.do-build == 'true' &&
-          inputs.chicken-egg-providers != '' &&
-          inputs.build-provider-packages != 'true'
       - name: "PyPI constraints"
         timeout-minutes: 25
         run: >

--- a/.github/workflows/prod-image-extra-checks.yml
+++ b/.github/workflows/prod-image-extra-checks.yml
@@ -57,6 +57,7 @@ jobs:
     with:
       build-type: "Bullseye"
       image-tag: bullseye-${{ inputs.image-tag }}
+      ci-image-tag: ${{ inputs.image-tag }}
       debian-version: "bullseye"
       python-versions: ${{ inputs.python-versions }}
       platform: "linux/amd64"
@@ -75,6 +76,7 @@ jobs:
     with:
       build-type: "MySQL Client"
       image-tag: mysql-${{ inputs.image-tag }}
+      ci-image-tag: ${{ inputs.image-tag }}
       install-mysql-client-type: "mysql"
       python-versions: ${{ inputs.python-versions }}
       platform: "linux/amd64"
@@ -93,6 +95,7 @@ jobs:
     with:
       build-type: "pip"
       image-tag: mysql-${{ inputs.image-tag }}
+      ci-image-tag: ${{ inputs.image-tag }}
       install-mysql-client-type: "mysql"
       python-versions: ${{ inputs.python-versions }}
       platform: "linux/amd64"


### PR DESCRIPTION
As of #38533 - we are building locally constraints for non-main production image builds. This change required CI images to be used and pulled before they were used. For "additional" image checks image-tag used in this case contained the "extra" prefix and the CI image could not be pulled.

This change fixes this, it also displays the right Python version when pulling CI image and forces it's use in the pull/constraint steps to be explicitly used when provider packages are built.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
