### PR TITLE
Fix calendar view with no DAG Run.

### DIFF
--- a/airflow/www/static/js/dag/details/dag/Calendar.tsx
+++ b/airflow/www/static/js/dag/details/dag/Calendar.tsx
@@ -21,7 +21,7 @@
 
 import React from "react";
 import type { EChartsOption } from "echarts";
-import { Box, Spinner, Flex } from "@chakra-ui/react";
+import { Box, Spinner, Flex, Text } from "@chakra-ui/react";
 
 import ReactECharts from "src/components/ReactECharts";
 import { useCalendarData } from "src/api";
@@ -36,6 +36,10 @@ const Calendar = () => {
   if (!calendarData) return null;
 
   const { dagStates } = calendarData;
+
+  if (dagStates.length < 1) {
+    return <Text>Calendar view requires at least one DAG Run.</Text>;
+  }
 
   const startDate = dagStates[0].date;
   const endDate = dagStates[dagStates.length - 1].date;


### PR DESCRIPTION
closes: #38875
related: #38875

Screenshot of the patch for calendar view with no dagrun.

![image](https://github.com/apache/airflow/assets/3972343/5baeda8d-a7c2-4f29-bdbf-93a6bf1a87c4)

