### PR TITLE
Starts execution directly from triggerer without going to worker

### DIFF
--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -472,7 +472,7 @@ class _TaskDecorator(ExpandableFactory, Generic[FParams, FReturn, OperatorSubcla
         partial_kwargs.setdefault("op_args", [])
         partial_kwargs.setdefault("op_kwargs", {})
         partial_kwargs.setdefault("starts_execution_from_triggerer", False)
-        partial_kwargs.setdefault("start_trigger", None)
+        partial_kwargs.setdefault("trigger", None)
         partial_kwargs.setdefault("next_method", None)
 
         # Mypy does not work well with a subclassed attrs class :(
@@ -513,7 +513,7 @@ class _TaskDecorator(ExpandableFactory, Generic[FParams, FReturn, OperatorSubcla
             # the operator arguments themselves, and should expand against it.
             expand_input_attr="op_kwargs_expand_input",
             starts_execution_from_triggerer=False,
-            start_trigger=None,
+            trigger=None,
             next_method=None,
         )
         return XComArg(operator=operator)

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -509,8 +509,8 @@ class _TaskDecorator(ExpandableFactory, Generic[FParams, FReturn, OperatorSubcla
             # task's expand() contribute to the op_kwargs operator argument, not
             # the operator arguments themselves, and should expand against it.
             expand_input_attr="op_kwargs_expand_input",
-            start_trigger=self.operator_class._start_trigger,
-            next_method=self.operator_class._next_method,
+            start_trigger=self.operator_class.start_trigger,
+            next_method=self.operator_class.next_method,
         )
         return XComArg(operator=operator)
 

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -509,6 +509,9 @@ class _TaskDecorator(ExpandableFactory, Generic[FParams, FReturn, OperatorSubcla
             # task's expand() contribute to the op_kwargs operator argument, not
             # the operator arguments themselves, and should expand against it.
             expand_input_attr="op_kwargs_expand_input",
+            # start with trigger is not supported in dynamic task mapping
+            start_trigger=None,
+            next_method=None,
         )
         return XComArg(operator=operator)
 

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -471,6 +471,7 @@ class _TaskDecorator(ExpandableFactory, Generic[FParams, FReturn, OperatorSubcla
         partial_kwargs.setdefault("executor_config", {})
         partial_kwargs.setdefault("op_args", [])
         partial_kwargs.setdefault("op_kwargs", {})
+        partial_kwargs.setdefault("starts_execution_from_triggerer", False)
         partial_kwargs.setdefault("start_trigger", None)
         partial_kwargs.setdefault("next_method", None)
 
@@ -511,6 +512,7 @@ class _TaskDecorator(ExpandableFactory, Generic[FParams, FReturn, OperatorSubcla
             # task's expand() contribute to the op_kwargs operator argument, not
             # the operator arguments themselves, and should expand against it.
             expand_input_attr="op_kwargs_expand_input",
+            starts_execution_from_triggerer=False,
             start_trigger=None,
             next_method=None,
         )

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -471,6 +471,9 @@ class _TaskDecorator(ExpandableFactory, Generic[FParams, FReturn, OperatorSubcla
         partial_kwargs.setdefault("executor_config", {})
         partial_kwargs.setdefault("op_args", [])
         partial_kwargs.setdefault("op_kwargs", {})
+        partial_kwargs.setdefault("starts_execution_from_triggerer", False)
+        partial_kwargs.setdefault("trigger", None)
+        partial_kwargs.setdefault("next_method", None)
 
         # Mypy does not work well with a subclassed attrs class :(
         _MappedOperator = cast(Any, DecoratedMappedOperator)
@@ -509,6 +512,9 @@ class _TaskDecorator(ExpandableFactory, Generic[FParams, FReturn, OperatorSubcla
             # task's expand() contribute to the op_kwargs operator argument, not
             # the operator arguments themselves, and should expand against it.
             expand_input_attr="op_kwargs_expand_input",
+            starts_execution_from_triggerer=False,
+            trigger=None,
+            next_method=None,
         )
         return XComArg(operator=operator)
 

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -472,7 +472,7 @@ class _TaskDecorator(ExpandableFactory, Generic[FParams, FReturn, OperatorSubcla
         partial_kwargs.setdefault("op_args", [])
         partial_kwargs.setdefault("op_kwargs", {})
         partial_kwargs.setdefault("starts_execution_from_triggerer", False)
-        partial_kwargs.setdefault("trigger", None)
+        partial_kwargs.setdefault("start_trigger", None)
         partial_kwargs.setdefault("next_method", None)
 
         # Mypy does not work well with a subclassed attrs class :(
@@ -513,7 +513,7 @@ class _TaskDecorator(ExpandableFactory, Generic[FParams, FReturn, OperatorSubcla
             # the operator arguments themselves, and should expand against it.
             expand_input_attr="op_kwargs_expand_input",
             starts_execution_from_triggerer=False,
-            trigger=None,
+            start_trigger=None,
             next_method=None,
         )
         return XComArg(operator=operator)

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -471,7 +471,6 @@ class _TaskDecorator(ExpandableFactory, Generic[FParams, FReturn, OperatorSubcla
         partial_kwargs.setdefault("executor_config", {})
         partial_kwargs.setdefault("op_args", [])
         partial_kwargs.setdefault("op_kwargs", {})
-        partial_kwargs.setdefault("starts_execution_from_triggerer", False)
         partial_kwargs.setdefault("start_trigger", None)
         partial_kwargs.setdefault("next_method", None)
 
@@ -512,7 +511,6 @@ class _TaskDecorator(ExpandableFactory, Generic[FParams, FReturn, OperatorSubcla
             # task's expand() contribute to the op_kwargs operator argument, not
             # the operator arguments themselves, and should expand against it.
             expand_input_attr="op_kwargs_expand_input",
-            starts_execution_from_triggerer=False,
             start_trigger=None,
             next_method=None,
         )

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -471,9 +471,6 @@ class _TaskDecorator(ExpandableFactory, Generic[FParams, FReturn, OperatorSubcla
         partial_kwargs.setdefault("executor_config", {})
         partial_kwargs.setdefault("op_args", [])
         partial_kwargs.setdefault("op_kwargs", {})
-        partial_kwargs.setdefault("starts_execution_from_triggerer", False)
-        partial_kwargs.setdefault("trigger", None)
-        partial_kwargs.setdefault("next_method", None)
 
         # Mypy does not work well with a subclassed attrs class :(
         _MappedOperator = cast(Any, DecoratedMappedOperator)
@@ -512,9 +509,6 @@ class _TaskDecorator(ExpandableFactory, Generic[FParams, FReturn, OperatorSubcla
             # task's expand() contribute to the op_kwargs operator argument, not
             # the operator arguments themselves, and should expand against it.
             expand_input_attr="op_kwargs_expand_input",
-            starts_execution_from_triggerer=False,
-            trigger=None,
-            next_method=None,
         )
         return XComArg(operator=operator)
 

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -509,9 +509,8 @@ class _TaskDecorator(ExpandableFactory, Generic[FParams, FReturn, OperatorSubcla
             # task's expand() contribute to the op_kwargs operator argument, not
             # the operator arguments themselves, and should expand against it.
             expand_input_attr="op_kwargs_expand_input",
-            # start with trigger is not supported in dynamic task mapping
-            start_trigger=None,
-            next_method=None,
+            start_trigger=self.operator_class._start_trigger,
+            next_method=self.operator_class._next_method,
         )
         return XComArg(operator=operator)
 

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -122,6 +122,8 @@ class AbstractOperator(Templater, DAGNode):
             "node_id",  # Duplicates task_id
             "task_group",  # Doesn't have a useful repr, no point showing in UI
             "inherits_from_empty_operator",  # impl detail
+            "_start_trigger",
+            "_next_method",
             # For compatibility with TG, for operators these are just the current task, no point showing
             "roots",
             "leaves",

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -122,8 +122,8 @@ class AbstractOperator(Templater, DAGNode):
             "node_id",  # Duplicates task_id
             "task_group",  # Doesn't have a useful repr, no point showing in UI
             "inherits_from_empty_operator",  # impl detail
-            "_start_trigger",
-            "_next_method",
+            "start_trigger",
+            "next_method",
             # For compatibility with TG, for operators these are just the current task, no point showing
             "roots",
             "leaves",

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -278,7 +278,7 @@ def partial(
     logger_name: str | None | ArgNotSet = NOTSET,
     allow_nested_operators: bool = True,
     starts_execution_from_triggerer: bool = False,
-    trigger: Trigger | None = None,
+    start_trigger: Trigger | None = None,
     next_method: str | None = None,
     **kwargs,
 ) -> OperatorPartial:
@@ -350,7 +350,7 @@ def partial(
         "logger_name": logger_name,
         "allow_nested_operators": allow_nested_operators,
         "starts_execution_from_triggerer": starts_execution_from_triggerer,
-        "trigger": trigger,
+        "start_trigger": start_trigger,
         "next_method": next_method,
     }
 
@@ -883,7 +883,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         logger_name: str | None = None,
         allow_nested_operators: bool = True,
         starts_execution_from_triggerer: bool = False,
-        trigger: Trigger | None = None,
+        start_trigger: Trigger | None = None,
         next_method: str | None = None,
         **kwargs,
     ):
@@ -1086,7 +1086,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
             SetupTeardownContext.update_context_map(self)
 
         self.starts_execution_from_triggerer = starts_execution_from_triggerer
-        self.trigger = trigger
+        self.start_trigger = start_trigger
         self.next_method = next_method
 
     def __eq__(self, other):

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -83,6 +83,7 @@ from airflow.models.param import ParamsDict
 from airflow.models.pool import Pool
 from airflow.models.taskinstance import TaskInstance, clear_task_instances
 from airflow.models.taskmixin import DependencyMixin
+from airflow.models.trigger import Trigger
 from airflow.serialization.enums import DagAttributeTypes
 from airflow.task.priority_strategy import PriorityWeightStrategy, validate_and_load_priority_weight_strategy
 from airflow.ti_deps.deps.mapped_task_upstream_dep import MappedTaskUpstreamDep
@@ -113,6 +114,7 @@ if TYPE_CHECKING:
     from airflow.models.baseoperatorlink import BaseOperatorLink
     from airflow.models.dag import DAG
     from airflow.models.operator import Operator
+    from airflow.models.trigger import Trigger
     from airflow.models.xcom_arg import XComArg
     from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
     from airflow.triggers.base import BaseTrigger
@@ -275,6 +277,9 @@ def partial(
     task_display_name: str | None | ArgNotSet = NOTSET,
     logger_name: str | None | ArgNotSet = NOTSET,
     allow_nested_operators: bool = True,
+    starts_execution_from_triggerer: bool = False,
+    trigger: Trigger = None,
+    next_method: str | None = None,
     **kwargs,
 ) -> OperatorPartial:
     from airflow.models.dag import DagContext
@@ -344,6 +349,9 @@ def partial(
         "task_display_name": task_display_name,
         "logger_name": logger_name,
         "allow_nested_operators": allow_nested_operators,
+        "starts_execution_from_triggerer": starts_execution_from_triggerer,
+        "trigger": trigger,
+        "next_method": next_method,
     }
 
     # Inject DAG-level default args into args provided to this function.
@@ -874,6 +882,9 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         task_display_name: str | None = None,
         logger_name: str | None = None,
         allow_nested_operators: bool = True,
+        starts_execution_from_triggerer: bool = False,
+        trigger: Trigger | None = None,
+        next_method: str | None = None,
         **kwargs,
     ):
         from airflow.models.dag import DagContext
@@ -1073,6 +1084,10 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         self._is_teardown = False
         if SetupTeardownContext.active:
             SetupTeardownContext.update_context_map(self)
+
+        self._starts_execution_from_triggerer = starts_execution_from_triggerer
+        self._trigger = trigger
+        self._next_method = next_method
 
     def __eq__(self, other):
         if type(self) is type(other):
@@ -1692,6 +1707,21 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         # needs to cope when `self` is a Serialized instance of a EmptyOperator or one
         # of its subclasses (which don't inherit from anything but BaseOperator).
         return getattr(self, "_is_empty", False)
+
+    @property
+    def starts_execution_from_triggerer(self):
+        """Used to determine if an Operator should start execution from triggerer."""
+        return getattr(self, "_starts_execution_from_triggerer", False)
+
+    @property
+    def trigger(self):
+        """Trigger when deferring task."""
+        return getattr(self, "_trigger", None)
+
+    @property
+    def next_method(self):
+        """Method to execute after finish deferring."""
+        return getattr(self, "_next_method", None)
 
     def defer(
         self,

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -278,7 +278,7 @@ def partial(
     logger_name: str | None | ArgNotSet = NOTSET,
     allow_nested_operators: bool = True,
     starts_execution_from_triggerer: bool = False,
-    trigger: Trigger | None = None,
+    trigger: Trigger = None,
     next_method: str | None = None,
     **kwargs,
 ) -> OperatorPartial:
@@ -1085,9 +1085,9 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         if SetupTeardownContext.active:
             SetupTeardownContext.update_context_map(self)
 
-        self.starts_execution_from_triggerer = starts_execution_from_triggerer
-        self.trigger = trigger
-        self.next_method = next_method
+        self._starts_execution_from_triggerer = starts_execution_from_triggerer
+        self._trigger = trigger
+        self._next_method = next_method
 
     def __eq__(self, other):
         if type(self) is type(other):
@@ -1707,6 +1707,21 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         # needs to cope when `self` is a Serialized instance of a EmptyOperator or one
         # of its subclasses (which don't inherit from anything but BaseOperator).
         return getattr(self, "_is_empty", False)
+
+    @property
+    def starts_execution_from_triggerer(self):
+        """Used to determine if an Operator should start execution from triggerer."""
+        return getattr(self, "_starts_execution_from_triggerer", False)
+
+    @property
+    def trigger(self):
+        """Trigger when deferring task."""
+        return getattr(self, "_trigger", None)
+
+    @property
+    def next_method(self):
+        """Method to execute after finish deferring."""
+        return getattr(self, "_next_method", None)
 
     def defer(
         self,

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -818,8 +818,8 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
     # Set to True for an operator instantiated by a mapped operator.
     __from_mapped = False
 
-    _start_trigger: BaseTrigger | None = None
-    _next_method: str | None = None
+    start_trigger: BaseTrigger | None = None
+    next_method: str | None = None
 
     def __init__(
         self,
@@ -1678,8 +1678,8 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
                     "is_teardown",
                     "on_failure_fail_dagrun",
                     "map_index_template",
-                    "_start_trigger",
-                    "_next_method",
+                    "start_trigger",
+                    "next_method",
                 }
             )
             DagContext.pop_context_managed_dag()
@@ -1697,16 +1697,6 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         # needs to cope when `self` is a Serialized instance of a EmptyOperator or one
         # of its subclasses (which don't inherit from anything but BaseOperator).
         return getattr(self, "_is_empty", False)
-
-    @property
-    def start_trigger(self) -> BaseTrigger | None:
-        """Trigger when deferring task."""
-        return self._start_trigger
-
-    @property
-    def next_method(self) -> str | None:
-        """Method to execute after finish deferring."""
-        return self._next_method
 
     def defer(
         self,

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -277,7 +277,6 @@ def partial(
     task_display_name: str | None | ArgNotSet = NOTSET,
     logger_name: str | None | ArgNotSet = NOTSET,
     allow_nested_operators: bool = True,
-    starts_execution_from_triggerer: bool = False,
     start_trigger: Trigger | None = None,
     next_method: str | None = None,
     **kwargs,
@@ -349,7 +348,6 @@ def partial(
         "task_display_name": task_display_name,
         "logger_name": logger_name,
         "allow_nested_operators": allow_nested_operators,
-        "starts_execution_from_triggerer": starts_execution_from_triggerer,
         "start_trigger": start_trigger,
         "next_method": next_method,
     }
@@ -882,7 +880,6 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         task_display_name: str | None = None,
         logger_name: str | None = None,
         allow_nested_operators: bool = True,
-        starts_execution_from_triggerer: bool = False,
         start_trigger: Trigger | None = None,
         next_method: str | None = None,
         **kwargs,
@@ -1085,7 +1082,6 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         if SetupTeardownContext.active:
             SetupTeardownContext.update_context_map(self)
 
-        self.starts_execution_from_triggerer = starts_execution_from_triggerer
         self.start_trigger = start_trigger
         self.next_method = next_method
 

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1075,6 +1075,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
             SetupTeardownContext.update_context_map(self)
 
         self._start_trigger: BaseTrigger | None = getattr(self, "_start_trigger", None)
+        self._next_method: str | None = getattr(self, "_next_method", None)
 
     def __eq__(self, other):
         if type(self) is type(other):
@@ -1698,12 +1699,12 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
     @property
     def start_trigger(self) -> BaseTrigger | None:
         """Trigger when deferring task."""
-        return getattr(self, "_start_trigger", None)
+        return self._start_trigger
 
     @property
     def next_method(self) -> str | None:
         """Method to execute after finish deferring."""
-        return getattr(self, "_next_method", None)
+        return self._next_method
 
     def defer(
         self,

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -277,6 +277,7 @@ def partial(
     task_display_name: str | None | ArgNotSet = NOTSET,
     logger_name: str | None | ArgNotSet = NOTSET,
     allow_nested_operators: bool = True,
+    starts_execution_from_triggerer: bool = False,
     start_trigger: Trigger | None = None,
     next_method: str | None = None,
     **kwargs,
@@ -348,6 +349,7 @@ def partial(
         "task_display_name": task_display_name,
         "logger_name": logger_name,
         "allow_nested_operators": allow_nested_operators,
+        "starts_execution_from_triggerer": starts_execution_from_triggerer,
         "start_trigger": start_trigger,
         "next_method": next_method,
     }
@@ -880,6 +882,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         task_display_name: str | None = None,
         logger_name: str | None = None,
         allow_nested_operators: bool = True,
+        starts_execution_from_triggerer: bool = False,
         start_trigger: Trigger | None = None,
         next_method: str | None = None,
         **kwargs,
@@ -1082,6 +1085,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         if SetupTeardownContext.active:
             SetupTeardownContext.update_context_map(self)
 
+        self.starts_execution_from_triggerer = starts_execution_from_triggerer
         self.start_trigger = start_trigger
         self.next_method = next_method
 

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -818,6 +818,9 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
     # Set to True for an operator instantiated by a mapped operator.
     __from_mapped = False
 
+    _start_trigger: BaseTrigger | None = None
+    _next_method: str | None = None
+
     def __init__(
         self,
         task_id: str,
@@ -1073,9 +1076,6 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         self._is_teardown = False
         if SetupTeardownContext.active:
             SetupTeardownContext.update_context_map(self)
-
-        self._start_trigger: BaseTrigger | None = getattr(self, "_start_trigger", None)
-        self._next_method: str | None = getattr(self, "_next_method", None)
 
     def __eq__(self, other):
         if type(self) is type(other):
@@ -1678,6 +1678,8 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
                     "is_teardown",
                     "on_failure_fail_dagrun",
                     "map_index_template",
+                    "_start_trigger",
+                    "_next_method",
                 }
             )
             DagContext.pop_context_managed_dag()

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -278,7 +278,7 @@ def partial(
     logger_name: str | None | ArgNotSet = NOTSET,
     allow_nested_operators: bool = True,
     starts_execution_from_triggerer: bool = False,
-    trigger: Trigger = None,
+    trigger: Trigger | None = None,
     next_method: str | None = None,
     **kwargs,
 ) -> OperatorPartial:
@@ -1085,9 +1085,9 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         if SetupTeardownContext.active:
             SetupTeardownContext.update_context_map(self)
 
-        self._starts_execution_from_triggerer = starts_execution_from_triggerer
-        self._trigger = trigger
-        self._next_method = next_method
+        self.starts_execution_from_triggerer = starts_execution_from_triggerer
+        self.trigger = trigger
+        self.next_method = next_method
 
     def __eq__(self, other):
         if type(self) is type(other):
@@ -1707,21 +1707,6 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         # needs to cope when `self` is a Serialized instance of a EmptyOperator or one
         # of its subclasses (which don't inherit from anything but BaseOperator).
         return getattr(self, "_is_empty", False)
-
-    @property
-    def starts_execution_from_triggerer(self):
-        """Used to determine if an Operator should start execution from triggerer."""
-        return getattr(self, "_starts_execution_from_triggerer", False)
-
-    @property
-    def trigger(self):
-        """Trigger when deferring task."""
-        return getattr(self, "_trigger", None)
-
-    @property
-    def next_method(self):
-        """Method to execute after finish deferring."""
-        return getattr(self, "_next_method", None)
 
     def defer(
         self,

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -344,8 +344,6 @@ def partial(
         "task_display_name": task_display_name,
         "logger_name": logger_name,
         "allow_nested_operators": allow_nested_operators,
-        "start_trigger": start_trigger,
-        "next_method": next_method,
     }
 
     # Inject DAG-level default args into args provided to this function.
@@ -1076,8 +1074,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         if SetupTeardownContext.active:
             SetupTeardownContext.update_context_map(self)
 
-        self._start_trigger: BaseTrigger | None = None
-        self._next_method: str | None = None
+        self._start_trigger: BaseTrigger | None = getattr(self, "_start_trigger", None)
 
     def __eq__(self, other):
         if type(self) is type(other):

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -278,7 +278,7 @@ def partial(
     logger_name: str | None | ArgNotSet = NOTSET,
     allow_nested_operators: bool = True,
     starts_execution_from_triggerer: bool = False,
-    start_trigger: Trigger | None = None,
+    trigger: Trigger | None = None,
     next_method: str | None = None,
     **kwargs,
 ) -> OperatorPartial:
@@ -350,7 +350,7 @@ def partial(
         "logger_name": logger_name,
         "allow_nested_operators": allow_nested_operators,
         "starts_execution_from_triggerer": starts_execution_from_triggerer,
-        "start_trigger": start_trigger,
+        "trigger": trigger,
         "next_method": next_method,
     }
 
@@ -883,7 +883,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         logger_name: str | None = None,
         allow_nested_operators: bool = True,
         starts_execution_from_triggerer: bool = False,
-        start_trigger: Trigger | None = None,
+        trigger: Trigger | None = None,
         next_method: str | None = None,
         **kwargs,
     ):
@@ -1086,7 +1086,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
             SetupTeardownContext.update_context_map(self)
 
         self.starts_execution_from_triggerer = starts_execution_from_triggerer
-        self.start_trigger = start_trigger
+        self.trigger = trigger
         self.next_method = next_method
 
     def __eq__(self, other):

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -1553,6 +1553,7 @@ class DagRun(Base, LoggingMixin):
 
                 trigger_cls_name, trigger_kwargs = ti.task.trigger
                 trigger_cls = import_string(trigger_cls_name)
+                ti._try_number += 1
                 ti.defer_task(
                     defer=TaskDeferred(trigger=trigger_cls(**trigger_kwargs), method_name="execute_complete"),
                     session=session,

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -1541,13 +1541,15 @@ class DagRun(Base, LoggingMixin):
             ):
                 dummy_ti_ids.append((ti.task_id, ti.map_index))
             elif (
-                ti.task.start_trigger
+                ti.task.starts_execution_from_triggerer
                 and not ti.task.on_execute_callback
                 and not ti.task.on_success_callback
                 and not ti.task.outlets
             ):
                 if not (ti.task.start_trigger and ti.task.next_method):
-                    raise AirflowException("When start_trigger it not None, next_method is required.")
+                    raise AirflowException(
+                        "When setting starts_execution_from_triggerer=True, start_trigger and next_method are required."
+                    )
 
                 trigger_cls_name, trigger_kwargs = ti.task.start_trigger
                 trigger_cls = import_string(trigger_cls_name)

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -1541,15 +1541,13 @@ class DagRun(Base, LoggingMixin):
             ):
                 dummy_ti_ids.append((ti.task_id, ti.map_index))
             elif (
-                ti.task.starts_execution_from_triggerer
+                ti.task.start_trigger
                 and not ti.task.on_execute_callback
                 and not ti.task.on_success_callback
                 and not ti.task.outlets
             ):
                 if not (ti.task.start_trigger and ti.task.next_method):
-                    raise AirflowException(
-                        "When setting starts_execution_from_triggerer=True, start_trigger and next_method are required."
-                    )
+                    raise AirflowException("When start_trigger it not None, next_method is required.")
 
                 trigger_cls_name, trigger_kwargs = ti.task.start_trigger
                 trigger_cls = import_string(trigger_cls_name)

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -1546,12 +1546,12 @@ class DagRun(Base, LoggingMixin):
                 and not ti.task.on_success_callback
                 and not ti.task.outlets
             ):
-                if not (ti.task.start_trigger and ti.task.next_method):
+                if not (ti.task.trigger and ti.task.next_method):
                     raise AirflowException(
-                        "When setting starts_execution_from_triggerer=True, start_trigger and next_method are required."
+                        "When setting starts_execution_from_triggerer=True, trigger and next_method are required."
                     )
 
-                trigger_cls_name, trigger_kwargs = ti.task.start_trigger
+                trigger_cls_name, trigger_kwargs = ti.task.trigger
                 trigger_cls = import_string(trigger_cls_name)
                 ti._try_number += 1
                 ti.defer_task(

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -1546,12 +1546,12 @@ class DagRun(Base, LoggingMixin):
                 and not ti.task.on_success_callback
                 and not ti.task.outlets
             ):
-                if not (ti.task.trigger and ti.task.next_method):
+                if not (ti.task.start_trigger and ti.task.next_method):
                     raise AirflowException(
-                        "When setting starts_execution_from_triggerer=True, trigger and next_method are required."
+                        "When setting starts_execution_from_triggerer=True, start_trigger and next_method are required."
                     )
 
-                trigger_cls_name, trigger_kwargs = ti.task.trigger
+                trigger_cls_name, trigger_kwargs = ti.task.start_trigger
                 trigger_cls = import_string(trigger_cls_name)
                 ti._try_number += 1
                 ti.defer_task(

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -1541,21 +1541,21 @@ class DagRun(Base, LoggingMixin):
             ):
                 dummy_ti_ids.append((ti.task_id, ti.map_index))
             elif (
-                ti.task.starts_execution_from_triggerer
+                ti.task.start_trigger
                 and not ti.task.on_execute_callback
                 and not ti.task.on_success_callback
                 and not ti.task.outlets
             ):
-                if not (ti.task.trigger and ti.task.next_method):
-                    raise AirflowException(
-                        "When setting starts_execution_from_triggerer=True, trigger and next_method are required."
-                    )
+                if not (ti.task.start_trigger and ti.task.next_method):
+                    raise AirflowException("When setting start_trigger, next_method is required.")
 
-                trigger_cls_name, trigger_kwargs = ti.task.trigger
+                trigger_cls_name, trigger_kwargs = ti.task.start_trigger
                 trigger_cls = import_string(trigger_cls_name)
                 ti._try_number += 1
                 ti.defer_task(
-                    defer=TaskDeferred(trigger=trigger_cls(**trigger_kwargs), method_name="execute_complete"),
+                    defer=TaskDeferred(
+                        trigger=trigger_cls(**trigger_kwargs), method_name=ti.task.next_method
+                    ),
                     session=session,
                 )
             else:

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -207,7 +207,7 @@ class OperatorPartial:
         start_date = partial_kwargs.pop("start_date")
         end_date = partial_kwargs.pop("end_date")
         starts_execution_from_triggerer = partial_kwargs.pop("starts_execution_from_triggerer")
-        start_trigger = partial_kwargs.pop("start_trigger")
+        trigger = partial_kwargs.pop("trigger")
         next_method = partial_kwargs.pop("next_method")
 
         try:
@@ -241,7 +241,7 @@ class OperatorPartial:
             # to BaseOperator.expand() contribute to operator arguments.
             expand_input_attr="expand_input",
             starts_execution_from_triggerer=starts_execution_from_triggerer,
-            start_trigger=start_trigger,
+            trigger=trigger,
             next_method=next_method,
         )
         return op
@@ -286,7 +286,7 @@ class MappedOperator(AbstractOperator):
     _task_type: str
     _operator_name: str
     starts_execution_from_triggerer: bool | None
-    start_trigger: Trigger | None
+    trigger: Trigger | None
     next_method: str | None
 
     dag: DAG | None

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -206,7 +206,6 @@ class OperatorPartial:
         task_group = partial_kwargs.pop("task_group")
         start_date = partial_kwargs.pop("start_date")
         end_date = partial_kwargs.pop("end_date")
-        starts_execution_from_triggerer = partial_kwargs.pop("starts_execution_from_triggerer")
         start_trigger = partial_kwargs.pop("start_trigger")
         next_method = partial_kwargs.pop("next_method")
 
@@ -240,7 +239,6 @@ class OperatorPartial:
             # For classic operators, this points to expand_input because kwargs
             # to BaseOperator.expand() contribute to operator arguments.
             expand_input_attr="expand_input",
-            starts_execution_from_triggerer=starts_execution_from_triggerer,
             start_trigger=start_trigger,
             next_method=next_method,
         )
@@ -285,7 +283,6 @@ class MappedOperator(AbstractOperator):
     _task_module: str
     _task_type: str
     _operator_name: str
-    starts_execution_from_triggerer: bool | None
     start_trigger: Trigger | None
     next_method: str | None
 

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -207,7 +207,7 @@ class OperatorPartial:
         start_date = partial_kwargs.pop("start_date")
         end_date = partial_kwargs.pop("end_date")
         starts_execution_from_triggerer = partial_kwargs.pop("starts_execution_from_triggerer")
-        trigger = partial_kwargs.pop("trigger")
+        start_trigger = partial_kwargs.pop("start_trigger")
         next_method = partial_kwargs.pop("next_method")
 
         try:
@@ -241,7 +241,7 @@ class OperatorPartial:
             # to BaseOperator.expand() contribute to operator arguments.
             expand_input_attr="expand_input",
             starts_execution_from_triggerer=starts_execution_from_triggerer,
-            trigger=trigger,
+            start_trigger=start_trigger,
             next_method=next_method,
         )
         return op
@@ -286,7 +286,7 @@ class MappedOperator(AbstractOperator):
     _task_type: str
     _operator_name: str
     starts_execution_from_triggerer: bool | None
-    trigger: Trigger | None
+    start_trigger: Trigger | None
     next_method: str | None
 
     dag: DAG | None

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -206,6 +206,9 @@ class OperatorPartial:
         task_group = partial_kwargs.pop("task_group")
         start_date = partial_kwargs.pop("start_date")
         end_date = partial_kwargs.pop("end_date")
+        starts_execution_from_triggerer = partial_kwargs.pop("starts_execution_from_triggerer")
+        trigger = partial_kwargs.pop("trigger")
+        next_method = partial_kwargs.pop("next_method")
 
         try:
             operator_name = self.operator_class.custom_operator_name  # type: ignore
@@ -237,6 +240,9 @@ class OperatorPartial:
             # For classic operators, this points to expand_input because kwargs
             # to BaseOperator.expand() contribute to operator arguments.
             expand_input_attr="expand_input",
+            starts_execution_from_triggerer=starts_execution_from_triggerer,
+            trigger=trigger,
+            next_method=next_method,
         )
         return op
 
@@ -279,7 +285,7 @@ class MappedOperator(AbstractOperator):
     _task_module: str
     _task_type: str
     _operator_name: str
-    starts_execution_from_triggerer: bool
+    starts_execution_from_triggerer: bool | None
     trigger: Trigger | None
     next_method: str | None
 

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -237,9 +237,8 @@ class OperatorPartial:
             # For classic operators, this points to expand_input because kwargs
             # to BaseOperator.expand() contribute to operator arguments.
             expand_input_attr="expand_input",
-            # start with trigger is not supported in dynamic task mapping
-            start_trigger=None,
-            next_method=None,
+            start_trigger=self.operator_class._start_trigger,
+            next_method=self.operator_class._next_method,
         )
         return op
 
@@ -312,6 +311,8 @@ class MappedOperator(AbstractOperator):
         (
             "parse_time_mapped_ti_count",
             "operator_class",
+            "_start_trigger",
+            "_next_method",
         )
     )
 

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -79,9 +79,9 @@ if TYPE_CHECKING:
     )
     from airflow.models.operator import Operator
     from airflow.models.param import ParamsDict
-    from airflow.models.trigger import Trigger
     from airflow.models.xcom_arg import XComArg
     from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
+    from airflow.triggers.base import BaseTrigger
     from airflow.utils.context import Context
     from airflow.utils.operator_resources import Resources
     from airflow.utils.task_group import TaskGroup
@@ -279,8 +279,7 @@ class MappedOperator(AbstractOperator):
     _task_module: str
     _task_type: str
     _operator_name: str
-    _starts_execution_from_triggerer: bool
-    _trigger: Trigger | None
+    _start_trigger: BaseTrigger | None
     _next_method: str | None
 
     dag: DAG | None
@@ -382,17 +381,12 @@ class MappedOperator(AbstractOperator):
         return self._is_empty
 
     @property
-    def starts_execution_from_triggerer(self) -> bool:
+    def start_trigger(self) -> BaseTrigger | None:
         """Implementing Operator."""
-        return self._starts_execution_from_triggerer
+        return self._start_trigger
 
     @property
-    def trigger(self) -> Trigger:
-        """Implementing Operator."""
-        return self._trigger
-
-    @property
-    def next_method(self) -> str:
+    def next_method(self) -> str | None:
         """Implementing Operator."""
         return self._next_method
 

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -206,9 +206,6 @@ class OperatorPartial:
         task_group = partial_kwargs.pop("task_group")
         start_date = partial_kwargs.pop("start_date")
         end_date = partial_kwargs.pop("end_date")
-        starts_execution_from_triggerer = partial_kwargs.pop("starts_execution_from_triggerer")
-        trigger = partial_kwargs.pop("trigger")
-        next_method = partial_kwargs.pop("next_method")
 
         try:
             operator_name = self.operator_class.custom_operator_name  # type: ignore
@@ -240,9 +237,6 @@ class OperatorPartial:
             # For classic operators, this points to expand_input because kwargs
             # to BaseOperator.expand() contribute to operator arguments.
             expand_input_attr="expand_input",
-            starts_execution_from_triggerer=starts_execution_from_triggerer,
-            trigger=trigger,
-            next_method=next_method,
         )
         return op
 
@@ -285,7 +279,7 @@ class MappedOperator(AbstractOperator):
     _task_module: str
     _task_type: str
     _operator_name: str
-    starts_execution_from_triggerer: bool | None
+    starts_execution_from_triggerer: bool
     trigger: Trigger | None
     next_method: str | None
 

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -279,9 +279,9 @@ class MappedOperator(AbstractOperator):
     _task_module: str
     _task_type: str
     _operator_name: str
-    _starts_execution_from_triggerer: bool
-    _trigger: Trigger | None
-    _next_method: str | None
+    starts_execution_from_triggerer: bool
+    trigger: Trigger | None
+    next_method: str | None
 
     dag: DAG | None
     task_group: TaskGroup | None
@@ -380,21 +380,6 @@ class MappedOperator(AbstractOperator):
     def inherits_from_empty_operator(self) -> bool:
         """Implementing Operator."""
         return self._is_empty
-
-    @property
-    def starts_execution_from_triggerer(self) -> bool:
-        """Implementing Operator."""
-        return self._starts_execution_from_triggerer
-
-    @property
-    def trigger(self) -> Trigger:
-        """Implementing Operator."""
-        return self._trigger
-
-    @property
-    def next_method(self) -> str:
-        """Implementing Operator."""
-        return self._next_method
 
     @property
     def roots(self) -> Sequence[AbstractOperator]:

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -79,6 +79,7 @@ if TYPE_CHECKING:
     )
     from airflow.models.operator import Operator
     from airflow.models.param import ParamsDict
+    from airflow.models.trigger import Trigger
     from airflow.models.xcom_arg import XComArg
     from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
     from airflow.utils.context import Context
@@ -278,6 +279,9 @@ class MappedOperator(AbstractOperator):
     _task_module: str
     _task_type: str
     _operator_name: str
+    _starts_execution_from_triggerer: bool
+    _trigger: Trigger | None
+    _next_method: str | None
 
     dag: DAG | None
     task_group: TaskGroup | None
@@ -376,6 +380,21 @@ class MappedOperator(AbstractOperator):
     def inherits_from_empty_operator(self) -> bool:
         """Implementing Operator."""
         return self._is_empty
+
+    @property
+    def starts_execution_from_triggerer(self) -> bool:
+        """Implementing Operator."""
+        return self._starts_execution_from_triggerer
+
+    @property
+    def trigger(self) -> Trigger:
+        """Implementing Operator."""
+        return self._trigger
+
+    @property
+    def next_method(self) -> str:
+        """Implementing Operator."""
+        return self._next_method
 
     @property
     def roots(self) -> Sequence[AbstractOperator]:

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -206,6 +206,7 @@ class OperatorPartial:
         task_group = partial_kwargs.pop("task_group")
         start_date = partial_kwargs.pop("start_date")
         end_date = partial_kwargs.pop("end_date")
+        starts_execution_from_triggerer = partial_kwargs.pop("starts_execution_from_triggerer")
         start_trigger = partial_kwargs.pop("start_trigger")
         next_method = partial_kwargs.pop("next_method")
 
@@ -239,6 +240,7 @@ class OperatorPartial:
             # For classic operators, this points to expand_input because kwargs
             # to BaseOperator.expand() contribute to operator arguments.
             expand_input_attr="expand_input",
+            starts_execution_from_triggerer=starts_execution_from_triggerer,
             start_trigger=start_trigger,
             next_method=next_method,
         )
@@ -283,6 +285,7 @@ class MappedOperator(AbstractOperator):
     _task_module: str
     _task_type: str
     _operator_name: str
+    starts_execution_from_triggerer: bool | None
     start_trigger: Trigger | None
     next_method: str | None
 

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -237,8 +237,8 @@ class OperatorPartial:
             # For classic operators, this points to expand_input because kwargs
             # to BaseOperator.expand() contribute to operator arguments.
             expand_input_attr="expand_input",
-            start_trigger=self.operator_class._start_trigger,
-            next_method=self.operator_class._next_method,
+            start_trigger=self.operator_class.start_trigger,
+            next_method=self.operator_class.next_method,
         )
         return op
 
@@ -281,8 +281,8 @@ class MappedOperator(AbstractOperator):
     _task_module: str
     _task_type: str
     _operator_name: str
-    _start_trigger: BaseTrigger | None
-    _next_method: str | None
+    start_trigger: BaseTrigger | None
+    next_method: str | None
 
     dag: DAG | None
     task_group: TaskGroup | None
@@ -311,8 +311,8 @@ class MappedOperator(AbstractOperator):
         (
             "parse_time_mapped_ti_count",
             "operator_class",
-            "_start_trigger",
-            "_next_method",
+            "start_trigger",
+            "next_method",
         )
     )
 
@@ -383,16 +383,6 @@ class MappedOperator(AbstractOperator):
     def inherits_from_empty_operator(self) -> bool:
         """Implementing Operator."""
         return self._is_empty
-
-    @property
-    def start_trigger(self) -> BaseTrigger | None:
-        """Implementing Operator."""
-        return self._start_trigger
-
-    @property
-    def next_method(self) -> str | None:
-        """Implementing Operator."""
-        return self._next_method
 
     @property
     def roots(self) -> Sequence[AbstractOperator]:

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -237,6 +237,9 @@ class OperatorPartial:
             # For classic operators, this points to expand_input because kwargs
             # to BaseOperator.expand() contribute to operator arguments.
             expand_input_attr="expand_input",
+            # start with trigger is not supported in dynamic task mapping
+            start_trigger=None,
+            next_method=None,
         )
         return op
 

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -279,9 +279,9 @@ class MappedOperator(AbstractOperator):
     _task_module: str
     _task_type: str
     _operator_name: str
-    starts_execution_from_triggerer: bool
-    trigger: Trigger | None
-    next_method: str | None
+    _starts_execution_from_triggerer: bool
+    _trigger: Trigger | None
+    _next_method: str | None
 
     dag: DAG | None
     task_group: TaskGroup | None
@@ -380,6 +380,21 @@ class MappedOperator(AbstractOperator):
     def inherits_from_empty_operator(self) -> bool:
         """Implementing Operator."""
         return self._is_empty
+
+    @property
+    def starts_execution_from_triggerer(self) -> bool:
+        """Implementing Operator."""
+        return self._starts_execution_from_triggerer
+
+    @property
+    def trigger(self) -> Trigger:
+        """Implementing Operator."""
+        return self._trigger
+
+    @property
+    def next_method(self) -> str:
+        """Implementing Operator."""
+        return self._next_method
 
     @property
     def roots(self) -> Sequence[AbstractOperator]:

--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -1,381 +1,651 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://airflow.apache.com/schemas/serialized-dags.json",
-  "definitions": {
-    "datetime": {
-      "description": "A date time, stored as fractional seconds since the epoch",
-      "type": "number"
-    },
-    "timedelta": {
-      "type": "number",
-      "minimum": 0
-    },
-    "typed_timedelta": {
-      "type": "object",
-      "properties": {
-        "__type": {
-          "type": "string",
-          "const": "timedelta"
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://airflow.apache.com/schemas/serialized-dags.json",
+    "definitions": {
+        "datetime": {
+            "description": "A date time, stored as fractional seconds since the epoch",
+            "type": "number"
         },
-        "__var": { "$ref": "#/definitions/timedelta" }
-      },
-      "required": [
-        "__type",
-        "__var"
-      ],
-      "additionalProperties": false
-    },
-    "typed_relativedelta": {
-      "type": "object",
-      "description": "A dateutil.relativedelta.relativedelta object",
-      "properties": {
-        "__type": {
-          "type": "string",
-          "const": "relativedelta"
+        "timedelta": {
+            "type": "number",
+            "minimum": 0
         },
-        "__var": {
-          "type": "object",
-          "properties": {
-            "weekday": {
-              "type": "array",
-              "items": { "type": "integer" },
-              "minItems": 1,
-              "maxItems": 2
-            }
-          },
-          "additionalProperties": { "type": "integer" }
-        }
-      }
-    },
-    "timezone": {
-      "anyOf": [
-        { "type": "string" },
-        { "type": "integer" }
-      ]
-    },
-    "dataset": {
-      "type": "object",
-      "properties": {
-        "uri": { "type": "string" },
-        "extra": {
-            "anyOf": [
-                {"type": "null"},
-                { "$ref": "#/definitions/dict" }
-            ]
-        }
-      },
-      "required": [ "uri", "extra" ]
-    },
-    "typed_dataset": {
-      "type": "object",
-      "properties": {
-        "__type": {
-          "type": "string",
-            "constant": "dataset"
-        },
-        "__var": { "$ref": "#/definitions/dataset" }
-      },
-      "required": [
-        "__type",
-        "__var"
-      ],
-      "additionalProperties": false
-    },
-    "typed_dataset_cond": {
-      "type": "object",
-      "properties": {
-        "__type": {
-            "anyOf": [{
-                "type": "string",
-                "constant": "dataset_or"
+        "typed_timedelta": {
+            "type": "object",
+            "properties": {
+                "__type": {
+                    "type": "string",
+                    "const": "timedelta"
+                },
+                "__var": {
+                    "$ref": "#/definitions/timedelta"
+                }
             },
-            {
-                "type": "string",
-                "constant": "dataset_and"
+            "required": [
+                "__type",
+                "__var"
+            ],
+            "additionalProperties": false
+        },
+        "typed_relativedelta": {
+            "type": "object",
+            "description": "A dateutil.relativedelta.relativedelta object",
+            "properties": {
+                "__type": {
+                    "type": "string",
+                    "const": "relativedelta"
+                },
+                "__var": {
+                    "type": "object",
+                    "properties": {
+                        "weekday": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            },
+                            "minItems": 1,
+                            "maxItems": 2
+                        }
+                    },
+                    "additionalProperties": {
+                        "type": "integer"
+                    }
+                }
             }
+        },
+        "timezone": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
             ]
         },
-        "__var": {
+        "dataset": {
+            "type": "object",
+            "properties": {
+                "uri": {
+                    "type": "string"
+                },
+                "extra": {
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        },
+                        {
+                            "$ref": "#/definitions/dict"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "uri",
+                "extra"
+            ]
+        },
+        "typed_dataset": {
+            "type": "object",
+            "properties": {
+                "__type": {
+                    "type": "string",
+                    "constant": "dataset"
+                },
+                "__var": {
+                    "$ref": "#/definitions/dataset"
+                }
+            },
+            "required": [
+                "__type",
+                "__var"
+            ],
+            "additionalProperties": false
+        },
+        "typed_dataset_cond": {
+            "type": "object",
+            "properties": {
+                "__type": {
+                    "anyOf": [
+                        {
+                            "type": "string",
+                            "constant": "dataset_or"
+                        },
+                        {
+                            "type": "string",
+                            "constant": "dataset_and"
+                        }
+                    ]
+                },
+                "__var": {
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/typed_dataset"
+                            },
+                            {
+                                "$ref": "#/definitions/typed_dataset_cond"
+                            }
+                        ]
+                    }
+                }
+            },
+            "required": [
+                "__type",
+                "__var"
+            ],
+            "additionalProperties": false
+        },
+        "dict": {
+            "description": "A python dictionary containing values of any type",
+            "type": "object"
+        },
+        "color": {
+            "type": "string",
+            "pattern": "^#[a-fA-F0-9]{3,6}$"
+        },
+        "extra_links": {
             "type": "array",
             "items": {
-                "anyOf": [
-                    {"$ref": "#/definitions/typed_dataset"},
-                    {    "$ref": "#/definitions/typed_dataset_cond"}
+                "type": "object",
+                "minProperties": 1,
+                "maxProperties": 1
+            }
+        },
+        "dag_dependencies": {
+            "type": "array",
+            "items": {
+                "type": "object"
+            }
+        },
+        "dag": {
+            "type": "object",
+            "properties": {
+                "params": {
+                    "$ref": "#/definitions/params_dict"
+                },
+                "_dag_id": {
+                    "type": "string"
+                },
+                "tasks": {
+                    "$ref": "#/definitions/tasks"
+                },
+                "timezone": {
+                    "$ref": "#/definitions/timezone"
+                },
+                "schedule_interval": {
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        },
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "$ref": "#/definitions/typed_timedelta"
+                        },
+                        {
+                            "$ref": "#/definitions/typed_relativedelta"
+                        }
                     ]
+                },
+                "dataset_triggers": {
+                    "$ref": "#/definitions/typed_dataset_cond"
+                },
+                "owner_links": {
+                    "type": "object"
+                },
+                "timetable": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "$ref": "#/definitions/dict"
+                        }
+                    }
+                },
+                "catchup": {
+                    "type": "boolean"
+                },
+                "is_subdag": {
+                    "type": "boolean"
+                },
+                "fileloc": {
+                    "type": "string"
+                },
+                "_processor_dags_folder": {
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "orientation": {
+                    "type": "string"
+                },
+                "_dag_display_property_value": {
+                    "type": "string"
+                },
+                "_description": {
+                    "type": "string"
+                },
+                "_concurrency": {
+                    "type": "number"
+                },
+                "_max_active_tasks": {
+                    "type": "number"
+                },
+                "max_active_runs": {
+                    "type": "number"
+                },
+                "max_consecutive_failed_dag_runs": {
+                    "type": "number"
+                },
+                "default_args": {
+                    "$ref": "#/definitions/dict"
+                },
+                "start_date": {
+                    "$ref": "#/definitions/datetime"
+                },
+                "end_date": {
+                    "$ref": "#/definitions/datetime"
+                },
+                "dagrun_timeout": {
+                    "$ref": "#/definitions/timedelta"
+                },
+                "doc_md": {
+                    "type": "string"
+                },
+                "_default_view": {
+                    "type": "string"
+                },
+                "_access_control": {
+                    "$ref": "#/definitions/dict"
+                },
+                "is_paused_upon_creation": {
+                    "type": "boolean"
+                },
+                "has_on_success_callback": {
+                    "type": "boolean"
+                },
+                "has_on_failure_callback": {
+                    "type": "boolean"
+                },
+                "render_template_as_native_obj": {
+                    "type": "boolean"
+                },
+                "tags": {
+                    "type": "array"
+                },
+                "_task_group": {
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        },
+                        {
+                            "$ref": "#/definitions/task_group"
+                        }
+                    ]
+                },
+                "edge_info": {
+                    "$ref": "#/definitions/edge_info"
+                },
+                "dag_dependencies": {
+                    "$ref": "#/definitions/dag_dependencies"
+                }
+            },
+            "required": [
+                "_dag_id",
+                "fileloc",
+                "tasks"
+            ],
+            "additionalProperties": false
+        },
+        "tasks": {
+            "type": "array",
+            "additionalProperties": {
+                "$ref": "#/definitions/operator"
+            }
+        },
+        "params_dict": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/param"
+            }
+        },
+        "param": {
+            "$comment": "A param for a dag / operator",
+            "type": "object",
+            "required": [
+                "__class",
+                "default"
+            ],
+            "properties": {
+                "__class": {
+                    "type": "string"
+                },
+                "default": {},
+                "description": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "schema": {
+                    "$ref": "#/definitions/dict"
+                }
+            }
+        },
+        "operator": {
+            "$comment": "A task/operator in a DAG",
+            "type": "object",
+            "required": [
+                "_task_type",
+                "_task_module",
+                "task_id",
+                "ui_color",
+                "ui_fgcolor",
+                "template_fields"
+            ],
+            "properties": {
+                "_task_type": {
+                    "type": "string"
+                },
+                "_task_module": {
+                    "type": "string"
+                },
+                "_operator_extra_links": {
+                    "$ref": "#/definitions/extra_links"
+                },
+                "task_id": {
+                    "type": "string"
+                },
+                "task_display_name": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string"
+                },
+                "start_date": {
+                    "$ref": "#/definitions/datetime"
+                },
+                "end_date": {
+                    "$ref": "#/definitions/datetime"
+                },
+                "trigger_rule": {
+                    "type": "string"
+                },
+                "depends_on_past": {
+                    "type": "boolean"
+                },
+                "ignore_first_depends_on_past": {
+                    "type": "boolean"
+                },
+                "wait_for_past_depends_before_skipping": {
+                    "type": "boolean"
+                },
+                "wait_for_downstream": {
+                    "type": "boolean"
+                },
+                "retries": {
+                    "type": "number"
+                },
+                "queue": {
+                    "type": "string"
+                },
+                "pool": {
+                    "type": "string"
+                },
+                "pool_slots": {
+                    "type": "number"
+                },
+                "execution_timeout": {
+                    "$ref": "#/definitions/timedelta"
+                },
+                "retry_delay": {
+                    "$ref": "#/definitions/timedelta"
+                },
+                "retry_exponential_backoff": {
+                    "type": "boolean"
+                },
+                "max_retry_delay": {
+                    "$ref": "#/definitions/timedelta"
+                },
+                "params": {
+                    "$ref": "#/definitions/params_dict"
+                },
+                "priority_weight": {
+                    "type": "number"
+                },
+                "weight_rule": {
+                    "type": "string"
+                },
+                "executor": {
+                    "type": "string"
+                },
+                "executor_config": {
+                    "$ref": "#/definitions/dict"
+                },
+                "do_xcom_push": {
+                    "type": "boolean"
+                },
+                "ui_color": {
+                    "$ref": "#/definitions/color"
+                },
+                "ui_fgcolor": {
+                    "$ref": "#/definitions/color"
+                },
+                "template_fields": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "subdag": {
+                    "$ref": "#/definitions/dag"
+                },
+                "downstream_task_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "_is_dummy": {
+                    "type": "boolean"
+                },
+                "deps": {
+                    "description": "list of dep classes -- if non-standard",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true
+                },
+                "doc": {
+                    "type": "string"
+                },
+                "doc_md": {
+                    "type": "string"
+                },
+                "doc_json": {
+                    "type": "string"
+                },
+                "doc_yaml": {
+                    "type": "string"
+                },
+                "doc_rst": {
+                    "type": "string"
+                },
+                "_logger_name": {
+                    "type": "string"
+                },
+                "_log_config_logger_name": {
+                    "type": "string"
+                },
+                "_is_mapped": {
+                    "const": true,
+                    "$comment": "only present when True"
+                },
+                "expand_input": {
+                    "type": "object"
+                },
+                "partial_kwargs": {
+                    "type": "object"
+                },
+                "map_index_template": {
+                    "type": "string"
+                },
+                "allow_nested_operators": {
+                    "type": "boolean"
+                },
+                "starts_execution_from_triggerer": {
+                    "type": "boolean"
+                },
+                "start_trigger": {
+                    "type": "object"
+                },
+                "next_method": {
+                    "type": "string"
+                }
+            },
+            "dependencies": {
+                "expand_input": [
+                    "partial_kwargs",
+                    "_is_mapped"
+                ],
+                "partial_kwargs": [
+                    "expand_input",
+                    "_is_mapped"
+                ],
+                "_is_mapped": [
+                    "expand_input",
+                    "partial_kwargs"
+                ]
+            },
+            "additionalProperties": true
+        },
+        "task_group": {
+            "$comment": "A TaskGroup containing tasks",
+            "type": "object",
+            "required": [
+                "_group_id",
+                "prefix_group_id",
+                "children",
+                "tooltip",
+                "ui_color",
+                "ui_fgcolor",
+                "upstream_group_ids",
+                "downstream_group_ids",
+                "upstream_task_ids",
+                "downstream_task_ids"
+            ],
+            "properties": {
+                "_group_id": {
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "is_mapped": {
+                    "type": "boolean"
+                },
+                "prefix_group_id": {
+                    "type": "boolean"
+                },
+                "children": {
+                    "$ref": "#/definitions/dict"
+                },
+                "tooltip": {
+                    "type": "string"
+                },
+                "ui_color": {
+                    "type": "string"
+                },
+                "ui_fgcolor": {
+                    "type": "string"
+                },
+                "upstream_group_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "downstream_group_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "upstream_task_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "downstream_task_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "additionalProperties": false
+        },
+        "edge_info": {
+            "$comment": "Metadata about DAG edges",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                        "label": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "label"
+                    ],
+                    "additionalProperties": false
+                }
             }
         }
-      },
-    "required": [
-        "__type",
-        "__var"
-        ],
-        "additionalProperties": false
     },
