### PR TITLE
add `kerberos-sidecar` and `kerberos-initcontainer` to pod-template-file

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -22,6 +22,8 @@
 {{- $tolerations := or .Values.workers.tolerations .Values.tolerations }}
 {{- $topologySpreadConstraints := or .Values.workers.topologySpreadConstraints .Values.topologySpreadConstraints }}
 {{- $securityContext := include "airflowPodSecurityContext" (list . .Values.workers) }}
+{{- $containerSecurityContextKerberosSidecar := include "containerSecurityContext" (list . .Values.workers.kerberosSidecar) }}
+{{- $containerLifecycleHooksKerberosSidecar := or .Values.workers.kerberosSidecar.containerLifecycleHooks .Values.containerLifecycleHooks }}
 {{- $containerSecurityContext := include "containerSecurityContext" (list . .Values.workers) }}
 {{- $containerLifecycleHooks := or .Values.workers.containerLifecycleHooks .Values.containerLifecycleHooks }}
 apiVersion: v1
@@ -40,12 +42,14 @@ metadata:
     {{- if .Values.airflowPodAnnotations }}
       {{- toYaml .Values.airflowPodAnnotations | nindent 4 }}
     {{- end }}
+    {{- if .Values.workers.kerberosInitContainer.enabled }}
+    checksum/kerberos-keytab: {{ include (print $.Template.BasePath "/secrets/kerberos-keytab-secret.yaml") . | sha256sum }}
+    {{- end }}
     {{- if .Values.workers.podAnnotations }}
       {{- toYaml .Values.workers.podAnnotations | nindent 4 }}
     {{- end }}
   {{- end }}
 spec:
-  {{- if or (and .Values.dags.gitSync.enabled (not .Values.dags.persistence.enabled)) .Values.workers.extraInitContainers }}
   initContainers:
     {{- if and .Values.dags.gitSync.enabled (not .Values.dags.persistence.enabled) }}
       {{- include "git_sync_container" (dict "Values" .Values "is_init" "true" "Template" .Template) | nindent 4 }}
@@ -53,7 +57,45 @@ spec:
     {{- if .Values.workers.extraInitContainers }}
       {{- toYaml .Values.workers.extraInitContainers | nindent 4 }}
     {{- end }}
-  {{- end }}
+    {{- if and (semverCompare ">=2.8.0" .Values.airflowVersion) .Values.workers.kerberosInitContainer.enabled }}
+    - name: kerberos-init
+      image: {{ template "airflow_image" . }}
+      imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
+      args: ["kerberos", "-o"]
+      resources: {{- toYaml .Values.workers.kerberosInitContainer.resources | nindent 8 }}
+      volumeMounts:
+        - name: logs
+          mountPath: {{ template "airflow_logs" . }}
+        {{- include "airflow_config_mount" . | nindent 8 }}
+        - name: config
+          mountPath: {{ .Values.kerberos.configPath | quote }}
+          subPath: krb5.conf
+          readOnly: true
+        - name: kerberos-keytab
+          subPath: "kerberos.keytab"
+          mountPath: {{ .Values.kerberos.keytabPath | quote }}
+          readOnly: true
+        - name: kerberos-ccache
+          mountPath: {{ .Values.kerberos.ccacheMountPath | quote }}
+          readOnly: false
+        {{- if .Values.volumeMounts }}
+          {{- toYaml .Values.volumeMounts | nindent 8 }}
+        {{- end }}
+        {{- if .Values.workers.extraVolumeMounts }}
+          {{- tpl (toYaml .Values.workers.extraVolumeMounts) . | nindent 8 }}
+        {{- end }}
+        {{- if or .Values.webserver.webserverConfig .Values.webserver.webserverConfigConfigMapName }}
+          {{- include "airflow_webserver_config_mount" . | nindent 8 }}
+        {{- end }}
+      envFrom: {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 6 }}
+      env:
+        - name: KRB5_CONFIG
+          value:  {{ .Values.kerberos.configPath | quote }}
+        - name: KRB5CCNAME
+          value:  {{ include "kerberos_ccache_path" . | quote }}
+        {{- include "custom_airflow_environment" . | indent 6 }}
+        {{- include "standard_airflow_environment" . | indent 6 }}
+    {{- end }}
   containers:
     - envFrom: {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 6 }}
       env:
@@ -83,6 +125,62 @@ spec:
         {{- if .Values.workers.extraVolumeMounts }}
           {{- tpl (toYaml .Values.workers.extraVolumeMounts) . | nindent 8 }}
         {{- end }}
+        {{- if .Values.kerberos.enabled }}
+        - name: kerberos-keytab
+          subPath: "kerberos.keytab"
+          mountPath: {{ .Values.kerberos.keytabPath | quote }}
+          readOnly: true
+        - name: config
+          mountPath: {{ .Values.kerberos.configPath | quote }}
+          subPath: krb5.conf
+          readOnly: true
+        - name: kerberos-ccache
+          mountPath: {{ .Values.kerberos.ccacheMountPath | quote }}
+          readOnly: true
+        {{- end }}
+    {{- if .Values.workers.kerberosSidecar.enabled }}
+    - name: worker-kerberos
+      image: {{ template "airflow_image" . }}
+      imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
+      securityContext: {{ $containerSecurityContextKerberosSidecar | nindent 8 }}
+      {{- if $containerLifecycleHooksKerberosSidecar }}
+      lifecycle: {{- tpl (toYaml $containerLifecycleHooksKerberosSidecar) . | nindent 8 }}
+      {{- end }}
+      args: ["kerberos"]
+      resources: {{- toYaml .Values.workers.kerberosSidecar.resources | nindent 8 }}
+      volumeMounts:
+        - name: logs
+          mountPath: {{ template "airflow_logs" . }}
+        {{- include "airflow_config_mount" . | nindent 8 }}
+        - name: config
+          mountPath: {{ .Values.kerberos.configPath | quote }}
+          subPath: krb5.conf
+          readOnly: true
+        - name: kerberos-keytab
+          subPath: "kerberos.keytab"
+          mountPath: {{ .Values.kerberos.keytabPath | quote }}
+          readOnly: true
+        - name: kerberos-ccache
+          mountPath: {{ .Values.kerberos.ccacheMountPath | quote }}
+          readOnly: false
+        {{- if .Values.volumeMounts }}
+          {{- toYaml .Values.volumeMounts | nindent 8 }}
+        {{- end }}
+        {{- if .Values.workers.extraVolumeMounts }}
+          {{- tpl (toYaml .Values.workers.extraVolumeMounts) . | nindent 8 }}
+        {{- end }}
+        {{- if or .Values.webserver.webserverConfig .Values.webserver.webserverConfigConfigMapName }}
+          {{- include "airflow_webserver_config_mount" . | nindent 8 }}
+        {{- end }}
+      envFrom: {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 6 }}
+      env:
+        - name: KRB5_CONFIG
+          value:  {{ .Values.kerberos.configPath | quote }}
+        - name: KRB5CCNAME
+          value:  {{ include "kerberos_ccache_path" . | quote }}
+        {{- include "custom_airflow_environment" . | indent 6 }}
+        {{- include "standard_airflow_environment" . | indent 6 }}
+    {{- end }}
     {{- if .Values.workers.extraContainers }}
       {{- toYaml .Values.workers.extraContainers | nindent 4 }}
     {{- end }}
@@ -135,6 +233,13 @@ spec:
     name: config
   {{- if .Values.volumes }}
     {{- toYaml .Values.volumes | nindent 2 }}
+  {{- end }}
+  {{- if .Values.kerberos.enabled }}
+  - name: kerberos-keytab
+    secret:
+      secretName: {{ include "kerberos_keytab_secret" . | quote }}
+  - name: kerberos-ccache
+    emptyDir: {}
   {{- end }}
   {{- if .Values.workers.extraVolumes }}
     {{- tpl (toYaml .Values.workers.extraVolumes) . | nindent 2 }}


### PR DESCRIPTION
today we have kerberos-init-container and kerberos-sidecar in `worker-deployment.yaml`.
we want to apply it also on `pod-template-file.yaml` for KubernetesExecutor.
related: https://github.com/apache/airflow/pull/11130 https://github.com/apache/airflow/pull/35548
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
