### PR TITLE
Fix loading configuration from providers for config endpoints

### DIFF
--- a/airflow/api_connexion/endpoints/config_endpoint.py
+++ b/airflow/api_connexion/endpoints/config_endpoint.py
@@ -85,6 +85,9 @@ def get_config(*, section: str | None = None) -> Response:
     elif expose_config:
         if section and not conf.has_section(section):
             raise NotFound("section not found.", detail=f"section={section} not found.")
+        from airflow.providers_manager import ProvidersManager
+
+        ProvidersManager().initialize_providers_configuration()
         conf_dict = conf.as_dict(display_source=False, display_sensitive=display_sensitive)
         if section:
             conf_section_value = conf_dict[section]
@@ -117,6 +120,9 @@ def get_value(*, section: str, option: str) -> Response:
     if return_type not in serializer:
         return Response(status=HTTPStatus.NOT_ACCEPTABLE)
     elif expose_config:
+        from airflow.providers_manager import ProvidersManager
+
+        ProvidersManager().initialize_providers_configuration()
         if not conf.has_option(section, option):
             raise NotFound(
                 "Config not found.", detail=f"The option [{section}/{option}] is not found in config."

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -713,6 +713,14 @@ class AirflowConfigParser(ConfigParser):
         self.configuration_description = retrieve_configuration_description(include_providers=False)
         self._default_values = create_default_config_parser(self.configuration_description)
         self._providers_configuration_loaded = False
+        # sensitive_config_values needs to be refreshed here. This is a cached_property, so we can delete
+        # the cached values, and it will be refreshed on next access. This has been an implementation
+        # detail in Python 3.8 but as of Python 3.9 it is documented behaviour.
+        # See https://docs.python.org/3/library/functools.html#functools.cached_property
+        try:
+            del self.sensitive_config_values
+        except AttributeError:
+            pass
 
     def validate(self):
         self._validate_sqlite3_version()


### PR DESCRIPTION
The configuration for providers is not loaded by default when airflow configuraiton is loaded, because loading configuration from providers is slow and configuration intialization is done by just importing airflow. In order to make sure configuration in API call we need to run

ProvidersManager().initialize_providers_configuration()

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
