### PR TITLE
Fix failing test after upgrade to the newer dependencies

### DIFF
--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -1715,10 +1715,7 @@ class TestBigQueryInsertJobOperator:
             operator.execute(MagicMock())
         lineage = operator.get_openlineage_facets_on_complete(None)
 
-        assert lineage.run_facets == {
-            "bigQuery_error": BigQueryErrorRunFacet(clientError=mock.ANY),
-            "externalQuery": mock.ANY,
-        }
+        assert lineage.run_facets["bigQuery_error"] == BigQueryErrorRunFacet(clientError=mock.ANY)
 
     @pytest.mark.db_test
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -1715,7 +1715,10 @@ class TestBigQueryInsertJobOperator:
             operator.execute(MagicMock())
         lineage = operator.get_openlineage_facets_on_complete(None)
 
-        assert lineage.run_facets == {"bigQuery_error": BigQueryErrorRunFacet(clientError=mock.ANY)}
+        assert lineage.run_facets == {
+            "bigQuery_error": BigQueryErrorRunFacet(clientError=mock.ANY),
+            "externalQuery": mock.ANY,
+        }
 
     @pytest.mark.db_test
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Fix failing tests into the main after upgrade to the newer openlineage packages

```diff
372,374c372,374
< openlineage-integration-common==1.10.2
< openlineage-python==1.10.2
< openlineage_sql==1.10.2
---
> openlineage-integration-common==1.11.3
> openlineage-python==1.11.3
> openlineage_sql==1.11.3
```

```console
>       assert lineage.run_facets == {"bigQuery_error": BigQueryErrorRunFacet(clientError=mock.ANY)}
E       assert {'externalQuery': ExternalQueryRunFacet(_producer='https://github.com/OpenLineage/OpenLineage/tree/1.11.3/client/python', _schemaURL='https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/BaseFacet', externalQueryId='1234', source='bigquery'), 'bigQuery_error': BigQueryErrorRunFacet(_producer='https://github.com/OpenLineage/OpenLineage/tree/1.11.3/client/python', _schemaURL='https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/bq-error-run-facet.json', clientError=': Traceback (most recent call last):\n  File "/Users/taragolis/.pyenv/versions/airflow-dev-env-39/lib/python3.9/site-packages/openlineage/common/provider/bigquery.py", line 132, in get_facets\n    job = self.client.get_job(job_id=job_id)  # type: ignore\n  File "/Users/taragolis/.pyenv/versions/3.9.10/lib/python3.9/unittest/mock.py", line 1092, in __call__\n    return self._mock_call(*args, **kwargs)\n  File "/Users/taragolis/.pyenv/versions/3.9.10/lib/python3.9/unittest/mock.py", line 1096, in _mock_call\n    return self._execute_mock_call(*args, **kwargs)\n  File "/Users/taragolis/.pyenv/versions/3.9.10/lib/python3.9/unittest/mock.py", line 1151, in _execute_mock_call\n    raise effect\nRuntimeError\n', parserError=None)} == {'bigQuery_error': BigQueryErrorRunFacet(_producer='https://github.com/OpenLineage/OpenLineage/tree/1.11.3/client/python', _schemaURL='https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/bq-error-run-facet.json', clientError=<ANY>, parserError=None)}
E         Common items:
E         {'bigQuery_error': BigQueryErrorRunFacet(_producer='https://github.com/OpenLineage/OpenLineage/tree/1.11.3/client/python', _schemaURL='https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/bq-error-run-facet.json', clientError=': Traceback (most recent call last):\n  File "/Users/taragolis/.pyenv/versions/airflow-dev-env-39/lib/python3.9/site-packages/openlineage/common/provider/bigquery.py", line 132, in get_facets\n    job = self.client.get_job(job_id=job_id)  # type: ignore\n  File "/Users/taragolis/.pyenv/versions/3.9.10/lib/python3.9/unittest/mock.py", line 1092, in __call__\n    return self._mock_call(*args, **kwargs)\n  File "/Users/taragolis/.pyenv/versions/3.9.10/lib/python3.9/unittest/mock.py", line 1096, in _mock_call\n    return self._execute_mock_call(*args, **kwargs)\n  File "/Users/taragolis/.pyenv/versions/3.9.10/lib/python3.9/unittest/mock.py", line 1151, in _execute_mock_call\n    raise effect\nRuntimeError\n', parserError=None)}
E         Left contains 1 more item:
E         {'externalQuery': ExternalQueryRunFacet(_producer='https://github.com/OpenLineage/OpenLineage/tree/1.11.3/client/python', _schemaURL='https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/BaseFacet', externalQueryId='1234', source='bigquery')}
E         Full diff:
E           {
E         -  'bigQuery_error': BigQueryErrorRunFacet(_producer='https://github.com/OpenLineage/OpenLineage/tree/1.11.3/client/python', _schemaURL='https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/bq-error-run-facet.json', clientError=<ANY>, parserError=None),
E         +  'bigQuery_error': BigQueryErrorRunFacet(_producer='https://github.com/OpenLineage/OpenLineage/tree/1.11.3/client/python', _schemaURL='https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/bq-error-run-facet.json', clientError=': Traceback (most recent call last):\n  File "/Users/taragolis/.pyenv/versions/airflow-dev-env-39/lib/python3.9/site-packages/openlineage/common/provider/bigquery.py", line 132, in get_facets\n    job = self.client.get_job(job_id=job_id)  # type: ignore\n  File "/Users/taragolis/.pyenv/versions/3.9.10/lib/python3.9/unittest/mock.py", line 1092, in __call__\n    return self._mock_call(*args, **kwargs)\n  File "/Users/taragolis/.pyenv/versions/3.9.10/lib/python3.9/unittest/mock.py", line 1096, in _mock_call\n    return self._execute_mock_call(*args, **kwargs)\n  File "/Users/taragolis/.pyenv/versions/3.9.10/lib/python3.9/unittest/mock.py", line 1151, in _execute_mock_call\n    raise effect\nRuntimeError\n', parserError=None),
E         +  'externalQuery': ExternalQueryRunFacet(_producer='https://github.com/OpenLineage/OpenLineage/tree/1.11.3/client/python', _schemaURL='https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/BaseFacet', externalQueryId='1234', source='bigquery'),
E           }
```

The solution it is pretty straightforward, and maybe it is not correct. cc @mobuchowski 

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
