### PR TITLE
Activate RUF006 rule to detect dangling asyncio tasks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -335,7 +335,7 @@ repos:
         types_or: [python, pyi]
         args: [--fix]
         require_serial: true
-        additional_dependencies: ["ruff==0.3.5"]
+        additional_dependencies: ["ruff==0.3.6"]
         exclude: ^.*/.*_vendor/|^tests/dags/test_imports.py
       - id: ruff-format
         name: Run 'ruff format' for extremely fast Python formatting
@@ -345,7 +345,7 @@ repos:
         types_or: [python, pyi]
         args: []
         require_serial: true
-        additional_dependencies: ["ruff==0.3.5"]
+        additional_dependencies: ["ruff==0.3.6"]
         exclude: ^.*/.*_vendor/|^tests/dags/test_imports.py|^airflow/contrib/
       - id: replace-bad-characters
         name: Replace bad characters

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -290,6 +290,7 @@ extend-select = [
     "B017", # Checks for pytest.raises context managers that catch Exception or BaseException.
     "B019", # Use of functools.lru_cache or functools.cache on methods can lead to memory leaks
     "TRY002", # Prohibit use of `raise Exception`, use specific exceptions instead.
+    "RUF006", # Checks for asyncio dangling task
 ]
 ignore = [
     "D203",

--- a/tests/providers/google/cloud/triggers/test_bigquery.py
+++ b/tests/providers/google/cloud/triggers/test_bigquery.py
@@ -601,7 +601,7 @@ class TestBigQueryValueCheckTrigger:
         get_job_output.return_value = {}
         get_records.return_value = [[2], [4]]
 
-        asyncio.create_task(value_check_trigger.run().__anext__())
+        await value_check_trigger.run().__anext__()
         await asyncio.sleep(0.5)
 
         generator = value_check_trigger.run()


### PR DESCRIPTION
This rule is useful to detect the asyncio tasks which are created without setting their reference to a variable because this could lead to unexpected results like removing them by GC.