### PR TITLE
Add color to log lines in UI for error and warnings based on keywords

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -979,6 +979,22 @@ logging:
       type: boolean
       example: ~
       default: "True"
+    color_log_error_keywords:
+      description: |
+        A comma separated list of keywords related to errors whose presence should display the line in red
+        color in UI
+      version_added: 2.10.0
+      type: string
+      example: ~
+      default: "error,exception"
+    color_log_warning_keywords:
+      description: |
+        A comma separated list of keywords related to warning whose presence should display the line in yellow
+        color in UI
+      version_added: 2.10.0
+      type: string
+      example: ~
+      default: "warn"
 metrics:
   description: |
     StatsD (https://github.com/etsy/statsd) integration settings.

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
@@ -41,9 +41,11 @@ export const logLevelColorMapping = {
 
 const errorKeywords = getMetaValue("color_log_error_keywords")
   .split(",")
+  .filter((keyword) => keyword.length > 0)
   .map((keyword) => keyword.toLowerCase());
 const warningKeywords = getMetaValue("color_log_warning_keywords")
   .split(",")
+  .filter((keyword) => keyword.length > 0)
   .map((keyword) => keyword.toLowerCase());
 
 export const parseLogs = (

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
@@ -20,7 +20,7 @@
 /* global moment */
 
 import { AnsiUp } from "ansi_up";
-import { getMetaValue, addColorKeyword } from "src/utils";
+import { getMetaValue, highlightByKeywords } from "src/utils";
 import { defaultFormatWithTZ } from "src/datetime_utils";
 
 export enum LogLevel {
@@ -122,7 +122,11 @@ export const parseLogs = (
         line.includes(fileSourceFilter)
       )
     ) {
-      parsedLine = addColorKeyword(parsedLine, errorKeywords, warningKeywords);
+      parsedLine = highlightByKeywords(
+        parsedLine,
+        errorKeywords,
+        warningKeywords
+      );
       // for lines with color convert to nice HTML
       const coloredLine = ansiUp.ansi_to_html(parsedLine);
 

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
@@ -20,6 +20,7 @@
 /* global moment */
 
 import { AnsiUp } from "ansi_up";
+import { getMetaValue, addColorKeyword } from "src/utils";
 import { defaultFormatWithTZ } from "src/datetime_utils";
 
 export enum LogLevel {
@@ -37,6 +38,13 @@ export const logLevelColorMapping = {
   [LogLevel.ERROR]: "red.200",
   [LogLevel.CRITICAL]: "red.400",
 };
+
+const errorKeywords = getMetaValue("color_log_error_keywords")
+  .split(",")
+  .map((keyword) => keyword.toLowerCase());
+const warningKeywords = getMetaValue("color_log_warning_keywords")
+  .split(",")
+  .map((keyword) => keyword.toLowerCase());
 
 export const parseLogs = (
   data: string | undefined,
@@ -112,6 +120,7 @@ export const parseLogs = (
         line.includes(fileSourceFilter)
       )
     ) {
+      parsedLine = addColorKeyword(parsedLine, errorKeywords, warningKeywords);
       // for lines with color convert to nice HTML
       const coloredLine = ansiUp.ansi_to_html(parsedLine);
 

--- a/airflow/www/static/js/utils/index.test.ts
+++ b/airflow/www/static/js/utils/index.test.ts
@@ -19,7 +19,12 @@
 
 import { isEmpty } from "lodash";
 import type { DagRun } from "src/types";
-import { getDagRunLabel, getTask, getTaskSummary } from ".";
+import {
+  getDagRunLabel,
+  getTask,
+  getTaskSummary,
+  highlightByKeywords,
+} from ".";
 
 const sampleTasks = {
   id: null,
@@ -146,5 +151,47 @@ describe("Test getDagRunLabel", () => {
   test("Passing an order overrides default", async () => {
     const runLabel = getDagRunLabel({ dagRun, ordering: ["executionDate"] });
     expect(runLabel).toBe(dagRun.executionDate);
+  });
+});
+
+describe("Test highlightByKeywords", () => {
+  test("Highlight error line by red color", async () => {
+    const originalLine = "line with Error";
+    const expected = `\x1b[1m\x1b[31mline with Error\x1b[39m\x1b[0m`;
+    const highlightedLine = highlightByKeywords(
+      originalLine,
+      ["error"],
+      ["warn"]
+    );
+    expect(highlightedLine).toBe(expected);
+  });
+  test("Highlight warning line by yellow color", async () => {
+    const originalLine = "line with Warning";
+    const expected = `\x1b[1m\x1b[33mline with Warning\x1b[39m\x1b[0m`;
+    const highlightedLine = highlightByKeywords(
+      originalLine,
+      ["error"],
+      ["warn"]
+    );
+    expect(highlightedLine).toBe(expected);
+  });
+  test("Highlight line by red color when line has both error and warning", async () => {
+    const originalLine = "line with error Warning";
+    const expected = `\x1b[1m\x1b[31mline with error Warning\x1b[39m\x1b[0m`;
+    const highlightedLine = highlightByKeywords(
+      originalLine,
+      ["error"],
+      ["warn"]
+    );
+    expect(highlightedLine).toBe(expected);
+  });
+  test("No highlight", async () => {
+    const originalLine = "sample line";
+    const highlightedLine = highlightByKeywords(
+      originalLine,
+      ["error"],
+      ["warn"]
+    );
+    expect(highlightedLine).toBe(originalLine);
   });
 });

--- a/airflow/www/static/js/utils/index.ts
+++ b/airflow/www/static/js/utils/index.ts
@@ -185,21 +185,21 @@ const toSentenceCase = (camelCase: string): string => {
   return "";
 };
 
-const addColorKeyword = (
+const highlightByKeywords = (
   parsedLine: string,
   errorKeywords: string[],
   warningKeywords: string[]
 ): string => {
   const lowerParsedLine = parsedLine.toLowerCase();
+  const red = (line: string) => `\x1b[1m\x1b[31m${line}\x1b[39m\x1b[0m`;
+  const yellow = (line: string) => `\x1b[1m\x1b[33m${line}\x1b[39m\x1b[0m`;
+
   const containsError = errorKeywords.some((keyword) =>
     lowerParsedLine.includes(keyword)
   );
-  const bold = (line: string) => `\x1b[1m${line}\x1b[0m`;
-  const red = (line: string) => `\x1b[31m${line}\x1b[39m`;
-  const yellow = (line: string) => `\x1b[33m${line}\x1b[39m`;
 
   if (containsError) {
-    return bold(red(parsedLine));
+    return red(parsedLine);
   }
 
   const containsWarning = warningKeywords.some((keyword) =>
@@ -207,7 +207,7 @@ const addColorKeyword = (
   );
 
   if (containsWarning) {
-    return bold(yellow(parsedLine));
+    return yellow(parsedLine);
   }
 
   return parsedLine;
@@ -225,5 +225,5 @@ export {
   getStatusBackgroundColor,
   useOffsetTop,
   toSentenceCase,
-  addColorKeyword,
+  highlightByKeywords,
 };

--- a/airflow/www/static/js/utils/index.ts
+++ b/airflow/www/static/js/utils/index.ts
@@ -185,6 +185,34 @@ const toSentenceCase = (camelCase: string): string => {
   return "";
 };
 
+const addColorKeyword = (
+  parsedLine: string,
+  errorKeywords: string[],
+  warningKeywords: string[]
+): string => {
+  const lowerParsedLine = parsedLine.toLowerCase();
+  const containsError = errorKeywords.some((keyword) =>
+    lowerParsedLine.includes(keyword)
+  );
+  const bold = (line: string) => `\x1b[1m${line}\x1b[0m`;
+  const red = (line: string) => `\x1b[31m${line}\x1b[39m`;
+  const yellow = (line: string) => `\x1b[33m${line}\x1b[39m`;
+
+  if (containsError) {
+    return bold(red(parsedLine));
+  }
+
+  const containsWarning = warningKeywords.some((keyword) =>
+    lowerParsedLine.includes(keyword)
+  );
+
+  if (containsWarning) {
+    return bold(yellow(parsedLine));
+  }
+
+  return parsedLine;
+};
+
 export {
   hoverDelay,
   finalStatesMap,
@@ -197,4 +225,5 @@ export {
   getStatusBackgroundColor,
   useOffsetTop,
   toSentenceCase,
+  addColorKeyword,
 };

--- a/airflow/www/templates/airflow/grid.html
+++ b/airflow/www/templates/airflow/grid.html
@@ -28,6 +28,8 @@
   <meta name="base_date" content="{{ request.args.get('base_date') if request.args.get('base_date') else '' }}">
   <meta name="default_wrap" content="{{ default_wrap }}">
   <meta name="dataset_events_api" content="{{ url_for('/api/v1.airflow_api_connexion_endpoints_dataset_endpoint_get_dataset_events') }}">
+  <meta name="color_log_error_keywords" content="{{ color_log_error_keywords }}">
+  <meta name="color_log_warning_keywords" content="{{ color_log_warning_keywords }}">
 {% endblock %}
 
 {% block content %}

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2786,6 +2786,9 @@ class Airflow(AirflowBaseView):
     @provide_session
     def grid(self, dag_id: str, session: Session = NEW_SESSION):
         """Get Dag's grid view."""
+        color_log_error_keywords = conf.get("logging", "color_log_error_keywords", fallback="")
+        color_log_warning_keywords = conf.get("logging", "color_log_warning_keywords", fallback="")
+
         dag = get_airflow_app().dag_bag.get_dag(dag_id, session=session)
         dag_model = DagModel.get_dagmodel(dag_id, session=session)
         if not dag:
@@ -2843,6 +2846,8 @@ class Airflow(AirflowBaseView):
             ),
             included_events_raw=included_events_raw,
             excluded_events_raw=excluded_events_raw,
+            color_log_error_keywords=color_log_error_keywords,
+            color_log_warning_keywords=color_log_warning_keywords,
         )
 
     @expose("/calendar")


### PR DESCRIPTION
closes: #37443
related: #37443

We have been using this feature in Airflow 2.3.4 in the legacy log page by applying regex against lines to apply color for them. It
received positive feedback from users since it's helpful in quickly identifying lines causing error while reading large log fies. This adds the feature to the new log tab in the grid. Users can set additional keywords besides common keywords like error and exception to highlight them since we found cases like "fail", "access denied", "missing" etc from trigger logs emitted by systems outside our Airflow that also were helpful in debugging but maybe not applicable to everyone. This also handles case where the log line already has an ansi code to wrap remaining part of the line with color to avoid conflict.

Error and exception lines in red color with bold style

![image](https://github.com/apache/airflow/assets/3972343/8de30a01-073c-477f-9932-f2ecc4570d80)

Case where warn keyword is present but it has it's own ansi code to handle nested ansi codes

![image](https://github.com/apache/airflow/assets/3972343/aec8ab83-5d85-4648-8074-4e6c03933ac5)

