### PR TITLE
[Experiment] Use `importlib` import mode for `pytest`

### DIFF
--- a/dev/breeze/README.md
+++ b/dev/breeze/README.md
@@ -66,6 +66,6 @@ PLEASE DO NOT MODIFY THE HASH BELOW! IT IS AUTOMATICALLY UPDATED BY PRE-COMMIT.
 
 ---------------------------------------------------------------------------------------------------------
 
-Package config hash: fdb1d2f95db1e0dba03a84a0854eb69ee931c09845071d69229e02f8ce0ffcca3da51a277a17a517119c3280a4055eee7138a6b2bba34f07f9e941f92578b67b
+Package config hash: d83480952a3947a2811458109992e8cb8404aebb8cf1f9bf0eee2e8217be796275fe874dd7f9ac1b906bc39ff758105d8a84b07761fd6ecee9b18cb3b2bfb083
 
 ---------------------------------------------------------------------------------------------------------

--- a/dev/breeze/pyproject.toml
+++ b/dev/breeze/pyproject.toml
@@ -87,7 +87,14 @@ line-length = 110
 target-version = ['py38', 'py39', 'py310', 'py311', 'py312']
 
 [tool.pytest.ini_options]
-addopts = "-rasl --verbosity=2 -p no:flaky -p no:nose -p no:legacypath"
+addopts = [
+    "-rasl",
+    "--verbosity=2",
+    "-p", "no:flaky",
+    "-p", "no:nose",
+    "-p", "no:legacypath",
+    "--import-mode=importlib",
+]
 norecursedirs = [
     ".eggs",
 ]

--- a/docker_tests/pyproject.toml
+++ b/docker_tests/pyproject.toml
@@ -15,7 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 [tool.pytest.ini_options]
-addopts = "-rasl --verbosity=2 -p no:flaky -p no:nose -p no:legacypath"
+addopts = [
+    "-rasl",
+    "--verbosity=2",
+    "-p", "no:flaky",
+    "-p", "no:nose",
+    "-p", "no:legacypath",
+    "--import-mode=importlib",
+]
 norecursedirs = [
     ".eggs",
 ]

--- a/kubernetes_tests/pyproject.toml
+++ b/kubernetes_tests/pyproject.toml
@@ -15,7 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 [tool.pytest.ini_options]
-addopts = "-rasl --verbosity=2 -p no:flaky -p no:nose -p no:legacypath"
+addopts = [
+    "-rasl",
+    "--verbosity=2",
+    "-p", "no:flaky",
+    "-p", "no:nose",
+    "-p", "no:legacypath",
+    "--import-mode=importlib",
+]
 norecursedirs = [
     ".eggs",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -446,6 +446,7 @@ addopts = [
     # Disable warnings summary, because we use our warning summary.
     "--disable-warnings",
     "--asyncio-mode=strict",
+    "--import-mode=importlib",
 ]
 norecursedirs = [
     ".eggs",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Just an experiment whether or not airflow tests could use `importlib` mode instead of `prepend`

- [import mode](https://docs.pytest.org/en/latest/explanation/pythonpath.html#import-modes)
- [Choosing a test layout / import rules](https://docs.pytest.org/en/latest/explanation/goodpractices.html#choosing-an-import-mode)

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
