### PR TITLE
Changed color of extra tasks to a readable color

### DIFF
--- a/airflow/sensors/external_task.py
+++ b/airflow/sensors/external_task.py
@@ -148,7 +148,7 @@ class ExternalTaskSensor(BaseSensorOperator):
     """
 
     template_fields = ["external_dag_id", "external_task_id", "external_task_ids", "external_task_group_id"]
-    ui_color = "#19647e"
+    ui_color = "#4db7db"
     operator_extra_links = [ExternalDagLink()]
 
     def __init__(
@@ -473,7 +473,7 @@ class ExternalTaskMarker(EmptyOperator):
     """
 
     template_fields = ["external_dag_id", "external_task_id", "execution_date"]
-    ui_color = "#19647e"
+    ui_color = "#4db7db"
     operator_extra_links = [ExternalDagLink()]
 
     # The _serialized_fields are lazily loaded when get_serialized_fields() method is called


### PR DESCRIPTION
closes #38845

Changed the color of the extra task in the Graph from this: 
 
![image](https://github.com/apache/airflow/assets/65827206/f43f2ac5-796c-425a-b4da-b1084c984f33)
![image](https://github.com/apache/airflow/assets/65827206/a64136a9-2e58-44ed-b6c0-8762996edc32)

to this:
![image](https://github.com/apache/airflow/assets/65827206/4716fa9f-8778-4a71-8d90-4ebcfa85c407)
![image](https://github.com/apache/airflow/assets/65827206/28db6282-6c3d-42d8-9ac4-7c75048e98e6)


This change can be viewed in these example dags:
example_external_task_marker_child
example_external_task_marker_parent