### PR TITLE
Add google-cloud-bigquery as explicit google-provider dependency

### DIFF
--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -109,6 +109,7 @@ dependencies:
   - google-auth-httplib2>=0.0.1
   - google-cloud-aiplatform>=1.42.1
   - google-cloud-automl>=2.12.0
+  - google-cloud-bigquery>=3.0.1
   - google-cloud-bigquery-datatransfer>=3.13.0
   - google-cloud-bigtable>=2.17.0
   - google-cloud-build>=3.22.0

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -529,6 +529,7 @@
       "google-cloud-automl>=2.12.0",
       "google-cloud-batch>=0.13.0",
       "google-cloud-bigquery-datatransfer>=3.13.0",
+      "google-cloud-bigquery>=3.0.1",
       "google-cloud-bigtable>=2.17.0",
       "google-cloud-build>=3.22.0",
       "google-cloud-compute>=1.10.0",


### PR DESCRIPTION
The new Google Cloud Bigquery released few days ago, caused some weird backtracking UV issue for Python 3.11 builds where airflow uses PyPI providers in PROD image builds. UV seems to fail on really old version of google-cloud-bigquery (1.28.2) that has a bad version specifier for one of the dependencies (de instead of dev).

We should add the google-cloud-bigquery explicitly and limit it to a relatively newer version. Airflow uses latest 3.20.1 version now in constraints and limiting bigquery to >= 3.0.1 (first non-yanked version released > 2 years ago in March 2022) is a good lower limit.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
