### PR TITLE
Fix schema assigment in PostgresOperator

### DIFF
--- a/airflow/providers/postgres/operators/postgres.py
+++ b/airflow/providers/postgres/operators/postgres.py
@@ -68,7 +68,7 @@ class PostgresOperator(SQLExecuteQueryOperator):
     ) -> None:
         if database is not None:
             hook_params = kwargs.pop("hook_params", {})
-            kwargs["hook_params"] = {"schema": database, **hook_params}
+            kwargs["hook_params"] = {"database": database, **hook_params}
 
         if runtime_parameters:
             warnings.warn(


### PR DESCRIPTION
When passing `schema` in PostgresOperator it throws deprecation warning as the hook converts it to `database` in
https://github.com/apache/airflow/blob/7ab24c7723c65c90626b10db63444b88c0380e14/airflow/providers/postgres/hooks/postgres.py#L80-L87
