### PR TITLE
Append/update builtins deprecations warnings instead of prepend

### DIFF
--- a/tests/_internals/capture_warnings.py
+++ b/tests/_internals/capture_warnings.py
@@ -127,8 +127,8 @@ class CaptureWarningsPlugin:
     def pytest_runtest_call(self, item: pytest.Item):
         with warnings.catch_warnings(record=True) as records:
             if not sys.warnoptions:
-                warnings.filterwarnings("always", category=DeprecationWarning)
-                warnings.filterwarnings("always", category=PendingDeprecationWarning)
+                warnings.filterwarnings("always", category=DeprecationWarning, append=True)
+                warnings.filterwarnings("always", category=PendingDeprecationWarning, append=True)
             yield
 
         for record in records:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Fix bug in test warning capture system introduced in https://github.com/apache/airflow/pull/38905
There is redefine `DeprecationWarning`, `PendingDeprecationWarning` which are ignored by default in Python, however the problem that it use Prepend/Insert

```
# From CaptureWarningsPlugin
00 = {tuple: 5} ('always', None, <class 'PendingDeprecationWarning'>, None, 0)
01 = {tuple: 5} ('always', None, <class 'DeprecationWarning'>, None, 0)
# Explicit set as pytest.mark.filterwarnings
02 = {tuple: 5} ('default', None, <class 'airflow.exceptions.RemovedInAirflow3Warning'>, None, 0)
# Implicit set during pytest collect
03 = {tuple: 5} ('error', None, <class 'airflow.exceptions.RemovedInAirflow3Warning'>, None, 0)
04 = {tuple: 5} ('error', None, <class 'airflow.utils.context.AirflowContextDeprecationWarning'>, None, 0)
05 = {tuple: 5} ('error', None, <class 'airflow.exceptions.AirflowProviderDeprecationWarning'>, None, 0)
...
```

As result error might not happen if `airflow.exceptions.RemovedInAirflow3Warning` raisedduring test run because it subclass of `DeprecationWarning` and in this case rule `'always', None, <class 'DeprecationWarning'>, None, 0` will choose instead of `'error', None, <class 'airflow.exceptions.RemovedInAirflow3Warning'>, None, 0`

After changes it update already existed and defined values in `warnings.filters`
```
# Explicit set as pytest.mark.filterwarnings
00 = {tuple: 5} ('default', None, <class 'airflow.exceptions.RemovedInAirflow3Warning'>, None, 0)
# Implicit set during pytest collect
01 = {tuple: 5} ('error', None, <class 'airflow.exceptions.RemovedInAirflow3Warning'>, None, 0)
02 = {tuple: 5} ('error', None, <class 'airflow.utils.context.AirflowContextDeprecationWarning'>, None, 0)
03 = {tuple: 5} ('error', None, <class 'airflow.exceptions.AirflowProviderDeprecationWarning'>, None, 0)
...
# Updated from CaptureWarningsPlugin
19 = {tuple: 5} ('always', None, <class 'PendingDeprecationWarning'>, None, 0)
20 = {tuple: 5} ('always', None, <class 'DeprecationWarning'>, None, 0)
...
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
