### PR TITLE
Ban `unittest` marks which presented into the `pytest`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -460,8 +460,13 @@ banned-module-level-imports = ["numpy", "pandas"]
 "logging.fatal".msg = "Instantiate new `logger = logging.getLogger(__name__)` and use it instead of root logger"
 "logging.critical".msg = "Instantiate new `logger = logging.getLogger(__name__)` and use it instead of root logger"
 "logging.log".msg = "Instantiate new `logger = logging.getLogger(__name__)` and use it instead of root logger"
-# Some specific cases
-"unittest.TestCase".msg = "Use pytest compatible classes"
+# unittest related restrictions
+"unittest.TestCase".msg = "Use pytest compatible classes: https://docs.pytest.org/en/stable/getting-started.html#group-multiple-tests-in-a-class"
+"unittest.skip".msg = "Use `pytest.mark.skip` instead: https://docs.pytest.org/en/stable/reference/reference.html#marks"
+"unittest.skipIf".msg = "Use `pytest.mark.skipif` instead: https://docs.pytest.org/en/stable/reference/reference.html#marks"
+"unittest.skipUnless".msg = "Use `pytest.mark.skipif` instead: https://docs.pytest.org/en/stable/reference/reference.html#marks"
+"unittest.expectedFailure".msg = "Use `pytest.mark.xfail` instead: https://docs.pytest.org/en/stable/reference/reference.html#marks"
+
 
 [tool.ruff.lint.flake8-type-checking]
 exempt-modules = ["typing", "typing_extensions"]

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -24,7 +24,6 @@ import os
 import re
 import shutil
 import sys
-import unittest
 from argparse import ArgumentParser
 from contextlib import contextmanager, redirect_stdout
 from io import StringIO
@@ -805,7 +804,7 @@ class TestLogsfromTaskRunCommand:
             # when not k8s executor pod, most output is redirected to logs
             assert len(lines) == 1
 
-    @unittest.skipIf(not hasattr(os, "fork"), "Forking not available")
+    @pytest.mark.skipif(not hasattr(os, "fork"), reason="Forking not available")
     def test_logging_with_run_task(self):
         with conf_vars({("core", "dags_folder"): self.dag_path}):
             task_command.task_run(self.parser.parse_args(self.task_args))
@@ -833,7 +832,7 @@ class TestLogsfromTaskRunCommand:
             f"task_id={self.task_id}, execution_date=20170101T000000" in logs
         )
 
-    @unittest.skipIf(not hasattr(os, "fork"), "Forking not available")
+    @pytest.mark.skipif(not hasattr(os, "fork"), reason="Forking not available")
     def test_run_task_with_pool(self):
         pool_name = "test_pool_run"
 

--- a/tests/providers/amazon/aws/hooks/test_s3.py
+++ b/tests/providers/amazon/aws/hooks/test_s3.py
@@ -21,7 +21,6 @@ import gzip as gz
 import inspect
 import os
 import re
-import unittest
 from datetime import datetime as std_datetime, timezone
 from unittest import mock, mock as async_mock
 from unittest.mock import MagicMock, Mock, patch
@@ -467,7 +466,6 @@ class TestAwsS3Hook:
 
     @async_mock.patch("airflow.providers.amazon.aws.triggers.s3.S3Hook.async_conn")
     @pytest.mark.asyncio
-    @unittest.expectedFailure
     async def test_s3_key_hook_get_head_object_raise_exception_async(self, mock_client):
         """
         Test for 500 error if key not found and assert based on response.


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Change `unittest` decorators which are remaining and has direct replacement in `pytest`

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
