### PR TITLE
Clean up output from cheat sheet and info commands

### DIFF
--- a/airflow/cli/commands/cheat_sheet_command.py
+++ b/airflow/cli/commands/cheat_sheet_command.py
@@ -51,11 +51,12 @@ def display_commands_index():
         console = AirflowConsole()
         if actions:
             table = SimpleTable(title=help_msg or "Miscellaneous commands")
-            table.add_column(width=40)
+            table.add_column(width=45)
             table.add_column()
             for action_command in sorted(actions, key=lambda d: d.name):
                 table.add_row(" ".join([*prefix, action_command.name]), action_command.help)
             console.print(table)
+            console.print()
 
         if groups:
             for group_command in sorted(groups, key=lambda d: d.name):

--- a/airflow/cli/simple_table.py
+++ b/airflow/cli/simple_table.py
@@ -133,7 +133,6 @@ class SimpleTable(Table):
         self.show_header = kwargs.get("show_header", False)
         self.title_style = kwargs.get("title_style", "bold green")
         self.title_justify = kwargs.get("title_justify", "left")
-        self.caption = kwargs.get("caption", " ")
 
     def add_column(self, *args, **kwargs) -> None:
         """Add a column to the table. We use different default."""


### PR DESCRIPTION
Before:
<img width="1062" alt="Screenshot 2024-04-09 at 2 29 40 PM" src="https://github.com/apache/airflow/assets/66968678/34508f33-6d0d-4229-b191-e8739d74184e">

After:
<img width="1104" alt="Screenshot 2024-04-09 at 2 29 11 PM" src="https://github.com/apache/airflow/assets/66968678/a7d904dc-a2bb-464f-9762-d5587cdee4d1">

This widens the first column of the cheat sheet so `airflow connections create-default-connections` doesn't wrap, and removes the default empty caption which just results in a white bar.