### PR TITLE
Hide internals of some groupped workflows

### DIFF
--- a/.github/workflows/additional-ci-image-checks.yml
+++ b/.github/workflows/additional-ci-image-checks.yml
@@ -104,7 +104,7 @@ jobs:
       use-uv: "true"
       include-success-outputs: ${{ inputs.include-success-outputs }}
       docker-cache: ${{ inputs.docker-cache }}
-    if: inputs.canary-run == 'true' && inputs.branch == 'main'
+    if: inputs.branch == 'main'
 
   # Check that after earlier cache push, breeze command will build quickly
   check-that-image-builds-quickly:
@@ -119,7 +119,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_USERNAME: ${{ github.actor }}
       VERBOSE: "true"
-    if: inputs.canary-run == 'true' && inputs.branch == 'main'
+    if: inputs.branch == 'main'
     steps:
       - name: "Cleanup repo"
         shell: bash
@@ -159,4 +159,3 @@ jobs:
       use-uv: "true"
       upgrade-to-newer-dependencies: ${{ inputs.upgrade-to-newer-dependencies }}
       docker-cache: ${{ inputs.docker-cache }}
-    if: inputs.canary-run == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,7 @@ jobs:
     name: "Additional CI image checks"
     needs: [build-info, wait-for-ci-images]
     uses: ./.github/workflows/additional-ci-image-checks.yml
+    if: needs.build-info.outputs.canary-run == 'true'
     with:
       runs-on: ${{ needs.build-info.outputs.runs-on }}
       image-tag: ${{ needs.build-info.outputs.image-tag }}
@@ -436,6 +437,11 @@ jobs:
       contents: read
       packages: read
     secrets: inherit
+    if: >
+      needs.build-info.outputs.run-tests == 'true' &&
+      (needs.build-info.outputs.canary-run == 'true' ||
+       needs.build-info.outputs.upgrade-to-newer-dependencies != 'false' ||
+       needs.build-info.outputs.full-tests-needed == 'true')
     with:
       runs-on: ${{ needs.build-info.outputs.runs-on }}
       image-tag: ${{ needs.build-info.outputs.image-tag }}
@@ -446,7 +452,6 @@ jobs:
       canary-run: ${{ needs.build-info.outputs.canary-run }}
       upgrade-to-newer-dependencies: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
       debug-resources: ${{ needs.build-info.outputs.debug-resources }}
-    if: needs.build-info.outputs.run-tests == 'true'
 
   tests-integration:
     name: Integration Tests
@@ -596,8 +601,8 @@ jobs:
       - tests-mysql
       - tests-postgres
       - tests-non-db
-      - tests-special
       - tests-integration
+      - tests-special
     uses: ./.github/workflows/finalize-tests.yml
     with:
       runs-on: ${{ needs.build-info.outputs.runs-on }}

--- a/.github/workflows/special-tests.yml
+++ b/.github/workflows/special-tests.yml
@@ -65,7 +65,6 @@ jobs:
       contents: read
       packages: read
     secrets: inherit
-    if: inputs.canary-run == 'true' || inputs.upgrade-to-newer-dependencies == 'true'
     with:
       runs-on: ${{ inputs.runs-on }}
       downgrade-sqlalchemy: "true"
@@ -88,7 +87,6 @@ jobs:
       contents: read
       packages: read
     secrets: inherit
-    if: inputs.canary-run == 'true' || inputs.upgrade-to-newer-dependencies == 'true'
     with:
       runs-on: ${{ inputs.runs-on }}
       upgrade-boto: "true"
@@ -111,7 +109,6 @@ jobs:
       contents: read
       packages: read
     secrets: inherit
-    if: inputs.canary-run == 'true' || inputs.upgrade-to-newer-dependencies == 'true'
     with:
       runs-on: ${{ inputs.runs-on }}
       pydantic: "v1"
@@ -134,7 +131,6 @@ jobs:
       contents: read
       packages: read
     secrets: inherit
-    if: inputs.canary-run == 'true' || inputs.upgrade-to-newer-dependencies == 'true'
     with:
       runs-on: ${{ inputs.runs-on }}
       pydantic: "none"
@@ -157,7 +153,6 @@ jobs:
       contents: read
       packages: read
     secrets: inherit
-    if: inputs.canary-run == 'true' || inputs.upgrade-to-newer-dependencies == 'true'
     with:
       runs-on: ${{ inputs.runs-on }}
       downgrade-pendulum: "true"
@@ -180,7 +175,6 @@ jobs:
       contents: read
       packages: read
     secrets: inherit
-    if: inputs.canary-run == 'true' || inputs.upgrade-to-newer-dependencies == 'true'
     with:
       runs-on: ${{ inputs.runs-on }}
       enable-aip-44: "false"
@@ -203,7 +197,6 @@ jobs:
       contents: read
       packages: read
     secrets: inherit
-    if: inputs.canary-run == 'true' || inputs.upgrade-to-newer-dependencies == 'true'
     with:
       runs-on: ${{ inputs.runs-on }}
       test-name: "Postgres"
@@ -225,7 +218,6 @@ jobs:
       contents: read
       packages: read
     secrets: inherit
-    if: inputs.canary-run == 'true' || inputs.upgrade-to-newer-dependencies == 'true'
     with:
       runs-on: ${{ inputs.runs-on }}
       test-name: "Postgres"


### PR DESCRIPTION
When the whole workflow can be skipped and it's one of the workflows than nothing depends on, we can skip the whole workflow rather than individual jobs - then the workflow will not be shown as unfolded with all the jobs skipped but as a single skipped workflow.

This is what we do for Additional CI image tests and Finalize tests & Special tests

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
