### PR TITLE
Fix duplicate "health" line in internal api openapi config

### DIFF
--- a/airflow/api_internal/openapi/internal_api_v1.yaml
+++ b/airflow/api_internal/openapi/internal_api_v1.yaml
@@ -73,7 +73,6 @@ paths:
       operationId: health
       deprecated: false
       x-openapi-router-controller: airflow.api_internal.endpoints.health_endpoint
-      operationId: health
       tags:
       - JSONRPC
       parameters: []


### PR DESCRIPTION
just a rebase mistake i think