### PR TITLE
Graph view improvements

### DIFF
--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -679,9 +679,11 @@ class TaskGroupContext:
 def task_group_to_dict(task_item_or_group):
     """Create a nested dict representation of this TaskGroup and its children used to construct the Graph."""
     from airflow.models.abstractoperator import AbstractOperator
+    from airflow.models.mappedoperator import MappedOperator
 
     if isinstance(task := task_item_or_group, AbstractOperator):
         setup_teardown_type = {}
+        is_mapped = isinstance(task, MappedOperator)
         if task.is_setup is True:
             setup_teardown_type["setupTeardownType"] = "setup"
         elif task.is_teardown is True:
@@ -694,6 +696,7 @@ def task_group_to_dict(task_item_or_group):
                 "style": f"fill:{task.ui_color};",
                 "rx": 5,
                 "ry": 5,
+                "isMapped": is_mapped,
                 **setup_teardown_type,
             },
         }

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -683,11 +683,13 @@ def task_group_to_dict(task_item_or_group):
 
     if isinstance(task := task_item_or_group, AbstractOperator):
         setup_teardown_type = {}
-        is_mapped = isinstance(task, MappedOperator)
+        is_mapped = {}
         if task.is_setup is True:
             setup_teardown_type["setupTeardownType"] = "setup"
         elif task.is_teardown is True:
             setup_teardown_type["setupTeardownType"] = "teardown"
+        if isinstance(task, MappedOperator):
+            is_mapped["isMapped"] = True
         return {
             "id": task.task_id,
             "value": {
@@ -696,7 +698,7 @@ def task_group_to_dict(task_item_or_group):
                 "style": f"fill:{task.ui_color};",
                 "rx": 5,
                 "ry": 5,
-                "isMapped": is_mapped,
+                **is_mapped,
                 **setup_teardown_type,
             },
         }

