### PR TITLE
AIP-61 When clearing a task, clear the executor field on TI DB records

### DIFF
--- a/airflow/serialization/pydantic/taskinstance.py
+++ b/airflow/serialization/pydantic/taskinstance.py
@@ -285,16 +285,21 @@ class TaskInstancePydantic(BaseModelPydantic, LoggingMixin):
             force_fail=force_fail,
         )
 
-    def refresh_from_task(self, task: Operator, pool_override: str | None = None) -> None:
+    def refresh_from_task(
+        self, task: Operator, pool_override: str | None = None, refresh_executor: bool = False
+    ) -> None:
         """
         Copy common attributes from the given task.
 
         :param task: The task object to copy from
         :param pool_override: Use the pool_override instead of task's pool
+        :param refresh_executor: whether or not to refresh the TI executor from the task
         """
         from airflow.models.taskinstance import _refresh_from_task
 
-        _refresh_from_task(task_instance=self, task=task, pool_override=pool_override)
+        _refresh_from_task(
+            task_instance=self, task=task, pool_override=pool_override, refresh_executor=refresh_executor
+        )
 
     def get_previous_dagrun(
         self,


### PR DESCRIPTION
If a user tags a task to run with a particular executor, then triggers a dag run, the task instance created persists the requested executor in the DB record for that TI. However, if the user made a mistake in the executor (typo, executor doesn't exist, changes their mind, etc) this change allows them to reset that field by clearing the task.

The task instance will be updated with the latest executor tagged for the task in the dag upon clearing.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
