### PR TITLE
Better cleanup `LazyDictWithCache` and `ProviderManager`

### DIFF
--- a/airflow/providers_manager.py
+++ b/airflow/providers_manager.py
@@ -120,11 +120,11 @@ class LazyDictWithCache(MutableMapping):
         return value
 
     def __delitem__(self, key):
-        self._raw_dict.__delitem__(key)
         try:
             self._resolved.remove(key)
         except KeyError:
             pass
+        self._raw_dict.__delitem__(key)
 
     def __iter__(self):
         return iter(self._raw_dict)
@@ -134,6 +134,10 @@ class LazyDictWithCache(MutableMapping):
 
     def __contains__(self, key):
         return key in self._raw_dict
+
+    def clear(self):
+        self._resolved.clear()
+        self._raw_dict.clear()
 
 
 def _read_schema_from_resources_or_local_file(filename: str) -> dict:

--- a/tests/always/test_providers_manager.py
+++ b/tests/always/test_providers_manager.py
@@ -477,17 +477,20 @@ def test_lazy_cache_dict_raises_error():
 def test_lazy_cache_dict_del_item():
     lazy_cache_dict = LazyDictWithCache()
 
-    lazy_cache_dict["spam"] = "egg"
+    def answer():
+        return 42
+
+    lazy_cache_dict["spam"] = answer
     assert "spam" in lazy_cache_dict._raw_dict
     assert "spam" not in lazy_cache_dict._resolved  # Not resoled yet
-    assert lazy_cache_dict["spam"] == "egg"
+    assert lazy_cache_dict["spam"] == 42
     assert "spam" in lazy_cache_dict._resolved
     del lazy_cache_dict["spam"]
     assert "spam" not in lazy_cache_dict._raw_dict
     assert "spam" not in lazy_cache_dict._resolved
 
-    lazy_cache_dict["foo"] = "bar"
-    assert lazy_cache_dict["foo"] == "bar"
+    lazy_cache_dict["foo"] = answer
+    assert lazy_cache_dict["foo"] == 42
     assert "foo" in lazy_cache_dict._resolved
     # Emulate some mess in data, e.g. value from `_raw_dict` deleted but not from `_resolved`
     del lazy_cache_dict._raw_dict["foo"]
@@ -497,7 +500,7 @@ def test_lazy_cache_dict_del_item():
         del lazy_cache_dict["foo"]
     assert "foo" not in lazy_cache_dict._resolved
 
-    lazy_cache_dict["baz"] = "qux"
+    lazy_cache_dict["baz"] = answer
     # Key in `_resolved` not created yet
     assert "baz" in lazy_cache_dict._raw_dict
     assert "baz" not in lazy_cache_dict._resolved
@@ -507,16 +510,19 @@ def test_lazy_cache_dict_del_item():
 
 
 def test_lazy_cache_dict_clear():
+    def answer():
+        return 42
+
     lazy_cache_dict = LazyDictWithCache()
     assert len(lazy_cache_dict) == 0
-    lazy_cache_dict["spam"] = "egg"
-    lazy_cache_dict["foo"] = "bar"
-    lazy_cache_dict["baz"] = "qux"
+    lazy_cache_dict["spam"] = answer
+    lazy_cache_dict["foo"] = answer
+    lazy_cache_dict["baz"] = answer
 
     assert len(lazy_cache_dict) == 3
     assert len(lazy_cache_dict._raw_dict) == 3
     assert not lazy_cache_dict._resolved
-    assert lazy_cache_dict["spam"] == "egg"
+    assert lazy_cache_dict["spam"] == 42
     assert len(lazy_cache_dict._resolved) == 1
     # Emulate some mess in data, contain some data into the `_resolved`
     lazy_cache_dict._resolved.add("biz")

