### PR TITLE
Add notification settings paramaters

### DIFF
--- a/airflow/providers/databricks/operators/databricks.py
+++ b/airflow/providers/databricks/operators/databricks.py
@@ -207,6 +207,7 @@ class DatabricksCreateJobsOperator(BaseOperator):
         .. seealso::
             For more information about templating see :ref:`concepts:jinja-templating`.
     :param name: An optional name for the job.
+    :param description: An optional description for the job.
     :param tags: A map of tags associated with the job.
     :param tasks: A list of task specifications to be executed by this job.
         Array of objects (JobTaskSettings).
@@ -214,7 +215,7 @@ class DatabricksCreateJobsOperator(BaseOperator):
         tasks of this job. Array of objects (JobCluster).
     :param email_notifications: Object (JobEmailNotifications).
     :param webhook_notifications: Object (WebhookNotifications).
-    :param notification_settings: Optional notification settings
+    :param notification_settings: Optional notification settings.
     :param timeout_seconds: An optional timeout applied to each run of this job.
     :param schedule: Object (CronSchedule).
     :param max_concurrent_runs: An optional maximum allowed number of concurrent runs of the job.
@@ -250,6 +251,7 @@ class DatabricksCreateJobsOperator(BaseOperator):
         *,
         json: Any | None = None,
         name: str | None = None,
+        description: str | None = None,
         tags: dict[str, str] | None = None,
         tasks: list[dict] | None = None,
         job_clusters: list[dict] | None = None,
@@ -278,6 +280,8 @@ class DatabricksCreateJobsOperator(BaseOperator):
         self.databricks_retry_args = databricks_retry_args
         if name is not None:
             self.json["name"] = name
+        if description is not None:
+            self.json["description"] = description
         if tags is not None:
             self.json["tags"] = tags
         if tasks is not None:

--- a/airflow/providers/databricks/operators/databricks.py
+++ b/airflow/providers/databricks/operators/databricks.py
@@ -254,6 +254,7 @@ class DatabricksCreateJobsOperator(BaseOperator):
         job_clusters: list[dict] | None = None,
         email_notifications: dict | None = None,
         webhook_notifications: dict | None = None,
+        notification_settings: dict | None = None,
         timeout_seconds: int | None = None,
         schedule: dict | None = None,
         max_concurrent_runs: int | None = None,
@@ -286,6 +287,8 @@ class DatabricksCreateJobsOperator(BaseOperator):
             self.json["email_notifications"] = email_notifications
         if webhook_notifications is not None:
             self.json["webhook_notifications"] = webhook_notifications
+        if notification_settings:
+            self.json["notification_settings"] = notification_settings
         if timeout_seconds is not None:
             self.json["timeout_seconds"] = timeout_seconds
         if schedule is not None:

--- a/airflow/providers/databricks/operators/databricks.py
+++ b/airflow/providers/databricks/operators/databricks.py
@@ -214,6 +214,7 @@ class DatabricksCreateJobsOperator(BaseOperator):
         tasks of this job. Array of objects (JobCluster).
     :param email_notifications: Object (JobEmailNotifications).
     :param webhook_notifications: Object (WebhookNotifications).
+    :param notification_settings: Optional notification settings
     :param timeout_seconds: An optional timeout applied to each run of this job.
     :param schedule: Object (CronSchedule).
     :param max_concurrent_runs: An optional maximum allowed number of concurrent runs of the job.

--- a/airflow/providers/databricks/operators/databricks.py
+++ b/airflow/providers/databricks/operators/databricks.py
@@ -287,7 +287,7 @@ class DatabricksCreateJobsOperator(BaseOperator):
             self.json["email_notifications"] = email_notifications
         if webhook_notifications is not None:
             self.json["webhook_notifications"] = webhook_notifications
-        if notification_settings:
+        if notification_settings is not None:
             self.json["notification_settings"] = notification_settings
         if timeout_seconds is not None:
             self.json["timeout_seconds"] = timeout_seconds

--- a/docs/apache-airflow-providers-databricks/operators/jobs_create.rst
+++ b/docs/apache-airflow-providers-databricks/operators/jobs_create.rst
@@ -44,6 +44,7 @@ override the top level ``json`` keys.
 
 Currently the named parameters that ``DatabricksCreateJobsOperator`` supports are:
   - ``name``
+  - ``description``
   - ``tags``
   - ``tasks``
   - ``job_clusters``

--- a/docs/apache-airflow-providers-databricks/operators/jobs_create.rst
+++ b/docs/apache-airflow-providers-databricks/operators/jobs_create.rst
@@ -49,6 +49,7 @@ Currently the named parameters that ``DatabricksCreateJobsOperator`` supports ar
   - ``job_clusters``
   - ``email_notifications``
   - ``webhook_notifications``
+  - ``notification_settings``
   - ``timeout_seconds``
   - ``schedule``
   - ``max_concurrent_runs``

--- a/tests/providers/databricks/operators/test_databricks.py
+++ b/tests/providers/databricks/operators/test_databricks.py
@@ -202,6 +202,10 @@ WEBHOOK_NOTIFICATIONS = {
         }
     ],
 }