-    "dict": {
-      "description": "A python dictionary containing values of any type",
-      "type": "object"
-    },
-    "color": {
-      "type": "string",
-      "pattern": "^#[a-fA-F0-9]{3,6}$"
-    },
-    "extra_links": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "minProperties": 1,
-        "maxProperties": 1
-      }
-    },
-    "dag_dependencies": {
-      "type": "array",
-      "items": {
-        "type": "object"
-      }
-    },
-    "dag": {
-      "type": "object",
-      "properties": {
-        "params": { "$ref": "#/definitions/params_dict" },
-        "_dag_id": { "type": "string" },
-        "tasks": {  "$ref": "#/definitions/tasks" },
-        "timezone": { "$ref": "#/definitions/timezone" },
-        "schedule_interval": {
-          "anyOf": [
-            { "type": "null" },
-            { "type": "string" },
-            { "$ref": "#/definitions/typed_timedelta" },
-            { "$ref": "#/definitions/typed_relativedelta" }
-          ]
-        },
-        "dataset_triggers": {
-        "$ref": "#/definitions/typed_dataset_cond"
-
-},
-        "owner_links": { "type": "object" },
-        "timetable": {
-          "type": "object",
-          "properties": {
-            "type": { "type": "string" },
-            "value": { "$ref": "#/definitions/dict" }
-          }
-        },
-        "catchup": { "type": "boolean" },
-        "is_subdag": { "type": "boolean" },
-        "fileloc": { "type" : "string"},
-        "_processor_dags_folder": {
-            "anyOf": [
-                { "type": "null" },
-                {"type": "string"}
+    "type": "object",
+    "allOf": [
+        {
+            "type": "object",
+            "properties": {
+                "__version": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0
+                },
+                "dag": {
+                    "$ref": "#/definitions/dag"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "__version",
+                "dag"
             ]
-        },
-        "orientation": { "type" : "string"},
-        "_dag_display_property_value": { "type" : "string"},
-        "_description": { "type" : "string"},
-        "_concurrency": { "type" : "number"},
-        "_max_active_tasks": { "type" : "number"},
-        "max_active_runs": { "type" : "number"},
-        "max_consecutive_failed_dag_runs": { "type" : "number"},
-        "default_args": { "$ref": "#/definitions/dict" },
-        "start_date": { "$ref": "#/definitions/datetime" },
-        "end_date": { "$ref": "#/definitions/datetime" },
-        "dagrun_timeout": { "$ref": "#/definitions/timedelta" },
-        "doc_md": { "type" : "string"},
-        "_default_view": { "type" : "string"},
-        "_access_control": {"$ref": "#/definitions/dict" },
-        "is_paused_upon_creation":  { "type": "boolean" },
-        "has_on_success_callback":  { "type": "boolean" },
-        "has_on_failure_callback":  { "type": "boolean" },
-        "render_template_as_native_obj":  { "type": "boolean" },
-        "tags": { "type": "array" },
-        "_task_group": {"anyOf": [
-          { "type": "null" },
-          { "$ref": "#/definitions/task_group" }
-        ]},
-        "edge_info": { "$ref": "#/definitions/edge_info" },
-        "dag_dependencies": { "$ref": "#/definitions/dag_dependencies" }
-      },
-      "required": [
-        "_dag_id",
-        "fileloc",
-        "tasks"
-      ],
-      "additionalProperties": false
-    },
-    "tasks": {
-      "type": "array",
-      "additionalProperties": { "$ref": "#/definitions/operator" }
-    },
-    "params_dict": {
-      "type": "object",
-      "additionalProperties": {"$ref": "#/definitions/param" }
-    },
-    "param": {
-      "$comment": "A param for a dag / operator",
-      "type": "object",
-      "required": [
-        "__class",
-        "default"
-      ],
-      "properties": {
-        "__class": { "type": "string" },
-        "default": {},
-        "description": {"anyOf": [{"type":"string"}, {"type":"null"}]},
-        "schema": { "$ref": "#/definitions/dict" }
-      }
-    },
-    "operator": {
-      "$comment": "A task/operator in a DAG",
-      "type": "object",
-      "required": [
-        "_task_type",
-        "_task_module",
-        "task_id",
-        "ui_color",
-        "ui_fgcolor",
-        "template_fields"
-      ],
-      "properties": {
-        "_task_type": { "type": "string" },
-        "_task_module": { "type": "string" },
-        "_operator_extra_links": { "$ref":  "#/definitions/extra_links" },
-        "task_id": { "type": "string" },
-        "task_display_name": { "type": "string" },
-        "label": { "type": "string" },
-        "owner": { "type": "string" },
-        "start_date": { "$ref": "#/definitions/datetime" },
-        "end_date": { "$ref": "#/definitions/datetime" },
-        "trigger_rule": { "type": "string" },
-        "depends_on_past": { "type": "boolean" },
-        "ignore_first_depends_on_past": { "type": "boolean" },
-        "wait_for_past_depends_before_skipping": { "type": "boolean" },
-        "wait_for_downstream": { "type": "boolean" },
-        "retries": { "type": "number" },
-        "queue": { "type": "string" },
-        "pool": { "type": "string" },
-        "pool_slots": { "type": "number" },
-        "execution_timeout": { "$ref": "#/definitions/timedelta" },
-        "retry_delay": { "$ref": "#/definitions/timedelta" },
-        "retry_exponential_backoff": { "type": "boolean" },
-        "max_retry_delay": { "$ref": "#/definitions/timedelta" },
-        "params": { "$ref": "#/definitions/params_dict" },
-        "priority_weight": { "type": "number" },
-        "weight_rule": { "type": "string" },
-        "executor": { "type": "string" },
-        "executor_config": { "$ref": "#/definitions/dict" },
-        "do_xcom_push": { "type": "boolean" },
-        "ui_color": { "$ref": "#/definitions/color" },
-        "ui_fgcolor": { "$ref": "#/definitions/color" },
-        "template_fields": {
-          "type": "array",
-          "items": { "type": "string" }
-        },
-        "subdag": { "$ref": "#/definitions/dag" },
-        "downstream_task_ids": {
-          "type": "array",
-          "items": { "type": "string" }
-        },
-        "_is_dummy": { "type": "boolean" },
-        "deps": {
-          "description": "list of dep classes -- if non-standard",
-          "type": "array",
-          "items": { "type": "string" },
-          "uniqueItems": true
-        },
-        "doc":  { "type": "string" },
-        "doc_md":  { "type": "string" },
-        "doc_json":  { "type": "string" },
-        "doc_yaml":  { "type": "string" },
-        "doc_rst":  { "type": "string" },
-        "_logger_name": { "type": "string" },
-        "_log_config_logger_name": { "type": "string" },
-        "_is_mapped": { "const": true, "$comment": "only present when True" },
-        "expand_input": { "type": "object" },
-        "partial_kwargs": { "type": "object" },
-        "map_index_template": { "type": "string" },
-        "starts_execution_from_triggerer": { "type": "boolean" },
-        "trigger": { "type": "object" },
-        "next_method": { "type": "string" }
-      },
-      "dependencies": {
-        "expand_input": ["partial_kwargs", "_is_mapped"],
-        "partial_kwargs": ["expand_input", "_is_mapped"],
-        "_is_mapped": ["expand_input", "partial_kwargs"]
-      },
-      "additionalProperties": true
-    },
-    "task_group": {
-      "$comment": "A TaskGroup containing tasks",
-      "type": "object",
-      "required": [
-        "_group_id",
-        "prefix_group_id",
-        "children",
-        "tooltip",
-        "ui_color",
-        "ui_fgcolor",
-        "upstream_group_ids",
-        "downstream_group_ids",
-        "upstream_task_ids",
-        "downstream_task_ids"
-      ],
-      "properties": {
-        "_group_id": {"anyOf": [{"type": "null"}, { "type": "string" }]},
-        "is_mapped": { "type": "boolean" },
-        "prefix_group_id": { "type": "boolean" },
-        "children":  { "$ref": "#/definitions/dict" },
-        "tooltip": { "type": "string" },
-        "ui_color": { "type": "string" },
-        "ui_fgcolor": { "type": "string" },
-        "upstream_group_ids": {
-          "type": "array",
-          "items": { "type": "string" }
-        },
-        "downstream_group_ids": {
-          "type": "array",
-          "items": { "type": "string" }
-        },
-        "upstream_task_ids": {
-          "type": "array",
-          "items": { "type": "string" }
-        },
-        "downstream_task_ids": {
-          "type": "array",
-          "items": { "type": "string" }
         }
-      },
-      "additionalProperties": false
-    },
-    "edge_info": {
-      "$comment": "Metadata about DAG edges",
-      "type": "object",
-      "additionalProperties": {
-        "type": "object",
-        "additionalProperties": {
-          "type": "object",
-          "properties": {
-            "label": { "type": "string" }
-          },
-          "required": ["label"],
-          "additionalProperties": false
-        }
-      }
-    }
-  },
-
-  "type": "object",
-  "allOf": [
-    {
-      "type": "object",
-      "properties": {
-        "__version": {
-          "type": "integer",
-          "exclusiveMinimum": 0
-        },
-        "dag": { "$ref": "#/definitions/dag" }
-      },
-      "additionalProperties": false,
-      "required": [ "__version", "dag" ]
-    }
-  ]
+    ]
 }

