### PR TITLE
Remove flag from AWS auth manager to use it

### DIFF
--- a/airflow/providers/amazon/aws/auth_manager/aws_auth_manager.py
+++ b/airflow/providers/amazon/aws/auth_manager/aws_auth_manager.py
@@ -24,7 +24,6 @@ from typing import TYPE_CHECKING, Container, Sequence, cast
 from flask import session, url_for
 
 from airflow.cli.cli_config import CLICommand, DefaultHelpParser, GroupCommand
-from airflow.configuration import conf
 from airflow.exceptions import AirflowOptionalProviderFeatureException
 from airflow.providers.amazon.aws.auth_manager.avp.entities import AvpEntities
 from airflow.providers.amazon.aws.auth_manager.avp.facade import (
@@ -33,10 +32,6 @@ from airflow.providers.amazon.aws.auth_manager.avp.facade import (
 )
 from airflow.providers.amazon.aws.auth_manager.cli.definition import (
     AWS_AUTH_MANAGER_COMMANDS,
-)
-from airflow.providers.amazon.aws.auth_manager.constants import (
-    CONF_ENABLE_KEY,
-    CONF_SECTION_NAME,
 )
 from airflow.providers.amazon.aws.auth_manager.security_manager.aws_security_manager_override import (
     AwsSecurityManagerOverride,
@@ -87,12 +82,7 @@ class AwsAuthManager(BaseAuthManager):
 
     def __init__(self, appbuilder: AirflowAppBuilder) -> None:
         super().__init__(appbuilder)
-        enable = conf.getboolean(CONF_SECTION_NAME, CONF_ENABLE_KEY)
         self._check_avp_schema_version()
-        if not enable:
-            raise NotImplementedError(
-                "The AWS auth manager is currently being built. It is not finalized. It is not intended to be used yet."
-            )
 
     @cached_property
     def avp_facade(self):

--- a/airflow/providers/amazon/aws/auth_manager/constants.py
+++ b/airflow/providers/amazon/aws/auth_manager/constants.py
@@ -18,7 +18,6 @@
 # Configuration keys
 from __future__ import annotations
 
-CONF_ENABLE_KEY = "enable"
 CONF_SECTION_NAME = "aws_auth_manager"
 CONF_CONN_ID_KEY = "conn_id"
 CONF_REGION_NAME_KEY = "region_name"

--- a/docs/apache-airflow-providers-amazon/auth-manager/manage/index.rst
+++ b/docs/apache-airflow-providers-amazon/auth-manager/manage/index.rst
@@ -19,9 +19,9 @@
 Manage Airflow environment with AWS auth manager
 ================================================
 
-When the AWS auth manager is used, all users and their permissions are no longer managed by
-Airflow itself but by AWS through two different services: AWS IAM Identity Center (users) and Amazon Verified
-Permissions (permissions).
+When the AWS auth manager is used, all users and their permissions are no longer managed by the Flask auth manager,
+which is default in Airflow, but by AWS-based authorization integration through two different services:
+AWS IAM Identity Center (users) and Amazon Verified Permissions (permissions).
 
 Manage users through AWS IAM Identity Center
 ============================================
@@ -55,7 +55,7 @@ Assign users and groups to the Airflow environment
 --------------------------------------------------
 
 .. note::
-  All users and groups defined in AWS IAM Identity Center do not have automatically access to the Airflow environment.
+  All users and groups defined in AWS IAM Identity Center do not have automatic access to the Airflow environment.
   You need to manually assign which user can access to Airflow.
 
 To assign users and groups to Airflow, please follow the steps below.
@@ -102,7 +102,7 @@ In cedar language, a policy is composed of three elements:
 * **Action**. What operation does the principal want to perform?
 * **Resource**. What does the principal want to perform the action on?
 
-Each of these three elements can have limited values in the context of the Airflow environment.
+Each of these three elements allow only a specific set of values in the context of the Airflow environment.
 You can see the list of principals, actions and resources in the policy store schema by following the steps below.
 
 1. Open the `Amazon Verified Permissions console <https://console.aws.amazon.com/verifiedpermissions>`_.
@@ -113,8 +113,7 @@ Example of policies
 -------------------
 
 Here are some example of policies you can define in Amazon Verified Permissions.
-You can use them as-is if they fit exactly your use case.
-You can also modify and/or combine them to create your owned tailor made policies.
+You can modify and/or combine them to create your owned tailor made policies.
 
 Give all permissions to specific user
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/providers/amazon/aws/auth_manager/test_aws_auth_manager.py
+++ b/tests/providers/amazon/aws/auth_manager/test_aws_auth_manager.py
@@ -83,7 +83,6 @@ def auth_manager():
                 "core",
                 "auth_manager",
             ): "airflow.providers.amazon.aws.auth_manager.aws_auth_manager.AwsAuthManager",
-            ("aws_auth_manager", "enable"): "True",
         }
     ):
         with patch.object(AwsAuthManager, "_check_avp_schema_version"):
