### PR TITLE
Fixed side effect of menu filtering causing disappearing menus

### DIFF
--- a/airflow/auth/managers/base_auth_manager.py
+++ b/airflow/auth/managers/base_auth_manager.py
@@ -21,6 +21,7 @@ from abc import abstractmethod
 from functools import cached_property
 from typing import TYPE_CHECKING, Container, Literal, Sequence
 
+from flask_appbuilder.menu import MenuItem
 from sqlalchemy import select
 
 from airflow.auth.managers.models.resource_details import (
@@ -34,7 +35,6 @@ from airflow.utils.session import NEW_SESSION, provide_session
 
 if TYPE_CHECKING:
     from flask import Blueprint
-    from flask_appbuilder.menu import MenuItem
     from sqlalchemy.orm import Session
 
     from airflow.auth.managers.models.base_user import BaseUser
@@ -397,13 +397,21 @@ class BaseAuthManager(LoggingMixin):
         )
         accessible_items = []
         for menu_item in items:
+            menu_item_copy = MenuItem(
+                name=menu_item.name,
+                icon=menu_item.icon,
+                label=menu_item.label,
+                childs=[],
+                baseview=menu_item.baseview,
+                cond=menu_item.cond,
+            )
             if menu_item.childs:
                 accessible_children = []
                 for child in menu_item.childs:
                     if self.security_manager.has_access(ACTION_CAN_ACCESS_MENU, child.name):
                         accessible_children.append(child)
-                menu_item.childs = accessible_children
-            accessible_items.append(menu_item)
+                menu_item_copy.childs = accessible_children
+            accessible_items.append(menu_item_copy)
         return accessible_items
 
     @abstractmethod

--- a/tests/auth/managers/test_base_auth_manager.py
+++ b/tests/auth/managers/test_base_auth_manager.py
@@ -313,3 +313,43 @@ class TestBaseAuthManager:
         assert result[1].name == "item3"
         assert len(result[1].childs) == 1
         assert result[1].childs[0].name == "item3.1"
+
+    @patch.object(EmptyAuthManager, "security_manager")
+    def test_filter_permitted_menu_items_twice(self, mock_security_manager, auth_manager):
+        mock_security_manager.has_access.side_effect = [
+            # 1st call
+            True,  # menu 1
+            False,  # menu 2
+            True,  # menu 3
+            True,  # Item 3.1
+            False,  # Item 3.2
+            # 2nd call
+            False,  # menu 1
+            True,  # menu 2
+            True,  # menu 3
+            False,  # Item 3.1
+            True,  # Item 3.2
+        ]
+
+        menu = Menu()
+        menu.add_link("item1")
+        menu.add_link("item2")
+        menu.add_link("item3")
+        menu.add_link("item3.1", category="item3")
+        menu.add_link("item3.2", category="item3")
+
+        result = auth_manager.filter_permitted_menu_items(menu.get_list())
+
+        assert len(result) == 2
+        assert result[0].name == "item1"
+        assert result[1].name == "item3"
+        assert len(result[1].childs) == 1
+        assert result[1].childs[0].name == "item3.1"
+
+        result = auth_manager.filter_permitted_menu_items(menu.get_list())
+
+        assert len(result) == 2
+        assert result[0].name == "item2"
+        assert result[1].name == "item3"
+        assert len(result[1].childs) == 1
+        assert result[1].childs[0].name == "item3.2"


### PR DESCRIPTION
The default implementation of filter_permitted_menu_items had a subtle side-effect. The filtering on child items was done in-place and modified the menu itself, so it was enough to get the same worker serve requests for multiple users for the same menu to get the items removed for subsequent user - even if they had permission to see it.

Deepcopying the menu items before filtering them should fix the problem

Fixes: #39204
Fixes: #39135

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
