### PR TITLE
Fix bug in LivyOperator when its trigger times out

### DIFF
--- a/airflow/providers/apache/livy/operators/livy.py
+++ b/airflow/providers/apache/livy/operators/livy.py
@@ -124,7 +124,7 @@ class LivyOperator(BaseOperator):
         self._extra_options = extra_options or {}
         self._extra_headers = extra_headers or {}
 
-        self._batch_id: int | str
+        self._batch_id: int | str | None = None
         self.retry_args = retry_args
         self.deferrable = deferrable
 
@@ -170,6 +170,7 @@ class LivyOperator(BaseOperator):
                     polling_interval=self._polling_interval,
                     extra_options=self._extra_options,
                     extra_headers=self._extra_headers,
+                    execution_timeout=self.execution_timeout,
                 ),
                 method_name="execute_complete",
             )
@@ -217,8 +218,12 @@ class LivyOperator(BaseOperator):
             for log_line in event["log_lines"]:
                 self.log.info(log_line)
 
-        if event["status"] == "error":
+        if event["status"] == "timeout":
+            self.hook.delete_batch(event["batch_id"])
+
+        if event["status"] in ["error", "timeout"]:
             raise AirflowException(event["response"])
+
         self.log.info(
             "%s completed with response %s",
             self.task_id,


### PR DESCRIPTION
### Related issue
closes: https://github.com/apache/airflow/issues/37898

### Explain

When a LivyOperator was instantiated with deferrable=True and its batch job ran for more time than the set execution_timeout, airflow would detect this timeout and would cancel the trigger and then try to kill the task with the 'on_kill' method.

But that would fail raising an AttributeError because the batch_id attribute wouldn't be defined in the constructor method.

From now on, the LivyTrigger will timeout itself before airflow does it, and it will send an event to the LivyOperator signaling that a timeout happened. This way, the operator can stop the running Livy batch job, and can fail the task instance gracefully.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

---