### PR TITLE
Undeprecate `BaseXCom.get_one` method

### DIFF
--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -29,7 +29,6 @@ from functools import cached_property, wraps
 from typing import TYPE_CHECKING, Any, Generator, Iterable, cast, overload
 
 import attr
-from deprecated import deprecated
 from sqlalchemy import (
     Column,
     ForeignKeyConstraint,
@@ -370,7 +369,6 @@ class BaseXCom(TaskInstanceDependencies, LoggingMixin):
     @staticmethod
     @provide_session
     @internal_api_call
-    @deprecated
     def get_one(
         execution_date: datetime.datetime | None = None,
         key: str | None = None,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

I guess `BaseXCom.get_one` is deprecated by a mistake in https://github.com/apache/airflow/pull/37058

```console
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/operators/test_trigger_dagrun.py::TestDagRunOperator::test_trigger_dagrun", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/operators/test_trigger_dagrun.py::TestDagRunOperator::test_trigger_dagrun_with_execution_date", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/operators/test_trigger_dagrun.py::TestDagRunOperator::test_trigger_dagrun_twice", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/operators/test_trigger_dagrun.py::TestDagRunOperator::test_trigger_dagrun_with_scheduled_dag_run", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/operators/test_trigger_dagrun.py::TestDagRunOperator::test_trigger_dagrun_with_templated_execution_date", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/operators/test_trigger_dagrun.py::TestDagRunOperator::test_trigger_dagrun_triggering_itself", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_pools. (Use Pool.get_pools() instead) -- Deprecated since version 2.2.4.", "node_id": "tests/api_experimental/auth/backend/test_basic_auth.py::TestBasicAuth::test_success", "filename": "airflow/www/api/experimental/endpoints.py", "lineno": 366}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_pools. (Use Pool.get_pools() instead) -- Deprecated since version 2.2.4.", "node_id": "tests/api_experimental/auth/backend/test_basic_auth.py::TestBasicAuth::test_experimental_api", "filename": "airflow/www/api/experimental/endpoints.py", "lineno": 366}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/api_connexion/endpoints/test_extra_link_endpoint.py::TestGetExtraLinks::test_should_respond_200", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/api_connexion/endpoints/test_extra_link_endpoint.py::TestGetExtraLinks::test_should_respond_200_missing_xcom", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/api_connexion/endpoints/test_extra_link_endpoint.py::TestGetExtraLinks::test_should_respond_200_multiple_links", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/api_connexion/endpoints/test_extra_link_endpoint.py::TestGetExtraLinks::test_should_respond_200_multiple_links_missing_xcom", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/api_connexion/endpoints/test_extra_link_endpoint.py::TestGetExtraLinks::test_should_respond_200_support_plugins", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/amazon/aws/links/test_athena.py::TestAthenaQueryResultsLink::test_empty_xcom", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/amazon/aws/links/test_athena.py::TestAthenaQueryResultsLink::test_extra_link", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/amazon/aws/links/test_batch.py::TestBatchJobDefinitionLink::test_empty_xcom", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/amazon/aws/links/test_batch.py::TestBatchJobDefinitionLink::test_extra_link", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/amazon/aws/links/test_batch.py::TestBatchJobDetailsLink::test_empty_xcom", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/amazon/aws/links/test_batch.py::TestBatchJobDetailsLink::test_extra_link", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/amazon/aws/links/test_batch.py::TestBatchJobQueueLink::test_empty_xcom", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/amazon/aws/links/test_batch.py::TestBatchJobQueueLink::test_extra_link", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/amazon/aws/links/test_emr.py::TestEmrClusterLink::test_empty_xcom", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/amazon/aws/links/test_emr.py::TestEmrClusterLink::test_extra_link", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/amazon/aws/links/test_emr.py::TestEmrLogsLink::test_empty_xcom", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/amazon/aws/links/test_emr.py::TestEmrLogsLink::test_extra_link", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/amazon/aws/links/test_emr.py::TestEmrLogsLink::test_missing_log_url", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/amazon/aws/links/test_emr.py::TestEmrServerlessLogsLink::test_empty_xcom", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/amazon/aws/links/test_emr.py::TestEmrServerlessLogsLink::test_extra_link", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/amazon/aws/links/test_emr.py::TestEmrServerlessDashboardLink::test_empty_xcom", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/amazon/aws/links/test_emr.py::TestEmrServerlessDashboardLink::test_extra_link", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/amazon/aws/links/test_emr.py::TestEmrServerlessS3LogsLink::test_empty_xcom", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/amazon/aws/links/test_emr.py::TestEmrServerlessS3LogsLink::test_extra_link", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/amazon/aws/links/test_emr.py::TestEmrServerlessCloudWatchLogsLink::test_empty_xcom", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/amazon/aws/links/test_emr.py::TestEmrServerlessCloudWatchLogsLink::test_extra_link", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/amazon/aws/links/test_glue.py::TestGlueJobRunDetailsLink::test_empty_xcom", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/amazon/aws/links/test_glue.py::TestGlueJobRunDetailsLink::test_extra_link", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/amazon/aws/links/test_logs.py::TestCloudWatchEventsLink::test_empty_xcom", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/amazon/aws/links/test_logs.py::TestCloudWatchEventsLink::test_extra_link", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/amazon/aws/links/test_step_function.py::TestStateMachineDetailsLink::test_empty_xcom", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/amazon/aws/links/test_step_function.py::TestStateMachineDetailsLink::test_extra_link", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/amazon/aws/links/test_step_function.py::TestStateMachineExecutionsDetailsLink::test_empty_xcom", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/amazon/aws/links/test_step_function.py::TestStateMachineExecutionsDetailsLink::test_extra_link", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/google/cloud/operators/test_bigquery.py::TestBigQueryOperator::test_bigquery_operator_extra_serialized_field_when_single_query", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/google/cloud/operators/test_bigquery.py::TestBigQueryOperator::test_bigquery_operator_extra_serialized_field_when_multiple_queries", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/google/cloud/operators/test_bigquery.py::TestBigQueryOperator::test_bigquery_operator_extra_link_when_missing_job_id", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/google/cloud/operators/test_bigquery.py::TestBigQueryOperator::test_bigquery_operator_extra_link_when_single_query", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/google/cloud/operators/test_bigquery.py::TestBigQueryOperator::test_bigquery_operator_extra_link_when_multiple_query", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/google/cloud/operators/test_dataproc.py::test_create_cluster_operator_extra_links", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/google/cloud/operators/test_dataproc.py::test_scale_cluster_operator_extra_links", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/google/cloud/operators/test_dataproc.py::test_submit_job_operator_extra_links", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/google/cloud/operators/test_dataproc.py::test_update_cluster_operator_extra_links", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/google/cloud/operators/test_dataproc.py::test_instantiate_workflow_operator_extra_links", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/google/cloud/operators/test_dataproc.py::test_instantiate_inline_workflow_operator_extra_links", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/google/cloud/operators/test_dataproc.py::test_submit_spark_job_operator_extra_links", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/cncf/kubernetes/operators/test_pod.py::TestKubernetesPodOperator::test_push_xcom_pod_info", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/common/io/xcom/test_backend.py::TestXComObjectStorageBackend::test_value_db", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/common/io/xcom/test_backend.py::TestXComObjectStorageBackend::test_value_storage", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/common/io/xcom/test_backend.py::TestXComObjectStorageBackend::test_compression", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/dbt/cloud/operators/test_dbt.py::TestDbtCloudRunJobOperator::test_run_job_operator_link", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/microsoft/azure/operators/test_data_factory.py::TestAzureDataFactoryRunPipelineOperator::test_run_pipeline_operator_link", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
{"category": "DeprecationWarning", "message": "Call to deprecated function (or staticmethod) get_one.", "node_id": "tests/providers/microsoft/azure/operators/test_synapse.py::TestAzureSynapseRunPipelineOperator::test_run_pipeline_operator_link", "filename": "airflow/api_internal/internal_api_call.py", "lineno": 127}
...
```

cc: @bolkedebruin 

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
