### PR TITLE
Add padding to bottom of log block.

### DIFF
--- a/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
@@ -114,7 +114,6 @@ const LogBlock = ({
       maxHeight={`calc(100% - ${offsetTop}px)`}
       overflowY="auto"
       p={3}
-      pb={0}
       display="block"
       whiteSpace={wrap ? "pre-wrap" : "pre"}
       border="1px solid"


### PR DESCRIPTION
With addition of grouping logs in the UI absence of padding at the bottom can be interfering with the scroll bar. Since pb={0} was already there should be a purpose for that but couldn't find it in git log. Similar to 0c9487f9466587f6cbc443ab2c9dc17d35c98f5d

Before : 

![logs_padding](https://github.com/apache/airflow/assets/3972343/a6e08601-7859-40f5-8134-62633df9c361)

After : 

![log_padding_after](https://github.com/apache/airflow/assets/3972343/5b2b8083-79f5-4070-837a-bb4e151a5cbd)
