### PR TITLE
Partially enable `B028` rule: no-explicit-stacklevel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -289,6 +289,7 @@ extend-select = [
     "B006", # Checks for uses of mutable objects as function argument defaults.
     "B017", # Checks for pytest.raises context managers that catch Exception or BaseException.
     "B019", # Use of functools.lru_cache or functools.cache on methods can lead to memory leaks
+    "B028", # No explicit stacklevel keyword argument found
     "TRY002", # Prohibit use of `raise Exception`, use specific exceptions instead.
     "RUF006", # Checks for asyncio dangling task
 ]
@@ -321,7 +322,7 @@ required-imports = ["from __future__ import annotations"]
 combine-as-imports = true
 
 [tool.ruff.lint.per-file-ignores]
-"airflow/__init__.py" = ["F401"]
+"airflow/__init__.py" = ["F401", "B028"]
 "airflow/models/__init__.py" = ["F401", "TCH004"]
 "airflow/models/sqla_models.py" = ["F401"]
 
@@ -379,6 +380,35 @@ combine-as-imports = true
 "tests/providers/qdrant/hooks/test_qdrant.py" = ["E402"]
 "tests/providers/qdrant/operators/test_qdrant.py" = ["E402"]
 "tests/providers/snowflake/operators/test_snowflake_sql.py" = ["E402"]
+
+# All the modules which do not follow B028 yet: https://docs.astral.sh/ruff/rules/no-explicit-stacklevel/
+"airflow/api_connexion/endpoints/forward_to_fab_endpoint.py" = ["B028"]
+"airflow/cli/commands/connection_command.py" = ["B028"]
+"airflow/cli/commands/dag_command.py" = ["B028"]
+"airflow/cli/commands/db_command.py" = ["B028"]
+"airflow/configuration.py" = ["B028"]
+"airflow/decorators/task_group.py" = ["B028"]
+"airflow/jobs/scheduler_job_runner.py" = ["B028"]
+"airflow/jobs/triggerer_job_runner.py" = ["B028"]
+"airflow/kubernetes/pre_7_4_0_compatibility/pod_generator.py" = ["B028"]
+"airflow/logging_config.py" = ["B028"]
+"airflow/metrics/otel_logger.py" = ["B028"]
+"airflow/metrics/validators.py" = ["B028"]
+"airflow/models/baseoperator.py" = ["B028"]
+"airflow/models/connection.py" = ["B028"]
+"airflow/models/mappedoperator.py" = ["B028"]
+"airflow/models/param.py" = ["B028"]
+"airflow/models/xcom.py" = ["B028"]
+"airflow/providers_manager.py" = ["B028"]
+"airflow/serialization/serialized_objects.py" = ["B028"]
+"airflow/settings.py" = ["B028"]
+"airflow/utils/context.py" = ["B028"]
+"airflow/utils/dot_renderer.py" = ["B028"]
+"airflow/www/app.py" = ["B028"]
+"airflow/www/extensions/init_views.py" = ["B028"]
+"airflow/providers/jdbc/hooks/jdbc.py" = ["B028"]
+"airflow/providers/microsoft/azure/hooks/synapse.py" = ["B028"]
+"helm_tests/airflow_aux/test_basic_helm_chart.py" = ["B028"]
 
 [tool.ruff.lint.flake8-tidy-imports]
 # Disallow all relative imports.


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This partially resolve in https://github.com/apache/airflow/pull/36831

However I forget/do not have a time to resolve other cases and additional `warnings.warn` without explicit `stacklevel` was added unfortunetly. For prevent add new ones which easily could be missed during code reviews, better enable it and created follow up task for resolve existed cases.

In most cases `stacklevel=2` is more suitable it will refers to the code which invoke this part but it can't be set blindly because it could be additionaly wraps.

With default `stacklevel=1` it refers to the line with warnings.warn, see: https://docs.astral.sh/ruff/rules/no-explicit-stacklevel/

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
