### PR TITLE
Provide mechanism to serialize airflow BaseTrigger object

### DIFF
--- a/airflow/serialization/enums.py
+++ b/airflow/serialization/enums.py
@@ -44,6 +44,7 @@ class DagAttributeTypes(str, Enum):
     TIMEDELTA = "timedelta"
     TIMEZONE = "timezone"
     RELATIVEDELTA = "relativedelta"
+    BASE_TRIGGER = "base_trigger"
     DICT = "dict"
     SET = "set"
     TUPLE = "tuple"


### PR DESCRIPTION
It is needed for AIP-44 when we pass the trigger object attached to the TaskDeferred exception object.