### PR TITLE
Fix grid header rendering

### DIFF
--- a/airflow/www/static/js/dag/details/Header.tsx
+++ b/airflow/www/static/js/dag/details/Header.tsx
@@ -28,32 +28,27 @@ import {
 import { getDagRunLabel, getMetaValue, getTask } from "src/utils";
 import useSelection from "src/dag/useSelection";
 import Time from "src/components/Time";
-import { useGridData, useTaskInstance } from "src/api";
+import { useGridData } from "src/api";
 import RunTypeIcon from "src/components/RunTypeIcon";
 
 import BreadcrumbText from "./BreadcrumbText";
 
-const dagId = getMetaValue("dag_id");
 const dagDisplayName = getMetaValue("dag_display_name");
 
-const Header = () => {
+interface Props {
+  mapIndex?: string | number | null;
+}
+
+const Header = ({ mapIndex }: Props) => {
   const {
     data: { dagRuns, groups, ordering },
   } = useGridData();
 
   const {
-    selected: { taskId, runId, mapIndex },
+    selected: { taskId, runId },
     onSelect,
     clearSelection,
   } = useSelection();
-
-  const { data: taskInstance } = useTaskInstance({
-    dagId,
-    dagRunId: runId || "",
-    taskId: taskId || "",
-    mapIndex,
-    enabled: mapIndex !== undefined,
-  });
 
   const dagRun = dagRuns.find((r) => r.runId === runId);
 
@@ -88,11 +83,7 @@ const Header = () => {
     );
   }
 
-  const lastIndex = taskId ? taskId.lastIndexOf(".") : null;
-  const taskName =
-    taskInstance?.taskDisplayName && lastIndex
-      ? taskInstance?.taskDisplayName.substring(lastIndex + 1)
-      : taskId;
+  const taskName = group?.label || group?.id || "";
 
   const isDagDetails = !runId && !taskId;
   const isRunDetails = !!(runId && !taskId);
@@ -141,10 +132,7 @@ const Header = () => {
           <BreadcrumbLink
             _hover={isMappedTaskDetails ? { cursor: "default" } : undefined}
           >
-            <BreadcrumbText
-              label="Map Index"
-              value={taskInstance?.renderedMapIndex || mapIndex}
-            />
+            <BreadcrumbText label="Map Index" value={mapIndex} />
           </BreadcrumbLink>
         </BreadcrumbItem>
       )}

--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -247,7 +247,11 @@ const Details = ({
         flexWrap="wrap"
         ml={6}
       >
-        <Header />
+        <Header
+          mapIndex={
+            mappedTaskInstance?.renderedMapIndex || mappedTaskInstance?.mapIndex
+          }
+        />
         <Flex flexWrap="wrap">
           {runId && !taskId && (
             <>


### PR DESCRIPTION
We were relying on fetching the Task Instance in order to render the task display name. But you didn't always have a task instance selected, we already have it as `task.label`, so let's use that instead.

Also, we already have the rendered map index so passing that to our header object instead.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