--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -293,7 +293,9 @@
         "expand_input": { "type": "object" },
         "partial_kwargs": { "type": "object" },
         "map_index_template": { "type": "string" },
-        "allow_nested_operators": { "type": "boolean" }
+        "starts_execution_from_triggerer": { "type": "boolean" },
+        "trigger": { "type": "object" },
+        "next_method": { "type": "string" }
       },
       "dependencies": {
         "expand_input": ["partial_kwargs", "_is_mapped"],

--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -511,9 +511,6 @@
                 "allow_nested_operators": {
                     "type": "boolean"
                 },
-                "starts_execution_from_triggerer": {
-                    "type": "boolean"
-                },
                 "start_trigger": {
                     "type": "object"
                 },

--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -293,9 +293,7 @@
         "expand_input": { "type": "object" },
         "partial_kwargs": { "type": "object" },
         "map_index_template": { "type": "string" },
-        "starts_execution_from_triggerer": { "type": "boolean" },
-        "trigger": { "type": "object" },
-        "next_method": { "type": "string" }
+        "allow_nested_operators": { "type": "boolean" }
       },
       "dependencies": {
         "expand_input": ["partial_kwargs", "_is_mapped"],

--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -511,6 +511,9 @@
                 "allow_nested_operators": {
                     "type": "boolean"
                 },
+                "starts_execution_from_triggerer": {
+                    "type": "boolean"
+                },
                 "start_trigger": {
                     "type": "object"
                 },

--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -1,651 +1,381 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://airflow.apache.com/schemas/serialized-dags.json",
-    "definitions": {
-        "datetime": {
-            "description": "A date time, stored as fractional seconds since the epoch",
-            "type": "number"
-        },
-        "timedelta": {
-            "type": "number",
-            "minimum": 0
-        },
-        "typed_timedelta": {
-            "type": "object",
-            "properties": {
-                "__type": {
-                    "type": "string",
-                    "const": "timedelta"
-                },
-                "__var": {
-                    "$ref": "#/definitions/timedelta"
-                }
-            },
-            "required": [
-                "__type",
-                "__var"
-            ],
-            "additionalProperties": false
-        },
-        "typed_relativedelta": {
-            "type": "object",
-            "description": "A dateutil.relativedelta.relativedelta object",
-            "properties": {
-                "__type": {
-                    "type": "string",
-                    "const": "relativedelta"
-                },
-                "__var": {
-                    "type": "object",
-                    "properties": {
-                        "weekday": {
-                            "type": "array",
-                            "items": {
-                                "type": "integer"
-                            },
-                            "minItems": 1,
-                            "maxItems": 2
-                        }
-                    },
-                    "additionalProperties": {
-                        "type": "integer"
-                    }
-                }
-            }
-        },
-        "timezone": {
-            "anyOf": [
-                {
-                    "type": "string"
-                },
-                {
-                    "type": "integer"
-                }
-            ]
-        },
-        "dataset": {
-            "type": "object",
-            "properties": {
-                "uri": {
-                    "type": "string"
-                },
-                "extra": {
-                    "anyOf": [
-                        {
-                            "type": "null"
-                        },
-                        {
-                            "$ref": "#/definitions/dict"
-                        }
-                    ]
-                }
-            },
-            "required": [
-                "uri",
-                "extra"
-            ]
-        },
-        "typed_dataset": {
-            "type": "object",
-            "properties": {
-                "__type": {
-                    "type": "string",
-                    "constant": "dataset"
-                },
-                "__var": {
-                    "$ref": "#/definitions/dataset"
-                }
-            },
-            "required": [
-                "__type",
-                "__var"
-            ],
-            "additionalProperties": false
-        },
-        "typed_dataset_cond": {
-            "type": "object",
-            "properties": {
-                "__type": {
-                    "anyOf": [
-                        {
-                            "type": "string",
-                            "constant": "dataset_or"
-                        },
-                        {
-                            "type": "string",
-                            "constant": "dataset_and"
-                        }
-                    ]
-                },
-                "__var": {
-                    "type": "array",
-                    "items": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/definitions/typed_dataset"
-                            },
-                            {
-                                "$ref": "#/definitions/typed_dataset_cond"
-                            }
-                        ]
-                    }
-                }
-            },
-            "required": [
-                "__type",
-                "__var"
-            ],
-            "additionalProperties": false
-        },
-        "dict": {
-            "description": "A python dictionary containing values of any type",
-            "type": "object"
-        },
-        "color": {
-            "type": "string",
-            "pattern": "^#[a-fA-F0-9]{3,6}$"
-        },
-        "extra_links": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "minProperties": 1,
-                "maxProperties": 1
-            }
-        },
-        "dag_dependencies": {
-            "type": "array",
-            "items": {
-                "type": "object"
-            }
-        },
-        "dag": {
-            "type": "object",
-            "properties": {
-                "params": {
-                    "$ref": "#/definitions/params_dict"
-                },
-                "_dag_id": {
-                    "type": "string"
-                },
-                "tasks": {
-                    "$ref": "#/definitions/tasks"
-                },
-                "timezone": {
-                    "$ref": "#/definitions/timezone"
-                },
-                "schedule_interval": {
-                    "anyOf": [
-                        {
-                            "type": "null"
-                        },
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "$ref": "#/definitions/typed_timedelta"
-                        },
-                        {
-                            "$ref": "#/definitions/typed_relativedelta"
-                        }
-                    ]
-                },
-                "dataset_triggers": {
-                    "$ref": "#/definitions/typed_dataset_cond"
-                },
-                "owner_links": {
-                    "type": "object"
-                },
-                "timetable": {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string"
-                        },
-                        "value": {
-                            "$ref": "#/definitions/dict"
-                        }
-                    }
-                },
-                "catchup": {
-                    "type": "boolean"
-                },
-                "is_subdag": {
-                    "type": "boolean"
-                },
-                "fileloc": {
-                    "type": "string"
-                },
-                "_processor_dags_folder": {
-                    "anyOf": [
-                        {
-                            "type": "null"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ]
-                },
-                "orientation": {
-                    "type": "string"
-                },
-                "_dag_display_property_value": {
-                    "type": "string"
-                },
-                "_description": {
-                    "type": "string"
-                },
-                "_concurrency": {
-                    "type": "number"
-                },
-                "_max_active_tasks": {
-                    "type": "number"
-                },
-                "max_active_runs": {
-                    "type": "number"
-                },
-                "max_consecutive_failed_dag_runs": {
-                    "type": "number"
-                },
-                "default_args": {
-                    "$ref": "#/definitions/dict"
-                },
-                "start_date": {
-                    "$ref": "#/definitions/datetime"
-                },
-                "end_date": {
-                    "$ref": "#/definitions/datetime"
-                },
-                "dagrun_timeout": {
-                    "$ref": "#/definitions/timedelta"
-                },
-                "doc_md": {
-                    "type": "string"
-                },
-                "_default_view": {
-                    "type": "string"
-                },
-                "_access_control": {
-                    "$ref": "#/definitions/dict"
-                },
-                "is_paused_upon_creation": {
-                    "type": "boolean"
-                },
-                "has_on_success_callback": {
-                    "type": "boolean"
-                },
-                "has_on_failure_callback": {
-                    "type": "boolean"
-                },
-                "render_template_as_native_obj": {
-                    "type": "boolean"
-                },
-                "tags": {
-                    "type": "array"
-                },
-                "_task_group": {
-                    "anyOf": [
-                        {
-                            "type": "null"
-                        },
-                        {
-                            "$ref": "#/definitions/task_group"
-                        }
-                    ]
-                },
-                "edge_info": {
-                    "$ref": "#/definitions/edge_info"
-                },
-                "dag_dependencies": {
-                    "$ref": "#/definitions/dag_dependencies"
-                }
-            },
-            "required": [
-                "_dag_id",
-                "fileloc",
-                "tasks"
-            ],
-            "additionalProperties": false
-        },
-        "tasks": {
-            "type": "array",
-            "additionalProperties": {
-                "$ref": "#/definitions/operator"
-            }
-        },
-        "params_dict": {
-            "type": "object",
-            "additionalProperties": {
-                "$ref": "#/definitions/param"
-            }
-        },
-        "param": {
-            "$comment": "A param for a dag / operator",
-            "type": "object",
-            "required": [
-                "__class",
-                "default"
-            ],
-            "properties": {
-                "__class": {
-                    "type": "string"
-                },
-                "default": {},
-                "description": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "schema": {
-                    "$ref": "#/definitions/dict"
-                }
-            }
-        },
-        "operator": {
-            "$comment": "A task/operator in a DAG",
-            "type": "object",
-            "required": [
-                "_task_type",
-                "_task_module",
-                "task_id",
-                "ui_color",
-                "ui_fgcolor",
-                "template_fields"
-            ],
-            "properties": {
-                "_task_type": {
-                    "type": "string"
-                },
-                "_task_module": {
-                    "type": "string"
-                },
-                "_operator_extra_links": {
-                    "$ref": "#/definitions/extra_links"
-                },
-                "task_id": {
-                    "type": "string"
-                },
-                "task_display_name": {
-                    "type": "string"
-                },
-                "label": {
-                    "type": "string"
-                },
-                "owner": {
-                    "type": "string"
-                },
-                "start_date": {
-                    "$ref": "#/definitions/datetime"
-                },
-                "end_date": {
-                    "$ref": "#/definitions/datetime"
-                },
-                "trigger_rule": {
-                    "type": "string"
-                },
-                "depends_on_past": {
-                    "type": "boolean"
-                },
-                "ignore_first_depends_on_past": {
-                    "type": "boolean"
-                },
-                "wait_for_past_depends_before_skipping": {
-                    "type": "boolean"
-                },
-                "wait_for_downstream": {
-                    "type": "boolean"
-                },
-                "retries": {
-                    "type": "number"
-                },
-                "queue": {
-                    "type": "string"
-                },
-                "pool": {
-                    "type": "string"
-                },
-                "pool_slots": {
-                    "type": "number"
-                },
-                "execution_timeout": {
-                    "$ref": "#/definitions/timedelta"
-                },
-                "retry_delay": {
-                    "$ref": "#/definitions/timedelta"
-                },
-                "retry_exponential_backoff": {
-                    "type": "boolean"
-                },
-                "max_retry_delay": {
-                    "$ref": "#/definitions/timedelta"
-                },
-                "params": {
-                    "$ref": "#/definitions/params_dict"
-                },
-                "priority_weight": {
-                    "type": "number"
-                },
-                "weight_rule": {
-                    "type": "string"
-                },
-                "executor": {
-                    "type": "string"
-                },
-                "executor_config": {
-                    "$ref": "#/definitions/dict"
-                },
-                "do_xcom_push": {
-                    "type": "boolean"
-                },
-                "ui_color": {
-                    "$ref": "#/definitions/color"
-                },
-                "ui_fgcolor": {
-                    "$ref": "#/definitions/color"
-                },
-                "template_fields": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "subdag": {
-                    "$ref": "#/definitions/dag"
-                },
-                "downstream_task_ids": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "_is_dummy": {
-                    "type": "boolean"
-                },
-                "deps": {
-                    "description": "list of dep classes -- if non-standard",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "uniqueItems": true
-                },
-                "doc": {
-                    "type": "string"
-                },
-                "doc_md": {
-                    "type": "string"
-                },
-                "doc_json": {
-                    "type": "string"
-                },
-                "doc_yaml": {
-                    "type": "string"
-                },
-                "doc_rst": {
-                    "type": "string"
-                },
-                "_logger_name": {
-                    "type": "string"
-                },
-                "_log_config_logger_name": {
-                    "type": "string"
-                },
-                "_is_mapped": {
-                    "const": true,
-                    "$comment": "only present when True"
-                },
-                "expand_input": {
-                    "type": "object"
-                },
-                "partial_kwargs": {
-                    "type": "object"
-                },
-                "map_index_template": {
-                    "type": "string"
-                },
-                "allow_nested_operators": {
-                    "type": "boolean"
-                },
-                "starts_execution_from_triggerer": {
-                    "type": "boolean"
-                },
-                "start_trigger": {
-                    "type": "object"
-                },
-                "next_method": {
-                    "type": "string"
-                }
-            },
-            "dependencies": {
-                "expand_input": [
-                    "partial_kwargs",
-                    "_is_mapped"
-                ],
-                "partial_kwargs": [
-                    "expand_input",
-                    "_is_mapped"
-                ],
-                "_is_mapped": [
-                    "expand_input",
-                    "partial_kwargs"
-                ]
-            },
-            "additionalProperties": true
-        },
-        "task_group": {
-            "$comment": "A TaskGroup containing tasks",
-            "type": "object",
-            "required": [
-                "_group_id",
-                "prefix_group_id",
-                "children",
-                "tooltip",
-                "ui_color",
-                "ui_fgcolor",
-                "upstream_group_ids",
-                "downstream_group_ids",
-                "upstream_task_ids",
-                "downstream_task_ids"
-            ],
-            "properties": {
-                "_group_id": {
-                    "anyOf": [
-                        {
-                            "type": "null"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ]
-                },
-                "is_mapped": {
-                    "type": "boolean"
-                },
-                "prefix_group_id": {
-                    "type": "boolean"
-                },
-                "children": {
-                    "$ref": "#/definitions/dict"
-                },
-                "tooltip": {
-                    "type": "string"
-                },
-                "ui_color": {
-                    "type": "string"
-                },
-                "ui_fgcolor": {
-                    "type": "string"
-                },
-                "upstream_group_ids": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "downstream_group_ids": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "upstream_task_ids": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "downstream_task_ids": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            },
-            "additionalProperties": false
-        },
-        "edge_info": {
-            "$comment": "Metadata about DAG edges",
-            "type": "object",
-            "additionalProperties": {
-                "type": "object",
-                "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                        "label": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "label"
-                    ],
-                    "additionalProperties": false
-                }
-            }
-        }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://airflow.apache.com/schemas/serialized-dags.json",
+  "definitions": {
+    "datetime": {
+      "description": "A date time, stored as fractional seconds since the epoch",
+      "type": "number"
     },
-    "type": "object",
-    "allOf": [
-        {
-            "type": "object",
-            "properties": {
-                "__version": {
-                    "type": "integer",
-                    "exclusiveMinimum": 0
-                },
-                "dag": {
-                    "$ref": "#/definitions/dag"
-                }
-            },
-            "additionalProperties": false,
-            "required": [
-                "__version",
-                "dag"
+    "timedelta": {
+      "type": "number",
+      "minimum": 0
+    },
+    "typed_timedelta": {
+      "type": "object",
+      "properties": {
+        "__type": {
+          "type": "string",
+          "const": "timedelta"
+        },
+        "__var": { "$ref": "#/definitions/timedelta" }
+      },
+      "required": [
+        "__type",
+        "__var"
+      ],
+      "additionalProperties": false
+    },
+    "typed_relativedelta": {
+      "type": "object",
+      "description": "A dateutil.relativedelta.relativedelta object",
+      "properties": {
+        "__type": {
+          "type": "string",
+          "const": "relativedelta"
+        },
+        "__var": {
+          "type": "object",
+          "properties": {
+            "weekday": {
+              "type": "array",
+              "items": { "type": "integer" },
+              "minItems": 1,
+              "maxItems": 2
+            }
+          },
+          "additionalProperties": { "type": "integer" }
+        }
+      }
+    },
+    "timezone": {
+      "anyOf": [
+        { "type": "string" },
+        { "type": "integer" }
+      ]
+    },
+    "dataset": {
+      "type": "object",
+      "properties": {
+        "uri": { "type": "string" },
+        "extra": {
+            "anyOf": [
+                {"type": "null"},
+                { "$ref": "#/definitions/dict" }
             ]
         }
-    ]
+      },
+      "required": [ "uri", "extra" ]
+    },
+    "typed_dataset": {
+      "type": "object",
+      "properties": {
+        "__type": {
+          "type": "string",
+            "constant": "dataset"
+        },
+        "__var": { "$ref": "#/definitions/dataset" }
+      },
+      "required": [
+        "__type",
+        "__var"
+      ],
+      "additionalProperties": false
+    },
+    "typed_dataset_cond": {
+      "type": "object",
+      "properties": {
+        "__type": {
+            "anyOf": [{
+                "type": "string",
+                "constant": "dataset_or"
+            },
+            {
+                "type": "string",
+                "constant": "dataset_and"
+            }
+            ]
+        },
+        "__var": {
+            "type": "array",
+            "items": {
+                "anyOf": [
+                    {"$ref": "#/definitions/typed_dataset"},
+                    {    "$ref": "#/definitions/typed_dataset_cond"}
+                    ]
+            }
+        }
+      },
+    "required": [
+        "__type",
+        "__var"
+        ],
+        "additionalProperties": false
+    },
+    "dict": {
+      "description": "A python dictionary containing values of any type",
+      "type": "object"
+    },
+    "color": {
+      "type": "string",
+      "pattern": "^#[a-fA-F0-9]{3,6}$"
+    },
+    "extra_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "minProperties": 1,
+        "maxProperties": 1
+      }
+    },
+    "dag_dependencies": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "dag": {
+      "type": "object",
+      "properties": {
+        "params": { "$ref": "#/definitions/params_dict" },
+        "_dag_id": { "type": "string" },
+        "tasks": {  "$ref": "#/definitions/tasks" },
+        "timezone": { "$ref": "#/definitions/timezone" },
+        "schedule_interval": {
+          "anyOf": [
+            { "type": "null" },
+            { "type": "string" },
+            { "$ref": "#/definitions/typed_timedelta" },
+            { "$ref": "#/definitions/typed_relativedelta" }
+          ]
+        },
+        "dataset_triggers": {
+        "$ref": "#/definitions/typed_dataset_cond"
+
+},
+        "owner_links": { "type": "object" },
+        "timetable": {
+          "type": "object",
+          "properties": {
+            "type": { "type": "string" },
+            "value": { "$ref": "#/definitions/dict" }
+          }
+        },
+        "catchup": { "type": "boolean" },
+        "is_subdag": { "type": "boolean" },
+        "fileloc": { "type" : "string"},
+        "_processor_dags_folder": {
+            "anyOf": [
+                { "type": "null" },
+                {"type": "string"}
+            ]
+        },
+        "orientation": { "type" : "string"},
+        "_dag_display_property_value": { "type" : "string"},
+        "_description": { "type" : "string"},
+        "_concurrency": { "type" : "number"},
+        "_max_active_tasks": { "type" : "number"},
+        "max_active_runs": { "type" : "number"},
+        "max_consecutive_failed_dag_runs": { "type" : "number"},
+        "default_args": { "$ref": "#/definitions/dict" },
+        "start_date": { "$ref": "#/definitions/datetime" },
+        "end_date": { "$ref": "#/definitions/datetime" },
+        "dagrun_timeout": { "$ref": "#/definitions/timedelta" },
+        "doc_md": { "type" : "string"},
+        "_default_view": { "type" : "string"},
+        "_access_control": {"$ref": "#/definitions/dict" },
+        "is_paused_upon_creation":  { "type": "boolean" },
+        "has_on_success_callback":  { "type": "boolean" },
+        "has_on_failure_callback":  { "type": "boolean" },
+        "render_template_as_native_obj":  { "type": "boolean" },
+        "tags": { "type": "array" },
+        "_task_group": {"anyOf": [
+          { "type": "null" },
+          { "$ref": "#/definitions/task_group" }
+        ]},
+        "edge_info": { "$ref": "#/definitions/edge_info" },
+        "dag_dependencies": { "$ref": "#/definitions/dag_dependencies" }
+      },
+      "required": [
+        "_dag_id",
+        "fileloc",
+        "tasks"
+      ],
+      "additionalProperties": false
+    },
+    "tasks": {
+      "type": "array",
+      "additionalProperties": { "$ref": "#/definitions/operator" }
+    },
+    "params_dict": {
+      "type": "object",
+      "additionalProperties": {"$ref": "#/definitions/param" }
+    },
+    "param": {
+      "$comment": "A param for a dag / operator",
+      "type": "object",
+      "required": [
+        "__class",
+        "default"
+      ],
+      "properties": {
+        "__class": { "type": "string" },
+        "default": {},
+        "description": {"anyOf": [{"type":"string"}, {"type":"null"}]},
+        "schema": { "$ref": "#/definitions/dict" }
+      }
+    },
+    "operator": {
+      "$comment": "A task/operator in a DAG",
+      "type": "object",
+      "required": [
+        "_task_type",
+        "_task_module",
+        "task_id",
+        "ui_color",
+        "ui_fgcolor",
+        "template_fields"
+      ],
+      "properties": {
+        "_task_type": { "type": "string" },
+        "_task_module": { "type": "string" },
+        "_operator_extra_links": { "$ref":  "#/definitions/extra_links" },
+        "task_id": { "type": "string" },
+        "task_display_name": { "type": "string" },
+        "label": { "type": "string" },
+        "owner": { "type": "string" },
+        "start_date": { "$ref": "#/definitions/datetime" },
+        "end_date": { "$ref": "#/definitions/datetime" },
+        "trigger_rule": { "type": "string" },
+        "depends_on_past": { "type": "boolean" },
+        "ignore_first_depends_on_past": { "type": "boolean" },
+        "wait_for_past_depends_before_skipping": { "type": "boolean" },
+        "wait_for_downstream": { "type": "boolean" },
+        "retries": { "type": "number" },
+        "queue": { "type": "string" },
+        "pool": { "type": "string" },
+        "pool_slots": { "type": "number" },
+        "execution_timeout": { "$ref": "#/definitions/timedelta" },
+        "retry_delay": { "$ref": "#/definitions/timedelta" },
+        "retry_exponential_backoff": { "type": "boolean" },
+        "max_retry_delay": { "$ref": "#/definitions/timedelta" },
+        "params": { "$ref": "#/definitions/params_dict" },
+        "priority_weight": { "type": "number" },
+        "weight_rule": { "type": "string" },
+        "executor": { "type": "string" },
+        "executor_config": { "$ref": "#/definitions/dict" },
+        "do_xcom_push": { "type": "boolean" },
+        "ui_color": { "$ref": "#/definitions/color" },
+        "ui_fgcolor": { "$ref": "#/definitions/color" },
+        "template_fields": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "subdag": { "$ref": "#/definitions/dag" },
+        "downstream_task_ids": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "_is_dummy": { "type": "boolean" },
+        "deps": {
+          "description": "list of dep classes -- if non-standard",
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true
+        },
+        "doc":  { "type": "string" },
+        "doc_md":  { "type": "string" },
+        "doc_json":  { "type": "string" },
+        "doc_yaml":  { "type": "string" },
+        "doc_rst":  { "type": "string" },
+        "_logger_name": { "type": "string" },
+        "_log_config_logger_name": { "type": "string" },
+        "_is_mapped": { "const": true, "$comment": "only present when True" },
+        "expand_input": { "type": "object" },
+        "partial_kwargs": { "type": "object" },
+        "map_index_template": { "type": "string" },
+        "starts_execution_from_triggerer": { "type": "boolean" },
+        "trigger": { "type": "object" },
+        "next_method": { "type": "string" }
+      },
+      "dependencies": {
+        "expand_input": ["partial_kwargs", "_is_mapped"],
+        "partial_kwargs": ["expand_input", "_is_mapped"],
+        "_is_mapped": ["expand_input", "partial_kwargs"]
+      },
+      "additionalProperties": true
+    },
+    "task_group": {
+      "$comment": "A TaskGroup containing tasks",
+      "type": "object",
+      "required": [
+        "_group_id",
+        "prefix_group_id",
+        "children",
+        "tooltip",
+        "ui_color",
+        "ui_fgcolor",
+        "upstream_group_ids",
+        "downstream_group_ids",
+        "upstream_task_ids",
+        "downstream_task_ids"
+      ],
+      "properties": {
+        "_group_id": {"anyOf": [{"type": "null"}, { "type": "string" }]},
+        "is_mapped": { "type": "boolean" },
+        "prefix_group_id": { "type": "boolean" },
+        "children":  { "$ref": "#/definitions/dict" },
+        "tooltip": { "type": "string" },
+        "ui_color": { "type": "string" },
+        "ui_fgcolor": { "type": "string" },
+        "upstream_group_ids": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "downstream_group_ids": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "upstream_task_ids": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "downstream_task_ids": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "edge_info": {
+      "$comment": "Metadata about DAG edges",
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "object",
+          "properties": {
+            "label": { "type": "string" }
+          },
+          "required": ["label"],
+          "additionalProperties": false
+        }
+      }
+    }
+  },
+
+  "type": "object",
+  "allOf": [
+    {
+      "type": "object",
+      "properties": {
+        "__version": {
+          "type": "integer",
+          "exclusiveMinimum": 0
+        },
+        "dag": { "$ref": "#/definitions/dag" }
+      },
+      "additionalProperties": false,
+      "required": [ "__version", "dag" ]
+    }
+  ]
 }

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -1211,7 +1211,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
         # Used to determine if an Operator is inherited from EmptyOperator
         setattr(op, "_is_empty", bool(encoded_op.get("_is_empty", False)))
 
