### PR TITLE
[fix] Simplify metrics handling

### DIFF
--- a/airflow/metrics/statsd_logger.py
+++ b/airflow/metrics/statsd_logger.py
@@ -90,6 +90,8 @@ class SafeStatsdLogger:
         tags: dict[str, str] | None = None,
     ) -> None:
         """Increment stat."""
+        if tags is not None:
+            stat = stat + "." + ".".join(str(value) for value in tags)
         if self.metrics_validator.test(stat):
             return self.statsd.incr(stat, count, rate)
         return None


### PR DESCRIPTION
This PR is to address an issue where statsd does not support tags, causing metrics to be submitted twice.
The implementation uses a dict to assemble a single long name in statsd_logger.

close #38655 