### PR TITLE
fix(airbyte/hooks): add schema and port to prevent InvalidURL error

### DIFF
--- a/airflow/providers/airbyte/hooks/airbyte.py
+++ b/airflow/providers/airbyte/hooks/airbyte.py
@@ -71,7 +71,12 @@ class AirbyteHook(HttpHook):
     async def get_headers_tenants_from_connection(self) -> tuple[dict[str, Any], str]:
         """Get Headers, tenants from the connection details."""
         connection: Connection = await sync_to_async(self.get_connection)(self.http_conn_id)
-        base_url = connection.host
+        # schema defaults to HTTP
+        schema = connection.schema if connection.schema else "http"
+        base_url = f"{schema}://{connection.host}"
+
+        if connection.port:
+            base_url += f":{connection.port}"
 
         if self.api_type == "config":
             credentials = f"{connection.login}:{connection.password}"

--- a/tests/providers/airbyte/hooks/test_airbyte.py
+++ b/tests/providers/airbyte/hooks/test_airbyte.py
@@ -67,6 +67,23 @@ class TestAirbyteHook:
         assert resp.status_code == 200
         assert resp.json() == self._mock_sync_conn_success_response_body
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "host, port, schema, expected_base_url, description",
+        [
+            ("test-airbyte", 8001, "http", "http://test-airbyte:8001", "uri_with_port_and_schema"),
+            ("test-airbyte", None, "https", "https://test-airbyte", "uri_with_schema"),
+            ("test-airbyte", None, None, "http://test-airbyte", "uri_without_port_and_schema"),
+        ],
+    )
+    async def test_get_base_url(self, host, port, schema, expected_base_url, description):
+        conn_id = f"test_conn_{description}"
+        conn = Connection(conn_id=conn_id, conn_type="airbyte", host=host, port=port, schema=schema)
+        hook = AirbyteHook(airbyte_conn_id=conn_id)
+        db.merge_conn(conn)
+        _, base_url = await hook.get_headers_tenants_from_connection()
+        assert base_url == expected_base_url
+
     def test_get_job_status(self, requests_mock):
         requests_mock.post(
             self.get_job_endpoint, status_code=200, json=self._mock_job_status_success_response_body


### PR DESCRIPTION
Fix #37449 through adding the schema and port to base_url in `get_headers_tenants_from_connection` so that aiohttp wouldn't raise the InvalidURL error.

![image](https://github.com/apache/airflow/assets/18432820/d523a600-ae2d-456a-b777-dbc639ffd247)


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
