### PR TITLE
Fix 'use case' spelling

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -382,7 +382,7 @@ html_theme_options["navbar_links"] = [
     {"href": "/community/", "text": "Community"},
     {"href": "/meetups/", "text": "Meetups"},
     {"href": "/docs/", "text": "Documentation"},
-    {"href": "/use-cases/", "text": "Use-cases"},
+    {"href": "/use-cases/", "text": "Use Cases"},
     {"href": "/announcements/", "text": "Announcements"},
     {"href": "/blog/", "text": "Blog"},
     {"href": "/ecosystem/", "text": "Ecosystem"},


### PR DESCRIPTION
The top-level site uses 'use case' but the documentation uses 'use-case'. The former seems to be the more popular spelling.

Home page:
<img width="589" alt="Screenshot 2024-04-08 at 12 12 06" src="https://github.com/apache/airflow/assets/605277/01d02e63-aca8-41c8-a6d7-d024b1ff4512">

Documentation:
<img width="571" alt="Screenshot 2024-04-08 at 12 11 49" src="https://github.com/apache/airflow/assets/605277/9ae55f1f-80df-4b80-a1ec-ca0c6b17ccd7">
