### PR TITLE
Retry merge commit retrieval on failure

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -91,8 +91,25 @@ jobs:
       - name: Discover PR merge commit
         id: discover-pr-merge-commit
         run: |
+          # Sometimes target-commit-sha cannot be
           TARGET_COMMIT_SHA="$(gh api '${{ github.event.pull_request.url }}' --jq .merge_commit_sha)"
-          echo "TARGET_COMMIT_SHA=$TARGET_COMMIT_SHA" >> ${GITHUB_ENV}
+          if [[ ${TARGET_COMMIT_SHA} == "" ]]; then
+            # Sometimes retrieving the merge commit SHA from PR fails. We retry it once. Otherwise we
+            # fall-back to github.event.pull_request.head.sha
+            echo
+            echo "Could not retrieve merge commit SHA from PR, waiting for 3 seconds and retrying."
+            echo
+            sleep 3
+            TARGET_COMMIT_SHA="$(gh api '${{ github.event.pull_request.url }}' --jq .merge_commit_sha)"
+            if [[ ${TARGET_COMMIT_SHA} == "" ]]; then
+              echo
+              echo "Could not retrieve merge commit SHA from PR, falling back to PR head SHA."
+              echo
+              TARGET_COMMIT_SHA="${{ github.event.pull_request.head.sha }}"
+            fi
+          fi
+          echo "TARGET_COMMIT_SHA=${TARGET_COMMIT_SHA}"
+          echo "TARGET_COMMIT_SHA=${TARGET_COMMIT_SHA}" >> ${GITHUB_ENV}
           echo "target-commit-sha=${TARGET_COMMIT_SHA}" >> ${GITHUB_OUTPUT}
         if: github.event_name == 'pull_request_target'
       # The labels in the event aren't updated when re-triggering the job, So lets hit the API to get


### PR DESCRIPTION
Sometimes when merge commit retrieval fails (because of race condition most likely as pull request event is no ready yet) build-images builds all images because selective check does not know the merge commit (in pull request target vuild image failure). That was the only side effect. because otherwise build image had a fallback to
github.event.pull_request.head.sha in this case.

With this PR, we will retry it and fallback explicitly to github.event.pull_request.head.sha if it does not work.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
