### PR TITLE
Use async db calls in WorkflowTrigger

### DIFF
--- a/airflow/triggers/external_task.py
+++ b/airflow/triggers/external_task.py
@@ -98,13 +98,7 @@ class WorkflowTrigger(BaseTrigger):
         """Check periodically tasks, task group or dag status."""
         while True:
             if self.failed_states:
-                failed_count = _get_count(
-                    self.execution_dates,
-                    self.external_task_ids,
-                    self.external_task_group_id,
-                    self.external_dag_id,
-                    self.failed_states,
-                )
+                failed_count = await self._get_count(self.failed_states)
                 if failed_count > 0:
                     yield TriggerEvent({"status": "failed"})
                     return
@@ -112,28 +106,32 @@ class WorkflowTrigger(BaseTrigger):
                     yield TriggerEvent({"status": "success"})
                     return
             if self.skipped_states:
-                skipped_count = _get_count(
-                    self.execution_dates,
-                    self.external_task_ids,
-                    self.external_task_group_id,
-                    self.external_dag_id,
-                    self.skipped_states,
-                )
+                skipped_count = await self._get_count(self.skipped_states)
                 if skipped_count > 0:
                     yield TriggerEvent({"status": "skipped"})
                     return
-            allowed_count = _get_count(
-                self.execution_dates,
-                self.external_task_ids,
-                self.external_task_group_id,
-                self.external_dag_id,
-                self.allowed_states,
-            )
+            allowed_count = await self._get_count(self.allowed_states)
             if allowed_count == len(self.execution_dates):
                 yield TriggerEvent({"status": "success"})
                 return
             self.log.info("Sleeping for %s seconds", self.poke_interval)
             await asyncio.sleep(self.poke_interval)
+
+    @sync_to_async
+    def _get_count(self, states: typing.Iterable[str] | None) -> int:
+        """
+        Get the count of records against dttm filter and states. Async wrapper for _get_count.
+
+        :param states: task or dag states
+        :return The count of records.
+        """
+        return _get_count(
+            dttm_filter=self.execution_dates,
+            external_task_ids=self.external_task_ids,
+            external_task_group_id=self.external_task_group_id,
+            external_dag_id=self.external_dag_id,
+            states=states,
+        )
 
 
 class TaskStateTrigger(BaseTrigger):

--- a/airflow/triggers/external_task.py
+++ b/airflow/triggers/external_task.py
@@ -21,6 +21,7 @@ import typing
 from typing import Any
 
 from asgiref.sync import sync_to_async
+from deprecated import deprecated
 from sqlalchemy import func
 
 from airflow.models import DagRun, TaskInstance
@@ -134,6 +135,7 @@ class WorkflowTrigger(BaseTrigger):
         )
 
 
+@deprecated(reason=("TaskStateTrigger has been deprecated and will be removed in future."))
 class TaskStateTrigger(BaseTrigger):
     """
     Waits asynchronously for a task in a different DAG to complete for a specific logical date.

--- a/airflow/triggers/external_task.py
+++ b/airflow/triggers/external_task.py
@@ -24,6 +24,7 @@ from asgiref.sync import sync_to_async
 from deprecated import deprecated
 from sqlalchemy import func
 
+from airflow.exceptions import RemovedInAirflow3Warning
 from airflow.models import DagRun, TaskInstance
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 from airflow.utils.sensor_helper import _get_count
@@ -135,7 +136,10 @@ class WorkflowTrigger(BaseTrigger):
         )
 
 
-@deprecated(reason=("TaskStateTrigger has been deprecated and will be removed in future."))
+@deprecated(
+    reason="TaskStateTrigger has been deprecated and will be removed in future.",
+    category=RemovedInAirflow3Warning,
+)
 class TaskStateTrigger(BaseTrigger):
     """
     Waits asynchronously for a task in a different DAG to complete for a specific logical date.

--- a/contributing-docs/testing/unit_tests.rst
+++ b/contributing-docs/testing/unit_tests.rst
@@ -66,7 +66,7 @@ For avoid this make sure:
 .. code-block:: python
 
     def test_deprecated_argument():
