### PR TITLE
Fix `sql_alchemy_engine_args` config example

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -528,7 +528,7 @@ database:
       version_added: 2.3.0
       type: string
       sensitive: true
-      example: '{"arg1": True}'
+      example: '{"arg1": true}'
       default: ~
     sql_engine_encoding:
       description: |


### PR DESCRIPTION
It's json, not python, so we need lowercase bools.