### PR TITLE
Improve helm chart annotation building script

### DIFF
--- a/dev/chart/build_changelog_annotations.py
+++ b/dev/chart/build_changelog_annotations.py
@@ -39,6 +39,7 @@ to:
 from __future__ import annotations
 
 import re
+from textwrap import indent
 
 import yaml
 
@@ -67,7 +68,7 @@ def parse_line(line: str) -> tuple[str | None, int | None]:
     return desc.strip(), int(pr_number)
 
 
-def print_entry(section: str, description: str, pr_number: int | None):
+def get_entry(section: str, description: str, pr_number: int | None) -> dict[str, str | list]:
     for unwanted_prefix in PREFIXES_TO_STRIP:
         if description.lower().startswith(unwanted_prefix.lower()):
             description = description[len(unwanted_prefix) :].strip()
@@ -80,12 +81,13 @@ def print_entry(section: str, description: str, pr_number: int | None):
         entry["links"] = [
             {"name": f"#{pr_number}", "url": f"https://github.com/apache/airflow/pull/{pr_number}"}
         ]
-    print(yaml.dump([entry]))
+    return entry
 
 
 in_first_release = False
 past_significant_changes = False
 section = ""
+entries = []
 with open("chart/RELEASE_NOTES.rst") as f:
     for line in f:
         line = line.strip()
@@ -106,4 +108,7 @@ with open("chart/RELEASE_NOTES.rst") as f:
         else:
             description, pr = parse_line(line)
             if description:
-                print_entry(section, description, pr)
+                entries.append(get_entry(section, description, pr))
+
+if entries:
+    print(indent(yaml.dump(entries), " " * 4), end="")


### PR DESCRIPTION
Very minor improvement, but this gets rid of a bunch of extra newlines and properly indents the annotations, allowing for an append redirect right into Chart.yaml.

Before:

```
$ python3 ./dev/chart/build_changelog_annotations.py
- description: Don't overwrite ``.Values.airflowPodAnnotations``
  kind: fixed
  links:
  - name: '#37917'
    url: https://github.com/apache/airflow/pull/37917

- description: Fix cluster-wide RBAC naming clash when using multiple ``multiNamespace``
    releases with the same name
  kind: fixed
  links:
  - name: '#37197'
    url: https://github.com/apache/airflow/pull/37197

- description: 'Misc: Default airflow version to 2.8.3'
  kind: changed
  links:
  - name: '#38036'
    url: https://github.com/apache/airflow/pull/38036

```



After:
```
$ python3 ./dev/chart/build_changelog_annotations.py                 
    - description: Don't overwrite ``.Values.airflowPodAnnotations``
      kind: fixed
      links:
      - name: '#37917'
        url: https://github.com/apache/airflow/pull/37917
    - description: Fix cluster-wide RBAC naming clash when using multiple ``multiNamespace``
        releases with the same name
      kind: fixed
      links:
      - name: '#37197'
        url: https://github.com/apache/airflow/pull/37197
    - description: 'Misc: Default airflow version to 2.8.3'
      kind: changed
      links:
      - name: '#38036'
        url: https://github.com/apache/airflow/pull/38036
```