### PR TITLE
Consolidate grid collapse actions to a single full screen toggle

### DIFF
--- a/airflow/www/static/js/dag/Main.tsx
+++ b/airflow/www/static/js/dag/Main.tsx
@@ -111,17 +111,23 @@ const Main = () => {
 
   const gridWidth = localStorage.getItem(gridWidthKey) || undefined;
 
-  const onToggleGridCollapse = useCallback(() => {
-    const gridElement = gridRef.current;
-    if (gridElement) {
-      if (isGridCollapsed) {
-        gridElement.style.width = localStorage.getItem(gridWidthKey) || "";
-      } else {
-        gridElement.style.width = collapsedWidth;
-      }
-      setIsGridCollapsed(!isGridCollapsed);
-    }
-  }, [isGridCollapsed]);
+  const onToggleGridCollapse = useCallback(
+    (collapseNext?: boolean) => {
+      const gridElement = gridRef.current;
+      const collapse =
+        collapseNext !== undefined ? collapseNext : !isGridCollapsed;
+      if (collapse !== undefined)
+        if (gridElement) {
+          if (!collapse) {
+            gridElement.style.width = localStorage.getItem(gridWidthKey) || "";
+          } else {
+            gridElement.style.width = collapsedWidth;
+          }
+          setIsGridCollapsed(collapse);
+        }
+    },
+    [isGridCollapsed]
+  );
 
   const resize = useCallback(
     (e: MouseEvent) => {
@@ -183,10 +189,10 @@ const Main = () => {
   const toggleFullScreen = () => {
     if (!isFullScreen) {
       setAccordionIndexes([]);
-      setIsGridCollapsed(true);
+      onToggleGridCollapse(true);
     } else {
       setAccordionIndexes([0]);
-      setIsGridCollapsed(false);
+      onToggleGridCollapse(false);
     }
   };
 

--- a/airflow/www/static/js/dag/Main.tsx
+++ b/airflow/www/static/js/dag/Main.tsx
@@ -32,8 +32,7 @@ import {
   AccordionPanel,
 } from "@chakra-ui/react";
 import { isEmpty, debounce } from "lodash";
-import { MdDoubleArrow } from "react-icons/md";
-import { useSearchParams } from "react-router-dom";
+import { FaExpandArrowsAlt, FaCompressArrowsAlt } from "react-icons/fa";
 
 import { useGridData } from "src/api";
 import { hoverDelay } from "src/utils";
@@ -41,14 +40,13 @@ import { hoverDelay } from "src/utils";
 import ShortcutCheatSheet from "src/components/ShortcutCheatSheet";
 import { useKeysPress } from "src/utils/useKeysPress";
 
-import Details, { TAB_PARAM } from "./details";
+import Details from "./details";
 import Grid from "./grid";
 import FilterBar from "./nav/FilterBar";
 import LegendRow from "./nav/LegendRow";
 import useToggleGroups from "./useToggleGroups";
 import keyboardShortcutIdentifier from "./keyboardShortcutIdentifier";
 
-const detailsPanelKey = "hideDetailsPanel";
 const minPanelWidth = 300;
 const collapsedWidth = "32px";
 
@@ -82,21 +80,12 @@ const Main = () => {
 
   const [accordionIndexes, setAccordionIndexes] = useState<Array<number>>([0]);
   const isFilterCollapsed = !accordionIndexes.length;
-  const toggleFilterCollapsed = () => {
-    if (isFilterCollapsed) setAccordionIndexes([0]);
-    else setAccordionIndexes([]);
-  };
 
-  const [searchParams] = useSearchParams();
   const resizeRef = useRef<HTMLDivElement>(null);
   const gridRef = useRef<HTMLDivElement>(null);
   const gridScrollRef = useRef<HTMLDivElement>(null);
   const ganttScrollRef = useRef<HTMLDivElement>(null);
 
-  const isPanelOpen =
-    localStorage.getItem(detailsPanelKey) !== "true" ||
-    !!searchParams.get(TAB_PARAM);
-  const { isOpen, onToggle } = useDisclosure({ defaultIsOpen: isPanelOpen });
   const [hoveredTaskState, setHoveredTaskState] = useState<
     string | null | undefined
   >();
@@ -121,18 +110,6 @@ const Main = () => {
   };
 
   const gridWidth = localStorage.getItem(gridWidthKey) || undefined;
-
-  const onPanelToggle = () => {
-    if (!isOpen) {
-      localStorage.setItem(detailsPanelKey, "false");
-    } else {
-      localStorage.setItem(detailsPanelKey, "true");
-      if (isGridCollapsed) {
-        setIsGridCollapsed(!isGridCollapsed);
-      }
-    }
-    onToggle();
-  };
 
   const onToggleGridCollapse = useCallback(() => {
     const gridElement = gridRef.current;
@@ -195,7 +172,7 @@ const Main = () => {
       };
     }
     return () => {};
-  }, [resize, isLoading, isOpen]);
+  }, [resize, isLoading]);
 
   useKeysPress(
     keyboardShortcutIdentifier.toggleShortcutCheatSheet,
@@ -222,18 +199,6 @@ const Main = () => {
       overflow="hidden"
       position="relative"
     >
-      <IconButton
-        position="absolute"
-        variant="ghost"
-        color="gray.400"
-        top={0}
-        left={0}
-        onClick={toggleFilterCollapsed}
-        icon={<MdDoubleArrow />}
-        aria-label="Toggle filters bar"
-        transform={isFilterCollapsed ? "rotateZ(90deg)" : "rotateZ(270deg)"}
-        transition="all 0.2s"
-      />
       <Accordion allowToggle index={accordionIndexes} borderTopWidth={0}>
         <AccordionItem
           sx={{
@@ -259,52 +224,58 @@ const Main = () => {
         ) : (
           <>
             <Box
-              flex={isOpen ? undefined : 1}
               minWidth={isGridCollapsed ? collapsedWidth : minPanelWidth}
               ref={gridRef}
               height="100%"
               width={isGridCollapsed ? collapsedWidth : gridWidth}
+              position="relative"
             >
+              <IconButton
+                icon={
+                  isFullScreen ? <FaExpandArrowsAlt /> : <FaCompressArrowsAlt />
+                }
+                fontSize="xl"
+                position="absolute"
+                right={0}
+                top={0}
+                variant="ghost"
+                color="gray.400"
+                size="sm"
+                aria-label="Toggle full screen details"
+                title="Toggle full screen details"
+                onClick={toggleFullScreen}
+              />
               <Grid
-                isPanelOpen={isOpen}
-                onPanelToggle={onPanelToggle}
                 hoveredTaskState={hoveredTaskState}
                 openGroupIds={openGroupIds}
                 onToggleGroups={onToggleGroups}
                 isGridCollapsed={isGridCollapsed}
-                setIsGridCollapsed={onToggleGridCollapse}
                 gridScrollRef={gridScrollRef}
                 ganttScrollRef={ganttScrollRef}
               />
             </Box>
-            {isOpen && (
-              <>
-                <Box
-                  width={2}
-                  cursor="ew-resize"
-                  bg="gray.200"
-                  ref={resizeRef}
-                  zIndex={1}
-                />
-                <Box
-                  flex={1}
-                  minWidth={minPanelWidth}
-                  zIndex={1}
-                  bg="white"
-                  height="100%"
-                >
-                  <Details
-                    openGroupIds={openGroupIds}
-                    onToggleGroups={onToggleGroups}
-                    hoveredTaskState={hoveredTaskState}
-                    gridScrollRef={gridScrollRef}
-                    ganttScrollRef={ganttScrollRef}
-                    isFullScreen={isFullScreen}
-                    toggleFullScreen={toggleFullScreen}
-                  />
-                </Box>
-              </>
-            )}
+            <Box
+              width={2}
+              cursor="ew-resize"
+              bg="gray.200"
+              ref={resizeRef}
+              zIndex={1}
+            />
+            <Box
+              flex={1}
+              minWidth={minPanelWidth}
+              zIndex={1}
+              bg="white"
+              height="100%"
+            >
+              <Details
+                openGroupIds={openGroupIds}
+                onToggleGroups={onToggleGroups}
+                hoveredTaskState={hoveredTaskState}
+                gridScrollRef={gridScrollRef}
+                ganttScrollRef={ganttScrollRef}
+              />
+            </Box>
           </>
         )}
       </Flex>

--- a/airflow/www/static/js/dag/details/graph/index.tsx
+++ b/airflow/www/static/js/dag/details/graph/index.tsx
@@ -28,9 +28,7 @@ import ReactFlow, {
   Panel,
   useOnViewportChange,
   Viewport,
-  ControlButton,
 } from "reactflow";
-import { BiCollapse, BiExpand } from "react-icons/bi";
 
 import { useDatasets, useGraphData, useGridData } from "src/api";
 import useSelection from "src/dag/useSelection";
@@ -49,19 +47,11 @@ interface Props {
   openGroupIds: string[];
   onToggleGroups: (groupIds: string[]) => void;
   hoveredTaskState?: string | null;
-  isFullScreen?: boolean;
-  toggleFullScreen?: () => void;
 }
 
 const dagId = getMetaValue("dag_id");
 
-const Graph = ({
-  openGroupIds,
-  onToggleGroups,
-  hoveredTaskState,
-  isFullScreen,
-  toggleFullScreen,
-}: Props) => {
+const Graph = ({ openGroupIds, onToggleGroups, hoveredTaskState }: Props) => {
   const graphRef = useRef(null);
   const { data } = useGraphData();
   const [arrange, setArrange] = useState(data?.arrange || "LR");
@@ -235,15 +225,7 @@ const Graph = ({
             </Box>
           </Panel>
           <Background />
-          <Controls showInteractive={false}>
-            <ControlButton
-              onClick={toggleFullScreen}
-              aria-label="Toggle full screen"
-              title="Toggle full screen"
-            >
-              {isFullScreen ? <BiCollapse /> : <BiExpand />}
-            </ControlButton>
-          </Controls>
+          <Controls showInteractive={false} />
           <MiniMap
             nodeStrokeWidth={15}
             nodeStrokeColor={(props) => nodeStrokeColor(props, colors)}

--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -77,8 +77,6 @@ interface Props {
   hoveredTaskState?: string | null;
   gridScrollRef: React.RefObject<HTMLDivElement>;
   ganttScrollRef: React.RefObject<HTMLDivElement>;
-  isFullScreen?: boolean;
-  toggleFullScreen?: () => void;
 }
 
 const tabToIndex = (tab?: string) => {
@@ -150,8 +148,6 @@ const Details = ({
   hoveredTaskState,
   gridScrollRef,
   ganttScrollRef,
-  isFullScreen,
-  toggleFullScreen,
 }: Props) => {
   const {
     selected: { runId, taskId, mapIndex },
@@ -241,12 +237,7 @@ const Details = ({
 
   return (
     <Flex flexDirection="column" height="100%">
-      <Flex
-        alignItems="center"
-        justifyContent="space-between"
-        flexWrap="wrap"
-        ml={6}
-      >
+      <Flex alignItems="center" justifyContent="space-between" flexWrap="wrap">
         <Header
           mapIndex={
             mappedTaskInstance?.renderedMapIndex || mappedTaskInstance?.mapIndex
@@ -418,8 +409,6 @@ const Details = ({
               openGroupIds={openGroupIds}
               onToggleGroups={onToggleGroups}
               hoveredTaskState={hoveredTaskState}
-              isFullScreen={isFullScreen}
-              toggleFullScreen={toggleFullScreen}
             />
           </TabPanel>
           <TabPanel p={0} height="100%">
@@ -469,8 +458,6 @@ const Details = ({
                     ? undefined
                     : instance.state
                 }
-                isFullScreen={isFullScreen}
-                toggleFullScreen={toggleFullScreen}
               />
             </TabPanel>
           )}

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
@@ -27,10 +27,8 @@ import {
   Icon,
   Spinner,
   Select,
-  IconButton,
 } from "@chakra-ui/react";
 import { MdWarning } from "react-icons/md";
-import { BiCollapse, BiExpand } from "react-icons/bi";
 
 import { getMetaValue } from "src/utils";
 import useTaskLog from "src/api/useTaskLog";
@@ -96,8 +94,6 @@ interface Props {
   executionDate: DagRun["executionDate"];
   tryNumber: TaskInstance["tryNumber"];
   state?: TaskInstance["state"];
-  isFullScreen?: boolean;
-  toggleFullScreen?: () => void;
 }
 
 const Logs = ({
@@ -108,8 +104,6 @@ const Logs = ({
   executionDate,
   tryNumber,
   state,
-  isFullScreen,
-  toggleFullScreen,
 }: Props) => {
   const [internalIndexes, externalIndexes] = getLinkIndexes(tryNumber);
   const [selectedTryNumber, setSelectedTryNumber] = useState<
@@ -297,19 +291,6 @@ const Logs = ({
             <LinkButton href={`${logUrl}&${params.toString()}`}>
               See More
             </LinkButton>
-            <IconButton
-              variant="ghost"
-              aria-label="Toggle full screen"
-              title="Toggle full screen"
-              onClick={toggleFullScreen}
-              icon={
-                isFullScreen ? (
-                  <BiCollapse height="24px" />
-                ) : (
-                  <BiExpand height="24px" />
-                )
-              }
-            />
           </Flex>
         </Flex>
       </Box>

--- a/airflow/www/static/js/dag/grid/index.tsx
+++ b/airflow/www/static/js/dag/grid/index.tsx
@@ -20,9 +20,7 @@
 /* global ResizeObserver */
 
 import React, { useRef, useEffect } from "react";
-import { Table, Tbody, Box, Thead, IconButton } from "@chakra-ui/react";
-
-import { MdDoubleArrow } from "react-icons/md";
+import { Table, Tbody, Box, Thead } from "@chakra-ui/react";
 
 import { useGridData } from "src/api";
 import { useOffsetTop } from "src/utils";
@@ -32,25 +30,19 @@ import DagRuns from "./dagRuns";
 import useSelection from "../useSelection";
 
 interface Props {
-  isPanelOpen?: boolean;
-  onPanelToggle?: () => void;
   hoveredTaskState?: string | null;
   openGroupIds: string[];
   onToggleGroups: (groupIds: string[]) => void;
   isGridCollapsed?: boolean;
-  setIsGridCollapsed?: (collapsed: boolean) => void;
   gridScrollRef?: React.RefObject<HTMLDivElement>;
   ganttScrollRef?: React.RefObject<HTMLDivElement>;
 }
 
 const Grid = ({
-  isPanelOpen = false,
-  onPanelToggle,
   hoveredTaskState,
   openGroupIds,
   onToggleGroups,
   isGridCollapsed,
-  setIsGridCollapsed,
   gridScrollRef,
   ganttScrollRef,
 }: Props) => {
@@ -121,75 +113,36 @@ const Grid = ({
   }, [tableRef, isGridCollapsed, gridScrollRef]);
 
   return (
-    <Box height="100%" position="relative">
-      {(isPanelOpen || isGridCollapsed) && (
-        <IconButton
-          fontSize="2xl"
-          variant="ghost"
-          color="gray.400"
-          size="sm"
-          position="absolute"
-          right={isGridCollapsed ? -10 : 0}
-          zIndex={2}
-          top={-8}
-          onClick={() =>
-            setIsGridCollapsed && setIsGridCollapsed(!isGridCollapsed)
-          }
-          title={isGridCollapsed ? "Restore grid" : "Collapse grid"}
-          aria-label={isGridCollapsed ? "Restore grid" : "Collapse grid"}
-          icon={<MdDoubleArrow />}
-          transform={isGridCollapsed ? undefined : "rotateZ(180deg)"}
-          transitionProperty="none"
-        />
-      )}
-      {!isGridCollapsed && (
-        <IconButton
-          fontSize="2xl"
-          variant="ghost"
-          color="gray.400"
-          size="sm"
-          position="absolute"
-          right={isPanelOpen ? -10 : 0}
-          zIndex={2}
-          top={-8}
-          onClick={onPanelToggle}
-          title={`${isPanelOpen ? "Hide" : "Show"} Details Panel`}
-          aria-label={isPanelOpen ? "Show Details" : "Hide Details"}
-          icon={<MdDoubleArrow />}
-          transform={isPanelOpen ? undefined : "rotateZ(180deg)"}
-          transitionProperty="none"
-        />
-      )}
-      <Box
-        maxHeight={`calc(100% - ${offsetTop}px)`}
-        ref={gridScrollRef}
-        overflow="auto"
-        position="relative"
-        mt={8}
-        overscrollBehavior="auto"
-        pb={4}
-      >
-        <Table borderRightWidth="16px" borderColor="transparent">
-          <Thead>
-            <DagRuns
-              groups={groups}
-              openGroupIds={openGroupIds}
-              onToggleGroups={onToggleGroups}
-              isGridCollapsed={isGridCollapsed}
-            />
-          </Thead>
-          <Tbody ref={tableRef}>
-            {renderTaskRows({
-              task: groups,
-              dagRunIds,
-              openGroupIds,
-              onToggleGroups,
-              hoveredTaskState,
-              isGridCollapsed,
-            })}
-          </Tbody>
-        </Table>
-      </Box>
+    <Box
+      height="100%"
+      maxHeight={`calc(100% - ${offsetTop}px)`}
+      ref={gridScrollRef}
+      overflow="auto"
+      position="relative"
+      mt={8}
+      overscrollBehavior="auto"
+      pb={4}
+    >
+      <Table borderRightWidth="16px" borderColor="transparent">
+        <Thead>
+          <DagRuns
+            groups={groups}
+            openGroupIds={openGroupIds}
+            onToggleGroups={onToggleGroups}
+            isGridCollapsed={isGridCollapsed}
+          />
+        </Thead>
+        <Tbody ref={tableRef}>
+          {renderTaskRows({
+            task: groups,
+            dagRunIds,
+            openGroupIds,
+            onToggleGroups,
+            hoveredTaskState,
+            isGridCollapsed,
+          })}
+        </Tbody>
+      </Table>
     </Box>
   );
 };

--- a/airflow/www/static/js/dag/nav/FilterBar.tsx
+++ b/airflow/www/static/js/dag/nav/FilterBar.tsx
@@ -122,7 +122,7 @@ const FilterBar = () => {
 
   return (
     <Flex backgroundColor="blackAlpha.200" p={4} justifyContent="space-between">
-      <Flex ml={10}>
+      <Flex>
         <Box px={2}>
           <Input
             {...inputStyles}


### PR DESCRIPTION
We have a lot of ways to change screen sizes in the grid view. Its a bit of a mess. You can collapse/expand the filter bar, you can collapse/expand the grid view, you can collapse/expand the details view, and you can only toggle everything from the logs and graph views.

Instead:
- remove the ability to hide the details view. The new run and task duration pages are good to see more details of run history
- Merge the two collapse filter/grid buttons into a single "Full screen" button and have that visible on all pages not just logs+graph


<img width="910" alt="Screenshot 2024-04-16 at 1 50 51 PM" src="https://github.com/apache/airflow/assets/4600967/8314a296-09cc-4e89-930e-3c56313712ce">

<img width="299" alt="Screenshot 2024-04-16 at 1 50 37 PM" src="https://github.com/apache/airflow/assets/4600967/e0f560f5-ba43-498e-ab8b-326b898b9922">


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