-        # start with trigger
+        # Deserialize start_trigger
         serialized_start_trigger = encoded_op.get("_start_trigger")
         if serialized_start_trigger:
             trigger_cls_name, trigger_kwargs = serialized_start_trigger
@@ -1259,6 +1259,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 operator_name = encoded_op["_operator_name"]
             except KeyError:
                 operator_name = encoded_op["_task_type"]
+
             op = MappedOperator(
                 operator_class=op_data,
                 expand_input=EXPAND_INPUT_EMPTY,
@@ -1282,7 +1283,6 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 end_date=None,
                 disallow_kwargs_override=encoded_op["_disallow_kwargs_override"],
                 expand_input_attr=encoded_op["_expand_input_attr"],
-                # start with trigger is not supported in dynamic task mapping
                 start_trigger=None,
                 next_method=None,
             )

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -1024,7 +1024,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
         # Used to determine if an Operator is inherited from EmptyOperator
         serialize_op["_is_empty"] = op.inherits_from_empty_operator
         serialize_op["starts_execution_from_triggerer"] = op.starts_execution_from_triggerer
-        serialize_op["start_trigger"] = op.start_trigger.serialize() if op.start_trigger else None
+        serialize_op["trigger"] = op.trigger.serialize() if op.trigger else None
         serialize_op["next_method"] = op.next_method
 
         if op.operator_extra_links:
