### PR TITLE
Enable `assert-raises-exception` rule (`B017`)

### DIFF
--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -1171,7 +1171,7 @@ class TestKubernetesPodOperatorSystem:
         # `create_pod` should be called because though there's still a pod to be found,
         # it will be `already_checked`
         with mock.patch(f"{POD_MANAGER_CLASS}.create_pod") as create_mock:
-            with pytest.raises(Exception):
+            with pytest.raises(ApiException, match=r'pods \\"test.[a-z0-9]+\\" not found'):
                 k.execute(context)
             create_mock.assert_called_once()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -287,6 +287,7 @@ extend-select = [
     "S101", # Checks use `assert` outside the test cases, test cases should be added into the exclusions
     "B004", # Checks for use of hasattr(x, "__call__") and replaces it with callable(x)
     "B006", # Checks for uses of mutable objects as function argument defaults.
+    "B017", # Checks for pytest.raises context managers that catch Exception or BaseException.
     "B019", # Use of functools.lru_cache or functools.cache on methods can lead to memory leaks
     "TRY002", # Prohibit use of `raise Exception`, use specific exceptions instead.
 ]

--- a/tests/hooks/test_package_index.py
+++ b/tests/hooks/test_package_index.py
@@ -111,7 +111,7 @@ def test_test_connection(monkeypatch: pytest.MonkeyPatch, mock_get_connection: s
         result = hook_instance.test_connection()
         assert result[0] == (success == 0)
     else:
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError, match="Please provide an index URL"):
             hook_instance.test_connection()
 
 

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -1816,11 +1816,11 @@ class TestSchedulerJob:
         """
         scheduler_job = Job(executor=mock.MagicMock(slots_available=8))
         self.job_runner = SchedulerJobRunner(job=scheduler_job, subdir=os.devnull, num_runs=1)
-        self.job_runner._run_scheduler_loop = mock.MagicMock(side_effect=Exception("oops"))
-        mock_processor_agent.return_value.end.side_effect = Exception("double oops")
-        scheduler_job.executor.end = mock.MagicMock(side_effect=Exception("triple oops"))
+        self.job_runner._run_scheduler_loop = mock.MagicMock(side_effect=RuntimeError("oops"))
+        mock_processor_agent.return_value.end.side_effect = RuntimeError("double oops")
+        scheduler_job.executor.end = mock.MagicMock(side_effect=RuntimeError("triple oops"))
 
-        with pytest.raises(Exception):
+        with pytest.raises(RuntimeError, match="oops"):
             run_job(scheduler_job, execute_callable=self.job_runner._execute)
 
         self.job_runner.processor_agent.end.assert_called_once()

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -1844,11 +1844,11 @@ class TestSchedulerJob:
         assert scheduler_job.executor is default_executor
         assert scheduler_job.executors == [default_executor, second_executor]
         self.job_runner = SchedulerJobRunner(job=scheduler_job, subdir=os.devnull, num_runs=1)
-        self.job_runner._run_scheduler_loop = mock.MagicMock(side_effect=Exception("oops"))
-        mock_processor_agent.return_value.end.side_effect = Exception("double oops")
-        scheduler_job.executor.end = mock.MagicMock(side_effect=Exception("triple oops"))
+        self.job_runner._run_scheduler_loop = mock.MagicMock(side_effect=RuntimeError("oops"))
+        mock_processor_agent.return_value.end.side_effect = RuntimeError("double oops")
+        scheduler_job.executor.end = mock.MagicMock(side_effect=RuntimeError("triple oops"))
 
-        with pytest.raises(Exception):
+        with pytest.raises(RuntimeError, match="oops"):
             run_job(scheduler_job, execute_callable=self.job_runner._execute)
 
         self.job_runner.processor_agent.end.assert_called_once()

--- a/tests/providers/amazon/aws/hooks/test_base_aws.py
+++ b/tests/providers/amazon/aws/hooks/test_base_aws.py
@@ -1055,7 +1055,7 @@ class ThrowErrorUntilCount:
         """
         if self.counter < self.count:
             self.counter += 1
-            raise Exception()
+            raise RuntimeError("Fake Unexpected Error")
         return True
 
 
@@ -1109,12 +1109,12 @@ class TestRetryDecorator:  # ptlint: disable=invalid-name
             count=2,
             quota_retry=quota_retry,
         )
