### PR TITLE
Paginate Airflow task logs

### DIFF
--- a/airflow/api_connexion/endpoints/log_endpoint.py
+++ b/airflow/api_connexion/endpoints/log_endpoint.py
@@ -104,12 +104,14 @@ def get_log(
     # return_type would be either the above two or None
     logs: Any
     if return_type == "application/json" or return_type is None:  # default
-        logs, metadata = task_log_reader.read_log_chunks(ti, task_try_number, metadata)
+        logs, metadata = task_log_reader.read_log_chunks(
+            ti, task_try_number, metadata, page_number=page_number
+        )
         logs = logs[0] if task_try_number is not None else logs
         # we must have token here, so we can safely ignore it
         token = URLSafeSerializer(key).dumps(metadata)  # type: ignore[assignment]
         return logs_schema.dump(LogResponseObject(continuation_token=token, content=logs))
     # text/plain. Stream
-    logs = task_log_reader.read_log_stream(ti, task_try_number, metadata, page_number=page_number)
+    logs = task_log_reader.read_log_stream(ti, task_try_number, metadata)
 
     return Response(logs, headers={"Content-Type": return_type})

--- a/airflow/api_connexion/endpoints/log_endpoint.py
+++ b/airflow/api_connexion/endpoints/log_endpoint.py
@@ -50,6 +50,7 @@ def get_log(
     task_try_number: int,
     full_content: bool = False,
     map_index: int = -1,
+    page_number: int | None = None,
     token: str | None = None,
     session: Session = NEW_SESSION,
 ) -> APIResponse:
@@ -109,6 +110,6 @@ def get_log(
         token = URLSafeSerializer(key).dumps(metadata)  # type: ignore[assignment]
         return logs_schema.dump(LogResponseObject(continuation_token=token, content=logs))
     # text/plain. Stream
-    logs = task_log_reader.read_log_stream(ti, task_try_number, metadata)
+    logs = task_log_reader.read_log_stream(ti, task_try_number, metadata, page_number=page_number)
 
     return Response(logs, headers={"Content-Type": return_type})

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1864,6 +1864,7 @@ paths:
       - $ref: "#/components/parameters/TaskTryNumber"
       - $ref: "#/components/parameters/FullContent"
       - $ref: "#/components/parameters/FilterMapIndex"
+      - $ref: "#/components/parameters/PageNumber"
       - $ref: "#/components/parameters/ContinuationToken"
 
     get:
@@ -2169,22 +2170,22 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateDatasetEvent'
+              $ref: "#/components/schemas/CreateDatasetEvent"
       responses:
-        '200':
+        "200":
           description: Success.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DatasetEvent'
+                $ref: "#/components/schemas/DatasetEvent"
         "400":
           $ref: "#/components/responses/BadRequest"
-        '401':
-          $ref: '#/components/responses/Unauthenticated'
-        '403':
-          $ref: '#/components/responses/PermissionDenied'
-        '404':
-          $ref: '#/components/responses/NotFound'
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "403":
+          $ref: "#/components/responses/PermissionDenied"
+        "404":
+          $ref: "#/components/responses/NotFound"
 
   /config:
     get:
@@ -4089,17 +4090,17 @@ components:
         ti_deps:
           type: array
           items:
-              type: string
+            type: string
           description: The plugin task instance dependencies
         listeners:
           type: array
           items:
-              type: string
+            type: string
           description: The plugin listeners
         timetables:
           type: array
           items:
-              type: string
+            type: string
           description: The plugin timetables
 
     PluginCollection:
@@ -5256,6 +5257,15 @@ components:
       description: |
         A full content will be returned.
         By default, only the first fragment will be returned.
+
+    PageNumber:
+      in: query
+      name: page_number
+      schema:
+        type: integer
+      required: false
+      description: |
+        Task log page number
 
     ContinuationToken:
       in: query

--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -908,6 +908,21 @@ class S3Hook(AwsBaseHook):
 
     @unify_bucket_name_and_key
     @provide_bucket_name
+    def get_content_length(self, key: str, bucket_name: str | None = None) -> dict | None:
+        """
+        Retrieve size of an object in bytes.
+
+        .. seealso::
+            - :external+boto3:py:meth:`S3.Client.head_object`
+
+        :param key: S3 key that will point to the file
+        :param bucket_name: Name of the bucket in which the file is stored
+        :return: Size of an object in bytes
+        """
+        return self.head_object(key, bucket_name)["ContentLength"]
+
+    @unify_bucket_name_and_key
+    @provide_bucket_name
     def check_for_key(self, key: str, bucket_name: str | None = None) -> bool:
         """
         Check if a key exists in a bucket.
@@ -950,7 +965,7 @@ class S3Hook(AwsBaseHook):
 
     @unify_bucket_name_and_key
     @provide_bucket_name
-    def read_key(self, key: str, bucket_name: str | None = None) -> str:
+    def read_key(self, key: str, bucket_name: str | None = None, range: str | None = None) -> str:
         """
         Read a key from S3.
 
@@ -959,10 +974,15 @@ class S3Hook(AwsBaseHook):
 
         :param key: S3 key that will point to the file
         :param bucket_name: Name of the bucket in which the file is stored
+        :param range: Byte range of object to fetch
         :return: the content of the key
         """
         obj = self.get_key(key, bucket_name)
-        return obj.get()["Body"].read().decode("utf-8")
+        if range is None:
+            body = obj.get()["Body"].read().decode("utf-8")
+        else:
+            body = obj.get(Range=range)["Body"].read().decode("utf-8")
+        return body
 
     @unify_bucket_name_and_key
     @provide_bucket_name

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -438,7 +438,7 @@ class FileTaskHandler(logging.Handler):
             log_relative_path,
         )
 
-    def read(self, task_instance, try_number=None, metadata=None):
+    def read(self, task_instance, try_number=None, metadata=None, page_number: int | None = None):
         """
         Read logs of given task instance from local machine.
 
@@ -468,7 +468,12 @@ class FileTaskHandler(logging.Handler):
 
         # subclasses implement _read and may not have log_type, which was added recently
         for i, try_number_element in enumerate(try_numbers):
-            log, out_metadata = self._read(task_instance, try_number_element, metadata)
+            if page_number is not None:
+                log, out_metadata = self._read(
+                    task_instance, try_number_element, metadata, page_number=page_number
+                )
+            else:
+                log, out_metadata = self._read(task_instance, try_number_element, metadata)
             # es_task_handler return logs grouped by host. wrap other handler returning log string
             # with default/ empty host so that UI can render the response in the same way
             logs[i] = log if self._read_grouped_logs() else [(task_instance.hostname, log)]

--- a/airflow/utils/log/log_reader.py
+++ b/airflow/utils/log/log_reader.py
@@ -40,7 +40,7 @@ class TaskLogReader:
     """Time to sleep between loops while waiting for more logs"""
 
     def read_log_chunks(
-        self, ti: TaskInstance, try_number: int | None, metadata
+        self, ti: TaskInstance, try_number: int | None, metadata, page_number: int | None = None
     ) -> tuple[list[tuple[tuple[str, str]]], dict[str, str]]:
         """
         Read chunks of Task Instance logs.
@@ -61,7 +61,10 @@ class TaskLogReader:
         contain information about the task log which can enable you read logs to the
         end.
         """
-        logs, metadatas = self.log_handler.read(ti, try_number, metadata=metadata)
+        if page_number is not None:
+            logs, metadata = self.log_handler.read(ti, try_number, metadata=metadata, page_number=page_number)
+        else:
+            logs, metadatas = self.log_handler.read(ti, try_number, metadata=metadata)
         metadata = metadatas[0]
         return logs, metadata
 

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
@@ -122,7 +122,6 @@ const LogBlock = ({
     >
       <div dangerouslySetInnerHTML={{ __html: parsedLogs }} />
       <div ref={codeBlockBottomDiv} />
-      1
     </Code>
   );
 };

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
@@ -122,6 +122,7 @@ const LogBlock = ({
     >
       <div dangerouslySetInnerHTML={{ __html: parsedLogs }} />
       <div ref={codeBlockBottomDiv} />
+      1
     </Code>
   );
 };

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
@@ -28,6 +28,7 @@ import {
   Spinner,
   Select,
   IconButton,
+  ButtonGroup,
 } from "@chakra-ui/react";
 import { MdWarning } from "react-icons/md";
 import { BiCollapse, BiExpand } from "react-icons/bi";
@@ -187,7 +188,7 @@ const Logs = ({
     <>
       {externalLogName && externalIndexes.length > 0 && (
         <Box my={1}>
-          <Text>View Logs in {externalLogName} (by attempts):</Text>
+          <Text>View Logs in {externalLogName} Task Instance Try Number:</Text>
           <Flex flexWrap="wrap">
             {externalIndexes.map((index) => (
               <LogLink
@@ -204,7 +205,7 @@ const Logs = ({
       <Box>
         {!showDropdown && (
           <Box>
-            <Text as="span"> (by attempts)</Text>
+            <Text as="span"> Task Instance Try Number</Text>
             <Flex my={1} justifyContent="space-between">
               <Flex flexWrap="wrap">
                 {internalIndexes.map((index) => (
@@ -328,14 +329,35 @@ const Logs = ({
       {isLoading ? (
         <Spinner />
       ) : (
-        !!parsedLogs && (
-          <LogBlock
-            parsedLogs={parsedLogs}
-            wrap={wrap}
-            tryNumber={taskTryNumber}
-            unfoldedGroups={unfoldedLogGroups}
-            setUnfoldedLogGroup={setUnfoldedLogGroup}
-          />
+        parsedLogs && (
+          <>
+            <LogBlock
+              parsedLogs={parsedLogs}
+              wrap={wrap}
+              tryNumber={taskTryNumber}
+              unfoldedGroups={unfoldedLogGroups}
+              setUnfoldedLogGroup={setUnfoldedLogGroup}
+            />
+            <Box>
+              <Text as="span">Log Page Number</Text>
+              <Flex flexWrap="wrap">
+                {/* TODO: Replace [0,1] with API call to get the log size -> # required pages */}
+                {[0, 1].map((index) => (
+                  <ButtonGroup size="sm">
+                    <Button
+                      key={index}
+                      variant={taskTryNumber === index ? "solid" : "ghost"}
+                      colorScheme="blue"
+                      onClick={() => setSelectedTryNumber(index)}
+                      data-testid={`log-attempt-select-button-${index}`}
+                    >
+                      {index}
+                    </Button>
+                  </ButtonGroup>
+                ))}
+              </Flex>
+            </Box>
+          </>
         )
       )}
     </>

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -604,6 +604,8 @@ export interface paths {
         full_content?: components["parameters"]["FullContent"];
         /** Filter on map index for mapped task. */
         map_index?: components["parameters"]["FilterMapIndex"];
+        /** Task log page number */
+        page_number?: components["parameters"]["PageNumber"];
         /**
          * A token that allows you to continue fetching logs.
          * If passed, it will specify the location from which the download should be continued.
@@ -2435,6 +2437,8 @@ export interface components {
      * By default, only the first fragment will be returned.
      */
     FullContent: boolean;
+    /** @description Task log page number */
+    PageNumber: number;
     /**
      * @description A token that allows you to continue fetching logs.
      * If passed, it will specify the location from which the download should be continued.
@@ -4352,6 +4356,8 @@ export interface operations {
         full_content?: components["parameters"]["FullContent"];
         /** Filter on map index for mapped task. */
         map_index?: components["parameters"]["FilterMapIndex"];
+        /** Task log page number */
+        page_number?: components["parameters"]["PageNumber"];
         /**
          * A token that allows you to continue fetching logs.
          * If passed, it will specify the location from which the download should be continued.


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:



How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

It's relatively easy for the webserver to get overwhelmed with large log files served from remote blob storage. Instead of just throwing more memory at the webserver, this seeks to paginate log files served from remote blob storage (at least with S3 to start)