### PR TITLE
DB tests are now moved to a single, separate workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,79 +335,28 @@ jobs:
       needs.build-info.outputs.default-branch == 'main' &&
       needs.build-info.outputs.latest-versions-only != 'true'
 
-  tests-postgres:
-    name: "Postgres tests"
-    uses: ./.github/workflows/run-unit-tests.yml
+  tests-db:
+    name: "DB tests"
+    uses: ./.github/workflows/tests-db.yml
     needs: [build-info, wait-for-ci-images]
     permissions:
       contents: read
       packages: read
     secrets: inherit
     with:
+      run-tests: ${{ needs.build-info.outputs.run-tests }}
       runs-on-as-json-default: ${{ needs.build-info.outputs.runs-on-as-json-default }}
-      backend: "postgres"
-      test-name: "Postgres"
-      test-scope: "DB"
       image-tag: ${{ needs.build-info.outputs.image-tag }}
-      python-versions: ${{ needs.build-info.outputs.python-versions }}
-      backend-versions: ${{ needs.build-info.outputs.postgres-versions }}
-      excludes: ${{ needs.build-info.outputs.postgres-exclude }}
       parallel-test-types-list-as-string: ${{ needs.build-info.outputs.parallel-test-types-list-as-string }}
-      include-success-outputs: ${{ needs.build-info.outputs.include-success-outputs }}
-      run-migration-tests: "true"
-      run-coverage: ${{ needs.build-info.outputs.run-coverage }}
-      debug-resources: ${{ needs.build-info.outputs.debug-resources }}
-    if: needs.build-info.outputs.run-tests == 'true'
-
-  tests-mysql:
-    name: "MySQL tests"
-    uses: ./.github/workflows/run-unit-tests.yml
-    needs: [build-info, wait-for-ci-images]
-    permissions:
-      contents: read
-      packages: read
-    secrets: inherit
-    with:
-      runs-on-as-json-default: ${{ needs.build-info.outputs.runs-on-as-json-default }}
-      backend: "mysql"
-      test-name: "MySQL"
-      test-scope: "DB"
-      image-tag: ${{ needs.build-info.outputs.image-tag }}
       python-versions: ${{ needs.build-info.outputs.python-versions }}
-      backend-versions: ${{ needs.build-info.outputs.mysql-versions }}
-      excludes: ${{ needs.build-info.outputs.mysql-exclude }}
-      parallel-test-types-list-as-string: ${{ needs.build-info.outputs.parallel-test-types-list-as-string }}
+      postgres-versions: ${{ needs.build-info.outputs.postgres-versions }}
+      mysql-versions: ${{ needs.build-info.outputs.mysql-versions }}
+      postgres-exclude: ${{ needs.build-info.outputs.postgres-exclude }}
+      mysql-exclude: ${{ needs.build-info.outputs.mysql-exclude }}
+      sqlite-exclude: ${{ needs.build-info.outputs.sqlite-exclude }}
       include-success-outputs: ${{ needs.build-info.outputs.include-success-outputs }}
       run-coverage: ${{ needs.build-info.outputs.run-coverage }}
-      run-migration-tests: "true"
       debug-resources: ${{ needs.build-info.outputs.debug-resources }}
-    if: needs.build-info.outputs.run-tests == 'true'
-
-  tests-sqlite:
-    name: "Sqlite tests"
-    uses: ./.github/workflows/run-unit-tests.yml
-    needs: [build-info, wait-for-ci-images]
-    permissions:
-      contents: read
-      packages: read
-    secrets: inherit
-    with:
-      runs-on-as-json-default: ${{ needs.build-info.outputs.runs-on-as-json-default }}
-      backend: "sqlite"
-      test-name: "Sqlite"
-      test-name-separator: ""
-      test-scope: "DB"
-      image-tag: ${{ needs.build-info.outputs.image-tag }}
-      python-versions: ${{ needs.build-info.outputs.python-versions }}
-      # No versions for sqlite
-      backend-versions: "['']"
-      excludes: ${{ needs.build-info.outputs.sqlite-exclude }}
-      parallel-test-types-list-as-string: ${{ needs.build-info.outputs.parallel-test-types-list-as-string }}
-      include-success-outputs: ${{ needs.build-info.outputs.include-success-outputs }}
-      run-coverage: ${{ needs.build-info.outputs.run-coverage }}
-      run-migration-tests: "true"
-      debug-resources: ${{ needs.build-info.outputs.debug-resources }}
-    if: needs.build-info.outputs.run-tests == 'true'
 
   tests-non-db:
     name: "Non-DB tests"
@@ -602,9 +551,7 @@ jobs:
       - wait-for-ci-images
       - wait-for-prod-images
       - static-checks-mypy-docs
-      - tests-sqlite
-      - tests-mysql
-      - tests-postgres
+      - tests-db
       - tests-non-db
       - tests-integration
       - tests-special