--- a/tests/always/test_providers_manager.py
+++ b/tests/always/test_providers_manager.py
@@ -42,6 +42,16 @@ from airflow.providers_manager import (
 AIRFLOW_SOURCES_ROOT = Path(__file__).resolve().parents[2]
 
 
+def test_cleanup_providers_manager(cleanup_providers_manager):
+    """Check the cleanup provider manager functionality."""
+    provider_manager = ProvidersManager()
+    assert isinstance(provider_manager.hooks, LazyDictWithCache)
+    hooks = provider_manager.hooks
+    ProvidersManager()._cleanup()
+    assert not len(hooks)
+    assert ProvidersManager().hooks is hooks
+
+
 class TestProviderManager:
     @pytest.fixture(autouse=True)
     def inject_fixtures(self, caplog, cleanup_providers_manager):
@@ -462,3 +472,58 @@ def test_lazy_cache_dict_raises_error():
     lazy_cache_dict["key"] = raise_method
     with pytest.raises(RuntimeError, match="test"):
         _ = lazy_cache_dict["key"]
+
+
+def test_lazy_cache_dict_del_item():
+    lazy_cache_dict = LazyDictWithCache()
+
+    lazy_cache_dict["spam"] = "egg"
+    assert "spam" in lazy_cache_dict._raw_dict
+    assert "spam" not in lazy_cache_dict._resolved  # Not resoled yet
+    assert lazy_cache_dict["spam"] == "egg"
+    assert "spam" in lazy_cache_dict._resolved
+    del lazy_cache_dict["spam"]
+    assert "spam" not in lazy_cache_dict._raw_dict
+    assert "spam" not in lazy_cache_dict._resolved
+
+    lazy_cache_dict["foo"] = "bar"
+    assert lazy_cache_dict["foo"] == "bar"
+    assert "foo" in lazy_cache_dict._resolved
+    # Emulate some mess in data, e.g. value from `_raw_dict` deleted but not from `_resolved`
+    del lazy_cache_dict._raw_dict["foo"]
+    assert "foo" in lazy_cache_dict._resolved
+    with pytest.raises(KeyError):
+        # Error expected here, but we still expect to remove also record into `resolved`
+        del lazy_cache_dict["foo"]
+    assert "foo" not in lazy_cache_dict._resolved
+
+    lazy_cache_dict["baz"] = "qux"
+    # Key in `_resolved` not created yet
+    assert "baz" in lazy_cache_dict._raw_dict
+    assert "baz" not in lazy_cache_dict._resolved
+    del lazy_cache_dict._raw_dict["baz"]
+    assert "baz" not in lazy_cache_dict._raw_dict
+    assert "baz" not in lazy_cache_dict._resolved
+
+
+def test_lazy_cache_dict_clear():
+    lazy_cache_dict = LazyDictWithCache()
+    assert len(lazy_cache_dict) == 0
+    lazy_cache_dict["spam"] = "egg"
+    lazy_cache_dict["foo"] = "bar"
+    lazy_cache_dict["baz"] = "qux"
+
+    assert len(lazy_cache_dict) == 3
+    assert len(lazy_cache_dict._raw_dict) == 3
+    assert not lazy_cache_dict._resolved
+    assert lazy_cache_dict["spam"] == "egg"
+    assert len(lazy_cache_dict._resolved) == 1
+    # Emulate some mess in data, contain some data into the `_resolved`
+    lazy_cache_dict._resolved.add("biz")
+    assert len(lazy_cache_dict) == 3
+    assert len(lazy_cache_dict._resolved) == 2
+    # And finally cleanup everything
+    lazy_cache_dict.clear()
+    assert len(lazy_cache_dict) == 0
+    assert not lazy_cache_dict._raw_dict
+    assert not lazy_cache_dict._resolved


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This changes most attempt to fix cleanup ProviderManager, which I guess only use in tests.
Right now it might keep some values between the test as result it might not unwrap some values.

Sample for demonstrate it

```python
class TestFoo:
    def test_http(self, cleanup_providers_manager):
        from airflow.providers_manager import ProvidersManager

        manager = ProvidersManager()
        hooks = manager.hooks
        info = hooks["http"]
        assert not callable(info)
        assert "http" in hooks._resolved

    def test_aws(self, cleanup_providers_manager):
        from airflow.providers_manager import ProvidersManager

        manager = ProvidersManager()
        hooks = manager.hooks
        info = hooks["aws"]
        assert not callable(info)
        assert "aws" in hooks._resolved
        assert "http" not in hooks._resolved

    def test_aws_again(self):
        from airflow.providers_manager import ProvidersManager

        manager = ProvidersManager()
        assert manager.hooks["aws"].package_name
```
and result

```console
❯ pytest tests/test_spam.py::TestFoo
================================================ test session starts ================================================
platform darwin -- Python 3.9.10, pytest-7.4.4, pluggy-1.4.0 -- /Users/taragolis/.pyenv/versions/3.9.10/envs/airflow-dev-env-39/bin/python
cachedir: .pytest_cache
rootdir: /Users/taragolis/Projects/common/airflow
configfile: pyproject.toml
plugins: cov-5.0.0, instafail-0.5.0, timeouts-1.2.1, anyio-4.3.0, custom-exit-code-0.3.0, rerunfailures-14.0, icdiff-0.9, xdist-3.5.0, time-machine-2.14.1, asyncio-0.23.6, mock-3.14.0, requests-mock-1.12.1
asyncio: mode=strict
setup timeout: 0.0s, execution timeout: 0.0s, teardown timeout: 0.0s
collected 3 items                                                                                                   

tests/test_spam.py::TestFoo::test_http PASSED                                                                 [ 33%]
tests/test_spam.py::TestFoo::test_aws FAILED                                                                  [ 66%]
tests/test_spam.py::TestFoo::test_aws_again FAILED                                                            [100%]

===================================================== FAILURES ======================================================
_________________________________________________ TestFoo.test_aws __________________________________________________

self = <tests.test_spam.TestFoo object at 0x10519ef70>, cleanup_providers_manager = None

    def test_aws(self, cleanup_providers_manager):
        from airflow.providers_manager import ProvidersManager
    
        manager = ProvidersManager()
        hooks = manager.hooks
        info = hooks["aws"]
        assert not callable(info)
        assert "aws" in hooks._resolved
>       assert "http" not in hooks._resolved
E       AssertionError: assert 'http' not in {'aws', 'http'}
E        +  where {'aws', 'http'} = <airflow.providers_manager.LazyDictWithCache object at 0x10994dfd0>._resolved

tests/test_spam.py:19: AssertionError
______________________________________________ TestFoo.test_aws_again _______________________________________________

self = <tests.test_spam.TestFoo object at 0x1051bd310>

    def test_aws_again(self):
        from airflow.providers_manager import ProvidersManager
    
        manager = ProvidersManager()
>       assert manager.hooks["aws"].package_name
E       AttributeError: 'functools.partial' object has no attribute 'package_name'

tests/test_spam.py:25: AttributeError
============================================== short test summary info ==============================================
FAILED tests/test_spam.py::TestFoo::test_aws - AssertionError: assert 'http' not in {'aws', 'http'}
FAILED tests/test_spam.py::TestFoo::test_aws_again - AttributeError: 'functools.partial' object has no attribute 'package_name'
============================================ 2 failed, 1 passed in 1.79s ============================================
```
   

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
