### PR TITLE
Fix supported k8s version in docs

### DIFF
--- a/docs/apache-airflow/installation/prerequisites.rst
+++ b/docs/apache-airflow/installation/prerequisites.rst
@@ -28,7 +28,7 @@ Airflow™ is tested with:
   * MySQL: 8.0, `Innovation <https://dev.mysql.com/blog-archive/introducing-mysql-innovation-and-long-term-support-lts-versions>`_
   * SQLite: 3.15.0+
 
-* Kubernetes: 1.25, 1.26, 1.27, 1.28, 1.29
+* Kubernetes: 1.26, 1.27, 1.28, 1.29
 
 The minimum memory required we recommend Airflow to run with is 4GB, but the actual requirements depend
 wildly on the deployment options you have

--- a/docs/helm-chart/index.rst
+++ b/docs/helm-chart/index.rst
@@ -59,7 +59,7 @@ deployment on a `Kubernetes <http://kubernetes.io>`__ cluster using the
 Requirements
 ------------
 
--  Kubernetes 1.25+ cluster
+-  Kubernetes 1.26+ cluster
 -  Helm 3.0+
 -  PV provisioner support in the underlying infrastructure (optionally)
 


### PR DESCRIPTION
These were missed when support for 1.25 was dropped.