### PR TITLE
Feature/pass airflow confi as job param

### DIFF
--- a/airflow/providers/databricks/operators/databricks.py
+++ b/airflow/providers/databricks/operators/databricks.py
@@ -313,8 +313,8 @@ class DatabricksCreateJobsOperator(BaseOperator):
         if "name" not in self.json:
             raise AirflowException("Missing required parameter: name")
         job_id = self._hook.find_job_id_by_name(self.json["name"])
-        if self.json.get("parameters") is None and self.params is not None:
-            job_params = self.params.items() if self.params.items() is not None else {}
+        if not self.json.get("parameters") and self.params:
+            job_params = self.params.items() if self.params.items() else {}
             param_list = []
             for k, v in job_params:
                 param_list.append({"name": k, "default": v})

--- a/airflow/providers/databricks/operators/databricks.py
+++ b/airflow/providers/databricks/operators/databricks.py
@@ -313,6 +313,15 @@ class DatabricksCreateJobsOperator(BaseOperator):
         if "name" not in self.json:
             raise AirflowException("Missing required parameter: name")
         job_id = self._hook.find_job_id_by_name(self.json["name"])
+
+        if self.json.get("parameters") is None and self.params is not None:
+            job_params = self.params.items() if self.params.items() is not None else {}
+            param_list = []
+            for k, v in job_params:
+                param_list.append({"name": k, "default": v})
+            self.log.info("Param list")
+            self.log.info(param_list)
+            self.json["parameters"] = param_list
         if job_id is None:
             return self._hook.create_job(self.json)
         self._hook.reset_job(str(job_id), self.json)

--- a/airflow/providers/databricks/operators/databricks.py
+++ b/airflow/providers/databricks/operators/databricks.py
@@ -313,14 +313,11 @@ class DatabricksCreateJobsOperator(BaseOperator):
         if "name" not in self.json:
             raise AirflowException("Missing required parameter: name")
         job_id = self._hook.find_job_id_by_name(self.json["name"])
-
         if self.json.get("parameters") is None and self.params is not None:
             job_params = self.params.items() if self.params.items() is not None else {}
             param_list = []
             for k, v in job_params:
                 param_list.append({"name": k, "default": v})
-            self.log.info("Param list")
-            self.log.info(param_list)
             self.json["parameters"] = param_list
         if job_id is None:
             return self._hook.create_job(self.json)

--- a/tests/providers/databricks/operators/test_databricks.py
+++ b/tests/providers/databricks/operators/test_databricks.py
@@ -442,7 +442,7 @@ class TestDatabricksCreateJobsOperator:
                 "max_concurrent_runs": MAX_CONCURRENT_RUNS,
                 "git_source": GIT_SOURCE,
                 "access_control_list": ACCESS_CONTROL_LIST,
-                "parameters": []
+                "parameters": [],
             }
         )
         db_mock_class.assert_called_once_with(
@@ -493,7 +493,7 @@ class TestDatabricksCreateJobsOperator:
                 "max_concurrent_runs": MAX_CONCURRENT_RUNS,
                 "git_source": GIT_SOURCE,
                 "access_control_list": ACCESS_CONTROL_LIST,
-                "parameters": []
+                "parameters": [],
             }
         )
         db_mock_class.assert_called_once_with(
@@ -593,7 +593,7 @@ class TestDatabricksCreateJobsOperator:
             "max_concurrent_runs": MAX_CONCURRENT_RUNS,
             "git_source": GIT_SOURCE,
             "access_control_list": ACCESS_CONTROL_LIST,
-            "parameters": JOB_PARAMS
+            "parameters": JOB_PARAMS,
         }
         op = DatabricksCreateJobsOperator(task_id=TASK_ID, json=json)
         db_mock = db_mock_class.return_value
@@ -614,7 +614,7 @@ class TestDatabricksCreateJobsOperator:
                 "max_concurrent_runs": MAX_CONCURRENT_RUNS,
                 "git_source": GIT_SOURCE,
                 "access_control_list": ACCESS_CONTROL_LIST,
