### PR TITLE
Avoid accidentally upgrading airflow in compatibility check

### DIFF
--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -473,11 +473,6 @@ BASE_PROVIDERS_COMPATIBILITY_CHECKS: list[dict[str, str]] = [
         "remove-providers": _exclusion(["openlineage", "common.io", "cohere", "fab", "qdrant"]),
     },
     {
-        "python-version": "3.9",
-        "airflow-version": "2.6.0",
-        "remove-providers": _exclusion(["openlineage", "common.io", "fab", "qdrant"]),
-    },
-    {
         "python-version": "3.8",
         "airflow-version": "2.7.1",
         "remove-providers": _exclusion(["common.io", "fab"]),

--- a/scripts/in_container/install_airflow_and_providers.py
+++ b/scripts/in_container/install_airflow_and_providers.py
@@ -500,6 +500,12 @@ def install_airflow_and_providers(
         for provider_package in installation_spec.provider_packages:
             base_install_providers_cmd.append(provider_package)
         install_providers_command = base_install_providers_cmd.copy()
+        # if airflow is also being installed we should add airflow to the base_install_providers_cmd
+        # to avoid accidentally upgrading airflow to a version that is different than installed in the
+        # previous step
+        if installation_spec.airflow_package:
+            base_install_providers_cmd.append(installation_spec.airflow_package)
+
         if installation_spec.provider_constraints_location:
             console.print(
                 f"[bright_blue]with constraints: {installation_spec.provider_constraints_location}\n"


### PR DESCRIPTION
When running compatibility check of providers with airflow, we install airflow first (with constraints) and providers as the next step (without constraints). This might - in some cases lead to accidental upgrade of airflow if `pip` decides to do so.

By adding airflow package to the list of providers to install, we will keep it from being accidentally upgraded.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
