### PR TITLE
Fix tests failing after removing double serialization

### DIFF
--- a/tests/api_internal/test_internal_api_call.py
+++ b/tests/api_internal/test_internal_api_call.py
@@ -135,7 +135,7 @@ class TestInternalApiCall:
             {
                 "jsonrpc": "2.0",
                 "method": "tests.api_internal.test_internal_api_call.TestInternalApiCall.fake_method",
-                "params": json.dumps(BaseSerialization.serialize({})),
+                "params": BaseSerialization.serialize({}),
             }
         )
         mock_requests.post.assert_called_once_with(
@@ -184,13 +184,11 @@ class TestInternalApiCall:
                 "jsonrpc": "2.0",
                 "method": "tests.api_internal.test_internal_api_call.TestInternalApiCall."
                 "fake_method_with_params",
-                "params": json.dumps(
-                    BaseSerialization.serialize(
-                        {
-                            "dag_id": "fake-dag",
-                            "task_id": 123,
-                        }
-                    )
+                "params": BaseSerialization.serialize(
+                    {
+                        "dag_id": "fake-dag",
+                        "task_id": 123,
+                    }
                 ),
             }
         )
@@ -223,12 +221,10 @@ class TestInternalApiCall:
                 "jsonrpc": "2.0",
                 "method": "tests.api_internal.test_internal_api_call.TestInternalApiCall."
                 "fake_class_method_with_params",
-                "params": json.dumps(
-                    BaseSerialization.serialize(
-                        {
-                            "dag_id": "fake-dag",
-                        }
-                    )
+                "params": BaseSerialization.serialize(
+                    {
+                        "dag_id": "fake-dag",
+                    }
                 ),
             }
         )
@@ -262,10 +258,7 @@ class TestInternalApiCall:
                 "jsonrpc": "2.0",
                 "method": "tests.api_internal.test_internal_api_call.TestInternalApiCall."
                 "fake_class_method_with_serialized_params",
-                "params": json.dumps(
-                    BaseSerialization.serialize({"ti": ti}, use_pydantic_models=True),
-                    default=BaseSerialization.serialize,
-                ),
+                "params": BaseSerialization.serialize({"ti": ti}, use_pydantic_models=True),
             }
         )
         mock_requests.post.assert_called_once_with(


### PR DESCRIPTION
The #38548 removed double serialization but some tests were not fixed to follow. This PR fixes it.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
