### PR TITLE
Update BaseSensor for AIP-44 compatibility

### DIFF
--- a/airflow/api_internal/endpoints/rpc_api_endpoint.py
+++ b/airflow/api_internal/endpoints/rpc_api_endpoint.py
@@ -27,6 +27,7 @@ from flask import Response
 
 from airflow.jobs.job import Job, most_recent_job
 from airflow.models.taskinstance import _get_template_context, _update_rtif
+from airflow.sensors.base import _orig_start_date
 from airflow.serialization.serialized_objects import BaseSerialization
 from airflow.utils.session import create_session
 
@@ -56,6 +57,7 @@ def _initialize_map() -> dict[str, Callable]:
         _get_template_context,
         _get_ti_db_access,
         _update_rtif,
+        _orig_start_date,
         DagFileProcessor.update_import_errors,
         DagFileProcessor.manage_slas,
         DagFileProcessorManager.deactivate_stale_dags,

--- a/airflow/sensors/base.py
+++ b/airflow/sensors/base.py
@@ -25,7 +25,7 @@ import traceback
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Callable, Iterable
 
-from sqlalchemy import asc, select
+from sqlalchemy import select
 
 from airflow import settings
 from airflow.api_internal.internal_api_call import InternalApiConfig, internal_api_call
@@ -90,7 +90,9 @@ class PokeReturnValue:
 
 @internal_api_call
 @provide_session
-def _orig_start_date(dag_id, task_id, run_id, map_index, try_number, session: Session = NEW_SESSION):
+def _orig_start_date(
+    dag_id: str, task_id: str, run_id: str, map_index: int, try_number: int, session: Session = NEW_SESSION
+):
     """
     Get the original start_date for a rescheduled task.
 
@@ -105,7 +107,7 @@ def _orig_start_date(dag_id, task_id, run_id, map_index, try_number, session: Se
             TaskReschedule.map_index == map_index,
             TaskReschedule.try_number == try_number,
         )
-        .order_by(asc(TaskReschedule.id))
+        .order_by(TaskReschedule.id.asc())
         .with_only_columns(TaskReschedule.start_date)
         .limit(1)
     )

--- a/airflow/sensors/base.py
+++ b/airflow/sensors/base.py
@@ -53,7 +53,8 @@ from airflow.utils.decorators import apply_defaults  # noqa: F401
 from airflow.utils.session import NEW_SESSION, provide_session
 
 if TYPE_CHECKING:
-    from airflow.settings import Session
+    from sqlalchemy.orm.session import Session
+
     from airflow.utils.context import Context
 
 # As documented in https://dev.mysql.com/doc/refman/5.7/en/datetime.html.

--- a/airflow/sensors/base.py
+++ b/airflow/sensors/base.py
@@ -25,7 +25,10 @@ import traceback
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Callable, Iterable
 
+from sqlalchemy import asc, select
+
 from airflow import settings
+from airflow.api_internal.internal_api_call import InternalApiConfig, internal_api_call
 from airflow.configuration import conf
 from airflow.exceptions import (
     AirflowException,
@@ -47,9 +50,10 @@ from airflow.utils import timezone
 # Google Provider before 3.0.0 imported apply_defaults from here.
 # See  https://github.com/apache/airflow/issues/16035
 from airflow.utils.decorators import apply_defaults  # noqa: F401
-from airflow.utils.session import create_session
+from airflow.utils.session import NEW_SESSION, provide_session
 
 if TYPE_CHECKING:
+    from airflow.settings import Session
     from airflow.utils.context import Context
 
 # As documented in https://dev.mysql.com/doc/refman/5.7/en/datetime.html.
@@ -58,6 +62,8 @@ _MYSQL_TIMESTAMP_MAX = datetime.datetime(2038, 1, 19, 3, 14, 7, tzinfo=timezone.
 
 @functools.lru_cache(maxsize=None)
 def _is_metadatabase_mysql() -> bool:
+    if InternalApiConfig.get_use_internal_api():
+        return False
     if settings.engine is None:
         raise AirflowException("Must initialize ORM first")
     return settings.engine.url.get_backend_name() == "mysql"
@@ -80,6 +86,29 @@ class PokeReturnValue:
 
     def __bool__(self) -> bool:
         return self.is_done
+
+
+@internal_api_call
+@provide_session
+def _orig_start_date(dag_id, task_id, run_id, map_index, try_number, session: Session = NEW_SESSION):
+    """
+    Get the original start_date for a rescheduled task.
+
+    :meta private:
+    """
+    return session.scalar(
+        select(TaskReschedule)
+        .where(
+            TaskReschedule.dag_id == dag_id,
+            TaskReschedule.task_id == task_id,
+            TaskReschedule.run_id == run_id,
+            TaskReschedule.map_index == map_index,
+            TaskReschedule.try_number == try_number,
+        )
+        .order_by(asc(TaskReschedule.id))
+        .with_only_columns(TaskReschedule.start_date)
+        .limit(1)
+    )
 
 
 class BaseSensorOperator(BaseOperator, SkipMixin):
@@ -211,17 +240,17 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
         if self.reschedule:
             # If reschedule, use the start date of the first try (first try can be either the very
             # first execution of the task, or the first execution after the task was cleared.)
-            max_tries: int = context["ti"].max_tries or 0
+            ti = context["ti"]
+            max_tries: int = ti.max_tries or 0
             retries: int = self.retries or 0
             first_try_number = max_tries - retries + 1
-            with create_session() as session:
-                start_date = session.scalar(
-                    TaskReschedule.stmt_for_task_instance(
-                        context["ti"], try_number=first_try_number, descending=False
-                    )
-                    .with_only_columns(TaskReschedule.start_date)
-                    .limit(1)
-                )
+            start_date = _orig_start_date(
+                dag_id=ti.dag_id,
+                task_id=ti.task_id,
+                run_id=ti.run_id,
+                map_index=ti.map_index,
+                try_number=first_try_number,
+            )
             if not start_date:
                 start_date = timezone.utcnow()
             started_at = start_date


### PR DESCRIPTION
Two things:
1. BaseSensor should not check if mysql when db isolation
2. BaseSensor should use the RPC server for fetching first start_date
