### PR TITLE
AIP-61: Allow multiple executors to load their CLI commands

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -58,13 +58,12 @@ airflow_commands = core_commands.copy()  # make a copy to prevent bad interactio
 log = logging.getLogger(__name__)
 
 
-executors = [executor for executor, _ in ExecutorLoader.import_all_executors()]
-
-for executor in executors:
+for executor_name in ExecutorLoader.get_executor_names():
     try:
+        executor, _ = ExecutorLoader.import_executor_cls(executor_name)
         airflow_commands.extend(executor.get_cli_commands())
     except Exception:
-        log.exception("Failed to load CLI commands from executor: %s", executor.__name__)
+        log.exception("Failed to load CLI commands from executor: %s", executor_name)
         log.error(
             "Ensure all dependencies are met and try again. If using a Celery based executor install "
             "a 3.3.0+ version of the Celery provider. If using a Kubernetes executor, install a "

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -56,19 +56,22 @@ if TYPE_CHECKING:
 airflow_commands = core_commands.copy()  # make a copy to prevent bad interactions in tests
 
 log = logging.getLogger(__name__)
-try:
-    executor, _ = ExecutorLoader.import_default_executor_cls(validate=False)
-    airflow_commands.extend(executor.get_cli_commands())
-except Exception:
-    executor_name = ExecutorLoader.get_default_executor_name()
-    log.exception("Failed to load CLI commands from executor: %s", executor_name)
-    log.error(
-        "Ensure all dependencies are met and try again. If using a Celery based executor install "
-        "a 3.3.0+ version of the Celery provider. If using a Kubernetes executor, install a "
-        "7.4.0+ version of the CNCF provider"
-    )
-    # Do not re-raise the exception since we want the CLI to still function for
-    # other commands.
+
+
+executors = [executor for executor, _ in ExecutorLoader.import_all_executors()]
+
+for executor in executors:
+    try:
+        airflow_commands.extend(executor.get_cli_commands())
+    except Exception:
+        log.exception("Failed to load CLI commands from executor: %s", executor.__name__)
+        log.error(
+            "Ensure all dependencies are met and try again. If using a Celery based executor install "
+            "a 3.3.0+ version of the Celery provider. If using a Kubernetes executor, install a "
+            "7.4.0+ version of the CNCF provider"
+        )
+        # Do not re-raise the exception since we want the CLI to still function for
+        # other commands.
 
 try:
     auth_mgr = get_auth_manager_cls()
@@ -90,8 +93,7 @@ if len(ALL_COMMANDS_DICT) < len(airflow_commands):
     dup = {k for k, v in Counter([c.name for c in airflow_commands]).items() if v > 1}
     raise CliConflictError(
         f"The following CLI {len(dup)} command(s) are defined more than once: {sorted(dup)}\n"
-        f"This can be due to the executor '{ExecutorLoader.get_default_executor_name()}' "
-        f"redefining core airflow CLI commands."
+        f"This can be due to an Executor or Auth Manager redefining core airflow CLI commands."
     )
 
 

--- a/airflow/executors/executor_loader.py
+++ b/airflow/executors/executor_loader.py
@@ -153,6 +153,14 @@ class ExecutorLoader:
         return executor_names
 
     @classmethod
+    def get_executor_names(cls) -> list[ExecutorName]:
+        """Return the executor names from Airflow configuration.
+
+        :return: List of executor names from Airflow configuration
+        """
+        return cls._get_executor_names()
+
+    @classmethod
     def get_default_executor_name(cls) -> ExecutorName:
         """Return the default executor name from Airflow configuration.
 
@@ -277,15 +285,6 @@ class ExecutorLoader:
                     ConnectorSource.PLUGIN,
                 )
         return _import_and_validate(executor_name.module_path), executor_name.connector_source
-
-    @classmethod
-    def import_all_executors(cls) -> list[tuple[type[BaseExecutor], ConnectorSource]]:
-        executor_names = cls._get_executor_names()
-        executor_classes = []
-        for executor_name in executor_names:
-            executor_class = cls.import_executor_cls(executor_name, validate=False)
-            executor_classes.append(executor_class)
-        return executor_classes
 
     @classmethod
     def import_default_executor_cls(cls, validate: bool = True) -> tuple[type[BaseExecutor], ConnectorSource]:

--- a/airflow/executors/executor_loader.py
+++ b/airflow/executors/executor_loader.py
@@ -279,6 +279,15 @@ class ExecutorLoader:
         return _import_and_validate(executor_name.module_path), executor_name.connector_source
 
     @classmethod
+    def import_all_executors(cls) -> list[tuple[type[BaseExecutor], ConnectorSource]]:
+        executor_names = cls._get_executor_names()
+        executor_classes = []
+        for executor_name in executor_names:
+            executor_class = cls.import_executor_cls(executor_name, validate=False)
+            executor_classes.append(executor_class)
+        return executor_classes
+
+    @classmethod
     def import_default_executor_cls(cls, validate: bool = True) -> tuple[type[BaseExecutor], ConnectorSource]:
         """
         Import the default executor class.

--- a/tests/executors/test_executor_loader.py
+++ b/tests/executors/test_executor_loader.py
@@ -26,7 +26,6 @@ from airflow import plugins_manager
 from airflow.exceptions import AirflowConfigException
 from airflow.executors import executor_loader
 from airflow.executors.executor_loader import ConnectorSource, ExecutorLoader, ExecutorName
-from airflow.providers.amazon.aws.executors.ecs.ecs_executor import AwsEcsExecutor
 from airflow.providers.celery.executors.celery_executor import CeleryExecutor
 from tests.test_utils.config import conf_vars
 
@@ -98,45 +97,6 @@ class TestExecutorLoader:
             assert executor.name is not None
             assert executor.name == ExecutorName("tests.executors.test_executor_loader.FakeExecutor")
             assert executor.name.connector_source == ConnectorSource.CUSTOM_PATH
-
-    @pytest.mark.parametrize(
-        ("executor_config", "expected_executor_classes", "expected_connector_sources"),
-        [
-            # Just one executor
-            (
-                "CeleryExecutor",
-                [
-                    CeleryExecutor,
-                ],
-                [
-                    ConnectorSource.CORE,
-                ],
-            ),
-            # Multiple Executors,
-            (
-                "CeleryExecutor, airflow.providers.amazon.aws.executors.ecs.ecs_executor.AwsEcsExecutor",
-                [
-                    CeleryExecutor,
-                    AwsEcsExecutor,
-                ],
-                [
-                    ConnectorSource.CORE,
-                    ConnectorSource.CUSTOM_PATH,
-                ],
-            ),
-        ],
-    )
-    def test_import_all_executors(
-        self, executor_config, expected_executor_classes, expected_connector_sources
-    ):
-        ExecutorLoader.block_use_of_hybrid_exec = mock.Mock()
-        with conf_vars({("core", "executor"): executor_config}):
-            executors = [executor for executor, _ in ExecutorLoader.import_all_executors()]
-            connector_sources = [
-                connector_source for _, connector_source in ExecutorLoader.import_all_executors()
-            ]
-            assert executors == expected_executor_classes
-            assert connector_sources == expected_connector_sources
 
     @pytest.mark.parametrize(
         ("executor_config", "expected_executors_list"),


### PR DESCRIPTION
Executors are able to vend custom CLI commands to the Airflow CLI. In order to support multiple Executors, we need to allow each configured Executor to vend its set of CLI commands. 

This PR introduces a method to load all Executor specific CLI commands, as well as associated unit tests. 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
