### PR TITLE
Determine fail_stop on client side when db isolated

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -3087,6 +3087,10 @@ class TaskInstance(Base, LoggingMixin):
         if TYPE_CHECKING:
             assert self.task
             assert self.task.dag
+        try:
+            fail_stop = self.task.dag.fail_stop
+        except Exception:
+            fail_stop = False
         _handle_failure(
             task_instance=self,
             error=error,
@@ -3094,7 +3098,7 @@ class TaskInstance(Base, LoggingMixin):
             test_mode=test_mode,
             context=context,
             force_fail=force_fail,
-            fail_stop=self.task.dag.fail_stop,
+            fail_stop=fail_stop,
         )
 
     def is_eligible_to_retry(self):

--- a/airflow/serialization/pydantic/taskinstance.py
+++ b/airflow/serialization/pydantic/taskinstance.py
@@ -279,6 +279,10 @@ class TaskInstancePydantic(BaseModelPydantic, LoggingMixin):
         if TYPE_CHECKING:
             assert self.task
             assert self.task.dag
+        try:
+            fail_stop = self.task.dag.fail_stop
+        except Exception:
+            fail_stop = False
         _handle_failure(
             task_instance=self,
             error=error,
@@ -286,7 +290,7 @@ class TaskInstancePydantic(BaseModelPydantic, LoggingMixin):
             test_mode=test_mode,
             context=context,
             force_fail=force_fail,
-            fail_stop=self.task.dag.fail_stop,
+            fail_stop=fail_stop,
         )
 
     def refresh_from_task(self, task: Operator, pool_override: str | None = None) -> None:

--- a/airflow/serialization/pydantic/taskinstance.py
+++ b/airflow/serialization/pydantic/taskinstance.py
@@ -276,6 +276,9 @@ class TaskInstancePydantic(BaseModelPydantic, LoggingMixin):
         """
         from airflow.models.taskinstance import _handle_failure
 
+        if TYPE_CHECKING:
+            assert self.task
+            assert self.task.dag
         _handle_failure(
             task_instance=self,
             error=error,
@@ -283,6 +286,7 @@ class TaskInstancePydantic(BaseModelPydantic, LoggingMixin):
             test_mode=test_mode,
             context=context,
             force_fail=force_fail,
+            fail_stop=self.task.dag.fail_stop,
         )
 
     def refresh_from_task(self, task: Operator, pool_override: str | None = None) -> None:


### PR DESCRIPTION
This is needed because we do not ser the dag on Operator objects.