### PR TITLE
Adding support to hive hook for high availability Hive installations

### DIFF
--- a/airflow/providers/apache/hive/hooks/hive.py
+++ b/airflow/providers/apache/hive/hooks/hive.py
@@ -161,10 +161,12 @@ class HiveCliHook(BaseHook):
         if self.use_beeline:
             hive_bin = "beeline"
             self._validate_beeline_parameters(conn)
-            jdbc_url = f"jdbc:hive2://{conn.host}:{conn.port}/{conn.schema}"
             if self.high_availability:
                 jdbc_url = f"jdbc:hive2://{conn.host}/{conn.schema}"
                 self.log.info("High Availability set, setting JDBC url as %s", jdbc_url)
+            else:
+                jdbc_url = f"jdbc:hive2://{conn.host}:{conn.port}/{conn.schema}"
+                self.log.info("High Availability not set, setting JDBC url as %s", jdbc_url)
             if conf.get("core", "security") == "kerberos":
                 template = conn.extra_dejson.get("principal", "hive/_HOST@EXAMPLE.COM")
                 if "_HOST" in template:
@@ -176,7 +178,7 @@ class HiveCliHook(BaseHook):
                     raise RuntimeError("The proxy_user should not contain the ';' character")
                 jdbc_url += f";principal={template};{proxy_user}"
                 if self.high_availability:
-                    if proxy_user:
+                    if not jdbc_url.endswith(";"):
                         jdbc_url += ";"
                     jdbc_url += "serviceDiscoveryMode=zooKeeper;ssl=true;zooKeeperNamespace=hiveserver2"
             elif self.auth:

--- a/airflow/providers/apache/hive/hooks/hive.py
+++ b/airflow/providers/apache/hive/hooks/hive.py
@@ -165,10 +165,9 @@ class HiveCliHook(BaseHook):
             hive_bin = "beeline"
             self._validate_beeline_parameters(conn)
             jdbc_url = f"jdbc:hive2://{conn.host}:{conn.port}/{conn.schema}"
-            print("conn is", conn)
-            print("conn parameters", conn.host, conn.port, conn.schema)
             if self.high_availability:
                 jdbc_url = f"jdbc:hive2://{conn.host}/{conn.schema}"
+                self.log.info("High Availability set, setting JDBC url as %s", jdbc_url)
             if conf.get("core", "security") == "kerberos":
                 template = conn.extra_dejson.get("principal", "hive/_HOST@EXAMPLE.COM")
                 if "_HOST" in template:

--- a/airflow/providers/apache/hive/hooks/hive.py
+++ b/airflow/providers/apache/hive/hooks/hive.py
@@ -100,9 +100,6 @@ class HiveCliHook(BaseHook):
     ) -> None:
         super().__init__()
         conn = self.get_connection(hive_cli_conn_id)
-
-        print("conn is from __init__", conn)
-
         self.hive_cli_params: str = hive_cli_params
         self.use_beeline: bool = conn.extra_dejson.get("use_beeline", False)
         self.auth = auth

--- a/airflow/providers/apache/hive/operators/hive.py
+++ b/airflow/providers/apache/hive/operators/hive.py
@@ -96,7 +96,6 @@ class HiveOperator(BaseOperator):
         hive_cli_params: str = "",
         auth: str | None = None,
         proxy_user: str | None = None,
-        high_availability: bool | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -112,7 +111,6 @@ class HiveOperator(BaseOperator):
         self.hive_cli_params = hive_cli_params
         self.auth = auth
         self.proxy_user = proxy_user
-        self.high_availability = high_availability
         job_name_template = conf.get_mandatory_value(
             "hive",
             "mapred_job_name_template",
@@ -131,7 +129,6 @@ class HiveOperator(BaseOperator):
             hive_cli_params=self.hive_cli_params,
             auth=self.auth,
             proxy_user=self.proxy_user,
-            high_availability=self.high_availability
         )
 
     @deprecated(reason="use `hook` property instead.", category=AirflowProviderDeprecationWarning)

--- a/airflow/providers/apache/hive/operators/hive.py
+++ b/airflow/providers/apache/hive/operators/hive.py
@@ -96,6 +96,7 @@ class HiveOperator(BaseOperator):
         hive_cli_params: str = "",
         auth: str | None = None,
         proxy_user: str | None = None,
