### PR TITLE
Use debug level for minischeduler skip

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -3563,7 +3563,7 @@ class TaskInstance(Base, LoggingMixin):
 
         except OperationalError as e:
             # Any kind of DB error here is _non fatal_ as this block is just an optimisation.
-            cls.logger().info(
+            cls.logger().debug(
                 "Skipping mini scheduling run due to exception: %s",
                 e.statement,
                 exc_info=True,


### PR DESCRIPTION
Now that we are using nowait, it will be more common that the minicheduler skips.  Leaving it at info level will cause unnecessary alarm to users.
