### PR TITLE
Don't double-serialize params node in RPC API

### DIFF
--- a/airflow/api_internal/endpoints/rpc_api_endpoint.py
+++ b/airflow/api_internal/endpoints/rpc_api_endpoint.py
@@ -115,7 +115,7 @@ def internal_airflow_api(body: dict[str, Any]) -> APIResponse:
     params = {}
     try:
         if body.get("params"):
-            params_json = json.loads(str(body.get("params")))
+            params_json = body.get("params")
             params = BaseSerialization.deserialize(params_json, use_pydantic_models=True)
     except Exception as e:
         log.error("Error when deserializing parameters for method: %s.", method_name)

--- a/airflow/api_internal/internal_api_call.py
+++ b/airflow/api_internal/internal_api_call.py
@@ -123,12 +123,9 @@ def internal_api_call(func: Callable[PS, RT]) -> Callable[PS, RT]:
         if "cls" in arguments_dict:  # used by @classmethod
             del arguments_dict["cls"]
 
-        args_json = json.dumps(
-            BaseSerialization.serialize(arguments_dict, use_pydantic_models=True),
-            default=BaseSerialization.serialize,
-        )
+        args_dict = BaseSerialization.serialize(arguments_dict, use_pydantic_models=True)
         method_name = f"{func.__module__}.{func.__qualname__}"
-        result = make_jsonrpc_request(method_name, args_json)
+        result = make_jsonrpc_request(method_name, args_dict)
         if result is None or result == b"":
             return None
         return BaseSerialization.deserialize(json.loads(result), use_pydantic_models=True)

--- a/airflow/api_internal/openapi/internal_api_v1.yaml
+++ b/airflow/api_internal/openapi/internal_api_v1.yaml
@@ -67,7 +67,7 @@ paths:
                   description: Method name
                 params:
                   title: Parameters
-                  type: string
+                  type: object
   "/health":
     get:
       operationId: health

--- a/tests/api_internal/endpoints/test_rpc_api_endpoint.py
+++ b/tests/api_internal/endpoints/test_rpc_api_endpoint.py
@@ -85,23 +85,23 @@ class TestRpcApiEndpoint:
     @pytest.mark.parametrize(
         "input_params, method_result, result_cmp_func, method_params",
         [
-            ("", None, lambda got, _: got == b"", {}),
-            ("", "test_me", equals, {}),
+            ({}, None, lambda got, _: got == b"", {}),
+            ({}, "test_me", equals, {}),
             (
-                json.dumps(BaseSerialization.serialize({"dag_id": 15, "task_id": "fake-task"})),
+                BaseSerialization.serialize({"dag_id": 15, "task_id": "fake-task"}),
                 ("dag_id_15", "fake-task", 1),
                 equals,
                 {"dag_id": 15, "task_id": "fake-task"},
             ),
             (
-                "",
+                {},
                 TaskInstance(task=EmptyOperator(task_id="task"), run_id="run_id", state=State.RUNNING),
                 lambda a, b: a.model_dump() == TaskInstancePydantic.model_validate(b).model_dump()
                 and isinstance(a.task, BaseOperator),
                 {},
             ),
             (
-                "",
+                {},
                 Connection(conn_id="test_conn", conn_type="http", host="", password=""),
                 lambda a, b: a.get_uri() == b.get_uri() and a.conn_id == b.conn_id,
                 {},
@@ -133,7 +133,7 @@ class TestRpcApiEndpoint:
 
     def test_method_with_exception(self):
         mock_test_method.side_effect = ValueError("Error!!!")
-        data = {"jsonrpc": "2.0", "method": TEST_METHOD_NAME, "params": ""}
+        data = {"jsonrpc": "2.0", "method": TEST_METHOD_NAME, "params": {}}
 
         response = self.client.post(
             "/internal_api/v1/rpcapi", headers={"Content-Type": "application/json"}, data=json.dumps(data)
@@ -143,7 +143,7 @@ class TestRpcApiEndpoint:
         mock_test_method.assert_called_once()
 
     def test_unknown_method(self):
-        data = {"jsonrpc": "2.0", "method": "i-bet-it-does-not-exist", "params": ""}
+        data = {"jsonrpc": "2.0", "method": "i-bet-it-does-not-exist", "params": {}}
 
         response = self.client.post(
             "/internal_api/v1/rpcapi", headers={"Content-Type": "application/json"}, data=json.dumps(data)
@@ -153,7 +153,7 @@ class TestRpcApiEndpoint:
         mock_test_method.assert_not_called()
 
     def test_invalid_jsonrpc(self):
-        data = {"jsonrpc": "1.0", "method": TEST_METHOD_NAME, "params": ""}
+        data = {"jsonrpc": "1.0", "method": TEST_METHOD_NAME, "params": {}}
 
         response = self.client.post(
             "/internal_api/v1/rpcapi", headers={"Content-Type": "application/json"}, data=json.dumps(data)


### PR DESCRIPTION
By not encoding params as json _first_ before finally serializing the whole payload, we avoid double-encoding the params, which makes it a little friendlier to debug.