-        with pytest.warn(AirflowProviderDeprecationWarning, match="expected warning pattern"):
+        with pytest.warns(AirflowProviderDeprecationWarning, match="expected warning pattern"):
             SomeDeprecatedClass(foo="bar", spam="egg")
 
 

--- a/tests/triggers/test_external_task.py
+++ b/tests/triggers/test_external_task.py
@@ -56,9 +56,9 @@ class TestWorkflowTrigger:
 
         gen = trigger.run()
         trigger_task = asyncio.create_task(gen.__anext__())
-        dummy_task = asyncio.create_task(dummy_async_fun())
+        fake_task = asyncio.create_task(fake_async_fun())
         await trigger_task
-        assert dummy_task.done()  # confirm that get_count is done in an async fashion
+        assert fake_task.done()  # confirm that get_count is done in an async fashion
         assert trigger_task.done()
         result = trigger_task.result()
         assert result.payload == {"status": "success"}
@@ -87,9 +87,9 @@ class TestWorkflowTrigger:
 
         gen = trigger.run()
         trigger_task = asyncio.create_task(gen.__anext__())
-        dummy_task = asyncio.create_task(dummy_async_fun())
+        fake_task = asyncio.create_task(fake_async_fun())
         await trigger_task
-        assert dummy_task.done()  # confirm that get_count is done in an async fashion
+        assert fake_task.done()  # confirm that get_count is done in an async fashion
         assert trigger_task.done()
         result = trigger_task.result()
         assert isinstance(result, TriggerEvent)
@@ -149,9 +149,9 @@ class TestWorkflowTrigger:
 
         gen = trigger.run()
         trigger_task = asyncio.create_task(gen.__anext__())
-        dummy_task = asyncio.create_task(dummy_async_fun())
+        fake_task = asyncio.create_task(fake_async_fun())
         await trigger_task
-        assert dummy_task.done()  # confirm that get_count is done in an async fashion
+        assert fake_task.done()  # confirm that get_count is done in an async fashion
         assert trigger_task.done()
         result = trigger_task.result()
         assert isinstance(result, TriggerEvent)
@@ -467,9 +467,9 @@ class TestDagStateTrigger:
 
 
 def mocked_get_count(*args, **kwargs):
-    time.sleep(0.3)
+    time.sleep(0.0001)
     return 1
 
 
-async def dummy_async_fun():
-    await asyncio.sleep(0.1)
+async def fake_async_fun():
+    await asyncio.sleep(0.00005)

--- a/tests/triggers/test_external_task.py
+++ b/tests/triggers/test_external_task.py
@@ -24,6 +24,7 @@ from unittest import mock
 import pytest
 from sqlalchemy.exc import SQLAlchemyError
 
+from airflow.exceptions import RemovedInAirflow3Warning
 from airflow.models.dag import DAG
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance
@@ -248,14 +249,15 @@ class TestTaskStateTrigger:
         session.add(instance)
         session.commit()
 
-        trigger = TaskStateTrigger(
-            dag_id=dag.dag_id,
-            task_id=instance.task_id,
-            states=self.STATES,
-            execution_dates=[timezone.datetime(2022, 1, 1)],
-            poll_interval=0.2,
-            trigger_start_time=trigger_start_time,
-        )
+        with pytest.warns(RemovedInAirflow3Warning, match="TaskStateTrigger has been deprecated"):
+            trigger = TaskStateTrigger(
+                dag_id=dag.dag_id,
+                task_id=instance.task_id,
+                states=self.STATES,
+                execution_dates=[timezone.datetime(2022, 1, 1)],
+                poll_interval=0.2,
+                trigger_start_time=trigger_start_time,
+            )
 
         task = asyncio.create_task(trigger.run().__anext__())
         await asyncio.sleep(0.5)
@@ -278,14 +280,15 @@ class TestTaskStateTrigger:
         trigger_start_time = utcnow()
         mock_utcnow.return_value = trigger_start_time + datetime.timedelta(seconds=61)
 
