### PR TITLE
Fix inconsistency of cache-directive vs. docker-cache

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -65,7 +65,7 @@ jobs:
       run-kubernetes-tests: ${{ steps.selective-checks.outputs.run-kubernetes-tests }}
       ci-image-build: ${{ steps.selective-checks.outputs.ci-image-build }}
       prod-image-build: ${{ steps.selective-checks.outputs.prod-image-build }}
-      cache-directive: ${{ steps.selective-checks.outputs.cache-directive }}
+      docker-cache: ${{ steps.selective-checks.outputs.docker-cache }}
       default-branch: ${{ steps.selective-checks.outputs.default-branch }}
       constraints-branch: ${{ steps.selective-checks.outputs.default-constraints-branch }}
       runs-on: ${{steps.selective-checks.outputs.runs-on}}
@@ -186,7 +186,7 @@ jobs:
       branch: ${{ needs.build-info.outputs.default-branch }}
       constraints-branch: ${{ needs.build-info.outputs.constraints-branch }}
       upgrade-to-newer-dependencies: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
-      docker-cache: ${{ needs.build-info.outputs.cache-directive }}
+      docker-cache: ${{ needs.build-info.outputs.docker-cache }}
 
   build-prod-images:
     name: Build PROD images
@@ -220,4 +220,4 @@ jobs:
       build-provider-packages: "true"
       upgrade-to-newer-dependencies: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
       chicken-egg-providers: ${{ needs.build-info.outputs.chicken-egg-providers }}
