### PR TITLE
Remove SparkInK8s internal deprecations

### DIFF
--- a/tests/deprecations_ignore.yml
+++ b/tests/deprecations_ignore.yml
@@ -648,8 +648,6 @@
 - tests/providers/cncf/kubernetes/operators/test_spark_kubernetes.py::test_resolve_application_file_real_file_not_exists
 - tests/providers/cncf/kubernetes/operators/test_spark_kubernetes.py::test_resolve_application_file_template_file
 - tests/providers/cncf/kubernetes/operators/test_spark_kubernetes.py::test_resolve_application_file_template_non_dictionary
-- tests/providers/cncf/kubernetes/operators/test_spark_kubernetes.py::test_spark_kubernetes_operator
-- tests/providers/cncf/kubernetes/operators/test_spark_kubernetes.py::test_spark_kubernetes_operator_hook
 - tests/providers/cncf/kubernetes/operators/test_spark_kubernetes.py::test_template_body_templating
 - tests/providers/cncf/kubernetes/test_kubernetes_helper_functions.py::TestCreatePodId::test_create_pod_id
 - tests/providers/cncf/kubernetes/test_kubernetes_helper_functions.py::TestCreatePodId::test_create_pod_id_dag_and_task


### PR DESCRIPTION
Part of the fixes for #38642

I executed `pytest tests/providers/cncf/kubernetes/operators/test_spark_kubernetes.py::test_spark_kubernetes_operator
` and `pytest tests/providers/cncf/kubernetes/operators/test_spark_kubernetes.py::test_spark_kubernetes_operator_hook`. Both are  running successfully without warnings. Executing with args `-W default` does raise warnings but they are not emitted into warnings.txt, so I believe they are warnings from 3rd party libraries. 

Hence I believe these 2 are false alarms and can be removed safely, but If that's not the case, I'm happy to fix the warnings for these 2 tests in this PR