@@ -1211,7 +1211,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
             "starts_execution_from_triggerer",
             bool(encoded_op.get("starts_execution_from_triggerer", False)),
         )
-        setattr(op, "start_trigger", encoded_op.get("start_trigger", None))
+        setattr(op, "trigger", encoded_op.get("trigger", None))
         setattr(op, "next_method", encoded_op.get("next_method", None))
 
     @staticmethod
@@ -1275,7 +1275,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 disallow_kwargs_override=encoded_op["_disallow_kwargs_override"],
                 expand_input_attr=encoded_op["_expand_input_attr"],
                 starts_execution_from_triggerer=encoded_op["starts_execution_from_triggerer"],
-                start_trigger=encoded_op["start_trigger"],
+                trigger=encoded_op["trigger"],
                 next_method=encoded_op["next_method"],
             )
         else:

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -1024,7 +1024,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
         # Used to determine if an Operator is inherited from EmptyOperator
         serialize_op["_is_empty"] = op.inherits_from_empty_operator
         serialize_op["starts_execution_from_triggerer"] = op.starts_execution_from_triggerer
-        serialize_op["trigger"] = op.trigger.serialize() if op.trigger else None
+        serialize_op["start_trigger"] = op.start_trigger.serialize() if op.start_trigger else None
         serialize_op["next_method"] = op.next_method
 
         if op.operator_extra_links:
@@ -1211,7 +1211,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
             "starts_execution_from_triggerer",
             bool(encoded_op.get("starts_execution_from_triggerer", False)),
         )
-        setattr(op, "trigger", encoded_op.get("trigger", None))
+        setattr(op, "start_trigger", encoded_op.get("start_trigger", None))
         setattr(op, "next_method", encoded_op.get("next_method", None))
 
     @staticmethod
@@ -1275,7 +1275,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 disallow_kwargs_override=encoded_op["_disallow_kwargs_override"],
                 expand_input_attr=encoded_op["_expand_input_attr"],
                 starts_execution_from_triggerer=encoded_op["starts_execution_from_triggerer"],
-                trigger=encoded_op["trigger"],
+                start_trigger=encoded_op["start_trigger"],
                 next_method=encoded_op["next_method"],
             )
         else:

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -1023,9 +1023,9 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
 
         # Used to determine if an Operator is inherited from EmptyOperator
         serialize_op["_is_empty"] = op.inherits_from_empty_operator
-        serialize_op["_starts_execution_from_triggerer"] = op.starts_execution_from_triggerer
-        serialize_op["_trigger"] = op.trigger.serialize() if op.trigger else None
-        serialize_op["_next_method"] = op.next_method
+        serialize_op["starts_execution_from_triggerer"] = op.starts_execution_from_triggerer
+        serialize_op["trigger"] = op.trigger.serialize() if op.trigger else None
+        serialize_op["next_method"] = op.next_method
 
         if op.operator_extra_links:
             serialize_op["_operator_extra_links"] = cls._serialize_operator_extra_links(
@@ -1208,11 +1208,11 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
         setattr(op, "_is_empty", bool(encoded_op.get("_is_empty", False)))
         setattr(
             op,
-            "_starts_execution_from_triggerer",
-            bool(encoded_op.get("_starts_execution_from_triggerer", False)),
+            "starts_execution_from_triggerer",
+            bool(encoded_op.get("starts_execution_from_triggerer", False)),
         )
-        setattr(op, "_trigger", encoded_op.get("_trigger", None))
-        setattr(op, "_next_method", encoded_op.get("_next_method", None))
+        setattr(op, "trigger", encoded_op.get("trigger", None))
+        setattr(op, "next_method", encoded_op.get("next_method", None))
 
     @staticmethod
     def set_task_dag_references(task: Operator, dag: DAG) -> None:
@@ -1274,6 +1274,9 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 end_date=None,
                 disallow_kwargs_override=encoded_op["_disallow_kwargs_override"],
                 expand_input_attr=encoded_op["_expand_input_attr"],
+                starts_execution_from_triggerer=encoded_op["starts_execution_from_triggerer"],
+                trigger=encoded_op["trigger"],
+                next_method=encoded_op["next_method"],
             )
         else:
             op = SerializedBaseOperator(task_id=encoded_op["task_id"])

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -70,6 +70,7 @@ from airflow.triggers.base import BaseTrigger
 from airflow.utils.code_utils import get_python_source
 from airflow.utils.context import Context, DatasetEventAccessor, DatasetEventAccessors
 from airflow.utils.docs import get_docs_url
+from airflow.utils.helpers import exactly_one
 from airflow.utils.module_loading import import_string, qualname
 from airflow.utils.operator_resources import Resources
 from airflow.utils.task_group import MappedTaskGroup, TaskGroup
@@ -1025,7 +1026,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
         # Used to determine if an Operator is inherited from EmptyOperator
         serialize_op["_is_empty"] = op.inherits_from_empty_operator
 
-        if bool(op.start_trigger) ^ bool(op.next_method):
+        if exactly_one(op.start_trigger is not None, op.next_method is not None):
             raise AirflowException("start_trigger and next_method should both be set.")
 
         serialize_op["start_trigger"] = op.start_trigger.serialize() if op.start_trigger else None

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -1023,6 +1023,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
 
         # Used to determine if an Operator is inherited from EmptyOperator
         serialize_op["_is_empty"] = op.inherits_from_empty_operator
+        serialize_op["starts_execution_from_triggerer"] = op.starts_execution_from_triggerer
         serialize_op["start_trigger"] = op.start_trigger.serialize() if op.start_trigger else None
         serialize_op["next_method"] = op.next_method
 
@@ -1205,6 +1206,11 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
 
         # Used to determine if an Operator is inherited from EmptyOperator
         setattr(op, "_is_empty", bool(encoded_op.get("_is_empty", False)))
+        setattr(
+            op,
+            "starts_execution_from_triggerer",
+            bool(encoded_op.get("starts_execution_from_triggerer", False)),
+        )
         setattr(op, "start_trigger", encoded_op.get("start_trigger", None))
         setattr(op, "next_method", encoded_op.get("next_method", None))
 
@@ -1268,6 +1274,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 end_date=None,
                 disallow_kwargs_override=encoded_op["_disallow_kwargs_override"],
                 expand_input_attr=encoded_op["_expand_input_attr"],
