### PR TITLE
Resolve test pool unit test warnings

### DIFF
--- a/tests/deprecations_ignore.yml
+++ b/tests/deprecations_ignore.yml
@@ -177,9 +177,6 @@
 - tests/models/test_dagbag.py::TestDagBag::test_load_subdags
 - tests/models/test_dagbag.py::TestDagBag::test_skip_cycle_dags
 - tests/models/test_mappedoperator.py::test_expand_mapped_task_instance_with_named_index
-- tests/models/test_pool.py::TestPool::test_default_pool_open_slots
-- tests/models/test_pool.py::TestPool::test_infinite_slots
-- tests/models/test_pool.py::TestPool::test_open_slots_including_deferred
 - tests/models/test_skipmixin.py::TestSkipMixin::test_mapped_tasks_skip_all_except
 - tests/models/test_skipmixin.py::TestSkipMixin::test_raise_exception_on_not_accepted_branch_task_ids_type
 - tests/models/test_skipmixin.py::TestSkipMixin::test_raise_exception_on_not_accepted_iterable_branch_task_ids_type

--- a/tests/deprecations_ignore.yml
+++ b/tests/deprecations_ignore.yml
@@ -179,7 +179,6 @@
 - tests/models/test_mappedoperator.py::test_expand_mapped_task_instance_with_named_index
 - tests/models/test_pool.py::TestPool::test_default_pool_open_slots
 - tests/models/test_pool.py::TestPool::test_infinite_slots
-- tests/models/test_pool.py::TestPool::test_open_slots
 - tests/models/test_pool.py::TestPool::test_open_slots_including_deferred
 - tests/models/test_skipmixin.py::TestSkipMixin::test_mapped_tasks_skip_all_except
 - tests/models/test_skipmixin.py::TestSkipMixin::test_raise_exception_on_not_accepted_branch_task_ids_type

--- a/tests/models/test_pool.py
+++ b/tests/models/test_pool.py
@@ -74,10 +74,12 @@ class TestPool:
             op1 = EmptyOperator(task_id="dummy1", pool="test_pool")
             op2 = EmptyOperator(task_id="dummy2", pool="test_pool")
             op3 = EmptyOperator(task_id="dummy3", pool="test_pool")
-        dag_maker.create_dagrun()
-        ti1 = TI(task=op1, execution_date=DEFAULT_DATE)
-        ti2 = TI(task=op2, execution_date=DEFAULT_DATE)
-        ti3 = TI(task=op3, execution_date=DEFAULT_DATE)
+
+        dr = dag_maker.create_dagrun()
+
+        ti1 = TI(task=op1, run_id=dr.run_id)
+        ti2 = TI(task=op2, run_id=dr.run_id)
+        ti3 = TI(task=op3, run_id=dr.run_id)
         ti1.state = State.RUNNING
         ti2.state = State.QUEUED
         ti3.state = State.DEFERRED

--- a/tests/models/test_pool.py
+++ b/tests/models/test_pool.py
@@ -122,9 +122,11 @@ class TestPool:
         ):
             op1 = EmptyOperator(task_id="dummy1", pool="test_pool")
             op2 = EmptyOperator(task_id="dummy2", pool="test_pool")
-        dag_maker.create_dagrun()
-        ti1 = TI(task=op1, execution_date=DEFAULT_DATE)
-        ti2 = TI(task=op2, execution_date=DEFAULT_DATE)
+
+        dr = dag_maker.create_dagrun()
+
+        ti1 = TI(task=op1, run_id=dr.run_id)
+        ti2 = TI(task=op2, run_id=dr.run_id)
         ti1.state = State.RUNNING
         ti2.state = State.DEFERRED
 
@@ -164,9 +166,11 @@ class TestPool:
         ):
             op1 = EmptyOperator(task_id="dummy1", pool="test_pool")
             op2 = EmptyOperator(task_id="dummy2", pool="test_pool")
-        dag_maker.create_dagrun()
-        ti1 = TI(task=op1, execution_date=DEFAULT_DATE)
-        ti2 = TI(task=op2, execution_date=DEFAULT_DATE)
+
+        dr = dag_maker.create_dagrun()
+
+        ti1 = TI(task=op1, run_id=dr.run_id)
+        ti2 = TI(task=op2, run_id=dr.run_id)
         ti1.state = State.RUNNING
         ti2.state = State.QUEUED
 
@@ -207,9 +211,11 @@ class TestPool:
         ):
             op1 = EmptyOperator(task_id="dummy1")
             op2 = EmptyOperator(task_id="dummy2", pool_slots=2)
-        dag_maker.create_dagrun()
-        ti1 = TI(task=op1, execution_date=DEFAULT_DATE)
-        ti2 = TI(task=op2, execution_date=DEFAULT_DATE)
+
+        dr = dag_maker.create_dagrun()
+
+        ti1 = TI(task=op1, run_id=dr.run_id)
+        ti2 = TI(task=op2, run_id=dr.run_id)
         ti1.state = State.RUNNING
         ti2.state = State.QUEUED
 


### PR DESCRIPTION
related: #38642

I removed the initialization of TaskInstance from using execution_date to using run_id
before changing when running the tests the following warn was given
[https://github.com/apache/airflow/blob/main/airflow/models/taskinstance.py](url)
```python
            warnings.warn(
                "Passing an execution_date to `TaskInstance()` is deprecated in favour of passing a run_id",
                RemovedInAirflow3Warning,
                # Stack level is 4 because SQLA adds some wrappers around the constructor
                stacklevel=4,
            )
``` 