### PR TITLE
Distribute parrallel (xdist) test by different rules

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -107,6 +107,10 @@ class AirflowOptionalProviderFeatureException(AirflowException):
     """Raise by providers when imports are missing for optional provider features."""
 
 
+class AirflowInternalRuntimeError(BaseException):
+    """Raise when unexpected or unintended error occurs."""
+
+
 class XComNotFound(AirflowException):
     """Raise when an XCom reference is being resolved against a non-existent XCom."""
 

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -33,7 +33,7 @@ from sqlalchemy.pool import NullPool
 
 from airflow import policies
 from airflow.configuration import AIRFLOW_HOME, WEBSERVER_CONFIG, conf  # noqa: F401
-from airflow.exceptions import RemovedInAirflow3Warning
+from airflow.exceptions import AirflowInternalRuntimeError, RemovedInAirflow3Warning
 from airflow.executors import executor_constants
 from airflow.logging_config import configure_logging
 from airflow.utils.orm_event_handlers import setup_event_handlers
@@ -210,7 +210,7 @@ class SkipDBTestsSession:
     """This fake session is used to skip DB tests when `_AIRFLOW_SKIP_DB_TESTS` is set."""
 
     def __init__(self):
-        raise RuntimeError(
+        raise AirflowInternalRuntimeError(
             "Your test accessed the DB but `_AIRFLOW_SKIP_DB_TESTS` is set.\n"
             "Either make sure your test does not use database or mark the test with `@pytest.mark.db_test`\n"
             "See https://github.com/apache/airflow/blob/main/contributing-docs/testing/unit_tests.rst#"

--- a/contributing-docs/testing/unit_tests.rst
+++ b/contributing-docs/testing/unit_tests.rst
@@ -1111,6 +1111,25 @@ This prepares airflow .whl package in the dist folder.
 Other Settings
 --------------
 
+Enable masking secrets in tests
+...............................
+
+By default masking secrets in test disabled because it might have side effects
+into the other tests which intends to check logging/stdout/stderr values
+
+If you need to test masking secrets in test cases
+you have to apply ``pytest.mark.enable_redact`` to the specific test case, class or module.
+
+
+.. code-block:: python
+
+    @pytest.mark.enable_redact
+    def test_masking(capsys):
+        mask_secret("eggs")
+        RedactedIO().write("spam eggs and potatoes")
+        assert "spam *** and potatoes" in capsys.readouterr().out
+
+
 Skip test on unsupported platform / environment
 ...............................................
 

--- a/dev/breeze/src/airflow_breeze/utils/run_tests.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_tests.py
@@ -371,6 +371,16 @@ def generate_args_for_pytest(
     args.extend(get_excluded_provider_args(python_version))
     if use_xdist:
         args.extend(["-n", str(parallelism) if parallelism else "auto"])
+        # Distribute tests by different rules, see:
+        # https://pytest-xdist.readthedocs.io/en/stable/distribution.html#running-tests-across-multiple-cpus
+        if test_type != "Helm":
+            # For regular tests, we distribute test into the worker by their containing file
+            # It should reduce different side effects,
+            # if the state of environment could be changed between tests.
+            args.extend(["--dist", "loadfile"])
+        else:
+            # For helm tests setup distribution for "steal" tests which queued into the lon running queue.
+            args.extend(["--dist", "worksteal"])
     # We have to disabke coverage for Python 3.12 because of the issue with coverage that takes too long, despite
     # Using experimental support for Python 3.12 PEP 669. The coverage.py is not yet fully compatible with the
     # full scope of PEP-669. That will be fully done when https://github.com/nedbat/coveragepy/issues/1746 is

--- a/scripts/ci/pre_commit/check_tests_in_right_folders.py
+++ b/scripts/ci/pre_commit/check_tests_in_right_folders.py
@@ -74,7 +74,7 @@ POSSIBLE_TEST_FOLDERS = [
     "www",
 ]
 
-EXCEPTIONS = ["tests/__init__.py", "tests/conftest.py"]
+EXCEPTIONS = ["tests/__init__.py", "tests/conftest.py", "tests/_internal.py"]
 
 if __name__ == "__main__":
     files = sys.argv[1:]

--- a/tests/_internal.py
+++ b/tests/_internal.py
@@ -1,0 +1,129 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest
+
+
+class LogCaptureFixtureWrapper:
+    """
+    Provides access and control of log capturing (extending).
+
+    This class is used to provide additional capabilities over the ``caplog`` fixture:
+        https://docs.pytest.org/en/stable/how-to/logging.html#caplog-fixture
+
+    .. code-block:: python
+        def test_something(self, ext_caplog):
+            # Use in resulting asserts only for this severities
+            ext_caplog.log_level = ["DEBUG", "INFO", "WARNING"]
+            # And only for `airflow.task`
+            ext_caplog.logger_name = "airflow.task"
+            do_something()
+            assert ext_caplog.messages == ["Foo", "Bar"]
+    """
+
+    def __init__(self, caplog: pytest.LogCaptureFixture):
+        self.caplog = caplog
+        self._logger_name: str | None = None
+        self._log_level: tuple[int, ...] | None = None
+
+    @property
+    def logger_name(self) -> str | None:
+        """Return records only for the specified logger name.
+
+        For reset filter by logger name set `None`.
+        """
+        return self._logger_name
+
+    @logger_name.setter
+    def logger_name(self, value: str | logging.Logger | None) -> None:
+        if isinstance(value, logging.Logger):
+            value = value.name
+        self._logger_name = value
+
+    @property
+    def log_level(self) -> tuple[int, ...] | None:
+        """Return records only for the specified logging severities.
+
+        For reset filter by logger severity set it to `None`.
+        """
+        return self._log_level
+
+    @log_level.setter
+    def log_level(self, value: list[str | int] | str | int | None) -> None:
+        if value is None:
+            self._log_level = None
+            return
+
+        if isinstance(value, (str, int)):
+            value = [value]
+        self._log_level = tuple(map(self._resolve_levelno, value))
+
+    @staticmethod
+    def _resolve_levelno(value: str | int) -> int:
+        if isinstance(value, int):
+            return value
+
+        levelno = logging.getLevelName(value)
+        if not isinstance(levelno, int):
+            msg = f"Invalid log level: {value!r}."
+            raise RuntimeError(msg)
+        return levelno
+
+    @property
+    def text(self) -> str:
+        """
+        The formatted log text (wrapper around caplog fixture).
+
+        Note: No filters are applied on this property and return result as it is captured in ``caplog``
+        """
+        return self.caplog.text
+
+    def _filter_record(self, record: logging.LogRecord):
+        if self.logger_name and self.logger_name != record.name:
+            return False
+        if self.log_level is not None and record.levelno not in self.log_level:
+            return False
+        return True
+
+    @property
+    def records(self) -> list[logging.LogRecord]:
+        """The list of log records with applying filters to it."""
+        return list(filter(self._filter_record, self.caplog.records))
+
+    @property
+    def record_tuples(self) -> list[tuple[str, int, str]]:
+        """A list of a stripped down version of log records with applying filters to it."""
+        return [(r.name, r.levelno, r.getMessage()) for r in self.records]
+
+    @property
+    def messages(self) -> list[str]:
+        """A list of format-interpolated log messages with applying filters to it."""
+        return [r.getMessage() for r in self.records]
+
+    def clear(self) -> None:
+        """Reset the list of log records and the captured log text (wrapper around caplog fixture)."""
+        self.caplog.clear()
+
+    def set_level(self, level: int | str, logger: str | None = None) -> None:
+        """Set threshold severity level for ``caplog``fixture."""
+        self.caplog.set_level(level, logger=logger)

--- a/tests/api_connexion/endpoints/test_connection_endpoint.py
+++ b/tests/api_connexion/endpoints/test_connection_endpoint.py
@@ -144,6 +144,7 @@ class TestGetConnection(TestConnectionEndpoint):
             "extra": "{'param': 'value'}",
         }
 
+    @pytest.mark.enable_redact
     def test_should_mask_sensitive_values_in_extra(self, session):
         connection_model = Connection(
             conn_id="test-connection-id",

--- a/tests/api_connexion/endpoints/test_dataset_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dataset_endpoint.py
@@ -620,6 +620,7 @@ class TestPostDatasetEvents(TestDatasetEndpoint):
             expected_extra=event_payload,
         )
 
+    @pytest.mark.enable_redact
     def test_should_mask_sensitive_extra_logs(self, session):
         self._create_dataset(session)
         event_payload = {"dataset_uri": "s3://bucket/key", "extra": {"password": "bar"}}

--- a/tests/api_connexion/endpoints/test_variable_endpoint.py
+++ b/tests/api_connexion/endpoints/test_variable_endpoint.py
@@ -366,6 +366,7 @@ class TestPostVariables(TestVariableEndpoint):
             "description": description,
         }
 
+    @pytest.mark.enable_redact
     def test_should_create_masked_variable(self, session):
         payload = {"key": "api_key", "value": "secret_key", "description": "secret"}
         response = self.client.post(

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -153,6 +153,7 @@ class TestCliTasks:
             task_command.task_test(args)
         assert f"Marking task as SUCCESS. dag_id={self.dag_id}, task_id={task_id}" in caplog.text
 
+    @pytest.mark.enable_redact
     @pytest.mark.filterwarnings("ignore::airflow.utils.context.AirflowContextDeprecationWarning")
     def test_test_filters_secrets(self, capsys):
         """Test ``airflow test`` does not print secrets to stdout.

--- a/tests/models/test_renderedtifields.py
+++ b/tests/models/test_renderedtifields.py
@@ -169,6 +169,7 @@ class TestRenderedTaskInstanceFields:
         # Fetching them will return None
         assert RTIF.get_templated_fields(ti=ti2) is None
 
+    @pytest.mark.enable_redact
     def test_secrets_are_masked_when_large_string(self, dag_maker):
         """
         Test that secrets are masked when the templated field is a large string

--- a/tests/providers/amazon/aws/auth_manager/avp/test_facade.py
+++ b/tests/providers/amazon/aws/auth_manager/avp/test_facade.py
@@ -41,9 +41,11 @@ test_user_no_group = AwsAuthManagerUser(user_id="test_user_no_group", groups=[])
 
 
 @pytest.fixture
-def facade():
+def facade(monkeypatch):
+    monkeypatch.setenv("AIRFLOW_CONN_AWS_DEFAULT", "aws://")
     with conf_vars(
         {
+            ("aws_auth_manager", "conn_id"): "aws_default",
             ("aws_auth_manager", "region_name"): REGION_NAME,
             ("aws_auth_manager", "avp_policy_store_id"): AVP_POLICY_STORE_ID,
         }

--- a/tests/providers/amazon/aws/executors/batch/test_batch_executor.py
+++ b/tests/providers/amazon/aws/executors/batch/test_batch_executor.py
@@ -48,6 +48,11 @@ ARN1 = "arn1"
 MOCK_JOB_ID = "batch-job-id"
 
 
+@pytest.fixture(autouse=True)
+def default_connection(monkeypatch):
+    monkeypatch.setenv("AIRFLOW_CONN_AWS_DEFAULT", "aws://")
+
+
 @pytest.fixture
 def set_env_vars():
     overrides: dict[tuple[str, str], str] = {

--- a/tests/providers/amazon/aws/executors/ecs/test_ecs_executor.py
+++ b/tests/providers/amazon/aws/executors/ecs/test_ecs_executor.py
@@ -129,6 +129,11 @@ def mock_config():
     return mock.Mock(spec=dict)
 
 
+@pytest.fixture(autouse=True)
+def default_connection(monkeypatch):
+    monkeypatch.setenv("AIRFLOW_CONN_AWS_DEFAULT", "aws://")
+
+
 @pytest.fixture
 def set_env_vars():
     overrides: dict[tuple[str, str], str] = {

--- a/tests/providers/openlineage/plugins/test_utils.py
+++ b/tests/providers/openlineage/plugins/test_utils.py
@@ -134,6 +134,7 @@ def test_is_name_redactable():
     assert _is_name_redactable("transparent", Mixined())
 
 
+@pytest.mark.enable_redact
 def test_redact_with_exclusions(monkeypatch):
     redactor = OpenLineageRedactor.from_masker(_secrets_masker())
 

--- a/tests/utils/log/test_secrets_masker.py
+++ b/tests/utils/log/test_secrets_masker.py
@@ -29,7 +29,6 @@ from unittest.mock import patch
 
 import pytest
 
-from airflow import settings
 from airflow.models import Connection
 from airflow.utils.log.secrets_masker import (
     RedactedIO,
@@ -41,8 +40,7 @@ from airflow.utils.log.secrets_masker import (
 from airflow.utils.state import DagRunState, JobState, State, TaskInstanceState
 from tests.test_utils.config import conf_vars
 
-settings.MASK_SECRETS_IN_LOGS = True
-
+pytestmark = pytest.mark.enable_redact
 p = "password"
 
 

--- a/tests/www/views/test_views_connection.py
+++ b/tests/www/views/test_views_connection.py
@@ -100,6 +100,7 @@ def test_all_fields_with_blanks(admin_client, session):
     assert "airflow" == conn.schema
 
 
+@pytest.mark.enable_redact
 def test_action_logging_connection_masked_secrets(session, admin_client):
     admin_client.post("/connection/add", data=conn_with_extra(), follow_redirects=True)
     _check_last_log_masked_connection(session, dag_id=None, event="connection.create", execution_date=None)

--- a/tests/www/views/test_views_decorators.py
+++ b/tests/www/views/test_views_decorators.py
@@ -146,6 +146,7 @@ def test_action_logging_variables_post(session, admin_client):
     _check_last_log(session, dag_id=None, event="variable.create", execution_date=None)
 
 
+@pytest.mark.enable_redact
 def test_action_logging_variables_masked_secrets(session, admin_client):
     form = dict(key="x_secret", val="randomval")
     admin_client.post("/variable/add", data=form)

--- a/tests/www/views/test_views_rendered.py
+++ b/tests/www/views/test_views_rendered.py
@@ -229,6 +229,7 @@ def test_user_defined_filter_and_macros_raise_error(admin_client, create_dag_run
     assert "originalerror: no filter named &#39;hello&#39;" in resp_html.lower()
 
 
+@pytest.mark.enable_redact
 @pytest.mark.usefixtures("patch_app")
 def test_rendered_template_secret(admin_client, create_dag_run, task_secret):
     """Test that the Rendered View masks values retrieved from secret variables."""
@@ -261,6 +262,7 @@ else:
     initial_db_init()
 
 
+@pytest.mark.enable_redact
 @pytest.mark.parametrize(
     "env, expected",
     [


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Change distribution from a random, to a less random for the regular parallel tests.
For helm tests, which usually do not have any problems with side effect, allow to steal tests from long running test queue, e.g. for some worker distributed long running tests

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
