### PR TITLE
openlineage, snowflake: do not run external queries for Snowflake when 

### DIFF
--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -309,6 +309,14 @@ class SQLExecuteQueryOperator(BaseSQLOperator):
 
         hook = self.get_db_hook()
 
+        try:
+            from airflow.providers.openlineage.utils.utils import should_use_external_connection
+
+            use_external_connection = should_use_external_connection(hook)
+        except ImportError:
+            # OpenLineage provider release < 1.8.0 - we always use connection
+            use_external_connection = True
+
         connection = hook.get_connection(getattr(hook, hook.conn_name_attr))
         try:
             database_info = hook.get_openlineage_database_info(connection)
@@ -334,6 +342,7 @@ class SQLExecuteQueryOperator(BaseSQLOperator):
             database_info=database_info,
             database=self.database,
             sqlalchemy_engine=hook.get_sqlalchemy_engine(),
+            use_connection=use_external_connection,
         )
 
         return operator_lineage

--- a/airflow/providers/openlineage/utils/utils.py
+++ b/airflow/providers/openlineage/utils/utils.py
@@ -384,3 +384,8 @@ def normalize_sql(sql: str | Iterable[str]):
         sql = [stmt for stmt in sql.split(";") if stmt != ""]
     sql = [obj for stmt in sql for obj in stmt.split(";") if obj != ""]
     return ";\n".join(sql)
+
+
+def should_use_external_connection(hook) -> bool:
+    # TODO: Add checking overrides
+    return hook.__class__.__name__ not in ["SnowflakeHook", "SnowflakeSqlApiHook"]

--- a/airflow/providers/snowflake/hooks/snowflake_sql_api.py
+++ b/airflow/providers/snowflake/hooks/snowflake_sql_api.py
@@ -86,7 +86,7 @@ class SnowflakeSqlApiHook(SnowflakeHook):
     @property
     def account_identifier(self) -> str:
         """Returns snowflake account identifier."""
-        conn_config = self._get_conn_params()
+        conn_config = self._get_conn_params
         account_identifier = f"https://{conn_config['account']}"
 
         if conn_config["region"]:
