### PR TITLE
Add a newsfragment for PR 38015 validation

### DIFF
--- a/newsfragments/38015.significant.rst
+++ b/newsfragments/38015.significant.rst
@@ -1,0 +1,6 @@
+Stronger validation for key parameter defaults in taskflow context variables
+
+As for the taskflow implementation in conjunction with context variable defaults invalid parameter orders can be
+generated, it is now not accepted anymore (and validated) that taskflow functions are defined with defaults
+other than ``None``. If you have done this before you most likely will see a broken DAG and a error message like
+``Error message: Context key parameter my_param can't have a default other than None``.


### PR DESCRIPTION
As I was stumbling over this problem in RC2 testing I propose we add a newsfragment in order to inform users about the stronger validation - which in my case rather looked like a breaking change.

related: #38015