@@ -100,7 +99,6 @@ def auth_manager_with_appbuilder():
                 "core",
                 "auth_manager",
             ): "airflow.providers.amazon.aws.auth_manager.aws_auth_manager.AwsAuthManager",
-            ("aws_auth_manager", "enable"): "True",
         }
     ):
         with patch.object(AwsAuthManager, "_check_avp_schema_version"):
@@ -120,7 +118,6 @@ def client_admin():
                 "core",
                 "auth_manager",
             ): "airflow.providers.amazon.aws.auth_manager.aws_auth_manager.AwsAuthManager",
-            ("aws_auth_manager", "enable"): "True",
             ("aws_auth_manager", "region_name"): "us-east-1",
             ("aws_auth_manager", "saml_metadata_url"): "/saml/metadata",
             ("aws_auth_manager", "avp_policy_store_id"): "avp_policy_store_id",

--- a/tests/providers/amazon/aws/auth_manager/test_constants.py
+++ b/tests/providers/amazon/aws/auth_manager/test_constants.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 from airflow.providers.amazon.aws.auth_manager.constants import (
     CONF_AVP_POLICY_STORE_ID_KEY,
     CONF_CONN_ID_KEY,
-    CONF_ENABLE_KEY,
     CONF_REGION_NAME_KEY,
     CONF_SAML_METADATA_URL_KEY,
     CONF_SECTION_NAME,
@@ -27,9 +26,6 @@ from airflow.providers.amazon.aws.auth_manager.constants import (
 
 
 class TestAwsAuthManagerConstants:
-    def test_conf_enable_key(self):
-        assert CONF_ENABLE_KEY == "enable"
-
     def test_conf_section_name(self):
         assert CONF_SECTION_NAME == "aws_auth_manager"
 

--- a/tests/providers/amazon/aws/auth_manager/views/test_auth.py
+++ b/tests/providers/amazon/aws/auth_manager/views/test_auth.py
@@ -54,7 +54,6 @@ def aws_app():
                 "core",
                 "auth_manager",
             ): "airflow.providers.amazon.aws.auth_manager.aws_auth_manager.AwsAuthManager",
-            ("aws_auth_manager", "enable"): "True",
             ("aws_auth_manager", "saml_metadata_url"): SAML_METADATA_URL,
         }
     ):
@@ -95,7 +94,6 @@ class TestAwsAuthManagerAuthenticationViews:
                     "core",
                     "auth_manager",
                 ): "airflow.providers.amazon.aws.auth_manager.aws_auth_manager.AwsAuthManager",
-                ("aws_auth_manager", "enable"): "True",
                 ("aws_auth_manager", "saml_metadata_url"): SAML_METADATA_URL,
             }
         ):
@@ -134,7 +132,6 @@ class TestAwsAuthManagerAuthenticationViews:
                     "core",
                     "auth_manager",
                 ): "airflow.providers.amazon.aws.auth_manager.aws_auth_manager.AwsAuthManager",
-                ("aws_auth_manager", "enable"): "True",
                 ("aws_auth_manager", "saml_metadata_url"): SAML_METADATA_URL,
             }
         ):

--- a/tests/system/providers/amazon/aws/tests/test_aws_auth_manager.py
+++ b/tests/system/providers/amazon/aws/tests/test_aws_auth_manager.py
@@ -121,7 +121,6 @@ def base_app(region_name, avp_policy_store_id):
                 "core",
                 "auth_manager",
             ): "airflow.providers.amazon.aws.auth_manager.aws_auth_manager.AwsAuthManager",
-            ("aws_auth_manager", "enable"): "True",
             ("aws_auth_manager", "region_name"): region_name,
             ("aws_auth_manager", "saml_metadata_url"): SAML_METADATA_URL,
             ("aws_auth_manager", "avp_policy_store_id"): avp_policy_store_id,


### PR DESCRIPTION
This flag was set to prevent usage (besides testing) while the auth manager was being implemented.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
