### PR TITLE
Force loading provider configuration when using config.as_dict

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -1439,11 +1439,13 @@ class AirflowConfigParser(ConfigParser):
             ("default", self._default_values),
             ("airflow.cfg", self),
         ]
+        # Force the providers configuration to be loaded
+        self.configuration_description = retrieve_configuration_description()
 
         self._replace_config_with_display_sources(
             config_sources,
             configs,
-            self.configuration_description if self.configuration_description else {},
+            self.configuration_description,
             display_source,
             raw,
             self.deprecated_options,


### PR DESCRIPTION
It's not clear to me why the sensitive_config_values excludes providers when config.as_dict is used on the webserver. This has resulted in displaying sensitive provider configurations even when non-sensitive-only is used as the value of [webserver]expose_config.

This fixed it but still, it's not clear to me where things went wrong.

cc @potiuk 