### PR TITLE
Make _get_ti compatible with RPC

### DIFF
--- a/airflow/api_internal/endpoints/rpc_api_endpoint.py
+++ b/airflow/api_internal/endpoints/rpc_api_endpoint.py
@@ -37,6 +37,7 @@ log = logging.getLogger(__name__)
 
 @functools.lru_cache
 def _initialize_map() -> dict[str, Callable]:
+    from airflow.cli.commands.task_command import _get_ti_db_access
     from airflow.dag_processing.manager import DagFileProcessorManager
     from airflow.dag_processing.processor import DagFileProcessor
     from airflow.models import Trigger, Variable, XCom
@@ -51,6 +52,7 @@ def _initialize_map() -> dict[str, Callable]:
     functions: list[Callable] = [
         _get_template_context,
         _update_rtif,
+        _get_ti_db_access,
         DagFileProcessor.update_import_errors,
         DagFileProcessor.manage_slas,
         DagFileProcessorManager.deactivate_stale_dags,

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -169,6 +169,9 @@ def _get_ti_db_access(
     session: Session = NEW_SESSION,
 ) -> tuple[TaskInstance | TaskInstancePydantic, bool]:
     """Get the task instance through DagRun.run_id, if that fails, get the TI the old way."""
+    if task.dag_id != dag.dag_id:
+        raise ValueError(f"Provided task '{task.task_id}' is not assigned to provided dag {dag.dag_id}.")
+
     if not exec_date_or_run_id and not create_if_necessary:
         raise ValueError("Must provide `exec_date_or_run_id` if not `create_if_necessary`.")
     if needs_expansion(task):

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -34,7 +34,7 @@ from pendulum.parsing.exceptions import ParserError
 from sqlalchemy import select
 
 from airflow import settings
-from airflow.api_internal.internal_api_call import InternalApiConfig
+from airflow.api_internal.internal_api_call import InternalApiConfig, internal_api_call
 from airflow.cli.simple_table import AirflowConsole
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException, DagRunNotFound, TaskDeferred, TaskInstanceNotFound
@@ -156,8 +156,10 @@ def _get_dag_run(
     raise ValueError(f"unknown create_if_necessary value: {create_if_necessary!r}")
 
 
+@internal_api_call
 @provide_session
-def _get_ti(
+def _get_ti_db_access(
+    dag: DAG,
     task: Operator,
     map_index: int,
     *,
@@ -167,9 +169,6 @@ def _get_ti(
     session: Session = NEW_SESSION,
 ) -> tuple[TaskInstance | TaskInstancePydantic, bool]:
     """Get the task instance through DagRun.run_id, if that fails, get the TI the old way."""
-    dag = task.dag
-    if dag is None:
-        raise ValueError("Cannot get task instance for a task not assigned to a DAG")
     if not exec_date_or_run_id and not create_if_necessary:
         raise ValueError("Must provide `exec_date_or_run_id` if not `create_if_necessary`.")
     if needs_expansion(task):
@@ -198,6 +197,33 @@ def _get_ti(
     else:
         ti = ti_or_none
     ti.refresh_from_task(task, pool_override=pool)
+    return ti, dr_created
+
+
+def _get_ti(
+    task: Operator,
+    map_index: int,
+    *,
+    exec_date_or_run_id: str | None = None,
+    pool: str | None = None,
+    create_if_necessary: CreateIfNecessary = False,
+):
+    dag = task.dag
+    if dag is None:
+        raise ValueError("Cannot get task instance for a task not assigned to a DAG")
+
+    ti, dr_created = _get_ti_db_access(
+        dag=dag,
+        task=task,
+        map_index=map_index,
+        exec_date_or_run_id=exec_date_or_run_id,
+        pool=pool,
+        create_if_necessary=create_if_necessary,
+    )
+    # setting ti.task is necessary for AIP-44 since the task object does not serialize perfectly
+    # if we update the serialization logic for Operator to also serialize the dag object on it,
+    # then this would not be necessary;
+    ti.task = task
     return ti, dr_created
 
 
@@ -517,7 +543,8 @@ def task_list(args, dag: DAG | None = None) -> None:
 
 
 class _SupportedDebugger(Protocol):
-    def post_mortem(self) -> None: ...
+    def post_mortem(self) -> None:
+        ...
 
 
 SUPPORTED_DEBUGGER_MODULES = [

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -543,8 +543,7 @@ def task_list(args, dag: DAG | None = None) -> None:
 
 
 class _SupportedDebugger(Protocol):
-    def post_mortem(self) -> None:
-        ...
+    def post_mortem(self) -> None: ...
 
 
 SUPPORTED_DEBUGGER_MODULES = [

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -112,17 +112,18 @@ def _get_dag_run(
        the logical date; otherwise use it as a run ID and set the logical date
        to the current time.
     """
+    session_kwarg = {"session": session} if session else {}
     if not exec_date_or_run_id and not create_if_necessary:
         raise ValueError("Must provide `exec_date_or_run_id` if not `create_if_necessary`.")
     execution_date: pendulum.DateTime | None = None
     if exec_date_or_run_id:
-        dag_run = DAG.fetch_dagrun(dag_id=dag.dag_id, run_id=exec_date_or_run_id, session=session)
+        dag_run = DAG.fetch_dagrun(dag_id=dag.dag_id, run_id=exec_date_or_run_id, **session_kwarg)
         if dag_run:
             return dag_run, False
         with suppress(ParserError, TypeError):
             execution_date = timezone.parse(exec_date_or_run_id)
         if execution_date:
-            dag_run = DAG.fetch_dagrun(dag_id=dag.dag_id, execution_date=execution_date, session=session)
+            dag_run = DAG.fetch_dagrun(dag_id=dag.dag_id, execution_date=execution_date, **session_kwarg)
         if dag_run:
             return dag_run, False
         elif not create_if_necessary:
@@ -150,7 +151,7 @@ def _get_dag_run(
             execution_date=dag_run_execution_date,
             run_id=_generate_temporary_run_id(),
             data_interval=dag.timetable.infer_manual_data_interval(run_after=dag_run_execution_date),
-            session=session,
+            **session_kwarg,
         )
         return dag_run, True
     raise ValueError(f"unknown create_if_necessary value: {create_if_necessary!r}")
@@ -166,6 +167,11 @@ def _get_ti(
     session: Session | None = None,
 ) -> tuple[TaskInstance | TaskInstancePydantic, bool]:
     """Get the task instance through DagRun.run_id, if that fails, get the TI the old way."""
+    # this is required by AIP-44; if there's a session here, let's use it
+    # if it's None, don't pass it (because @provide_session does not check
+    # whether the provided session is None or not
+    session_kwarg = {"session": session} if session else {}
+
     dag = task.dag
     if dag is None:
         raise ValueError("Cannot get task instance for a task not assigned to a DAG")
@@ -180,10 +186,10 @@ def _get_ti(
         dag=dag,
         exec_date_or_run_id=exec_date_or_run_id,
         create_if_necessary=create_if_necessary,
-        session=session,
+        **session_kwarg,
     )
 
-    ti_or_none = dag_run.get_task_instance(task.task_id, map_index=map_index, session=session)
+    ti_or_none = dag_run.get_task_instance(task.task_id, map_index=map_index, **session_kwarg)
     ti: TaskInstance | TaskInstancePydantic
     if ti_or_none is None:
         if not create_if_necessary:
@@ -516,7 +522,8 @@ def task_list(args, dag: DAG | None = None) -> None:
 
 
 class _SupportedDebugger(Protocol):
-    def post_mortem(self) -> None: ...
+    def post_mortem(self) -> None:
+        ...
 
 
 SUPPORTED_DEBUGGER_MODULES = [

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -156,7 +156,6 @@ def _get_dag_run(
     raise ValueError(f"unknown create_if_necessary value: {create_if_necessary!r}")
 
 
-@provide_session
 def _get_ti(
     task: Operator,
     map_index: int,
@@ -164,7 +163,7 @@ def _get_ti(
     exec_date_or_run_id: str | None = None,
     pool: str | None = None,
     create_if_necessary: CreateIfNecessary = False,
-    session: Session = NEW_SESSION,
+    session: Session | None = None,
 ) -> tuple[TaskInstance | TaskInstancePydantic, bool]:
     """Get the task instance through DagRun.run_id, if that fails, get the TI the old way."""
     dag = task.dag

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -776,7 +776,6 @@ def _get_template_context(
         nonlocal dag_run
         if dag_run not in session:
             dag_run = session.merge(dag_run, load=False)
-
         dataset_events = dag_run.consumed_dataset_events
         triggering_events: dict[str, list[DatasetEvent | DatasetEventPydantic]] = defaultdict(list)
         for event in dataset_events:

--- a/airflow/serialization/pydantic/dag_run.py
+++ b/airflow/serialization/pydantic/dag_run.py
@@ -78,7 +78,7 @@ class DagRunPydantic(BaseModelPydantic):
     def get_task_instance(
         self,
         task_id: str,
-        session: Session,
+        session: Session | None = None,
         *,
         map_index: int = -1,
     ) -> TI | TaskInstancePydantic | None:

--- a/airflow/serialization/pydantic/dag_run.py
+++ b/airflow/serialization/pydantic/dag_run.py
@@ -78,7 +78,7 @@ class DagRunPydantic(BaseModelPydantic):
     def get_task_instance(
         self,
         task_id: str,
-        session: Session | None = None,
+        session: Session,
         *,
         map_index: int = -1,
     ) -> TI | TaskInstancePydantic | None:

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -539,9 +539,9 @@ class BaseSerialization:
         elif isinstance(var, Resources):
             return var.to_dict()
         elif isinstance(var, MappedOperator):
-            return SerializedBaseOperator.serialize_mapped_operator(var)
+            return cls._encode(SerializedBaseOperator.serialize_mapped_operator(var), type_=DAT.OP)
         elif isinstance(var, BaseOperator):
-            return SerializedBaseOperator.serialize_operator(var)
+            return cls._encode(SerializedBaseOperator.serialize_operator(var), type_=DAT.OP)
         elif isinstance(var, cls._datetime_types):
             return cls._encode(var.timestamp(), type_=DAT.DATETIME)
         elif isinstance(var, datetime.timedelta):
@@ -1476,9 +1476,15 @@ class SerializedDAG(DAG, BaseSerialization):
                 v = set(v)
             elif k == "tasks":
                 SerializedBaseOperator._load_operator_extra_links = cls._load_operator_extra_links
-
-                v = {task["task_id"]: SerializedBaseOperator.deserialize_operator(task) for task in v}
+                tasks = {}
+                for obj in v:
+                    if obj.get(Encoding.TYPE) == DAT.OP:
+                        deser = SerializedBaseOperator.deserialize_operator(obj[Encoding.VAR])
+                        tasks[deser.task_id] = deser
+                    else:  # this is backcompat for pre-2.10
+                        tasks[obj["task_id"]] = SerializedBaseOperator.deserialize_operator(obj)
                 k = "task_dict"
+                v = tasks
             elif k == "timezone":
                 v = cls._deserialize_timezone(v)
             elif k == "dagrun_timeout":

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -1481,7 +1481,7 @@ class SerializedDAG(DAG, BaseSerialization):
                     if obj.get(Encoding.TYPE) == DAT.OP:
                         deser = SerializedBaseOperator.deserialize_operator(obj[Encoding.VAR])
                         tasks[deser.task_id] = deser
-                    else:  # this is backcompat for pre-2.10
+                    else:  # todo: remove in Airflow 3.0 (backcompat for pre-2.10)
                         tasks[obj["task_id"]] = SerializedBaseOperator.deserialize_operator(obj)
                 k = "task_dict"
                 v = tasks

--- a/tests/providers/amazon/aws/links/test_base_aws.py
+++ b/tests/providers/amazon/aws/links/test_base_aws.py
@@ -203,7 +203,7 @@ class BaseAwsLinksTestCase:
         """Test: Operator links should exist for serialized DAG."""
         self.create_op_and_ti(self.link_class, dag_id="test_link_serialize", task_id=self.task_id)
         serialized_dag = self.dag_maker.get_serialized_data()
-        operator_extra_link = serialized_dag["dag"]["tasks"][0]["_operator_extra_links"]
+        operator_extra_link = serialized_dag["dag"]["tasks"][0]["__var"]["_operator_extra_links"]
         error_message = "Operator links should exist for serialized DAG"
         assert operator_extra_link == [{self.full_qualname: {}}], error_message
 

--- a/tests/providers/amazon/aws/operators/test_emr_serverless.py
+++ b/tests/providers/amazon/aws/operators/test_emr_serverless.py
@@ -38,7 +38,7 @@ from airflow.providers.amazon.aws.operators.emr import (
     EmrServerlessStopApplicationOperator,
 )
 from airflow.serialization.serialized_objects import (
-    SerializedBaseOperator,
+    BaseSerialization,
 )
 from airflow.utils.types import NOTSET
 
@@ -1118,11 +1118,10 @@ class TestEmrServerlessStartJobOperator:
             configuration_overrides=[s3_configuration_overrides, cloudwatch_configuration_overrides],
         )
 
-        serialize = SerializedBaseOperator.serialize
-        deserialize = SerializedBaseOperator.deserialize_operator
-        deserialized_operator = deserialize(serialize(operator))
+        ser_operator = BaseSerialization.serialize(operator)
+        deser_operator = BaseSerialization.deserialize(ser_operator)
 
-        assert deserialized_operator.operator_extra_links == [
+        assert deser_operator.operator_extra_links == [
             EmrServerlessS3LogsLink(),
             EmrServerlessCloudWatchLogsLink(),
         ]
@@ -1140,11 +1139,10 @@ class TestEmrServerlessStartJobOperator:
             configuration_overrides=[s3_configuration_overrides, cloudwatch_configuration_overrides],
         )
 
-        serialize = SerializedBaseOperator.serialize
-        deserialize = SerializedBaseOperator.deserialize_operator
-        deserialized_operator = deserialize(serialize(operator))
+        ser_operator = BaseSerialization.serialize(operator)
+        deser_operator = BaseSerialization.deserialize(ser_operator)
 
-        assert deserialized_operator.operator_extra_links == [
+        assert deser_operator.operator_extra_links == [
             EmrServerlessS3LogsLink(),
             EmrServerlessCloudWatchLogsLink(),
             EmrServerlessDashboardLink(),

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -729,7 +729,7 @@ class TestBigQueryOperator:
             sql="SELECT * FROM test_table",
         )
         serialized_dag = dag_maker.get_serialized_data()
-        assert "sql" in serialized_dag["dag"]["tasks"][0]
+        assert "sql" in serialized_dag["dag"]["tasks"][0]["__var"]
 
         dag = SerializedDAG.from_dict(serialized_dag)
         simple_task = dag.task_dict[TASK_ID]
@@ -740,7 +740,7 @@ class TestBigQueryOperator:
         #########################################################
 
         # Check Serialized version of operator link
-        assert serialized_dag["dag"]["tasks"][0]["_operator_extra_links"] == [
+        assert serialized_dag["dag"]["tasks"][0]["__var"]["_operator_extra_links"] == [
             {"airflow.providers.google.cloud.operators.bigquery.BigQueryConsoleLink": {}}
         ]
 
@@ -766,7 +766,7 @@ class TestBigQueryOperator:
             sql=["SELECT * FROM test_table", "SELECT * FROM test_table2"],
         )
         serialized_dag = dag_maker.get_serialized_data()
-        assert "sql" in serialized_dag["dag"]["tasks"][0]
+        assert "sql" in serialized_dag["dag"]["tasks"][0]["__var"]
 
         dag = SerializedDAG.from_dict(serialized_dag)
         simple_task = dag.task_dict[TASK_ID]
@@ -777,7 +777,7 @@ class TestBigQueryOperator:
         #########################################################
 
         # Check Serialized version of operator link
-        assert serialized_dag["dag"]["tasks"][0]["_operator_extra_links"] == [
+        assert serialized_dag["dag"]["tasks"][0]["__var"]["_operator_extra_links"] == [
             {"airflow.providers.google.cloud.operators.bigquery.BigQueryConsoleIndexableLink": {"index": 0}},
             {"airflow.providers.google.cloud.operators.bigquery.BigQueryConsoleIndexableLink": {"index": 1}},
         ]

--- a/tests/providers/google/cloud/operators/test_dataproc.py
+++ b/tests/providers/google/cloud/operators/test_dataproc.py
@@ -1065,7 +1065,7 @@ def test_create_cluster_operator_extra_links(dag_maker, create_task_instance_of_
     deserialized_task = deserialized_dag.task_dict[TASK_ID]
 
     # Assert operator links for serialized DAG
-    assert serialized_dag["dag"]["tasks"][0]["_operator_extra_links"] == [
+    assert serialized_dag["dag"]["tasks"][0]["__var"]["_operator_extra_links"] == [
         {"airflow.providers.google.cloud.links.dataproc.DataprocClusterLink": {}}
     ]
 
@@ -1167,7 +1167,7 @@ def test_scale_cluster_operator_extra_links(dag_maker, create_task_instance_of_o
     deserialized_task = deserialized_dag.task_dict[TASK_ID]
 
     # Assert operator links for serialized DAG
-    assert serialized_dag["dag"]["tasks"][0]["_operator_extra_links"] == [
+    assert serialized_dag["dag"]["tasks"][0]["__var"]["_operator_extra_links"] == [
         {"airflow.providers.google.cloud.links.dataproc.DataprocLink": {}}
     ]
 
@@ -1562,7 +1562,7 @@ def test_submit_job_operator_extra_links(mock_hook, dag_maker, create_task_insta
     deserialized_task = deserialized_dag.task_dict[TASK_ID]
 
     # Assert operator links for serialized_dag
-    assert serialized_dag["dag"]["tasks"][0]["_operator_extra_links"] == [
+    assert serialized_dag["dag"]["tasks"][0]["__var"]["_operator_extra_links"] == [
         {"airflow.providers.google.cloud.links.dataproc.DataprocJobLink": {}}
     ]
 
@@ -1767,7 +1767,7 @@ def test_update_cluster_operator_extra_links(dag_maker, create_task_instance_of_
     deserialized_task = deserialized_dag.task_dict[TASK_ID]
 
     # Assert operator links for serialized_dag
-    assert serialized_dag["dag"]["tasks"][0]["_operator_extra_links"] == [
+    assert serialized_dag["dag"]["tasks"][0]["__var"]["_operator_extra_links"] == [
         {"airflow.providers.google.cloud.links.dataproc.DataprocClusterLink": {}}
     ]
 
@@ -1989,7 +1989,7 @@ def test_instantiate_workflow_operator_extra_links(mock_hook, dag_maker, create_
     deserialized_task = deserialized_dag.task_dict[TASK_ID]
 
     # Assert operator links for serialized_dag
-    assert serialized_dag["dag"]["tasks"][0]["_operator_extra_links"] == [
+    assert serialized_dag["dag"]["tasks"][0]["__var"]["_operator_extra_links"] == [
         {"airflow.providers.google.cloud.links.dataproc.DataprocWorkflowLink": {}}
     ]
 
@@ -2151,7 +2151,7 @@ def test_instantiate_inline_workflow_operator_extra_links(
     deserialized_task = deserialized_dag.task_dict[TASK_ID]
 
     # Assert operator links for serialized_dag
-    assert serialized_dag["dag"]["tasks"][0]["_operator_extra_links"] == [
+    assert serialized_dag["dag"]["tasks"][0]["__var"]["_operator_extra_links"] == [
         {"airflow.providers.google.cloud.links.dataproc.DataprocWorkflowLink": {}}
     ]
 
@@ -2472,7 +2472,7 @@ def test_submit_spark_job_operator_extra_links(mock_hook, dag_maker, create_task
     deserialized_task = deserialized_dag.task_dict[TASK_ID]
 
     # Assert operator links for serialized DAG
-    assert serialized_dag["dag"]["tasks"][0]["_operator_extra_links"] == [
+    assert serialized_dag["dag"]["tasks"][0]["__var"]["_operator_extra_links"] == [
         {"airflow.providers.google.cloud.links.dataproc.DataprocLink": {}}
     ]
 

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -161,62 +161,68 @@ serialized_simple_dag_ground_truth = {
         "_processor_dags_folder": f"{repo_root}/tests/dags",
         "tasks": [
             {
-                "task_id": "bash_task",
-                "owner": "airflow",
-                "retries": 1,
-                "retry_delay": 300.0,
-                "max_retry_delay": 600.0,
-                "sla": 100.0,
-                "downstream_task_ids": [],
-                "_is_empty": False,
-                "ui_color": "#f0ede4",
-                "ui_fgcolor": "#000",
-                "template_ext": [".sh", ".bash"],
-                "template_fields": ["bash_command", "env", "cwd"],
-                "template_fields_renderers": {"bash_command": "bash", "env": "json"},
-                "bash_command": "echo {{ task.task_id }}",
-                "_task_type": "BashOperator",
-                "_task_module": "airflow.operators.bash",
-                "pool": "default_pool",
-                "is_setup": False,
-                "is_teardown": False,
-                "on_failure_fail_dagrun": False,
-                "executor_config": {
-                    "__type": "dict",
-                    "__var": {
-                        "pod_override": {
-                            "__type": "k8s.V1Pod",
-                            "__var": PodGenerator.serialize_pod(executor_config_pod),
-                        }
+                "__type": "operator",
+                "__var": {
+                    "task_id": "bash_task",
+                    "owner": "airflow",
+                    "retries": 1,
+                    "retry_delay": 300.0,
+                    "max_retry_delay": 600.0,
+                    "sla": 100.0,
+                    "downstream_task_ids": [],
+                    "_is_empty": False,
+                    "ui_color": "#f0ede4",
+                    "ui_fgcolor": "#000",
+                    "template_ext": [".sh", ".bash"],
+                    "template_fields": ["bash_command", "env", "cwd"],
+                    "template_fields_renderers": {"bash_command": "bash", "env": "json"},
+                    "bash_command": "echo {{ task.task_id }}",
+                    "_task_type": "BashOperator",
+                    "_task_module": "airflow.operators.bash",
+                    "pool": "default_pool",
+                    "is_setup": False,
+                    "is_teardown": False,
+                    "on_failure_fail_dagrun": False,
+                    "executor_config": {
+                        "__type": "dict",
+                        "__var": {
+                            "pod_override": {
+                                "__type": "k8s.V1Pod",
+                                "__var": PodGenerator.serialize_pod(executor_config_pod),
+                            }
+                        },
                     },
+                    "doc_md": "### Task Tutorial Documentation",
+                    "_log_config_logger_name": "airflow.task.operators",
+                    "weight_rule": "downstream",
                 },
-                "doc_md": "### Task Tutorial Documentation",
-                "_log_config_logger_name": "airflow.task.operators",
-                "weight_rule": "downstream",
             },
             {
-                "task_id": "custom_task",
-                "retries": 1,
-                "retry_delay": 300.0,
-                "max_retry_delay": 600.0,
-                "sla": 100.0,
-                "downstream_task_ids": [],
-                "_is_empty": False,
-                "_operator_extra_links": [{"tests.test_utils.mock_operators.CustomOpLink": {}}],
-                "ui_color": "#fff",
-                "ui_fgcolor": "#000",
-                "template_ext": [],
-                "template_fields": ["bash_command"],
-                "template_fields_renderers": {},
-                "_task_type": "CustomOperator",
-                "_operator_name": "@custom",
-                "_task_module": "tests.test_utils.mock_operators",
-                "pool": "default_pool",
-                "is_setup": False,
-                "is_teardown": False,
-                "on_failure_fail_dagrun": False,
-                "_log_config_logger_name": "airflow.task.operators",
-                "weight_rule": "downstream",
+                "__type": "operator",
+                "__var": {
+                    "task_id": "custom_task",
+                    "retries": 1,
+                    "retry_delay": 300.0,
+                    "max_retry_delay": 600.0,
+                    "sla": 100.0,
+                    "downstream_task_ids": [],
+                    "_is_empty": False,
+                    "_operator_extra_links": [{"tests.test_utils.mock_operators.CustomOpLink": {}}],
+                    "ui_color": "#fff",
+                    "ui_fgcolor": "#000",
+                    "template_ext": [],
+                    "template_fields": ["bash_command"],
+                    "template_fields_renderers": {},
+                    "_task_type": "CustomOperator",
+                    "_operator_name": "@custom",
+                    "_task_module": "tests.test_utils.mock_operators",
+                    "pool": "default_pool",
+                    "is_setup": False,
+                    "is_teardown": False,
+                    "on_failure_fail_dagrun": False,
+                    "_log_config_logger_name": "airflow.task.operators",
+                    "weight_rule": "downstream",
+                },
             },
         ],
         "schedule_interval": {"__type": "timedelta", "__var": 86400.0},
@@ -1049,7 +1055,7 @@ class TestStringifiedDAGs:
             CustomOperator(task_id="simple_task", bash_command=bash_command)
 
         serialized_dag = SerializedDAG.to_dict(dag)
-        assert "bash_command" in serialized_dag["dag"]["tasks"][0]
+        assert "bash_command" in serialized_dag["dag"]["tasks"][0]["__var"]
 
         dag = SerializedDAG.from_dict(serialized_dag)
         simple_task = dag.task_dict["simple_task"]
@@ -2380,7 +2386,7 @@ def test_sensor_expand_deserialized_unmap():
 
     serialize = SerializedBaseOperator.serialize
 
-    deserialize = SerializedBaseOperator.deserialize_operator
+    deserialize = SerializedBaseOperator.deserialize
     assert deserialize(serialize(mapped)).unmap(None) == deserialize(serialize(normal))
 
 
@@ -2653,7 +2659,7 @@ def test_mapped_task_with_operator_extra_links_property():
     with DAG("test-dag", start_date=datetime(2020, 1, 1)) as dag:
         _DummyOperator.partial(task_id="task").expand(inputs=[1, 2, 3])
     serialized_dag = SerializedBaseOperator.serialize(dag)
-    assert serialized_dag[Encoding.VAR]["tasks"][0] == {
+    assert serialized_dag[Encoding.VAR]["tasks"][0]["__var"] == {
         "task_id": "task",
         "expand_input": {
             "type": "dict-of-lists",

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -1059,7 +1059,7 @@ class TestStringifiedDAGs:
         # Verify Operator Links work with Serialized Operator
         #########################################################
         # Check Serialized version of operator link only contains the inbuilt Op Link
-        assert serialized_dag["dag"]["tasks"][0]["_operator_extra_links"] == serialized_links
+        assert serialized_dag["dag"]["tasks"][0]["__var"]["_operator_extra_links"] == serialized_links
 
         # Test all the extra_links are set
         assert simple_task.extra_links == sorted({*links, "airflow", "github", "google"})


### PR DESCRIPTION
Ok, taking yet another approach with this.

It turns out there was a non-obvious 4th usage of session in this function, so I went back to trying to make it an RPC call.

The problem is, we don't have a TaskPydantic model, and when you serialize an operator object it doesn't really do it properly because it doesn't "encode" it i.e. it doesn't add the TYPE var so the receiver has no idea what the object is.  This, I assume, is because historically an operator was always only serialized as part of another object.

What I did to "fix" this is I make base serialization serialize operator objects "properly", i.e. running through `_encode`.

This necessitated a change to the way SerDag deserializes its tasks.

The other wonky thing here is that we expect (somewhere in the execution process) the task object on a TI to also have a dag, which, happens to get lost in serialization (and yeah, would be a bit reduntant perhaps to include that when serializing DAG for example... think the DAG ser'd on each task....), so what I do is add it back after the TI comes back through the RPC....  It's a bit of a mess but that's kind of where we're at.

Please give it a look when you can @uranusjr @potiuk and let me know what you think of the approach.  I suspect there will be a test failure or two that I have to correct with this change.

Orig:
~The only usages of the provided session in this function are calls to other funcs which are also decorated with provide_session, and which are already RPC calls. There does not seem to be a reason that they all need to be in the same session.  So we should be able to simply remove this decorator, thus making this function AIP-44 compatible.~