+                starts_execution_from_triggerer=encoded_op["starts_execution_from_triggerer"],
                 start_trigger=encoded_op["start_trigger"],
                 next_method=encoded_op["next_method"],
             )

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -1282,6 +1282,9 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 end_date=None,
                 disallow_kwargs_override=encoded_op["_disallow_kwargs_override"],
                 expand_input_attr=encoded_op["_expand_input_attr"],
+                # start with trigger is not supported in dynamic task mapping
+                start_trigger=None,
+                next_method=None,
             )
         else:
             op = SerializedBaseOperator(task_id=encoded_op["task_id"])

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -1023,7 +1023,6 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
 
         # Used to determine if an Operator is inherited from EmptyOperator
         serialize_op["_is_empty"] = op.inherits_from_empty_operator
-        serialize_op["starts_execution_from_triggerer"] = op.starts_execution_from_triggerer
         serialize_op["start_trigger"] = op.start_trigger.serialize() if op.start_trigger else None
         serialize_op["next_method"] = op.next_method
 
@@ -1206,11 +1205,6 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
 
         # Used to determine if an Operator is inherited from EmptyOperator
         setattr(op, "_is_empty", bool(encoded_op.get("_is_empty", False)))
-        setattr(
-            op,
-            "starts_execution_from_triggerer",
-            bool(encoded_op.get("starts_execution_from_triggerer", False)),
-        )
         setattr(op, "start_trigger", encoded_op.get("start_trigger", None))
         setattr(op, "next_method", encoded_op.get("next_method", None))
 
@@ -1274,7 +1268,6 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 end_date=None,
                 disallow_kwargs_override=encoded_op["_disallow_kwargs_override"],
                 expand_input_attr=encoded_op["_expand_input_attr"],
-                starts_execution_from_triggerer=encoded_op["starts_execution_from_triggerer"],
                 start_trigger=encoded_op["start_trigger"],
                 next_method=encoded_op["next_method"],
             )

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -1023,8 +1023,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
 
         # Used to determine if an Operator is inherited from EmptyOperator
         serialize_op["_is_empty"] = op.inherits_from_empty_operator
-        serialize_op["_starts_execution_from_triggerer"] = op.starts_execution_from_triggerer
-        serialize_op["_trigger"] = op.trigger.serialize() if op.trigger else None
+        serialize_op["_start_trigger"] = op.start_trigger.serialize() if op.start_trigger else None
         serialize_op["_next_method"] = op.next_method
 
         if op.operator_extra_links:
@@ -1206,12 +1205,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
 
         # Used to determine if an Operator is inherited from EmptyOperator
         setattr(op, "_is_empty", bool(encoded_op.get("_is_empty", False)))
-        setattr(
-            op,
-            "_starts_execution_from_triggerer",
-            bool(encoded_op.get("_starts_execution_from_triggerer", False)),
-        )
-        setattr(op, "_trigger", encoded_op.get("_trigger", None))
+        setattr(op, "_start_trigger", encoded_op.get("_start_trigger", None))
         setattr(op, "_next_method", encoded_op.get("_next_method", None))
 
     @staticmethod

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -1026,10 +1026,10 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
         serialize_op["_is_empty"] = op.inherits_from_empty_operator
 
         if bool(op.start_trigger) ^ bool(op.next_method):
-            raise AirflowException("_start_trigger and _next_method should be both set.")
+            raise AirflowException("start_trigger and next_method should both be set.")
 
-        serialize_op["_start_trigger"] = op.start_trigger.serialize() if op.start_trigger else None
-        serialize_op["_next_method"] = op.next_method
+        serialize_op["start_trigger"] = op.start_trigger.serialize() if op.start_trigger else None
+        serialize_op["next_method"] = op.next_method
 
         if op.operator_extra_links:
             serialize_op["_operator_extra_links"] = cls._serialize_operator_extra_links(
@@ -1212,15 +1212,15 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
         setattr(op, "_is_empty", bool(encoded_op.get("_is_empty", False)))
 
         # Deserialize start_trigger
-        serialized_start_trigger = encoded_op.get("_start_trigger")
+        serialized_start_trigger = encoded_op.get("start_trigger")
         if serialized_start_trigger:
             trigger_cls_name, trigger_kwargs = serialized_start_trigger
             trigger_cls = import_string(trigger_cls_name)
             start_trigger = trigger_cls(**trigger_kwargs)
-            setattr(op, "_start_trigger", start_trigger)
+            setattr(op, "start_trigger", start_trigger)
         else:
-            setattr(op, "_start_trigger", None)
-        setattr(op, "_next_method", encoded_op.get("_next_method", None))
+            setattr(op, "start_trigger", None)
+        setattr(op, "next_method", encoded_op.get("next_method", None))
 
     @staticmethod
     def set_task_dag_references(task: Operator, dag: DAG) -> None:

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -1023,9 +1023,9 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
 
         # Used to determine if an Operator is inherited from EmptyOperator
         serialize_op["_is_empty"] = op.inherits_from_empty_operator
-        serialize_op["starts_execution_from_triggerer"] = op.starts_execution_from_triggerer
-        serialize_op["trigger"] = op.trigger.serialize() if op.trigger else None
-        serialize_op["next_method"] = op.next_method
+        serialize_op["_starts_execution_from_triggerer"] = op.starts_execution_from_triggerer
+        serialize_op["_trigger"] = op.trigger.serialize() if op.trigger else None
+        serialize_op["_next_method"] = op.next_method
 
         if op.operator_extra_links:
             serialize_op["_operator_extra_links"] = cls._serialize_operator_extra_links(
@@ -1208,11 +1208,11 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
         setattr(op, "_is_empty", bool(encoded_op.get("_is_empty", False)))
         setattr(
             op,
-            "starts_execution_from_triggerer",
-            bool(encoded_op.get("starts_execution_from_triggerer", False)),
+            "_starts_execution_from_triggerer",
+            bool(encoded_op.get("_starts_execution_from_triggerer", False)),
         )
-        setattr(op, "trigger", encoded_op.get("trigger", None))
-        setattr(op, "next_method", encoded_op.get("next_method", None))
+        setattr(op, "_trigger", encoded_op.get("_trigger", None))
+        setattr(op, "_next_method", encoded_op.get("_next_method", None))
 
     @staticmethod
     def set_task_dag_references(task: Operator, dag: DAG) -> None:
@@ -1274,9 +1274,6 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 end_date=None,
                 disallow_kwargs_override=encoded_op["_disallow_kwargs_override"],
                 expand_input_attr=encoded_op["_expand_input_attr"],
-                starts_execution_from_triggerer=encoded_op["starts_execution_from_triggerer"],
-                trigger=encoded_op["trigger"],
-                next_method=encoded_op["next_method"],
             )
         else:
             op = SerializedBaseOperator(task_id=encoded_op["task_id"])

--- a/docs/apache-airflow/authoring-and-scheduling/deferring.rst
+++ b/docs/apache-airflow/authoring-and-scheduling/deferring.rst
@@ -141,6 +141,38 @@ The ``self.defer`` call raises the ``TaskDeferred`` exception, so it can work an
 
 ``execution_timeout`` on operators is determined from the *total runtime*, not individual executions between deferrals. This means that if ``execution_timeout`` is set, an operator can fail while it's deferred or while it's running after a deferral, even if it's only been resumed for a few seconds.
 
+Triggering Deferral from Start
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you want to defer your task directly to the triggerer without going into the worker, you can add the attributes ``_start_trigger`` and ``_next_method`` in the ``__init__`` method of your deferrable operator.
+
+* ``_start_trigger``: An instance of a trigger you want to defer to. It will be serialized into the database.
+* ``_next_method``: The method name on your operator that you want Airflow to call when it resumes.
+
+
+This is particularly useful when deferring is the only thing the ``execute`` method does. Here's a basic refinement of the previous example.
+
+.. code-block:: python
+
+    from datetime import timedelta
+    from typing import Any
+
+    from airflow.sensors.base import BaseSensorOperator
+    from airflow.triggers.temporal import TimeDeltaTrigger
+    from airflow.utils.context import Context
+
+
+    class WaitOneHourSensor(BaseSensorOperator):
+        def __init__(self, *args: list[Any], **kwargs: dict[str, Any]) -> None:
+            super().__init__(*args, **kwargs)
+            self._start_trigger = TimeDeltaTrigger(timedelta(hours=1))
+            self._next_method = "execute_complete"
+
+        def execute_complete(self, context: Context, event: dict[str, Any] | None = None) -> None:
+            # We have no more work to do here. Mark as complete.
+            return
+
+
 Writing Triggers
 ~~~~~~~~~~~~~~~~
 

--- a/docs/apache-airflow/authoring-and-scheduling/deferring.rst
+++ b/docs/apache-airflow/authoring-and-scheduling/deferring.rst
@@ -144,10 +144,10 @@ The ``self.defer`` call raises the ``TaskDeferred`` exception, so it can work an
 Triggering Deferral from Start
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you want to defer your task directly to the triggerer without going into the worker, you can add the class level attributes ``_start_trigger`` and ``_next_method`` to your deferrable operator.
+If you want to defer your task directly to the triggerer without going into the worker, you can add the class level attributes ``start_trigger`` and ``_next_method`` to your deferrable operator.
 
-* ``_start_trigger``: An instance of a trigger you want to defer to. It will be serialized into the database.
-* ``_next_method``: The method name on your operator that you want Airflow to call when it resumes.
+* ``start_trigger``: An instance of a trigger you want to defer to. It will be serialized into the database.
+* ``next_method``: The method name on your operator that you want Airflow to call when it resumes.
 
 
 This is particularly useful when deferring is the only thing the ``execute`` method does. Here's a basic refinement of the previous example.
@@ -163,17 +163,17 @@ This is particularly useful when deferring is the only thing the ``execute`` met
 
 
     class WaitOneHourSensor(BaseSensorOperator):
-        _start_trigger = TimeDeltaTrigger(timedelta(hours=1))
-        _next_method = "execute_complete"
+        start_trigger = TimeDeltaTrigger(timedelta(hours=1))
+        next_method = "execute_complete"
 
         def execute_complete(self, context: Context, event: dict[str, Any] | None = None) -> None:
             # We have no more work to do here. Mark as complete.
             return
 
-``_start_trigger`` and ``_next_method`` can also be set at the instance level for more flexible configuration.
+``start_trigger`` and ``next_method`` can also be set at the instance level for more flexible configuration.
 
 .. warning::
-    Dynamic task mapping is not supported when ``_start_trigger`` and ``_next_method`` are assigned in instance level.
+    Dynamic task mapping is not supported when ``start_trigger`` and ``next_method`` are assigned in instance level.
 
 .. code-block:: python
 
@@ -188,8 +188,8 @@ This is particularly useful when deferring is the only thing the ``execute`` met
     class WaitOneHourSensor(BaseSensorOperator):
         def __init__(self, *args: list[Any], **kwargs: dict[str, Any]) -> None:
             super().__init__(*args, **kwargs)
-            self._start_trigger = TimeDeltaTrigger(timedelta(hours=1))
-            self._next_method = "execute_complete"
+            self.start_trigger = TimeDeltaTrigger(timedelta(hours=1))
+            self.next_method = "execute_complete"
 
         def execute_complete(self, context: Context, event: dict[str, Any] | None = None) -> None:
             # We have no more work to do here. Mark as complete.

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -40,6 +40,7 @@ from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import ShortCircuitOperator
 from airflow.serialization.serialized_objects import SerializedDAG
 from airflow.stats import Stats
+from airflow.triggers.testing import SuccessTrigger
 from airflow.utils import timezone
 from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.trigger_rule import TriggerRule
@@ -1984,6 +1985,33 @@ def test_schedule_tis_map_index(dag_maker, session):
     assert ti0.state == TaskInstanceState.SUCCESS
     assert ti1.state == TaskInstanceState.SCHEDULED
     assert ti2.state == TaskInstanceState.SUCCESS
+
+
+def test_schedule_tis_start_trigger(dag_maker, session):
+    """
+    Test that an operator with _start_trigger and _next_method set can be directly
+    deferred during scheduling.
+    """
+    trigger = SuccessTrigger()
+
+    class TestOperator(BaseOperator):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self._start_trigger = trigger
+            self._next_method = "execute_complete"
+
+        def execute_complete(self):
+            pass
+
+    with dag_maker(session=session):
+        task = TestOperator(task_id="test_task")
+
+    dr: DagRun = dag_maker.create_dagrun()
+
+    ti = TI(task=task, run_id=dr.run_id, state=None)
+    assert ti.state is None
+    dr.schedule_tis((ti,), session=session)
+    assert ti.state == TaskInstanceState.DEFERRED
 
 
 def test_mapped_expand_kwargs(dag_maker):

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -1997,8 +1997,8 @@ def test_schedule_tis_start_trigger(dag_maker, session):
     class TestOperator(BaseOperator):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
-            self._start_trigger = trigger
-            self._next_method = "execute_complete"
+            self.start_trigger = trigger
+            self.next_method = "execute_complete"
 
         def execute_complete(self):
             pass

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -195,6 +195,9 @@ serialized_simple_dag_ground_truth = {
                     "doc_md": "### Task Tutorial Documentation",
                     "_log_config_logger_name": "airflow.task.operators",
                     "weight_rule": "downstream",
+                    "starts_execution_from_triggerer": False,
+                    "start_trigger": None,
+                    "next_method": None,
                 },
             },
             {
@@ -222,6 +225,9 @@ serialized_simple_dag_ground_truth = {
                     "on_failure_fail_dagrun": False,
                     "_log_config_logger_name": "airflow.task.operators",
                     "weight_rule": "downstream",
+                    "starts_execution_from_triggerer": False,
+                    "start_trigger": None,
+                    "next_method": None,
                 },
             },
         ],
@@ -1312,6 +1318,9 @@ class TestStringifiedDAGs:
             "wait_for_past_depends_before_skipping": False,
             "weight_rule": _DownstreamPriorityWeightStrategy(),
             "multiple_outputs": False,
+            "starts_execution_from_triggerer": False,
+            "start_trigger": None,
+            "next_method": None,
         }, """
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
@@ -2206,7 +2215,7 @@ def test_operator_expand_serde():
         "_disallow_kwargs_override": False,
         "_expand_input_attr": "expand_input",
         "starts_execution_from_triggerer": False,
-        "trigger": None,
+        "start_trigger": None,
         "next_method": None,
     }
 
@@ -2224,7 +2233,7 @@ def test_operator_expand_serde():
         "ui_color": "#f0ede4",
         "ui_fgcolor": "#000",
         "starts_execution_from_triggerer": False,
-        "trigger": None,
+        "start_trigger": None,
         "next_method": None,
     }
     assert op.expand_input.value["bash_command"] == literal
@@ -2264,7 +2273,7 @@ def test_operator_expand_xcomarg_serde():
         "_disallow_kwargs_override": False,
         "_expand_input_attr": "expand_input",
         "starts_execution_from_triggerer": False,
-        "trigger": None,
+        "start_trigger": None,
         "next_method": None,
     }
 
@@ -2321,6 +2330,9 @@ def test_operator_expand_kwargs_literal_serde(strict):
         "ui_fgcolor": "#000",
         "_disallow_kwargs_override": strict,
         "_expand_input_attr": "expand_input",
+        "starts_execution_from_triggerer": False,
+        "start_trigger": None,
+        "next_method": None,
     }
 
     op = BaseSerialization.deserialize(serialized)
@@ -2368,7 +2380,7 @@ def test_operator_expand_kwargs_xcomarg_serde(strict):
         "_disallow_kwargs_override": strict,
         "_expand_input_attr": "expand_input",
         "starts_execution_from_triggerer": False,
-        "trigger": None,
+        "start_trigger": None,
         "next_method": None,
     }
 
@@ -2466,6 +2478,9 @@ def test_taskflow_expand_serde():
                 "__var": {"arg1": [1, 2, {"__type": "dict", "__var": {"a": "b"}}]},
             },
             "retry_delay": {"__type": "timedelta", "__var": 30.0},
+            "starts_execution_from_triggerer": False,
+            "start_trigger": None,
+            "next_method": None,
         },
         "op_kwargs_expand_input": {
             "type": "dict-of-lists",
@@ -2486,6 +2501,9 @@ def test_taskflow_expand_serde():
         "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"},
         "_disallow_kwargs_override": False,
         "_expand_input_attr": "op_kwargs_expand_input",
+        "starts_execution_from_triggerer": False,
+        "start_trigger": None,
+        "next_method": None,
     }
 
     deserialized = BaseSerialization.deserialize(serialized)
@@ -2505,6 +2523,9 @@ def test_taskflow_expand_serde():
         "op_args": [],
         "op_kwargs": {"arg1": [1, 2, {"a": "b"}]},
         "retry_delay": timedelta(seconds=30),
+        "starts_execution_from_triggerer": False,
+        "start_trigger": None,
+        "next_method": None,
     }
 
     # Ensure the serialized operator can also be correctly pickled, to ensure
@@ -2523,6 +2544,9 @@ def test_taskflow_expand_serde():
         "op_args": [],
         "op_kwargs": {"arg1": [1, 2, {"a": "b"}]},
         "retry_delay": timedelta(seconds=30),
+        "starts_execution_from_triggerer": False,
+        "start_trigger": None,
+        "next_method": None,
     }
 
 
@@ -2561,9 +2585,9 @@ def test_taskflow_expand_kwargs_serde(strict):
                 "__var": {"arg1": [1, 2, {"__type": "dict", "__var": {"a": "b"}}]},
             },
             "retry_delay": {"__type": "timedelta", "__var": 30.0},
-            "next_method": None,
             "starts_execution_from_triggerer": False,
-            "trigger": None,
+            "start_trigger": None,
+            "next_method": None,
         },
         "op_kwargs_expand_input": {
             "type": "list-of-dicts",
@@ -2582,7 +2606,7 @@ def test_taskflow_expand_kwargs_serde(strict):
         "_disallow_kwargs_override": strict,
         "_expand_input_attr": "op_kwargs_expand_input",
         "starts_execution_from_triggerer": False,
-        "trigger": None,
+        "start_trigger": None,
         "next_method": None,
     }
 
@@ -2605,7 +2629,7 @@ def test_taskflow_expand_kwargs_serde(strict):
         "op_kwargs": {"arg1": [1, 2, {"a": "b"}]},
         "retry_delay": timedelta(seconds=30),
         "starts_execution_from_triggerer": False,
-        "trigger": None,
+        "start_trigger": None,
         "next_method": None,
     }
 
@@ -2626,7 +2650,7 @@ def test_taskflow_expand_kwargs_serde(strict):
         "op_kwargs": {"arg1": [1, 2, {"a": "b"}]},
         "retry_delay": timedelta(seconds=30),
         "starts_execution_from_triggerer": False,
-        "trigger": None,
+        "start_trigger": None,
         "next_method": None,
     }
 
@@ -2712,9 +2736,9 @@ def test_mapped_task_with_operator_extra_links_property():
         "_task_module": "tests.serialization.test_dag_serialization",
         "_is_empty": False,
         "_is_mapped": True,
-        "next_method": None,
         "starts_execution_from_triggerer": False,
-        "trigger": None,
+        "start_trigger": None,
+        "next_method": None,
     }
     deserialized_dag = SerializedDAG.deserialize_dag(serialized_dag[Encoding.VAR])
     assert deserialized_dag.task_dict["task"].operator_extra_links == [AirflowLink2()]

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -195,6 +195,7 @@ serialized_simple_dag_ground_truth = {
                     "doc_md": "### Task Tutorial Documentation",
                     "_log_config_logger_name": "airflow.task.operators",
                     "weight_rule": "downstream",
+                    "starts_execution_from_triggerer": False,
                     "start_trigger": None,
                     "next_method": None,
                 },
@@ -224,6 +225,7 @@ serialized_simple_dag_ground_truth = {
                     "on_failure_fail_dagrun": False,
                     "_log_config_logger_name": "airflow.task.operators",
                     "weight_rule": "downstream",
+                    "starts_execution_from_triggerer": False,
                     "start_trigger": None,
                     "next_method": None,
                 },
@@ -1316,6 +1318,7 @@ class TestStringifiedDAGs:
             "wait_for_past_depends_before_skipping": False,
             "weight_rule": _DownstreamPriorityWeightStrategy(),
             "multiple_outputs": False,
+            "starts_execution_from_triggerer": False,
             "start_trigger": None,
             "next_method": None,
         }, """