-      docker-cache: ${{ needs.build-info.outputs.cache-directive }}
+      docker-cache: ${{ needs.build-info.outputs.docker-cache }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       GITHUB_CONTEXT: ${{ toJson(github) }}
     outputs:
       image-tag: ${{ github.event.pull_request.head.sha || github.sha }}
-      cache-directive: ${{ steps.selective-checks.outputs.cache-directive }}
+      docker-cache: ${{ steps.selective-checks.outputs.docker-cache }}
       affected-providers-list-as-string: >-
         ${{ steps.selective-checks.outputs.affected-providers-list-as-string }}
       upgrade-to-newer-dependencies: ${{ steps.selective-checks.outputs.upgrade-to-newer-dependencies }}
@@ -193,7 +193,7 @@ jobs:
       use-uv: "true"
       upgrade-to-newer-dependencies: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
       constraints-branch: ${{ needs.build-info.outputs.default-constraints-branch }}
-      docker-cache: ${{ needs.build-info.outputs.cache-directive }}
+      docker-cache: ${{ needs.build-info.outputs.docker-cache }}
 
   wait-for-ci-images:
     timeout-minutes: 120
@@ -246,7 +246,7 @@ jobs:
       default-python-version: ${{ needs.build-info.outputs.default-python-version }}
       upgrade-to-newer-dependencies: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
       skip-pre-commits: ${{ needs.build-info.outputs.skip-pre-commits }}
-      docker-cache: ${{ needs.build-info.outputs.cache-directive }}
+      docker-cache: ${{ needs.build-info.outputs.docker-cache }}
       canary-run: ${{ needs.build-info.outputs.canary-run }}
       mypy-folders: ${{ needs.build-info.outputs.mypy-folders }}
       needs-mypy: ${{ needs.build-info.outputs.needs-mypy }}
@@ -502,7 +502,7 @@ jobs:
       upgrade-to-newer-dependencies: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
       chicken-egg-providers: ${{ needs.build-info.outputs.chicken-egg-providers }}
       constraints-branch: ${{ needs.build-info.outputs.default-constraints-branch }}
-      docker-cache: ${{ needs.build-info.outputs.cache-directive }}
+      docker-cache: ${{ needs.build-info.outputs.docker-cache }}
 
   wait-for-prod-images:
     timeout-minutes: 80
@@ -558,7 +558,7 @@ jobs:
       image-tag: ${{ needs.build-info.outputs.image-tag }}
       upgrade-to-newer-dependencies: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
       chicken-egg-providers: ${{ needs.build-info.outputs.chicken-egg-providers }}
-      docker-cache: ${{ needs.build-info.outputs.cache-directive }}
+      docker-cache: ${{ needs.build-info.outputs.docker-cache }}
       default-python-version: ${{ needs.build-info.outputs.default-python-version }}
       canary-run: ${{ needs.build-info.outputs.canary-run }}
     if: needs.build-info.outputs.prod-image-build == 'true'
@@ -613,5 +613,5 @@ jobs:
       in-workflow-build: ${{ needs.build-info.outputs.in-workflow-build }}
       upgrade-to-newer-dependencies: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
       include-success-outputs: ${{ needs.build-info.outputs.include-success-outputs }}
-      docker-cache: ${{ needs.build-info.outputs.cache-directive }}
+      docker-cache: ${{ needs.build-info.outputs.docker-cache }}
       canary-run: ${{ needs.build-info.outputs.canary-run }}

--- a/dev/breeze/doc/ci/04_selective_checks.md
+++ b/dev/breeze/doc/ci/04_selective_checks.md
@@ -172,7 +172,6 @@ Github Actions to pass the list of parameters to a command to execute
 | all-versions                           | If set to true, then all python, k8s, DB versions are used for tests.                                | false                                     |                |
 | basic-checks-only                      | Whether to run all static checks ("false") or only basic set of static checks ("true")               | false                                     |                |
 | build_system_changed_in_pyproject_toml | When builds system dependencies changed in pyproject.toml changed in the PR.                         | false                                     |                |
-| cache-directive                        | Which cache should be used for images ("registry", "local" , "disabled")                             | registry                                  |                |
 | chicken-egg-providers                  | List of providers that should be considered as "chicken-egg" - expecting development Airflow version |                                           |                |
 | ci-image-build                         | Whether CI image build is needed                                                                     | true                                      |                |
 | debug-resources                        | Whether resources usage should be printed during parallel job execution ("true"/ "false")            | false                                     |                |
@@ -184,6 +183,7 @@ Github Actions to pass the list of parameters to a command to execute
 | default-mysql-version                  | Which MySQL version to use as default                                                                | 5.7                                       |                |
 | default-postgres-version               | Which Postgres version to use as default                                                             | 10                                        |                |
 | default-python-version                 | Which Python version to use as default                                                               | 3.8                                       |                |
+| docker-cache                           | Which cache should be used for images ("registry", "local" , "disabled")                             | registry                                  |                |
 | docs-build                             | Whether to build documentation ("true"/"false")                                                      | true                                      |                |
 | docs-list-as-string                    | What filter to apply to docs building - based on which documentation packages should be built        | apache-airflow helm-chart google          |                |
 | full-tests-needed                      | Whether this build runs complete set of tests or only subset (for faster PR builds) [1]              | false                                     |                |
@@ -301,7 +301,7 @@ am overview of possible labels and their meaning:
 | canary                        | is-canary-run                 | If set, the PR run from apache/airflow repo behaves as `canary` run (can only be run by maintainer).            |
 | debug ci resources            | debug-ci-resources            | If set, then debugging resources is enabled during parallel tests and you can see them in the output.           |
 | default versions only         | all-versions, *-versions-*    | If set, the number of Python and Kubernetes, DB versions used by the build will be limited to the default ones. |
-| disable image cache           | cache-directive               | If set, the image cache is disables when building the image.                                                    |
+| disable image cache           | docker-cache                  | If set, the image cache is disables when building the image.                                                    |
 | include success outputs       | include-success-outputs       | By default, outputs of successful parallel tests are not shown - enabling this flag will make then shown.       |
 | latest versions only          | *-versions-*, *-versions-*    | If set, the number of Python, Kubernetes, DB versions used by the build will be limited to the latest ones.     |
 | all versions                  | all-versions, *-versions-*    | Run tests for all python and k8s versions.                                                                      |

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -1069,7 +1069,7 @@ class SelectiveChecks:
         return True
 
     @cached_property
-    def cache_directive(self) -> str:
+    def docker_cache(self) -> str:
         return (
             "disabled"
             if (self._github_event == GithubEvents.SCHEDULE or DISABLE_IMAGE_CACHE_LABEL in self._pr_labels)


### PR DESCRIPTION
This was the same parameter but inconsistently named across the CI/Selective checks. This PR fixes the inconsistency and changes it to `docker-cache` across the board.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
