### PR TITLE
Task info dag 37564

### DIFF
--- a/airflow/api_connexion/endpoints/dag_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_endpoint.py
@@ -73,7 +73,7 @@ def get_dag(
 @security.requires_access_dag("GET")
 @provide_session
 def get_dag_details(
-    *, dag_id: str, fields: Collection[str] | None = None, session: Session = NEW_SESSION
+    *, dag_id: str, fields: Collection[str] | None = None, include_tasks=False, session: Session = NEW_SESSION
 ) -> APIResponse:
     """Get details of DAG."""
     dag: DAG = get_airflow_app().dag_bag.get_dag(dag_id)

--- a/airflow/api_connexion/endpoints/dag_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_endpoint.py
@@ -35,6 +35,7 @@ from airflow.api_connexion.schemas.dag_schema import (
     DAGSchema,
     dag_schema,
     dags_collection_schema,
+    DAGDetailSchemaWithTasksInfo,
 )
 from airflow.exceptions import AirflowException, DagNotFound
 from airflow.models.dag import DagModel, DagTag
@@ -83,7 +84,10 @@ def get_dag_details(
         if not key.startswith("_") and not hasattr(dag_model, key):
             setattr(dag_model, key, value)
     try:
-        dag_detail_schema = DAGDetailSchema(only=fields) if fields else DAGDetailSchema()
+        if not include_tasks:
+            dag_detail_schema = DAGDetailSchema(only=fields) if fields else DAGDetailSchema()
+        else:
+            dag_detail_schema = DAGDetailSchemaWithTasksInfo(only=fields) if fields else DAGDetailSchemaWithTasksInfo()
     except ValueError as e:
         raise BadRequest("DAGDetailSchema init error", detail=str(e))
     return dag_detail_schema.dump(dag_model)

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1937,6 +1937,14 @@ paths:
       tags: [DAG]
       parameters:
         - $ref: "#/components/parameters/ReturnFields"
+        - name: include_tasks
+          in: query
+          schema:
+            type: boolean
+            default: false
+          required: false
+          description: |
+            If set, return task_ids of DAG
       responses:
         "200":
           description: Success.

--- a/airflow/api_connexion/schemas/dag_schema.py
+++ b/airflow/api_connexion/schemas/dag_schema.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, NamedTuple
-from operator import attrgetter
 
 from itsdangerous import URLSafeSerializer
 from marshmallow import Schema, fields
@@ -159,6 +158,7 @@ class DAGDetailSchemaWithTasksInfo(DAGDetailSchema):
     @staticmethod
     def get_tasks_info(obj: DAG):
         from airflow.api_connexion.schemas.task_schema import TaskCollection, task_collection_schema_without_subdag
+        from operator import attrgetter
         tasks = obj.task_dict.values()
         try:
             tasks = sorted(tasks, key=attrgetter("task_id".lstrip("-")), reverse=("task_id"[0:1] == "-"))

--- a/airflow/api_connexion/schemas/dag_schema.py
+++ b/airflow/api_connexion/schemas/dag_schema.py
@@ -24,7 +24,6 @@ from marshmallow import Schema, fields
 from marshmallow_sqlalchemy import SQLAlchemySchema, auto_field
 
 from airflow.api_connexion.schemas.common_schema import ScheduleIntervalSchema, TimeDeltaSchema, TimezoneField
-from airflow.api_connexion.schemas.task_schema import task_collection_schema, TaskCollection
 from airflow.configuration import conf
 from airflow.models.dag import DagModel, DagTag
 
@@ -158,14 +157,15 @@ class DAGDetailSchemaWithTasksInfo(DAGDetailSchema):
 
     tasks = fields.Method("get_tasks_info", dump_only=True)
     @staticmethod
-    def get_tasks_info(obj: DAG) :
+    def get_tasks_info(obj: DAG):
+        from airflow.api_connexion.schemas.task_schema import TaskCollection, task_collection_schema_without_subdag
         tasks = obj.task_dict.values()
         try:
             tasks = sorted(tasks, key=attrgetter("task_id".lstrip("-")), reverse=("task_id"[0:1] == "-"))
         except AttributeError as err:
             raise BadRequest(detail=str(err))
         task_collection = TaskCollection(tasks=tasks, total_entries=len(tasks))
-        return task_collection_schema.dump(task_collection)['tasks']
+        return task_collection_schema_without_subdag.dump(task_collection)['tasks']
 
 class DAGCollection(NamedTuple):
     """List of DAGs with metadata."""

--- a/airflow/api_connexion/schemas/task_schema.py
+++ b/airflow/api_connexion/schemas/task_schema.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, NamedTuple
 
 from marshmallow import Schema, fields
 
+from airflow.api_connexion.schemas.dag_schema import DAGSchema
 from airflow.api_connexion.schemas.common_schema import (
     ClassReferenceSchema,
     ColorField,
@@ -32,7 +33,6 @@ if TYPE_CHECKING:
     from airflow.models.operator import Operator
 
 class SubDagMixin:
-    from airflow.api_connexion.schemas.dag_schema import DAGSchema
     sub_dag = fields.Nested(DAGSchema, dump_only=True)
 
 class TaskSchema(Schema, SubDagMixin):

--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -46,6 +46,7 @@ def current_file_token(url_safe_serializer) -> str:
 
 DAG_ID = "test_dag"
 TASK_ID = "op1"
+TASK_ID2 = "op2"
 DAG2_ID = "test_dag2"
 DAG3_ID = "test_dag3"
 UTC_JSON_REPR = "UTC" if pendulum.__version__.startswith("3") else "Timezone('UTC')"
@@ -83,7 +84,8 @@ def configured_app(minimal_app_for_api):
         params={"foo": 1},
         tags=["example"],
     ) as dag:
-        EmptyOperator(task_id=TASK_ID)
+        EmptyOperator(task_id=TASK_ID, params={"foo": "bar"})
+        EmptyOperator(task_id=TASK_ID2)
 
     with DAG(DAG2_ID, start_date=datetime(2020, 6, 15)) as dag2:  # no doc_md
         EmptyOperator(task_id=TASK_ID)
@@ -698,6 +700,191 @@ class TestGetDagDetails(TestDagEndpoint):
             "timezone": UTC_JSON_REPR,
         }
         expected.update({"last_parsed": response.json["last_parsed"]})
+        assert response.json == expected
+
+    def test_should_response_200_with_include_tasks_false(self, url_safe_serializer):
+        self._create_dag_model_for_details_endpoint(self.dag_id)
+        current_file_token = url_safe_serializer.dumps("/tmp/dag.py")
+        response = self.client.get(
+            f"/api/v1/dags/{self.dag_id}/details?include_tasks=false", environ_overrides={"REMOTE_USER": "test"}
+        )
+        assert response.status_code == 200
+        last_parsed = response.json["last_parsed"]
+        expected = {
+            "catchup": True,
+            "concurrency": 16,
+            "dag_id": "test_dag",
+            "dag_run_timeout": None,
+            "default_view": None,
+            "description": None,
+            "doc_md": "details",
+            "end_date": None,
+            "fileloc": "/tmp/dag.py",
+            "file_token": current_file_token,
+            "has_import_errors": False,
+            "has_task_concurrency_limits": True,
+            "is_active": True,
+            "is_paused": False,
+            "is_paused_upon_creation": None,
+            "is_subdag": False,
+            "last_expired": None,
+            "last_parsed": last_parsed,
+            "last_parsed_time": None,
+            "last_pickled": None,
+            "max_active_runs": 16,
+            "max_active_tasks": 16,
+            "next_dagrun": None,
+            "next_dagrun_create_after": None,
+            "next_dagrun_data_interval_end": None,
+            "next_dagrun_data_interval_start": None,
+            "orientation": "LR",
+            "owners": [],
+            "params": {
+                "foo": {
+                    "__class": "airflow.models.param.Param",
+                    "description": None,
+                    "schema": {},
+                    "value": 1,
+                }
+            },
+            "pickle_id": None,
+            "render_template_as_native_obj": False,
+            "root_dag_id": None,
+            "schedule_interval": {"__type": "CronExpression", "value": "2 2 * * *"},
+            "scheduler_lock": None,
+            "start_date": "2020-06-15T00:00:00+00:00",
+            "tags": [],
+            "template_searchpath": None,
+            "timetable_description": None,
+            "timezone": UTC_JSON_REPR,
+        }
+        assert response.json == expected
+
+    def test_should_response_200_with_include_tasks_true(self, url_safe_serializer):
+        self._create_dag_model_for_details_endpoint(self.dag_id)
+        current_file_token = url_safe_serializer.dumps("/tmp/dag.py")
+        response = self.client.get(
+            f"/api/v1/dags/{self.dag_id}/details?include_tasks=true", environ_overrides={"REMOTE_USER": "test"}
+        )
+        assert response.status_code == 200
+        last_parsed = response.json["last_parsed"]
+        expected = {
+            "catchup": True,
+            "concurrency": 16,
+            "dag_id": "test_dag",
+            "dag_run_timeout": None,
+            "default_view": None,
+            "description": None,
+            "doc_md": "details",
+            "end_date": None,
+            "fileloc": "/tmp/dag.py",
+            "file_token": current_file_token,
+            "has_import_errors": False,
+            "has_task_concurrency_limits": True,
+            "is_active": True,
+            "is_paused": False,
+            "is_paused_upon_creation": None,
+            "is_subdag": False,
+            "last_expired": None,
+            "last_parsed": last_parsed,
+            "last_parsed_time": None,
+            "last_pickled": None,
+            "max_active_runs": 16,
+            "max_active_tasks": 16,
+            "next_dagrun": None,
+            "next_dagrun_create_after": None,
+            "next_dagrun_data_interval_end": None,
+            "next_dagrun_data_interval_start": None,
+            "orientation": "LR",
+            "owners": [],
+            "params": {
+                "foo": {
+                    "__class": "airflow.models.param.Param",
+                    "description": None,
+                    "schema": {},
+                    "value": 1,
+                }
+            },
+            "pickle_id": None,
+            "render_template_as_native_obj": False,
+            "root_dag_id": None,
+            "schedule_interval": {"__type": "CronExpression", "value": "2 2 * * *"},
+            "scheduler_lock": None,
+            "start_date": "2020-06-15T00:00:00+00:00",
+            "tags": [],
+            "tasks": [
+                {
+                    "class_ref": {
+                        "class_name": "EmptyOperator",
+                        "module_path": "airflow.operators.empty",
+                    },
+                    "depends_on_past": False,
+                    "downstream_task_ids": [],
+                    "end_date": None,
+                    "execution_timeout": None,
+                    "extra_links": [],
+                    "operator_name": "EmptyOperator",
+                    "owner": "airflow",
+                    "params": {
+                        "foo": {
+                            "__class": "airflow.models.param.Param",
+                            "value": "bar",
+                            "description": None,
+                            "schema": {},
+                        }
+                    },
+                    "pool": "default_pool",
+                    "pool_slots": 1.0,
+                    "priority_weight": 1.0,
+                    "queue": "default",
+                    "retries": 0.0,
+                    "retry_delay": {"__type": "TimeDelta", "days": 0, "seconds": 300, "microseconds": 0},
+                    "retry_exponential_backoff": False,
+                    "start_date": "2020-06-15T00:00:00+00:00",
+                    "task_id": TASK_ID,
+                    "template_fields": [],
+                    "trigger_rule": "all_success",
+                    "ui_color": "#e8f7e4",
+                    "ui_fgcolor": "#000",
+                    "wait_for_downstream": False,
+                    "weight_rule": "downstream",
+                    "is_mapped": False,
+                },
+                {
+                    "class_ref": {
+                        "class_name": "EmptyOperator",
+                        "module_path": "airflow.operators.empty",
+                    },
+                    "depends_on_past": False,
+                    "downstream_task_ids": [],
+                    "end_date": None,
+                    "execution_timeout": None,
+                    "extra_links": [],
+                    "operator_name": "EmptyOperator",
+                    "owner": "airflow",
+                    "params": {},
+                    "pool": "default_pool",
+                    "pool_slots": 1.0,
+                    "priority_weight": 1.0,
+                    "queue": "default",
+                    "retries": 0.0,
+                    "retry_delay": {"__type": "TimeDelta", "days": 0, "seconds": 300, "microseconds": 0},
+                    "retry_exponential_backoff": False,
+                    "start_date": "2020-06-16T00:00:00+00:00",
+                    "task_id": TASK_ID2,
+                    "template_fields": [],
+                    "trigger_rule": "all_success",
+                    "ui_color": "#e8f7e4",
+                    "ui_fgcolor": "#000",
+                    "wait_for_downstream": False,
+                    "weight_rule": "downstream",
+                    "is_mapped": False,
+                },
+            ],
+            "template_searchpath": None,
+            "timetable_description": None,
+            "timezone": UTC_JSON_REPR,
+        }
         assert response.json == expected
 
     def test_should_raises_401_unauthenticated(self):

--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -714,7 +714,9 @@ class TestGetDagDetails(TestDagEndpoint):
             "catchup": True,
             "concurrency": 16,
             "dag_id": "test_dag",
+            "dag_display_name": "test_dag",
             "dag_run_timeout": None,
+            "dataset_expression": None,
             "default_view": None,
             "description": None,
             "doc_md": "details",
@@ -733,6 +735,7 @@ class TestGetDagDetails(TestDagEndpoint):
             "last_pickled": None,
             "max_active_runs": 16,
             "max_active_tasks": 16,
+            "max_consecutive_failed_dag_runs": 0,
             "next_dagrun": None,
             "next_dagrun_create_after": None,
             "next_dagrun_data_interval_end": None,
@@ -772,7 +775,9 @@ class TestGetDagDetails(TestDagEndpoint):
             "catchup": True,
             "concurrency": 16,
             "dag_id": "test_dag",
+            "dag_display_name": "test_dag",
             "dag_run_timeout": None,
+            "dataset_expression": None,
             "default_view": None,
             "description": None,
             "doc_md": "details",
@@ -791,6 +796,7 @@ class TestGetDagDetails(TestDagEndpoint):
             "last_pickled": None,
             "max_active_runs": 16,
             "max_active_tasks": 16,
+            "max_consecutive_failed_dag_runs": 0,
             "next_dagrun": None,
             "next_dagrun_create_after": None,
             "next_dagrun_data_interval_end": None,
@@ -842,6 +848,7 @@ class TestGetDagDetails(TestDagEndpoint):
                     "retry_exponential_backoff": False,
                     "start_date": "2020-06-15T00:00:00+00:00",
                     "task_id": TASK_ID,
+                    "task_display_name": TASK_ID,
                     "template_fields": [],
                     "trigger_rule": "all_success",
                     "ui_color": "#e8f7e4",
@@ -872,6 +879,7 @@ class TestGetDagDetails(TestDagEndpoint):
                     "retry_exponential_backoff": False,
                     "start_date": "2020-06-16T00:00:00+00:00",
                     "task_id": TASK_ID2,
+                    "task_display_name": TASK_ID2,
                     "template_fields": [],
                     "trigger_rule": "all_success",
                     "ui_color": "#e8f7e4",
@@ -886,6 +894,7 @@ class TestGetDagDetails(TestDagEndpoint):
             "timezone": UTC_JSON_REPR,
         }
         assert response.json == expected