@@ -2211,6 +2214,7 @@ def test_operator_expand_serde():
         "ui_fgcolor": "#000",
         "_disallow_kwargs_override": False,
         "_expand_input_attr": "expand_input",
+        "starts_execution_from_triggerer": False,
         "start_trigger": None,
         "next_method": None,
     }
@@ -2228,6 +2232,7 @@ def test_operator_expand_serde():
         "template_fields_renderers": {"bash_command": "bash", "env": "json"},
         "ui_color": "#f0ede4",
         "ui_fgcolor": "#000",
+        "starts_execution_from_triggerer": False,
         "start_trigger": None,
         "next_method": None,
     }
@@ -2267,6 +2272,7 @@ def test_operator_expand_xcomarg_serde():
         "ui_fgcolor": "#000",
         "_disallow_kwargs_override": False,
         "_expand_input_attr": "expand_input",
+        "starts_execution_from_triggerer": False,
         "start_trigger": None,
         "next_method": None,
     }
@@ -2324,6 +2330,7 @@ def test_operator_expand_kwargs_literal_serde(strict):
         "ui_fgcolor": "#000",
         "_disallow_kwargs_override": strict,
         "_expand_input_attr": "expand_input",
+        "starts_execution_from_triggerer": False,
         "start_trigger": None,
         "next_method": None,
     }
@@ -2372,6 +2379,7 @@ def test_operator_expand_kwargs_xcomarg_serde(strict):
         "ui_fgcolor": "#000",
         "_disallow_kwargs_override": strict,
         "_expand_input_attr": "expand_input",
+        "starts_execution_from_triggerer": False,
         "start_trigger": None,
         "next_method": None,
     }
@@ -2470,6 +2478,7 @@ def test_taskflow_expand_serde():
                 "__var": {"arg1": [1, 2, {"__type": "dict", "__var": {"a": "b"}}]},
             },
             "retry_delay": {"__type": "timedelta", "__var": 30.0},
+            "starts_execution_from_triggerer": False,
             "start_trigger": None,
             "next_method": None,
         },
@@ -2492,6 +2501,7 @@ def test_taskflow_expand_serde():
         "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"},
         "_disallow_kwargs_override": False,
         "_expand_input_attr": "op_kwargs_expand_input",
+        "starts_execution_from_triggerer": False,
         "start_trigger": None,
         "next_method": None,
     }
@@ -2513,6 +2523,7 @@ def test_taskflow_expand_serde():
         "op_args": [],
         "op_kwargs": {"arg1": [1, 2, {"a": "b"}]},
         "retry_delay": timedelta(seconds=30),
+        "starts_execution_from_triggerer": False,
         "start_trigger": None,
         "next_method": None,
     }
@@ -2533,6 +2544,7 @@ def test_taskflow_expand_serde():
         "op_args": [],
         "op_kwargs": {"arg1": [1, 2, {"a": "b"}]},
         "retry_delay": timedelta(seconds=30),
+        "starts_execution_from_triggerer": False,
         "start_trigger": None,
         "next_method": None,
     }
@@ -2573,6 +2585,7 @@ def test_taskflow_expand_kwargs_serde(strict):
                 "__var": {"arg1": [1, 2, {"__type": "dict", "__var": {"a": "b"}}]},
             },
             "retry_delay": {"__type": "timedelta", "__var": 30.0},
+            "starts_execution_from_triggerer": False,
             "start_trigger": None,
             "next_method": None,
         },
@@ -2592,6 +2605,7 @@ def test_taskflow_expand_kwargs_serde(strict):
         "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"},
         "_disallow_kwargs_override": strict,
         "_expand_input_attr": "op_kwargs_expand_input",
+        "starts_execution_from_triggerer": False,
         "start_trigger": None,
         "next_method": None,
     }
@@ -2614,6 +2628,7 @@ def test_taskflow_expand_kwargs_serde(strict):
         "op_args": [],
         "op_kwargs": {"arg1": [1, 2, {"a": "b"}]},
         "retry_delay": timedelta(seconds=30),
+        "starts_execution_from_triggerer": False,
         "start_trigger": None,
         "next_method": None,
     }
@@ -2634,6 +2649,7 @@ def test_taskflow_expand_kwargs_serde(strict):
         "op_args": [],
         "op_kwargs": {"arg1": [1, 2, {"a": "b"}]},
         "retry_delay": timedelta(seconds=30),
+        "starts_execution_from_triggerer": False,
         "start_trigger": None,
         "next_method": None,
     }
@@ -2720,6 +2736,7 @@ def test_mapped_task_with_operator_extra_links_property():
         "_task_module": "tests.serialization.test_dag_serialization",
         "_is_empty": False,
         "_is_mapped": True,
+        "starts_execution_from_triggerer": False,
         "start_trigger": None,
         "next_method": None,
     }

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -195,9 +195,6 @@ serialized_simple_dag_ground_truth = {
                     "doc_md": "### Task Tutorial Documentation",
                     "_log_config_logger_name": "airflow.task.operators",
                     "weight_rule": "downstream",
-                    "starts_execution_from_triggerer": False,
-                    "start_trigger": None,
-                    "next_method": None,
                 },
             },
             {
@@ -225,9 +222,6 @@ serialized_simple_dag_ground_truth = {
                     "on_failure_fail_dagrun": False,
                     "_log_config_logger_name": "airflow.task.operators",
                     "weight_rule": "downstream",
-                    "starts_execution_from_triggerer": False,
-                    "start_trigger": None,
-                    "next_method": None,
                 },
             },
         ],
@@ -1318,9 +1312,6 @@ class TestStringifiedDAGs:
             "wait_for_past_depends_before_skipping": False,
             "weight_rule": _DownstreamPriorityWeightStrategy(),
             "multiple_outputs": False,
-            "starts_execution_from_triggerer": False,
-            "start_trigger": None,
-            "next_method": None,
         }, """
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
@@ -2215,7 +2206,7 @@ def test_operator_expand_serde():
         "_disallow_kwargs_override": False,
         "_expand_input_attr": "expand_input",
         "starts_execution_from_triggerer": False,
-        "start_trigger": None,
+        "trigger": None,
         "next_method": None,
     }
 
@@ -2233,7 +2224,7 @@ def test_operator_expand_serde():
         "ui_color": "#f0ede4",
         "ui_fgcolor": "#000",
         "starts_execution_from_triggerer": False,
-        "start_trigger": None,
+        "trigger": None,
         "next_method": None,
     }
     assert op.expand_input.value["bash_command"] == literal
@@ -2273,7 +2264,7 @@ def test_operator_expand_xcomarg_serde():
         "_disallow_kwargs_override": False,
         "_expand_input_attr": "expand_input",
         "starts_execution_from_triggerer": False,
-        "start_trigger": None,
+        "trigger": None,
         "next_method": None,
     }
 
@@ -2330,9 +2321,6 @@ def test_operator_expand_kwargs_literal_serde(strict):
         "ui_fgcolor": "#000",
         "_disallow_kwargs_override": strict,
         "_expand_input_attr": "expand_input",
-        "starts_execution_from_triggerer": False,
-        "start_trigger": None,
-        "next_method": None,
     }
 
     op = BaseSerialization.deserialize(serialized)
@@ -2380,7 +2368,7 @@ def test_operator_expand_kwargs_xcomarg_serde(strict):
         "_disallow_kwargs_override": strict,
         "_expand_input_attr": "expand_input",
         "starts_execution_from_triggerer": False,
-        "start_trigger": None,
+        "trigger": None,
         "next_method": None,
     }
 
@@ -2478,9 +2466,6 @@ def test_taskflow_expand_serde():
                 "__var": {"arg1": [1, 2, {"__type": "dict", "__var": {"a": "b"}}]},
             },
             "retry_delay": {"__type": "timedelta", "__var": 30.0},
-            "starts_execution_from_triggerer": False,
-            "start_trigger": None,
-            "next_method": None,
         },
         "op_kwargs_expand_input": {
             "type": "dict-of-lists",
@@ -2501,9 +2486,6 @@ def test_taskflow_expand_serde():
         "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"},
         "_disallow_kwargs_override": False,
         "_expand_input_attr": "op_kwargs_expand_input",
-        "starts_execution_from_triggerer": False,
-        "start_trigger": None,
-        "next_method": None,
     }
 
     deserialized = BaseSerialization.deserialize(serialized)
@@ -2523,9 +2505,6 @@ def test_taskflow_expand_serde():
         "op_args": [],
         "op_kwargs": {"arg1": [1, 2, {"a": "b"}]},
         "retry_delay": timedelta(seconds=30),
-        "starts_execution_from_triggerer": False,
-        "start_trigger": None,
-        "next_method": None,
     }
 
     # Ensure the serialized operator can also be correctly pickled, to ensure
@@ -2544,9 +2523,6 @@ def test_taskflow_expand_serde():
         "op_args": [],
         "op_kwargs": {"arg1": [1, 2, {"a": "b"}]},
         "retry_delay": timedelta(seconds=30),
-        "starts_execution_from_triggerer": False,
-        "start_trigger": None,
-        "next_method": None,
     }
 
 
@@ -2585,9 +2561,9 @@ def test_taskflow_expand_kwargs_serde(strict):
                 "__var": {"arg1": [1, 2, {"__type": "dict", "__var": {"a": "b"}}]},
             },
             "retry_delay": {"__type": "timedelta", "__var": 30.0},
-            "starts_execution_from_triggerer": False,
-            "start_trigger": None,
             "next_method": None,
+            "starts_execution_from_triggerer": False,
+            "trigger": None,
         },
         "op_kwargs_expand_input": {
             "type": "list-of-dicts",
@@ -2606,7 +2582,7 @@ def test_taskflow_expand_kwargs_serde(strict):
         "_disallow_kwargs_override": strict,
         "_expand_input_attr": "op_kwargs_expand_input",
         "starts_execution_from_triggerer": False,
-        "start_trigger": None,
+        "trigger": None,
         "next_method": None,
     }
 
@@ -2629,7 +2605,7 @@ def test_taskflow_expand_kwargs_serde(strict):
         "op_kwargs": {"arg1": [1, 2, {"a": "b"}]},
         "retry_delay": timedelta(seconds=30),
         "starts_execution_from_triggerer": False,
-        "start_trigger": None,
+        "trigger": None,
         "next_method": None,
     }
 
@@ -2650,7 +2626,7 @@ def test_taskflow_expand_kwargs_serde(strict):
         "op_kwargs": {"arg1": [1, 2, {"a": "b"}]},
         "retry_delay": timedelta(seconds=30),
         "starts_execution_from_triggerer": False,
-        "start_trigger": None,
+        "trigger": None,
         "next_method": None,
     }
 
@@ -2736,9 +2712,9 @@ def test_mapped_task_with_operator_extra_links_property():
         "_task_module": "tests.serialization.test_dag_serialization",
         "_is_empty": False,
         "_is_mapped": True,
-        "starts_execution_from_triggerer": False,
-        "start_trigger": None,
         "next_method": None,
+        "starts_execution_from_triggerer": False,
+        "trigger": None,
     }
     deserialized_dag = SerializedDAG.deserialize_dag(serialized_dag[Encoding.VAR])
     assert deserialized_dag.task_dict["task"].operator_extra_links == [AirflowLink2()]

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -2205,6 +2205,9 @@ def test_operator_expand_serde():
         "ui_fgcolor": "#000",
         "_disallow_kwargs_override": False,
         "_expand_input_attr": "expand_input",
+        "starts_execution_from_triggerer": False,
+        "trigger": None,
+        "next_method": None,
     }
 
     op = BaseSerialization.deserialize(serialized)
@@ -2220,6 +2223,9 @@ def test_operator_expand_serde():
         "template_fields_renderers": {"bash_command": "bash", "env": "json"},
         "ui_color": "#f0ede4",
         "ui_fgcolor": "#000",
+        "starts_execution_from_triggerer": False,
+        "trigger": None,
+        "next_method": None,
     }
     assert op.expand_input.value["bash_command"] == literal
     assert op.partial_kwargs["executor_config"] == {"dict": {"sub": "value"}}
@@ -2257,6 +2263,9 @@ def test_operator_expand_xcomarg_serde():
         "ui_fgcolor": "#000",
         "_disallow_kwargs_override": False,
         "_expand_input_attr": "expand_input",
+        "starts_execution_from_triggerer": False,
+        "trigger": None,
+        "next_method": None,
     }
 
     op = BaseSerialization.deserialize(serialized)
@@ -2358,6 +2367,9 @@ def test_operator_expand_kwargs_xcomarg_serde(strict):
         "ui_fgcolor": "#000",
         "_disallow_kwargs_override": strict,
         "_expand_input_attr": "expand_input",
+        "starts_execution_from_triggerer": False,
+        "trigger": None,
+        "next_method": None,
     }
 
     op = BaseSerialization.deserialize(serialized)
@@ -2549,6 +2561,9 @@ def test_taskflow_expand_kwargs_serde(strict):
                 "__var": {"arg1": [1, 2, {"__type": "dict", "__var": {"a": "b"}}]},
             },
             "retry_delay": {"__type": "timedelta", "__var": 30.0},
+            "next_method": None,
+            "starts_execution_from_triggerer": False,
+            "trigger": None,
         },
         "op_kwargs_expand_input": {
             "type": "list-of-dicts",
@@ -2566,6 +2581,9 @@ def test_taskflow_expand_kwargs_serde(strict):
         "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"},
         "_disallow_kwargs_override": strict,
         "_expand_input_attr": "op_kwargs_expand_input",
+        "starts_execution_from_triggerer": False,
+        "trigger": None,
+        "next_method": None,
     }
 
     deserialized = BaseSerialization.deserialize(serialized)
@@ -2586,6 +2604,9 @@ def test_taskflow_expand_kwargs_serde(strict):
         "op_args": [],
         "op_kwargs": {"arg1": [1, 2, {"a": "b"}]},
         "retry_delay": timedelta(seconds=30),
+        "starts_execution_from_triggerer": False,
+        "trigger": None,
+        "next_method": None,
     }
 
     # Ensure the serialized operator can also be correctly pickled, to ensure
@@ -2604,6 +2625,9 @@ def test_taskflow_expand_kwargs_serde(strict):
         "op_args": [],
         "op_kwargs": {"arg1": [1, 2, {"a": "b"}]},
         "retry_delay": timedelta(seconds=30),
+        "starts_execution_from_triggerer": False,
+        "trigger": None,
+        "next_method": None,
     }
 
 
@@ -2688,6 +2712,9 @@ def test_mapped_task_with_operator_extra_links_property():
         "_task_module": "tests.serialization.test_dag_serialization",
         "_is_empty": False,
         "_is_mapped": True,
+        "next_method": None,
+        "starts_execution_from_triggerer": False,
+        "trigger": None,
     }
     deserialized_dag = SerializedDAG.deserialize_dag(serialized_dag[Encoding.VAR])
     assert deserialized_dag.task_dict["task"].operator_extra_links == [AirflowLink2()]

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -196,8 +196,8 @@ serialized_simple_dag_ground_truth = {
                     "doc_md": "### Task Tutorial Documentation",
                     "_log_config_logger_name": "airflow.task.operators",
                     "weight_rule": "downstream",
-                    "_next_method": None,
-                    "_start_trigger": None,
+                    "next_method": None,
+                    "start_trigger": None,
                 },
             },
             {
@@ -225,8 +225,8 @@ serialized_simple_dag_ground_truth = {
                     "on_failure_fail_dagrun": False,
                     "_log_config_logger_name": "airflow.task.operators",
                     "weight_rule": "downstream",
-                    "_next_method": None,
-                    "_start_trigger": None,
+                    "next_method": None,
+                    "start_trigger": None,
                 },
             },
         ],
@@ -2141,23 +2141,23 @@ class TestStringifiedDAGs:
     @pytest.mark.db_test
     def test_start_trigger_and_next_method_in_serialized_dag(self):
         """
-        Test that when we provide _start_trigger and _next_method, the DAG can be correctly serialized.
+        Test that when we provide start_trigger and next_method, the DAG can be correctly serialized.
         """
         trigger = SuccessTrigger()
 
         class TestOperator(BaseOperator):
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
-                self._start_trigger = trigger
-                self._next_method = "execute_complete"
+                self.start_trigger = trigger
+                self.next_method = "execute_complete"
 
             def execute_complete(self):
                 pass
 
         class Test2Operator(BaseOperator):
             def __init__(self, *args, **kwargs):
-                self._start_trigger = trigger
-                self._next_method = "execute_complete"
+                self.start_trigger = trigger
+                self.next_method = "execute_complete"
                 super().__init__(*args, **kwargs)
 
             def execute_complete(self):
@@ -2172,13 +2172,13 @@ class TestStringifiedDAGs:
         serialized_obj = SerializedDAG.to_dict(dag)
 
         for task in serialized_obj["dag"]["tasks"]:
-            assert task["__var"]["_start_trigger"] == trigger.serialize()
-            assert task["__var"]["_next_method"] == "execute_complete"
+            assert task["__var"]["start_trigger"] == trigger.serialize()
+            assert task["__var"]["next_method"] == "execute_complete"
 
     @pytest.mark.db_test
     def test_start_trigger_in_serialized_dag_but_no_next_method(self):
         """
