### PR TITLE
Add fallback `region_name` value to AWS Executors

### DIFF
--- a/airflow/providers/amazon/aws/executors/batch/batch_executor.py
+++ b/airflow/providers/amazon/aws/executors/batch/batch_executor.py
@@ -153,7 +153,7 @@ class AwsBatchExecutor(BaseExecutor):
             AllBatchConfigKeys.AWS_CONN_ID,
             fallback=CONFIG_DEFAULTS[AllBatchConfigKeys.AWS_CONN_ID],
         )
-        region_name = conf.get(CONFIG_GROUP_NAME, AllBatchConfigKeys.REGION_NAME)
+        region_name = conf.get(CONFIG_GROUP_NAME, AllBatchConfigKeys.REGION_NAME, fallback=None)
         self.batch = BatchClientHook(aws_conn_id=aws_conn_id, region_name=region_name).conn
         self.attempts_since_last_successful_connection += 1
         self.last_connection_reload = timezone.utcnow()

--- a/airflow/providers/amazon/aws/executors/ecs/ecs_executor.py
+++ b/airflow/providers/amazon/aws/executors/ecs/ecs_executor.py
@@ -183,7 +183,7 @@ class AwsEcsExecutor(BaseExecutor):
             AllEcsConfigKeys.AWS_CONN_ID,
             fallback=CONFIG_DEFAULTS[AllEcsConfigKeys.AWS_CONN_ID],
         )
-        region_name = conf.get(CONFIG_GROUP_NAME, AllEcsConfigKeys.REGION_NAME)
+        region_name = conf.get(CONFIG_GROUP_NAME, AllEcsConfigKeys.REGION_NAME, fallback=None)
         self.ecs = EcsHook(aws_conn_id=aws_conn_id, region_name=region_name).conn
         self.attempts_since_last_successful_connection += 1
         self.last_connection_reload = timezone.utcnow()

--- a/tests/providers/amazon/aws/executors/ecs/test_ecs_executor.py
+++ b/tests/providers/amazon/aws/executors/ecs/test_ecs_executor.py
@@ -367,9 +367,6 @@ class TestEcsExecutorTask:
 class TestAwsEcsExecutor:
     """Tests the AWS ECS Executor."""
 
-    def teardown_method(self) -> None:
-        self._unset_conf()
-
     def test_execute(self, mock_airflow_key, mock_executor):
         """Test execution from end-to-end."""
         airflow_key = mock_airflow_key()
@@ -1016,12 +1013,6 @@ class TestAwsEcsExecutor:
         )
         assert 0 == len(mock_executor.pending_tasks)
 
