### PR TITLE
Allow importing the aws executors with a shorter path

### DIFF
--- a/airflow/providers/amazon/aws/executors/batch/__init__.py
+++ b/airflow/providers/amazon/aws/executors/batch/__init__.py
@@ -16,10 +16,6 @@
 # under the License.
 from __future__ import annotations  # Added by precommit hooks
 
-# from airflow.providers.amazon.aws.executors.batch.batch_executor import AwsBatchExecutor
-from airflow.providers.amazon.aws.executors.batch import batch_executor
+__all__ = ["AwsBatchExecutor"]
 
-# precommit hooks (rust as of the time of commit) throws F401 - "Module imported but unused"
-# One of the solutions it suggests is using a "redundant alias". This is used below instead of doing a #no-qa
-# type ignore of the issue.
-AwsBatchExecutor = batch_executor.AwsBatchExecutor
+from airflow.providers.amazon.aws.executors.batch.batch_executor import AwsBatchExecutor

--- a/airflow/providers/amazon/aws/executors/batch/__init__.py
+++ b/airflow/providers/amazon/aws/executors/batch/__init__.py
@@ -14,8 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from __future__ import annotations
+from __future__ import annotations  # Added by precommit hooks
 
 from airflow.providers.amazon.aws.executors.batch.batch_executor import AwsBatchExecutor
 
+# precommit hooks (rust as of the time of commit) throws F401 - "Module imported but unused"
+# One of the solutions it suggests is using a "redundant alias". This is used below instead of doing a #no-qa
+# type ignore of the issue.
 AwsBatchExecutor = AwsBatchExecutor

--- a/airflow/providers/amazon/aws/executors/batch/__init__.py
+++ b/airflow/providers/amazon/aws/executors/batch/__init__.py
@@ -16,9 +16,10 @@
 # under the License.
 from __future__ import annotations  # Added by precommit hooks
 
-from airflow.providers.amazon.aws.executors.batch.batch_executor import AwsBatchExecutor
+# from airflow.providers.amazon.aws.executors.batch.batch_executor import AwsBatchExecutor
+from airflow.providers.amazon.aws.executors.batch import batch_executor
 
 # precommit hooks (rust as of the time of commit) throws F401 - "Module imported but unused"
 # One of the solutions it suggests is using a "redundant alias". This is used below instead of doing a #no-qa
 # type ignore of the issue.
-AwsBatchExecutor = AwsBatchExecutor
+AwsBatchExecutor = batch_executor.AwsBatchExecutor

--- a/airflow/providers/amazon/aws/executors/batch/__init__.py
+++ b/airflow/providers/amazon/aws/executors/batch/__init__.py
@@ -14,3 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
+
+from airflow.providers.amazon.aws.executors.batch.batch_executor import AwsBatchExecutor
+
+AwsBatchExecutor = AwsBatchExecutor

--- a/airflow/providers/amazon/aws/executors/ecs/__init__.py
+++ b/airflow/providers/amazon/aws/executors/ecs/__init__.py
@@ -14,8 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from __future__ import annotations
+from __future__ import annotations  # Added by precommit hooks
 
 from airflow.providers.amazon.aws.executors.ecs.ecs_executor import AwsEcsExecutor
 
+# precommit hooks (rust as of the time of commit) throws F401 - "Module imported but unused"
+# One of the solutions it suggests is using a "redundant alias". This is used below instead of doing a #no-qa
+# type ignore of the issue.
 AwsEcsExecutor = AwsEcsExecutor

--- a/airflow/providers/amazon/aws/executors/ecs/__init__.py
+++ b/airflow/providers/amazon/aws/executors/ecs/__init__.py
@@ -16,9 +16,6 @@
 # under the License.
 from __future__ import annotations  # Added by precommit hooks
 
-from airflow.providers.amazon.aws.executors.ecs import ecs_executor
+__all__ = ["AwsEcsExecutor"]
 
-# precommit hooks (rust as of the time of commit) throws F401 - "Module imported but unused"
-# One of the solutions it suggests is using a "redundant alias". This is used below instead of doing a #no-qa
-# type ignore of the issue.
-AwsEcsExecutor = ecs_executor.AwsEcsExecutor
+from airflow.providers.amazon.aws.executors.ecs.ecs_executor import AwsEcsExecutor

--- a/airflow/providers/amazon/aws/executors/ecs/__init__.py
+++ b/airflow/providers/amazon/aws/executors/ecs/__init__.py
@@ -14,3 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
+
+from airflow.providers.amazon.aws.executors.ecs.ecs_executor import AwsEcsExecutor
+
+AwsEcsExecutor = AwsEcsExecutor

--- a/airflow/providers/amazon/aws/executors/ecs/__init__.py
+++ b/airflow/providers/amazon/aws/executors/ecs/__init__.py
@@ -16,9 +16,9 @@
 # under the License.
 from __future__ import annotations  # Added by precommit hooks
 
-from airflow.providers.amazon.aws.executors.ecs.ecs_executor import AwsEcsExecutor
+from airflow.providers.amazon.aws.executors.ecs import ecs_executor
 
 # precommit hooks (rust as of the time of commit) throws F401 - "Module imported but unused"
 # One of the solutions it suggests is using a "redundant alias". This is used below instead of doing a #no-qa
 # type ignore of the issue.
-AwsEcsExecutor = AwsEcsExecutor
+AwsEcsExecutor = ecs_executor.AwsEcsExecutor

--- a/tests/providers/amazon/aws/executors/batch/test_batch_executor.py
+++ b/tests/providers/amazon/aws/executors/batch/test_batch_executor.py
@@ -834,3 +834,8 @@ class TestBatchExecutorConfig:
         final_run_task_kwargs = executor._submit_job_kwargs(mock_ti_key, command, "queue", exec_config)
 
         assert final_run_task_kwargs == expected_result
+
+    def test_short_import_path(self):
+        from airflow.providers.amazon.aws.executors.batch import AwsBatchExecutor as AwsBatchExecutorShortPath
+
+        assert AwsBatchExecutor is AwsBatchExecutorShortPath

--- a/tests/providers/amazon/aws/executors/ecs/test_ecs_executor.py
+++ b/tests/providers/amazon/aws/executors/ecs/test_ecs_executor.py
@@ -1703,3 +1703,8 @@ class TestEcsExecutorConfig:
         final_run_task_kwargs = executor._run_task_kwargs(mock_ti_key, command, "queue", exec_config)
 
         assert final_run_task_kwargs == expected_result
+
+    def test_short_import_path(self):
+        from airflow.providers.amazon.aws.executors.ecs import AwsEcsExecutor as AwsEcsExecutorShortPath
+
+        assert AwsEcsExecutor is AwsEcsExecutorShortPath


### PR DESCRIPTION
Import the aws executors in the `__init__.py` module of their respective directories so that they can be imported with a shorter and more natural looking module path.

For example, this modules path:

`airflow.providers.amazon.aws.executors.batch.batch_executor.AwsBatchExecutor`

Becomes:

`airflow.providers.amazon.aws.executors.batch.AwsBatchExecutor`

fixes #38524 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
