### PR TITLE
More human friendly "show tables" output for db cleanup

### DIFF
--- a/airflow/utils/db_cleanup.py
+++ b/airflow/utils/db_cleanup.py
@@ -323,16 +323,18 @@ def _confirm_drop_archives(*, tables: list[str]):
     if len(tables) > 3:
         text_ = f"{len(tables)} archived tables prefixed with {ARCHIVE_TABLE_PREFIX}"
     else:
-        text_ = f"the following archived tables {tables}"
+        text_ = f"the following archived tables: {', '.join(tables)}"
     question = (
         f"You have requested that we drop {text_}.\n"
-        f"This is irreversible. Consider backing up the tables first \n"
+        f"This is irreversible. Consider backing up the tables first.\n"
     )
     print(question)
     if len(tables) > 3:
-        show_tables = ask_yesno("Show tables? (y/n): ")
+        show_tables = ask_yesno("Show tables that will be dropped? (y/n): ")
         if show_tables:
-            print(tables, "\n")
+            for table in tables:
+                print(f"  {table}")
+            print("\n")
     answer = input("Enter 'drop archived tables' (without quotes) to proceed.\n").strip()
     if answer != "drop archived tables":
         raise SystemExit("User did not confirm; exiting.")

--- a/tests/utils/test_db_cleanup.py
+++ b/tests/utils/test_db_cleanup.py
@@ -395,17 +395,17 @@ class TestDBCleanup:
     @patch("airflow.utils.db_cleanup.ask_yesno")
     def test_confirm_drop_archives(self, mock_ask_yesno, tables):
         expected = (
-            f"You have requested that we drop the following archived tables {tables}.\n"
-            "This is irreversible. Consider backing up the tables first"
+            f"You have requested that we drop the following archived tables: {', '.join(tables)}.\n"
+            "This is irreversible. Consider backing up the tables first."
         )
         if len(tables) > 3:
             expected = (
                 f"You have requested that we drop {len(tables)} archived tables prefixed with "
                 f"_airflow_deleted__.\n"
-                "This is irreversible. Consider backing up the tables first \n"
-                "\n"
-                f"{tables}"
+                "This is irreversible. Consider backing up the tables first.\n"
             )
+            for table in tables:
+                expected += f"\n  {table}"
 
         mock_ask_yesno.return_value = True
         with patch("sys.stdout", new=StringIO()) as fake_out, patch(


### PR DESCRIPTION
Don't print the string representation of a list, print out just the table names.

Before:
```
You have requested that we drop 4 archived tables prefixed with _airflow_deleted__.
This is irreversible. Consider backing up the tables first                               
                                                                                         
Show tables? (y/n):                                                                      
y                                                                                        
['_airflow_deleted__dag__20240401153649', '_airflow_deleted__dag_run__20240401153649', '_airflow_deleted__job__20240401153649', '_airflow_deleted__log__20240401153649'] 
```

After:
```
You have requested that we drop 4 archived tables prefixed with _airflow_deleted__.
This is irreversible. Consider backing up the tables first.

Show tables that will be dropped? (y/n): 
y
  _airflow_deleted__dag__20240401153649
  _airflow_deleted__dag_run__20240401153649
  _airflow_deleted__job__20240401153649
  _airflow_deleted__log__20240401153649
```

And with less than 3 tables...
Before:
```
You have requested that we drop the following archived tables ['_airflow_deleted__job__20240401153649', '_airflow_deleted__log__20240401153649'].
This is irreversible. Consider backing up the tables first 
```

After:
```
You have requested that we drop the following archived tables: _airflow_deleted__job__20240401153649, _airflow_deleted__log__20240401153649.
This is irreversible. Consider backing up the tables first.

```