### PR TITLE
Improve DataprocCreateClusterOperator in Triggers for Enhanced Error Handling and Resource Cleanup

### DIFF
--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -816,6 +816,7 @@ class DataprocCreateClusterOperator(GoogleCloudBaseOperator):
                             gcp_conn_id=self.gcp_conn_id,
                             impersonation_chain=self.impersonation_chain,
                             polling_interval_seconds=self.polling_interval_seconds,
+                            delete_on_error=self.delete_on_error,
                         ),
                         method_name="execute_complete",
                     )

--- a/airflow/providers/google/cloud/triggers/dataproc.py
+++ b/airflow/providers/google/cloud/triggers/dataproc.py
@@ -158,7 +158,6 @@ class DataprocClusterTrigger(DataprocBaseTrigger):
         )
 
     async def run(self) -> AsyncIterator[TriggerEvent]:
-        """Run the trigger."""
         try:
             while True:
                 cluster = await self.fetch_cluster()
@@ -168,7 +167,7 @@ class DataprocClusterTrigger(DataprocBaseTrigger):
                     yield TriggerEvent(
                         {
                             "cluster_name": self.cluster_name,
-                            "cluster_state": state.ERROR,
+                            "cluster_state": ClusterStatus.State.DELETING,
                             "cluster": cluster,
                         }
                     )

--- a/airflow/providers/google/cloud/triggers/dataproc.py
+++ b/airflow/providers/google/cloud/triggers/dataproc.py
@@ -61,7 +61,10 @@ class DataprocBaseTrigger(BaseTrigger):
         )
 
     def get_sync_hook(self):
-        # The sync hook is used to delete the cluster in case of cancellation of task.
+        # The synchronous hook is utilized to delete the cluster when a task is cancelled.
+        # This is because the asynchronous hook deletion is not awaited when the trigger task
+        # is cancelled. The call for deleting the cluster through the sync hook is not a blocking
+        # call, which means it does not wait until the cluster is deleted.
         return DataprocHook(
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.impersonation_chain,
@@ -165,7 +168,7 @@ class DataprocClusterTrigger(DataprocBaseTrigger):
                     yield TriggerEvent(
                         {
                             "cluster_name": self.cluster_name,
-                            "cluster_state": state.DELETING,
+                            "cluster_state": state.ERROR,
                             "cluster": cluster,
                         }
                     )
@@ -185,7 +188,10 @@ class DataprocClusterTrigger(DataprocBaseTrigger):
             try:
                 if self.delete_on_error:
                     self.log.info("Deleting cluster %s.", self.cluster_name)
-                    # The sync hook is used to delete the cluster in case of cancellation of task.
+                    # The synchronous hook is utilized to delete the cluster when a task is cancelled.
+                    # This is because the asynchronous hook deletion is not awaited when the trigger task
+                    # is cancelled. The call for deleting the cluster through the sync hook is not a blocking
+                    # call, which means it does not wait until the cluster is deleted.
                     self.get_sync_hook().delete_cluster(
                         region=self.region, cluster_name=self.cluster_name, project_id=self.project_id
                     )

--- a/airflow/providers/google/cloud/triggers/dataproc.py
+++ b/airflow/providers/google/cloud/triggers/dataproc.py
@@ -181,6 +181,7 @@ class DataprocClusterTrigger(DataprocBaseTrigger):
                         }
                     )
                     return
+                self.log.info("Current state is %s", state)
                 self.log.info("Sleeping for %s seconds.", self.polling_interval_seconds)
                 await asyncio.sleep(self.polling_interval_seconds)
         except asyncio.CancelledError:
@@ -205,7 +206,7 @@ class DataprocClusterTrigger(DataprocBaseTrigger):
             project_id=self.project_id, region=self.region, cluster_name=self.cluster_name
         )
 
-    async def delete_when_error_occurred(self, cluster: Cluster):
+    async def delete_when_error_occurred(self, cluster: Cluster) -> None:
         """
         Delete the cluster on error.
 
@@ -218,9 +219,7 @@ class DataprocClusterTrigger(DataprocBaseTrigger):
             )
             self.log.info("Cluster %s has been deleted.", self.cluster_name)
         else:
-            self.log.info(
-                "Cluster %s is not be deleted as delete_on_error is set to False.", self.cluster_name
-            )
+            self.log.info("Cluster %s is not deleted as delete_on_error is set to False.", self.cluster_name)
 
 
 class DataprocBatchTrigger(DataprocBaseTrigger):

--- a/airflow/providers/google/cloud/triggers/dataproc.py
+++ b/airflow/providers/google/cloud/triggers/dataproc.py
@@ -151,7 +151,7 @@ class DataprocClusterTrigger(DataprocBaseTrigger):
         try:
             while True:
                 cluster = await self.fetch_cluster_status()
-                if self.is_terminal_state(cluster.status.state):
+                if self.check_cluster_state(cluster.status.state):
                     if cluster.status.state == ClusterStatus.State.ERROR:
                         await self.gather_diagnostics_and_maybe_delete(cluster)
                     else:
@@ -174,9 +174,9 @@ class DataprocClusterTrigger(DataprocBaseTrigger):
             project_id=self.project_id, region=self.region, cluster_name=self.cluster_name
         )
 
-    def is_terminal_state(self, state: ClusterStatus.State) -> bool:
+    def check_cluster_state(self, state: ClusterStatus.State) -> bool:
         """
