### PR TITLE
KPO xcom sidecar PodDefault usage

### DIFF
--- a/airflow/providers/cncf/kubernetes/pod_generator.py
+++ b/airflow/providers/cncf/kubernetes/pod_generator.py
@@ -50,7 +50,7 @@ from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import (
     rand_str,
 )
 from airflow.providers.cncf.kubernetes.pod_generator_deprecated import (
-    PodDefaults,
+    PodDefaults as PodDefaultsDeprecated,
     PodGenerator as PodGeneratorDeprecated,
 )
 from airflow.utils import yaml
@@ -180,10 +180,10 @@ class PodGenerator:
         """Add sidecar."""
         pod_cp = copy.deepcopy(pod)
         pod_cp.spec.volumes = pod.spec.volumes or []
-        pod_cp.spec.volumes.insert(0, PodDefaults.VOLUME)
+        pod_cp.spec.volumes.insert(0, PodDefaultsDeprecated.VOLUME)
         pod_cp.spec.containers[0].volume_mounts = pod_cp.spec.containers[0].volume_mounts or []
-        pod_cp.spec.containers[0].volume_mounts.insert(0, PodDefaults.VOLUME_MOUNT)
-        pod_cp.spec.containers.append(PodDefaults.SIDECAR_CONTAINER)
+        pod_cp.spec.containers[0].volume_mounts.insert(0, PodDefaultsDeprecated.VOLUME_MOUNT)
+        pod_cp.spec.containers.append(PodDefaultsDeprecated.SIDECAR_CONTAINER)
 
         return pod_cp
 

--- a/airflow/providers/cncf/kubernetes/pod_launcher_deprecated.py
+++ b/airflow/providers/cncf/kubernetes/pod_launcher_deprecated.py
@@ -33,7 +33,7 @@ from requests.exceptions import HTTPError
 
 from airflow.exceptions import AirflowException, RemovedInAirflow3Warning
 from airflow.providers.cncf.kubernetes.kube_client import get_kube_client
-from airflow.providers.cncf.kubernetes.pod_generator import PodDefaults
+from airflow.providers.cncf.kubernetes.pod_generator import PodDefaultsDeprecated
 from airflow.settings import pod_mutation_hook
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.state import State
@@ -272,7 +272,7 @@ class PodLauncher(LoggingMixin):
             self._client.connect_get_namespaced_pod_exec,
             pod.metadata.name,
             pod.metadata.namespace,
-            container=PodDefaults.SIDECAR_CONTAINER_NAME,
+            container=PodDefaultsDeprecated.SIDECAR_CONTAINER_NAME,
             command=["/bin/sh"],
             stdin=True,
             stdout=True,
@@ -281,7 +281,7 @@ class PodLauncher(LoggingMixin):
             _preload_content=False,
         )
         try:
-            result = self._exec_pod_command(resp, f"cat {PodDefaults.XCOM_MOUNT_PATH}/return.json")
+            result = self._exec_pod_command(resp, f"cat {PodDefaultsDeprecated.XCOM_MOUNT_PATH}/return.json")
             self._exec_pod_command(resp, "kill -s SIGINT 1")
         finally:
             resp.close()

--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -42,7 +42,7 @@ from urllib3.exceptions import HTTPError, TimeoutError
 
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.cncf.kubernetes.callbacks import ExecutionMode, KubernetesPodOperatorCallback
-from airflow.providers.cncf.kubernetes.pod_generator import PodDefaults
+from airflow.providers.cncf.kubernetes.utils.xcom_sidecar import PodDefaults
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.timezone import utcnow
 

--- a/tests/providers/cncf/kubernetes/test_pod_generator.py
+++ b/tests/providers/cncf/kubernetes/test_pod_generator.py
@@ -29,7 +29,7 @@ from airflow import __version__
 from airflow.exceptions import AirflowConfigException
 from airflow.providers.cncf.kubernetes.executors.kubernetes_executor import PodReconciliationError
 from airflow.providers.cncf.kubernetes.pod_generator import (
-    PodDefaults,
+    PodDefaultsDeprecated,
     PodGenerator,
     datetime_to_label_safe_datestring,
     extend_object_field,
@@ -174,7 +174,7 @@ class TestPodGenerator:
         container_two = {
             "name": "airflow-xcom-sidecar",
             "image": "alpine",
-            "command": ["sh", "-c", PodDefaults.XCOM_CMD],
+            "command": ["sh", "-c", PodDefaultsDeprecated.XCOM_CMD],
             "volumeMounts": [{"name": "xcom", "mountPath": "/airflow/xcom"}],
             "resources": {"requests": {"cpu": "1m"}},
         }


### PR DESCRIPTION
We should use the same, non deprecated, version of PodDefaults for the xcom sidecar when creating and reading xcom.