### PR TITLE
Improve task filtering UX

### DIFF
--- a/airflow/www/static/js/dag/details/FilterTasks.tsx
+++ b/airflow/www/static/js/dag/details/FilterTasks.tsx
@@ -28,9 +28,11 @@ import {
 } from "@chakra-ui/react";
 import useFilters from "src/dag/useFilters";
 import { MdArrowDropDown } from "react-icons/md";
+import { useGridData } from "src/api";
+import { getTask } from "src/utils";
 
 interface Props {
-  taskId: string;
+  taskId: string | null;
 }
 
 const FilterTasks = ({ taskId }: Props) => {
@@ -40,34 +42,48 @@ const FilterTasks = ({ taskId }: Props) => {
     resetRoot,
   } = useFilters();
 
-  const onFilterUpstream = () =>
-    onFilterTasksChange({
-      root: taskId,
-      filterUpstream: true,
-      filterDownstream: false,
-    });
-
-  const onFilterDownstream = () =>
-    onFilterTasksChange({
-      root: taskId,
-      filterUpstream: false,
-      filterDownstream: true,
-    });
-
-  const onFilterAll = () =>
-    onFilterTasksChange({
-      root: taskId,
-      filterUpstream: true,
-      filterDownstream: true,
-    });
+  const {
+    data: { groups },
+  } = useGridData();
 
   const label = "Filter upstream and/or downstream of a task";
+
+  if (!root && !taskId) return null;
+
+  const onFilterUpstream = () => {
+    if (taskId)
+      onFilterTasksChange({
+        root: taskId,
+        filterUpstream: true,
+        filterDownstream: false,
+      });
+  };
+
+  const onFilterDownstream = () => {
+    if (taskId)
+      onFilterTasksChange({
+        root: taskId,
+        filterUpstream: false,
+        filterDownstream: true,
+      });
+  };
+
+  const onFilterAll = () => {
+    if (taskId)
+      onFilterTasksChange({
+        root: taskId,
+        filterUpstream: true,
+        filterDownstream: true,
+      });
+  };
+
+  const task = root ? getTask({ taskId: root, task: groups }) : undefined;
 
   return (
     <Menu>
       <MenuButton
         as={Button}
-        variant="outline"
+        variant={root ? "solid" : "outline"}
         colorScheme="blue"
         transition="all 0.2s"
         title={label}
@@ -75,15 +91,23 @@ const FilterTasks = ({ taskId }: Props) => {
         mt={2}
       >
         <Flex>
-          {!root ? "Filter Tasks " : "Clear Task Filter "}
+          {root
+            ? `Filtered on ${task?.label || "unknown"}`
+            : "Filter DAG by task"}
           <MdArrowDropDown size="16px" />
         </Flex>
       </MenuButton>
       <MenuList>
-        <MenuItem onClick={onFilterUpstream}>Filter Upstream</MenuItem>
-        <MenuItem onClick={onFilterDownstream}>Filter Downstream</MenuItem>
-        <MenuItem onClick={onFilterAll}>Filter Upstream & Downstream</MenuItem>
-        {!!root && <MenuItem onClick={resetRoot}>Reset Root</MenuItem>}
+        {!!root && <MenuItem onClick={resetRoot}>Reset</MenuItem>}
+        {!!taskId && (
+          <>
+            <MenuItem onClick={onFilterUpstream}>Only upstream</MenuItem>
+            <MenuItem onClick={onFilterDownstream}>Only downstream</MenuItem>
+            <MenuItem onClick={onFilterAll}>
+              Both upstream & downstream
+            </MenuItem>
+          </>
+        )}
       </MenuList>
     </Menu>
   );

--- a/airflow/www/static/js/dag/details/Header.tsx
+++ b/airflow/www/static/js/dag/details/Header.tsx
@@ -124,7 +124,7 @@ const Header = ({ mapIndex }: Props) => {
           </BreadcrumbLink>
         </BreadcrumbItem>
       )}
-      {mapIndex !== undefined && (
+      {mapIndex !== undefined && mapIndex !== -1 && (
         <BreadcrumbItem isCurrentPage mt={4}>
           <BreadcrumbLink
             _hover={isMappedTaskDetails ? { cursor: "default" } : undefined}

--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -287,7 +287,7 @@ const Details = ({
               />
             </>
           )}
-          {taskId && runId && <FilterTasks taskId={taskId} />}
+          <FilterTasks taskId={taskId} />
         </Flex>
       </Flex>
       <Divider my={2} />


### PR DESCRIPTION
Continuation of https://github.com/apache/airflow/pull/38660

It was not always obvious if the DAG page was being filtered by the upstream/downstream of a task. A few fixes:
- if a filter is applied, make the button blue
- if a filter is applied, display the dropdown regardless of task/run selection
- update copy
- don't show map index in breadrcrumb if it is -1


<img width="1071" alt="Screenshot 2024-04-18 at 12 15 14 PM" src="https://github.com/apache/airflow/assets/4600967/07a81973-9811-4d76-8a90-e9d1e88b67ae">
<img width="778" alt="Screenshot 2024-04-18 at 12 14 58 PM" src="https://github.com/apache/airflow/assets/4600967/ccbbaaa9-b4d5-4ac0-99ca-ea468358bc4e">


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