--- a/airflow/www/static/js/dag/TaskName.tsx
+++ b/airflow/www/static/js/dag/TaskName.tsx
@@ -54,7 +54,6 @@ const TaskName = ({
       data-testid={id}
       color={colors.gray[800]}
       fontSize={isZoomedOut ? 24 : undefined}
-      textAlign="justify"
       {...rest}
     >
       <chakra.span onClick={onClick}>

--- a/airflow/www/static/js/dag/details/graph/DagNode.tsx
+++ b/airflow/www/static/js/dag/details/graph/DagNode.tsx
@@ -18,7 +18,7 @@
  */
 
 import React from "react";
-import { Box, Flex, Text } from "@chakra-ui/react";
+import { Flex, Text, useTheme } from "@chakra-ui/react";
 import type { NodeProps } from "reactflow";
 
 import { SimpleStatus } from "src/dag/StatusBox";
@@ -53,10 +53,12 @@ const DagNode = ({
 }: NodeProps<CustomNodeProps>) => {
   const { onSelect } = useSelection();
   const containerRef = useContainerRef();
+  const { colors } = useTheme();
 
   if (!task) return null;
 
-  const bg = isOpen ? "blackAlpha.50" : "white";
+  const isGroup = !!task.children?.length;
+  const groupBg = isOpen ? `${colors.blue[500]}15` : "blue.50";
   const { isMapped } = task;
   const mappedStates = instance?.mappedStates;
 
@@ -67,9 +69,9 @@ const DagNode = ({
     : label;
 
   let operatorTextColor = "";
-  let operatorBG = "";
+  let operatorBg = "";
   if (style) {
-    [, operatorBG] = style.split(":");
+    [, operatorBg] = style.split(":");
   }
 
   if (labelStyle) {
@@ -83,6 +85,12 @@ const DagNode = ({
       ? stateColors[instance.state]
       : "gray.400";
 
+  let borderWidth = 2;
+  if (isZoomedOut) {
+    if (isSelected) borderWidth = 8;
+    else borderWidth = 6;
+  } else if (isSelected) borderWidth = 4;
+
   return (
     <Tooltip
       label={
@@ -95,15 +103,16 @@ const DagNode = ({
       placement="top"
       openDelay={hoverDelay}
     >
-      <Box
+      <Flex
         borderRadius={isZoomedOut ? 10 : 5}
-        borderWidth={(isSelected ? 4 : 2) * (isZoomedOut ? 3 : 1)}
+        borderWidth={borderWidth}
         borderColor={nodeBorderColor}
+        wordBreak="break-word"
         bg={
-          !task.children?.length && operatorBG
+          !task.children?.length && operatorBg
             ? // Fade the operator color to clash less with the task instance status
-              `color-mix(in srgb, ${operatorBG.replace(";", "")} 80%, white)`
-            : bg
+              `color-mix(in srgb, ${operatorBg.replace(";", "")} 80%, white)`
+            : groupBg
         }
         height={`${height}px`}
         width={`${width}px`}
@@ -121,6 +130,10 @@ const DagNode = ({
         }}
         px={isZoomedOut ? 1 : 2}
         mt={isZoomedOut ? -2 : 0}
+        alignItems={isZoomedOut && !isGroup ? "center" : undefined}
+        justifyContent={isZoomedOut && !isGroup ? "center" : undefined}
+        flexDirection="column"
+        overflow="wrap"
       >
         <TaskName
           label={taskName}
@@ -131,9 +144,7 @@ const DagNode = ({
             onToggleCollapse();
           }}
           setupTeardownType={setupTeardownType}
-          fontWeight="bold"
           isZoomedOut={isZoomedOut}
-          mt={isZoomedOut ? -2 : 0}
           noOfLines={2}
         />
         {!isZoomedOut && (
@@ -159,7 +170,7 @@ const DagNode = ({
             )}
           </>
         )}
-      </Box>
+      </Flex>
     </Tooltip>
   );
 };

--- a/airflow/www/static/js/dag/details/graph/DagNode.tsx
+++ b/airflow/www/static/js/dag/details/graph/DagNode.tsx
@@ -57,7 +57,6 @@ const DagNode = ({
 
   if (!task) return null;
 
-  const isGroup = !!task.children?.length;
   const groupBg = isOpen ? `${colors.blue[500]}15` : "blue.50";
   const { isMapped } = task;
   const mappedStates = instance?.mappedStates;
@@ -87,7 +86,7 @@ const DagNode = ({
 
   let borderWidth = 2;
   if (isZoomedOut) {
-    if (isSelected) borderWidth = 8;
+    if (isSelected) borderWidth = 10;
     else borderWidth = 6;
   } else if (isSelected) borderWidth = 4;
 
@@ -130,8 +129,8 @@ const DagNode = ({
         }}
         px={isZoomedOut ? 1 : 2}
         mt={isZoomedOut ? -2 : 0}
-        alignItems={isZoomedOut && !isGroup ? "center" : undefined}
-        justifyContent={isZoomedOut && !isGroup ? "center" : undefined}
+        alignItems={isZoomedOut && !isOpen ? "center" : undefined}
+        justifyContent={isZoomedOut && !isOpen ? "center" : undefined}
         flexDirection="column"
         overflow="wrap"
       >

--- a/airflow/www/static/js/dag/grid/renderTaskRows.tsx
+++ b/airflow/www/static/js/dag/grid/renderTaskRows.tsx
@@ -182,11 +182,11 @@ const Row = (props: RowProps) => {
               pl={level * 4 + 4}
               setupTeardownType={task.setupTeardownType}
               pr={4}
-              fontWeight={
-                isGroup || (task.isMapped && !isParentMapped)
-                  ? "bold"
-                  : "normal"
-              }
+              // fontWeight={
+              //   isGroup || (task.isMapped && !isParentMapped)
+              //     ? "bold"
+              //     : "normal"
+              // }
               noOfLines={1}
             />
           </Td>

--- a/airflow/www/static/js/dag/grid/renderTaskRows.tsx
+++ b/airflow/www/static/js/dag/grid/renderTaskRows.tsx
@@ -182,11 +182,6 @@ const Row = (props: RowProps) => {
               pl={level * 4 + 4}
               setupTeardownType={task.setupTeardownType}
               pr={4}
-              // fontWeight={
-              //   isGroup || (task.isMapped && !isParentMapped)
-              //     ? "bold"
-              //     : "normal"
-              // }
               noOfLines={1}
             />
           </Td>

--- a/airflow/www/static/js/types/index.ts
+++ b/airflow/www/static/js/types/index.ts
@@ -143,6 +143,7 @@ interface DepNode {
     labelStyle?: string;
     style?: string;
     setupTeardownType?: "setup" | "teardown";
+    isMapped?: boolean;
   };
   children?: DepNode[];
   edges?: MidEdge[];

--- a/airflow/www/static/js/utils/graph.ts
+++ b/airflow/www/static/js/utils/graph.ts
@@ -173,8 +173,10 @@ const generateGraph = ({
         }));
       closedGroupIds.push(id);
     }
-    const extraLabelLength =
-      value.label.length > 20 ? value.label.length - 19 : 0;
+
+    const label = value.isMapped ? `${value.label} [100]` : value.label;
+    const labelLength = getTextWidth(label, font);
+    const width = labelLength > 200 ? labelLength : 200;
 
     return {
       id,
@@ -184,9 +186,8 @@ const generateGraph = ({
         isJoinNode,
         childCount,
       },
-      // Make tasks with long names wider
-      width: isJoinNode ? 10 : 200 + extraLabelLength * 5,
-      height: isJoinNode ? 10 : 70,
+      width: isJoinNode ? 10 : width,
+      height: isJoinNode ? 10 : 80,
     };
   };
 


### PR DESCRIPTION
The text was getting cut off too many times for graph view nodes. The zoomed out version was also hard to read. 


Before:
<img width="420" alt="Screenshot 2024-04-11 at 1 14 15 PM" src="https://github.com/apache/airflow/assets/4600967/6c93cb8a-b970-4de0-b2ec-9310405f1dd7">
<img width="805" alt="Screenshot 2024-04-11 at 1 14 10 PM" src="https://github.com/apache/airflow/assets/4600967/b995506d-d5db-49bd-ba27-c75d119d60c1">


After:
<img width="496" alt="Screenshot 2024-04-11 at 1 02 15 PM" src="https://github.com/apache/airflow/assets/4600967/f32302e0-dbd2-4e7b-9905-7b68f5b431cd">
<img width="875" alt="Screenshot 2024-04-11 at 1 02 12 PM" src="https://github.com/apache/airflow/assets/4600967/bfe616cd-275a-420f-a680-35f39d847880">


Two questions:
- Should the simplified mode happen automatically when zooming out, or by toggling a checkbox?
- What other information would people find useful to include in the details node view?


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
