### PR TITLE
Restore airflow_local_settings after the `test_should_use_configured_log_name`

### DIFF
--- a/tests/providers/google/cloud/log/test_stackdriver_task_handler.py
+++ b/tests/providers/google/cloud/log/test_stackdriver_task_handler.py
@@ -27,6 +27,7 @@ from google.cloud.logging_v2.types import ListLogEntriesRequest, ListLogEntriesR
 from airflow.providers.google.cloud.log.stackdriver_task_handler import StackdriverTaskHandler
 from airflow.utils import timezone
 from airflow.utils.state import TaskInstanceState
+from tests.test_utils.config import conf_vars
 from tests.test_utils.db import clear_db_dags, clear_db_runs
 
 
@@ -71,28 +72,33 @@ def test_should_pass_message_to_client(mock_client, mock_get_creds_and_project_i
 @mock.patch("airflow.providers.google.cloud.log.stackdriver_task_handler.get_credentials_and_project_id")
 @mock.patch("airflow.providers.google.cloud.log.stackdriver_task_handler.gcp_logging.Client")
 def test_should_use_configured_log_name(mock_client, mock_get_creds_and_project_id):
+    import importlib
+    import logging
+
+    from airflow import settings
+    from airflow.config_templates import airflow_local_settings
+
     mock_get_creds_and_project_id.return_value = ("creds", "project_id")
 
-    with mock.patch.dict(
-        "os.environ",
-        AIRFLOW__LOGGING__REMOTE_LOGGING="true",
-        AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER="stackdriver://host/path",
-    ):
-        import importlib
-        import logging
+    try:
+        with conf_vars(
+            {
+                ("logging", "remote_logging"): "True",
+                ("logging", "remote_base_log_folder"): "stackdriver://host/path",
+            }
+        ):
+            importlib.reload(airflow_local_settings)
+            settings.configure_logging()
 
-        from airflow import settings
-        from airflow.config_templates import airflow_local_settings
-
+            logger = logging.getLogger("airflow.task")
+            handler = logger.handlers[0]
+            assert isinstance(handler, StackdriverTaskHandler)
+            with mock.patch.object(handler, "transport_type") as transport_type_mock:
+                logger.error("foo")
+                transport_type_mock.assert_called_once_with(mock_client.return_value, "path")
+    finally:
         importlib.reload(airflow_local_settings)
         settings.configure_logging()
-
-        logger = logging.getLogger("airflow.task")
-        handler = logger.handlers[0]
-        assert isinstance(handler, StackdriverTaskHandler)
-        with mock.patch.object(handler, "transport_type") as transport_type_mock:
-            logger.error("foo")
-            transport_type_mock.assert_called_once_with(mock_client.return_value, "path")
 
 
 @pytest.mark.db_test


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This test add some side effect for all tests after it, as result some of them might fail with "random" error

```console
pytest tests/providers/google/cloud/log/test_stackdriver_task_handler.py::test_should_use_configured_log_name tests/providers/google/common

...

FAILED tests/providers/google/common/hooks/test_discovery_api.py::TestGoogleDiscoveryApiHook::test_get_conn - google.auth.exceptions.DefaultCredentialsError: Your default credentials were not found. To set up Application Default Credentials, see https://cloud.google.com/docs/authentication/external/set-up-adc for more information.
======================================================= 1 failed, 83 passed, 2 skipped, 4 warnings in 10.72s =======================================================
Compute Engine Metadata server unavailable on attempt 1 of 3. Reason: [Errno 111] Connection refused
Compute Engine Metadata server unavailable on attempt 2 of 3. Reason: [Errno 111] Connection refused
Compute Engine Metadata server unavailable on attempt 3 of 3. Reason: [Errno 111] Connection refused
Authentication failed using Compute Engine authentication due to unavailable metadata server.
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/logging/__init__.py", line 2127, in shutdown
    h.close()
  File "/opt/airflow/airflow/providers/google/cloud/log/stackdriver_task_handler.py", line 385, in close
    self._transport.flush()
  File "/usr/local/lib/python3.8/functools.py", line 967, in __get__
    val = self.func(instance)
  File "/opt/airflow/airflow/providers/google/cloud/log/stackdriver_task_handler.py", line 156, in _transport
    return self.transport_type(self._client, self.gcp_log_name)  # type: ignore[call-arg]
  File "/opt/airflow/airflow/providers/google/cloud/log/stackdriver_task_handler.py", line 133, in _client
    credentials, project = self._credentials_and_project
  File "/usr/local/lib/python3.8/functools.py", line 967, in __get__
    val = self.func(instance)
  File "/opt/airflow/airflow/providers/google/cloud/log/stackdriver_task_handler.py", line 125, in _credentials_and_project
    credentials, project = get_credentials_and_project_id(
  File "/opt/airflow/airflow/providers/google/cloud/utils/credentials_provider.py", line 362, in get_credentials_and_project_id
    return _CredentialProvider(*args, **kwargs).get_credentials_and_project()
  File "/opt/airflow/airflow/providers/google/cloud/utils/credentials_provider.py", line 243, in get_credentials_and_project
    credentials, project_id = self._get_credentials_using_adc()
  File "/opt/airflow/airflow/providers/google/cloud/utils/credentials_provider.py", line 348, in _get_credentials_using_adc
    credentials, project_id = google.auth.default(scopes=self.scopes)
  File "/usr/local/lib/python3.8/site-packages/google/auth/_default.py", line 691, in default
    raise exceptions.DefaultCredentialsError(_CLOUD_SDK_MISSING_CREDENTIALS)
google.auth.exceptions.DefaultCredentialsError: Your default credentials were not found. To set up Application Default Credentials, see https://cloud.google.com/docs/authentication/external/set-up-adc for more information.

```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