+NOTIFICATION_SETTINGS = {
+    "no_alert_for_canceled_runs": True,
+    "no_alert_for_skipped_runs": True
+}
 TIMEOUT_SECONDS = 86400
 SCHEDULE = {
     "quartz_cron_expression": "20 30 * * * ?",
@@ -414,6 +418,7 @@ class TestDatabricksCreateJobsOperator:
             "job_clusters": JOB_CLUSTERS,
             "email_notifications": EMAIL_NOTIFICATIONS,
             "webhook_notifications": WEBHOOK_NOTIFICATIONS,
+            "notification_settings": NOTIFICATION_SETTINGS,
             "timeout_seconds": TIMEOUT_SECONDS,
             "schedule": SCHEDULE,
             "max_concurrent_runs": MAX_CONCURRENT_RUNS,
@@ -436,6 +441,7 @@ class TestDatabricksCreateJobsOperator:
                 "job_clusters": JOB_CLUSTERS,
                 "email_notifications": EMAIL_NOTIFICATIONS,
                 "webhook_notifications": WEBHOOK_NOTIFICATIONS,
+                "notification_settings": NOTIFICATION_SETTINGS,
                 "timeout_seconds": TIMEOUT_SECONDS,
                 "schedule": SCHEDULE,
                 "max_concurrent_runs": MAX_CONCURRENT_RUNS,
@@ -466,6 +472,7 @@ class TestDatabricksCreateJobsOperator:
             "job_clusters": JOB_CLUSTERS,
             "email_notifications": EMAIL_NOTIFICATIONS,
             "webhook_notifications": WEBHOOK_NOTIFICATIONS,
+            "notification_settings": NOTIFICATION_SETTINGS,
             "timeout_seconds": TIMEOUT_SECONDS,
             "schedule": SCHEDULE,
             "max_concurrent_runs": MAX_CONCURRENT_RUNS,
@@ -486,6 +493,7 @@ class TestDatabricksCreateJobsOperator:
                 "job_clusters": JOB_CLUSTERS,
                 "email_notifications": EMAIL_NOTIFICATIONS,
                 "webhook_notifications": WEBHOOK_NOTIFICATIONS,
+                "notification_settings": NOTIFICATION_SETTINGS,
                 "timeout_seconds": TIMEOUT_SECONDS,
                 "schedule": SCHEDULE,
                 "max_concurrent_runs": MAX_CONCURRENT_RUNS,

--- a/tests/providers/databricks/operators/test_databricks.py
+++ b/tests/providers/databricks/operators/test_databricks.py
@@ -203,10 +203,7 @@ WEBHOOK_NOTIFICATIONS = {
         }
     ],
 }
-NOTIFICATION_SETTINGS = {
-    "no_alert_for_canceled_runs": True,
-    "no_alert_for_skipped_runs": True
-}
+NOTIFICATION_SETTINGS = {"no_alert_for_canceled_runs": True, "no_alert_for_skipped_runs": True}
 TIMEOUT_SECONDS = 86400
 SCHEDULE = {
     "quartz_cron_expression": "20 30 * * * ?",

--- a/tests/providers/databricks/operators/test_databricks.py
+++ b/tests/providers/databricks/operators/test_databricks.py
@@ -63,6 +63,7 @@ RUN_ID = 1
 RUN_PAGE_URL = "run-page-url"
 JOB_ID = "42"
 JOB_NAME = "job-name"
+JOB_DESCRIPTION = "job-description"
 NOTEBOOK_PARAMS = {"dry-run": "true", "oldest-time-to-consider": "1457570074236"}
 JAR_PARAMS = ["param1", "param2"]
 RENDERED_TEMPLATED_JAR_PARAMS = [f"/test-{DATE}"]
@@ -413,6 +414,7 @@ class TestDatabricksCreateJobsOperator:
         """
         json = {
             "name": JOB_NAME,
+            "description": JOB_DESCRIPTION,
             "tags": TAGS,
             "tasks": TASKS,
             "job_clusters": JOB_CLUSTERS,
@@ -436,6 +438,7 @@ class TestDatabricksCreateJobsOperator:
         expected = utils.normalise_json_content(
             {
                 "name": JOB_NAME,
+                "description": JOB_DESCRIPTION,
                 "tags": TAGS,
                 "tasks": TASKS,
                 "job_clusters": JOB_CLUSTERS,
@@ -467,6 +470,7 @@ class TestDatabricksCreateJobsOperator:
         """
         json = {
             "name": JOB_NAME,
+            "description": JOB_DESCRIPTION,
             "tags": TAGS,
             "tasks": TASKS,
             "job_clusters": JOB_CLUSTERS,
@@ -488,6 +492,7 @@ class TestDatabricksCreateJobsOperator:
         expected = utils.normalise_json_content(
             {
                 "name": JOB_NAME,
+                "description": JOB_DESCRIPTION,
                 "tags": TAGS,
                 "tasks": TASKS,
                 "job_clusters": JOB_CLUSTERS,


### PR DESCRIPTION
### Issue: 
Databricks CreateJobOperator does not have param for `notification_settings` and `description` field. Notification settings are required to skip alerts for cancelled runs.
link: [notification_settings](https://docs.databricks.com/api/workspace/jobs/create#notification_settings)