### PR TITLE
Fix PROD image package installation in CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -780,6 +780,10 @@ function install_airflow_and_providers_from_docker_context_files(){
                 ${ADDITIONAL_PIP_INSTALL_FLAGS} --constraint "${local_constraints_file}" \
                 "${install_airflow_package[@]}" "${installing_providers_packages[@]}"
             set +x
+            echo
+            echo "${COLOR_BLUE}Copying ${local_constraints_file} to ${HOME}/constraints.txt${COLOR_RESET}"
+            echo
+            cp "${local_constraints_file}" "${HOME}/constraints.txt"
         else
             echo
             echo "${COLOR_BLUE}Installing docker-context-files packages with constraints from GitHub${COLOR_RESET}"

--- a/dev/breeze/src/airflow_breeze/params/build_prod_params.py
+++ b/dev/breeze/src/airflow_breeze/params/build_prod_params.py
@@ -143,6 +143,19 @@ class BuildProdParams(CommonBuildParams):
             )
             self.airflow_constraints_location = constraints_location
             extra_build_flags.extend(self.args_for_remote_install)
+        elif self.install_packages_from_context:
+            extra_build_flags.extend(
+                [
+                    "--build-arg",
+                    "AIRFLOW_SOURCES_FROM=/empty",
+                    "--build-arg",
+                    "AIRFLOW_SOURCES_TO=/empty",
+                    "--build-arg",
+                    f"AIRFLOW_INSTALLATION_METHOD={self.installation_method}",
+                    "--build-arg",
+                    f"AIRFLOW_CONSTRAINTS_REFERENCE={self.airflow_constraints_reference}",
+                ],
+            )
         else:
             extra_build_flags.extend(
                 [

--- a/docker_tests/test_prod_image.py
+++ b/docker_tests/test_prod_image.py
@@ -175,6 +175,12 @@ class TestPythonPackages:
     def test_check_dependencies_imports(self, package_name, import_names, default_docker_image):
         run_python_in_docker(f"import {','.join(import_names)}", image=default_docker_image)
 
+    def test_there_is_no_opt_airflow_airflow_folder(self, default_docker_image):
+        output = run_bash_in_docker(
+            "find /opt/airflow/airflow/ 2>/dev/null | wc -l", image=default_docker_image
+        )
+        assert output == "0"
+
 
 class TestExecuteAsRoot:
     def test_execute_airflow_as_root(self, default_docker_image):

--- a/scripts/docker/install_from_docker_context_files.sh
+++ b/scripts/docker/install_from_docker_context_files.sh
@@ -86,6 +86,10 @@ function install_airflow_and_providers_from_docker_context_files(){
                 ${ADDITIONAL_PIP_INSTALL_FLAGS} --constraint "${local_constraints_file}" \
                 "${install_airflow_package[@]}" "${installing_providers_packages[@]}"
             set +x
+            echo
+            echo "${COLOR_BLUE}Copying ${local_constraints_file} to ${HOME}/constraints.txt${COLOR_RESET}"
+            echo
+            cp "${local_constraints_file}" "${HOME}/constraints.txt"
         else
             echo
             echo "${COLOR_BLUE}Installing docker-context-files packages with constraints from GitHub${COLOR_RESET}"


### PR DESCRIPTION
When PROD image packages are installed in in CI, the local sources should not be present in the image, also constraints from sources shoudl replace the one downloaded from main.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
