### PR TITLE
Partially resolve invalid escape sequences (`W605`)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -296,6 +296,7 @@ extend-select = [
     "B019", # Use of functools.lru_cache or functools.cache on methods can lead to memory leaks
     "B028", # No explicit stacklevel keyword argument found
     "TRY002", # Prohibit use of `raise Exception`, use specific exceptions instead.
+    "W605", # Checks for invalid escape sequences which deprecated since Python 3.6
 ]
 ignore = [
     "D203",
@@ -388,6 +389,9 @@ combine-as-imports = true
 # All the modules which do not follow B028 yet: https://docs.astral.sh/ruff/rules/no-explicit-stacklevel/
 "airflow/providers/jdbc/hooks/jdbc.py" = ["B028"]
 "helm_tests/airflow_aux/test_basic_helm_chart.py" = ["B028"]
+
+# https://github.com/apache/airflow/issues/39252
+"airflow/providers/amazon/aws/hooks/eks.py" = ["W605"]
 
 [tool.ruff.lint.flake8-tidy-imports]
 # Disallow all relative imports.

--- a/scripts/in_container/verify_providers.py
+++ b/scripts/in_container/verify_providers.py
@@ -45,7 +45,7 @@ GENERATED_PROVIDERS_DEPENDENCIES_FILE = AIRFLOW_SOURCES_ROOT / "generated" / "pr
 ALL_DEPENDENCIES = json.loads(GENERATED_PROVIDERS_DEPENDENCIES_FILE.read_text())
 
 USE_AIRFLOW_VERSION = os.environ.get("USE_AIRFLOW_VERSION") or ""
-IS_AIRFLOW_VERSION_PROVIDED = re.match("^(\d+)\.(\d+)\.(\d+)\S*$", USE_AIRFLOW_VERSION)
+IS_AIRFLOW_VERSION_PROVIDED = re.match(r"^(\d+)\.(\d+)\.(\d+)\S*$", USE_AIRFLOW_VERSION)
 
 
 class EntityType(Enum):

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -1904,7 +1904,7 @@ def test_parse_version_info(text_input, expected_tuple):
     ],
 )
 def test_parse_version_invalid_parts(text_input):
-    with pytest.raises(ValueError, match="expected 5 components separated by '\.'"):
+    with pytest.raises(ValueError, match=r"expected 5 components separated by '\.'"):
         _parse_version_info(text_input)
 
 

--- a/tests/providers/amazon/aws/operators/test_sqs.py
+++ b/tests/providers/amazon/aws/operators/test_sqs.py
@@ -95,8 +95,8 @@ class TestSqsPublishOperator:
 
         op = SqsPublishOperator(**self.default_op_kwargs, sqs_queue=FIFO_QUEUE_NAME)
         error_message = (
-            "An error occurred \(MissingParameter\) when calling the SendMessage operation: "
-            "The request must contain the parameter MessageGroupId."
+            r"An error occurred \(MissingParameter\) when calling the SendMessage operation: "
+            r"The request must contain the parameter MessageGroupId."
         )
         with pytest.raises(ClientError, match=error_message):
             op.execute(mocked_context)

--- a/tests/providers/amazon/aws/sensors/test_quicksight.py
+++ b/tests/providers/amazon/aws/sensors/test_quicksight.py
@@ -111,7 +111,7 @@ class TestQuickSightSensor:
             assert sensor.quicksight_hook is sensor.hook
 
         with mock.patch("airflow.providers.amazon.aws.hooks.sts.StsHook") as mocked_class, pytest.warns(
-            AirflowProviderDeprecationWarning, match="consider to use `.*hook\.account_id` instead"
+            AirflowProviderDeprecationWarning, match=r"consider to use `.*hook\.account_id` instead"
         ):
             mocked_sts_hook = mock.MagicMock(name="FakeStsHook")
             mocked_class.return_value = mocked_sts_hook

--- a/tests/providers/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/tests/providers/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -1625,7 +1625,7 @@ class TestKubernetesJobWatcher:
                                 "state": {
                                     "waiting": {
                                         "reason": "CreateContainerError",
-                                        "message": 'Error: Error response from daemon: create \invalid\path: "\\invalid\path" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path',
+                                        "message": r'Error: Error response from daemon: create \invalid\path: "\invalid\path" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path',
                                     }
                                 },
                                 "lastState": {},

