### PR TITLE
Update signature of TaskReschedule to not use task

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2907,7 +2907,8 @@ class TaskInstance(Base, LoggingMixin):
         # Log reschedule request
         session.add(
             TaskReschedule(
-                self.task,
+                self.task_id,
+                self.dag_id,
                 self.run_id,
                 self._try_number,
                 actual_start_date,

--- a/airflow/models/taskreschedule.py
+++ b/airflow/models/taskreschedule.py
@@ -37,7 +37,6 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Query, Session
     from sqlalchemy.sql import Select
 
-    from airflow.models.operator import Operator
     from airflow.models.taskinstance import TaskInstance
     from airflow.serialization.pydantic.taskinstance import TaskInstancePydantic
 
@@ -84,7 +83,8 @@ class TaskReschedule(TaskInstanceDependencies):
 
     def __init__(
         self,
-        task: Operator,
+        task_id: str,
+        dag_id: str,
         run_id: str,
         try_number: int,
         start_date: datetime.datetime,
@@ -92,8 +92,8 @@ class TaskReschedule(TaskInstanceDependencies):
         reschedule_date: datetime.datetime,
         map_index: int = -1,
     ) -> None:
-        self.dag_id = task.dag_id
-        self.task_id = task.task_id
+        self.dag_id = dag_id
+        self.task_id = task_id
         self.run_id = run_id
         self.map_index = map_index
         self.try_number = try_number

--- a/tests/api_experimental/common/test_delete_dag.py
+++ b/tests/api_experimental/common/test_delete_dag.py
@@ -99,7 +99,8 @@ class TestDeleteDAGSuccessfulDelete:
             session.add(TaskFail(ti=ti))
             session.add(
                 TR(
-                    task=ti.task,
+                    task_id=ti.task_id,
+                    dag_id=ti.dag_id,
                     run_id=ti.run_id,
                     start_date=test_date,
                     end_date=test_date,

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -2322,7 +2322,8 @@ def test_clearing_task_and_moving_from_non_mapped_to_mapped(dag_maker, session):
     ti = session.query(TaskInstance).filter_by(**filter_kwargs).one()
 
     tr = TaskReschedule(
-        task=ti,
+        task_id=ti.task_id,
+        dag_id=ti.dag_id,
         run_id=ti.run_id,
         try_number=ti.try_number,
         start_date=timezone.datetime(2017, 1, 1),

--- a/tests/ti_deps/deps/test_ready_to_reschedule_dep.py
+++ b/tests/ti_deps/deps/test_ready_to_reschedule_dep.py
@@ -86,7 +86,8 @@ class TestNotInReschedulePeriodDep:
             dt = ti.execution_date + timedelta(minutes=minutes_timedelta)
             trs.append(
                 TaskReschedule(
-                    task=ti.task,
+                    task_id=ti.task_id,
+                    dag_id=ti.dag_id,
                     run_id=ti.run_id,
                     try_number=ti.try_number,
                     map_index=ti.map_index,

--- a/tests/www/views/test_views_tasks.py
+++ b/tests/www/views/test_views_tasks.py
@@ -974,7 +974,8 @@ def test_action_muldelete_task_instance(session, admin_client, task_search_tuple
     # add task reschedules for those tasks to make sure that the delete cascades to the required tables
     trs = [
         TaskReschedule(
-            task=task,
+            task_id=task.task_id,
+            dag_id=task.dag_id,
             run_id=task.run_id,
             try_number=1,
             start_date=timezone.datetime(2021, 1, 1),


### PR DESCRIPTION
It is better / cleaner, especially from AIP-44 perspective, if we pass around the needed attrs instead of a task object.
