### PR TITLE
Drop pre-release specification from pre-installed provider versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1085,7 +1085,7 @@ repos:
         entry: "^\\s*from re\\s|^\\s*import re\\s"
         pass_filenames: true
         files: \.py$
-        exclude: ^airflow/providers|^dev/.*\.py$|^scripts/.*\.py$|^tests/|^\w+_tests/|^docs/.*\.py$|^airflow/utils/helpers.py$
+        exclude: ^airflow/providers|^dev/.*\.py$|^scripts/.*\.py$|^tests/|^\w+_tests/|^docs/.*\.py$|^airflow/utils/helpers.py$|^hatch_build.py$
       - id: check-deferrable-default-value
         name: Check default value of deferrable attribute
         language: python

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -20,6 +20,7 @@ import itertools
 import json
 import logging
 import os
+import re
 import sys
 from pathlib import Path
 from subprocess import run
@@ -555,7 +556,22 @@ def get_provider_id(provider_spec: str) -> str:
 
 def get_provider_requirement(provider_spec: str) -> str:
     if ">=" in provider_spec:
+        # we cannot import `airflow` here directly as it would pull re2 and a number of airflow
+        # dependencies so we need to read airflow version by matching a regexp
+        airflow_init_content = (AIRFLOW_ROOT_PATH / "airflow" / "__init__.py").read_text()
+        airflow_version_pattern = r'__version__ = "(\d+\.\d+\.\d+\S*)"'
+        airflow_version_match = re.search(airflow_version_pattern, airflow_init_content)
+        if not airflow_version_match:
+            raise RuntimeError("Cannot find Airflow version in airflow/__init__.py")
+        from packaging.version import Version
+
+        current_airflow_version = Version(airflow_version_match.group(1))
         provider_id, min_version = provider_spec.split(">=")
+        provider_version = Version(min_version)
+        if provider_version.is_prerelease and not current_airflow_version.is_prerelease:
+            # strip pre-release version from the pre-installed provider's version when we are preparing
+            # the official package
+            min_version = str(provider_version.base_version)
         return f"apache-airflow-providers-{provider_id.replace('.', '-')}>={min_version}"
     else:
         return f"apache-airflow-providers-{provider_spec.replace('.', '-')}"


### PR DESCRIPTION
When Airflow installs a pre-release provider version we can add the `>=x.y.zdev0` or `>=x.y.zrc1` to pre-release provider specification.

This is necessary to install dev0 or rc* packages when we release them for testing, when the pre-installed provider is a "chicken-egg" provider that does not yet have an "official" version - because otherwise the dependency would not allow the provider to be installed.

However, the "final" package should have just `>=x.y.z` without the pre-release specification, because by the time we release the final version, the pre-release provider package should be already released.

This PR implements such pre-release stripping. In cse we prepare the "final" version of the airflow package, all the preinstalled provider's specifications got the `>=version` stripped off all the prerelease information. The `>=1.2.0dev0` or `>=1.2.0rc1` is for example turned into `>=1.2.0`.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
