### PR TITLE
Move significant newsfragment for 2.9.0 to release notes

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -111,6 +111,14 @@ Xcom table column ``value`` type has changed from ``blob`` to ``longblob``. This
 
 To downgrade from revision: ``b4078ac230a1``, ensure that you don't have Xcom values larger than 65,535 bytes. Otherwise, you'll need to clean those rows or run ``airflow db clean xcom`` to clean the Xcom table.
 
+Stronger validation for key parameter defaults in taskflow context variables (#38015)
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+As for the taskflow implementation in conjunction with context variable defaults invalid parameter orders can be
+generated, it is now not accepted anymore (and validated) that taskflow functions are defined with defaults
+other than ``None``. If you have done this before you most likely will see a broken DAG and a error message like
+``Error message: Context key parameter my_param can't have a default other than None``.
+
 New Features
 """"""""""""
 - Allow users to write dag_id and task_id in their national characters, added display name for dag / task (v2) (#38446)

--- a/airflow/reproducible_build.yaml
+++ b/airflow/reproducible_build.yaml
@@ -1,2 +1,2 @@
-release-notes-hash: 416d01241f2b6ed259e8d991fb7ac1f8
-source-date-epoch: 1712672348
+release-notes-hash: aad86522e49984ce17db1b8647cfb54a
+source-date-epoch: 1714165337

--- a/newsfragments/38015.significant.rst
+++ b/newsfragments/38015.significant.rst
@@ -1,6 +1,0 @@
-Stronger validation for key parameter defaults in taskflow context variables
-
-As for the taskflow implementation in conjunction with context variable defaults invalid parameter orders can be
-generated, it is now not accepted anymore (and validated) that taskflow functions are defined with defaults
-other than ``None``. If you have done this before you most likely will see a broken DAG and a error message like
-``Error message: Context key parameter my_param can't have a default other than None``.


### PR DESCRIPTION
Once the release is out, these should be added directly to the release notes - newsfragments are all about future releases!

Related: #38811 

cc @jscheffl 