### PR TITLE
Test connection in Qdrant provider

### DIFF
--- a/airflow/providers/qdrant/hooks/qdrant.py
+++ b/airflow/providers/qdrant/hooks/qdrant.py
@@ -126,3 +126,7 @@ class QdrantHook(BaseHook):
             return True, "Connection established!"
         except (UnexpectedResponse, RpcError, ValueError) as e:
             return False, str(e)
+
+    def test_connection(self) -> tuple[bool, str]:
+        """Test the connection to the Qdrant instance."""
+        return self.verify_connection()

--- a/airflow/providers/qdrant/provider.yaml
+++ b/airflow/providers/qdrant/provider.yaml
@@ -38,7 +38,7 @@ integrations:
     tags: [software]
 
 dependencies:
-  - qdrant_client>=1.7.0
+  - qdrant_client>=1.9.0
   - apache-airflow>=2.7.0
 
 hooks:

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -950,7 +950,7 @@
   "qdrant": {
     "deps": [
       "apache-airflow>=2.7.0",
-      "qdrant_client>=1.7.0"
+      "qdrant_client>=1.9.0"
     ],
     "devel-deps": [],
     "cross-providers-deps": [],

--- a/scripts/ci/docker-compose/integration-qdrant.yml
+++ b/scripts/ci/docker-compose/integration-qdrant.yml
@@ -18,7 +18,7 @@
 version: "3.8"
 services:
   qdrant:
-    image: qdrant/qdrant:latest
+    image: qdrant/qdrant:v1.9.0
     labels:
       breeze.description: "Integration required for Qdrant tests."
     ports:

--- a/tests/integration/providers/qdrant/operators/test_qdrant_ingest.py
+++ b/tests/integration/providers/qdrant/operators/test_qdrant_ingest.py
@@ -60,7 +60,7 @@ class TestQdrantIngestOperator:
 
         hook = operator.hook
 
-        hook.conn.recreate_collection(
+        hook.conn.create_collection(
             collection_name, vectors_config=VectorParams(size=dimensions, distance=Distance.COSINE)
         )
 


### PR DESCRIPTION
## Description

This PR
- Implemented support for testing the connection to a Qdrant instance in the connections UI.

- Pins the version of the testing image to avoid unexpected test failures in the future.

- Updates the client library version as the [later versions](https://github.com/qdrant/qdrant-client/releases) include useful improvements.

