### PR TITLE
Add hook_params to template_fields for BaseSQLOperator-related Operators

### DIFF
--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -220,7 +220,7 @@ class SQLExecuteQueryOperator(BaseSQLOperator):
         :ref:`howto/operator:SQLExecuteQueryOperator`
     """
 
-    template_fields: Sequence[str] = ("conn_id", "sql", "parameters")
+    template_fields: Sequence[str] = ("conn_id", "sql", "parameters", "hook_params")
     template_ext: Sequence[str] = (".sql", ".json")
     template_fields_renderers = {"sql": "sql", "parameters": "json"}
     ui_color = "#cdaaed"
@@ -416,7 +416,7 @@ class SQLColumnCheckOperator(BaseSQLOperator):
         :ref:`howto/operator:SQLColumnCheckOperator`
     """
 
-    template_fields: Sequence[str] = ("partition_clause", "table", "sql")
+    template_fields: Sequence[str] = ("partition_clause", "table", "sql", "hook_params")
     template_fields_renderers = {"sql": "sql"}
 
     sql_check_template = """
@@ -644,7 +644,7 @@ class SQLTableCheckOperator(BaseSQLOperator):
         :ref:`howto/operator:SQLTableCheckOperator`
     """
 
-    template_fields: Sequence[str] = ("partition_clause", "table", "sql", "conn_id")
+    template_fields: Sequence[str] = ("partition_clause", "table", "sql", "conn_id", "hook_params")
 
     template_fields_renderers = {"sql": "sql"}
 
@@ -760,7 +760,7 @@ class SQLCheckOperator(BaseSQLOperator):
     :param parameters: (optional) the parameters to render the SQL query with.
     """
 
-    template_fields: Sequence[str] = ("sql",)
+    template_fields: Sequence[str] = ("sql", "hook_params")
     template_ext: Sequence[str] = (
         ".hql",
         ".sql",
@@ -809,6 +809,7 @@ class SQLValueCheckOperator(BaseSQLOperator):
     template_fields: Sequence[str] = (
         "sql",
         "pass_value",
+        "hook_params",
     )
     template_ext: Sequence[str] = (
         ".hql",
@@ -906,7 +907,7 @@ class SQLIntervalCheckOperator(BaseSQLOperator):
     """
 
     __mapper_args__ = {"polymorphic_identity": "SQLIntervalCheckOperator"}
-    template_fields: Sequence[str] = ("sql1", "sql2")
+    template_fields: Sequence[str] = ("sql1", "sql2", "hook_params")
     template_ext: Sequence[str] = (
         ".hql",
         ".sql",
@@ -1034,7 +1035,7 @@ class SQLThresholdCheckOperator(BaseSQLOperator):
     :param max_threshold: numerical value or max threshold sql to be executed (templated)
     """
 
-    template_fields: Sequence[str] = ("sql", "min_threshold", "max_threshold")
+    template_fields: Sequence[str] = ("sql", "min_threshold", "max_threshold", "hook_params")
     template_ext: Sequence[str] = (
         ".hql",
         ".sql",

--- a/airflow/providers/common/sql/sensors/sql.py
+++ b/airflow/providers/common/sql/sensors/sql.py
@@ -51,7 +51,7 @@ class SqlSensor(BaseSensorOperator):
             Should match the desired hook constructor params.
     """
 
-    template_fields: Sequence[str] = ("sql",)
+    template_fields: Sequence[str] = ("sql", "hook_params")
     template_ext: Sequence[str] = (
         ".hql",
         ".sql",

--- a/tests/providers/common/sql/operators/test_sql.py
+++ b/tests/providers/common/sql/operators/test_sql.py
@@ -632,9 +632,7 @@ class TestSQLCheckOperatorDbHook:
             return_value=Connection(conn_id="sql_default", conn_type="postgres"),
         ) as mock_get_conn:
             mock_get_conn.return_value = Connection(conn_id="snowflake_default", conn_type="snowflake")
-            self._operator.hook_params = {
-                "session_parameters": {"query_tag": "{{ ds }}"}
-            }
+            self._operator.hook_params = {"session_parameters": {"query_tag": "{{ ds }}"}}
             logical_date = "2024-04-02"
             self._operator.render_template_fields({"ds": logical_date})
 

--- a/tests/providers/common/sql/operators/test_sql.py
+++ b/tests/providers/common/sql/operators/test_sql.py
@@ -626,6 +626,21 @@ class TestSQLCheckOperatorDbHook:
             assert self._operator._hook.use_legacy_sql
             assert self._operator._hook.location == "us-east1"
 
+    def test_sql_operator_hook_params_templated(self):
+        with mock.patch(
+            "airflow.providers.common.sql.operators.sql.BaseHook.get_connection",
+            return_value=Connection(conn_id="sql_default", conn_type="postgres"),
+        ) as mock_get_conn:
+            mock_get_conn.return_value = Connection(conn_id="snowflake_default", conn_type="snowflake")
+            self._operator.hook_params = {
+                "session_parameters": {"query_tag": "{{ ds }}"}
+            }
+            logical_date = "2024-04-02"
+            self._operator.render_template_fields({"ds": logical_date})
+
+            assert self._operator._hook.conn_type == "snowflake"
+            assert self._operator._hook.session_parameters == {"query_tag": logical_date}
+
 
 class TestCheckOperator:
     def setup_method(self):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This PR adds `hook_params` to `template_fields` for all Operators inheriting from BaseSQLOperator.

This change is necessary to pass DAG related attributes as query tags / labels when interacting with databases such as Snowflake or Big Query.
For example, here is how we can add meaningful tags to a Snowflake query with templated `hook_params`:
```python
...
sql_execute_query_operator = SQLExecuteQueryOperator(
        task_id="sql_execute_query_operator_task",
        conn_id=snowflake_conn_id,
        sql="SELECT '1';",
        hook_params={
            "session_parameters": {
                "query_tag": "'dag_id': '{{ dag.dag_id }}'"
            }
        }
    )
...
```

<!-- Please keep an empty line above the dashes. -->