### PR TITLE
fix: sqa deprecations for airflow tests

### DIFF
--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -187,12 +187,12 @@ class TestTaskInstanceEndpoint:
                 )
                 session.add(dr)
             ti = TaskInstance(task=tasks[i], **self.ti_init)
+            session.add(ti)
             ti.dag_run = dr
             ti.note = "placeholder-note"
 
             for key, value in self.ti_extras.items():
                 setattr(ti, key, value)
-            session.add(ti)
             tis.append(ti)
 
         session.commit()

--- a/tests/api_connexion/schemas/test_task_instance_schema.py
+++ b/tests/api_connexion/schemas/test_task_instance_schema.py
@@ -65,6 +65,7 @@ class TestTaskInstanceSchema:
 
     def test_task_instance_schema_without_sla_and_rendered(self, session):
         ti = TI(task=self.task, **self.default_ti_init)
+        session.add(ti)
         for key, value in self.default_ti_extras.items():
             setattr(ti, key, value)
         serialized_ti = task_instance_schema.dump((ti, None, None))
@@ -109,6 +110,7 @@ class TestTaskInstanceSchema:
         session.add(sla_miss)
         session.flush()
         ti = TI(task=self.task, **self.default_ti_init)
+        session.add(ti)
         for key, value in self.default_ti_extras.items():
             setattr(ti, key, value)
         self.task.template_fields = ["partitions"]

--- a/tests/api_experimental/common/test_mark_tasks.py
+++ b/tests/api_experimental/common/test_mark_tasks.py
@@ -21,7 +21,7 @@ import datetime
 from typing import Callable
 
 import pytest
