### PR TITLE
AIP-61: Extra input validation for multiple executors

### DIFF
--- a/airflow/executors/executor_loader.py
+++ b/airflow/executors/executor_loader.py
@@ -120,10 +120,11 @@ class ExecutorLoader:
                 # complicated. Multiple Executors of the same type will be supported by a future multitenancy
                 # AIP.
                 # The module component should always be a module or plugin path.
-                if not split_name[1] or split_name[1] in CORE_EXECUTOR_NAMES:
+                module_path = split_name[1]
+                if not module_path or module_path in CORE_EXECUTOR_NAMES or "." not in module_path:
                     raise AirflowConfigException(
-                        f"Incorrectly formatted executor configuration: {name}\n"
-                        "second portion of an executor configuration must be a module path"
+                        "Incorrectly formatted executor configuration. Second portion of an executor "
+                        f"configuration must be a module path or plugin but received: {module_path}"
                     )
                 else:
                     executor_names.append(ExecutorName(alias=split_name[0], module_path=split_name[1]))

--- a/tests/executors/test_executor_loader.py
+++ b/tests/executors/test_executor_loader.py
@@ -205,6 +205,7 @@ class TestExecutorLoader:
             "LocalExecutor, CeleryExecutor:, DebugExecutor",
             "LocalExecutor, my_cool_alias:",
             "LocalExecutor, my_cool_alias:CeleryExecutor",
+            "LocalExecutor, module.path.first:alias_second",
         ],
     )
     def test_get_hybrid_executors_from_config_core_executors_bad_config_format(self, executor_config):


### PR DESCRIPTION
Ensure the user provides the module path as the second portion of the alias:module_path input, not the other way around

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