-        with pytest.raises(Exception):
+        with pytest.raises(RuntimeError, match="Fake Unexpected Error"):
             _non_retryable_test(custom_fn)
 
     def test_raise_exception_when_no_retry_args(self):
         custom_fn = ThrowErrorUntilCount(count=2, quota_retry=None)
-        with pytest.raises(Exception):
+        with pytest.raises(RuntimeError, match="Fake Unexpected Error"):
             _retryable_test(custom_fn)
 
 

--- a/tests/providers/amazon/aws/hooks/test_glue_catalog.py
+++ b/tests/providers/amazon/aws/hooks/test_glue_catalog.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from unittest import mock
 
 import boto3
+import botocore.exceptions
 import pytest
 from botocore.exceptions import ClientError
 from moto import mock_aws
@@ -115,8 +116,9 @@ class TestGlueCatalogHook:
         self.client.create_database(DatabaseInput={"Name": DB_NAME})
         self.client.create_table(DatabaseName=DB_NAME, TableInput=TABLE_INPUT)
 
-        with pytest.raises(Exception):
+        with pytest.raises(botocore.exceptions.ClientError) as err_ctx:
             self.hook.get_table(DB_NAME, "dummy_table")
+        assert err_ctx.value.response["Error"]["Code"] == "EntityNotFoundException"
 
     def test_get_table_location(self):
         self.client.create_database(DatabaseInput={"Name": DB_NAME})

--- a/tests/providers/amazon/aws/log/test_s3_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_s3_task_handler.py
@@ -100,10 +100,11 @@ class TestS3TaskHandler:
         assert not self.s3_task_handler.s3_log_exists("s3://nonexistentbucket/foo")
 
     def test_log_exists_no_hook(self):
-        with mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook") as mock_hook:
+        handler = S3TaskHandler(self.local_log_location, self.remote_log_base)
+        with mock.patch.object(S3Hook, "__init__", spec=S3Hook) as mock_hook:
             mock_hook.side_effect = ConnectionError("Fake: Failed to connect")
             with pytest.raises(ConnectionError, match="Fake: Failed to connect"):
-                self.s3_task_handler.s3_log_exists(self.remote_log_location)
+                handler.s3_log_exists(self.remote_log_location)
 
     def test_set_context_raw(self):
         self.ti.raw = True

--- a/tests/providers/amazon/aws/log/test_s3_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_s3_task_handler.py
@@ -101,8 +101,8 @@ class TestS3TaskHandler:
 
     def test_log_exists_no_hook(self):
         with mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook") as mock_hook:
-            mock_hook.side_effect = Exception("Failed to connect")
-            with pytest.raises(Exception):
+            mock_hook.side_effect = ConnectionError("Fake: Failed to connect")
+            with pytest.raises(ConnectionError, match="Fake: Failed to connect"):
                 self.s3_task_handler.s3_log_exists(self.remote_log_location)
 
     def test_set_context_raw(self):

--- a/tests/providers/amazon/aws/utils/test_task_log_fetcher.py
+++ b/tests/providers/amazon/aws/utils/test_task_log_fetcher.py
@@ -83,12 +83,10 @@ class TestAwsTaskLogFetcher:
         with pytest.raises(StopIteration):
             next(self.log_fetcher._get_log_events())
 
-    @mock.patch(
-        "airflow.providers.amazon.aws.hooks.logs.AwsLogsHook.get_log_events",
-        side_effect=Exception(),
-    )
+    @mock.patch("airflow.providers.amazon.aws.hooks.logs.AwsLogsHook.get_log_events")
     def test_get_log_events_with_unexpected_error(self, get_log_events_mock):
-        with pytest.raises(Exception):
+        get_log_events_mock.side_effect = ConnectionError("Fake: Failed to connect")
+        with pytest.raises(ConnectionError, match="Fake: Failed to connect"):
             next(self.log_fetcher._get_log_events())
 
     @mock.patch.object(AwsLogsHook, "conn", new_callable=PropertyMock)

--- a/tests/providers/google/common/hooks/test_base_google.py
+++ b/tests/providers/google/common/hooks/test_base_google.py
@@ -247,9 +247,9 @@ class TestProvideGcpCredentialFile:
 
         @hook.GoogleBaseHook.provide_gcp_credential_file
         def assert_gcp_credential_file_in_env(_):
