### PR TITLE
Update docstring `LivyOperator` retry_args and deferrable docs

### DIFF
--- a/airflow/providers/apache/livy/operators/livy.py
+++ b/airflow/providers/apache/livy/operators/livy.py
@@ -61,8 +61,8 @@ class LivyOperator(BaseOperator):
         depends on the option that's being modified.
     :param extra_headers: A dictionary of headers passed to the HTTP request to livy.
     :param retry_args: Arguments which define the retry behaviour.
+        See Tenacity documentation at https://github.com/jd/tenacity
     :param deferrable: Run operator in the deferrable mode
-            See Tenacity documentation at https://github.com/jd/tenacity
     """
 
     template_fields: Sequence[str] = ("spark_params",)


### PR DESCRIPTION
Fixes explanation of `retry_args` and `deferrable` parameters which were mixed into each other after #29047.