### PR TITLE
Mark WASB blob tests as DB tests

### DIFF
--- a/tests/providers/microsoft/azure/triggers/test_wasb.py
+++ b/tests/providers/microsoft/azure/triggers/test_wasb.py
@@ -35,6 +35,8 @@ TEST_DATA_STORAGE_BLOB_PREFIX = TEST_DATA_STORAGE_BLOB_NAME[:10]
 TEST_WASB_CONN_ID = "wasb_default"
 POKE_INTERVAL = 5.0
 
+pytestmark = pytest.mark.db_test
+
 
 class TestWasbBlobSensorTrigger:
     TRIGGER = WasbBlobSensorTrigger(
@@ -78,7 +80,6 @@ class TestWasbBlobSensorTrigger:
         assert task.done() is False
         asyncio.get_event_loop().stop()
 
-    @pytest.mark.db_test
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.microsoft.azure.hooks.wasb.WasbAsyncHook.check_for_blob_async")
     async def test_success(self, mock_check_for_blob):
@@ -115,7 +116,6 @@ class TestWasbBlobSensorTrigger:
             assert message in caplog.text
         asyncio.get_event_loop().stop()
 
-    @pytest.mark.db_test
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.microsoft.azure.hooks.wasb.WasbAsyncHook.check_for_blob_async")
     async def test_trigger_exception(self, mock_check_for_blob):
@@ -170,7 +170,6 @@ class TestWasbPrefixSensorTrigger:
         assert task.done() is False
         asyncio.get_event_loop().stop()
 
-    @pytest.mark.db_test
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.microsoft.azure.hooks.wasb.WasbAsyncHook.check_for_prefix_async")
     async def test_success(self, mock_check_for_prefix):
@@ -208,7 +207,6 @@ class TestWasbPrefixSensorTrigger:
             mock_log_info.assert_called_once_with(message)
         asyncio.get_event_loop().stop()
 
-    @pytest.mark.db_test
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.microsoft.azure.hooks.wasb.WasbAsyncHook.check_for_prefix_async")
     async def test_trigger_exception(self, mock_check_for_prefix):


### PR DESCRIPTION
The WASB blob tests started to fail intermittently after retries were implemented in #38910. Without understanding all the details, it seems that the async tests run in xdist mode of tests suffer from the bug of pytest-xdist - because the thread that runs some of the tests is not main and it likely interferes with signals handling and is likely an incarnation of
https://github.com/pytest-dev/pytest-xdist/issues/620 (which still needs to be solved in pytest-xdist)

Since those two tests that keeps on failing intermittently and the other tests have been marked as db_test - likely for the same reason, we should simply mark all the module as db_test to avoid the interference.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
