### PR TITLE
Fix few nits in tag-providers command

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -21,7 +21,6 @@ import operator
 import os
 import random
 import re
-import shlex
 import shutil
 import subprocess
 import sys
@@ -973,8 +972,12 @@ def tag_providers(
     remotes = ["origin", "apache"]
     for remote in remotes:
         try:
-            command = ["git", "remote", "get-url", "--push", shlex.quote(remote)]
-            result = run_command(command, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True)
+            result = run_command(
+                ["git", "remote", "get-url", "--push", remote],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+            )
             if "apache/airflow.git" in result.stdout:
                 found_remote = remote
                 break
@@ -993,7 +996,7 @@ def tag_providers(
                 tag = f"{provider}/{match.group(2)}"
                 try:
                     run_command(
-                        ["git", "tag", shlex.quote(tag), "-m", f"Release {date.today()} of providers"],
+                        ["git", "tag", tag, "-m", f"Release {date.today()} of providers"],
                         check=True,
                     )
                     tags.append(tag)
@@ -1002,11 +1005,8 @@ def tag_providers(
 
     if tags:
         try:
-            push_command = ["git", "push", remote] + [shlex.quote(tag) for tag in tags]
             push_result = run_command(
-                push_command,
-                text=True,
-                capture_output=True,
+                ["git", "push", found_remote, *tags],
                 check=False,
             )
             if push_result.returncode == 0:
@@ -1016,7 +1016,7 @@ def tag_providers(
             if clean_local_tags:
                 for tag in tags:
                     try:
-                        run_command(["git", "tag", "-d", shlex.quote(tag)], check=True)
+                        run_command(["git", "tag", "-d", tag], check=True)
                     except subprocess.CalledProcessError:
                         pass
                 get_console().print("\n[success]Cleaning up local tags...[/]")


### PR DESCRIPTION
Few small changes after checking the tag-providers command:

* removed capturing output when pushing tags - this way we see what we pushed
* removed command variables
* better array concatenation with unpacking
* removed shlex.quote

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
