### PR TITLE
Expose count of scheduled tasks in metrics

### DIFF
--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1587,11 +1587,14 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             Stats.gauge(f"pool.queued_slots.{pool_name}", slot_stats["queued"])
             Stats.gauge(f"pool.running_slots.{pool_name}", slot_stats["running"])
             Stats.gauge(f"pool.deferred_slots.{pool_name}", slot_stats["deferred"])
+            Stats.gauge(f"pool.scheduled_slots.{pool_name}", slot_stats["scheduled"])
+
             # Same metrics with tagging
             Stats.gauge("pool.open_slots", slot_stats["open"], tags={"pool_name": pool_name})
             Stats.gauge("pool.queued_slots", slot_stats["queued"], tags={"pool_name": pool_name})
             Stats.gauge("pool.running_slots", slot_stats["running"], tags={"pool_name": pool_name})
             Stats.gauge("pool.deferred_slots", slot_stats["deferred"], tags={"pool_name": pool_name})
+            Stats.gauge("pool.scheduled_slots", slot_stats["scheduled"], tags={"pool_name": pool_name})
 
     @provide_session
     def adopt_or_reset_orphaned_tasks(self, session: Session = NEW_SESSION) -> int:

--- a/docs/apache-airflow/administration-and-deployment/logging-monitoring/metrics.rst
+++ b/docs/apache-airflow/administration-and-deployment/logging-monitoring/metrics.rst
@@ -238,6 +238,8 @@ Name                                                Description
 ``pool.running_slots``                              Number of running slots in the pool. Metric with pool_name tagging.
 ``pool.deferred_slots.<pool_name>``                 Number of deferred slots in the pool
 ``pool.deferred_slots``                             Number of deferred slots in the pool. Metric with pool_name tagging.
+``pool.scheduled_tasks.<pool_name>``                Number of scheduled tasks in the pool
+``pool.scheduled_tasks``                            Number of scheduled tasks in the pool. Metric with pool_name tagging.
 ``pool.starving_tasks.<pool_name>``                 Number of starving tasks in the pool
 ``pool.starving_tasks``                             Number of starving tasks in the pool. Metric with pool_name tagging.
 ``triggers.running.<hostname>``                     Number of triggers currently running for a triggerer (described by hostname)


### PR DESCRIPTION
This pull request introduces a new metric that tracks the number of tasks in the SCHEDULED state. This can help with monitoring and debugging situations where tasks are stuck or otherwise accumulate in the `SCHEDULED` state.
