### PR TITLE
Fix error when setting try_number from TaskInstancePydantic

### DIFF
--- a/airflow/serialization/pydantic/taskinstance.py
+++ b/airflow/serialization/pydantic/taskinstance.py
@@ -23,7 +23,7 @@ from typing_extensions import Annotated
 
 from airflow.models import Operator
 from airflow.models.baseoperator import BaseOperator
-from airflow.models.taskinstance import TaskInstance
+from airflow.models.taskinstance import TaskInstance, _get_try_number, _set_try_number
 from airflow.serialization.pydantic.dag import DagModelPydantic
 from airflow.serialization.pydantic.dag_run import DagRunPydantic
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -84,7 +84,6 @@ class TaskInstancePydantic(BaseModelPydantic, LoggingMixin):
     execution_date: Optional[datetime]
     duration: Optional[float]
     state: Optional[str]
-    try_number: int
     _try_number: int
     max_tries: int
     hostname: str
@@ -116,6 +115,18 @@ class TaskInstancePydantic(BaseModelPydantic, LoggingMixin):
     raw: Optional[bool]
     is_trigger_log_context: Optional[bool]
     model_config = ConfigDict(from_attributes=True, arbitrary_types_allowed=True)
+
+    def __init__(self, **data):
+        super().__init__(**data)
+        self._try_number = 0
+
+    @property
+    def try_number(self):
+        return _get_try_number(task_instance=self)
+
+    @try_number.setter
+    def try_number(self, value):
+        _set_try_number(task_instance=self, value=value)
 
     @property
     def _logger_name(self):


### PR DESCRIPTION
Here we get rid of the public attr `try_number` and just keep private _try_number and use the same try_number logic as in models/TaskInstance

with this (and a few other changes) a task will run in db isolation mode, but the logging isn't quite right as it will go to two different files. (attempt=1 and attempt=2)  have to figure out why.  but this is basically "more correct" than status quo IMHO.

i followed example here: https://docs.pydantic.dev/latest/concepts/models/#private-model-attributes