-        Test that when we provide _start_trigger without _next_method, an AriflowException should be raised.
+        Test that when we provide start_trigger without next_method, an AriflowException should be raised.
         """
 
         trigger = SuccessTrigger()
@@ -2186,14 +2186,14 @@ class TestStringifiedDAGs:
         class TestOperator(BaseOperator):
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
-                self._start_trigger = trigger
+                self.start_trigger = trigger
 
         dag = DAG(dag_id="test_dag", start_date=datetime(2023, 11, 9))
 
         with dag:
             TestOperator(task_id="test_task")
 
-        with pytest.raises(AirflowException, match="_start_trigger and _next_method should be both set."):
+        with pytest.raises(AirflowException, match="start_trigger and next_method should both be set."):
             SerializedDAG.to_dict(dag)
 
 
@@ -2245,8 +2245,8 @@ def test_operator_expand_serde():
         "_is_mapped": True,
         "_task_module": "airflow.operators.bash",
         "_task_type": "BashOperator",
-        "_start_trigger": None,
-        "_next_method": None,
+        "start_trigger": None,
+        "next_method": None,
         "downstream_task_ids": [],
         "expand_input": {
             "type": "dict-of-lists",
@@ -2278,8 +2278,8 @@ def test_operator_expand_serde():
 
     assert op.operator_class == {
         "_task_type": "BashOperator",
-        "_start_trigger": None,
-        "_next_method": None,
+        "start_trigger": None,
+        "next_method": None,
         "downstream_task_ids": [],
         "task_id": "a",
         "template_ext": [".sh", ".bash"],
@@ -2324,8 +2324,8 @@ def test_operator_expand_xcomarg_serde():
         "ui_fgcolor": "#000",
         "_disallow_kwargs_override": False,
         "_expand_input_attr": "expand_input",
-        "_next_method": None,
-        "_start_trigger": None,
+        "next_method": None,
+        "start_trigger": None,
     }
 
     op = BaseSerialization.deserialize(serialized)
@@ -2381,8 +2381,8 @@ def test_operator_expand_kwargs_literal_serde(strict):
         "ui_fgcolor": "#000",
         "_disallow_kwargs_override": strict,
         "_expand_input_attr": "expand_input",
-        "_next_method": None,
-        "_start_trigger": None,
+        "next_method": None,
+        "start_trigger": None,
     }
 
     op = BaseSerialization.deserialize(serialized)
@@ -2429,8 +2429,8 @@ def test_operator_expand_kwargs_xcomarg_serde(strict):
         "ui_fgcolor": "#000",
         "_disallow_kwargs_override": strict,
         "_expand_input_attr": "expand_input",
-        "_next_method": None,
-        "_start_trigger": None,
+        "next_method": None,
+        "start_trigger": None,
     }
 
     op = BaseSerialization.deserialize(serialized)
@@ -2547,8 +2547,8 @@ def test_taskflow_expand_serde():
         "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"},
         "_disallow_kwargs_override": False,
         "_expand_input_attr": "op_kwargs_expand_input",
-        "_next_method": None,
-        "_start_trigger": None,
+        "next_method": None,
+        "start_trigger": None,
     }
 
     deserialized = BaseSerialization.deserialize(serialized)
@@ -2613,8 +2613,8 @@ def test_taskflow_expand_kwargs_serde(strict):
         "_task_module": "airflow.decorators.python",
         "_task_type": "_PythonDecoratedOperator",
         "_operator_name": "@task",
-        "_next_method": None,
-        "_start_trigger": None,
+        "next_method": None,
+        "start_trigger": None,
         "downstream_task_ids": [],
         "partial_kwargs": {
             "is_setup": False,
@@ -2765,8 +2765,8 @@ def test_mapped_task_with_operator_extra_links_property():
         "_task_module": "tests.serialization.test_dag_serialization",
         "_is_empty": False,
         "_is_mapped": True,
-        "_next_method": None,
-        "_start_trigger": None,
+        "next_method": None,
+        "start_trigger": None,
     }
     deserialized_dag = SerializedDAG.deserialize_dag(serialized_dag[Encoding.VAR])
     assert deserialized_dag.task_dict["task"].operator_extra_links == [AirflowLink2()]

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -2205,9 +2205,6 @@ def test_operator_expand_serde():
         "ui_fgcolor": "#000",
         "_disallow_kwargs_override": False,
         "_expand_input_attr": "expand_input",
-        "starts_execution_from_triggerer": False,
-        "trigger": None,
-        "next_method": None,
     }
 
     op = BaseSerialization.deserialize(serialized)
@@ -2223,9 +2220,6 @@ def test_operator_expand_serde():
         "template_fields_renderers": {"bash_command": "bash", "env": "json"},
         "ui_color": "#f0ede4",
         "ui_fgcolor": "#000",
-        "starts_execution_from_triggerer": False,
-        "trigger": None,
-        "next_method": None,
     }
     assert op.expand_input.value["bash_command"] == literal
     assert op.partial_kwargs["executor_config"] == {"dict": {"sub": "value"}}
@@ -2263,9 +2257,6 @@ def test_operator_expand_xcomarg_serde():
         "ui_fgcolor": "#000",
         "_disallow_kwargs_override": False,
         "_expand_input_attr": "expand_input",
-        "starts_execution_from_triggerer": False,
-        "trigger": None,
-        "next_method": None,
     }
 
     op = BaseSerialization.deserialize(serialized)
@@ -2367,9 +2358,6 @@ def test_operator_expand_kwargs_xcomarg_serde(strict):
         "ui_fgcolor": "#000",
         "_disallow_kwargs_override": strict,
         "_expand_input_attr": "expand_input",
-        "starts_execution_from_triggerer": False,
-        "trigger": None,
-        "next_method": None,
     }
 
     op = BaseSerialization.deserialize(serialized)
@@ -2561,9 +2549,6 @@ def test_taskflow_expand_kwargs_serde(strict):
                 "__var": {"arg1": [1, 2, {"__type": "dict", "__var": {"a": "b"}}]},
             },
             "retry_delay": {"__type": "timedelta", "__var": 30.0},
-            "next_method": None,
-            "starts_execution_from_triggerer": False,
-            "trigger": None,
         },
         "op_kwargs_expand_input": {
             "type": "list-of-dicts",
@@ -2581,9 +2566,6 @@ def test_taskflow_expand_kwargs_serde(strict):
         "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"},
         "_disallow_kwargs_override": strict,
         "_expand_input_attr": "op_kwargs_expand_input",
-        "starts_execution_from_triggerer": False,
-        "trigger": None,
-        "next_method": None,
     }
 
     deserialized = BaseSerialization.deserialize(serialized)
@@ -2604,9 +2586,6 @@ def test_taskflow_expand_kwargs_serde(strict):
         "op_args": [],
         "op_kwargs": {"arg1": [1, 2, {"a": "b"}]},
         "retry_delay": timedelta(seconds=30),
-        "starts_execution_from_triggerer": False,
-        "trigger": None,
-        "next_method": None,
     }
 
     # Ensure the serialized operator can also be correctly pickled, to ensure
@@ -2625,9 +2604,6 @@ def test_taskflow_expand_kwargs_serde(strict):
         "op_args": [],
         "op_kwargs": {"arg1": [1, 2, {"a": "b"}]},
         "retry_delay": timedelta(seconds=30),
-        "starts_execution_from_triggerer": False,
-        "trigger": None,
-        "next_method": None,
     }
 
 
@@ -2712,9 +2688,6 @@ def test_mapped_task_with_operator_extra_links_property():
         "_task_module": "tests.serialization.test_dag_serialization",
         "_is_empty": False,
         "_is_mapped": True,
-        "next_method": None,
-        "starts_execution_from_triggerer": False,
-        "trigger": None,
     }
     deserialized_dag = SerializedDAG.deserialize_dag(serialized_dag[Encoding.VAR])
     assert deserialized_dag.task_dict["task"].operator_extra_links == [AirflowLink2()]

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -2168,7 +2168,7 @@ class TestStringifiedDAGs:
 
         with dag:
             TestOperator(task_id="test_task_1")
-            TestOperator(task_id="test_task_2")
+            Test2Operator(task_id="test_task_2")
 
         serialized_obj = SerializedDAG.to_dict(dag)
 

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -1317,7 +1317,6 @@ class TestStringifiedDAGs:
             "wait_for_past_depends_before_skipping": False,
             "weight_rule": _DownstreamPriorityWeightStrategy(),
             "multiple_outputs": False,
-            "_start_trigger": None,
         }, """
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
@@ -2247,6 +2246,7 @@ def test_operator_expand_serde():
         "_task_module": "airflow.operators.bash",
         "_task_type": "BashOperator",
         "_start_trigger": None,
+        "_next_method": None,
         "downstream_task_ids": [],
         "expand_input": {
             "type": "dict-of-lists",
@@ -2270,7 +2270,6 @@ def test_operator_expand_serde():
         "ui_fgcolor": "#000",
         "_disallow_kwargs_override": False,
         "_expand_input_attr": "expand_input",
-        "_next_method": None,
     }
 
     op = BaseSerialization.deserialize(serialized)
@@ -2280,6 +2279,7 @@ def test_operator_expand_serde():
     assert op.operator_class == {
         "_task_type": "BashOperator",
         "_start_trigger": None,
+        "_next_method": None,
         "downstream_task_ids": [],
         "task_id": "a",
         "template_ext": [".sh", ".bash"],

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -195,6 +195,8 @@ serialized_simple_dag_ground_truth = {
                     "doc_md": "### Task Tutorial Documentation",
                     "_log_config_logger_name": "airflow.task.operators",
                     "weight_rule": "downstream",
+                    "_next_method": None,
+                    "_start_trigger": None,
                 },
             },
             {
@@ -222,6 +224,8 @@ serialized_simple_dag_ground_truth = {
                     "on_failure_fail_dagrun": False,
                     "_log_config_logger_name": "airflow.task.operators",
                     "weight_rule": "downstream",
+                    "_next_method": None,
+                    "_start_trigger": None,
                 },
             },
         ],
@@ -1312,6 +1316,7 @@ class TestStringifiedDAGs:
             "wait_for_past_depends_before_skipping": False,
             "weight_rule": _DownstreamPriorityWeightStrategy(),
             "multiple_outputs": False,
+            "_start_trigger": None,
         }, """
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
@@ -2182,6 +2187,7 @@ def test_operator_expand_serde():
         "_is_mapped": True,
         "_task_module": "airflow.operators.bash",
         "_task_type": "BashOperator",
+        "_start_trigger": None,
         "downstream_task_ids": [],
         "expand_input": {
             "type": "dict-of-lists",
@@ -2205,6 +2211,7 @@ def test_operator_expand_serde():
         "ui_fgcolor": "#000",
         "_disallow_kwargs_override": False,
         "_expand_input_attr": "expand_input",
+        "_next_method": None,
     }
 
     op = BaseSerialization.deserialize(serialized)
@@ -2213,6 +2220,7 @@ def test_operator_expand_serde():
 
     assert op.operator_class == {
         "_task_type": "BashOperator",
+        "_start_trigger": None,
         "downstream_task_ids": [],
         "task_id": "a",
         "template_ext": [".sh", ".bash"],
@@ -2257,6 +2265,8 @@ def test_operator_expand_xcomarg_serde():
         "ui_fgcolor": "#000",
         "_disallow_kwargs_override": False,
         "_expand_input_attr": "expand_input",
+        "_next_method": None,
+        "_start_trigger": None,
     }
 
     op = BaseSerialization.deserialize(serialized)
@@ -2312,6 +2322,8 @@ def test_operator_expand_kwargs_literal_serde(strict):
         "ui_fgcolor": "#000",
         "_disallow_kwargs_override": strict,
         "_expand_input_attr": "expand_input",
+        "_next_method": None,
+        "_start_trigger": None,
     }
 
     op = BaseSerialization.deserialize(serialized)
@@ -2358,6 +2370,8 @@ def test_operator_expand_kwargs_xcomarg_serde(strict):
         "ui_fgcolor": "#000",
         "_disallow_kwargs_override": strict,
         "_expand_input_attr": "expand_input",
+        "_next_method": None,
+        "_start_trigger": None,
     }
 
     op = BaseSerialization.deserialize(serialized)
@@ -2474,6 +2488,8 @@ def test_taskflow_expand_serde():
         "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"},
         "_disallow_kwargs_override": False,
         "_expand_input_attr": "op_kwargs_expand_input",
+        "_next_method": None,
+        "_start_trigger": None,
     }
 
     deserialized = BaseSerialization.deserialize(serialized)
@@ -2538,6 +2554,8 @@ def test_taskflow_expand_kwargs_serde(strict):
         "_task_module": "airflow.decorators.python",
         "_task_type": "_PythonDecoratedOperator",
         "_operator_name": "@task",
+        "_next_method": None,
+        "_start_trigger": None,
         "downstream_task_ids": [],
         "partial_kwargs": {
             "is_setup": False,
@@ -2688,6 +2706,8 @@ def test_mapped_task_with_operator_extra_links_property():
         "_task_module": "tests.serialization.test_dag_serialization",
         "_is_empty": False,
         "_is_mapped": True,
+        "_next_method": None,
+        "_start_trigger": None,
     }
     deserialized_dag = SerializedDAG.deserialize_dag(serialized_dag[Encoding.VAR])
     assert deserialized_dag.task_dict["task"].operator_extra_links == [AirflowLink2()]

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -195,7 +195,6 @@ serialized_simple_dag_ground_truth = {
                     "doc_md": "### Task Tutorial Documentation",
                     "_log_config_logger_name": "airflow.task.operators",
                     "weight_rule": "downstream",
-                    "starts_execution_from_triggerer": False,
                     "start_trigger": None,
                     "next_method": None,
                 },
@@ -225,7 +224,6 @@ serialized_simple_dag_ground_truth = {
                     "on_failure_fail_dagrun": False,
                     "_log_config_logger_name": "airflow.task.operators",
                     "weight_rule": "downstream",
-                    "starts_execution_from_triggerer": False,
                     "start_trigger": None,
                     "next_method": None,
                 },
@@ -1318,7 +1316,6 @@ class TestStringifiedDAGs:
             "wait_for_past_depends_before_skipping": False,
             "weight_rule": _DownstreamPriorityWeightStrategy(),
             "multiple_outputs": False,
-            "starts_execution_from_triggerer": False,
             "start_trigger": None,
             "next_method": None,
         }, """
@@ -2214,7 +2211,6 @@ def test_operator_expand_serde():
         "ui_fgcolor": "#000",
         "_disallow_kwargs_override": False,
         "_expand_input_attr": "expand_input",
-        "starts_execution_from_triggerer": False,
         "start_trigger": None,
         "next_method": None,
     }
@@ -2232,7 +2228,6 @@ def test_operator_expand_serde():
         "template_fields_renderers": {"bash_command": "bash", "env": "json"},
         "ui_color": "#f0ede4",
         "ui_fgcolor": "#000",
-        "starts_execution_from_triggerer": False,
         "start_trigger": None,
         "next_method": None,
     }
@@ -2272,7 +2267,6 @@ def test_operator_expand_xcomarg_serde():
         "ui_fgcolor": "#000",
         "_disallow_kwargs_override": False,
         "_expand_input_attr": "expand_input",
-        "starts_execution_from_triggerer": False,
         "start_trigger": None,
         "next_method": None,
     }
@@ -2330,7 +2324,6 @@ def test_operator_expand_kwargs_literal_serde(strict):
         "ui_fgcolor": "#000",
         "_disallow_kwargs_override": strict,
         "_expand_input_attr": "expand_input",
-        "starts_execution_from_triggerer": False,
         "start_trigger": None,
         "next_method": None,
     }
@@ -2379,7 +2372,6 @@ def test_operator_expand_kwargs_xcomarg_serde(strict):
         "ui_fgcolor": "#000",
         "_disallow_kwargs_override": strict,
         "_expand_input_attr": "expand_input",
-        "starts_execution_from_triggerer": False,
         "start_trigger": None,
         "next_method": None,
     }
@@ -2478,7 +2470,6 @@ def test_taskflow_expand_serde():
                 "__var": {"arg1": [1, 2, {"__type": "dict", "__var": {"a": "b"}}]},
             },
             "retry_delay": {"__type": "timedelta", "__var": 30.0},
-            "starts_execution_from_triggerer": False,
             "start_trigger": None,
             "next_method": None,
         },
@@ -2501,7 +2492,6 @@ def test_taskflow_expand_serde():
         "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"},
         "_disallow_kwargs_override": False,
         "_expand_input_attr": "op_kwargs_expand_input",
-        "starts_execution_from_triggerer": False,
         "start_trigger": None,
         "next_method": None,
     }
@@ -2523,7 +2513,6 @@ def test_taskflow_expand_serde():
         "op_args": [],
         "op_kwargs": {"arg1": [1, 2, {"a": "b"}]},
         "retry_delay": timedelta(seconds=30),
-        "starts_execution_from_triggerer": False,
         "start_trigger": None,
         "next_method": None,
     }
@@ -2544,7 +2533,6 @@ def test_taskflow_expand_serde():
         "op_args": [],
         "op_kwargs": {"arg1": [1, 2, {"a": "b"}]},
         "retry_delay": timedelta(seconds=30),
-        "starts_execution_from_triggerer": False,
         "start_trigger": None,
         "next_method": None,
     }
@@ -2585,7 +2573,6 @@ def test_taskflow_expand_kwargs_serde(strict):
                 "__var": {"arg1": [1, 2, {"__type": "dict", "__var": {"a": "b"}}]},
             },
             "retry_delay": {"__type": "timedelta", "__var": 30.0},
-            "starts_execution_from_triggerer": False,
             "start_trigger": None,
             "next_method": None,
         },
@@ -2605,7 +2592,6 @@ def test_taskflow_expand_kwargs_serde(strict):
         "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"},
         "_disallow_kwargs_override": strict,
         "_expand_input_attr": "op_kwargs_expand_input",
-        "starts_execution_from_triggerer": False,
         "start_trigger": None,
         "next_method": None,
     }
@@ -2628,7 +2614,6 @@ def test_taskflow_expand_kwargs_serde(strict):
         "op_args": [],
         "op_kwargs": {"arg1": [1, 2, {"a": "b"}]},
         "retry_delay": timedelta(seconds=30),
-        "starts_execution_from_triggerer": False,
         "start_trigger": None,
         "next_method": None,
     }
@@ -2649,7 +2634,6 @@ def test_taskflow_expand_kwargs_serde(strict):
         "op_args": [],
         "op_kwargs": {"arg1": [1, 2, {"a": "b"}]},
         "retry_delay": timedelta(seconds=30),
-        "starts_execution_from_triggerer": False,
         "start_trigger": None,
         "next_method": None,
     }
@@ -2736,7 +2720,6 @@ def test_mapped_task_with_operator_extra_links_property():
         "_task_module": "tests.serialization.test_dag_serialization",
         "_is_empty": False,
         "_is_mapped": True,
-        "starts_execution_from_triggerer": False,
         "start_trigger": None,
         "next_method": None,
     }


### PR DESCRIPTION
## Why
For some operators such as [S3KeySensor](https://github.com/apache/airflow/blob/8246a892b26c8fbe9c00858027ca4a741da5b523/airflow/providers/amazon/aws/sensors/s3.py#L150-L156) with deferrable set to True, running `execute` method in workers might not be necessary. It would be better if we could have a way to run a task in triggerer directly without going into the worker. 

In the current solution, we still need to run `next_method/execute_complete` in the worker. This PR serves as a POC / first step of running the whole execution in triggerer in asyncronize manner.

## What
Introduce `_start_trigger` and `_next_method` to `BaseOperator`. If an operator defines both `_start_trigger` and `_next_method` in the `__init__` method, the scheduler will directly defer the task without going to the worker.

```python
from __future__ import annotations

from airflow.models.baseoperator import BaseOperator
from airflow.triggers.testing import SuccessTrigger


class StartFromTriggerOperator(BaseOperator):
    _start_trigger = SuccessTrigger()
    _next_method = "execute_complete"

    def execute_complete(self, context, event=None) -> None:
        self.log.info("execute complete")
```

These attributes can also be assigned at the instance level. However, dynamic task mapping is not supported in this setup. 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
