### PR TITLE
Enhance Secret Name Selection Based on gitSync Image Version

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -223,29 +223,28 @@ If release name contains chart name it will be used as a full name.
     - name: GITSYNC_SSH_KNOWN_HOSTS
       value: "false"
     {{- end }}
-    {{- if .Values.dags.gitSync.credentialsSecret_v3 }}
-    - name: GIT_SYNC_USERNAME
-      valueFrom:
-        secretKeyRef:
-          name: {{ .Values.dags.gitSync.credentialsSecret_v3 | quote }}
-          key: GIT_SYNC_USERNAME
-    - name: GIT_SYNC_PASSWORD
-      valueFrom:
-        secretKeyRef:
-          name: {{ .Values.dags.gitSync.credentialsSecret_v3 | quote }}
-          key: GIT_SYNC_PASSWORD
-    {{- else if .Values.dags.gitSync.credentialsSecret_v4 }}
+    {{- else if and .Values.dags.gitSync.credentialsSecret (semverCompare ">=v4.0.0" .Values.images.gitSync.tag)}}
     - name: GITSYNC_USERNAME
       valueFrom:
         secretKeyRef:
-          name: {{ .Values.dags.gitSync.credentialsSecret_v4 | quote }}
+          name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
           key: GITSYNC_USERNAME
     - name: GITSYNC_PASSWORD
       valueFrom:
         secretKeyRef:
-          name: {{ .Values.dags.gitSync.credentialsSecret_v4 | quote }}
+          name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
           key: GITSYNC_PASSWORD
-    {{- end }}
+      {{- else }}
+    - name: GIT_SYNC_USERNAME
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
+          key: GIT_SYNC_USERNAME
+    - name: GIT_SYNC_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
+          key: GIT_SYNC_PASSWORD
     {{- end }}
     - name: GIT_SYNC_REV
       value: {{ .Values.dags.gitSync.rev | quote }}

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -223,27 +223,29 @@ If release name contains chart name it will be used as a full name.
     - name: GITSYNC_SSH_KNOWN_HOSTS
       value: "false"
     {{- end }}
-    {{ else if .Values.dags.gitSync.credentialsSecret }}
+    {{- if .Values.dags.gitSync.credentialsSecret_v3 }}
     - name: GIT_SYNC_USERNAME
       valueFrom:
         secretKeyRef:
-          name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
+          name: {{ .Values.dags.gitSync.credentialsSecret_v3 | quote }}
           key: GIT_SYNC_USERNAME
-    - name: GITSYNC_USERNAME
-      valueFrom:
-        secretKeyRef:
-          name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
-          key: GITSYNC_USERNAME
     - name: GIT_SYNC_PASSWORD
       valueFrom:
         secretKeyRef:
-          name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
+          name: {{ .Values.dags.gitSync.credentialsSecret_v3 | quote }}
           key: GIT_SYNC_PASSWORD
+    {{- else if .Values.dags.gitSync.credentialsSecret_v4 }}
+    - name: GITSYNC_USERNAME
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.dags.gitSync.credentialsSecret_v4 | quote }}
+          key: GITSYNC_USERNAME
     - name: GITSYNC_PASSWORD
       valueFrom:
         secretKeyRef:
-          name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
+          name: {{ .Values.dags.gitSync.credentialsSecret_v4 | quote }}
           key: GITSYNC_PASSWORD
+    {{- end }}
     {{- end }}
     - name: GIT_SYNC_REV
       value: {{ .Values.dags.gitSync.rev | quote }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2484,8 +2484,7 @@ dags:
     #     GITSYNC_PASSWORD: <base64_encoded_git_password>
     # and specify the name of the secret below
     #
-    # credentialsSecret_v3: git-credentials
-    # credentialsSecret_v4: git-credentials
+    # credentialsSecret: git-credentials
     #
     #
     # If you are using an ssh clone url, you can load

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2484,7 +2484,8 @@ dags:
     #     GITSYNC_PASSWORD: <base64_encoded_git_password>
     # and specify the name of the secret below
     #
-    # credentialsSecret: git-credentials
+    # credentialsSecret_v3: git-credentials
+    # credentialsSecret_v4: git-credentials
     #
     #
     # If you are using an ssh clone url, you can load


### PR DESCRIPTION
### Enhance Secret Name Selection Based on `gitSync` Image Version

This pull request introduces a conditional logic enhancement within the Helm chart templates to dynamically select the appropriate secret name based on the `gitSync` image version. Specifically, the addition targets scenarios where the `gitSync` image version is `v4.0.0` or newer. This is achieved through the Helm condition:

```yaml
{{- else if and .Values.dags.gitSync.credentialsSecret (semverCompare ">=v4.0.0" .Values.images.gitSync.tag)}}
```

The modification ensures that the deployment utilizes the correct credentials for `gitSync`, enhancing compatibility and security for different version requirements. This change is particularly important for environments with strict versioning and authentication mechanisms, ensuring smoother upgrades and maintenance.

The update aligns with the Apache License, Version 2.0, and adheres to ASF's contribution guidelines. Comprehensive testing has been conducted to ensure no regressions in functionality. This contribution is a step towards more flexible and secure Helm chart configurations for the Apache Airflow community.