-    @staticmethod
-    def _unset_conf():
-        for env in os.environ:
-            if env.startswith(f"AIRFLOW__{CONFIG_GROUP_NAME.upper()}__"):
-                os.environ.pop(env)
-
     def _mock_sync(
         self,
         executor: AwsEcsExecutor,
@@ -1198,18 +1189,16 @@ class TestAwsEcsExecutor:
 class TestEcsExecutorConfig:
     @pytest.fixture
     def assign_subnets(self):
-        os.environ[f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.SUBNETS}".upper()] = "sub1,sub2"
+        with conf_vars({(CONFIG_GROUP_NAME, AllEcsConfigKeys.SUBNETS): "sub1,sub2"}):
+            yield
 
-    @staticmethod
-    def teardown_method() -> None:
-        for env in os.environ:
-            if env.startswith(f"AIRFLOW__{CONFIG_GROUP_NAME}__".upper()):
-                os.environ.pop(env)
+    @pytest.fixture
+    def assign_container_name(self):
+        with conf_vars({(CONFIG_GROUP_NAME, AllEcsConfigKeys.CONTAINER_NAME): "foobar"}):
+            yield
 
     def test_flatten_dict(self):
-        os.environ[f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.SUBNETS}".upper()] = "sub1,sub2"
         nested_dict = {"a": "a", "b": "b", "c": {"d": "d"}}
-
         assert _recursive_flatten_dict(nested_dict) == {"a": "a", "b": "b", "d": "d"}
 
     def test_validate_config_defaults(self):
@@ -1229,29 +1218,24 @@ class TestEcsExecutorConfig:
             assert file_defaults[key] == CONFIG_DEFAULTS[key]
 
     def test_subnets_required(self):
-        assert f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.SUBNETS}".upper() not in os.environ
-
-        os.environ[f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.REGION_NAME}".upper()] = "us-west-1"
-        os.environ[f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.CLUSTER}".upper()] = "some-cluster"
-        os.environ[f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.CONTAINER_NAME}".upper()] = (
-            "container-name"
-        )
-        os.environ[f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.TASK_DEFINITION}".upper()] = (
-            "some-task-def"
-        )
-        os.environ[f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.LAUNCH_TYPE}".upper()] = "FARGATE"
-        os.environ[f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.PLATFORM_VERSION}".upper()] = "LATEST"
-        os.environ[f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.ASSIGN_PUBLIC_IP}".upper()] = "False"
-        os.environ[f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.SECURITY_GROUPS}".upper()] = "sg1,sg2"
-
-        with pytest.raises(ValueError) as raised:
-            ecs_executor_config.build_task_kwargs()
+        conf_overrides = {
+            (CONFIG_GROUP_NAME, AllEcsConfigKeys.SUBNETS): None,
+            (CONFIG_GROUP_NAME, AllEcsConfigKeys.REGION_NAME): "us-west-1",
+            (CONFIG_GROUP_NAME, AllEcsConfigKeys.CLUSTER): "some-cluster",
+            (CONFIG_GROUP_NAME, AllEcsConfigKeys.CONTAINER_NAME): "container-name",
+            (CONFIG_GROUP_NAME, AllEcsConfigKeys.TASK_DEFINITION): "some-task-def",
+            (CONFIG_GROUP_NAME, AllEcsConfigKeys.LAUNCH_TYPE): "FARGATE",
+            (CONFIG_GROUP_NAME, AllEcsConfigKeys.PLATFORM_VERSION): "LATEST",
+            (CONFIG_GROUP_NAME, AllEcsConfigKeys.ASSIGN_PUBLIC_IP): "False",
+            (CONFIG_GROUP_NAME, AllEcsConfigKeys.SECURITY_GROUPS): "sg1,sg2",
+        }
+        with conf_vars(conf_overrides):
+            with pytest.raises(ValueError) as raised:
+                ecs_executor_config.build_task_kwargs()
         assert raised.match("At least one subnet is required to run a task.")
 
+    @conf_vars({(CONFIG_GROUP_NAME, AllEcsConfigKeys.CONTAINER_NAME): "container-name"})
     def test_config_defaults_are_applied(self, assign_subnets):
-        os.environ[f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.CONTAINER_NAME}".upper()] = (
-            "container-name"
-        )
         from airflow.providers.amazon.aws.executors.ecs import ecs_executor_config
 
         task_kwargs = _recursive_flatten_dict(ecs_executor_config.build_task_kwargs())
@@ -1273,54 +1257,50 @@ class TestEcsExecutorConfig:
                     expected_value = parse_assign_public_ip(expected_value)
                 assert expected_value == task_kwargs[found_keys[expected_key]]
 
-    def test_provided_values_override_defaults(self, assign_subnets):
+    def test_provided_values_override_defaults(self, assign_subnets, assign_container_name, monkeypatch):
         """
         Expected precedence is default values are overwritten by values provided explicitly,
         and those values are overwritten by those provided in run_task_kwargs.
         """
+        run_task_kwargs_env_key = f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.RUN_TASK_KWARGS}".upper()
+        platform_version_env_key = (
+            f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.PLATFORM_VERSION}".upper()
+        )
         default_version = CONFIG_DEFAULTS[AllEcsConfigKeys.PLATFORM_VERSION]
         templated_version = "1"
         first_explicit_version = "2"
         second_explicit_version = "3"
 
-        run_task_kwargs_env_key = f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.RUN_TASK_KWARGS}".upper()
-        platform_version_env_key = (
-            f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.PLATFORM_VERSION}".upper()
-        )
-        # Required param which doesn't have a default
-        os.environ[f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.CONTAINER_NAME}".upper()] = "foobar"
-
         # Confirm the default value is applied when no value is provided.
