### PR TITLE
Move `*_wait_for_done_logging` into the db tests

### DIFF
--- a/tests/providers/apache/beam/hooks/test_beam.py
+++ b/tests/providers/apache/beam/hooks/test_beam.py
@@ -386,12 +386,14 @@ class TestBeamHook:
 
 
 class TestBeamRunner:
+    @pytest.mark.db_test
     @mock.patch("subprocess.Popen")
     @mock.patch("select.select")
     def test_beam_wait_for_done_logging(self, mock_select, mock_popen, caplog):
-        fake_logger = logging.getLogger("fake-logger")
+        logger_name = "fake-beam-wait-for-done-logger"
+        fake_logger = logging.getLogger(logger_name)
 
-        cmd = ["test", "cmd"]
+        cmd = ["fake", "cmd"]
         mock_proc = MagicMock(name="FakeProc")
         fake_stderr_fd = MagicMock(name="FakeStderr")
         fake_stdout_fd = MagicMock(name="FakeStdout")
@@ -399,13 +401,14 @@ class TestBeamRunner:
         mock_proc.stderr = fake_stderr_fd
         mock_proc.stdout = fake_stdout_fd
         fake_stderr_fd.readline.side_effect = [
-            b"test-stderr",
+            b"apache-beam-stderr-1",
+            b"apache-beam-stderr-2",
             StopIteration,
-            b"error-stderr",
+            b"apache-beam-stderr-3",
             StopIteration,
-            b"other-stderr",
+            b"apache-beam-other-stderr",
         ]
-        fake_stdout_fd.readline.side_effect = [b"test-stdout", StopIteration]
+        fake_stdout_fd.readline.side_effect = [b"apache-beam-stdout", StopIteration]
         mock_select.side_effect = [
             ([fake_stderr_fd], None, None),
             (None, None, None),
@@ -415,20 +418,22 @@ class TestBeamRunner:
         mock_proc.returncode = 1
         mock_popen.return_value = mock_proc
 
+        caplog.clear()
         with pytest.raises(AirflowException, match="Apache Beam process failed with return code 1"):
             run_beam_command(cmd, fake_logger)
 
         mock_popen.assert_called_once_with(
             cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True, cwd=None
         )
-        info_messages = [rt[2] for rt in caplog.record_tuples if rt[0] == "fake-logger" and rt[1] == 20]
-        assert "Running command: test cmd" in info_messages
-        assert "test-stdout" in info_messages
+        info_messages = [rt[2] for rt in caplog.record_tuples if rt[0] == logger_name and rt[1] == 20]
+        assert "Running command: fake cmd" in info_messages
+        assert "apache-beam-stdout" in info_messages
 
-        warn_messages = [rt[2] for rt in caplog.record_tuples if rt[0] == "fake-logger" and rt[1] == 30]
-        assert "test-stderr" in warn_messages
-        assert "error-stderr" in warn_messages
-        assert "other-stderr" in warn_messages
+        warn_messages = [rt[2] for rt in caplog.record_tuples if rt[0] == logger_name and rt[1] == 30]
+        assert "apache-beam-stderr-1" in warn_messages
+        assert "apache-beam-stderr-2" in warn_messages
+        assert "apache-beam-stderr-3" in warn_messages
+        assert "apache-beam-other-stderr" in warn_messages
 
 
 class TestBeamOptionsToArgs:

--- a/tests/providers/google/cloud/hooks/test_dataflow.py
+++ b/tests/providers/google/cloud/hooks/test_dataflow.py
@@ -1904,12 +1904,14 @@ class TestDataflow:
         )
         assert found_job_id is None
 
+    @pytest.mark.db_test
     @mock.patch("subprocess.Popen")
     @mock.patch("select.select")
     def test_dataflow_wait_for_done_logging(self, mock_select, mock_popen, caplog):
-        fake_logger = logging.getLogger("fake-logger")
+        logger_name = "fake-dataflow-wait-for-done-logger"
+        fake_logger = logging.getLogger(logger_name)
 
-        cmd = ["test", "cmd"]
+        cmd = ["fake", "cmd"]
         mock_proc = MagicMock(name="FakeProc")
         fake_stderr_fd = MagicMock(name="FakeStderr")
         fake_stdout_fd = MagicMock(name="FakeStdout")
