### PR TITLE
Improve rendered_template ux in react dag page

### DIFF
--- a/airflow/www/static/js/dag/details/taskInstance/Details.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Details.tsx
@@ -231,29 +231,6 @@ const Details = ({ gridInstance, taskInstance, group }: Props) => {
               </Td>
             </Tr>
           )}
-          {taskInstance?.renderedFields && (
-            <>
-              {Object.keys(taskInstance.renderedFields).map((key) => {
-                const renderedFields = taskInstance.renderedFields as Record<
-                  string,
-                  unknown
-                >;
-                if (renderedFields[key]) {
-                  return (
-                    <Tr key={key}>
-                      <Td>{key}</Td>
-                      <Td>
-                        <Code fontSize="md">
-                          {JSON.stringify(renderedFields[key])}
-                        </Code>
-                      </Td>
-                    </Tr>
-                  );
-                }
-                return null;
-              })}
-            </>
-          )}
           {!!taskInstance?.pool && (
             <Tr>
               <Td>Pool</Td>
@@ -300,6 +277,42 @@ const Details = ({ gridInstance, taskInstance, group }: Props) => {
           )}
         </Tbody>
       </Table>
+      {taskInstance?.renderedFields && (
+        <Box mt={3}>
+          <Text as="strong" mb={3}>
+            Rendered Templates
+          </Text>
+          <Table>
+            <Tbody>
+              {Object.keys(taskInstance.renderedFields).map((key) => {
+                const renderedFields = taskInstance.renderedFields as Record<
+                  string,
+                  unknown
+                >;
+                let field = renderedFields[key];
+                if (field) {
+                  if (typeof field !== "string") {
+                    try {
+                      field = JSON.stringify(field);
+                    } catch (e) {
+                      // skip
+                    }
+                  }
+                  return (
+                    <Tr key={key}>
+                      <Td>{key}</Td>
+                      <Td>
+                        <Code fontSize="md">{field as string}</Code>
+                      </Td>
+                    </Tr>
+                  );
+                }
+                return null;
+              })}
+            </Tbody>
+          </Table>
+        </Box>
+      )}
     </Box>
   );
 };

--- a/airflow/www/static/js/dag/details/taskInstance/Nav.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Nav.tsx
@@ -29,7 +29,6 @@ const dagId = getMetaValue("dag_id");
 const isK8sExecutor = getMetaValue("k8s_or_k8scelery_executor") === "True";
 const taskInstancesUrl = getMetaValue("task_instances_list_url");
 const renderedK8sUrl = getMetaValue("rendered_k8s_url");
-const renderedTemplatesUrl = getMetaValue("rendered_templates_url");
 const taskUrl = getMetaValue("task_url");
 const gridUrl = getMetaValue("grid_url");
 
@@ -50,7 +49,6 @@ const Nav = forwardRef<HTMLDivElement, Props>(
       map_index: mapIndex ?? -1,
     });
     const detailsLink = `${taskUrl}&${params}`;
-    const renderedLink = `${renderedTemplatesUrl}&${params}`;
     const k8sLink = `${renderedK8sUrl}&${params}`;
     const listParams = new URLSearchParamsWrapper({
       _flt_3_dag_id: dagId,
@@ -79,7 +77,6 @@ const Nav = forwardRef<HTMLDivElement, Props>(
         {(!isMapped || mapIndex !== undefined) && (
           <>
             <LinkButton href={detailsLink}>More Details</LinkButton>
-            <LinkButton href={renderedLink}>Rendered Template</LinkButton>
             {isK8sExecutor && (
               <LinkButton href={k8sLink}>K8s Pod Spec</LinkButton>
             )}
@@ -88,11 +85,8 @@ const Nav = forwardRef<HTMLDivElement, Props>(
             )}
           </>
         )}
-        <LinkButton
-          href={allInstancesLink}
-          title="View all instances across all DAG runs"
-        >
-          List Instances, all runs
+        <LinkButton href={allInstancesLink} title="View all">
+          List All Instances
         </LinkButton>
       </Flex>
     );

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -65,7 +65,6 @@
   <meta name="graph_url" content="{{ url_for('Airflow.graph', dag_id=dag.dag_id, root=root) }}">
   <meta name="task_url" content="{{ url_for('Airflow.task', dag_id=dag.dag_id) }}">
   <meta name="log_url" content="{{ url_for('Airflow.log', dag_id=dag.dag_id) }}">
-  <meta name="rendered_templates_url" content="{{ url_for('Airflow.rendered_templates', dag_id=dag.dag_id) }}">
   <meta name="rendered_k8s_url" content="{{ url_for('Airflow.rendered_k8s', dag_id=dag.dag_id) }}">
   <meta name="task_instances_list_url" content="{{ url_for('TaskInstanceModelView.list') }}">
   <meta name="tag_index_url" content="{{ url_for('Airflow.index', tags='_TAG_NAME_') }}">


### PR DESCRIPTION
Before, rendered templates were mixed in with other details and not always parsed well:
<img width="868" alt="Screenshot 2024-04-18 at 3 43 44 PM" src="https://github.com/apache/airflow/assets/4600967/3a6bd120-87b8-425d-bf38-8cdafea0d01e">

After, rendered templates are given their own section, are parsed better and there is no table striping to hide the code block background:
<img width="857" alt="Screenshot 2024-04-18 at 3 43 25 PM" src="https://github.com/apache/airflow/assets/4600967/5f8fde0f-1a9b-43c5-893e-1aab630025a0">

Also removed the link to the legacy rendered templates page.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
