### PR TITLE
Fix `SAWarning` 'Coercing Subquery object into a select() for use in IN()'

### DIFF
--- a/airflow/api_connexion/endpoints/import_error_endpoint.py
+++ b/airflow/api_connexion/endpoints/import_error_endpoint.py
@@ -94,11 +94,9 @@ def get_import_errors(
     if not can_read_all_dags:
         # if the user doesn't have access to all DAGs, only display errors from visible DAGs
         readable_dag_ids = security.get_readable_dags()
-        dagfiles_subq = (
-            select(DagModel.fileloc).distinct().where(DagModel.dag_id.in_(readable_dag_ids)).subquery()
-        )
-        query = query.where(ImportErrorModel.filename.in_(dagfiles_subq))
-        count_query = count_query.where(ImportErrorModel.filename.in_(dagfiles_subq))
+        dagfiles_stmt = select(DagModel.fileloc).distinct().where(DagModel.dag_id.in_(readable_dag_ids))
+        query = query.where(ImportErrorModel.filename.in_(dagfiles_stmt))
+        count_query = count_query.where(ImportErrorModel.filename.in_(dagfiles_stmt))
 
     total_entries = session.scalars(count_query).one()
     import_errors = session.scalars(query.offset(offset).limit(limit)).all()

--- a/airflow/utils/db_cleanup.py
+++ b/airflow/utils/db_cleanup.py
@@ -186,9 +186,7 @@ def _do_delete(*, query, orm_model, skip_archive, session):
     if dialect_name == "sqlite":
         pk_cols = source_table.primary_key.columns
         delete = source_table.delete().where(
-            tuple_(*pk_cols).in_(
-                select(*[target_table.c[x.name] for x in source_table.primary_key.columns]).subquery()
-            )
+            tuple_(*pk_cols).in_(select(*[target_table.c[x.name] for x in source_table.primary_key.columns]))
         )
     else:
         delete = source_table.delete().where(

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -952,10 +952,7 @@ class Airflow(AirflowBaseView):
                     # if the user doesn't have access to all DAGs, only display errors from visible DAGs
                     import_errors = import_errors.where(
                         errors.ImportError.filename.in_(
-                            select(DagModel.fileloc)
-                            .distinct()
-                            .where(DagModel.dag_id.in_(filter_dag_ids))
-                            .subquery()
+                            select(DagModel.fileloc).distinct().where(DagModel.dag_id.in_(filter_dag_ids))
                         )
                     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -466,6 +466,7 @@ filterwarnings = [
     "error::pytest.PytestCollectionWarning",
     # Avoid building cartesian product which might impact performance
     "error:SELECT statement has a cartesian product between FROM:sqlalchemy.exc.SAWarning:airflow",
+    'error:Coercing Subquery object into a select\(\) for use in IN\(\):sqlalchemy.exc.SAWarning:airflow',
     "ignore::DeprecationWarning:flask_appbuilder.filemanager",
     "ignore::DeprecationWarning:flask_appbuilder.widgets",
     # FAB do not support SQLAclhemy 2


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This is not necessary to call `subquery` if we intend to use `select` statement into the in statement.
This one just produce annoying warning.

```json
[
  {
    "category": "sqlalchemy.exc.SAWarning",
    "message": "Coercing Subquery object into a select() for use in IN(); please pass a select() construct explicitly",
    "node_id": "tests/api_connexion/endpoints/test_import_error_endpoint.py::TestGetImportErrorsEndpoint::test_get_import_errors_single_dag",
    "filename": "airflow/api_connexion/endpoints/import_error_endpoint.py",
    "lineno": 100,
    "count": 1
  },
  {
    "category": "sqlalchemy.exc.SAWarning",
    "message": "Coercing Subquery object into a select() for use in IN(); please pass a select() construct explicitly",
    "node_id": "tests/api_connexion/endpoints/test_import_error_endpoint.py::TestGetImportErrorsEndpoint::test_get_import_errors_single_dag",
    "filename": "airflow/api_connexion/endpoints/import_error_endpoint.py",
    "lineno": 101,
    "count": 1
  },
  {
    "category": "sqlalchemy.exc.SAWarning",
    "message": "Coercing Subquery object into a select() for use in IN(); please pass a select() construct explicitly",
    "node_id": "tests/www/views/test_views_home.py::test_home_importerrors_filtered_singledag_user",
    "filename": "airflow/www/views.py",
    "lineno": 954,
    "count": 6
  },
  {
    "category": "sqlalchemy.exc.SAWarning",
    "message": "Coercing Subquery object into a select() for use in IN(); please pass a select() construct explicitly",
    "node_id": "tests/utils/test_db_cleanup.py::TestDBCleanup::test__cleanup_table",
    "filename": "airflow/utils/db_cleanup.py",
    "lineno": 189,
    "count": 5
  }
]
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
