### PR TITLE
Fix dag run link params

### DIFF
--- a/airflow/www/static/js/dag/useFilters.tsx
+++ b/airflow/www/static/js/dag/useFilters.tsx
@@ -182,6 +182,7 @@ const useFilters = (): FilterHookReturn => {
     searchParams.delete(BASE_DATE_PARAM);
     searchParams.delete(RUN_TYPE_PARAM);
     searchParams.delete(RUN_STATE_PARAM);
+    searchParams.delete(EXECUTION_DATE_PARAM);
     setSearchParams(searchParams);
   };
 

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -532,8 +532,8 @@ def dag_run_link(attr):
     """Generate a URL to the Graph view for a DagRun."""
     dag_id = attr.get("dag_id")
     run_id = attr.get("run_id")
-    execution_date = attr.get("dag_run.execution_date") or attr.get("execution_date")
-    url = url_for("Airflow.graph", dag_id=dag_id, run_id=run_id, execution_date=execution_date)
+
+    url = url_for("Airflow.graph", dag_id=dag_id, dag_run_id=run_id)
     return Markup('<a href="{url}">{run_id}</a>').format(url=url, run_id=run_id)
 
 


### PR DESCRIPTION
When linking to the graph from browse -> task instance / dag runs, we were sending `run_id` but the grid view uses `dag_run_id`. Also, when dag_run_id is specified we don't need execution_date

Additionally, when a user Clear Filters we should clear the execution_date too.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