-                "parameters": JOB_PARAMS
+                "parameters": JOB_PARAMS,
             }
         )
 

--- a/tests/providers/databricks/operators/test_databricks.py
+++ b/tests/providers/databricks/operators/test_databricks.py
@@ -441,6 +441,7 @@ class TestDatabricksCreateJobsOperator:
                 "max_concurrent_runs": MAX_CONCURRENT_RUNS,
                 "git_source": GIT_SOURCE,
                 "access_control_list": ACCESS_CONTROL_LIST,
+                "parameters": []
             }
         )
         db_mock_class.assert_called_once_with(
@@ -491,6 +492,7 @@ class TestDatabricksCreateJobsOperator:
                 "max_concurrent_runs": MAX_CONCURRENT_RUNS,
                 "git_source": GIT_SOURCE,
                 "access_control_list": ACCESS_CONTROL_LIST,
+                "parameters": []
             }
         )
         db_mock_class.assert_called_once_with(

--- a/tests/providers/databricks/operators/test_databricks.py
+++ b/tests/providers/databricks/operators/test_databricks.py
@@ -220,6 +220,7 @@ ACCESS_CONTROL_LIST = [
         "permission_level": "CAN_MANAGE",
     }
 ]
+JOB_PARAMS = [{"name": "param1", "default": "value1"}]
 
 
 def mock_dict(d: dict):
@@ -574,6 +575,58 @@ class TestDatabricksCreateJobsOperator:
         )
 
         db_mock.update_job_permission.assert_not_called()
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_create_job_with_job_parameter(self, db_mock_class):
+        """
+        Test create job with job parameters.
+        """
+        json = {
+            "name": JOB_NAME,
+            "tags": TAGS,
+            "tasks": TASKS,
+            "job_clusters": JOB_CLUSTERS,
+            "email_notifications": EMAIL_NOTIFICATIONS,
+            "webhook_notifications": WEBHOOK_NOTIFICATIONS,
+            "timeout_seconds": TIMEOUT_SECONDS,
+            "schedule": SCHEDULE,
+            "max_concurrent_runs": MAX_CONCURRENT_RUNS,
+            "git_source": GIT_SOURCE,
+            "access_control_list": ACCESS_CONTROL_LIST,
+            "parameters": JOB_PARAMS
+        }
+        op = DatabricksCreateJobsOperator(task_id=TASK_ID, json=json)
+        db_mock = db_mock_class.return_value
+        db_mock.find_job_id_by_name.return_value = None
+
+        op.execute({})
+
+        expected = utils.normalise_json_content(
+            {
+                "name": JOB_NAME,
+                "tags": TAGS,
+                "tasks": TASKS,
+                "job_clusters": JOB_CLUSTERS,
+                "email_notifications": EMAIL_NOTIFICATIONS,
+                "webhook_notifications": WEBHOOK_NOTIFICATIONS,
+                "timeout_seconds": TIMEOUT_SECONDS,
+                "schedule": SCHEDULE,
+                "max_concurrent_runs": MAX_CONCURRENT_RUNS,
+                "git_source": GIT_SOURCE,
+                "access_control_list": ACCESS_CONTROL_LIST,
+                "parameters": JOB_PARAMS
+            }
+        )
+
+        db_mock_class.assert_called_once_with(
+            DEFAULT_CONN_ID,
+            retry_limit=op.databricks_retry_limit,
+            retry_delay=op.databricks_retry_delay,
+            retry_args=None,
+            caller="DatabricksCreateJobsOperator",
+        )
+
+        db_mock.create_job.assert_called_once_with(expected)
 
 
 class TestDatabricksSubmitRunOperator:


### PR DESCRIPTION
Fixes: #39002 

### Tests:

1. empty airflow config and empty job parameter -- empty job parameter
2. empty airflow config and some job parameter in databricks operator -- job params from operator get applied
3. non empty airflow config with empty job parameter -- airflow config gets passed as job param
4. non empty airflow config with non empty job parameter --  job params from operator get applied
