### PR TITLE
Unhide CI instructions when dependencies need regeneration

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/md5_build_check.py
+++ b/dev/breeze/src/airflow_breeze/utils/md5_build_check.py
@@ -114,7 +114,7 @@ def calculate_md5_checksum_for_files(
                     ]
                 )
             # Regenerate provider_dependencies.json
-            run_command(
+            result = run_command(
                 [
                     sys.executable,
                     os.fspath(
@@ -126,7 +126,10 @@ def calculate_md5_checksum_for_files(
                     ),
                 ],
                 cwd=AIRFLOW_SOURCES_ROOT,
+                check=False,
             )
+            if result.returncode != 0:
+                sys.exit(result.returncode)
     for file in FILES_FOR_REBUILD_CHECK:
         is_modified = check_md5_sum_for_file(file, md5sum_cache_dir, update)
         if is_modified:

--- a/scripts/ci/pre_commit/update_providers_dependencies.py
+++ b/scripts/ci/pre_commit/update_providers_dependencies.py
@@ -227,6 +227,8 @@ if __name__ == "__main__":
     DEPENDENCIES_JSON_FILE_PATH.write_text(new_content)
     if new_content != old_content:
         if os.environ.get("CI"):
+            # make sure the message is printed outside the folded section
+            console.print("::endgroup::")
             console.print()
             console.print(f"There is a need to regenerate {DEPENDENCIES_JSON_FILE_PATH}")
             console.print(


### PR DESCRIPTION
The instructions on what to do was hidden in a folded group and we need to make sure it is printed straight in the output.

Also we should not print the nasty traceback, as it is not very useul, the failing python command already prints appropriate error/informational messages and there is no need to clutter the output with the traceback when the command fails.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
