### PR TITLE
Optimize preparing packages for PROD image builds

### DIFF
--- a/.github/workflows/additional-prod-image-tests.yml
+++ b/.github/workflows/additional-prod-image-tests.yml
@@ -16,7 +16,7 @@
 # under the License.
 #
 ---
-name: All PROD image tests
+name: Additional PROD image tests
 on:  # yamllint disable-line rule:truthy
   workflow_call:
     inputs:

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -158,6 +158,7 @@ jobs:
           PR_LABELS: ${{ steps.get-latest-pr-labels.outputs.pull-request-labels }}
           GITHUB_CONTEXT: ${{ toJson(github) }}
 
+
   build-ci-images:
     name: Build CI images
     permissions:
@@ -203,6 +204,7 @@ jobs:
       runs-on: '["ubuntu-22.04"]'
       build-type: "Regular"
       do-build: ${{ needs.build-info.outputs.ci-image-build }}
+      upload-package-artifact: "true"
       target-commit-sha: ${{ needs.build-info.outputs.target-commit-sha }}
       pull-request-target: "true"
       is-committer-build: ${{ needs.build-info.outputs.is-committer-build }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -489,6 +489,7 @@ jobs:
       runs-on: '["ubuntu-22.04"]'
       build-type: "Regular"
       do-build: ${{ needs.build-info.outputs.in-workflow-build }}
+      upload-package-artifact: "true"
       image-tag: ${{ needs.build-info.outputs.image-tag }}
       ci-image-tag: ${{ needs.build-info.outputs.image-tag }}
       platform: "linux/amd64"

--- a/.github/workflows/prod-image-build.yml
+++ b/.github/workflows/prod-image-build.yml
@@ -38,6 +38,12 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: "true"
         type: string
+      upload-package-artifact:
+        description: >
+          Whether to upload package artifacts (true/false). If false, the job will rely on artifacts prepared
+          by the main prod-image build job.
+        required: true
+        type: string
       target-commit-sha:
         description: "The commit SHA to checkout for the build"
         required: false
@@ -110,6 +116,74 @@ on:  # yamllint disable-line rule:truthy
         required: true
         type: string
 jobs:
+
+  build-prod-packages:
+    name: "${{ inputs.do-build == 'true' && 'Build' || 'Skip building' }} Airflow and provider packages"
+    timeout-minutes: 10
+    runs-on: ["ubuntu-22.04"]
+    env:
+      PYTHON_MAJOR_MINOR_VERSION: "${{ inputs.default-python-version }}"
+    steps:
+      - name: "Cleanup repo"
+        shell: bash
+        run: docker run -v "${GITHUB_WORKSPACE}:/workspace" -u 0:0 bash -c "rm -rf /workspace/*"
+        if: inputs.do-build == 'true' && inputs.upload-package-artifact == 'true'
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+        if: inputs.do-build == 'true' && inputs.upload-package-artifact == 'true'
+      - name: Cleanup docker
+        uses: ./.github/actions/cleanup-docker
+        if: inputs.do-build == 'true' && inputs.upload-package-artifact == 'true'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "${{ inputs.default-python-version }}"
+        if: inputs.do-build == 'true' && inputs.upload-package-artifact == 'true'
+      - name: "Cleanup dist and context file"
+        shell: bash
+        run: rm -fv ./dist/* ./docker-context-files/*
+        if: inputs.do-build == 'true' && inputs.upload-package-artifact == 'true'
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
+        if: inputs.do-build == 'true' && inputs.upload-package-artifact == 'true'
+      - name: "Prepare providers packages"
+        shell: bash
+        run: >
+          breeze release-management prepare-provider-packages
+          --package-list-file ./prod_image_installed_providers.txt
+          --package-format wheel --version-suffix-for-pypi dev0
+        if: >
+          inputs.do-build == 'true' &&
+          inputs.upload-package-artifact == 'true' &&
+          inputs.build-provider-packages == 'true'
+      - name: "Prepare chicken-eggs provider packages"
+        # In case of provider packages which use latest dev0 version of providers, we should prepare them
+        # from the source code, not from the PyPI because they have apache-airflow>=X.Y.Z dependency
+        # And when we prepare them from sources they will have apache-airflow>=X.Y.Z.dev0
+        shell: bash
+        run: >
+          breeze release-management prepare-provider-packages
+          --package-format wheel --version-suffix-for-pypi dev0 ${{ inputs.chicken-egg-providers }}
+        if: >
+          inputs.do-build  == 'true' &&
+          inputs.upload-package-artifact == 'true' &&
+          inputs.chicken-egg-providers != ''
+      - name: "Prepare airflow package"
+        shell: bash
+        run: >
+          breeze release-management prepare-airflow-package
+          --package-format wheel --version-suffix-for-pypi dev0
+        if: inputs.do-build  == 'true' && inputs.upload-package-artifact == 'true'
+      - name: "Upload prepared packages as artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+          name: prod-packages
+          path: ./dist
+          retention-days: 7
+          if-no-files-found: error
+        if: inputs.do-build  == 'true' && inputs.upload-package-artifact == 'true'
+
   build-prod-images:
     strategy:
       fail-fast: true
@@ -123,6 +197,8 @@ PROD ${{ inputs.build-type }} image\
 ${{ matrix.python-version }}${{ inputs.do-build == 'true' && ':' || '' }}\
 ${{ inputs.do-build == 'true' && inputs.image-tag || '' }}"
     runs-on: ${{ fromJSON(inputs.runs-on) }}
+    needs:
+      - build-prod-packages
     env:
       BACKEND: sqlite
       DEFAULT_BRANCH: ${{ inputs.branch }}
@@ -209,33 +285,11 @@ ${{ inputs.do-build == 'true' && inputs.image-tag || '' }}"
         shell: bash
         run: rm -fv ./dist/* ./docker-context-files/*
         if: inputs.do-build == 'true'
-      - name: "Prepare providers packages"
-        shell: bash
-        run: >
-          breeze release-management prepare-provider-packages
-          --package-list-file ./prod_image_installed_providers.txt
-          --package-format wheel --version-suffix-for-pypi dev0
-        if: inputs.do-build == 'true' && inputs.build-provider-packages == 'true'
-      - name: "Prepare chicken-eggs provider packages"
-        # In case of provider packages which use latest dev0 version of providers, we should prepare them
-        # from the source code, not from the PyPI because they have apache-airflow>=X.Y.Z dependency
-        # And when we prepare them from sources they will have apache-airflow>=X.Y.Z.dev0
-        shell: bash
-        run: >
-          breeze release-management prepare-provider-packages
-          --package-format wheel --version-suffix-for-pypi dev0 ${{ inputs.chicken-egg-providers }}
-        if: >
-          inputs.do-build == 'true' && inputs.build-provider-packages != 'true' &&
-          inputs.chicken-egg-providers != ''
-      - name: "Prepare airflow package"
-        shell: bash
-        run: >
-          breeze release-management prepare-airflow-package
-          --package-format wheel --version-suffix-for-pypi dev0
-        if: inputs.do-build == 'true'
-      - name: "Copy dist packages to docker-context files"
-        shell: bash
-        run: cp -v --no-preserve=mode,ownership ./dist/*.whl ./docker-context-files
+      - name: "Download packages prepared as artifacts"
+        uses: actions/download-artifact@v4
+        with:
+          name: prod-packages
+          path: ./docker-context-files
         if: inputs.do-build == 'true'
       - name: "Download constraints from the CI build"
         uses: actions/download-artifact@v4

--- a/.github/workflows/prod-image-extra-checks.yml
+++ b/.github/workflows/prod-image-extra-checks.yml
@@ -56,6 +56,7 @@ jobs:
     uses: ./.github/workflows/prod-image-build.yml
     with:
       build-type: "Bullseye"
+      upload-package-artifact: "false"
       image-tag: bullseye-${{ inputs.image-tag }}
       ci-image-tag: ${{ inputs.image-tag }}
       debian-version: "bullseye"
@@ -75,6 +76,7 @@ jobs:
     uses: ./.github/workflows/prod-image-build.yml
     with:
       build-type: "MySQL Client"
+      upload-package-artifact: "false"
       image-tag: mysql-${{ inputs.image-tag }}
       ci-image-tag: ${{ inputs.image-tag }}
       install-mysql-client-type: "mysql"
@@ -94,6 +96,7 @@ jobs:
     uses: ./.github/workflows/prod-image-build.yml
     with:
       build-type: "pip"
+      upload-package-artifact: "false"
       image-tag: mysql-${{ inputs.image-tag }}
       ci-image-tag: ${{ inputs.image-tag }}
       install-mysql-client-type: "mysql"

--- a/.github/workflows/push-image-cache.yml
+++ b/.github/workflows/push-image-cache.yml
@@ -174,15 +174,11 @@ jobs:
         uses: ./.github/actions/breeze
       - name: "Cleanup dist and context file"
         run: rm -fv ./dist/* ./docker-context-files/*
-      - name: "Prepare airflow package for PROD build"
-        run: breeze release-management prepare-airflow-package --package-format wheel
-      - name: "Prepare providers packages for PROD build"
-        run: >
-          breeze release-management prepare-provider-packages
-          --package-list-file ./prod_image_installed_providers.txt
-          --package-format wheel
-      - name: "Copy dist packages to docker-context files"
-        run: cp -v --no-preserve=mode,ownership ./dist/*.whl ./docker-context-files
+      - name: "Download packages prepared as artifacts"
+        uses: actions/download-artifact@v4
+        with:
+          name: prod-packages
+          path: ./docker-context-files
       - name: "Start ARM instance"
         run: ./scripts/ci/images/ci_start_arm_instance_and_connect_to_docker.sh
         if: inputs.platform == 'linux/arm64'


### PR DESCRIPTION
With this change provider and airflow packages are prepared only once for all PROD image builds and uploaded as artifacts. This saves ~ 4 minutes per PROD image build (which is multiplied by the number of Python versions we have and by all the additional PROD image checks we have.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
