### PR TITLE
Don't queue runs on DatasetEvent for disabled DAGs

### DIFF
--- a/airflow/datasets/manager.py
+++ b/airflow/datasets/manager.py
@@ -25,13 +25,14 @@ from sqlalchemy.orm import joinedload
 from airflow.configuration import conf
 from airflow.datasets import Dataset
 from airflow.listeners.listener import get_listener_manager
-from airflow.models.dataset import DatasetDagRunQueue, DatasetEvent, DatasetModel
+from airflow.models.dataset import DagScheduleDatasetReference, DatasetDagRunQueue, DatasetEvent, DatasetModel
 from airflow.stats import Stats
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 if TYPE_CHECKING:
     from sqlalchemy.orm.session import Session
 
+    from airflow.models.dag import DagModel
     from airflow.models.taskinstance import TaskInstance
 
 
@@ -73,7 +74,7 @@ class DatasetManager(LoggingMixin):
         dataset_model = session.scalar(
             select(DatasetModel)
             .where(DatasetModel.uri == dataset.uri)
-            .options(joinedload(DatasetModel.consuming_dags))
+            .options(joinedload(DatasetModel.consuming_dags).joinedload(DagScheduleDatasetReference.dag))
         )
         if not dataset_model:
             self.log.warning("DatasetModel %s not found", dataset)
@@ -99,8 +100,7 @@ class DatasetManager(LoggingMixin):
         self.notify_dataset_changed(dataset=dataset)
 
         Stats.incr("dataset.updates")
-        if dataset_model.consuming_dags:
-            self._queue_dagruns(dataset_model, session)
+        self._queue_dagruns(dataset_model, session)
         session.flush()
         return dataset_event
 
@@ -127,26 +127,30 @@ class DatasetManager(LoggingMixin):
         return self._slow_path_queue_dagruns(dataset, session)
 
     def _slow_path_queue_dagruns(self, dataset: DatasetModel, session: Session) -> None:
-        consuming_dag_ids = [x.dag_id for x in dataset.consuming_dags]
-        self.log.debug("consuming dag ids %s", consuming_dag_ids)
-
-        # Don't error whole transaction when a single RunQueue item conflicts.
-        # https://docs.sqlalchemy.org/en/14/orm/session_transaction.html#using-savepoint
-        for dag_id in consuming_dag_ids:
-            item = DatasetDagRunQueue(target_dag_id=dag_id, dataset_id=dataset.id)
+        def _queue_dagrun_if_needed(dag: DagModel) -> str | None:
+            if not dag.is_active or dag.is_paused:
+                return None
+            item = DatasetDagRunQueue(target_dag_id=dag.dag_id, dataset_id=dataset.id)
+            # Don't error whole transaction when a single RunQueue item conflicts.
+            # https://docs.sqlalchemy.org/en/14/orm/session_transaction.html#using-savepoint
             try:
                 with session.begin_nested():
                     session.merge(item)
             except exc.IntegrityError:
                 self.log.debug("Skipping record %s", item, exc_info=True)
+            return dag.dag_id
+
+        queued_results = (_queue_dagrun_if_needed(ref.dag) for ref in dataset.consuming_dags)
+        if queued_dag_ids := [r for r in queued_results if r is not None]:
+            self.log.debug("consuming dag ids %s", queued_dag_ids)
 
     def _postgres_queue_dagruns(self, dataset: DatasetModel, session: Session) -> None:
         from sqlalchemy.dialects.postgresql import insert
 
-        stmt = insert(DatasetDagRunQueue).values(dataset_id=dataset.id).on_conflict_do_nothing()
+        consuming_dags = (r.dag for r in dataset.consuming_dags)
         session.execute(
-            stmt,
-            [{"target_dag_id": target_dag.dag_id} for target_dag in dataset.consuming_dags],
+            insert(DatasetDagRunQueue).values(dataset_id=dataset.id).on_conflict_do_nothing(),
+            [{"target_dag_id": dag.dag_id} for dag in consuming_dags if dag.is_active and not dag.is_paused],
         )
 
 

--- a/airflow/models/dataset.py
+++ b/airflow/models/dataset.py
@@ -112,6 +112,8 @@ class DagScheduleDatasetReference(Base):
     updated_at = Column(UtcDateTime, default=timezone.utcnow, onupdate=timezone.utcnow, nullable=False)
 
     dataset = relationship("DatasetModel", back_populates="consuming_dags")
+    dag = relationship("DagModel")
+
     queue_records = relationship(
         "DatasetDagRunQueue",
         primaryjoin="""and_(

--- a/newsfragments/38891.significant.rst
+++ b/newsfragments/38891.significant.rst
@@ -5,3 +5,6 @@ trigger it, and the DAG would run when it is unpaused or added back in a DAG
 file. This has been changed; a DAG's dataset schedule can now only be satisfied
 by events that occur when the DAG is active. While this is a breaking change,
 the previous behavior is considered a bug.
+
+The behavior of time-based scheduling is unchanged, including the timetable part
+of ``DatasetOrTimeSchedule``.

--- a/newsfragments/38891.significant.rst
+++ b/newsfragments/38891.significant.rst
@@ -1,0 +1,7 @@
+Datasets no longer trigger inactive DAGs
+
+Previously, when a DAG is paused or removed, incoming dataset events would still
+trigger it, and the DAG would run when it is unpaused or added back in a DAG
+file. This has been changed; a DAG's dataset schedule can now only be satisfied
+by events that occur when the DAG is active. While this is a breaking change,
+the previous behavior is considered a bug.

--- a/tests/datasets/test_manager.py
+++ b/tests/datasets/test_manager.py
@@ -70,8 +70,8 @@ class TestDatasetManager:
         dsem = DatasetManager()
 
         ds = Dataset(uri="test_dataset_uri")
-        dag1 = DagModel(dag_id="dag1")
-        dag2 = DagModel(dag_id="dag2")
+        dag1 = DagModel(dag_id="dag1", is_active=True)
+        dag2 = DagModel(dag_id="dag2", is_active=True)
         session.add_all([dag1, dag2])
 
         dsm = DatasetModel(uri="test_dataset_uri")


### PR DESCRIPTION
Maybe fix #38826?

This adds an additional filter on consuming DAG, and only create a DatasetDagRunQueue entry if the DAG is both active (i.e. still exists in a DAG file) and unpaused.

There are still questions unanswered:

1. Do we consider catchup? The immediate problem here is catchup is not stored on DagModel, and checking it from DAG creates significant overhead.
2. Do we just change the behavior outright? This is a breaking change since users relying on a disabled DAG can still accumulating events (that trigger runs later) as a feature will see it broken. We can maybe categorize the current behavior as a bug.