### PR TITLE
Fix/helm chart: workers.command for KubernetesExecutor

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -111,6 +111,9 @@ spec:
       lifecycle: {{- tpl (toYaml $containerLifecycleHooks) . | nindent 8 }}
       {{- end }}
       name: base
+      {{- if .Values.workers.command }}
+      command: {{ tpl (toYaml .Values.workers.command) . | nindent 8 }}
+      {{- end }}
       resources: {{- toYaml .Values.workers.resources | nindent 8 }}
       volumeMounts:
         - mountPath: {{ template "airflow_logs" . }}

--- a/helm_tests/airflow_aux/test_pod_template_file.py
+++ b/helm_tests/airflow_aux/test_pod_template_file.py
@@ -911,3 +911,30 @@ class TestPodTemplateFile:
         )
 
         assert ["test", "command", "to", "run"] == jmespath.search("spec.containers[0].command", docs[0])
+
+    def test_should_not_add_command_by_default(self):
+        docs = render_chart(
+            values={},
+            show_only=["templates/pod-template-file.yaml"],
+            chart_dir=self.temp_chart_dir,
+        )
+
+        assert None is jmespath.search("spec.containers[0].command", docs[0])
+
+    def test_should_not_add_command_if_value_none(self):
+        docs = render_chart(
+            values={"workers": {"command": None}},
+            show_only=["templates/pod-template-file.yaml"],
+            chart_dir=self.temp_chart_dir,
+        )
+
+        assert None is jmespath.search("spec.containers[0].command", docs[0])
+
+    def test_should_not_add_command_if_value_empty(self):
+        docs = render_chart(
+            values={"workers": {"command": []}},
+            show_only=["templates/pod-template-file.yaml"],
+            chart_dir=self.temp_chart_dir,
+        )
+
+        assert None is jmespath.search("spec.containers[0].command", docs[0])

--- a/helm_tests/airflow_aux/test_pod_template_file.py
+++ b/helm_tests/airflow_aux/test_pod_template_file.py
@@ -919,10 +919,18 @@ class TestPodTemplateFile:
 
         assert expected == jmespath.search("spec.containers[0].command", docs[0])
 
-    @pytest.mark.parametrize("values", [{"workers": {"command": None}}, {"workers": {"command": []}}, None])
-    def test_should_not_add_command(self, values):
+    @pytest.mark.parametrize("cmd", [None, []])
+    def test_should_not_add_command(self, cmd):
         docs = render_chart(
-            values=values,
+            values={"workers": {"command": cmd}},
+            show_only=["templates/pod-template-file.yaml"],
+            chart_dir=self.temp_chart_dir,
+        )
+
+        assert None is jmespath.search("spec.containers[0].command", docs[0])
+
+    def test_should_not_add_command_by_default(self):
+        docs = render_chart(
             show_only=["templates/pod-template-file.yaml"],
             chart_dir=self.temp_chart_dir,
         )

--- a/helm_tests/airflow_aux/test_pod_template_file.py
+++ b/helm_tests/airflow_aux/test_pod_template_file.py
@@ -900,3 +900,14 @@ class TestPodTemplateFile:
         if expected_init_containers == 1:
             assert initContainers[0]["name"] == "kerberos-init"
             assert initContainers[0]["args"] == ["kerberos", "-o"]
+
+    def test_should_add_command(self):
+        docs = render_chart(
+            values={
+                "workers": {"command": ["test", "command", "to", "run"]},
+            },
+            show_only=["templates/pod-template-file.yaml"],
+            chart_dir=self.temp_chart_dir,
+        )
+
+        assert ["test", "command", "to", "run"] == jmespath.search("spec.containers[0].command", docs[0])


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

**Helm-chart version used:** 1.13.1 (latest)
**Airflow version used:** 2.8.4

The `workers.command` value override is ignored if `KubernetesExecutor` is used.

I wanted to add a custom `command` parameter to the base container in the pods that are created to execute the tasks, but I failed to do so with the following values.yaml override:

```yaml
airflow:
  executor: KubernetesExecutor

  workers:
    command: ['my-test-command']
```

I have found that this value is only used in the `worker-deployment.yaml`, but not in the `pod-template-file.kubernetes-helm-yaml` which seems to be used for `KubernetesExecutor`.

Based on the `workers.command` [documentation](https://airflow.apache.org/docs/helm-chart/stable/parameters-ref.html#workers) this does seem to be a bug.

### Potential workaround

To make this work and prove that this is actually needed in my case, I have used the following override in the dag definition:

```python
from datetime import datetime
from airflow import DAG
from kubernetes.client import models as k8s

default_args = {
    'executor_config': {
        'pod_override': k8s.V1Pod(
            spec=k8s.V1PodSpec(
                containers=[
                    k8s.V1Container(
                        name='base',
                        command=['my', 'command', 'to', 'run'],
                    )
                ],
            )
        ),
    }
}

with DAG(dag_id='test', default_args=default_args, start_date=datetime(2024, 1, 1), schedule=None) as dag:
    ....
```

This gets the job done, but it would be a lot nicer to be able to do this from the helm-chart, especially as this should be the default behaviour in my case for each dag.

---

I have checked open issues, but did not find one that mentions this problem. Also, this is my first PR here, so even against my best intentions, I might have missed something in the contributing guidelines, so all feedback and help is welcome :)

Branch is freshly rebased! :)

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
