### PR TITLE
Fix inital value for _batch_id attribute in livy operator

### DIFF
--- a/airflow/providers/apache/livy/operators/livy.py
+++ b/airflow/providers/apache/livy/operators/livy.py
@@ -124,7 +124,7 @@ class LivyOperator(BaseOperator):
         self._extra_options = extra_options or {}
         self._extra_headers = extra_headers or {}
 
-        self._batch_id: int | str = None
+        self._batch_id: int | str | None = None
         self.retry_args = retry_args
         self.deferrable = deferrable
 

--- a/airflow/providers/apache/livy/operators/livy.py
+++ b/airflow/providers/apache/livy/operators/livy.py
@@ -124,7 +124,7 @@ class LivyOperator(BaseOperator):
         self._extra_options = extra_options or {}
         self._extra_headers = extra_headers or {}
 
-        self._batch_id: int | str
+        self._batch_id: int | str = None
         self.retry_args = retry_args
         self.deferrable = deferrable
 


### PR DESCRIPTION
### Related issue

closes: #37898

### Explain

when the livy operator is rewaked up after trigger is time out, the _batch_id is not initialized, which cause it to raise this exeption:
`AttributeError: 'LivyOperator' object has no attribute '_batch_id'`
 
this problem arises because an initial value is not defined for _batch_id. by initializing this attribute to None, this problem will be solved.
