### PR TITLE
fix: sqa deprecations for airflow core

### DIFF
--- a/airflow/utils/db_cleanup.py
+++ b/airflow/utils/db_cleanup.py
@@ -196,8 +196,8 @@ def _do_delete(*, query, orm_model, skip_archive, session):
     session.execute(delete)
     session.commit()
     if skip_archive:
-        metadata.bind = session.get_bind()
-        target_table.drop()
+        bind = session.get_bind()
+        target_table.drop(bind=bind)
     session.commit()
     print("Finished Performing Delete")
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -846,9 +846,7 @@ class Airflow(AirflowBaseView):
 
             is_paused_count = dict(
                 session.execute(
-                    all_dags.with_only_columns([DagModel.is_paused, func.count()]).group_by(
-                        DagModel.is_paused
-                    )
+                    all_dags.with_only_columns(DagModel.is_paused, func.count()).group_by(DagModel.is_paused)
                 ).all()
             )
 
@@ -3294,7 +3292,7 @@ class Airflow(AirflowBaseView):
             latest_run = dag_model.get_last_dagrun(session=session)
 
             events = [
-                dict(info)
+                dict(info._mapping)
                 for info in session.execute(
                     select(
                         DatasetModel.id,
@@ -3456,7 +3454,7 @@ class Airflow(AirflowBaseView):
             count_query = count_query.where(*filters)
 
             query = session.execute(query)
-            datasets = [dict(dataset) for dataset in query]
+            datasets = [dict(dataset._mapping) for dataset in query]
             data = {"datasets": datasets, "total_entries": session.scalar(count_query)}
 
             return (


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

related: #28723

fix deprecations for SQLAlchemy 2.0 for Airflow core.

@Taragolis I linked your changes as well in the list. 

Further I have noticed 2 things. First of all I fixed an issue that was not listed in the orginal issue. I assume it might was missing as it a mysql specfic, e.g. [example](https://github.com/apache/airflow/blob/main/airflow/utils/db_cleanup.py#L166) Thus it would make sense to run the checks for mysql and any other supported db as well.

Second I could not fix `airflow/cli/commands/task_command.py:202` and I am not really sure if this is really something that needs to be fixed. I went through the SQA docs and it might be a warning we have in 1.4 that will be gone whenever we have 2.0 without any real error. But hard to tell. I will further investigate.


### Reported in core

- [x] airflow/models/taskinstance.py:1869 fixed by #39195
- [x] airflow/models/taskinstance.py:1871 fixed by #39195

- [x] airflow/www/views.py:845
- [x] airflow/www/views.py:3455
- [x] airflow/www/views.py:3455
- [x] airflow/www/views.py:3293
- [x] airflow/www/views.py:3293
- [x] airflow/jobs/scheduler_job_runner.py:1642 fixed by #39195
- [x] airflow/models/trigger.py:141 fixed by #39198

- [x] airflow/utils/db_cleanup.py:200
- [ ] airflow/cli/commands/task_command.py:202
- [x] airflow/models/taskinstance.py:524 fixed by #39195


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
