### PR TITLE
Provide mechanism to serialize airflow exceptions

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -75,6 +75,9 @@ class AirflowRescheduleException(AirflowException):
         super().__init__()
         self.reschedule_date = reschedule_date
 
+    def serialize(self):
+        return "AirflowRescheduleException", (), {"reschedule_date": self.reschedule_date}
+
 
 class InvalidStatsNameException(AirflowException):
     """Raise when name of the stats is invalid."""
@@ -388,6 +391,18 @@ class TaskDeferred(BaseException):
         # Check timeout type at runtime
         if self.timeout is not None and not hasattr(self.timeout, "total_seconds"):
             raise ValueError("Timeout value must be a timedelta")
+
+    def serialize(self):
+        return (
+            self.__class__.__name__,
+            (),
+            {
+                "trigger": self.trigger,
+                "method_name": self.method_name,
+                "kwargs": self.kwargs,
+                "timeout": self.timeout,
+            },
+        )
 
     def __repr__(self) -> str:
         return f"<TaskDeferred trigger={self.trigger} method={self.method_name}>"

--- a/airflow/serialization/enums.py
+++ b/airflow/serialization/enums.py
@@ -45,6 +45,7 @@ class DagAttributeTypes(str, Enum):
     TIMEZONE = "timezone"
     RELATIVEDELTA = "relativedelta"
     BASE_TRIGGER = "base_trigger"
+    AIRFLOW_EXC_SER = "airflow_exc_ser"
     DICT = "dict"
     SET = "set"
     TUPLE = "tuple"

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -715,7 +715,6 @@ class BaseSerialization:
         elif type_ == DAT.RELATIVEDELTA:
             return decode_relativedelta(var)
         elif type_ == DAT.AIRFLOW_EXC_SER:
-            print(f"var={var}")
             deser = cls.deserialize(var, use_pydantic_models=use_pydantic_models)
             exc_cls_name = deser["exc_cls_name"]
             args = deser["args"]

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -38,7 +38,7 @@ from pendulum.tz.timezone import FixedTimezone, Timezone
 from airflow.compat.functools import cache
 from airflow.configuration import conf
 from airflow.datasets import Dataset, DatasetAll, DatasetAny
-from airflow.exceptions import AirflowException, RemovedInAirflow3Warning, SerializationError
+from airflow.exceptions import AirflowException, RemovedInAirflow3Warning, SerializationError, TaskDeferred
 from airflow.jobs.job import Job
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.connection import Connection
@@ -561,6 +561,16 @@ class BaseSerialization:
             return cls._encode(encode_timezone(var), type_=DAT.TIMEZONE)
         elif isinstance(var, relativedelta.relativedelta):
             return cls._encode(encode_relativedelta(var), type_=DAT.RELATIVEDELTA)
+        elif isinstance(var, (AirflowException, TaskDeferred)) and hasattr(var, "serialize"):
+            exc_cls_name, args, kwargs = var.serialize()
+            return cls._encode(
+                cls.serialize(
+                    {"exc_cls_name": exc_cls_name, "args": args, "kwargs": kwargs},
+                    use_pydantic_models=use_pydantic_models,
+                    strict=strict,
+                ),
+                type_=DAT.AIRFLOW_EXC_SER,
+            )
         elif isinstance(var, BaseTrigger):
             return cls._encode(
                 cls.serialize(var.serialize(), use_pydantic_models=use_pydantic_models, strict=strict),
@@ -704,6 +714,15 @@ class BaseSerialization:
             return decode_timezone(var)
         elif type_ == DAT.RELATIVEDELTA:
             return decode_relativedelta(var)
+        elif type_ == DAT.AIRFLOW_EXC_SER:
+            print(f"var={var}")
+            deser = cls.deserialize(var, use_pydantic_models=use_pydantic_models)
+            exc_cls_name = deser["exc_cls_name"]
+            args = deser["args"]
+            kwargs = deser["kwargs"]
+            del deser
+            exc_cls = import_string(f"airflow.exceptions.{exc_cls_name}")
+            return exc_cls(*args, **kwargs)
         elif type_ == DAT.BASE_TRIGGER:
             tr_cls_name, kwargs = cls.deserialize(var, use_pydantic_models=use_pydantic_models)
             tr_cls = import_string(tr_cls_name)

--- a/tests/serialization/test_serialized_objects.py
+++ b/tests/serialization/test_serialized_objects.py
@@ -23,13 +23,14 @@ import warnings
 from datetime import datetime, timedelta
 from importlib import import_module
 
+import pendulum
 import pytest
 from dateutil import relativedelta
 from kubernetes.client import models as k8s
 from pendulum.tz.timezone import Timezone
 
 from airflow.datasets import Dataset
-from airflow.exceptions import SerializationError
+from airflow.exceptions import AirflowRescheduleException, SerializationError, TaskDeferred
 from airflow.jobs.job import Job
 from airflow.models.connection import Connection
 from airflow.models.dag import DAG, DagModel, DagTag
@@ -50,6 +51,7 @@ from airflow.serialization.pydantic.taskinstance import TaskInstancePydantic
 from airflow.serialization.pydantic.tasklog import LogTemplatePydantic
 from airflow.serialization.serialized_objects import BaseSerialization
 from airflow.settings import _ENABLE_AIP_44
+from airflow.triggers.base import BaseTrigger
 from airflow.utils import timezone
 from airflow.utils.context import DatasetEventAccessors
 from airflow.utils.operator_resources import Resources
@@ -426,3 +428,39 @@ def test_ser_of_dataset_event_accessor():
     deser = BaseSerialization.deserialize(ser)
     assert deser["hi"].extra == "blah1"
     assert d["yo"].extra == {"this": "that", "the": "other"}
+
+
+class MyTrigger(BaseTrigger):
+    def __init__(self, hi):
+        self.hi = hi
+
+    def serialize(self):
+        return "tests.serialization.test_serialized_objects.MyTrigger", {"hi": self.hi}
+
+    async def run(self):
+        yield
+
+
+def test_roundtrip_exceptions():
+    """This is for AIP-44 when we need to send certain non-error exceptions
+    as part of an RPC call e.g. TaskDeferred or AirflowRescheduleException."""
+    some_date = pendulum.now()
+    resched_exc = AirflowRescheduleException(reschedule_date=some_date)
+    ser = BaseSerialization.serialize(resched_exc)
+    deser = BaseSerialization.deserialize(ser)
+    assert isinstance(deser, AirflowRescheduleException)
+    assert deser.reschedule_date == some_date
+    del ser
+    del deser
+    exc = TaskDeferred(
+        trigger=MyTrigger(hi="yo"),
+        method_name="meth_name",
+        kwargs={"have": "pie"},
+        timeout=timedelta(seconds=30),
+    )
+    ser = BaseSerialization.serialize(exc)
+    deser = BaseSerialization.deserialize(ser)
+    assert deser.trigger.hi == "yo"
+    assert deser.method_name == "meth_name"
+    assert deser.kwargs == {"have": "pie"}
+    assert deser.timeout == timedelta(seconds=30)


### PR DESCRIPTION
This is needed for AIP-44 because there are cases where we pass an exception object around to functions which do database calls.
