### PR TITLE
Undeprecating `DBApiHookForTests._make_common_data_structure`

### DIFF
--- a/airflow/providers/common/sql/hooks/sql.py
+++ b/airflow/providers/common/sql/hooks/sql.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import contextlib
+import warnings
 from contextlib import closing
 from datetime import datetime
 from typing import (
@@ -36,7 +37,6 @@ from typing import (
 from urllib.parse import urlparse
 
 import sqlparse
-from deprecated import deprecated
 from more_itertools import chunked
 from sqlalchemy import create_engine
 
@@ -422,14 +422,6 @@ class DbApiHook(BaseHook):
         else:
             return results
 
-    @deprecated(
-        reason=(
-            "The `_make_serializable` method is deprecated and support will be removed in a future "
-            "version of the common.sql provider. Please update the DbApiHook's provider "
-            "to a version based on common.sql >= 1.9.1."
-        ),
-        category=AirflowProviderDeprecationWarning,
-    )
     def _make_common_data_structure(self, result: T | Sequence[T]) -> tuple | list[tuple]:
         """Ensure the data returned from an SQL command is a standard tuple or list[tuple].
 
@@ -444,6 +436,13 @@ class DbApiHook(BaseHook):
         # Back-compatibility call for providers implementing old ´_make_serializable' method.
         with contextlib.suppress(AttributeError):
             result = self._make_serializable(result=result)  # type: ignore[attr-defined]
+            warnings.warn(
+                "The `_make_serializable` method is deprecated and support will be removed in a future "
+                f"version of the common.sql provider. Please update the {self.__class__.__name__}'s provider "
+                "to a version based on common.sql >= 1.9.1.",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
+            )
 
         if isinstance(result, Sequence):
             return cast(List[tuple], result)

--- a/tests/providers/common/sql/hooks/test_sql.py
+++ b/tests/providers/common/sql/hooks/test_sql.py
@@ -18,10 +18,13 @@
 #
 from __future__ import annotations
 
+import warnings
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import Connection
 from airflow.providers.common.sql.hooks.sql import DbApiHook, fetch_all_handler
 from airflow.utils.session import provide_session
@@ -226,3 +229,22 @@ def test_no_query(empty_statement):
     with pytest.raises(ValueError) as err:
         dbapi_hook.run(sql=empty_statement)
     assert err.value.args[0] == "List of SQL statements is empty"
+
+
+def test_make_common_data_structure_hook_has_deprecated_method():
+    """If hook implements ``_make_serializable`` warning should be raised on call."""
+
+    class DBApiHookForMakeSerializableTests(DBApiHookForTests):
+        def _make_serializable(self, result: Any):
+            return result
+
+    hook = DBApiHookForMakeSerializableTests()
+    with pytest.warns(AirflowProviderDeprecationWarning, match="`_make_serializable` method is deprecated"):
+        hook._make_common_data_structure(["foo", "bar", "baz"])
+
+
+def test_make_common_data_structure_no_deprecated_method():
+    """If hook not implements ``_make_serializable`` there is no warning should be raised on call."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", AirflowProviderDeprecationWarning)
+        DBApiHookForTests()._make_common_data_structure(["foo", "bar", "baz"])

--- a/tests/providers/common/sql/hooks/test_sql.py
+++ b/tests/providers/common/sql/hooks/test_sql.py
@@ -231,6 +231,7 @@ def test_no_query(empty_statement):
     assert err.value.args[0] == "List of SQL statements is empty"
 
 
+@pytest.mark.db_test
 def test_make_common_data_structure_hook_has_deprecated_method():
     """If hook implements ``_make_serializable`` warning should be raised on call."""
 
@@ -243,6 +244,7 @@ def test_make_common_data_structure_hook_has_deprecated_method():
         hook._make_common_data_structure(["foo", "bar", "baz"])
 
 
+@pytest.mark.db_test
 def test_make_common_data_structure_no_deprecated_method():
     """If hook not implements ``_make_serializable`` there is no warning should be raised on call."""
     with warnings.catch_warnings():


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

https://github.com/apache/airflow/pull/36876 - incorrectly deprecate invalid method `DBApiHookForTests._make_common_data_structure` intends to be overwritten into the subclasses, and error should be raised only in case if subclass implements `_make_serializable`

<details>
  <summary>Python be like</summary>
  
![image](https://github.com/apache/airflow/assets/3998685/136af38a-d300-43b5-a1ec-5a8d5992529a)
  
</details>


Found during https://github.com/apache/airflow/pull/38504, thanks @dstandish to point what is wrong here 

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
