### PR TITLE
Bugfix to correct GCSHook being called even when not required with BeamRunPythonPipelineOperator

### DIFF
--- a/airflow/providers/apache/beam/operators/beam.py
+++ b/airflow/providers/apache/beam/operators/beam.py
@@ -364,11 +364,13 @@ class BeamRunPythonPipelineOperator(BeamBasePipelineOperator):
 
     def execute_sync(self, context: Context):
         with ExitStack() as exit_stack:
-            gcs_hook = GCSHook(gcp_conn_id=self.gcp_conn_id)
             if self.py_file.lower().startswith("gs://"):
+                gcs_hook = GCSHook(gcp_conn_id=self.gcp_conn_id)
                 tmp_gcs_file = exit_stack.enter_context(gcs_hook.provide_file(object_url=self.py_file))
                 self.py_file = tmp_gcs_file.name
             if self.snake_case_pipeline_options.get("requirements_file", "").startswith("gs://"):
+                if 'gcs_hook' not in locals():
+                    gcs_hook = GCSHook(gcp_conn_id=self.gcp_conn_id)    
                 tmp_req_file = exit_stack.enter_context(
                     gcs_hook.provide_file(object_url=self.snake_case_pipeline_options["requirements_file"])
                 )

--- a/airflow/providers/apache/beam/operators/beam.py
+++ b/airflow/providers/apache/beam/operators/beam.py
@@ -369,8 +369,7 @@ class BeamRunPythonPipelineOperator(BeamBasePipelineOperator):
                 tmp_gcs_file = exit_stack.enter_context(gcs_hook.provide_file(object_url=self.py_file))
                 self.py_file = tmp_gcs_file.name
             if self.snake_case_pipeline_options.get("requirements_file", "").startswith("gs://"):
-                if 'gcs_hook' not in locals():
-                    gcs_hook = GCSHook(gcp_conn_id=self.gcp_conn_id)    
+                gcs_hook = GCSHook(gcp_conn_id=self.gcp_conn_id)    
                 tmp_req_file = exit_stack.enter_context(
                     gcs_hook.provide_file(object_url=self.snake_case_pipeline_options["requirements_file"])
                 )

--- a/airflow/providers/apache/beam/operators/beam.py
+++ b/airflow/providers/apache/beam/operators/beam.py
@@ -369,7 +369,7 @@ class BeamRunPythonPipelineOperator(BeamBasePipelineOperator):
                 tmp_gcs_file = exit_stack.enter_context(gcs_hook.provide_file(object_url=self.py_file))
                 self.py_file = tmp_gcs_file.name
             if self.snake_case_pipeline_options.get("requirements_file", "").startswith("gs://"):
-                gcs_hook = GCSHook(gcp_conn_id=self.gcp_conn_id)    
+                gcs_hook = GCSHook(gcp_conn_id=self.gcp_conn_id)
                 tmp_req_file = exit_stack.enter_context(
                     gcs_hook.provide_file(object_url=self.snake_case_pipeline_options["requirements_file"])
                 )

--- a/tests/providers/apache/beam/operators/test_beam.py
+++ b/tests/providers/apache/beam/operators/test_beam.py
@@ -265,15 +265,13 @@ class TestBeamRunPythonPipelineOperator:
         """
         local_test_op_args = {
             "task_id": TASK_ID,
-            "py_file": 'local_file.py',
-            "py_options": ['-m'],
+            "py_file": "local_file.py",
+            "py_options": ["-m"],
             "default_pipeline_options": {
                 "project": TEST_PROJECT,
-                'requirements_file': 'local_requirements.txt'
+                "requirements_file": "local_requirements.txt",
             },
-            "pipeline_options": {
-                "output": 'test_local/output', "labels": {"foo": "bar"}
-            }
+            "pipeline_options": {"output": "test_local/output", "labels": {"foo": "bar"}},
         }
 
         op = BeamRunPythonPipelineOperator(**local_test_op_args)
@@ -290,15 +288,13 @@ class TestBeamRunPythonPipelineOperator:
         """
         local_test_op_args = {
             "task_id": TASK_ID,
-            "py_file": 'gs://gcs_file.py',
-            "py_options": ['-m'],
+            "py_file": "gs://gcs_file.py",
+            "py_options": ["-m"],
             "default_pipeline_options": {
                 "project": TEST_PROJECT,
-                'requirements_file': 'local_requirements.txt'
+                "requirements_file": "local_requirements.txt",
             },
-            "pipeline_options": {
-                "output": 'test_local/output', "labels": {"foo": "bar"}
-            }
+            "pipeline_options": {"output": "test_local/output", "labels": {"foo": "bar"}},
         }
         op = BeamRunPythonPipelineOperator(**local_test_op_args)
         context_mock = mock.MagicMock()
@@ -312,23 +308,21 @@ class TestBeamRunPythonPipelineOperator:
         """
         Test that execute method calls GCSHook when only pipeline_options 'requirements_file' starts with
         'gs://'.
-        Note: "pipeline_options" is merged with and overrides keys in "default_pipeline_options" when 
-              BeamRunPythonPipelineOperator is instantiated, so testing GCS 'requirements_file' specified 
+        Note: "pipeline_options" is merged with and overrides keys in "default_pipeline_options" when
+              BeamRunPythonPipelineOperator is instantiated, so testing GCS 'requirements_file' specified
               in "pipeline_options"
         """
         local_test_op_args = {
             "task_id": TASK_ID,
-            "py_file": 'local_file.py',
-            "py_options": ['-m'],
+            "py_file": "local_file.py",
+            "py_options": ["-m"],
             "default_pipeline_options": {
                 "project": TEST_PROJECT,
-                'requirements_file': 'gs://gcs_requirements.txt'
+                "requirements_file": "gs://gcs_requirements.txt",
             },
-            "pipeline_options": {
-                "output": 'test_local/output', "labels": {"foo": "bar"}
-            }
+            "pipeline_options": {"output": "test_local/output", "labels": {"foo": "bar"}},
         }
-        
+
         op = BeamRunPythonPipelineOperator(**local_test_op_args)
         context_mock = mock.MagicMock()
 


### PR DESCRIPTION
This resolves #38713 by modifying BeamRunPythonPipelineOperator.execute_sync() to only call GCSHook when necessary

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
