### PR TITLE
Resolve core unit test internal warning

### DIFF
--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -136,14 +136,14 @@ class TestCore:
 
         with dag_maker(schedule=timedelta(weeks=1)):
             task = EmptyOperator(task_id="test_externally_triggered_dag_context")
-        dag_maker.create_dagrun(
+        dr = dag_maker.create_dagrun(
             run_type=DagRunType.SCHEDULED,
             execution_date=execution_date,
             external_trigger=True,
         )
         task.run(start_date=execution_date, end_date=execution_date)
 
-        ti = TI(task=task, execution_date=execution_date)
+        ti = TI(task=task, run_id=dr.run_id)
         context = ti.get_template_context()
 
         # next_ds should be the execution date for manually triggered runs
@@ -169,14 +169,14 @@ class TestCore:
                 params={"key_2": "value_2_new", "key_3": "value_3"},
             )
             task2 = EmptyOperator(task_id="task2")
-        dag_maker.create_dagrun(
+        dr = dag_maker.create_dagrun(
             run_type=DagRunType.SCHEDULED,
             external_trigger=True,
         )
         task1.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
         task2.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-        ti1 = TI(task=task1, execution_date=DEFAULT_DATE)
-        ti2 = TI(task=task2, execution_date=DEFAULT_DATE)
+        ti1 = TI(task=task1, run_id=dr.run_id)
+        ti2 = TI(task=task2, run_id=dr.run_id)
         context1 = ti1.get_template_context()
         context2 = ti2.get_template_context()
 

--- a/tests/deprecations_ignore.yml
+++ b/tests/deprecations_ignore.yml
@@ -70,6 +70,7 @@
 
 
 # Core
+- tests/core/test_impersonation_tests.py::TestImpersonation::test_impersonation_subdag
 - tests/core/test_stats.py::TestCustomStatsName::test_does_not_send_stats_using_statsd_when_the_name_is_not_valid
 - tests/core/test_stats.py::TestCustomStatsName::test_does_send_stats_using_statsd_when_the_name_is_valid
 - tests/core/test_stats.py::TestPatternOrBasicValidatorConfigOption::test_pattern_or_basic_picker

--- a/tests/deprecations_ignore.yml
+++ b/tests/deprecations_ignore.yml
@@ -70,9 +70,6 @@
 
 
 # Core
-- tests/core/test_core.py::TestCore::test_dag_params_and_task_params
-- tests/core/test_core.py::TestCore::test_externally_triggered_dagrun
-- tests/core/test_impersonation_tests.py::TestImpersonation::test_impersonation_subdag
 - tests/core/test_stats.py::TestCustomStatsName::test_does_not_send_stats_using_statsd_when_the_name_is_not_valid
 - tests/core/test_stats.py::TestCustomStatsName::test_does_send_stats_using_statsd_when_the_name_is_valid
 - tests/core/test_stats.py::TestPatternOrBasicValidatorConfigOption::test_pattern_or_basic_picker


### PR DESCRIPTION
Part of the fixes for https://github.com/apache/airflow/issues/38642

tests inside `tests/core/test_core.py` can now be executed without raising any internal warnings. Meanwhile, I run `pytest --include-quarantined tests/core/test_impersonation_tests.py::TestImpersonation::test_impersonation_subdag` and didn't get any warnings, so I believe this is just false alarm 
