### PR TITLE
Increment try_number while clearing deferred tasks.

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -273,6 +273,12 @@ def clear_task_instances(
                 ti.state = TaskInstanceState.RESTARTING
                 job_ids.append(ti.job_id)
         else:
+            # When the task is deferred the try_number is decremented so that the same try
+            # number is used when the task resumes execution to process the  event. But in case of
+            # clearing the try number should be incremented so that the next run doesn't reuse the same try_number
+            if ti.state == TaskInstanceState.DEFERRED:
+                ti._try_number += 1
+
             ti_dag = dag if dag and dag.dag_id == ti.dag_id else dag_bag.get_dag(ti.dag_id, session=session)
             task_id = ti.task_id
             if ti_dag and ti_dag.has_task(task_id):

--- a/tests/www/views/test_views_tasks.py
+++ b/tests/www/views/test_views_tasks.py
@@ -859,8 +859,8 @@ def test_task_instance_clear(session, request, client_fixture, should_succeed):
 def test_task_instance_clear_deferred(session, admin_client, create_task_instance):
     """Ensures clearing a task instance in deferred state increments _try_number for next execution."""
     task_instance = create_task_instance(
-        dag_id="example_bash_operator",
-        task_id="run_this_last",
+        dag_id="example_bash_decorator",
+        task_id="runme_0",
         execution_date=timezone.utcnow(),
         state=State.DEFERRED,
     )


### PR DESCRIPTION
closes: #38735
related: #38735

This is already done while marking tasks as success/failure. Should this be done for up_for_reschedule tasks too? See also https://github.com/apache/airflow/pull/30669

https://github.com/apache/airflow/blob/d03ba594b3158c127c1c1b3f1d0c31fb93104367/airflow/api/common/mark_tasks.py#L161-L164
