### PR TITLE
Revert "Temporarily remove protection on v2-9-stable to create beta 2 (#38431)"

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -105,10 +105,10 @@ github:
       required_pull_request_reviews:
         required_approving_review_count: 1
       required_linear_history: true
-      #    v2-9-stable:
-      #      required_pull_request_reviews:
-      #        required_approving_review_count: 1
-      #      required_linear_history: true
+    v2-9-stable:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+      required_linear_history: true
   collaborators:
     - Lee-W
     - RNHTTR


### PR DESCRIPTION

This reverts commit 8520778930e1888eafe427e1dc8dbb85744a5c6c.