--- a/.github/workflows/tests-db.yml
+++ b/.github/workflows/tests-db.yml
@@ -1,0 +1,152 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+name: DB tests
+on:  # yamllint disable-line rule:truthy
+  workflow_call:
+    inputs:
+      run-tests:
+        description: "Whether to run tests or not (true/false)"
+        required: true
+        type: string
+      runs-on-as-json-default:
+        description: "The array of labels (in json form) determining default runner used for the build."
+        required: true
+        type: string
+      image-tag:
+        description: "Tag to set for the image"
+        required: true
+        type: string
+      python-versions:
+        description: "The list of python versions (stringified JSON array) to run the tests on."
+        required: true
+        type: string
+      postgres-versions:
+        description: "The list of postgres versions (stringified JSON array) to run the tests on."
+        required: true
+        type: string
+      mysql-versions:
+        description: "The list of mysql versions (stringified JSON array) to run the tests on."
+        required: true
+        type: string
+      postgres-exclude:
+        description: >
+          Excluded postgres combos (stringified JSON array of python-version/postgre-version dicts)
+        required: true
+        type: string
+      mysql-exclude:
+        description: >
+          Excluded postgres combos (stringified JSON array of python-version/postgre-version dicts)
+        required: true
+        type: string
+      sqlite-exclude:
+        description: >
+          Excluded postgres combos (stringified JSON array of python-version/postgre-version dicts)
+        required: true
+        type: string
+      parallel-test-types-list-as-string:
+        description: "The list of parallel test types to run separated by spaces"
+        required: true
+        type: string
+      include-success-outputs:
+        description: "Whether to include success outputs or not (true/false)"
+        required: false
+        default: "false"
+        type: string
+      run-coverage:
+        description: "Whether to run coverage or not (true/false)"
+        required: true
+        type: string
+      debug-resources:
+        description: "Whether to debug resources or not (true/false)"
+        required: true
+        type: string
+jobs:
+  tests-postgres:
+    name: "Postgres tests"
+    uses: ./.github/workflows/run-unit-tests.yml
+    needs: [build-info, wait-for-ci-images]
+    permissions:
+      contents: read
+      packages: read
+    secrets: inherit
+    with:
+      runs-on-as-json-default: ${{ inputs.runs-on-as-json-default }}
+      backend: "postgres"
+      test-name: "Postgres"
+      test-scope: "DB"
+      image-tag: ${{ inputs.image-tag }}
+      python-versions: ${{ inputs.python-versions }}
+      backend-versions: ${{ inputs.postgres-versions }}
+      excludes: ${{ inputs.postgres-exclude }}
+      parallel-test-types-list-as-string: ${{ inputs.parallel-test-types-list-as-string }}
+      include-success-outputs: ${{ inputs.include-success-outputs }}
+      run-migration-tests: "true"
+      run-coverage: ${{ inputs.run-coverage }}
+      debug-resources: ${{ inputs.debug-resources }}
+    if: inputs.run-tests == 'true'
+
+  tests-mysql:
+    name: "MySQL tests"
+    uses: ./.github/workflows/run-unit-tests.yml
+    needs: [build-info, wait-for-ci-images]
+    permissions:
+      contents: read
+      packages: read
+    secrets: inherit
+    with:
+      runs-on-as-json-default: ${{ inputs.runs-on-as-json-default }}
+      backend: "mysql"
+      test-name: "MySQL"
+      test-scope: "DB"
+      image-tag: ${{ inputs.image-tag }}
+      python-versions: ${{ inputs.python-versions }}
+      backend-versions: ${{ inputs.mysql-versions }}
+      excludes: ${{ inputs.mysql-exclude }}
+      parallel-test-types-list-as-string: ${{ inputs.parallel-test-types-list-as-string }}
+      include-success-outputs: ${{ inputs.include-success-outputs }}
+      run-coverage: ${{ inputs.run-coverage }}
+      run-migration-tests: "true"
+      debug-resources: ${{ inputs.debug-resources }}
+    if: inputs.run-tests == 'true'
+
+  tests-sqlite:
+    name: "Sqlite tests"
+    uses: ./.github/workflows/run-unit-tests.yml
+    needs: [build-info, wait-for-ci-images]
+    permissions:
+      contents: read
+      packages: read
+    secrets: inherit
+    with:
+      runs-on-as-json-default: ${{ inputs.runs-on-as-json-default }}
+      backend: "sqlite"
+      test-name: "Sqlite"
+      test-name-separator: ""
+      test-scope: "DB"
+      image-tag: ${{ inputs.image-tag }}
+      python-versions: ${{ inputs.python-versions }}
+      # No versions for sqlite
+      backend-versions: "['']"
+      excludes: ${{ inputs.sqlite-exclude }}
+      parallel-test-types-list-as-string: ${{ inputs.parallel-test-types-list-as-string }}
+      include-success-outputs: ${{ inputs.include-success-outputs }}
+      run-coverage: ${{ inputs.run-coverage }}
+      run-migration-tests: "true"
+      debug-resources: ${{ inputs.debug-resources }}
+    if: inputs.run-tests == 'true'


### PR DESCRIPTION
This one wil group all the DB tests together in separate, foldable section - which will save some real estate in github actions. Those tess were never considered as separate and having single dependency on all db-tests is a bit easier to keep.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