@@ -1917,13 +1919,14 @@ class TestDataflow:
         mock_proc.stderr = fake_stderr_fd
         mock_proc.stdout = fake_stdout_fd
         fake_stderr_fd.readline.side_effect = [
-            b"test-stderr",
+            b"dataflow-stderr-1",
+            b"dataflow-stderr-2",
             StopIteration,
-            b"error-stderr",
+            b"dataflow-stderr-3",
             StopIteration,
-            b"other-stderr",
+            b"dataflow-other-stderr",
         ]
-        fake_stdout_fd.readline.side_effect = [b"test-stdout", StopIteration]
+        fake_stdout_fd.readline.side_effect = [b"dataflow-stdout", StopIteration]
         mock_select.side_effect = [
             ([fake_stderr_fd], None, None),
             (None, None, None),
@@ -1933,20 +1936,22 @@ class TestDataflow:
         mock_proc.returncode = 1
         mock_popen.return_value = mock_proc
 
+        caplog.clear()
         with pytest.raises(AirflowException, match="Apache Beam process failed with return code 1"):
-            run_beam_command(cmd=["test", "cmd"], log=fake_logger)
+            run_beam_command(cmd=cmd, log=fake_logger)
 
         mock_popen.assert_called_once_with(
             cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True, cwd=None
         )
-        info_messages = [rt[2] for rt in caplog.record_tuples if rt[0] == "fake-logger" and rt[1] == 20]
-        assert "Running command: test cmd" in info_messages
-        assert "test-stdout" in info_messages
+        info_messages = [rt[2] for rt in caplog.record_tuples if rt[0] == logger_name and rt[1] == 20]
+        assert "Running command: fake cmd" in info_messages
+        assert "dataflow-stdout" in info_messages
 
-        warn_messages = [rt[2] for rt in caplog.record_tuples if rt[0] == "fake-logger" and rt[1] == 30]
-        assert "test-stderr" in warn_messages
-        assert "error-stderr" in warn_messages
-        assert "other-stderr" in warn_messages
+        warn_messages = [rt[2] for rt in caplog.record_tuples if rt[0] == logger_name and rt[1] == 30]
+        assert "dataflow-stderr-1" in warn_messages
+        assert "dataflow-stderr-2" in warn_messages
+        assert "dataflow-stderr-3" in warn_messages
+        assert "dataflow-other-stderr" in warn_messages
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Different measures for fix flakey behaviour in this similar tests, both og them test `run_beam_command` from Apache Beam Provider - one test in Apache Beam Provider another in Google Provider  

```python
>       assert "Running command: test cmd" in info_messages
E       AssertionError: assert 'Running command: test cmd' in ['Running command: *** cmd', 'Start waiting for Apache Beam process to complete.', 'Waiting for Apache Beam process to complete.', '***-stdout', 'Process exited with return code: 1']

tests/providers/google/cloud/hooks/test_dataflow.py:1943: AssertionError
----------------------------- Captured stdout call -----------------------------
[2024-03-28T20:35:51.809+0000] {beam.py:138} INFO - Running command: *** cmd
[2024-03-28T20:35:51.810+0000] {beam.py:149} INFO - Start waiting for Apache Beam process to complete.
[2024-03-28T20:35:51.811+0000] {beam.py:117} WARNING - ***-stderr
[2024-03-28T20:35:51.811+0000] {beam.py:155} INFO - Waiting for Apache Beam process to complete.
[2024-03-28T20:35:51.812+0000] {beam.py:117} WARNING - error-stderr
[2024-03-28T20:35:51.812+0000] {beam.py:117} WARNING - other-stderr
[2024-03-28T20:35:51.812+0000] {beam.py:117} INFO - ***-stdout
[2024-03-28T20:35:51.812+0000] {beam.py:170} INFO - Process exited with return code: 1
------------------------------ Captured log call -------------------------------
INFO     fake-logger:beam.py:138 Running command: *** cmd
INFO     fake-logger:beam.py:149 Start waiting for Apache Beam process to complete.
WARNING  fake-logger:beam.py:117 ***-stderr
INFO     fake-logger:beam.py:155 Waiting for Apache Beam process to complete.
WARNING  fake-logger:beam.py:117 error-stderr
WARNING  fake-logger:beam.py:117 other-stderr
INFO     fake-logger:beam.py:117 ***-stdout
INFO     fake-logger:beam.py:170 Process exited with return code: 1
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