-        assert run_task_kwargs_env_key not in os.environ
-        assert platform_version_env_key not in os.environ
+        monkeypatch.delenv(platform_version_env_key, raising=False)
+        monkeypatch.delenv(run_task_kwargs_env_key, raising=False)
         from airflow.providers.amazon.aws.executors.ecs import ecs_executor_config
 
         task_kwargs = ecs_executor_config.build_task_kwargs()
-
         assert task_kwargs["platformVersion"] == default_version
 
         # Provide a new value explicitly and assert that it is applied over the default.
-        os.environ[platform_version_env_key] = first_explicit_version
+        monkeypatch.setenv(platform_version_env_key, first_explicit_version)
         task_kwargs = ecs_executor_config.build_task_kwargs()
-
         assert task_kwargs["platformVersion"] == first_explicit_version
 
         # Provide a value via template and assert that it is applied over the explicit value.
-        os.environ[run_task_kwargs_env_key] = json.dumps(
-            {AllEcsConfigKeys.PLATFORM_VERSION: templated_version}
+        monkeypatch.setenv(
+            run_task_kwargs_env_key,
+            json.dumps({AllEcsConfigKeys.PLATFORM_VERSION: templated_version}),
         )
         task_kwargs = ecs_executor_config.build_task_kwargs()
-
         assert task_kwargs["platformVersion"] == templated_version
 
         # Provide a new value explicitly and assert it is not applied over the templated values.
-        os.environ[platform_version_env_key] = second_explicit_version
+        monkeypatch.setenv(platform_version_env_key, second_explicit_version)
         task_kwargs = ecs_executor_config.build_task_kwargs()
-
         assert task_kwargs["platformVersion"] == templated_version
 
     @mock.patch.object(EcsHook, "conn")
-    def test_count_can_not_be_modified_by_the_user(self, _, assign_subnets):
+    def test_count_can_not_be_modified_by_the_user(
+        self, _, assign_subnets, assign_container_name, monkeypatch
+    ):
         """The ``count`` parameter must always be 1; verify that the user can not override this value."""
         templated_version = "1"
         templated_cluster = "templated_cluster_name"
@@ -1330,13 +1310,12 @@ class TestEcsExecutorConfig:
             "count": 2,  # The user should not be allowed to overwrite count, it must be value of 1
         }
 
-        run_task_kwargs_env_key = f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.RUN_TASK_KWARGS}".upper()
-        # Required param which doesn't have a default
-        os.environ[f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.CONTAINER_NAME}".upper()] = "foobar"
-
         # Provide values via task run kwargs template and assert that they are applied,
         # which verifies that the OTHER values were changed.
-        os.environ[run_task_kwargs_env_key] = json.dumps(provided_run_task_kwargs)
+        monkeypatch.setenv(
+            f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.RUN_TASK_KWARGS}".upper(),
+            json.dumps(provided_run_task_kwargs),
+        )
         task_kwargs = ecs_executor_config.build_task_kwargs()
         assert task_kwargs["platformVersion"] == templated_version
         assert task_kwargs["cluster"] == templated_cluster
@@ -1344,7 +1323,7 @@ class TestEcsExecutorConfig:
         # Assert that count was NOT overridden when the others were applied.
         assert task_kwargs["count"] == 1
 
-    def test_verify_tags_are_used_as_provided(self, assign_subnets):
+    def test_verify_tags_are_used_as_provided(self, assign_subnets, assign_container_name, monkeypatch):
         """Confirm that the ``tags`` provided are not converted to camelCase."""
         templated_tags = {"Apache": "Airflow"}
 
@@ -1353,16 +1332,13 @@ class TestEcsExecutorConfig:
         }
 
         run_task_kwargs_env_key = f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.RUN_TASK_KWARGS}".upper()
-        # Required param which doesn't have a default
-        os.environ[f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.CONTAINER_NAME}".upper()] = "foobar"
-
-        os.environ[run_task_kwargs_env_key] = json.dumps(provided_run_task_kwargs)
+        monkeypatch.setenv(run_task_kwargs_env_key, json.dumps(provided_run_task_kwargs))
         task_kwargs = ecs_executor_config.build_task_kwargs()
 
         # Verify that tag names are exempt from the camel-case conversion.
         assert task_kwargs["tags"] == templated_tags
 
