### PR TITLE
Fix check of correct dag when remote call for _get_ti

### DIFF
--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -169,8 +169,11 @@ def _get_ti_db_access(
     session: Session = NEW_SESSION,
 ) -> tuple[TaskInstance | TaskInstancePydantic, bool]:
     """Get the task instance through DagRun.run_id, if that fails, get the TI the old way."""
-    if task.dag_id != dag.dag_id:
-        raise ValueError(f"Provided task '{task.task_id}' is not assigned to provided dag {dag.dag_id}.")
+    # this check is imperfect because diff dags could have tasks with same name
+    # but in a task, dag_id is a property that accesses its dag, and we don't
+    # currently include the dag when serializing an operator
+    if task.task_id not in dag.task_dict:
+        raise ValueError(f"Provided task {task.task_id} is not in dag '{dag.dag_id}.")
 
     if not exec_date_or_run_id and not create_if_necessary:
         raise ValueError("Must provide `exec_date_or_run_id` if not `create_if_necessary`.")


### PR DESCRIPTION
We actually can't use the check `if task.dag_id != dag.dag_id` when it's a RPC call because we _don't actually serialize dag_ as part of the serialized operator.  And this sorta makes sense, because when serialization of Operator was added, it was always going to be in the context of a serialized _dag_.  So why add the serialized dag on the operator?  Indeed, if you fully represented the dag on the operator itself, you'd encounter infinite recursion!
But anyway, when we round trip an operator through BaseSerialization, we lose information about the dag.
@uranusjr @potiuk @jedcunningham  I think it might be worth spending a brain cycle or two considering this.  Do you think perhaps that we should add `dag_id` as an attribute?  Or perhaps we could or should provide a mechanism to add a "partial" dag object that has at least the attrs we need on the `Operator.dag` attr?  Otherwise we can leave well enough alone and move on.  I don't think we _really_ need this check (@uranusjr you suggested adding it so you might weigh in)