### PR TITLE
Rollback session and InternalApiConfig settings in the end of each tests in `tests/core/test_settings.py`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1176,7 +1176,9 @@ def _clear_db(request):
         if exc_module != "builtins":
             exc_name_parts.insert(0, exc_module)
         extra_msg = "" if request.config.option.db_init else ", try to run with flag --with-db-init"
-        pytest.exit(f"Unable clear test DB{extra_msg}, got error {'.'.join(exc_name_parts)}: {ex}")
+        pytest.exit(
+            f"Unable clear test DB{extra_msg}, got error {'.'.join(exc_name_parts)}: {ex}", returncode=-1
+        )
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

After #38563 core tests after the `pytest tests/core/test_settings.py::test_create_session_ctx_mgr_no_call_methods` terminated. This happen because `airflow.settings` changed between tests cases as result side effect spread across tests cases

This PR is temporary fix, because it might happen in the other places in tests and this one one prevent side effects only in one test module

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
