### PR TITLE
Fix problem that links in legacy log view can not be clicked

### DIFF
--- a/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
@@ -62,6 +62,7 @@ export const parseLogs = (
   const parsedLines: Array<string> = [];
   const fileSources: Set<string> = new Set();
   const ansiUp = new AnsiUp();
+  ansiUp.url_allowlist = {};
 
   const urlRegex = /((https?:\/\/|http:\/\/)[^\s]+)/g;
   // Detect log groups which can be collapsed

--- a/airflow/www/static/js/ti_log.js
+++ b/airflow/www/static/js/ti_log.js
@@ -195,11 +195,14 @@ function handleLogGroupClick(e) {
   if (e.target.id?.endsWith(unfoldIdSuffix)) {
     e.target.style.display = "none";
     e.target.nextSibling.style.display = "inline";
-  } else if (e.target.id?.endsWith(foldIdSuffix)) {
+    return false;
+  }
+  if (e.target.id?.endsWith(foldIdSuffix)) {
     e.target.parentNode.style.display = "none";
     e.target.parentNode.previousSibling.style.display = "inline";
+    return false;
   }
-  return false;
+  return true;
 }
 
 function setDownloadUrl(tryNumber) {

--- a/airflow/www/static/js/ti_log.js
+++ b/airflow/www/static/js/ti_log.js
@@ -111,6 +111,7 @@ function autoTailingLog(tryNumber, metadata = null, autoTailing = false) {
 
       // Text coloring, detect urls and log timestamps
       const ansiUp = new AnsiUp();
+      ansiUp.url_allowlist = {};
       // Detect urls and log timestamps
       const urlRegex =
         /http(s)?:\/\/[\w.-]+(\.?:[\w.-]+)*([/?#][\w\-._~:/?#[\]@!$&'()*+,;=.%]+)?/g;


### PR DESCRIPTION
During production rollout of (my bad) contributions of Airflow 2.9.0 I realized that the links from the text in the legacy log view are generated but not clickable. The event-handler for the log grouping masks them.

This PR fixes the snipped of JavaScript and fixes the "non clickable links".

As making this fix in discussions with others we realized thatthe `ansi_up` library also creates links, in order to prevent problems with this in comparison with the link generation we do in the other script code, this PR disables link generation from `ansi_up`. Double link generation looks strange. Proposing to keep our "existing" regex as this was stable and the result I got from `ansi_up` were not directly working, might be a bug in this lib.

How to test:
- Run Airflow from this PR
- Run the `example_bash_operator` DAG
- Open the logs from the task `run_after_loop`
- Click on the log tab
- Click in the "more Logs" link on the right side to get to legacy log view
- Click on the link to apache, see it opens