-            raise Exception()
+            raise RuntimeError("Some exception occurred")
 
-        with pytest.raises(Exception):
+        with pytest.raises(RuntimeError, match="Some exception occurred"):
             assert_gcp_credential_file_in_env(self.instance)
 
         assert os.environ[CREDENTIALS] == ENV_VALUE
@@ -273,9 +273,9 @@ class TestProvideGcpCredentialFile:
 
         @hook.GoogleBaseHook.provide_gcp_credential_file
         def assert_gcp_credential_file_in_env(_):
-            raise Exception()
+            raise RuntimeError("Some exception occurred")
 
-        with pytest.raises(Exception):
+        with pytest.raises(RuntimeError, match="Some exception occurred"):
             assert_gcp_credential_file_in_env(self.instance)
 
         assert CREDENTIALS not in os.environ
@@ -325,9 +325,9 @@ class TestProvideGcpCredentialFileAsContext:
         key_path = "/test/key-path"
         self.instance.extras = {"key_path": key_path}
 
-        with pytest.raises(Exception):
+        with pytest.raises(RuntimeError, match="Some exception occurred"):
             with self.instance.provide_gcp_credential_file_as_context():
-                raise Exception()
+                raise RuntimeError("Some exception occurred")
 
         assert os.environ[CREDENTIALS] == ENV_VALUE
 
@@ -346,9 +346,9 @@ class TestProvideGcpCredentialFileAsContext:
         key_path = "/test/key-path"
         self.instance.extras = {"key_path": key_path}
 
-        with pytest.raises(Exception):
+        with pytest.raises(RuntimeError, match="Some exception occurred"):
             with self.instance.provide_gcp_credential_file_as_context():
-                raise Exception()
+                raise RuntimeError("Some exception occurred")
 
         assert CREDENTIALS not in os.environ
 

--- a/tests/providers/mysql/transfers/test_s3_to_mysql.py
+++ b/tests/providers/mysql/transfers/test_s3_to_mysql.py
@@ -85,9 +85,9 @@ class TestS3ToMySqlTransfer:
     @patch("airflow.providers.mysql.transfers.s3_to_mysql.MySqlHook.bulk_load_custom")
     @patch("airflow.providers.mysql.transfers.s3_to_mysql.os.remove")
     def test_execute_exception(self, mock_remove, mock_bulk_load_custom, mock_download_file):
-        mock_bulk_load_custom.side_effect = Exception
+        mock_bulk_load_custom.side_effect = RuntimeError("Some exception occurred")
 
-        with pytest.raises(Exception):
+        with pytest.raises(RuntimeError, match="Some exception occurred"):
             S3ToMySqlOperator(**self.s3_to_mysql_transfer_kwargs).execute({})
 
         mock_download_file.assert_called_once_with(key=self.s3_to_mysql_transfer_kwargs["s3_source_key"])

--- a/tests/providers/openlineage/plugins/test_openlineage_adapter.py
+++ b/tests/providers/openlineage/plugins/test_openlineage_adapter.py
@@ -105,7 +105,7 @@ def test_create_client_from_config_with_options():
     }
 )
 def test_fails_to_create_client_without_type():
-    with pytest.raises(Exception):
+    with pytest.raises(KeyError):
         OpenLineageAdapter().get_or_create_openlineage_client()
 
 

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -951,7 +951,7 @@ class TestSSHHook:
         )
         session.add(conn)
         session.flush()
-        with pytest.raises(Exception):
+        with pytest.raises(AirflowException, match="Key must have BEGIN and END"):
             SSHHook(ssh_conn_id=conn.conn_id)
         session.delete(conn)
         session.commit()


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Enable rule which prohibit to use `pytest.raises(Exception)` or `pytest.raises(BaseException)` without specifying match parameter, in most cases if you could provide match filter, you also might provide exact exception which is expected.

This rulle additional helper prevent catch unexpected exceptions, e.g.

```python
def test():
    with pytest.raises(Exception):
        assert 2 + 2 == 5   # Instead of this we had in the past cases where assert do not pass, however tests pass
```

https://docs.astral.sh/ruff/rules/assert-raises-exception/

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
