### PR TITLE
Add support for OrbStack in breeze

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -612,7 +612,7 @@ def remove_docker_networks(networks: list[str] | None = None) -> None:
 # and it does not require the user to belong to the "docker" group.
 # The "default" context is the traditional one that requires "/var/run/docker.sock" to be writeable by the
 # user running the docker command.
-PREFERRED_CONTEXTS = ["desktop-linux", "default"]
+PREFERRED_CONTEXTS = ["orbstack", "desktop-linux", "default"]
 
 
 def autodetect_docker_context():


### PR DESCRIPTION
I've moved away from Docker Desktop to [OrbStack](https://orbstack.dev/). So far everything seems to be working just fine, so I'd like to make it easier for others to use orbstack without mangling their docker context :)