### PR TITLE
Fix too long constraint generation in `pip` builds

### DIFF
--- a/.github/workflows/prod-image-build.yml
+++ b/.github/workflows/prod-image-build.yml
@@ -258,6 +258,9 @@ ${{ inputs.do-build == 'true' && inputs.image-tag || '' }}"
           breeze release-management generate-constraints --python  "${{ matrix.python-version }}"
           --airflow-constraints-mode constraints --answer yes
           --chicken-egg-providers "${{ inputs.chicken-egg-providers }}"
+        env:
+          # always use UV for constraints generation even if we build `pip` image
+          USE_UV: "true"
         if: inputs.do-build == 'true' && inputs.build-provider-packages != 'true'
       # This cleanup is needed as we will run out of disk space if we keep both CI and PROD images
       # on public runners.

--- a/scripts/in_container/run_generate_constraints.py
+++ b/scripts/in_container/run_generate_constraints.py
@@ -367,6 +367,7 @@ def generate_constraints_pypi_providers(config_params: ConfigParams) -> None:
                     f"a chicken egg provider"
                 )
                 packages_to_install.append(f"{provider_package} @ file://{file.as_posix()}")
+                break
             else:
                 console.print(
                     f"[yellow]Skipping {provider_package} as it is not found in dist folder to install."


### PR DESCRIPTION
Even if we are using `pip` to generate image, we still want to make sure constraints generation is done by UV as it is far more efficient.

This PR fixes too long constraint generation we seein v2-* branch now.

It also adds missing break in constraint generation that produces a misleading warning that chicken-egg provider package has not been used.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
