### PR TITLE
FIX bug duplicated add base_folder to oss_remote_log_location in oss_wri…

### DIFF
--- a/airflow/providers/alibaba/cloud/log/oss_task_handler.py
+++ b/airflow/providers/alibaba/cloud/log/oss_task_handler.py
@@ -172,7 +172,7 @@ class OSSTaskHandler(FileTaskHandler, LoggingMixin):
         """
         oss_remote_log_location = f"{self.base_folder}/{remote_log_location}"
         pos = 0
-        if append and self.oss_log_exists(oss_remote_log_location):
+        if append and self.oss_log_exists(remote_log_location):
             head = self.hook.head_key(self.bucket_name, oss_remote_log_location)
             pos = head.content_length
         self.log.info("log write pos is: %s", pos)


### PR DESCRIPTION
As title said.

This bug will cause  deferrable operators can not append multiple run logs into a expected single oss log file.