### PR TITLE
[OpenLineage] Fix datasets in GCSTimeSpanFileTransformOperator

### DIFF
--- a/tests/providers/google/cloud/operators/test_gcs.py
+++ b/tests/providers/google/cloud/operators/test_gcs.py
@@ -21,6 +21,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest import mock
 
+import pytest
 from openlineage.client.facet import (
     LifecycleStateChange,
     LifecycleStateChangeDatasetFacet,
@@ -483,15 +484,78 @@ class TestGCSTimeSpanFileTransformOperator:
             ]
         )
 
+    @pytest.mark.parametrize(
+        ("source_prefix", "dest_prefix", "inputs", "outputs"),
+        (
+            (
+                None,
+                None,
+                [Dataset(f"gs://{TEST_BUCKET}", "/")],
+                [Dataset(f"gs://{TEST_BUCKET}_dest", "/")],
+            ),
+            (
+                None,
+                "dest_pre/",
+                [Dataset(f"gs://{TEST_BUCKET}", "/")],
+                [Dataset(f"gs://{TEST_BUCKET}_dest", "dest_pre")],
+            ),
+            (
+                "source_pre/",
+                None,
+                [Dataset(f"gs://{TEST_BUCKET}", "source_pre")],
+                [Dataset(f"gs://{TEST_BUCKET}_dest", "/")],
+            ),
+            (
+                "source_pre/",
+                "dest_pre/",
+                [Dataset(f"gs://{TEST_BUCKET}", "source_pre")],
+                [Dataset(f"gs://{TEST_BUCKET}_dest", "dest_pre")],
+            ),
+            (
+                "source_pre",
+                "dest_pre",
+                [Dataset(f"gs://{TEST_BUCKET}", "/")],
+                [Dataset(f"gs://{TEST_BUCKET}_dest", "/")],
+            ),
+            (
+                "dir1/source_pre",
+                "dir2/dest_pre",
+                [Dataset(f"gs://{TEST_BUCKET}", "dir1")],
+                [Dataset(f"gs://{TEST_BUCKET}_dest", "dir2")],
+            ),
+            (
+                "",
+                "/",
+                [Dataset(f"gs://{TEST_BUCKET}", "/")],
+                [Dataset(f"gs://{TEST_BUCKET}_dest", "/")],
+            ),
+            (
+                "source/a.txt",
+                "target/",
+                [Dataset(f"gs://{TEST_BUCKET}", "source/a.txt")],
+                [Dataset(f"gs://{TEST_BUCKET}_dest", "target")],
+            ),
+        ),
+        ids=(
+            "no prefixes",
+            "dest prefix only",
+            "source prefix only",
+            "both with ending slash",
+            "both without ending slash",
+            "both as directory with prefix",
+            "both empty or root",
+            "source prefix is file path",
+        ),
+    )
     @mock.patch("airflow.providers.google.cloud.operators.gcs.TemporaryDirectory")
     @mock.patch("airflow.providers.google.cloud.operators.gcs.subprocess")
     @mock.patch("airflow.providers.google.cloud.operators.gcs.GCSHook")
-    def test_get_openlineage_facets_on_complete(self, mock_hook, mock_subprocess, mock_tempdir):
+    def test_get_openlineage_facets_on_complete(
+        self, mock_hook, mock_subprocess, mock_tempdir, source_prefix, dest_prefix, inputs, outputs
+    ):
         source_bucket = TEST_BUCKET
-        source_prefix = "source_prefix"
 
         destination_bucket = TEST_BUCKET + "_dest"
-        destination_prefix = "destination_prefix"
         destination = "destination"
 
         file1 = "file1"
@@ -508,8 +572,8 @@ class TestGCSTimeSpanFileTransformOperator:
 
         mock_tempdir.return_value.__enter__.side_effect = ["source", destination]
         mock_hook.return_value.list_by_timespan.return_value = [
-            f"{source_prefix}/{file1}",
-            f"{source_prefix}/{file2}",
+            f"{source_prefix or ''}{file1}",
+            f"{source_prefix or ''}{file2}",
         ]
 
         mock_proc = mock.MagicMock()
@@ -529,7 +593,7 @@ class TestGCSTimeSpanFileTransformOperator:
             source_prefix=source_prefix,
             source_gcp_conn_id="",
             destination_bucket=destination_bucket,
-            destination_prefix=destination_prefix,
+            destination_prefix=dest_prefix,
             destination_gcp_conn_id="",
             transform_script="script.py",
         )
@@ -541,32 +605,11 @@ class TestGCSTimeSpanFileTransformOperator:
             ]
             op.execute(context=context)
 
-        expected_inputs = [
-            Dataset(
-                namespace=f"gs://{source_bucket}",
-                name=f"{source_prefix}/{file1}",
-            ),
-            Dataset(
-                namespace=f"gs://{source_bucket}",
-                name=f"{source_prefix}/{file2}",
-            ),
-        ]
-        expected_outputs = [
-            Dataset(
-                namespace=f"gs://{destination_bucket}",
-                name=f"{destination_prefix}/{file1}",
-            ),
-            Dataset(
-                namespace=f"gs://{destination_bucket}",
-                name=f"{destination_prefix}/{file2}",
-            ),
-        ]
-
         lineage = op.get_openlineage_facets_on_complete(None)
-        assert len(lineage.inputs) == 2
-        assert len(lineage.outputs) == 2
-        assert lineage.inputs == expected_inputs
-        assert lineage.outputs == expected_outputs
+        assert len(lineage.inputs) == len(inputs)
+        assert len(lineage.outputs) == len(outputs)
+        assert sorted(lineage.inputs) == sorted(inputs)
+        assert sorted(lineage.outputs) == sorted(outputs)
 
 
 class TestGCSDeleteBucketOperator:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Currently we are including all files as datasets which can lead to increasing the size of the event and make matching datasets between jobs harder.

With that change, we are using prefixes from the user as dataset names and not full file paths. This way, user can easily control the size of the event and also ensure proper matching, when the same two prefixes are passed to different operators. I am also removing the list of files that was saved for the purpose of lineage datasets, introduced in #35838 .


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
