### PR TITLE
Fix ti.start_date is set even in pre-running state by ti.set_state

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1890,10 +1890,11 @@ class TaskInstance(Base, LoggingMixin):
         current_time = timezone.utcnow()
         ti.log.debug("Setting task state for %s to %s", ti, state)
         ti.state = state
-        ti.start_date = ti.start_date or current_time
-        if ti.state in State.finished or ti.state == TaskInstanceState.UP_FOR_RETRY:
-            ti.end_date = ti.end_date or current_time
-            ti.duration = (ti.end_date - ti.start_date).total_seconds()
+        if ti.state not in (TaskInstanceState.SCHEDULED, TaskInstanceState.QUEUED):
+            ti.start_date = ti.start_date or current_time
+            if ti.state in State.finished or ti.state == TaskInstanceState.UP_FOR_RETRY:
+                ti.end_date = ti.end_date or current_time
+                ti.duration = (ti.end_date - ti.start_date).total_seconds()
         session.merge(ti)
         return True
 

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1512,6 +1512,24 @@ class TestTaskInstance:
             assert ti.are_dependencies_met()
 
     @pytest.mark.parametrize(
+        "before_state, after_state, expected_has_start_date",
+        [
+            (TaskInstanceState.SCHEDULED, TaskInstanceState.QUEUED, False),
+            (TaskInstanceState.SCHEDULED, TaskInstanceState.RUNNING, True),
+            (TaskInstanceState.SCHEDULED, TaskInstanceState.SUCCESS, True),
+        ],
+    )
+    @provide_session
+    def test_set_state(
+        self, before_state, after_state, expected_has_start_date, create_task_instance, session=None
+    ):
+        ti = create_task_instance(session=session)
+        ti.set_state(before_state)
+        ti.set_state(after_state)
+        actual_has_start_date = ti.start_date is not None
+        assert actual_has_start_date == expected_has_start_date
+
+    @pytest.mark.parametrize(
         "downstream_ti_state, expected_are_dependents_done",
         [
             (State.SUCCESS, True),


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

related: https://github.com/apache/airflow/issues/38632 and https://github.com/apache/airflow/pull/34771#discussion_r1542257954

From the discussion of above PR, ti.start_date is normally set when ti transitions to the RUNNING state.
But the current ti.set_state method has set start_date even though the state is prior to RUNNING.

This creates an unstable situation where start_date is present in SCHEDULED and QUEUED ti generated by backfilling, but not in ti that is not.

This is an unnatural behavior for ti's state transitions, so we try to fix it.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
