### PR TITLE
Add a generic system test in `tests/system/` and run it in the CI

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -175,6 +175,8 @@ jobs:
             breeze testing tests --test-type "All-Quarantined" || true
           elif [[ "${{ inputs.test-scope }}" == "ARM collection" ]]; then
             breeze testing tests --collect-only --remove-arm-packages
+          elif [[ "${{ inputs.test-scope }}" == "System" ]]; then
+            breeze testing tests tests/system/example_empty.py --system core
           else
             echo "Unknown test scope: ${{ inputs.test-scope }}"
             exit 1

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -141,6 +141,7 @@ jobs:
       PYTHON_MAJOR_MINOR_VERSION: "${{ matrix.python-version }}"
       UPGRADE_BOTO: "${{ inputs.upgrade-boto }}"
       VERBOSE: "true"
+      SYSTEM_TESTS_ENV_ID: "test"
     steps:
       - name: "Cleanup repo"
         shell: bash

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -141,7 +141,6 @@ jobs:
       PYTHON_MAJOR_MINOR_VERSION: "${{ matrix.python-version }}"
       UPGRADE_BOTO: "${{ inputs.upgrade-boto }}"
       VERBOSE: "true"
-      SYSTEM_TESTS_ENV_ID: "test"
     steps:
       - name: "Cleanup repo"
         shell: bash

--- a/.github/workflows/special-tests.yml
+++ b/.github/workflows/special-tests.yml
@@ -230,3 +230,24 @@ jobs:
       include-success-outputs: ${{ needs.build-info.outputs.include-success-outputs }}
       run-coverage: ${{ inputs.run-coverage }}
       debug-resources: ${{ inputs.debug-resources }}
+
+  tests-system:
+    name: "System test"
+    uses: ./.github/workflows/run-unit-tests.yml
+    permissions:
+      contents: read
+      packages: read
+    secrets: inherit
+    with:
+      runs-on-as-json-default: ${{ inputs.runs-on-as-json-default }}
+      test-name: "SystemTest"
+      test-scope: "System"
+      backend: "postgres"
+      image-tag: ${{ inputs.image-tag }}
+      python-versions: "['${{ inputs.default-python-version }}']"
+      backend-versions: "['${{ inputs.default-postgres-version }}']"
+      excludes: "[]"
+      parallel-test-types-list-as-string: ${{ inputs.parallel-test-types-list-as-string }}
+      include-success-outputs: ${{ needs.build-info.outputs.include-success-outputs }}
+      run-coverage: ${{ inputs.run-coverage }}
+      debug-resources: ${{ inputs.debug-resources }}

--- a/dev/breeze/src/airflow_breeze/params/shell_params.py
+++ b/dev/breeze/src/airflow_breeze/params/shell_params.py
@@ -529,6 +529,7 @@ class ShellParams:
         _set_var(_env, "STANDALONE_DAG_PROCESSOR", self.standalone_dag_processor)
         _set_var(_env, "START_AIRFLOW", self.start_airflow)
         _set_var(_env, "SUSPENDED_PROVIDERS_FOLDERS", self.suspended_providers_folders)
+        _set_var(_env, "SYSTEM_TESTS_ENV_ID", None, "")
         _set_var(_env, "TEST_TYPE", self.test_type, "")
         _set_var(_env, "UPGRADE_BOTO", self.upgrade_boto)
         _set_var(_env, "PYDANTIC", self.pydantic)

--- a/dev/breeze/src/airflow_breeze/utils/run_tests.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_tests.py
@@ -350,7 +350,6 @@ def generate_args_for_pytest(
             # p - passed
             # P - passed with output
             #
-            "-rfEX",
         ]
     )
     if skip_db_tests:

--- a/dev/breeze/src/airflow_breeze/utils/run_tests.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_tests.py
@@ -350,6 +350,7 @@ def generate_args_for_pytest(
             # p - passed
             # P - passed with output
             #
+            "-rfEX",
         ]
     )
     if skip_db_tests:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1198,7 +1198,7 @@ def clear_lru_cache():
 @pytest.fixture(autouse=True)
 def refuse_to_run_test_from_wrongly_named_files(request: pytest.FixtureRequest):
     filepath = request.node.path
-    is_system_test: bool = "tests/system/" in os.fspath(filepath.parent)
+    is_system_test: bool = "tests/system/" in os.fspath(filepath)
     test_name = request.node.name
     if request.node.cls:
         test_name = f"{request.node.cls.__name__}.{test_name}"

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -51,7 +51,14 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
     rootdir = config.rootpath
     for item in items:
         rel_path = item.path.relative_to(rootdir)
+
+        # Provider system tests
         match = re.match(".+/system/providers/([^/]+)", str(rel_path))
         if match:
             provider = match.group(1)
             item.add_marker(pytest.mark.system(provider))
+
+        # Core system tests
+        match = re.match(".+/system/[^/]+", str(rel_path))
+        if match:
+            item.add_marker(pytest.mark.system("core"))

--- a/tests/system/example_empty.py
+++ b/tests/system/example_empty.py
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from datetime import datetime
+
+from airflow.models.baseoperator import chain
+from airflow.models.dag import DAG
+from airflow.operators.empty import EmptyOperator
+
+DAG_ID = "example_empty"
+
+with DAG(
+    dag_id=DAG_ID,
+    schedule="@once",
+    start_date=datetime(2021, 1, 1),
+    tags=["example"],
+    catchup=False,
+) as dag:
+    task = EmptyOperator(task_id="task")
+
+    chain(task)
+
+    from tests.system.utils.watcher import watcher
+
+    # This test needs watcher in order to properly mark success/failure
+    # when "tearDown" task with trigger rule is part of the DAG
+    list(dag.tasks) >> watcher()
+
+
+from tests.system.utils import get_test_run  # noqa: E402
+
+# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+test_run = get_test_run(dag)


### PR DESCRIPTION
Several times in the past, it happened that bug(s) were introduced in Airflow codebase which breaks all system tests. The issue is, we do not run system in Airflow CI, thus these bugs get merged and we need to fix them afterwards.

To prevent that, I'd like to add a step in Airflow CI to catch these bugs before merging. The idea is to create a dummy system test (a simple DAG using EmptyOperator) and run this system test as part of the CI.

[See Slack thread](https://apache-airflow.slack.com/archives/C06K9Q5G2UA/p1712772405407389).

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
