### PR TITLE
remove display of  param from the UI

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -134,9 +134,6 @@
            <span class="material-icons text-muted js-tooltip" aria-hidden="true" data-original-title="Auto Pauses: After {{ dag_model.max_consecutive_failed_dag_runs|string }} consecutive failures">motion_photos_paused</span>
             {% endif %}
         {% endif %}
-        {% if root %}
-          <span class="text-muted">ROOT:</span> {{ root }}
-        {% endif %}
       </h3>
     </div>
     <div>


### PR DESCRIPTION
Displaying the root param in the UI was added in 2015 for some reason, but after checking the current usage, I believe it is completely useless:

http://localhost:28080/dags/dag_1/calendar?root=some%20message

<img width="1268" alt="Screenshot 2024-04-01 at 23 43 58" src="https://github.com/apache/airflow/assets/21311487/946c2531-17f3-4776-86bb-140ed4fbe224">