-        Check if the state is terminal.
+        Check if the state is error or running.
 
         :param state: The state of the cluster.
         """

--- a/tests/providers/google/cloud/triggers/test_dataproc.py
+++ b/tests/providers/google/cloud/triggers/test_dataproc.py
@@ -208,7 +208,7 @@ class TestDataprocClusterTrigger:
             trigger_event = event
 
         assert trigger_event.payload["cluster_name"] == TEST_CLUSTER_NAME
-        assert trigger_event.payload["cluster_state"] == ClusterStatus.State.DELETING
+        assert trigger_event.payload["cluster_state"] == ClusterStatus.State.ERROR
 
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.google.cloud.hooks.dataproc.DataprocAsyncHook.get_cluster")

--- a/tests/providers/google/cloud/triggers/test_dataproc.py
+++ b/tests/providers/google/cloud/triggers/test_dataproc.py
@@ -147,6 +147,7 @@ class TestDataprocClusterTrigger:
             "gcp_conn_id": TEST_GCP_CONN_ID,
             "impersonation_chain": None,
             "polling_interval_seconds": TEST_POLL_INTERVAL,
+            "delete_on_error": True,
         }
 
     @pytest.mark.asyncio

--- a/tests/providers/google/cloud/triggers/test_dataproc.py
+++ b/tests/providers/google/cloud/triggers/test_dataproc.py
@@ -263,12 +263,16 @@ class TestDataprocClusterTrigger:
         mock_delete_cluster.return_value = delete_future
 
         cluster = await async_get_cluster(status=ClusterStatus(state=ClusterStatus.State.ERROR))
-        event = await cluster_trigger.gather_diagnostics_and_delete_on_error(cluster)
+        self.delete_on_error = True
 
-        mock_delete_cluster.assert_called_once()
-        assert (
-            "deleted" in event.payload["action"]
-        ), "The cluster should be deleted due to error state and delete_on_error=True"
+        await cluster_trigger.gather_diagnostics_and_delete_on_error(cluster)
+
+        mock_diagnose_cluster.assert_called_once_with(
+            region="region", cluster_name="cluster_name", project_id="project-id"
+        )
+        mock_delete_cluster.assert_called_once_with(
+            region="region", cluster_name="cluster_name", project_id="project-id"
+        )
 
 
 @pytest.mark.db_test

--- a/tests/providers/google/cloud/triggers/test_dataproc.py
+++ b/tests/providers/google/cloud/triggers/test_dataproc.py
@@ -238,16 +238,9 @@ class TestDataprocClusterTrigger:
         mock_get_cluster.return_value = async_get_cluster(
             status=ClusterStatus(state=ClusterStatus.State.RUNNING)
         )
-        cluster = await cluster_trigger.fetch_cluster_status()
+        cluster = await cluster_trigger.fetch_cluster()
 
         assert cluster.status.state == ClusterStatus.State.RUNNING, "The cluster state should be RUNNING"
-
-    def test_check_luster_state(self, cluster_trigger):
-        """Test if specific states are correctly identified."""
-        assert cluster_trigger.check_cluster_state(
-            ClusterStatus.State.RUNNING
-        ), "RUNNING should be correct state"
-        assert cluster_trigger.check_cluster_state(ClusterStatus.State.ERROR), "ERROR should be correct state"
 
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.google.cloud.hooks.dataproc.DataprocAsyncHook.diagnose_cluster")
@@ -270,7 +263,7 @@ class TestDataprocClusterTrigger:
         mock_delete_cluster.return_value = delete_future
 
         cluster = await async_get_cluster(status=ClusterStatus(state=ClusterStatus.State.ERROR))
-        event = await cluster_trigger.gather_diagnostics_and_maybe_delete(cluster)
+        event = await cluster_trigger.gather_diagnostics_and_delete_on_error(cluster)
 
         mock_delete_cluster.assert_called_once()
         assert (


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
This PR introduces improvements to the `DataprocCreateClusterOperator`, specifically addressing deficiencies in handling clusters that are created in an ERROR state when operating in deferrable mode

Previously, when the `DataprocCreateClusterOperator` was operating in deferrable mode, it did not correctly handle scenarios where clusters were initially created in an ERROR state. The lack of appropriate error handling and resource cleanup led to subsequent retries encountering these errored clusters, attempting deletion, and resulting in pipeline failures. 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
