### PR TITLE
Add health endpoint to the RPC server

### DIFF
--- a/airflow/api_internal/endpoints/health_endpoint.py
+++ b/airflow/api_internal/endpoints/health_endpoint.py
@@ -17,10 +17,6 @@
 
 from __future__ import annotations
 
-import logging
-
-log = logging.getLogger(__name__)
-
 
 def health():
-    return True
+    return {}

--- a/airflow/api_internal/endpoints/health_endpoint.py
+++ b/airflow/api_internal/endpoints/health_endpoint.py
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def health():
+    return True

--- a/airflow/api_internal/openapi/internal_api_v1.yaml
+++ b/airflow/api_internal/openapi/internal_api_v1.yaml
@@ -68,6 +68,18 @@ paths:
                 params:
                   title: Parameters
                   type: string
+  "/health":
+    get:
+      operationId: health
+      deprecated: false
+      x-openapi-router-controller: airflow.api_internal.endpoints.health_endpoint
+      operationId: health
+      tags:
+      - JSONRPC
+      parameters: []
+      responses:
+        '200':
+          description: Successful response
 x-headers: []
 x-explorer-enabled: true
 x-proxy-enabled: true


### PR DESCRIPTION
Will be necessary for helm chart.

Right now I just have it returning True, because presumably if it can respond to such a request, it's health. Not sure if there's a more robust indicator of its readiness.... 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