@@ -147,7 +147,7 @@ class SnowflakeSqlApiHook(SnowflakeHook):
             When executing the statement, Snowflake replaces placeholders (? and :name) in
             the statement with these specified values.
         """
-        conn_config = self._get_conn_params()
+        conn_config = self._get_conn_params
 
         req_id = uuid.uuid4()
         url = f"{self.account_identifier}.snowflakecomputing.com/api/v2/statements"
@@ -186,7 +186,7 @@ class SnowflakeSqlApiHook(SnowflakeHook):
 
     def get_headers(self) -> dict[str, Any]:
         """Form auth headers based on either OAuth token or JWT token from private key."""
-        conn_config = self._get_conn_params()
+        conn_config = self._get_conn_params
 
         # Use OAuth if refresh_token and client_id and client_secret are provided
         if all(
@@ -225,7 +225,7 @@ class SnowflakeSqlApiHook(SnowflakeHook):
 
     def get_oauth_token(self) -> str:
         """Generate temporary OAuth access token using refresh token in connection details."""
-        conn_config = self._get_conn_params()
+        conn_config = self._get_conn_params
         url = f"{self.account_identifier}.snowflakecomputing.com/oauth/token-request"
         data = {
             "grant_type": "refresh_token",

--- a/tests/providers/amazon/aws/operators/test_redshift_sql.py
+++ b/tests/providers/amazon/aws/operators/test_redshift_sql.py
@@ -158,7 +158,8 @@ class TestRedshiftSQLOpenLineage:
                 "SVV_REDSHIFT_COLUMNS.data_type, "
                 "SVV_REDSHIFT_COLUMNS.database_name \n"
                 "FROM SVV_REDSHIFT_COLUMNS \n"
-                "WHERE SVV_REDSHIFT_COLUMNS.table_name IN ('little_table') "
+                "WHERE SVV_REDSHIFT_COLUMNS.schema_name = 'database.public' "
+                "AND SVV_REDSHIFT_COLUMNS.table_name IN ('little_table') "
                 "OR SVV_REDSHIFT_COLUMNS.database_name = 'another_db' "
                 "AND SVV_REDSHIFT_COLUMNS.schema_name = 'another_schema' AND "
                 "SVV_REDSHIFT_COLUMNS.table_name IN ('popular_orders_day_of_week')"
@@ -171,7 +172,8 @@ class TestRedshiftSQLOpenLineage:
                 "SVV_REDSHIFT_COLUMNS.data_type, "
                 "SVV_REDSHIFT_COLUMNS.database_name \n"
                 "FROM SVV_REDSHIFT_COLUMNS \n"
-                "WHERE SVV_REDSHIFT_COLUMNS.table_name IN ('Test_table')"
+                "WHERE SVV_REDSHIFT_COLUMNS.schema_name = 'database.public' "
+                "AND SVV_REDSHIFT_COLUMNS.table_name IN ('Test_table')"
             ),
         ]
 

--- a/tests/providers/snowflake/hooks/test_snowflake_sql_api.py
+++ b/tests/providers/snowflake/hooks/test_snowflake_sql_api.py
@@ -20,7 +20,7 @@ import unittest
 import uuid
 from typing import TYPE_CHECKING, Any
 from unittest import mock
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, PropertyMock
 
 import pytest
 import requests
@@ -168,7 +168,10 @@ class TestSnowflakeSqlApiHook:
         ],
     )
     @mock.patch("airflow.providers.snowflake.hooks.snowflake_sql_api.requests")
-    @mock.patch("airflow.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHook._get_conn_params")
+    @mock.patch(
+        "airflow.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHook._get_conn_params",
+        new_callable=PropertyMock,
+    )
     @mock.patch("airflow.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHook.get_headers")
     def test_execute_query(
         self,
@@ -197,7 +200,10 @@ class TestSnowflakeSqlApiHook:
         [(SINGLE_STMT, 1, {"statementHandle": "uuid"}, ["uuid"])],
     )
     @mock.patch("airflow.providers.snowflake.hooks.snowflake_sql_api.requests")
-    @mock.patch("airflow.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHook._get_conn_params")
+    @mock.patch(
+        "airflow.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHook._get_conn_params",
+        new_callable=PropertyMock,
+    )
     @mock.patch("airflow.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHook.get_headers")
     def test_execute_query_exception_without_statement_handle(
         self,
@@ -262,7 +268,10 @@ class TestSnowflakeSqlApiHook:
             with pytest.raises(AirflowException, match='Response: {"foo": "bar"}, Status Code: 500'):
                 hook.check_query_output(query_ids)
 
-    @mock.patch("airflow.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHook._get_conn_params")
+    @mock.patch(
+        "airflow.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHook._get_conn_params",
+        new_callable=PropertyMock,
+    )
     @mock.patch("airflow.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHook.get_headers")
     def test_get_request_url_header_params(self, mock_get_header, mock_conn_param):
         """Test get_request_url_header_params by mocking _get_conn_params and get_headers"""
@@ -274,7 +283,10 @@ class TestSnowflakeSqlApiHook:
         assert url == "https://airflow.af_region.snowflakecomputing.com/api/v2/statements/uuid"
 
     @mock.patch("airflow.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHook.get_private_key")
-    @mock.patch("airflow.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHook._get_conn_params")
+    @mock.patch(
+        "airflow.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHook._get_conn_params",
+        new_callable=PropertyMock,
+    )
     @mock.patch("airflow.providers.snowflake.utils.sql_api_generate_jwt.JWTGenerator.get_token")
     def test_get_headers_should_support_private_key(self, mock_get_token, mock_conn_param, mock_private_key):
         """Test get_headers method by mocking get_private_key and _get_conn_params method"""
@@ -285,7 +297,10 @@ class TestSnowflakeSqlApiHook:
         assert result == HEADERS
 
     @mock.patch("airflow.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHook.get_oauth_token")
-    @mock.patch("airflow.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHook._get_conn_params")
+    @mock.patch(
+        "airflow.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHook._get_conn_params",
+        new_callable=PropertyMock,
+    )
     def test_get_headers_should_support_oauth(self, mock_conn_param, mock_oauth_token):
         """Test get_headers method by mocking get_oauth_token and _get_conn_params method"""
         mock_conn_param.return_value = CONN_PARAMS_OAUTH
@@ -296,7 +311,10 @@ class TestSnowflakeSqlApiHook:
 
     @mock.patch("airflow.providers.snowflake.hooks.snowflake_sql_api.HTTPBasicAuth")
     @mock.patch("requests.post")
-    @mock.patch("airflow.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHook._get_conn_params")
+    @mock.patch(
+        "airflow.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHook._get_conn_params",
+        new_callable=PropertyMock,
+    )
     def test_get_oauth_token(self, mock_conn_param, requests_post, mock_auth):
         """Test get_oauth_token method makes the right http request"""
         BASIC_AUTH = {"Authorization": "Basic usernamepassword"}

--- a/tests/providers/snowflake/operators/test_snowflake_sql.py
+++ b/tests/providers/snowflake/operators/test_snowflake_sql.py
@@ -17,7 +17,8 @@
 # under the License.
 from __future__ import annotations
 
-from unittest.mock import MagicMock, call, patch
+from unittest import mock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from _pytest.outcomes import importorskip
@@ -37,8 +38,6 @@ from openlineage.client.facet import (
     ColumnLineageDatasetFacet,
     ColumnLineageDatasetFacetFieldsAdditional,
     ColumnLineageDatasetFacetFieldsAdditionalInputFields,
-    SchemaDatasetFacet,
-    SchemaField,
     SqlJobFacet,
 )
 from openlineage.client.run import Dataset
@@ -163,7 +162,9 @@ def test_exec_success(sql, return_last, split_statement, hook_results, hook_desc
         )
 
 
-def test_execute_openlineage_events():
+@mock.patch("airflow.providers.openlineage.utils.utils.should_use_external_connection")
+def test_execute_openlineage_events(should_use_external_connection):
+    should_use_external_connection.return_value = False
     DB_NAME = "DATABASE"
     DB_SCHEMA_NAME = "PUBLIC"
 
@@ -174,9 +175,6 @@ def test_execute_openlineage_events():
         get_conn = MagicMock(name="conn")
         get_connection = MagicMock()
 
-        def get_first(self, *_):
-            return [f"{DB_NAME}.{DB_SCHEMA_NAME}"]
-
     dbapi_hook = SnowflakeHookForTests()
 
     class SnowflakeOperatorForTest(SnowflakeOperator):
@@ -185,7 +183,7 @@ def test_execute_openlineage_events():
 
     sql = (
         "INSERT INTO Test_table\n"
-        "SELECT t1.*, t2.additional_constant FROM ANOTHER_db.another_schema.popular_orders_day_of_week t1\n"
+        "SELECT t1.*, t2.additional_constant FROM ANOTHER_DB.ANOTHER_SCHEMA.popular_orders_day_of_week t1\n"
         "JOIN little_table t2 ON t1.order_day_of_week = t2.order_day_of_week;\n"
         "FORGOT TO COMMENT"
     )
@@ -223,6 +221,7 @@ def test_execute_openlineage_events():
     dbapi_hook.get_connection.return_value = Connection(
         conn_id="snowflake_default",
         conn_type="snowflake",
+        schema="PUBLIC",
         extra={
             "account": "test_account",
             "region": "us-east",
@@ -233,55 +232,17 @@ def test_execute_openlineage_events():
     dbapi_hook.get_conn.return_value.cursor.return_value.fetchall.side_effect = rows
 
     lineage = op.get_openlineage_facets_on_start()
-    assert dbapi_hook.get_conn.return_value.cursor.return_value.execute.mock_calls == [
-        call(
-            "SELECT database.information_schema.columns.table_schema, database.information_schema.columns.table_name, "
-            "database.information_schema.columns.column_name, database.information_schema.columns.ordinal_position, "
-            "database.information_schema.columns.data_type, database.information_schema.columns.table_catalog \n"
-            "FROM database.information_schema.columns \n"
-            "WHERE database.information_schema.columns.table_name IN ('LITTLE_TABLE') "
-            "UNION ALL "
-            "SELECT another_db.information_schema.columns.table_schema, another_db.information_schema.columns.table_name, "
-            "another_db.information_schema.columns.column_name, another_db.information_schema.columns.ordinal_position, "
-            "another_db.information_schema.columns.data_type, another_db.information_schema.columns.table_catalog \n"
-            "FROM another_db.information_schema.columns \n"
-            "WHERE another_db.information_schema.columns.table_schema = 'ANOTHER_SCHEMA' "
-            "AND another_db.information_schema.columns.table_name IN ('POPULAR_ORDERS_DAY_OF_WEEK')"
-        ),
-        call(
-            "SELECT database.information_schema.columns.table_schema, database.information_schema.columns.table_name, "
-            "database.information_schema.columns.column_name, database.information_schema.columns.ordinal_position, "
-            "database.information_schema.columns.data_type, database.information_schema.columns.table_catalog \n"
-            "FROM database.information_schema.columns \n"
-            "WHERE database.information_schema.columns.table_name IN ('TEST_TABLE')"
-        ),
-    ]
+    # Not calling Snowflake
+    assert dbapi_hook.get_conn.return_value.cursor.return_value.execute.mock_calls == []
 
     assert lineage.inputs == [
         Dataset(
             namespace="snowflake://test_account.us-east.aws",
-            name=f"{ANOTHER_DB_NAME}.{ANOTHER_DB_SCHEMA}.POPULAR_ORDERS_DAY_OF_WEEK",
-            facets={
-                "schema": SchemaDatasetFacet(
-                    fields=[
-                        SchemaField(name="ORDER_DAY_OF_WEEK", type="TEXT"),
-                        SchemaField(name="ORDER_PLACED_ON", type="TIMESTAMP_NTZ"),
-                        SchemaField(name="ORDERS_PLACED", type="NUMBER"),
-                    ]
-                )
-            },
+            name=f"{DB_NAME}.{DB_SCHEMA_NAME}.LITTLE_TABLE",
         ),
         Dataset(
             namespace="snowflake://test_account.us-east.aws",
-            name=f"{DB_NAME}.{DB_SCHEMA_NAME}.LITTLE_TABLE",
-            facets={
-                "schema": SchemaDatasetFacet(
-                    fields=[
-                        SchemaField(name="ORDER_DAY_OF_WEEK", type="TEXT"),
-                        SchemaField(name="ADDITIONAL_CONSTANT", type="TEXT"),
-                    ]
-                )
-            },
+            name=f"{ANOTHER_DB_NAME}.{ANOTHER_DB_SCHEMA}.POPULAR_ORDERS_DAY_OF_WEEK",
         ),
     ]
     assert lineage.outputs == [
@@ -289,14 +250,6 @@ def test_execute_openlineage_events():
             namespace="snowflake://test_account.us-east.aws",
             name=f"{DB_NAME}.{DB_SCHEMA_NAME}.TEST_TABLE",
             facets={
-                "schema": SchemaDatasetFacet(
-                    fields=[
-                        SchemaField(name="ORDER_DAY_OF_WEEK", type="TEXT"),
-                        SchemaField(name="ORDER_PLACED_ON", type="TIMESTAMP_NTZ"),
-                        SchemaField(name="ORDERS_PLACED", type="NUMBER"),
-                        SchemaField(name="ADDITIONAL_CONSTANT", type="TEXT"),
-                    ]
-                ),
                 "columnLineage": ColumnLineageDatasetFacet(
                     fields={
                         "additional_constant": ColumnLineageDatasetFacetFieldsAdditional(


### PR DESCRIPTION
Currently, we call Snowflake (and other DBs) to get schemas of tables used in particular queries. 

However, Snowflake [connector management is buggy](https://github.com/snowflakedb/snowflake-connector-python/issues/1567) and leaves us in a hanging, deadlocked state sometimes, which causes OpenLineage collection to fail and . 

This PR prevents that by never calling Snowflake during OpenLineage method execution, and relying purely on information received from SQL parsing and Airflow Connection.

The negative consequence of that PR is lack of schema information in OpenLineage events, but this is a good tradeoff - most important feature of OpenLineage should be not affecting running tasks.