### PR TITLE
Fix typo in templates-ref.rst

### DIFF
--- a/docs/apache-airflow/templates-ref.rst
+++ b/docs/apache-airflow/templates-ref.rst
@@ -39,7 +39,7 @@ Variable                                    Type                  Description
 ``{{ data_interval_start }}``               `pendulum.DateTime`_  Start of the data interval. Added in version 2.2.
 ``{{ data_interval_end }}``                 `pendulum.DateTime`_  End of the data interval. Added in version 2.2.
 ``{{ logical_date }}``                      `pendulum.DateTime`_  | A date-time that logically identifies the current DAG run. This value does not contain any semantics, but is simply a value for identification.
-                                                                  | Use ``data_interval_start`` and ``date_interval_end`` instead if you want a value that has real-world semantics,
+                                                                  | Use ``data_interval_start`` and ``data_interval_end`` instead if you want a value that has real-world semantics,
                                                                   | such as to get a slice of rows from the database based on timestamps.
 ``{{ ds }}``                                str                   | The DAG run's logical date as ``YYYY-MM-DD``.
                                                                   | Same as ``{{ logical_date | ds }}``.


### PR DESCRIPTION
There is a typo in variable name in documentation.
Suggested change is:
`date_interval_end` => `data_interval_end`
