### PR TITLE
Fix AttributeError: 'DagRunNote' object has no attribute 'dag_id'

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -1661,7 +1661,5 @@ class DagRunNote(Base):
         self.user_id = user_id
 
     def __repr__(self):
-        prefix = f"<{self.__class__.__name__}: {self.dag_id}.{self.dagrun_id} {self.run_id}"
-        if self.map_index != -1:
-            prefix += f" map_index={self.map_index}"
+        prefix = f"<{self.__class__.__name__}: {self.dag_run_id}.{self.content}"
         return prefix + ">"

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -1661,5 +1661,5 @@ class DagRunNote(Base):
         self.user_id = user_id
 
     def __repr__(self):
-        prefix = f"<{self.__class__.__name__}: {self.dag_run_id}.{self.content}"
+        prefix = f"<{self.__class__.__name__}: {self.dag_run.dag_id}.{self.dag_run_id} {self.dag_run.run_id} {self.content}"
         return prefix + ">"


### PR DESCRIPTION
'DagRunNote' object has no attribute dag_id\dagrun_id\run_id\map_index
so replace those attributes to existing attributes dag_run_id\content

Closes: #38816