### PR TITLE
Fix templated env_vars field in `KubernetesPodOperator` to allow for compatibility with `XComArgs`

### DIFF
--- a/airflow/providers/cncf/kubernetes/backcompat/backwards_compat_converters.py
+++ b/airflow/providers/cncf/kubernetes/backcompat/backwards_compat_converters.py
@@ -76,10 +76,20 @@ def convert_env_vars(env_vars: list[k8s.V1EnvVar] | dict[str, str]) -> list[k8s.
 
     If the collection is a str-str dict, convert it into a list of ``V1EnvVar``s.
     """
-    if isinstance(env_vars, list):
-        return env_vars
     if isinstance(env_vars, dict):
         return [k8s.V1EnvVar(name=k, value=v) for k, v in env_vars.items()]
+    return env_vars
+
+
+def convert_env_vars_or_raise_error(env_vars: list[k8s.V1EnvVar] | dict[str, str]) -> list[k8s.V1EnvVar]:
+    """
+    Separate function to convert env var collection for kubernetes and then raise an error if it is still the wrong type.
+
+    This is used after the template strings have been rendered.
+    """
+    env_vars = convert_env_vars(env_vars)
+    if isinstance(env_vars, list):
+        return env_vars
     raise AirflowException(f"Expected dict or list, got {type(env_vars)}")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ dynamic = ["version", "optional-dependencies", "dependencies"]
 #
 # END DEPRECATED EXTRAS HERE
 #
-# !!!!!! Those provuders are defined in the `airflow/providers/<provider>/provider.yaml` files  !!!!!!!
+# !!!!!! Those providers are defined in the `airflow/providers/<provider>/provider.yaml` files  !!!!!!!
 #
 # Those extras are available as regular Airflow extras, they install provider packages in standard builds
 # or dependencies that are necessary to enable the feature in editable build.


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Allows for usage of `XComArgs` for `env_vars` field in `KubernetesPodOperator` by moving the raise error conditional statement to after the jinja template strings are rendered.
Also by extension, allows for usage of passing a jinja template string to the `env_vars` field when `render_as_native_obj=True` converts it to a dictionary

related discussion: https://github.com/apache/airflow/discussions/38522
The example dag on the related discussion now works

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
