### PR TITLE
Copy menu_item href for nav bar

### DIFF
--- a/airflow/auth/managers/base_auth_manager.py
+++ b/airflow/auth/managers/base_auth_manager.py
@@ -404,6 +404,7 @@ class BaseAuthManager(LoggingMixin):
                 childs=[],
                 baseview=menu_item.baseview,
                 cond=menu_item.cond,
+                href=menu_item.href,
             )
             if menu_item.childs:
                 accessible_children = []

--- a/airflow/auth/managers/base_auth_manager.py
+++ b/airflow/auth/managers/base_auth_manager.py
@@ -398,13 +398,10 @@ class BaseAuthManager(LoggingMixin):
         accessible_items = []
         for menu_item in items:
             menu_item_copy = MenuItem(
-                name=menu_item.name,
-                icon=menu_item.icon,
-                label=menu_item.label,
-                childs=[],
-                baseview=menu_item.baseview,
-                cond=menu_item.cond,
-                href=menu_item.href,
+                **{
+                    **menu_item.__dict__,
+                    "childs": [],
+                }
             )
             if menu_item.childs:
                 accessible_children = []

--- a/tests/auth/managers/test_base_auth_manager.py
+++ b/tests/auth/managers/test_base_auth_manager.py
@@ -300,7 +300,15 @@ class TestBaseAuthManager:
         mock_security_manager.has_access.side_effect = [True, False, True, True, False]
 
         menu = Menu()
-        menu.add_link("item1")
+        menu.add_link(
+            # These may not all be valid types, but it does let us check each attr is copied
+            name="item1",
+            href="h1",
+            icon="i1",
+            label="l1",
+            baseview="b1",
+            cond="c1",
+        )
         menu.add_link("item2")
         menu.add_link("item3")
         menu.add_link("item3.1", category="item3")
@@ -313,6 +321,12 @@ class TestBaseAuthManager:
         assert result[1].name == "item3"
         assert len(result[1].childs) == 1
         assert result[1].childs[0].name == "item3.1"
+        # check we've copied every attr
+        assert result[0].href == "h1"
+        assert result[0].icon == "i1"
+        assert result[0].label == "l1"
+        assert result[0].baseview == "b1"
+        assert result[0].cond == "c1"
 
     @patch.object(EmptyAuthManager, "security_manager")
     def test_filter_permitted_menu_items_twice(self, mock_security_manager, auth_manager):


### PR DESCRIPTION
In https://github.com/apache/airflow/pull/39229, we forgot to copy the menu href and then all the nav bar links were broken.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
