### PR TITLE
Mark `extending/add-build-essential-extend/Dockerfile` docker example test as XFAIL

### DIFF
--- a/.github/workflows/additional-prod-image-tests.yml
+++ b/.github/workflows/additional-prod-image-tests.yml
@@ -93,7 +93,7 @@ jobs:
 
   test-examples-of-prod-image-building:
     timeout-minutes: 60
-    name: "Test examples of POD image building"
+    name: "Test examples of PROD image building"
     runs-on: ${{ fromJSON(inputs.runs-on-as-json-public) }}
     env:
       GITHUB_REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This test starts failed during build `mpi4py` package, currently it blocks to run finalise step for tests, e.g. summarise warnings.

https://github.com/apache/airflow/actions/runs/8666405114/job/23769539549?pr=38905

```console
#6 13.21 Building wheels for collected packages: mpi4py
#6 13.21   Building wheel for mpi4py (pyproject.toml): started
#6 14.13   Building wheel for mpi4py (pyproject.toml): finished with status 'error'
#6 14.16   error: subprocess-exited-with-error
#6 14.16   
#6 14.16   × Building wheel for mpi4py (pyproject.toml) did not run successfully.
#6 14.16   │ exit code: 1
#6 14.16   ╰─> [212 lines of output]
#6 14.16       running bdist_wheel
#6 14.16       running build
#6 14.16       running build_src
#6 14.16       running build_py
#6 14.16       creating build
#6 14.16       creating build/lib.linux-x86_64-cpython-38
#6 14.16       creating build/lib.linux-x86_64-cpython-38/mpi4py
#6 14.16       copying src/mpi4py/run.py -> build/lib.linux-x86_64-cpython-38/mpi4py
#6 14.16       copying src/mpi4py/__init__.py -> build/lib.linux-x86_64-cpython-38/mpi4py
#6 14.16       copying src/mpi4py/bench.py -> build/lib.linux-x86_64-cpython-38/mpi4py
#6 14.16       copying src/mpi4py/__main__.py -> build/lib.linux-x86_64-cpython-38/mpi4py
#6 14.16       creating build/lib.linux-x86_64-cpython-38/mpi4py/futures
#6 14.16       copying src/mpi4py/futures/_base.py -> build/lib.linux-x86_64-cpython-38/mpi4py/futures
#6 14.16       copying src/mpi4py/futures/pool.py -> build/lib.linux-x86_64-cpython-38/mpi4py/futures
#6 14.16       copying src/mpi4py/futures/_core.py -> build/lib.linux-x86_64-cpython-38/mpi4py/futures
#6 14.16       copying src/mpi4py/futures/server.py -> build/lib.linux-x86_64-cpython-38/mpi4py/futures
#6 14.16       copying src/mpi4py/futures/__init__.py -> build/lib.linux-x86_64-cpython-38/mpi4py/futures
#6 14.16       copying src/mpi4py/futures/aplus.py -> build/lib.linux-x86_64-cpython-38/mpi4py/futures
#6 14.16       copying src/mpi4py/futures/__main__.py -> build/lib.linux-x86_64-cpython-38/mpi4py/futures
#6 14.16       copying src/mpi4py/futures/_lib.py -> build/lib.linux-x86_64-cpython-38/mpi4py/futures
#6 14.16       creating build/lib.linux-x86_64-cpython-38/mpi4py/util
#6 14.16       copying src/mpi4py/util/dtlib.py -> build/lib.linux-x86_64-cpython-38/mpi4py/util
#6 14.16       copying src/mpi4py/util/__init__.py -> build/lib.linux-x86_64-cpython-38/mpi4py/util
#6 14.16       copying src/mpi4py/util/pkl5.py -> build/lib.linux-x86_64-cpython-38/mpi4py/util
#6 14.16       copying src/mpi4py/MPI.pyi -> build/lib.linux-x86_64-cpython-38/mpi4py
#6 14.16       copying src/mpi4py/run.pyi -> build/lib.linux-x86_64-cpython-38/mpi4py
#6 14.16       copying src/mpi4py/__main__.pyi -> build/lib.linux-x86_64-cpython-38/mpi4py
#6 14.16       copying src/mpi4py/bench.pyi -> build/lib.linux-x86_64-cpython-38/mpi4py
#6 14.16       copying src/mpi4py/__init__.pyi -> build/lib.linux-x86_64-cpython-38/mpi4py
#6 14.16       copying src/mpi4py/dl.pyi -> build/lib.linux-x86_64-cpython-38/mpi4py
#6 14.16       copying src/mpi4py/py.typed -> build/lib.linux-x86_64-cpython-38/mpi4py
#6 14.16       copying src/mpi4py/__init__.pxd -> build/lib.linux-x86_64-cpython-38/mpi4py
#6 14.16       copying src/mpi4py/MPI.pxd -> build/lib.linux-x86_64-cpython-38/mpi4py
#6 14.16       copying src/mpi4py/libmpi.pxd -> build/lib.linux-x86_64-cpython-38/mpi4py
#6 14.16       creating build/lib.linux-x86_64-cpython-38/mpi4py/include
#6 14.16       creating build/lib.linux-x86_64-cpython-38/mpi4py/include/mpi4py
#6 14.16       copying src/mpi4py/include/mpi4py/mpi4py.MPI.h -> build/lib.linux-x86_64-cpython-38/mpi4py/include/mpi4py
#6 14.16       copying src/mpi4py/include/mpi4py/mpi4py.MPI_api.h -> build/lib.linux-x86_64-cpython-38/mpi4py/include/mpi4py
#6 14.16       copying src/mpi4py/include/mpi4py/mpi4py.h -> build/lib.linux-x86_64-cpython-38/mpi4py/include/mpi4py
#6 14.16       copying src/mpi4py/include/mpi4py/mpi4py.i -> build/lib.linux-x86_64-cpython-38/mpi4py/include/mpi4py
#6 14.16       copying src/mpi4py/include/mpi4py/mpi.pxi -> build/lib.linux-x86_64-cpython-38/mpi4py/include/mpi4py
#6 14.16       copying src/mpi4py/futures/__main__.pyi -> build/lib.linux-x86_64-cpython-38/mpi4py/futures
#6 14.16       copying src/mpi4py/futures/_core.pyi -> build/lib.linux-x86_64-cpython-38/mpi4py/futures
#6 14.16       copying src/mpi4py/futures/server.pyi -> build/lib.linux-x86_64-cpython-38/mpi4py/futures
#6 14.16       copying src/mpi4py/futures/__init__.pyi -> build/lib.linux-x86_64-cpython-38/mpi4py/futures
#6 14.16       copying src/mpi4py/futures/pool.pyi -> build/lib.linux-x86_64-cpython-38/mpi4py/futures
#6 14.16       copying src/mpi4py/futures/_lib.pyi -> build/lib.linux-x86_64-cpython-38/mpi4py/futures
#6 14.16       copying src/mpi4py/futures/aplus.pyi -> build/lib.linux-x86_64-cpython-38/mpi4py/futures
#6 14.16       copying src/mpi4py/util/pkl5.pyi -> build/lib.linux-x86_64-cpython-38/mpi4py/util
#6 14.16       copying src/mpi4py/util/dtlib.pyi -> build/lib.linux-x86_64-cpython-38/mpi4py/util
#6 14.16       copying src/mpi4py/util/__init__.pyi -> build/lib.linux-x86_64-cpython-38/mpi4py/util
#6 14.16       running build_clib
#6 14.16       MPI configuration: [mpi] from 'mpi.cfg'
#6 14.16       MPI C compiler:    /usr/bin/mpicc
#6 14.16       MPI C++ compiler:  /usr/bin/mpicxx
#6 14.16       MPI F compiler:    /usr/bin/mpifort
#6 14.16       MPI F90 compiler:  /usr/bin/mpif90
#6 14.16       MPI F77 compiler:  /usr/bin/mpif77
#6 14.16       checking for library 'lmpe' ...
#6 14.16       /usr/bin/mpicc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -c _configtest.c -o _configtest.o
#6 14.16       /usr/bin/mpicc _configtest.o -llmpe -o _configtest
#6 14.16       /usr/bin/ld: cannot find -llmpe: No such file or directory
#6 14.16       collect2: error: ld returned 1 exit status
#6 14.16       failure.
#6 14.16       removing: _configtest.c _configtest.o
#6 14.16       building 'mpe' dylib library
#6 14.16       creating build/temp.linux-x86_64-cpython-38
#6 14.16       creating build/temp.linux-x86_64-cpython-38/src
#6 14.16       creating build/temp.linux-x86_64-cpython-38/src/lib-pmpi
#6 14.16       /usr/bin/mpicc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -c src/lib-pmpi/mpe.c -o build/temp.linux-x86_64-cpython-38/src/lib-pmpi/mpe.o
#6 14.16       creating build/lib.linux-x86_64-cpython-38/mpi4py/lib-pmpi
#6 14.16       /usr/bin/mpicc -shared -Wl,--no-as-needed build/temp.linux-x86_64-cpython-38/src/lib-pmpi/mpe.o -o build/lib.linux-x86_64-cpython-38/mpi4py/lib-pmpi/libmpe.so
#6 14.16       checking for library 'vt-mpi' ...
#6 14.16       /usr/bin/mpicc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -c _configtest.c -o _configtest.o
#6 14.16       /usr/bin/mpicc _configtest.o -lvt-mpi -o _configtest
#6 14.16       /usr/bin/ld: cannot find -lvt-mpi: No such file or directory
#6 14.16       collect2: error: ld returned 1 exit status
#6 14.16       failure.
#6 14.16       removing: _configtest.c _configtest.o
#6 14.16       checking for library 'vt.mpi' ...
#6 14.16       /usr/bin/mpicc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -c _configtest.c -o _configtest.o
#6 14.16       /usr/bin/mpicc _configtest.o -lvt.mpi -o _configtest
#6 14.16       /usr/bin/ld: cannot find -lvt.mpi: No such file or directory
#6 14.16       collect2: error: ld returned 1 exit status
#6 14.16       failure.
#6 14.16       removing: _configtest.c _configtest.o
#6 14.16       building 'vt' dylib library
#6 14.16       /usr/bin/mpicc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -c src/lib-pmpi/vt.c -o build/temp.linux-x86_64-cpython-38/src/lib-pmpi/vt.o
#6 14.16       /usr/bin/mpicc -shared -Wl,--no-as-needed build/temp.linux-x86_64-cpython-38/src/lib-pmpi/vt.o -o build/lib.linux-x86_64-cpython-38/mpi4py/lib-pmpi/libvt.so
#6 14.16       checking for library 'vt-mpi' ...
#6 14.16       /usr/bin/mpicc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -c _configtest.c -o _configtest.o
#6 14.16       /usr/bin/mpicc _configtest.o -lvt-mpi -o _configtest
#6 14.16       /usr/bin/ld: cannot find -lvt-mpi: No such file or directory
#6 14.16       collect2: error: ld returned 1 exit status
#6 14.16       failure.
#6 14.16       removing: _configtest.c _configtest.o
#6 14.16       checking for library 'vt.mpi' ...
#6 14.16       /usr/bin/mpicc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -c _configtest.c -o _configtest.o
#6 14.16       /usr/bin/mpicc _configtest.o -lvt.mpi -o _configtest
#6 14.16       /usr/bin/ld: cannot find -lvt.mpi: No such file or directory
#6 14.16       collect2: error: ld returned 1 exit status
#6 14.16       failure.
#6 14.16       removing: _configtest.c _configtest.o
#6 14.16       building 'vt-mpi' dylib library
#6 14.16       /usr/bin/mpicc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -c src/lib-pmpi/vt-mpi.c -o build/temp.linux-x86_64-cpython-38/src/lib-pmpi/vt-mpi.o
#6 14.16       /usr/bin/mpicc -shared -Wl,--no-as-needed build/temp.linux-x86_64-cpython-38/src/lib-pmpi/vt-mpi.o -o build/lib.linux-x86_64-cpython-38/mpi4py/lib-pmpi/libvt-mpi.so
#6 14.16       checking for library 'vt-hyb' ...
#6 14.16       /usr/bin/mpicc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -c _configtest.c -o _configtest.o
#6 14.16       /usr/bin/mpicc _configtest.o -lvt-hyb -o _configtest
#6 14.16       /usr/bin/ld: cannot find -lvt-hyb: No such file or directory
#6 14.16       collect2: error: ld returned 1 exit status
#6 14.16       failure.
#6 14.16       removing: _configtest.c _configtest.o
#6 14.16       checking for library 'vt.ompi' ...
#6 14.16       /usr/bin/mpicc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -c _configtest.c -o _configtest.o
#6 14.16       /usr/bin/mpicc _configtest.o -lvt.ompi -o _configtest
#6 14.16       /usr/bin/ld: cannot find -lvt.ompi: No such file or directory
#6 14.16       collect2: error: ld returned 1 exit status
#6 14.16       failure.
#6 14.16       removing: _configtest.c _configtest.o
#6 14.16       building 'vt-hyb' dylib library
#6 14.16       /usr/bin/mpicc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -c src/lib-pmpi/vt-hyb.c -o build/temp.linux-x86_64-cpython-38/src/lib-pmpi/vt-hyb.o
#6 14.16       /usr/bin/mpicc -shared -Wl,--no-as-needed build/temp.linux-x86_64-cpython-38/src/lib-pmpi/vt-hyb.o -o build/lib.linux-x86_64-cpython-38/mpi4py/lib-pmpi/libvt-hyb.so
#6 14.16       running build_ext
#6 14.16       MPI configuration: [mpi] from 'mpi.cfg'
#6 14.16       MPI C compiler:    /usr/bin/mpicc
#6 14.16       MPI C++ compiler:  /usr/bin/mpicxx
#6 14.16       MPI F compiler:    /usr/bin/mpifort
#6 14.16       MPI F90 compiler:  /usr/bin/mpif90
#6 14.16       MPI F77 compiler:  /usr/bin/mpif77
#6 14.16       checking for dlopen() availability ...
#6 14.16       checking for header 'dlfcn.h' ...
#6 14.16       gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/home/airflow/.local/include -I/usr/local/include/python3.8 -c _configtest.c -o _configtest.o
#6 14.16       success!
#6 14.16       removing: _configtest.c _configtest.o
#6 14.16       success!
#6 14.16       checking for library 'dl' ...
#6 14.16       gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/home/airflow/.local/include -I/usr/local/include/python3.8 -c _configtest.c -o _configtest.o
#6 14.16       Traceback (most recent call last):
#6 14.16         File "/home/airflow/.local/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
#6 14.16           main()
#6 14.16         File "/home/airflow/.local/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
#6 14.16           json_out['return_val'] = hook(**hook_input['kwargs'])
#6 14.16         File "/home/airflow/.local/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 251, in build_wheel
#6 14.16           return _build_backend().build_wheel(wheel_directory, config_settings,
#6 14.16         File "/tmp/pip-build-env-edy3kq5i/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 410, in build_wheel
#6 14.16           return self._build_with_temp_dir(
#6 14.16         File "/tmp/pip-build-env-edy3kq5i/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 395, in _build_with_temp_dir
#6 14.16           self.run_setup()
#6 14.16         File "/tmp/pip-build-env-edy3kq5i/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 311, in run_setup
#6 14.16           exec(code, locals())
#6 14.16         File "<string>", line 644, in <module>
#6 14.16         File "<string>", line 641, in main
#6 14.16         File "<string>", line 492, in run_setup
#6 14.16         File "/tmp/pip-install-f_toa7f8/mpi4py_38c005ab88564a30a5f545a9f728ba39/conf/mpidistutils.py", line 541, in setup
#6 14.16           return fcn_setup(**attrs)
#6 14.16         File "/tmp/pip-build-env-edy3kq5i/overlay/lib/python3.8/site-packages/setuptools/__init__.py", line 104, in setup
#6 14.16           return distutils.core.setup(**attrs)
#6 14.16         File "/tmp/pip-build-env-edy3kq5i/overlay/lib/python3.8/site-packages/setuptools/_distutils/core.py", line 184, in setup
#6 14.16           return run_commands(dist)
#6 14.16         File "/tmp/pip-build-env-edy3kq5i/overlay/lib/python3.8/site-packages/setuptools/_distutils/core.py", line 200, in run_commands
#6 14.16           dist.run_commands()
#6 14.16         File "/tmp/pip-build-env-edy3kq5i/overlay/lib/python3.8/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
#6 14.16           self.run_command(cmd)
#6 14.16         File "/tmp/pip-build-env-edy3kq5i/overlay/lib/python3.8/site-packages/setuptools/dist.py", line 967, in run_command
#6 14.16           super().run_command(command)
#6 14.16         File "/tmp/pip-build-env-edy3kq5i/overlay/lib/python3.8/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
#6 14.16           cmd_obj.run()
#6 14.16         File "/tmp/pip-build-env-edy3kq5i/overlay/lib/python3.8/site-packages/wheel/bdist_wheel.py", line 368, in run
#6 14.16           self.run_command("build")
#6 14.16         File "/tmp/pip-build-env-edy3kq5i/overlay/lib/python3.8/site-packages/setuptools/_distutils/cmd.py", line 316, in run_command
#6 14.16           self.distribution.run_command(command)
#6 14.16         File "/tmp/pip-build-env-edy3kq5i/overlay/lib/python3.8/site-packages/setuptools/dist.py", line 967, in run_command
#6 14.16           super().run_command(command)
#6 14.16         File "/tmp/pip-build-env-edy3kq5i/overlay/lib/python3.8/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
#6 14.16           cmd_obj.run()
#6 14.16         File "/tmp/pip-build-env-edy3kq5i/overlay/lib/python3.8/site-packages/setuptools/_distutils/command/build.py", line 132, in run
#6 14.16           self.run_command(cmd_name)
#6 14.16         File "/tmp/pip-build-env-edy3kq5i/overlay/lib/python3.8/site-packages/setuptools/_distutils/cmd.py", line 316, in run_command
#6 14.16           self.distribution.run_command(command)
#6 14.16         File "/tmp/pip-build-env-edy3kq5i/overlay/lib/python3.8/site-packages/setuptools/dist.py", line 967, in run_command
#6 14.16           super().run_command(command)
#6 14.16         File "/tmp/pip-build-env-edy3kq5i/overlay/lib/python3.8/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
#6 14.16           cmd_obj.run()
#6 14.16         File "/tmp/pip-install-f_toa7f8/mpi4py_38c005ab88564a30a5f545a9f728ba39/conf/mpidistutils.py", line [1213](https://github.com/apache/airflow/actions/runs/8666405114/job/23769539549?pr=38905#step:9:1214), in run
#6 14.16           cmd_build_ext.build_ext.run(self)
#6 14.16         File "/tmp/pip-build-env-edy3kq5i/overlay/lib/python3.8/site-packages/setuptools/command/build_ext.py", line 91, in run
#6 14.16           _build_ext.run(self)
#6 14.16         File "/tmp/pip-build-env-edy3kq5i/overlay/lib/python3.8/site-packages/setuptools/_distutils/command/build_ext.py", line 359, in run
#6 14.16           self.build_extensions()
#6 14.16         File "/tmp/pip-install-f_toa7f8/mpi4py_38c005ab88564a30a5f545a9f728ba39/conf/mpidistutils.py", line 1241, in build_extensions
#6 14.16           self.build_extension(ext)
#6 14.16         File "/tmp/pip-install-f_toa7f8/mpi4py_38c005ab88564a30a5f545a9f728ba39/conf/mpidistutils.py", line 1272, in build_extension
#6 14.16           self.config_extension(ext)
#6 14.16         File "/tmp/pip-install-f_toa7f8/mpi4py_38c005ab88564a30a5f545a9f728ba39/conf/mpidistutils.py", line 1255, in config_extension
#6 14.16           configure(ext, config_cmd)
#6 14.16         File "<string>", line 188, in configure_dl
#6 14.16         File "/tmp/pip-install-f_toa7f8/mpi4py_38c005ab88564a30a5f545a9f728ba39/conf/mpidistutils.py", line 607, in check_library
#6 14.16           ok = self.try_link(body,  headers, include_dirs,
#6 14.16         File "/tmp/pip-build-env-edy3kq5i/overlay/lib/python3.8/site-packages/setuptools/_distutils/command/config.py", line 246, in try_link
#6 14.16           self._link(body, headers, include_dirs, libraries, library_dirs, lang)
#6 14.16         File "/tmp/pip-build-env-edy3kq5i/overlay/lib/python3.8/site-packages/setuptools/_distutils/command/config.py", line 138, in _link
#6 14.16           self.compiler.link_executable(
#6 14.16         File "/tmp/pip-build-env-edy3kq5i/overlay/lib/python3.8/site-packages/setuptools/_distutils/ccompiler.py", line 781, in link_executable
#6 14.16           self.link(
#6 14.16         File "/tmp/pip-build-env-edy3kq5i/overlay/lib/python3.8/site-packages/setuptools/_distutils/unixccompiler.py", line 233, in link
#6 14.16           lib_opts = gen_lib_options(self, library_dirs, runtime_library_dirs, libraries)
#6 14.16         File "/tmp/pip-build-env-edy3kq5i/overlay/lib/python3.8/site-packages/setuptools/_distutils/ccompiler.py", line [1232](https://github.com/apache/airflow/actions/runs/8666405114/job/23769539549?pr=38905#step:9:1233), in gen_lib_options
#6 14.16           lib_opts.extend(always_iterable(compiler.runtime_library_dir_option(dir)))
#6 14.16         File "/tmp/pip-install-f_toa7f8/mpi4py_38c005ab88564a30a5f545a9f728ba39/conf/mpidistutils.py", line 68, in rpath_option
#6 14.16           if option.startswith('-R'):
#6 14.16       AttributeError: 'list' object has no attribute 'startswith'
#6 14.16       [end of output]
#6 14.16   
#6 14.16   note: This error originates from a subprocess, and is likely not a problem with pip.
#6 14.17   ERROR: Failed building wheel for mpi4py
```

Temporary mark it as XFAIL and allow to do it in the future for other Dockerfiles examples

related: #38988

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