+
 
     def test_should_raises_401_unauthenticated(self):
         response = self.client.get(f"/api/v1/dags/{self.dag_id}/details")


### PR DESCRIPTION
Description
The absence of task names in the DAG details API necessitates separate calls for task and DAG information, hindering process efficiency.
close https://github.com/apache/airflow/issues/37564

Use case/motivation
Currently, task names are not included in the DAG details API endpoint. Tasks represent the execution component of a DAG also various API endpoints require task names. Therefore, to retrieve task names, one must query the "/dags/{dag_id}/tasks" endpoint. Additionally, to obtain basic DAG details, the "/dags/{dag_id}/details" endpoint is utilized. In my use case, automation of certain processes necessitates both DAG information and task names. Consequently, the need to utilize two separate API endpoints slows down the overall process, particularly considering the multitude of DAGs. It would be advantageous to consolidate this information into a single API call, considering that tasks are integral part of a DAG.

Approach
Added new schema"DAGDetailSchemaWithTasksInfo" to DagSchema.py for task ID information. To include tasks, we have to add a query parameter (include_tasks).

http://localhost:8080/api/v1/dags/example_trigger_target_dag/details?include_tasks=True
http://localhost:8080/api/v1/dags/example_trigger_target_dag/details?include_tasks=


<img width="1122" alt="image" src="https://github.com/apache/airflow/assets/41102134/1725e2bf-230e-45db-8662-9e62aa56d5fc">
<img width="1239" alt="image" src="https://github.com/apache/airflow/assets/41102134/d17fc65a-786a-42f1-99bd-422f8d4a9153">


