### PR TITLE
Use `model_dump` instead of `dict` for serialize Pydantic V2 model

### DIFF
--- a/airflow/serialization/serde.py
+++ b/airflow/serialization/serde.py
@@ -168,7 +168,7 @@ def serialize(o: object, depth: int = 0) -> U | None:
 
     # pydantic models are recursive
     if _is_pydantic(cls):
-        data = o.dict()  # type: ignore[attr-defined]
+        data = o.model_dump()  # type: ignore[attr-defined]
         dct[DATA] = serialize(data, depth + 1)
         return dct
 

--- a/tests/serialization/test_serde.py
+++ b/tests/serialization/test_serde.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import datetime
 import enum
+import warnings
 from collections import namedtuple
 from dataclasses import dataclass
 from importlib import import_module
@@ -438,10 +439,12 @@ class TestSerDe:
         assert i == s
 
     def test_pydantic(self):
-        pytest.importorskip("pydantic", minversion="2.0.0")
-        i = U(x=10, v=V(W(10), ["l1", "l2"], (1, 2), 10), u=(1, 2))
-        e = serialize(i)
-        s = deserialize(e)
+        pydantic = pytest.importorskip("pydantic", minversion="2.0.0")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", category=pydantic.warnings.PydanticDeprecationWarning)
+            i = U(x=10, v=V(W(10), ["l1", "l2"], (1, 2), 10), u=(1, 2))
+            e = serialize(i)
+            s = deserialize(e)
         assert i == s
 
     def test_error_when_serializing_callable_without_name(self):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

We intends to serialise Pydantic V2 models, at least we check V2 attributes

https://github.com/apache/airflow/blob/b2a05225f87269017fd1f24ab39e000a9c064767/airflow/serialization/serde.py#L339-L345

So there is no reason to call in this block [deprecated methods/attributes](https://docs.pydantic.dev/2.6/migration/#changes-to-pydanticbasemodel)

```json
{
  "category": "pydantic.warnings.PydanticDeprecatedSince20",
  "message": "The `dict` method is deprecated; use `model_dump` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.6/migration/",
  "node_id": "tests/serialization/test_serde.py::TestSerDe::test_pydantic",
  "filename": "pydantic/main.py",
  "lineno": 1024,
  "count": 1
}
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