-from sqlalchemy.orm import eagerload
+from sqlalchemy.orm import joinedload
 
 from airflow import models
 from airflow.api.common.mark_tasks import (
@@ -134,7 +134,7 @@ class TestMarkTasks:
             return (
                 session.query(TI)
                 .join(TI.dag_run)
-                .options(eagerload(TI.dag_run))
+                .options(joinedload(TI.dag_run))
                 .filter(TI.dag_id == dag.dag_id, DR.execution_date.in_(execution_dates))
                 .all()
             )

--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -1909,8 +1909,8 @@ class TestBackfillJob:
         ti.map_index = 0
         for map_index in range(1, 3):
             ti = TI(consumer_op, run_id=dr.run_id, map_index=map_index)
-            ti.dag_run = dr
             session.add(ti)
+            ti.dag_run = dr
         session.flush()
 
         executor = MockExecutor()

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -2115,8 +2115,8 @@ def test_schedulable_task_exist_when_rerun_removed_upstream_mapped_task(session,
     task = ti.task
     for map_index in range(1, 5):
         ti = TI(task, run_id=dr.run_id, map_index=map_index)
-        ti.dag_run = dr
         session.add(ti)
+        ti.dag_run = dr
     session.flush()
     tis = dr.get_task_instances()
     for ti in tis:

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1484,8 +1484,8 @@ class TestTaskInstance:
         ti.map_index = 0
         for map_index in range(1, 5):
             ti = TaskInstance(ti.task, run_id=dr.run_id, map_index=map_index)
-            ti.dag_run = dr
             session.add(ti)
+            ti.dag_run = dr
         session.flush()
         downstream = ti.task
         ti = dr.get_task_instance(task_id="do_something_else", map_index=3, session=session)

--- a/tests/providers/fab/auth_manager/api_endpoints/test_user_schema.py
+++ b/tests/providers/fab/auth_manager/api_endpoints/test_user_schema.py
@@ -66,11 +66,11 @@ class TestUserCollectionItemSchema(TestUserBase):
             username="test",
             password="test",
             email=TEST_EMAIL,
-            roles=[self.role],
             created_on=timezone.parse(DEFAULT_TIME),
             changed_on=timezone.parse(DEFAULT_TIME),
         )
         self.session.add(user_model)
+        user_model.roles = [self.role]
         self.session.commit()
         user = self.session.query(User).filter(User.email == TEST_EMAIL).first()
         deserialized_user = user_collection_item_schema.dump(user)

--- a/tests/serialization/test_pydantic_models.py
+++ b/tests/serialization/test_pydantic_models.py
@@ -159,8 +159,12 @@ def test_serializing_pydantic_dataset_event(session, create_task_instance, creat
     ds2_event_1 = DatasetEvent(dataset_id=2)
     ds2_event_2 = DatasetEvent(dataset_id=2)
 
-    DagScheduleDatasetReference(dag_id=dag.dag_id, dataset=ds1)
-    TaskOutletDatasetReference(task_id=task1.task_id, dag_id=dag.dag_id, dataset=ds1)
+    dag_ds_ref = DagScheduleDatasetReference(dag_id=dag.dag_id)
+    session.add(dag_ds_ref)
+    dag_ds_ref.dataset = ds1
+    task_ds_ref = TaskOutletDatasetReference(task_id=task1.task_id, dag_id=dag.dag_id)
+    session.add(task_ds_ref)
+    task_ds_ref.dataset = ds1
 
     dr.consumed_dataset_events.append(ds1_event)
     dr.consumed_dataset_events.append(ds2_event_1)

--- a/tests/ti_deps/deps/test_trigger_rule_dep.py
+++ b/tests/ti_deps/deps/test_trigger_rule_dep.py
@@ -137,8 +137,8 @@ def get_mapped_task_dagrun(session, dag_maker):
             ti.map_index = 0
             for map_index in range(1, 5):
                 ti = TaskInstance(ti.task, run_id=dr.run_id, map_index=map_index)
-                ti.dag_run = dr
                 session.add(ti)
+                ti.dag_run = dr
             session.flush()
             tis = dr.get_task_instances(session=session)
             for ti in tis:

--- a/tests/utils/test_log_handlers.py
+++ b/tests/utils/test_log_handlers.py
@@ -493,6 +493,7 @@ class TestFileTaskLogHandler:
             job = Job()
             t = Trigger("", {})
             t.triggerer_job = job
+            session.add(t)
             ti.triggerer = t
             t.task_instance = ti
         h = FileTaskHandler(base_log_folder=os.fspath(tmp_path))


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

related: #28723

fix deprecations for SQLAlchemy 2.0 for Airflow tests.

~~@Taragolis I went through all test warnings. IMO for the majority of SQA 2.0 warnings there isn't something to do. That is often the case with the warnngs '_object is being merged into a Session along the backref cascade..._ ' SQA is warning the a object is pulled into the session with a backref cascade and not explicit. But often we compensate for that by adding the object a few lines later in the session which should be fine. In such cases we still get a warning but there won't be an issue later. [Here ](https://github.com/sqlalchemy/sqlalchemy/discussions/7693#discussioncomment-7290572) it is also explained.~~

### Fixed reported in tests
- [x] [tests/providers/fab/auth_manager/api_endpoints/test_user_schema.py:63](https://github.com/apache/airflow/blob/15eedd080428314cf6e27443f91624459d17a77d/tests/providers/fab/auth_manager/api_endpoints/test_user_schema.py#L63)
- [x] [tests/jobs/test_backfill_job.py:1912](https://github.com/apache/airflow/blob/15eedd080428314cf6e27443f91624459d17a77d/tests/jobs/test_backfill_job.py#L1912)
- [x] [tests/models/test_dagrun.py:2090](https://github.com/apache/airflow/blob/15eedd080428314cf6e27443f91624459d17a77d/tests/models/test_dagrun.py#L2090)
- [x] [tests/models/test_taskinstance.py:1487](https://github.com/apache/airflow/blob/15eedd080428314cf6e27443f91624459d17a77d/tests/models/test_taskinstance.py#L1487)
- [x] [tests/ti_deps/deps/test_trigger_rule_dep.py:140](https://github.com/apache/airflow/blob/15eedd080428314cf6e27443f91624459d17a77d/tests/ti_deps/deps/test_trigger_rule_dep.py#L140)
- [x] [tests/api_connexion/endpoints/test_task_instance_endpoint.py:190](https://github.com/apache/airflow/blob/15eedd080428314cf6e27443f91624459d17a77d/tests/api_connexion/endpoints/test_task_instance_endpoint.py#L190)
- [x] [tests/serialization/test_pydantic_models.py:162](https://github.com/apache/airflow/blob/15eedd080428314cf6e27443f91624459d17a77d/tests/serialization/test_pydantic_models.py#L162)
- [x] [tests/serialization/test_pydantic_models.py:163](https://github.com/apache/airflow/blob/15eedd080428314cf6e27443f91624459d17a77d/tests/serialization/test_pydantic_models.py#L163)
- [x] [tests/utils/test_log_handlers.py:475](https://github.com/apache/airflow/blob/15eedd080428314cf6e27443f91624459d17a77d/tests/utils/test_log_handlers.py#L475)
- [x] [tests/api_experimental/common/test_mark_tasks.py:137](https://github.com/apache/airflow/blob/15eedd080428314cf6e27443f91624459d17a77d/tests/api_experimental/common/test_mark_tasks.py#L137)
- [x] [tests/api_connexion/schemas/test_task_instance_schema.py:69](https://github.com/apache/airflow/blob/15eedd080428314cf6e27443f91624459d17a77d/tests/api_connexion/schemas/test_task_instance_schema.py#L69)
- [x] [tests/api_connexion/schemas/test_task_instance_schema.py:113](https://github.com/apache/airflow/blob/15eedd080428314cf6e27443f91624459d17a77d/tests/api_connexion/schemas/test_task_instance_schema.py#L113)


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).

