### PR TITLE
Executor loader shouldn't check db compat with db isolation

### DIFF
--- a/airflow/executors/executor_loader.py
+++ b/airflow/executors/executor_loader.py
@@ -24,6 +24,7 @@ import os
 from contextlib import suppress
 from typing import TYPE_CHECKING
 
+from airflow.api_internal.internal_api_call import InternalApiConfig
 from airflow.exceptions import AirflowConfigException, AirflowException
 from airflow.executors.executor_constants import (
     CELERY_EXECUTOR,
@@ -319,6 +320,9 @@ class ExecutorLoader:
 
         # This is set in tests when we want to be able to use SQLite.
         if os.environ.get("_AIRFLOW__SKIP_DATABASE_EXECUTOR_COMPATIBILITY_CHECK") == "1":
+            return
+
+        if InternalApiConfig.get_use_internal_api():
             return
 
         from airflow.settings import engine


### PR DESCRIPTION
Small piece for AIP-44