### PR TITLE
fix: add retry logic in case of google auth refresh credential error

### DIFF
--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -1580,6 +1580,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
                 time.sleep(5)
 
     @GoogleBaseHook.fallback_to_default_project_id
+    @GoogleBaseHook.refresh_credentials_retry()
     def get_job(
         self,
         job_id: str,

--- a/airflow/providers/google/common/hooks/base_google.py
+++ b/airflow/providers/google/common/hooks/base_google.py
@@ -114,6 +114,19 @@ def is_operation_in_progress_exception(exception: Exception) -> bool:
     return False
 
 
+def is_refresh_credentials_exception(exception: Exception) -> bool:
+    """
+    Handle refresh credentials exceptions.
+
+    Some calls return 502 (server error) in case a new token cannot be obtained.
+
+    * Google BigQuery
+    """
+    if isinstance(exception, RefreshError):
+        return "Unable to acquire impersonated credentials" in str(exception)
+    return False
+
+
 class retry_if_temporary_quota(tenacity.retry_if_exception):
     """Retries if there was an exception for exceeding the temporary quote limit."""
 
@@ -122,10 +135,17 @@ class retry_if_temporary_quota(tenacity.retry_if_exception):
 
 
 class retry_if_operation_in_progress(tenacity.retry_if_exception):
-    """Retries if there was an exception for exceeding the temporary quote limit."""
+    """Retries if there was an exception in case of operation in progress."""
 
     def __init__(self):
         super().__init__(is_operation_in_progress_exception)
+
+
+class retry_if_temporary_refresh_credentials(tenacity.retry_if_exception):
+    """Retries if there was an exception for refreshing credentials."""
+
+    def __init__(self):
+        super().__init__(is_refresh_credentials_exception)
 
 
 # A fake project_id to use in functions decorated by fallback_to_default_project_id
@@ -426,7 +446,7 @@ class GoogleBaseHook(BaseHook):
     def quota_retry(*args, **kwargs) -> Callable:
         """Provide a mechanism to repeat requests in response to exceeding a temporary quota limit."""
 
-        def decorator(fun: Callable):
+        def decorator(func: Callable):
             default_kwargs = {
                 "wait": tenacity.wait_exponential(multiplier=1, max=100),
                 "retry": retry_if_temporary_quota(),
@@ -434,7 +454,7 @@ class GoogleBaseHook(BaseHook):
                 "after": tenacity.after_log(log, logging.DEBUG),
             }
             default_kwargs.update(**kwargs)
-            return tenacity.retry(*args, **default_kwargs)(fun)
+            return tenacity.retry(*args, **default_kwargs)(func)
 
         return decorator
 
@@ -442,7 +462,7 @@ class GoogleBaseHook(BaseHook):
     def operation_in_progress_retry(*args, **kwargs) -> Callable[[T], T]:
         """Provide a mechanism to repeat requests in response to operation in progress (HTTP 409) limit."""
 
-        def decorator(fun: T):
+        def decorator(func: T):
             default_kwargs = {
                 "wait": tenacity.wait_exponential(multiplier=1, max=300),
                 "retry": retry_if_operation_in_progress(),
@@ -450,7 +470,25 @@ class GoogleBaseHook(BaseHook):
                 "after": tenacity.after_log(log, logging.DEBUG),
             }
             default_kwargs.update(**kwargs)
-            return cast(T, tenacity.retry(*args, **default_kwargs)(fun))
+            return cast(T, tenacity.retry(*args, **default_kwargs)(func))
+
+        return decorator
+
+    @staticmethod
+    def refresh_credentials_retry(*args, **kwargs) -> Callable[[T], T]:
+        """Provide a mechanism to repeat requests in response to a temporary refresh credential issue."""
+
+        def decorator(func: T):
+            default_kwargs = {
+                "wait": tenacity.wait_exponential(multiplier=1, max=5),
+                "stop": tenacity.stop_after_attempt(3),
+                "retry": retry_if_temporary_refresh_credentials(),
+                "reraise": True,
+                "before": tenacity.before_log(log, logging.DEBUG),
+                "after": tenacity.after_log(log, logging.DEBUG),
+            }
+            default_kwargs.update(**kwargs)
+            return cast(T, tenacity.retry(*args, **default_kwargs)(func))
 
         return decorator
 

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -26,6 +26,7 @@ import google.auth
 import pytest
 from gcloud.aio.bigquery import Job, Table as Table_async
 from google.api_core import page_iterator
+from google.auth.exceptions import RefreshError
 from google.cloud.bigquery import DEFAULT_RETRY, DatasetReference, Table, TableReference
 from google.cloud.bigquery.dataset import AccessEntry, Dataset, DatasetListItem
 from google.cloud.bigquery.table import _EmptyRowIterator
@@ -597,6 +598,37 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
         mock_client.assert_called_once_with(location=LOCATION, project_id=PROJECT_ID)
         mock_client.return_value.get_job.assert_called_once_with(job_id=JOB_ID)
         mock_client.return_value.get_job.return_value.done.assert_called_once_with(retry=DEFAULT_RETRY)
+
+    @mock.patch("tenacity.nap.time.sleep", mock.MagicMock())
+    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_client")
+    def test_get_job_credentials_refresh_error(self, mock_client):
+        error = "Unable to acquire impersonated credentials"
+        response_body = "<!DOCTYPE html>\n<html lang=en>\n  <meta charset=utf-8>\n"
+        mock_job = mock.MagicMock(
+            job_id="123456_hash",
+            error_result=False,
+            state="PENDING",
+            done=lambda: False,
+        )
+        mock_client.return_value.get_job.side_effect = [RefreshError(error, response_body), mock_job]
+
+        job = self.hook.get_job(job_id=JOB_ID, location=LOCATION, project_id=PROJECT_ID)
+        mock_client.assert_any_call(location=LOCATION, project_id=PROJECT_ID)
+        assert mock_client.call_count == 2
+        assert job == mock_job
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            RefreshError("Other error", "test body"),
+            ValueError(),
+        ],
+    )
+    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_client")
+    def test_get_job_credentials_error(self, mock_client, error):
+        mock_client.return_value.get_job.side_effect = error
+        with pytest.raises(type(error)):
+            self.hook.get_job(job_id=JOB_ID, location=LOCATION, project_id=PROJECT_ID)
 
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.poll_job_complete")
     @mock.patch("logging.Logger.info")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Occasionally, acquire impersonated credentials can fail with a 502 HTTP (Server error). It raises a `google.auth.exceptions.RefreshError`. Using task retries is sometimes not a good option as, e.g. a submitted BigQuey query should not be submitted again. 

The error occur in tasks running in deferred mode where acquiring impersonated credentials happens frequently every x seconds depending on the task's poll_interval.

In this case we should have some retry to acquire impersonated credentials.

_Note:_ The deferable version of `BigQueryInsertJobOperator` is using the the synchronous client call with the event loop's run_in_executor() method. https://github.com/apache/airflow/issues/35833

closes: #38532 


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
