### PR TITLE
limit simple-salesforce version which breaks MyPy checks

### DIFF
--- a/airflow/providers/salesforce/provider.yaml
+++ b/airflow/providers/salesforce/provider.yaml
@@ -55,7 +55,9 @@ versions:
 
 dependencies:
   - apache-airflow>=2.6.0
-  - simple-salesforce>=1.0.0
+  # simple-salesforce 1.12.6 breaks static checks, so we limit it to <1.12.6 for now
+  # https://github.com/apache/airflow/pull/39045
+  - simple-salesforce>=1.0.0,<1.12.6
   # In pandas 2.2 minimal version of the sqlalchemy is 2.0
   # https://pandas.pydata.org/docs/whatsnew/v2.2.0.html#increased-minimum-versions-for-dependencies
   # However Airflow not fully supports it yet: https://github.com/apache/airflow/issues/28723

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -970,7 +970,7 @@
     "deps": [
       "apache-airflow>=2.6.0",
       "pandas>=1.2.5,<2.2",
-      "simple-salesforce>=1.0.0"
+      "simple-salesforce>=1.0.0,<1.12.6"
     ],
     "devel-deps": [],
     "cross-providers-deps": [],


### PR DESCRIPTION
[simple-salesforce 1.12.6](https://pypi.org/project/simple-salesforce/) was released 6 hours ago, and it looks like it breaks our MyPy checks, for ex: https://github.com/apache/airflow/actions/runs/8696175615/job/23849178353?pr=38874

This PR adds an upper bound for the supported version until we fix the issues.