### PR TITLE
Fix triggerer race condition in HA setting

### DIFF
--- a/airflow/jobs/triggerer_job_runner.py
+++ b/airflow/jobs/triggerer_job_runner.py
@@ -683,7 +683,7 @@ class TriggerRunner(threading.Thread, LoggingMixin):
             # and can happen when a single trigger Job is being run on multiple TriggerRunners
             # in a High-Availability setup.
             if new_trigger_orm.task_instance is None:
-                self.log.warning(
+                self.log.info(
                     (
                         "TaskInstance for Trigger ID %s is None. It was likely updated by another trigger job. "
                         "Skipping trigger instantiation."

--- a/airflow/jobs/triggerer_job_runner.py
+++ b/airflow/jobs/triggerer_job_runner.py
@@ -678,6 +678,17 @@ class TriggerRunner(threading.Thread, LoggingMixin):
                 self.failed_triggers.append((new_id, e))
                 continue
 
+            # If new_trigger_orm.task_instance is None, this means the TaskInstance
+            # row was updated by either Trigger.submit_event or Trigger.submit_failure
+            # and can happen when a single trigger Job is being run on multiple TriggerRunners
+            # in a High-Availability setup.
+            if new_trigger_orm.task_instance is None:
+                self.log.warning((
+                    "TaskInstance for Trigger ID %s is None. It was likely updated by another trigger job. "
+                    "Skipping trigger instantiation."
+                ), new_id)
+                continue
+
             try:
                 new_trigger_instance = trigger_class(**new_trigger_orm.kwargs)
             except TypeError as err:

--- a/airflow/jobs/triggerer_job_runner.py
+++ b/airflow/jobs/triggerer_job_runner.py
@@ -683,10 +683,13 @@ class TriggerRunner(threading.Thread, LoggingMixin):
             # and can happen when a single trigger Job is being run on multiple TriggerRunners
             # in a High-Availability setup.
             if new_trigger_orm.task_instance is None:
-                self.log.warning((
-                    "TaskInstance for Trigger ID %s is None. It was likely updated by another trigger job. "
-                    "Skipping trigger instantiation."
-                ), new_id)
+                self.log.warning(
+                    (
+                        "TaskInstance for Trigger ID %s is None. It was likely updated by another trigger job. "
+                        "Skipping trigger instantiation."
+                    ),
+                    new_id,
+                )
                 continue
 
             try:

--- a/tests/jobs/test_triggerer_job.py
+++ b/tests/jobs/test_triggerer_job.py
@@ -393,7 +393,7 @@ def test_trigger_create_race_condition_38599(session, tmp_path):
     # Start first TriggererJobRunner immediately.
     # This TriggererJobRunner will immediately load the trigger and start running it.
     # Once the trigger is finished, it will, however, stall after the first loop in handle_events,
-    # preventing the trigger from being cleaned up.
+    # preventing the trigger from being cleaned up. This simulates what may happen during high load.
     job_runner1 = TriggererJobRunner_(job1)
     job_runner1.trigger_runner = TriggerRunnerWithCreateCount_()
     thread1 = Thread(target=job_runner1._execute)

--- a/tests/jobs/test_triggerer_job.py
+++ b/tests/jobs/test_triggerer_job.py
@@ -366,8 +366,7 @@ def test_trigger_create_race_condition_38599(session, tmp_path):
     loop = asyncio.get_event_loop()
     loop.run_until_complete(job_runner1.trigger_runner.create_triggers())
     assert len(job_runner1.trigger_runner.triggers) == 1
-    trigger_task_key = list(job_runner1.trigger_runner.triggers.keys())[0]
-    trigger_task_info = job_runner1.trigger_runner.triggers[trigger_task_key]
+    trigger_task_key, trigger_task_info = next(iter(job_runner1.trigger_runner.triggers.items()))
     loop.run_until_complete(trigger_task_info["task"])
     assert trigger_task_info["task"].done()
 

--- a/tests/jobs/test_triggerer_job.py
+++ b/tests/jobs/test_triggerer_job.py
@@ -369,7 +369,9 @@ def test_trigger_create_race_condition_38599(session, tmp_path):
             # Delay calling update_triggers to increase the window of opportunity
             time.sleep(1)
             super().update_triggers(requested_trigger_ids)
-            self.requested_trigger_count = getattr(self, "requested_trigger_count", 0) + len(requested_trigger_ids)
+            self.requested_trigger_count = getattr(self, "requested_trigger_count", 0) + len(
+                requested_trigger_ids
+            )
 
     class TriggererJobRunner_(TriggererJobRunner):
         """TriggererJobRunner whose handle_events blocks until there is an event."""

--- a/tests/jobs/test_triggerer_job.py
+++ b/tests/jobs/test_triggerer_job.py
@@ -308,6 +308,7 @@ class TestTriggerRunner:
         assert "Trigger failed" in caplog.text
         assert "got an unexpected keyword argument 'not_exists_arg'" in caplog.text
 
+
 def test_trigger_create_race_condition_38599(session, tmp_path):
     """
     This verifies the resolution of race condition documented in github issue #38599.
@@ -357,14 +358,13 @@ def test_trigger_create_race_condition_38599(session, tmp_path):
         async def create_triggers(self):
             num_triggers_to_create = len(self.to_create)
             await super().create_triggers()
-            self.trigger_creation_count = (
-                getattr(self, "trigger_creation_count", 0) + num_triggers_to_create
-            )
+            self.trigger_creation_count = getattr(self, "trigger_creation_count", 0) + num_triggers_to_create
 
     class TriggerRunnerWithUpdateDelay_(TriggerRunnerWithCreateCount_):
         """TriggerRunner with a 5 second delay added at the beginning of update_triggers
         to increase the window that the race condition may occur.
         """
+
         def update_triggers(self, *args, **kwargs):
             # Delay calling update_triggers to increase the window of opportunity
             time.sleep(5)
@@ -372,27 +372,21 @@ def test_trigger_create_race_condition_38599(session, tmp_path):
 
         async def create_triggers(self):
             await super().create_triggers()
-            self.create_triggers_count = (
-                getattr(self, "create_triggers_count", 0) + 1
-            )
+            self.create_triggers_count = getattr(self, "create_triggers_count", 0) + 1
 
     class TriggererJobRunner_(TriggererJobRunner):
-        """TriggererJobRunner whose handle_events blocks until there is an event.
-        """
+        """TriggererJobRunner whose handle_events blocks until there is an event."""
+
         def load_triggers(self):
             super().load_triggers()
-            self.load_triggers_count = (
-                getattr(self, "load_triggers_count", 0) + 1
-            )
+            self.load_triggers_count = getattr(self, "load_triggers_count", 0) + 1
 
         def handle_events(self):
             # Wait for event during the first loop
             while not self.trigger_runner.events and getattr(self, "handle_events_count", 0) == 0:
                 time.sleep(0.1)
             super().handle_events()
-            self.handle_events_count = (
-                getattr(self, "handle_events_count", 0) + 1
-            )
+            self.handle_events_count = getattr(self, "handle_events_count", 0) + 1
             # Prevent Trigger.clean_unused() from deleting the trigger
             time.sleep(5)
 

--- a/tests/jobs/test_triggerer_job.py
+++ b/tests/jobs/test_triggerer_job.py
@@ -390,6 +390,7 @@ def test_trigger_create_race_condition_38599(session, tmp_path):
     instances = path.read_text().splitlines()
     assert instances == ["hi"]
 
+
 def test_trigger_create_race_condition_18392(session, tmp_path):
     """
     This verifies the resolution of race condition documented in github issue #18392.


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

Fix triggerer race condition when there are multiple instances
---
closes: #38599

Detailed description is in the issue linked above. I was able to reproduce the issue in the latest main branch.

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