-    def test_that_provided_kwargs_are_moved_to_correct_nesting(self, assign_subnets):
+    def test_that_provided_kwargs_are_moved_to_correct_nesting(self, monkeypatch):
         """
         kwargs such as subnets, security groups,  public ip, and container name are valid run task kwargs,
         but they are not placed at the root of the kwargs dict, they should be nested in various sub dicts.
@@ -1375,7 +1351,7 @@ class TestEcsExecutorConfig:
             AllEcsConfigKeys.SUBNETS: "sub1,sub2",
         }
         for key, value in kwargs_to_test.items():
-            os.environ[f"AIRFLOW__{CONFIG_GROUP_NAME}__{key}".upper()] = value
+            monkeypatch.setenv(f"AIRFLOW__{CONFIG_GROUP_NAME}__{key}".upper(), value)
 
         run_task_kwargs = ecs_executor_config.build_task_kwargs()
         run_task_kwargs_network_config = run_task_kwargs["networkConfiguration"]["awsvpcConfiguration"]
@@ -1455,43 +1431,35 @@ class TestEcsExecutorConfig:
 
         executor.ecs = ecs_mock
 
-        os.environ[f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.CHECK_HEALTH_ON_STARTUP}".upper()] = (
-            "False"
-        )
-
-        executor.start()
+        with conf_vars({(CONFIG_GROUP_NAME, AllEcsConfigKeys.CHECK_HEALTH_ON_STARTUP): "False"}):
+            executor.start()
 
         ecs_mock.stop_task.assert_not_called()
 
-    def test_providing_both_capacity_provider_and_launch_type_fails(self, set_env_vars):
-        os.environ[f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.CAPACITY_PROVIDER_STRATEGY}".upper()] = (
-            "[{'capacityProvider': 'cp1', 'weight': 5}, {'capacityProvider': 'cp2', 'weight': 1}]"
-        )
-        expected_error = (
+    def test_providing_both_capacity_provider_and_launch_type_fails(self, set_env_vars, monkeypatch):
+        cps = "[{'capacityProvider': 'cp1', 'weight': 5}, {'capacityProvider': 'cp2', 'weight': 1}]"
+        expected_error = re.escape(
             "capacity_provider_strategy and launch_type are mutually exclusive, you can not provide both."
         )
-
-        with pytest.raises(ValueError, match=expected_error):
-            AwsEcsExecutor()
+        with conf_vars({(CONFIG_GROUP_NAME, AllEcsConfigKeys.CAPACITY_PROVIDER_STRATEGY): cps}):
+            with pytest.raises(ValueError, match=expected_error):
+                AwsEcsExecutor()
 
     def test_providing_capacity_provider(self, set_env_vars):
         # If a capacity provider strategy is supplied without a launch type, use the strategy.
-
         valid_capacity_provider = (
             "[{'capacityProvider': 'cp1', 'weight': 5}, {'capacityProvider': 'cp2', 'weight': 1}]"
         )
+        conf_overrides = {
+            (CONFIG_GROUP_NAME, AllEcsConfigKeys.CAPACITY_PROVIDER_STRATEGY): valid_capacity_provider,
+            (CONFIG_GROUP_NAME, AllEcsConfigKeys.LAUNCH_TYPE): None,
+        }
+        with conf_vars(conf_overrides):
+            from airflow.providers.amazon.aws.executors.ecs import ecs_executor_config
 
-        os.environ[f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.CAPACITY_PROVIDER_STRATEGY}".upper()] = (
-            valid_capacity_provider
-        )
-        os.environ.pop(f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.LAUNCH_TYPE}".upper())
-
-        from airflow.providers.amazon.aws.executors.ecs import ecs_executor_config
-
-        task_kwargs = ecs_executor_config.build_task_kwargs()
-
-        assert "launchType" not in task_kwargs
-        assert task_kwargs["capacityProviderStrategy"] == valid_capacity_provider
+            task_kwargs = ecs_executor_config.build_task_kwargs()
+            assert "launchType" not in task_kwargs
+            assert task_kwargs["capacityProviderStrategy"] == valid_capacity_provider
 
     @mock.patch.object(EcsHook, "conn")
     def test_providing_no_capacity_provider_no_lunch_type_with_cluster_default(self, mock_conn, set_env_vars):
@@ -1500,28 +1468,24 @@ class TestEcsExecutorConfig:
         mock_conn.describe_clusters.return_value = {
             "clusters": [{"defaultCapacityProviderStrategy": ["some_strategy"]}]
         }
-        os.environ.pop(f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.LAUNCH_TYPE}".upper())
+        with conf_vars({(CONFIG_GROUP_NAME, AllEcsConfigKeys.LAUNCH_TYPE): None}):
+            from airflow.providers.amazon.aws.executors.ecs import ecs_executor_config
 
-        from airflow.providers.amazon.aws.executors.ecs import ecs_executor_config
-
-        task_kwargs = ecs_executor_config.build_task_kwargs()
-        assert "launchType" not in task_kwargs
-        assert "capacityProviderStrategy" not in task_kwargs
-        mock_conn.describe_clusters.assert_called_once()
+            task_kwargs = ecs_executor_config.build_task_kwargs()
+            assert "launchType" not in task_kwargs
+            assert "capacityProviderStrategy" not in task_kwargs
+            mock_conn.describe_clusters.assert_called_once()
 
     @mock.patch.object(EcsHook, "conn")
     def test_providing_no_capacity_provider_no_lunch_type_no_cluster_default(self, mock_conn, set_env_vars):
         # If no capacity provider strategy is supplied and no launch type, and the cluster
         # does not have a default capacity provider strategy, use the FARGATE launch type.
-
         mock_conn.describe_clusters.return_value = {"clusters": [{"status": "ACTIVE"}]}
+        with conf_vars({(CONFIG_GROUP_NAME, AllEcsConfigKeys.LAUNCH_TYPE): None}):
+            from airflow.providers.amazon.aws.executors.ecs import ecs_executor_config
 
-        os.environ.pop(f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.LAUNCH_TYPE}".upper())
-
-        from airflow.providers.amazon.aws.executors.ecs import ecs_executor_config
-
-        task_kwargs = ecs_executor_config.build_task_kwargs()
-        assert task_kwargs["launchType"] == "FARGATE"
+            task_kwargs = ecs_executor_config.build_task_kwargs()
+            assert task_kwargs["launchType"] == "FARGATE"
 
     @pytest.mark.parametrize(
         "run_task_kwargs, exec_config, expected_result",
@@ -1726,10 +1690,10 @@ class TestEcsExecutorConfig:
         ],
     )
     def test_run_task_kwargs_exec_config_overrides(
-        self, set_env_vars, run_task_kwargs, exec_config, expected_result
+        self, set_env_vars, run_task_kwargs, exec_config, expected_result, monkeypatch
     ):
         run_task_kwargs_env_key = f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.RUN_TASK_KWARGS}".upper()
-        os.environ[run_task_kwargs_env_key] = json.dumps(run_task_kwargs)
+        monkeypatch.setenv(run_task_kwargs_env_key, json.dumps(run_task_kwargs))
 
         mock_ti_key = mock.Mock(spec=TaskInstanceKey)
         command = ["command"]

--- a/tests/providers/amazon/aws/executors/ecs/test_ecs_executor.py
+++ b/tests/providers/amazon/aws/executors/ecs/test_ecs_executor.py
@@ -54,6 +54,7 @@ from airflow.providers.amazon.aws.hooks.ecs import EcsHook
 from airflow.utils.helpers import convert_camel_to_snake
 from airflow.utils.state import State, TaskInstanceState
 from airflow.utils.timezone import utcnow
+from tests.test_utils.config import conf_vars
 
 pytestmark = pytest.mark.db_test
 
@@ -130,16 +131,20 @@ def mock_config():
 
 @pytest.fixture
 def set_env_vars():
-    os.environ[f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.REGION_NAME}".upper()] = "us-west-1"
-    os.environ[f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.CLUSTER}".upper()] = "some-cluster"
-    os.environ[f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.CONTAINER_NAME}".upper()] = "container-name"
-    os.environ[f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.TASK_DEFINITION}".upper()] = "some-task-def"
-    os.environ[f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.LAUNCH_TYPE}".upper()] = "FARGATE"
-    os.environ[f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.PLATFORM_VERSION}".upper()] = "LATEST"
-    os.environ[f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.ASSIGN_PUBLIC_IP}".upper()] = "False"
-    os.environ[f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.SECURITY_GROUPS}".upper()] = "sg1,sg2"
-    os.environ[f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.SUBNETS}".upper()] = "sub1,sub2"
-    os.environ[f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.MAX_RUN_TASK_ATTEMPTS}".upper()] = "3"
+    overrides: dict[tuple[str, str], str] = {
+        (CONFIG_GROUP_NAME, AllEcsConfigKeys.REGION_NAME): "us-west-1",
+        (CONFIG_GROUP_NAME, AllEcsConfigKeys.CLUSTER): "some-cluster",
+        (CONFIG_GROUP_NAME, AllEcsConfigKeys.CONTAINER_NAME): "container-name",
+        (CONFIG_GROUP_NAME, AllEcsConfigKeys.TASK_DEFINITION): "some-task-def",
+        (CONFIG_GROUP_NAME, AllEcsConfigKeys.LAUNCH_TYPE): "FARGATE",
+        (CONFIG_GROUP_NAME, AllEcsConfigKeys.PLATFORM_VERSION): "LATEST",
+        (CONFIG_GROUP_NAME, AllEcsConfigKeys.ASSIGN_PUBLIC_IP): "False",
+        (CONFIG_GROUP_NAME, AllEcsConfigKeys.SECURITY_GROUPS): "sg1,sg2",
+        (CONFIG_GROUP_NAME, AllEcsConfigKeys.SUBNETS): "sub1,sub2",
+        (CONFIG_GROUP_NAME, AllEcsConfigKeys.MAX_RUN_TASK_ATTEMPTS): "3",
+    }
+    with conf_vars(overrides):
+        yield
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Add fallback to `region_name` it might not obtained if configuration not persists in `airflow.cfg` or in env vars or configuration loaded without provider configurations

In addition use `conf_vars` helper for configure tests, it will automatically undo configuration in the end of test, so it reduce side effect when one test allow to pass/fail next text tests.

Originally it cause flakey behaviour in parallel non-db tests when it might run tests agains not properly configured tests in `main` or PRs

```console
________________ TestAwsBatchExecutor.test_health_check_failure ________________
[gw6] linux -- Python 3.12.2 /usr/local/bin/python

self = <tests.providers.amazon.aws.executors.batch.test_batch_executor.TestAwsBatchExecutor object at 0x7effd436bc20>
mock_executor = <MagicMock name='load' id='139637296591360'>

    @mock.patch(
        "airflow.providers.amazon.aws.executors.batch.boto_schema.BatchDescribeJobsResponseSchema.load"
    )
    def test_health_check_failure(self, mock_executor):
        mock_executor.batch.describe_jobs.side_effect = Exception("Test_failure")
>       executor = AwsBatchExecutor()

tests/providers/amazon/aws/executors/batch/test_batch_executor.py:519: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
airflow/providers/amazon/aws/executors/batch/batch_executor.py:102: in __init__
    self.load_batch_connection(check_connection=False)
airflow/providers/amazon/aws/executors/batch/batch_executor.py:156: in load_batch_connection
    region_name = conf.get(CONFIG_GROUP_NAME, AllBatchConfigKeys.REGION_NAME)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <airflow.configuration.AirflowConfigParser object at 0x7f0002c10500>
section = 'aws_batch_executor', key = 'region_name', suppress_warnings = False
_extra_stacklevel = 0, kwargs = {}, warning_emitted = False
option_description = {}, deprecated_section = None, deprecated_key = None

    def get(  # type: ignore[override,misc]
        self,
        section: str,
        key: str,
        suppress_warnings: bool = False,
        _extra_stacklevel: int = 0,
        **kwargs,
    ) -> str | None:
        section = section.lower()
        key = key.lower()
        warning_emitted = False
        deprecated_section: str | None
        deprecated_key: str | None
    
        option_description = self.configuration_description.get(section, {}).get(key, {})
        if option_description.get("deprecated"):
            deprecation_reason = option_description.get("deprecation_reason", "")
            warnings.warn(
                f"The '{key}' option in section {section} is deprecated. {deprecation_reason}",
                DeprecationWarning,
                stacklevel=2 + _extra_stacklevel,
            )
        # For when we rename whole sections
        if section in self.inversed_deprecated_sections:
            deprecated_section, deprecated_key = (section, key)
            section = self.inversed_deprecated_sections[section]
            if not self._suppress_future_warnings:
                warnings.warn(
                    f"The config section [{deprecated_section}] has been renamed to "
                    f"[{section}]. Please update your `conf.get*` call to use the new name",
                    FutureWarning,
                    stacklevel=2 + _extra_stacklevel,
                )
            # Don't warn about individual rename if the whole section is renamed
            warning_emitted = True
        elif (section, key) in self.inversed_deprecated_options:
            # Handle using deprecated section/key instead of the new section/key
            new_section, new_key = self.inversed_deprecated_options[(section, key)]
            if not self._suppress_future_warnings and not warning_emitted:
                warnings.warn(
                    f"section/key [{section}/{key}] has been deprecated, you should use"
                    f"[{new_section}/{new_key}] instead. Please update your `conf.get*` call to use the "
                    "new name",
                    FutureWarning,
                    stacklevel=2 + _extra_stacklevel,
                )
                warning_emitted = True
            deprecated_section, deprecated_key = section, key
            section, key = (new_section, new_key)
        elif section in self.deprecated_sections:
            # When accessing the new section name, make sure we check under the old config name
            deprecated_key = key
   deprecated_section = self.deprecated_sections[section][0]
        else:
            deprecated_section, deprecated_key, _ = self.deprecated_options.get(
                (section, key), (None, None, None)
            )
        # first check environment variables
        option = self._get_environment_variables(
            deprecated_key,
            deprecated_section,
            key,
            section,
            issue_warning=not warning_emitted,
            extra_stacklevel=_extra_stacklevel,
        )
        if option is not None:
            return option
    
        # ...then the config file
        option = self._get_option_from_config_file(
            deprecated_key,
            deprecated_section,
            key,
            kwargs,
            section,
            issue_warning=not warning_emitted,
            extra_stacklevel=_extra_stacklevel,
        )
        if option is not None:
            return option
    
        # ...then commands
        option = self._get_option_from_commands(
            deprecated_key,
            deprecated_section,
            key,
            section,
            issue_warning=not warning_emitted,
            extra_stacklevel=_extra_stacklevel,
        )
        if option is not None:
            return option
    
        # ...then from secret backends
        option = self._get_option_from_secrets(
            deprecated_key,
            deprecated_section,
            key,
            section,
            issue_warning=not warning_emitted,
            extra_stacklevel=_extra_stacklevel,
        )
        if option is not None:
            return option
    
        # ...then the default config
        if self.get_default_value(section, key) is not None or "fallback" in kwargs:
            return expand_env_var(self.get_default_value(section, key, **kwargs))
    
        if self.get_default_pre_2_7_value(section, key) is not None:
            # no expansion needed
            return self.get_default_pre_2_7_value(section, key, **kwargs)
    
        if not suppress_warnings:
            log.warning("section/key [%s/%s] not found in config", section, key)
    
>       raise AirflowConfigException(f"section/key [{section}/{key}] not found in config")
E       airflow.exceptions.AirflowConfigException: section/key [aws_batch_executor/region_name] not found in config

airflow/configuration.py:1052: AirflowConfigException
----------------------------- Captured stdout call -----------------------------
[2024-04-03T10:14:13.235+0000] {batch_executor.py:150} INFO - Loading Connection information
[2024-04-03T10:14:13.237+0000] {configuration.py:1050} WARNING - section/*** [aws_batch_executor/region_name] not found in config

FAILED tests/providers/amazon/aws/executors/batch/test_batch_executor.py::TestAwsBatchExecutor::test_health_check_failure - airflow.exceptions.AirflowConfigException: section/key [aws_batch_executor/region_name] not found in config
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
