### PR TITLE
Use default_factory instead of calling the method in dataclass

### DIFF
--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -368,6 +368,7 @@ def get_airflow_version():
     return airflow_version
 
 
+@lru_cache(maxsize=None)
 def get_airflow_extras():
     airflow_dockerfile = AIRFLOW_SOURCES_ROOT / "Dockerfile"
     with open(airflow_dockerfile) as dockerfile:

--- a/dev/breeze/src/airflow_breeze/params/build_prod_params.py
+++ b/dev/breeze/src/airflow_breeze/params/build_prod_params.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import json
 import re
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from airflow_breeze.branch_defaults import AIRFLOW_BRANCH, DEFAULT_AIRFLOW_CONSTRAINTS_BRANCH
 from airflow_breeze.global_constants import (
@@ -43,7 +43,7 @@ class BuildProdParams(CommonBuildParams):
     airflow_constraints_mode: str = "constraints"
     airflow_constraints_reference: str = DEFAULT_AIRFLOW_CONSTRAINTS_BRANCH
     cleanup_context: bool = False
-    airflow_extras: str = get_airflow_extras()
+    airflow_extras: str = field(default_factory=get_airflow_extras)
     disable_airflow_repo_cache: bool = False
     disable_mssql_client_installation: bool = False
     disable_mysql_client_installation: bool = False


### PR DESCRIPTION
The method `get_airflow_extras` is called each time we import the module, which we can avoid by defining the attribute as a filed and setting the method as a default factory.