+        high_availability: bool | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -111,6 +112,7 @@ class HiveOperator(BaseOperator):
         self.hive_cli_params = hive_cli_params
         self.auth = auth
         self.proxy_user = proxy_user
+        self.high_availability = high_availability
         job_name_template = conf.get_mandatory_value(
             "hive",
             "mapred_job_name_template",
@@ -129,6 +131,7 @@ class HiveOperator(BaseOperator):
             hive_cli_params=self.hive_cli_params,
             auth=self.auth,
             proxy_user=self.proxy_user,
+            high_availability=self.high_availability
         )
 
     @deprecated(reason="use `hook` property instead.", category=AirflowProviderDeprecationWarning)

--- a/docs/apache-airflow-providers-apache-hive/connections/hive_cli.rst
+++ b/docs/apache-airflow-providers-apache-hive/connections/hive_cli.rst
@@ -73,6 +73,10 @@ Proxy User (optional)
 Principal (optional)
     Specify the JDBC Hive principal to be used with Hive Beeline.
 
+High Availability (optional)
+    Specify as ``True`` if you want to connect to a Hive installation running in high
+    availability mode. Specify host accordingly.
+
 
 When specifying the connection in environment variable you should specify
 it using URI syntax.

--- a/tests/providers/apache/hive/hooks/test_hive.py
+++ b/tests/providers/apache/hive/hooks/test_hive.py
@@ -901,3 +901,37 @@ class TestHiveCli:
         # Run
         with pytest.raises(RuntimeError, match="The principal should not contain the ';' character"):
             hook._prepare_cli_cmd()
+
+    @pytest.mark.parametrize(
+        "extra_dejson, expected_keys",
+        [
+            (
+                {"high_availability": "true"},
+                "serviceDiscoveryMode=zooKeeper;ssl=true;zooKeeperNamespace=hiveserver2",
+            ),
+            (
+                {"high_availability": "false"},
+                "serviceDiscoveryMode=zooKeeper;ssl=true;zooKeeperNamespace=hiveserver2",
+            ),
+            ({}, "serviceDiscoveryMode=zooKeeper;ssl=true;zooKeeperNamespace=hiveserver2"),
+        ],
+    )
+    def test_high_availability(self, extra_dejson, expected_keys):
+        hook = MockHiveCliHook()
+        returner = mock.MagicMock()
+        returner.extra_dejson = extra_dejson
+        returner.login = "admin"
+        hook.use_beeline = True
+        hook.conn = returner
+        hook.high_availability = (
+            True
+            if ("high_availability" in extra_dejson and extra_dejson["high_availability"] == "true")
+            else False
+        )
+
+        result = hook._prepare_cli_cmd()
+
+        if hook.high_availability:
+            assert expected_keys in result[2]
+        else:
+            assert expected_keys not in result[2]

--- a/tests/providers/apache/hive/hooks/test_hive.py
+++ b/tests/providers/apache/hive/hooks/test_hive.py
@@ -914,6 +914,12 @@ class TestHiveCli:
                 "serviceDiscoveryMode=zooKeeper;ssl=true;zooKeeperNamespace=hiveserver2",
             ),
             ({}, "serviceDiscoveryMode=zooKeeper;ssl=true;zooKeeperNamespace=hiveserver2"),
+            # with proxy user
+            (
+                {"proxy_user": "a_user_proxy", "high_availability": "true"},
+                "hive.server2.proxy.user=a_user_proxy;"
+                "serviceDiscoveryMode=zooKeeper;ssl=true;zooKeeperNamespace=hiveserver2",
+            ),
         ],
     )
     def test_high_availability(self, extra_dejson, expected_keys):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Right now there is a limitation where the HiveOperator incorrectly parses and constructs the beeline command if hive "high availability" url is given for host. I was able to work this around by adding this change to extra and changing the HiveHook code but a better fix would be to add a new field called HA, which when selected, parses the connection better in the hook itself.

I would like to propose adding this into the connection form for Hive CLI type in a better way. Recently some change was made to remove extra and integrate this into the form and simplify it: https://github.com/apache/airflow/pull/37043/.
Would propose adding similar fields for HA and if enabled, the beeline command construction would vary slightly. 

MY HA URL looks somewhat like this btw: `jdbc:hive2://host1:port1,host2:port2,host3:port3/default;principal=hive/principal@REALM;serviceDiscoveryMode=zooKeeper;ssl=true;zooKeeperNamespace=hiveserver2`

Tested using a HA setting, beeline works as expected.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
