### PR TITLE
Fix Mark Instance state buttons stay disabled if user lacks permission (#37451)

### DIFF
--- a/airflow/www/static/js/dag/details/taskInstance/taskActions/ClearInstance.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/taskActions/ClearInstance.tsx
@@ -38,6 +38,7 @@ import keyboardShortcutIdentifier from "src/dag/keyboardShortcutIdentifier";
 import ActionButton from "./ActionButton";
 import ActionModal from "./ActionModal";
 
+const canEditTaskInstance = getMetaValue("can_edit_taskinstance") === "True";
 const canEdit = getMetaValue("can_edit") === "True";
 const dagId = getMetaValue("dag_id");
 
@@ -248,7 +249,7 @@ const ClearInstance = ({
       <Button
         title={clearLabel}
         aria-label={clearLabel}
-        isDisabled={!canEdit}
+        isDisabled={!canEdit || !canEditTaskInstance}
         colorScheme="blue"
         onClick={onOpen}
         {...otherProps}
@@ -256,7 +257,7 @@ const ClearInstance = ({
         Clear task
       </Button>
       {/* Only mount modal if user can edit */}
-      {canEdit && (
+      {canEdit && canEditTaskInstance && (
         <ClearModal
           runId={runId}
           taskId={taskId}

--- a/airflow/www/static/js/dag/details/taskInstance/taskActions/MarkInstanceAs.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/taskActions/MarkInstanceAs.tsx
@@ -50,6 +50,7 @@ import { SimpleStatus } from "../../../StatusBox";
 import ActionButton from "./ActionButton";
 import ActionModal from "./ActionModal";
 
+const canEditTaskInstance = getMetaValue("can_edit_taskinstance") === "True";
 const canEdit = getMetaValue("can_edit") === "True";
 const dagId = getMetaValue("dag_id");
 
@@ -288,7 +289,7 @@ const MarkInstanceAs = ({
           transition="all 0.2s"
           title={markLabel}
           aria-label={markLabel}
-          disabled={!canEdit}
+          disabled={!canEdit || !canEditTaskInstance}
           {...otherProps}
         >
           <Flex>
@@ -308,7 +309,7 @@ const MarkInstanceAs = ({
         </MenuList>
       </Menu>
       {/* Only load modal is user can edit */}
-      {canEdit && (
+      {canEdit && canEditTaskInstance && (
         <MarkAsModal
           runId={runId}
           taskId={taskId}

--- a/airflow/www/templates/airflow/grid.html
+++ b/airflow/www/templates/airflow/grid.html
@@ -30,6 +30,7 @@
   <meta name="dataset_events_api" content="{{ url_for('/api/v1.airflow_api_connexion_endpoints_dataset_endpoint_get_dataset_events') }}">
   <meta name="color_log_error_keywords" content="{{ color_log_error_keywords }}">
   <meta name="color_log_warning_keywords" content="{{ color_log_warning_keywords }}">
+  <meta name="can_edit_taskinstance" content="{{ can_edit_taskinstance }}">
 {% endblock %}
 
 {% block content %}

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2879,6 +2879,11 @@ class Airflow(AirflowBaseView):
         if default_dag_run_display_number not in num_runs_options:
             insort_left(num_runs_options, default_dag_run_display_number)
 
+        can_edit_taskinstance = get_auth_manager().is_authorized_dag(
+            method="PUT",
+            access_entity=DagAccessEntity.TASK_INSTANCE,
+        )
+
         return self.render_template(
             "airflow/grid.html",
             show_trigger_form_if_no_params=conf.getboolean("webserver", "show_trigger_form_if_no_params"),
@@ -2886,6 +2891,7 @@ class Airflow(AirflowBaseView):
             dag=dag,
             doc_md=doc_md,
             num_runs=num_runs,
+            can_edit_taskinstance=can_edit_taskinstance,
             show_external_log_redirect=task_log_reader.supports_external_link,
             external_log_name=external_log_name,
             dag_model=dag_model,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #37451

<!-- Please keep an empty line above the dashes. -->
This bug adresses a visual issue occuring when attempting to mark task states as Failed or Sucess, or when using clear button without the 'can edit on Task Instances' role. This resulted in a not expected partially empty screen in the dag menu.

The fix resolves the issue by disabling both the "Clear Task" and "Mark state as…" buttons when the user lacks permission, same as the behavior when the user can't edit on DAGs.

Now, in 'views.py', an additional meta named 'can_edit_taskintances' is passed to 'grid.html' based on the user's task instance edit permission, same as the meta 'can_edit' from user's dag edit permission defined in 'dag.html'.

Both 'canEdit' and 'canEditTaskInstances' definitions were moved inside the React components. This was necessary just for the variables to be mockable during testing, as these variables were defined before the component was loaded.