### PR TITLE
add log for running callback

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -117,7 +117,6 @@ from airflow.utils.context import (
 from airflow.utils.email import send_email
 from airflow.utils.helpers import prune_dict, render_template_to_string
 from airflow.utils.log.logging_mixin import LoggingMixin
-from airflow.utils.module_loading import qualname
 from airflow.utils.net import get_hostname
 from airflow.utils.operator_helpers import ExecutionCallableRunner, context_to_airflow_vars
 from airflow.utils.platform import getuser
@@ -1230,12 +1229,11 @@ def _run_finished_callback(
     if callbacks:
         callbacks = callbacks if isinstance(callbacks, list) else [callbacks]
         for callback in callbacks:
-            callback_name = qualname(callback).split(".")[-1]
+            log.info("Executing %s callback", callback.__name__)
             try:
-                log.info("Executing %s callback", callback_name)
                 callback(context)
             except Exception:
-                log.exception("Error when executing %s callback", callback_name)  # type: ignore[attr-defined]
+                log.exception("Error when executing %s callback", callback.__name__)  # type: ignore[attr-defined]
 
 
 def _log_state(*, task_instance: TaskInstance | TaskInstancePydantic, lead_msg: str = "") -> None:

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1230,8 +1230,8 @@ def _run_finished_callback(
     if callbacks:
         callbacks = callbacks if isinstance(callbacks, list) else [callbacks]
         for callback in callbacks:
+            callback_name = qualname(callback).split(".")[-1]
             try:
-                callback_name = qualname(callback).split(".")[-1]
                 log.info("Executing %s callback", callback_name)
                 callback(context)
             except Exception:

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1231,9 +1231,10 @@ def _run_finished_callback(
         callbacks = callbacks if isinstance(callbacks, list) else [callbacks]
         for callback in callbacks:
             try:
+                callback_name = qualname(callback).split(".")[-1]
+                log.info("Executing %s callback", callback_name)
                 callback(context)
             except Exception:
-                callback_name = qualname(callback).split(".")[-1]
                 log.exception("Error when executing %s callback", callback_name)  # type: ignore[attr-defined]
 
 

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2879,7 +2879,9 @@ class TestTaskInstance:
         get_listener_manager().pm.hook.on_task_instance_failed = listener_callback_on_error
 
         mock_on_failure_1 = mock.MagicMock()
+        mock_on_failure_1.__name__ = "mock_on_failure_1"
         mock_on_retry_1 = mock.MagicMock()
+        mock_on_retry_1.__name__ = "mock_on_retry_1"
         dag, task1 = create_dummy_dag(
             dag_id="test_handle_failure",
             schedule=None,
@@ -2916,7 +2918,9 @@ class TestTaskInstance:
         mock_on_retry_1.assert_not_called()
 
         mock_on_failure_2 = mock.MagicMock()
+        mock_on_failure_2.__name__ = "mock_on_failure_2"
         mock_on_retry_2 = mock.MagicMock()
+        mock_on_retry_2.__name__ = "mock_on_retry_2"
         task2 = EmptyOperator(
             task_id="test_handle_failure_on_retry",
             on_failure_callback=mock_on_failure_2,
@@ -2938,7 +2942,9 @@ class TestTaskInstance:
 
         # test the scenario where normally we would retry but have been asked to fail
         mock_on_failure_3 = mock.MagicMock()
+        mock_on_failure_3.__name__ = "mock_on_failure_3"
         mock_on_retry_3 = mock.MagicMock()
+        mock_on_retry_3.__name__ = "mock_on_retry_3"
         task3 = EmptyOperator(
             task_id="test_handle_failure_on_force_fail",
             on_failure_callback=mock_on_failure_3,
@@ -3454,6 +3460,7 @@ class TestTaskInstance:
             raise AirflowSkipException
 
         callback_function = mock.MagicMock()
+        callback_function.__name__ = "callback_function"
 
         with dag_maker(dag_id="test_skipped_task"):
             task = PythonOperator(
@@ -3549,6 +3556,7 @@ def test_sensor_timeout(mode, retries, dag_maker):
         raise AirflowSensorTimeout
 
     mock_on_failure = mock.MagicMock()
+    mock_on_failure.__name__ = "mock_on_failure"
     with dag_maker(dag_id=f"test_sensor_timeout_{mode}_{retries}"):
         PythonSensor(
             task_id="test_raise_sensor_timeout",
@@ -3577,6 +3585,7 @@ def test_mapped_sensor_timeout(mode, retries, dag_maker):
         raise AirflowSensorTimeout
 
     mock_on_failure = mock.MagicMock()
+    mock_on_failure.__name__ = "mock_on_failure"
     with dag_maker(dag_id=f"test_sensor_timeout_{mode}_{retries}"):
         PythonSensor.partial(
             task_id="test_raise_sensor_timeout",

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2858,8 +2858,9 @@ class TestTaskInstance:
         ],
     )
     @patch("logging.Logger.exception")
+    @patch("logging.Logger.info")
     def test_finished_callbacks_handle_and_log_exception(
-        self, mock_log, finished_state, create_task_instance
+        self, mock_log_info, mock_log_exception, finished_state, create_task_instance
     ):
         called = completed = False
 
@@ -2877,7 +2878,8 @@ class TestTaskInstance:
             callback_name = callback_input[0] if isinstance(callback_input, list) else callback_input
             callback_name = qualname(callback_name).split(".")[-1]
             expected_message = "Error when executing %s callback"
-            mock_log.assert_called_with(expected_message, callback_name)
+            mock_log_info.assert_called_with("Executing %s callback", callback_name)
+            mock_log_exception.assert_called_with(expected_message, callback_name)
 
     @provide_session
     def test_handle_failure(self, create_dummy_dag, session=None):


### PR DESCRIPTION
Today there is no log when running callbacks, in our company client want to know if callbacks where running.
I think this should be info log and not debug log.
If you have a better message let me know 😄 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
