### PR TITLE
Prepare docs 1st wave (RC3) + ad hoc April 2024 (#38995)

### DIFF
--- a/airflow/providers/cncf/kubernetes/CHANGELOG.rst
+++ b/airflow/providers/cncf/kubernetes/CHANGELOG.rst
@@ -27,6 +27,14 @@
 Changelog
 ---------
 
+8.1.1
+.....
+
+Bug Fixes
+~~~~~~~~~
+
+* ``Avoid logging empty line KPO (#38247)``
+
 8.1.0
 .....
 

--- a/airflow/providers/cncf/kubernetes/__init__.py
+++ b/airflow/providers/cncf/kubernetes/__init__.py
@@ -27,7 +27,7 @@ import packaging.version
 
 __all__ = ["__version__"]
 
-__version__ = "8.1.0"
+__version__ = "8.1.1"
 
 try:
     from airflow import __version__ as airflow_version

--- a/airflow/providers/cncf/kubernetes/provider.yaml
+++ b/airflow/providers/cncf/kubernetes/provider.yaml
@@ -22,9 +22,10 @@ description: |
     `Kubernetes <https://kubernetes.io/>`__
 
 state: ready
-source-date-epoch: 1712665231
+source-date-epoch: 1713253055
 # note that those versions are maintained by release manager - do not update them manually
 versions:
+  - 8.1.1
   - 8.1.0
   - 8.0.1
   - 8.0.0

--- a/airflow/providers/databricks/CHANGELOG.rst
+++ b/airflow/providers/databricks/CHANGELOG.rst
@@ -34,6 +34,7 @@ Features
 
 * ``Add cancel_previous_run to DatabricksRunNowOperator (#38702)``
 * ``add repair_run support to DatabricksRunNowOperator in deferrable mode (#38619)``
+* ``Adds job_id as path param in update permission (#38962)``
 
 Bug Fixes
 ~~~~~~~~~
@@ -58,6 +59,7 @@ Misc
    * ``Prepare docs 1st wave (RC1) March 2024 (#37876)``
    * ``update pre-commit (#37665)``
    * ``Prepare docs 1st wave (RC1) April 2024 (#38863)``
+   * ``Prepare docs 1st wave (RC2) April 2024 (#38995)``
 
 6.2.0
 .....

--- a/airflow/providers/databricks/CHANGELOG.rst
+++ b/airflow/providers/databricks/CHANGELOG.rst
@@ -42,6 +42,7 @@ Bug Fixes
 * ``Fix remaining D401 checks (#37434)``
 * ``Update ACL during job reset (#38741)``
 * ``Remove extra slash from update permission endpoint (#38918)``
+* ``DatabricksRunNowOperator: fix typo in latest_repair_id (#39050)``
 
 Misc
 ~~~~

--- a/airflow/providers/fab/CHANGELOG.rst
+++ b/airflow/providers/fab/CHANGELOG.rst
@@ -20,6 +20,19 @@
 Changelog
 ---------
 
+1.0.4
+.....
+
+Bug Fixes
+~~~~~~~~~
+
+* ``Remove button for reset my password when we have reset password (#38957)``
+
+.. Below changes are excluded from the changelog. Move them to
+   appropriate section above if needed. Do not delete the lines(!):
+   * ``Activate RUF019 that checks for unnecessary key check (#38950)``
+
+
 1.0.3
 .....
 

--- a/airflow/providers/fab/__init__.py
+++ b/airflow/providers/fab/__init__.py
@@ -27,7 +27,7 @@ import packaging.version
 
 __all__ = ["__version__"]
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 
 try:
     from airflow import __version__ as airflow_version

--- a/airflow/providers/fab/provider.yaml
+++ b/airflow/providers/fab/provider.yaml
@@ -28,10 +28,11 @@ description: |
 # For providers until we think it should be released.
 state: ready
 
-source-date-epoch: 1712665766
+source-date-epoch: 1713253066
 
 # note that those versions are maintained by release manager - do not update them manually
 versions:
+  - 1.0.4
   - 1.0.3
   - 1.0.2
   - 1.0.1

--- a/docs/apache-airflow-providers-cncf-kubernetes/commits.rst
+++ b/docs/apache-airflow-providers-cncf-kubernetes/commits.rst
@@ -35,14 +35,26 @@ For high-level changelog, see :doc:`package information including changelog <ind
 
 
 
+8.1.1
+.....
+
+Latest change: 2024-04-15
+
+=================================================================================================  ===========  =========================================
+Commit                                                                                             Committed    Subject
+=================================================================================================  ===========  =========================================
+`43919c2fa6 <https://github.com/apache/airflow/commit/43919c2fa6cbffd65239cb7fa3db2abb0545a260>`_  2024-04-15   ``Avoid logging empty line KPO (#38247)``
+=================================================================================================  ===========  =========================================
+
 8.1.0
 .....
 
-Latest change: 2024-04-09
+Latest change: 2024-04-10
 
 =================================================================================================  ===========  ===================================================================================================
 Commit                                                                                             Committed    Subject
 =================================================================================================  ===========  ===================================================================================================
+`5fa80b6aea <https://github.com/apache/airflow/commit/5fa80b6aea60f93cdada66f160e2b54f723865ca>`_  2024-04-10   ``Prepare docs 1st wave (RC1) April 2024 (#38863)``
 `78f84b9147 <https://github.com/apache/airflow/commit/78f84b914733648d4a9230d1804df0052115906b>`_  2024-04-09   ``fix: try002 for provider cncf kubernetes (#38799)``
 `a19a9cb523 <https://github.com/apache/airflow/commit/a19a9cb52388118e5fc735a25cc42229576482ad>`_  2024-04-05   ``removed usage of deprecated function  for naming the pod in provider k8s pod.py (#38638)``
 `ab5aabe50b <https://github.com/apache/airflow/commit/ab5aabe50b1023a7db0d256751eadd033091af63>`_  2024-04-02   ``Implement delete_on_status parameter for KubernetesDeleteJobOperator (#38458)``

--- a/docs/apache-airflow-providers-cncf-kubernetes/index.rst
+++ b/docs/apache-airflow-providers-cncf-kubernetes/index.rst
@@ -87,7 +87,7 @@ apache-airflow-providers-cncf-kubernetes package
 `Kubernetes <https://kubernetes.io/>`__
 
 
-Release: 8.1.0
+Release: 8.1.1
 
 Provider package
 ----------------

--- a/docs/apache-airflow-providers-databricks/commits.rst
+++ b/docs/apache-airflow-providers-databricks/commits.rst
@@ -38,11 +38,12 @@ For high-level changelog, see :doc:`package information including changelog <ind
 6.3.0
 .....
 
-Latest change: 2024-04-14
+Latest change: 2024-04-16
 
 =================================================================================================  ===========  ======================================================================================================
 Commit                                                                                             Committed    Subject
 =================================================================================================  ===========  ======================================================================================================
+`66df296a6e <https://github.com/apache/airflow/commit/66df296a6e54d42909231230a1c76f260dd15d0b>`_  2024-04-16   ``[FIX] typo in parameter (#39050)``
 `629545bea2 <https://github.com/apache/airflow/commit/629545bea2afa55dbda9b839734b4851d9da566e>`_  2024-04-14   ``Adds job_id as path param in update permission (#38962)``
 `f9dcc82fb6 <https://github.com/apache/airflow/commit/f9dcc82fb690777e0cb4951f5ae5a4bde1e15c54>`_  2024-04-13   ``Prepare docs 1st wave (RC2) April 2024 (#38995)``
 `4a669fb1a9 <https://github.com/apache/airflow/commit/4a669fb1a9891809932a7fdba202c6baa369d537>`_  2024-04-11   ``Remove extra slash from update permission endpoint (#38918)``

--- a/docs/apache-airflow-providers-databricks/commits.rst
+++ b/docs/apache-airflow-providers-databricks/commits.rst
@@ -38,11 +38,13 @@ For high-level changelog, see :doc:`package information including changelog <ind
 6.3.0
 .....
 
-Latest change: 2024-04-11
+Latest change: 2024-04-14
 
 =================================================================================================  ===========  ======================================================================================================
 Commit                                                                                             Committed    Subject
 =================================================================================================  ===========  ======================================================================================================
+`629545bea2 <https://github.com/apache/airflow/commit/629545bea2afa55dbda9b839734b4851d9da566e>`_  2024-04-14   ``Adds job_id as path param in update permission (#38962)``
+`f9dcc82fb6 <https://github.com/apache/airflow/commit/f9dcc82fb690777e0cb4951f5ae5a4bde1e15c54>`_  2024-04-13   ``Prepare docs 1st wave (RC2) April 2024 (#38995)``
 `4a669fb1a9 <https://github.com/apache/airflow/commit/4a669fb1a9891809932a7fdba202c6baa369d537>`_  2024-04-11   ``Remove extra slash from update permission endpoint (#38918)``
 `5fa80b6aea <https://github.com/apache/airflow/commit/5fa80b6aea60f93cdada66f160e2b54f723865ca>`_  2024-04-10   ``Prepare docs 1st wave (RC1) April 2024 (#38863)``
 `6f21f7dc9b <https://github.com/apache/airflow/commit/6f21f7dc9b8e7d47480f59145d803b6907e3ec7d>`_  2024-04-10   ``Update ACL during job reset (#38741)``

--- a/docs/apache-airflow-providers-fab/commits.rst
+++ b/docs/apache-airflow-providers-fab/commits.rst
@@ -35,6 +35,18 @@ For high-level changelog, see :doc:`package information including changelog <ind
 
 
 
+1.0.4
+.....
+
+Latest change: 2024-04-15
+
+=================================================================================================  ===========  ============================================================================
+Commit                                                                                             Committed    Subject
+=================================================================================================  ===========  ============================================================================
+`f8104325b7 <https://github.com/apache/airflow/commit/f8104325b7a66d4e98ff3a6c3555f90c796071c6>`_  2024-04-15   ``Activate RUF019 that checks for unnecessary key check (#38950)``
+`c3bb80da93 <https://github.com/apache/airflow/commit/c3bb80da939025dd49b646a819f5e984faf9ddfc>`_  2024-04-12   ``Remove button for reset my password when we have reset password (#38957)``
+=================================================================================================  ===========  ============================================================================
+
 1.0.3
 .....
 
@@ -43,6 +55,7 @@ Latest change: 2024-04-10
 =================================================================================================  ===========  ==================================================================
 Commit                                                                                             Committed    Subject
 =================================================================================================  ===========  ==================================================================
+`5fa80b6aea <https://github.com/apache/airflow/commit/5fa80b6aea60f93cdada66f160e2b54f723865ca>`_  2024-04-10   ``Prepare docs 1st wave (RC1) April 2024 (#38863)``
 `53cd7173b4 <https://github.com/apache/airflow/commit/53cd7173b4781e8cd46fd96b1e107b2d1bcf4966>`_  2024-04-10   ``Fix azure authentication when no email is set (#38872)``
 `6d3d2075ae <https://github.com/apache/airflow/commit/6d3d2075ae782104b7840779c91fb2be5a61cf24>`_  2024-04-07   ``fix: try002 for provider fab (#38801)``
 `e700f4150a <https://github.com/apache/airflow/commit/e700f4150a60fd019e20cfd650ab397c6276dd77>`_  2024-03-30   ``Rename 'allowed_filter_attrs' to 'allowed_sort_attrs' (#38626)``

--- a/docs/apache-airflow-providers-fab/index.rst
+++ b/docs/apache-airflow-providers-fab/index.rst
@@ -76,7 +76,7 @@ apache-airflow-providers-fab package
 `Flask App Builder <https://flask-appbuilder.readthedocs.io/>`__
 
 
-Release: 1.0.3
+Release: 1.0.4
 
 Provider package
 ----------------


### PR DESCRIPTION
This release contains:

RC3 for databricks
RC1 for cncf.kubernetes
RC1 for fab