### PR TITLE
The dev0 suffix should only be applied in main

### DIFF
--- a/.github/workflows/prod-image-build.yml
+++ b/.github/workflows/prod-image-build.yml
@@ -122,6 +122,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs-on-as-json-public) }}
     env:
       PYTHON_MAJOR_MINOR_VERSION: "${{ inputs.default-python-version }}"
+      VERSION_SUFFIX_FOR_PYPI: ${{ inputs.branch == 'main' && 'dev0' || '' }}
     steps:
       - name: "Cleanup repo"
         shell: bash
@@ -157,19 +158,16 @@ jobs:
         run: >
           breeze release-management prepare-provider-packages
           --package-list-file ./prod_image_installed_providers.txt
-          --package-format wheel --version-suffix-for-pypi dev0
+          --package-format wheel
         if: >
           inputs.do-build == 'true' &&
           inputs.upload-package-artifact == 'true' &&
           inputs.build-provider-packages == 'true'
       - name: "Prepare chicken-eggs provider packages"
-        # In case of provider packages which use latest dev0 version of providers, we should prepare them
-        # from the source code, not from the PyPI because they have apache-airflow>=X.Y.Z dependency
-        # And when we prepare them from sources they will have apache-airflow>=X.Y.Z.dev0
         shell: bash
         run: >
           breeze release-management prepare-provider-packages
-          --package-format wheel --version-suffix-for-pypi dev0 ${{ inputs.chicken-egg-providers }}
+          --package-format wheel ${{ inputs.chicken-egg-providers }}
         if: >
           inputs.do-build  == 'true' &&
           inputs.upload-package-artifact == 'true' &&
@@ -177,8 +175,7 @@ jobs:
       - name: "Prepare airflow package"
         shell: bash
         run: >
-          breeze release-management prepare-airflow-package
-          --package-format wheel --version-suffix-for-pypi dev0
+          breeze release-management prepare-airflow-package --package-format wheel
         if: inputs.do-build  == 'true' && inputs.upload-package-artifact == 'true'
       - name: "Upload prepared packages as artifacts"
         uses: actions/upload-artifact@v4
@@ -208,7 +205,7 @@ ${{ inputs.do-build == 'true' && inputs.image-tag || '' }}"
       BACKEND: sqlite
       DEFAULT_BRANCH: ${{ inputs.branch }}
       DEFAULT_CONSTRAINTS_BRANCH: ${{ inputs.constraints-branch }}
-      VERSION_SUFFIX_FOR_PYPI: "dev0"
+      VERSION_SUFFIX_FOR_PYPI: ${{ inputs.branch == 'main' && 'dev0' || '' }}
       INCLUDE_NOT_READY_PROVIDERS: "true"
       # You can override CONSTRAINTS_GITHUB_REPOSITORY by setting secret in your repo but by default the
       # Airflow one is going to be used


### PR DESCRIPTION
For production build we should apply the package prefix depending on branch we are in.  In main we apply dev0 suffix for development, but in the release branch we should not apply the suffix.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
