### PR TITLE
Fix 'polling_interval' parameter docs in LivyOperator

### DIFF
--- a/airflow/providers/apache/livy/operators/livy.py
+++ b/airflow/providers/apache/livy/operators/livy.py
@@ -55,7 +55,7 @@ class LivyOperator(BaseOperator):
     :param proxy_user: user to impersonate when running the job. (templated)
     :param livy_conn_id: reference to a pre-defined Livy Connection.
     :param livy_conn_auth_type: The auth type for the Livy Connection.
-    :param polling_interval: time in seconds between polling for job completion. Don't poll for values >=0
+    :param polling_interval: time in seconds between polling for job completion. Don't poll for values <= 0
     :param extra_options: A dictionary of options, where key is string and value
         depends on the option that's being modified.
     :param extra_headers: A dictionary of headers passed to the HTTP request to livy.


### PR DESCRIPTION
### Explain
There is no issue linked to this PR.

The documentation of the LivyOperator had an error:
`:param polling_interval: time in seconds between polling for job completion. Don't poll for values >= 0`

Actually, the operator will not poll when the `polling_interval` is less than or equal (<=) to 0. This PR changes that >= sign to a <= in the docs.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
