### PR TITLE
Fix doc redirects

### DIFF
--- a/docs/apache-airflow/redirects.txt
+++ b/docs/apache-airflow/redirects.txt
@@ -19,8 +19,8 @@
 
 administration-and-deployment/security/index.rst security/index.rst
 administration-and-deployment/security/kerberos.rst security/kerberos.rst
-administration-and-deployment/security/access-control.rst ../../apache-airflow-providers-fab/stable/auth-manager/access-control.rst
-administration-and-deployment/security/access-control/index.rst ../../apache-airflow-providers-fab/stable/auth-manager/access-control.rst
+administration-and-deployment/security/access-control.rst ../apache-airflow-providers-fab/stable/auth-manager/access-control.rst
+administration-and-deployment/security/access-control/index.rst ../apache-airflow-providers-fab/stable/auth-manager/access-control.rst
 administration-and-deployment/security/api.rst security/api.rst
 administration-and-deployment/security/audit_logs.rst security/audit_logs.rst
 administration-and-deployment/security/flower.rst security/flower.rst

--- a/docs/apache-airflow/redirects.txt
+++ b/docs/apache-airflow/redirects.txt
@@ -19,6 +19,13 @@
 
 administration-and-deployment/security/index.rst security/index.rst
 administration-and-deployment/security/kerberos.rst security/kerberos.rst
+
+# Moving FAB auth manager related docs to providers
+## The ``../`` indicates that it will move to the root of the docs directory, unlike the rest of
+## the entries here which move to docs/apache-airflow.
+## It's okay to include ``/stable/``, because there's no relationship between a version of
+## Airflow and the version of any provider package.
+
 administration-and-deployment/security/access-control.rst ../apache-airflow-providers-fab/stable/auth-manager/access-control.rst
 administration-and-deployment/security/access-control/index.rst ../apache-airflow-providers-fab/stable/auth-manager/access-control.rst
 administration-and-deployment/security/api.rst security/api.rst
@@ -37,7 +44,7 @@ howto/use-alternative-secrets-backend.rst security/secrets/secrets-backend/index
 security.rst security/index.rst
 
 # Move the documentation from core to FAB provider
-security/access-control.rst ../../apache-airflow-providers-fab/stable/auth-manager/access-control.rst
+security/access-control.rst ../apache-airflow-providers-fab/stable/auth-manager/access-control.rst
 
 # Operators guides
 howto/operator/external.rst howto/operator/external_task_sensor.rst
@@ -47,7 +54,7 @@ howto/customize-dag-ui-page-instance-name.rst howto/customize-ui.rst#customizing
 howto/customize-state-colors-ui.rst howto/customize-ui.rst#customizing-state-colours
 
 # Web UI
-howto/add-new-role.rst ../../apache-airflow-providers-fab/stable/auth-manager/access-control.rst
+howto/add-new-role.rst ../apache-airflow-providers-fab/stable/auth-manager/access-control.rst
 
 # Set up a database
 howto/initialize-database.rst howto/set-up-database.rst


### PR DESCRIPTION
Some doc redirection is broken and end up redirecting to the wrong page. The current redirection redirects to https://airflow.apache.org/apache-airflow-providers-fab/docs/stable/auth-manager/access-control.html instead of https://airflow.apache.org/docs/apache-airflow-providers-fab/docs/stable/auth-manager/access-control.html

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
