### PR TITLE
Widen cheat sheet column to avoid wrapping commands

### DIFF
--- a/airflow/cli/commands/cheat_sheet_command.py
+++ b/airflow/cli/commands/cheat_sheet_command.py
@@ -51,7 +51,7 @@ def display_commands_index():
         console = AirflowConsole()
         if actions:
             table = SimpleTable(title=help_msg or "Miscellaneous commands")
-            table.add_column(width=40)
+            table.add_column(width=46)
             table.add_column()
             for action_command in sorted(actions, key=lambda d: d.name):
                 table.add_row(" ".join([*prefix, action_command.name]), action_command.help)

--- a/tests/cli/commands/test_cheat_sheet_command.py
+++ b/tests/cli/commands/test_cheat_sheet_command.py
@@ -74,17 +74,17 @@ MOCK_COMMANDS: list[CLICommand] = [
 ]
 
 ALL_COMMANDS = """\
-airflow cmd_b                             | Help text D
+airflow cmd_b                                   | Help text D
 """
 
 SECTION_A = """\
-airflow cmd_a cmd_b                       | Help text B
-airflow cmd_a cmd_c                       | Help text C
+airflow cmd_a cmd_b                             | Help text B
+airflow cmd_a cmd_c                             | Help text C
 """
 
 SECTION_E = """\
-airflow cmd_e cmd_f                       | Help text F
-airflow cmd_e cmd_g                       | Help text G
+airflow cmd_e cmd_f                             | Help text F
+airflow cmd_e cmd_g                             | Help text G
 """
 
 


### PR DESCRIPTION
Before:
<img width="1037" alt="Screenshot 2024-04-09 at 10 57 11 PM" src="https://github.com/apache/airflow/assets/66968678/22c1cacc-5a06-4e73-9572-5b2d5f7cbe1c">

After:
<img width="1098" alt="Screenshot 2024-04-09 at 10 56 43 PM" src="https://github.com/apache/airflow/assets/66968678/a520c2e6-090e-45ba-8035-926a04f5127e">
