### PR TITLE
Rename SparkSubmitOperator argument queue as yarn_queue

### DIFF
--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -82,9 +82,9 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                          (will overwrite any spark_binary defined in the connection's extra JSON)
     :param properties_file: Path to a file from which to load extra properties. If not
                               specified, this will look for conf/spark-defaults.conf.
-    :param queue: The name of the YARN queue to which the application is submitted.
+    :param yarn_queue: The name of the YARN queue to which the application is submitted.
                         (will overwrite any yarn queue defined in the connection's extra JSON)
-    :param deploy_mode: Whether to deploy your driver on the worker nodes (cluster) or locally as an    client.
+    :param deploy_mode: Whether to deploy your driver on the worker nodes (cluster) or locally as an client.
                         (will overwrite any deployment mode defined in the connection's extra JSON)
     :param use_krb5ccache: if True, configure spark to use ticket cache instead of relying
         on keytab for Kerberos login
@@ -165,7 +165,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         verbose: bool = False,
         spark_binary: str | None = None,
         properties_file: str | None = None,
-        queue: str | None = None,
+        yarn_queue: str | None = None,
         deploy_mode: str | None = None,
         *,
         use_krb5ccache: bool = False,
@@ -201,7 +201,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         self._kubernetes_driver_pod: str | None = None
         self.spark_binary = spark_binary
         self._properties_file = properties_file
-        self._queue = queue
+        self._yarn_queue = yarn_queue
         self._deploy_mode = deploy_mode
         self._connection = self._resolve_connection()
         self._is_yarn = "yarn" in self._connection["master"]
@@ -248,7 +248,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
 
             # Determine optional yarn queue from the extra field
             extra = conn.extra_dejson
-            conn_data["queue"] = self._queue if self._queue else extra.get("queue")
+            conn_data["yarn_queue"] = self._yarn_queue if self._yarn_queue else extra.get("queue")
             conn_data["deploy_mode"] = self._deploy_mode if self._deploy_mode else extra.get("deploy-mode")
             if not self.spark_binary:
                 self.spark_binary = extra.get("spark-binary", DEFAULT_SPARK_BINARY)
@@ -386,8 +386,8 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
             connection_cmd += ["--class", self._java_class]
         if self._verbose:
             connection_cmd += ["--verbose"]
-        if self._connection["queue"]:
-            connection_cmd += ["--queue", self._connection["queue"]]
+        if self._connection["yarn_queue"]:
+            connection_cmd += ["--queue", self._connection["yarn_queue"]]
         if self._connection["deploy_mode"]:
             connection_cmd += ["--deploy-mode", self._connection["deploy_mode"]]
 

--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -248,7 +248,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
 
             # Determine optional yarn queue from the extra field
             extra = conn.extra_dejson
-            conn_data["yarn_queue"] = self._yarn_queue if self._yarn_queue else extra.get("queue")
+            conn_data["queue"] = self._yarn_queue if self._yarn_queue else extra.get("queue")
             conn_data["deploy_mode"] = self._deploy_mode if self._deploy_mode else extra.get("deploy-mode")
             if not self.spark_binary:
                 self.spark_binary = extra.get("spark-binary", DEFAULT_SPARK_BINARY)
@@ -386,8 +386,8 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
             connection_cmd += ["--class", self._java_class]
         if self._verbose:
             connection_cmd += ["--verbose"]
-        if self._connection["yarn_queue"]:
-            connection_cmd += ["--queue", self._connection["yarn_queue"]]
+        if self._connection["queue"]:
+            connection_cmd += ["--queue", self._connection["queue"]]
         if self._connection["deploy_mode"]:
             connection_cmd += ["--deploy-mode", self._connection["deploy_mode"]]
 

--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -231,7 +231,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         # Build from connection master or default to yarn if not available
         conn_data = {
             "master": "yarn",
-            "queue": None,
+            "queue": None,  # yarn queue
             "deploy_mode": None,
             "spark_binary": self.spark_binary or DEFAULT_SPARK_BINARY,
             "namespace": None,

--- a/airflow/providers/apache/spark/operators/spark_submit.py
+++ b/airflow/providers/apache/spark/operators/spark_submit.py
@@ -72,7 +72,7 @@ class SparkSubmitOperator(BaseOperator):
                          (will overwrite any spark_binary defined in the connection's extra JSON)
     :param properties_file: Path to a file from which to load extra properties. If not
                               specified, this will look for conf/spark-defaults.conf.
-    :param queue: The name of the YARN queue to which the application is submitted.
+    :param yarn_queue: The name of the YARN queue to which the application is submitted.
                         (will overwrite any yarn queue defined in the connection's extra JSON)
     :param deploy_mode: Whether to deploy your driver on the worker nodes (cluster) or locally as a client.
                         (will overwrite any deployment mode defined in the connection's extra JSON)
@@ -129,7 +129,7 @@ class SparkSubmitOperator(BaseOperator):
         verbose: bool = False,
         spark_binary: str | None = None,
         properties_file: str | None = None,
-        queue: str | None = None,
+        yarn_queue: str | None = None,
         deploy_mode: str | None = None,
         use_krb5ccache: bool = False,
         **kwargs: Any,
@@ -161,7 +161,7 @@ class SparkSubmitOperator(BaseOperator):
         self._verbose = verbose
         self._spark_binary = spark_binary
         self.properties_file = properties_file
-        self._queue = queue
+        self._yarn_queue = yarn_queue
         self._deploy_mode = deploy_mode
         self._hook: SparkSubmitHook | None = None
         self._conn_id = conn_id
@@ -206,7 +206,7 @@ class SparkSubmitOperator(BaseOperator):
             verbose=self._verbose,
             spark_binary=self._spark_binary,
             properties_file=self.properties_file,
-            queue=self._queue,
+            yarn_queue=self._yarn_queue,
             deploy_mode=self._deploy_mode,
             use_krb5ccache=self._use_krb5ccache,
         )

--- a/tests/providers/apache/spark/operators/test_spark_submit.py
+++ b/tests/providers/apache/spark/operators/test_spark_submit.py
@@ -171,10 +171,10 @@ class TestSparkSubmitOperator:
             task_id="spark_submit_job", spark_binary="sparky", dag=self.dag, **config
         )
         cmd = " ".join(operator._get_hook()._build_spark_submit_command("test"))
-        assert "--queue yarn_dev_queue2" in cmd
+        assert "--queue yarn_dev_queue2" in cmd  # yarn queue
         assert "--deploy-mode client2" in cmd
         assert "sparky" in cmd
-        assert operator.queue == "airflow_custom_queue"  # custom airflow queue
+        assert operator.queue == "airflow_custom_queue"  # airflow queue
 
         # if we don't pass any overrides in arguments, default values
         config["yarn_queue"] = None
@@ -182,7 +182,7 @@ class TestSparkSubmitOperator:
         config.pop("queue", None)  # using default airflow queue
         operator2 = SparkSubmitOperator(task_id="spark_submit_job2", dag=self.dag, **config)
         cmd2 = " ".join(operator2._get_hook()._build_spark_submit_command("test"))
-        assert "--queue root.default" in cmd2
+        assert "--queue root.default" in cmd2  # yarn queue
         assert "--deploy-mode client2" not in cmd2
         assert "spark-submit" in cmd2
         assert operator2.queue == "default"  # airflow queue

--- a/tests/providers/apache/spark/operators/test_spark_submit.py
+++ b/tests/providers/apache/spark/operators/test_spark_submit.py
@@ -67,7 +67,7 @@ class TestSparkSubmitOperator:
             "args should keep embedded spaces",
         ],
         "use_krb5ccache": True,
-        "queue": "yarn_dev_queue2",
+        "yarn_queue": "yarn_dev_queue2",
         "deploy_mode": "client2",
     }
 
@@ -122,7 +122,7 @@ class TestSparkSubmitOperator:
                 "args should keep embedded spaces",
             ],
             "spark_binary": "sparky",
-            "queue": "yarn_dev_queue2",
+            "yarn_queue": "yarn_dev_queue2",
             "deploy_mode": "client2",
             "use_krb5ccache": True,
             "properties_file": "conf/spark-custom.conf",
@@ -153,10 +153,11 @@ class TestSparkSubmitOperator:
         assert expected_dict["driver_memory"] == operator._driver_memory
         assert expected_dict["application_args"] == operator.application_args
         assert expected_dict["spark_binary"] == operator._spark_binary
-        assert expected_dict["queue"] == operator._queue
         assert expected_dict["deploy_mode"] == operator._deploy_mode
         assert expected_dict["properties_file"] == operator.properties_file
         assert expected_dict["use_krb5ccache"] == operator._use_krb5ccache
+        assert expected_dict["queue"] == "something"  # TODO: verify and check default airflow queue here
+        assert expected_dict["yarn_queue"] == operator._yarn_queue
 
     @pytest.mark.db_test
     def test_spark_submit_cmd_connection_overrides(self):
@@ -173,7 +174,7 @@ class TestSparkSubmitOperator:
         assert "sparky" in cmd
 
         # if we don't pass any overrides in arguments
-        config["queue"] = None
+        config["yarn_queue"] = None
         config["deploy_mode"] = None
         operator2 = SparkSubmitOperator(task_id="spark_submit_job2", dag=self.dag, **config)
         cmd2 = " ".join(operator2._get_hook()._build_spark_submit_command("test"))


### PR DESCRIPTION
closes: #38461
related: #35911


## Description 
We added a yarn queue parameter in **SparkSubmitOperator** in #35911,
but this parameter overrode **BaseOperator** value where a queue is an Airflow queue.

## Proposed Fix/Solution 
Renaming the argument in **SparkSubmitOperator** to avoid any confusion and issues going forward,
even though in Sparksubmit it's called '--queue'.
