### PR TITLE
Make audit log before/after filterable

### DIFF
--- a/airflow/www/static/js/dag/details/AuditLog.tsx
+++ b/airflow/www/static/js/dag/details/AuditLog.tsx
@@ -25,7 +25,6 @@ import {
   Flex,
   FormControl,
   FormLabel,
-  Input,
   SimpleGrid,
   RadioGroup,
   Stack,
@@ -54,6 +53,7 @@ import { CodeCell, TimeCell } from "src/components/NewTable/NewCells";
 import { MdRefresh } from "react-icons/md";
 import { useTimezone } from "src/context/timezone";
 import { isoFormatWithoutTZ } from "src/datetime_utils";
+import DateTimeInput from "src/components/DateTimeInput";
 
 const configExcludedEvents = getMetaValue("excluded_audit_log_events");
 const configIncludedEvents = getMetaValue("included_audit_log_events");
@@ -218,16 +218,14 @@ const AuditLog = ({ taskId, run }: Props) => {
       <SimpleGrid columns={4} columnGap={2}>
         <FormControl>
           <FormLabel>Show Logs After</FormLabel>
-          <Input
-            type="datetime-local"
+          <DateTimeInput
             value={afterTime}
             onChange={(e) => setAfter(e.target.value)}
           />
         </FormControl>
         <FormControl>
           <FormLabel>Show Logs Before</FormLabel>
-          <Input
-            type="datetime-local"
+          <DateTimeInput
             value={beforeTime}
             onChange={(e) => setBefore(e.target.value)}
           />

--- a/airflow/www/static/js/dag/details/AuditLog.tsx
+++ b/airflow/www/static/js/dag/details/AuditLog.tsx
@@ -24,14 +24,13 @@ import {
   Box,
   Flex,
   FormControl,
-  FormHelperText,
   FormLabel,
   Input,
   SimpleGrid,
-  Button,
   RadioGroup,
   Stack,
   Radio,
+  IconButton,
 } from "@chakra-ui/react";
 import { createColumnHelper } from "@tanstack/react-table";
 import { snakeCase } from "lodash";
@@ -53,6 +52,8 @@ import { NewTable } from "src/components/NewTable/NewTable";
 import { useTableURLState } from "src/components/NewTable/useTableUrlState";
 import { CodeCell, TimeCell } from "src/components/NewTable/NewCells";
 import { MdRefresh } from "react-icons/md";
+import { useTimezone } from "src/context/timezone";
+import { isoFormatWithoutTZ } from "src/datetime_utils";
 
 const configExcludedEvents = getMetaValue("excluded_audit_log_events");
 const configIncludedEvents = getMetaValue("included_audit_log_events");
@@ -92,16 +93,27 @@ const AuditLog = ({ taskId, run }: Props) => {
   }
   const [eventFilter, setEventFilter] = useState(defaultEventFilter);
   const [events, setEvents] = useState(defaultEvents);
+  const [before, setBefore] = useState("");
+  const [after, setAfter] = useState("");
 
   const sort = tableURLState.sorting[0];
   const orderBy = sort ? `${sort.desc ? "-" : ""}${snakeCase(sort.id)}` : "";
+
+  const { timezone } = useTimezone();
+
+  // @ts-ignore
+  const beforeTime = moment(before).tz(timezone).format(isoFormatWithoutTZ);
+  // @ts-ignore
+  const afterTime = moment(after).tz(timezone).format(isoFormatWithoutTZ);
 
   const { data, isLoading, isFetching, refetch } = useEventLogs({
     dagId,
     taskId,
     runId: run?.runId || undefined,
-    before: run?.lastSchedulingDecision || undefined,
-    after: run?.queuedAt || undefined,
+    // @ts-ignore
+    before: before ? moment(before).format() : undefined,
+    // @ts-ignore
+    after: after ? moment(after).format() : undefined,
     orderBy,
     limit: tableURLState.pagination.pageSize,
     offset:
@@ -191,15 +203,14 @@ const AuditLog = ({ taskId, run }: Props) => {
       overflowY="auto"
     >
       <Flex justifyContent="right" mb={2}>
-        <Button
-          leftIcon={<MdRefresh />}
+        <IconButton
+          aria-label="Refresh"
+          icon={<MdRefresh />}
           onClick={() => refetch()}
           variant="outline"
           colorScheme="blue"
           mr={2}
-        >
-          Refresh
-        </Button>
+        />
         <LinkButton href={getMetaValue("audit_log_url")}>
           View full cluster Audit Log
         </LinkButton>
@@ -208,42 +219,18 @@ const AuditLog = ({ taskId, run }: Props) => {
         <FormControl>
           <FormLabel>Show Logs After</FormLabel>
           <Input
-            type="datetime"
-            // @ts-ignore
-            placeholder={run?.queuedAt ? moment(run?.queuedAt).format() : ""}
-            isDisabled
+            type="datetime-local"
+            value={afterTime}
+            onChange={(e) => setAfter(e.target.value)}
           />
-          {!!run && run?.queuedAt && (
-            <FormHelperText>After selected DAG Run Queued At</FormHelperText>
-          )}
         </FormControl>
         <FormControl>
           <FormLabel>Show Logs Before</FormLabel>
           <Input
-            type="datetime"
-            placeholder={
-              run?.lastSchedulingDecision
-                ? // @ts-ignore
-                  moment(run?.lastSchedulingDecision).format()
-                : ""
-            }
-            isDisabled
+            type="datetime-local"
+            value={beforeTime}
+            onChange={(e) => setBefore(e.target.value)}
           />
-          {!!run && run?.lastSchedulingDecision && (
-            <FormHelperText>
-              Before selected DAG Run Last Scheduling Decision
-            </FormHelperText>
-          )}
-        </FormControl>
-        <FormControl>
-          <FormLabel>Filter by Run ID</FormLabel>
-          <Input placeholder={run?.runId} isDisabled />
-          <FormHelperText />
-        </FormControl>
-        <FormControl>
-          <FormLabel>Filter by Task ID</FormLabel>
-          <Input placeholder={taskId} isDisabled />
-          <FormHelperText />
         </FormControl>
         <FormControl>
           <FormLabel display="flex" alignItems="center">


### PR DESCRIPTION
Before we preset the audit log before and after fields with the task instance or dag run queued to end times. And the filter bars were disabled.

Now:
- remove preset values since we do a better job of recording run_id and actions after the dag run, like marking as failed or adding a note, would be missing
- allow a user to filter before and after times
- remove the disabled task id and run id filter bars since the breadcrumb already shows that


<img width="994" alt="Screenshot 2024-04-18 at 1 17 02 PM" src="https://github.com/apache/airflow/assets/4600967/9a853207-3e0e-49b8-a991-6b8083340ab4">


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
