### PR TITLE
Disable by default redact sensitive values in tests

### DIFF
--- a/contributing-docs/testing/unit_tests.rst
+++ b/contributing-docs/testing/unit_tests.rst
@@ -1111,6 +1111,25 @@ This prepares airflow .whl package in the dist folder.
 Other Settings
 --------------
 
+Enable masking secrets in tests
+...............................
+
+By default masking secrets in test disabled because it might have side effects
+into the other tests which intends to check logging/stdout/stderr values
+
+If you need to test masking secrets in test cases
+you have to apply ``pytest.mark.enable_redact`` to the specific test case, class or module.
+
+
+.. code-block:: python
+
+    @pytest.mark.enable_redact
+    def test_masking(capsys):
+        mask_secret("eggs")
+        RedactedIO().write("spam eggs and potatoes")
+        assert "spam *** and potatoes" in capsys.readouterr().out
+
+
 Skip test on unsupported platform / environment
 ...............................................
 

--- a/tests/api_connexion/endpoints/test_connection_endpoint.py
+++ b/tests/api_connexion/endpoints/test_connection_endpoint.py
@@ -144,6 +144,7 @@ class TestGetConnection(TestConnectionEndpoint):
             "extra": "{'param': 'value'}",
         }
 
+    @pytest.mark.enable_redact
     def test_should_mask_sensitive_values_in_extra(self, session):
         connection_model = Connection(
             conn_id="test-connection-id",

--- a/tests/api_connexion/endpoints/test_dataset_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dataset_endpoint.py
@@ -620,6 +620,7 @@ class TestPostDatasetEvents(TestDatasetEndpoint):
             expected_extra=event_payload,
         )
 
+    @pytest.mark.enable_redact
     def test_should_mask_sensitive_extra_logs(self, session):
         self._create_dataset(session)
         event_payload = {"dataset_uri": "s3://bucket/key", "extra": {"password": "bar"}}

--- a/tests/api_connexion/endpoints/test_variable_endpoint.py
+++ b/tests/api_connexion/endpoints/test_variable_endpoint.py
@@ -366,6 +366,7 @@ class TestPostVariables(TestVariableEndpoint):
             "description": description,
         }
 
+    @pytest.mark.enable_redact
     def test_should_create_masked_variable(self, session):
         payload = {"key": "api_key", "value": "secret_key", "description": "secret"}
         response = self.client.post(

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -153,6 +153,7 @@ class TestCliTasks:
             task_command.task_test(args)
         assert f"Marking task as SUCCESS. dag_id={self.dag_id}, task_id={task_id}" in caplog.text
 
+    @pytest.mark.enable_redact
     @pytest.mark.filterwarnings("ignore::airflow.utils.context.AirflowContextDeprecationWarning")
     def test_test_filters_secrets(self, capsys):
         """Test ``airflow test`` does not print secrets to stdout.

--- a/tests/models/test_renderedtifields.py
+++ b/tests/models/test_renderedtifields.py
@@ -169,6 +169,7 @@ class TestRenderedTaskInstanceFields:
         # Fetching them will return None
         assert RTIF.get_templated_fields(ti=ti2) is None
 
+    @pytest.mark.enable_redact
     def test_secrets_are_masked_when_large_string(self, dag_maker):
         """
         Test that secrets are masked when the templated field is a large string

--- a/tests/providers/openlineage/plugins/test_utils.py
+++ b/tests/providers/openlineage/plugins/test_utils.py
@@ -134,6 +134,7 @@ def test_is_name_redactable():
     assert _is_name_redactable("transparent", Mixined())
 
 
+@pytest.mark.enable_redact
 def test_redact_with_exclusions(monkeypatch):
     redactor = OpenLineageRedactor.from_masker(_secrets_masker())
 

--- a/tests/utils/log/test_secrets_masker.py
+++ b/tests/utils/log/test_secrets_masker.py
@@ -29,7 +29,6 @@ from unittest.mock import patch
 
 import pytest
 
-from airflow import settings
 from airflow.models import Connection
 from airflow.utils.log.secrets_masker import (
     RedactedIO,
@@ -41,8 +40,7 @@ from airflow.utils.log.secrets_masker import (
 from airflow.utils.state import DagRunState, JobState, State, TaskInstanceState
 from tests.test_utils.config import conf_vars
 
-settings.MASK_SECRETS_IN_LOGS = True
-
+pytestmark = pytest.mark.enable_redact
 p = "password"
 
 

--- a/tests/www/views/test_views_connection.py
+++ b/tests/www/views/test_views_connection.py
@@ -100,6 +100,7 @@ def test_all_fields_with_blanks(admin_client, session):
     assert "airflow" == conn.schema
 
 
+@pytest.mark.enable_redact
 def test_action_logging_connection_masked_secrets(session, admin_client):
     admin_client.post("/connection/add", data=conn_with_extra(), follow_redirects=True)
     _check_last_log_masked_connection(session, dag_id=None, event="connection.create", execution_date=None)

--- a/tests/www/views/test_views_decorators.py
+++ b/tests/www/views/test_views_decorators.py
@@ -146,6 +146,7 @@ def test_action_logging_variables_post(session, admin_client):
     _check_last_log(session, dag_id=None, event="variable.create", execution_date=None)
 
 
+@pytest.mark.enable_redact
 def test_action_logging_variables_masked_secrets(session, admin_client):
     form = dict(key="x_secret", val="randomval")
     admin_client.post("/variable/add", data=form)

--- a/tests/www/views/test_views_rendered.py
+++ b/tests/www/views/test_views_rendered.py
@@ -229,6 +229,7 @@ def test_user_defined_filter_and_macros_raise_error(admin_client, create_dag_run
     assert "originalerror: no filter named &#39;hello&#39;" in resp_html.lower()
 
 
+@pytest.mark.enable_redact
 @pytest.mark.usefixtures("patch_app")
 def test_rendered_template_secret(admin_client, create_dag_run, task_secret):
     """Test that the Rendered View masks values retrieved from secret variables."""
@@ -261,6 +262,7 @@ else:
     initial_db_init()
 
 
+@pytest.mark.enable_redact
 @pytest.mark.parametrize(
     "env, expected",
     [


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Found (TBH it happen before) during https://github.com/apache/airflow/pull/38711 and decoupled from that PR

This measure for avoid side effects in the other tests which intends to check logging/stdout/stderr, e.g.

Test 1 read connection which contains password "hi"
Test 2 check logging contain something like `This awesome log record`

If Test2 run before the Test everything would be fine, in the other order record in logging would be `T***s awesome log record`

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