--- a/tests/providers/databricks/sensors/test_databricks_partition.py
+++ b/tests/providers/databricks/sensors/test_databricks_partition.py
@@ -157,6 +157,6 @@ class TestDatabricksPartitionSensor:
         self.partition_sensor.partitions = partitions
         _check_table_partitions.return_value = False
         with pytest.raises(
-            expected_exception, match=f"Specified partition\(s\): {partitions} were not found."
+            expected_exception, match=rf"Specified partition\(s\): {partitions} were not found."
         ):
             self.partition_sensor.poke(context={})

--- a/tests/providers/dbt/cloud/operators/test_dbt.py
+++ b/tests/providers/dbt/cloud/operators/test_dbt.py
@@ -235,13 +235,13 @@ class TestDbtCloudRunJobOperator:
                 assert mock_run_job.return_value.data["id"] == RUN_ID
             elif expected_output == "exception":
                 # The operator should fail if the job run fails or is cancelled.
-                error_message = "has failed or has been cancelled\.$"
+                error_message = r"has failed or has been cancelled\.$"
                 with pytest.raises(DbtCloudJobRunException, match=error_message):
                     operator.execute(context=self.mock_context)
             else:
                 # Demonstrating the operator timing out after surpassing the configured timeout value.
                 timeout = self.config["timeout"]
-                error_message = f"has not reached a terminal status after {timeout} seconds\.$"
+                error_message = rf"has not reached a terminal status after {timeout} seconds\.$"
                 with pytest.raises(DbtCloudJobRunException, match=error_message):
                     operator.execute(context=self.mock_context)
 

--- a/tests/providers/docker/hooks/test_docker.py
+++ b/tests/providers/docker/hooks/test_docker.py
@@ -271,7 +271,7 @@ def test_construct_tls_config(assert_hostname, ssl_version):
         tls_params["ssl_version"] = ssl_version
 
     if DOCKER_PY_7_PLUS and (assert_hostname is not None or ssl_version is not None):
-        ctx = pytest.warns(UserWarning, match="removed in `docker\.TLSConfig` constructor arguments")
+        ctx = pytest.warns(UserWarning, match=r"removed in `docker\.TLSConfig` constructor arguments")
         no_warns = False
     else:
         ctx = warnings.catch_warnings()

--- a/tests/providers/slack/transfers/test_sql_to_slack.py
+++ b/tests/providers/slack/transfers/test_sql_to_slack.py
@@ -220,7 +220,7 @@ class TestSqlToSlackApiFileOperator:
         mock_df.configure_mock(**{"empty.return_value": True})
         mock_get_query_results.return_value = mock_df
 
-        with pytest.raises(ValueError, match="output df must be non-empty\. Failing"):
+        with pytest.raises(ValueError, match=r"output df must be non-empty\. Failing"):
             op.execute(mock.MagicMock())
         mock_slack_hook_cls.assert_not_called()
 

--- a/tests/serialization/test_serde.py
+++ b/tests/serialization/test_serde.py
@@ -285,7 +285,7 @@ class TestSerDe:
     @conf_vars(
         {
             ("core", "allowed_deserialization_classes"): "",
-            ("core", "allowed_deserialization_classes_regexp"): "tests\.airflow\..",
+            ("core", "allowed_deserialization_classes_regexp"): r"tests\.airflow\..",
         }
     )
     @pytest.mark.usefixtures("recalculate_patterns")
@@ -299,7 +299,7 @@ class TestSerDe:
     @conf_vars(
         {
             ("core", "allowed_deserialization_classes"): "",
-            ("core", "allowed_deserialization_classes_regexp"): "tests\.airflow\.deep",
+            ("core", "allowed_deserialization_classes_regexp"): r"tests\.airflow\.deep",
         }
     )
     @pytest.mark.usefixtures("recalculate_patterns")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Recent changes in warnings capture shows that we use deprecated escape sequences, for avoid it we might want to turn it on [`W605`](https://docs.astral.sh/ruff/rules/invalid-escape-sequence/) rule, this one is autofixable

Fortunately all violation of this rule happen in tests or dev except one case, which is not covered by this PR, see: https://github.com/apache/airflow/issues/39252

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