-        trigger = TaskStateTrigger(
-            dag_id="dag1",
-            task_id="task1",
-            states=self.STATES,
-            execution_dates=[timezone.datetime(2022, 1, 1)],
-            poll_interval=0.2,
-            trigger_start_time=trigger_start_time,
-        )
+        with pytest.warns(RemovedInAirflow3Warning, match="TaskStateTrigger has been deprecated"):
+            trigger = TaskStateTrigger(
+                dag_id="dag1",
+                task_id="task1",
+                states=self.STATES,
+                execution_dates=[timezone.datetime(2022, 1, 1)],
+                poll_interval=0.2,
+                trigger_start_time=trigger_start_time,
+            )
 
         trigger.count_running_dags = mock.AsyncMock()
         trigger.count_running_dags.return_value = 0
@@ -310,14 +313,15 @@ class TestTaskStateTrigger:
         trigger_start_time = utcnow()
         mock_utcnow.return_value = trigger_start_time + datetime.timedelta(seconds=20)
 
-        trigger = TaskStateTrigger(
-            dag_id="dag1",
-            task_id="task1",
-            states=self.STATES,
-            execution_dates=[timezone.datetime(2022, 1, 1)],
-            poll_interval=0.2,
-            trigger_start_time=trigger_start_time,
-        )
+        with pytest.warns(RemovedInAirflow3Warning, match="TaskStateTrigger has been deprecated"):
+            trigger = TaskStateTrigger(
+                dag_id="dag1",
+                task_id="task1",
+                states=self.STATES,
+                execution_dates=[timezone.datetime(2022, 1, 1)],
+                poll_interval=0.2,
+                trigger_start_time=trigger_start_time,
+            )
 
         trigger.count_running_dags = mock.AsyncMock()
         trigger.count_running_dags.return_value = 0
@@ -357,14 +361,15 @@ class TestTaskStateTrigger:
             trigger_start_time + datetime.timedelta(seconds=20),
         ]
 
-        trigger = TaskStateTrigger(
-            dag_id="dag1",
-            task_id="task1",
-            states=self.STATES,
-            execution_dates=[timezone.datetime(2022, 1, 1)],
-            poll_interval=0.2,
-            trigger_start_time=trigger_start_time,
-        )
+        with pytest.warns(RemovedInAirflow3Warning, match="TaskStateTrigger has been deprecated"):
+            trigger = TaskStateTrigger(
+                dag_id="dag1",
+                task_id="task1",
+                states=self.STATES,
+                execution_dates=[timezone.datetime(2022, 1, 1)],
+                poll_interval=0.2,
+                trigger_start_time=trigger_start_time,
+            )
 
         trigger.count_running_dags = mock.AsyncMock()
         trigger.count_running_dags.side_effect = [SQLAlchemyError]
@@ -384,14 +389,15 @@ class TestTaskStateTrigger:
         and classpath.
         """
         trigger_start_time = utcnow()
-        trigger = TaskStateTrigger(
-            dag_id=self.DAG_ID,
-            task_id=self.TASK_ID,
-            states=self.STATES,
-            execution_dates=[timezone.datetime(2022, 1, 1)],
-            poll_interval=5,
-            trigger_start_time=trigger_start_time,
-        )
+        with pytest.warns(RemovedInAirflow3Warning, match="TaskStateTrigger has been deprecated"):
+            trigger = TaskStateTrigger(
+                dag_id=self.DAG_ID,
+                task_id=self.TASK_ID,
+                states=self.STATES,
+                execution_dates=[timezone.datetime(2022, 1, 1)],
+                poll_interval=5,
+                trigger_start_time=trigger_start_time,
+            )
         classpath, kwargs = trigger.serialize()
         assert classpath == "airflow.triggers.external_task.TaskStateTrigger"
         assert kwargs == {


### PR DESCRIPTION
This closes: #38672

I opted to slightly extend some existing unit tests rather than write mostly identical new ones. If the `@sync_to_async` decorator and the `await`s before `self._get_count` are removed the tests will fail because the trigger and dummy tasks are executed sequentially.

Should I also remove `TaskStateTrigger` in this PR? It is not used anymore outside of tests.