### PR TITLE
Fix CronTriggerTimetable candidates to reflect doc

### DIFF
--- a/airflow/timetables/trigger.py
+++ b/airflow/timetables/trigger.py
@@ -98,7 +98,11 @@ class CronTriggerTimetable(CronMixin, Timetable):
             else:
                 next_start_time = self._align_to_next(restriction.earliest)
         else:
-            start_time_candidates = [self._align_to_prev(timezone.coerce_datetime(timezone.utcnow()))]
+            utc_now = timezone.coerce_datetime(timezone.utcnow())
+            aligned_to_prev = self._align_to_prev(utc_now)
+            start_time_candidates = [aligned_to_prev]
+            if aligned_to_prev < utc_now:
+                start_time_candidates.append(self._get_next(aligned_to_prev))
             if last_automated_data_interval is not None:
                 start_time_candidates.append(self._get_next(last_automated_data_interval.end))
             if restriction.earliest is not None:

--- a/tests/timetables/test_trigger_timetable.py
+++ b/tests/timetables/test_trigger_timetable.py
@@ -47,7 +47,7 @@ DELTA_FROM_MIDNIGHT = datetime.timedelta(minutes=30, hours=16)
     [
         pytest.param(
             None,
-            YESTERDAY + DELTA_FROM_MIDNIGHT,
+            CURRENT_TIME + DELTA_FROM_MIDNIGHT,
             id="first-run",
         ),
         pytest.param(
@@ -88,7 +88,7 @@ def test_daily_cron_trigger_no_catchup_first_starts_at_next_schedule(
         pytest.param(
             pendulum.DateTime(2022, 7, 27, 0, 30, 0, tzinfo=utc),
             START_DATE,
-            DagRunInfo.exact(pendulum.DateTime(2022, 7, 27, 0, 0, 0, tzinfo=utc)),
+            DagRunInfo.exact(pendulum.DateTime(2022, 7, 27, 1, 0, 0, tzinfo=utc)),
             id="current_time_not_on_boundary",
         ),
         pytest.param(
@@ -100,7 +100,7 @@ def test_daily_cron_trigger_no_catchup_first_starts_at_next_schedule(
         pytest.param(
             pendulum.DateTime(2022, 7, 27, 1, 30, 0, tzinfo=utc),
             START_DATE,
-            DagRunInfo.exact(pendulum.DateTime(2022, 7, 27, 1, 0, 0, tzinfo=utc)),
+            DagRunInfo.exact(pendulum.DateTime(2022, 7, 27, 2, 0, 0, tzinfo=utc)),
             id="current_time_miss_one_interval_not_on_boundary",
         ),
         pytest.param(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
It seems like the implementation of `CronTriggerTimetable` does not reflect the [docs](https://airflow.apache.org/docs/apache-airflow/stable/authoring-and-scheduling/timetable.html#the-time-when-a-dag-run-is-triggered):

> Suppose there are two running DAGs using the two timetables with a cron expression `@daily` or `0 0 * * *`. If you pause the DAGs at 3PM on January 31st and re-enable them at 3PM on February 2nd, [CronTriggerTimetable](https://airflow.apache.org/docs/apache-airflow/stable/authoring-and-scheduling/timetable.html#crontriggertimetable) skips the DAG runs which are supposed to trigger on February 1st and 2nd. The next DAG run will be triggered at 12AM on February 3rd. [CronDataIntervalTimetable](https://airflow.apache.org/docs/apache-airflow/stable/authoring-and-scheduling/timetable.html#crondataintervaltimetable), on the other hand, skips the DAG runs which are supposed to trigger on February 1st only. A DAG run for February 2nd is immediately triggered after you re-enable the DAG.

In fact when a DAG using `CronTriggerTimetable` is enabled it istantly start without waiting for the next cron occurence. This PR fixes it by adding a "next" `start_time_candidate` if the found one is before current time.

Related to this discussion: #35647

---