### PR TITLE
Fix logic of clean log for find cmd arg of retention

### DIFF
--- a/scripts/docker/clean-logs.sh
+++ b/scripts/docker/clean-logs.sh
@@ -21,6 +21,7 @@ set -euo pipefail
 
 readonly DIRECTORY="${AIRFLOW_HOME:-/usr/local/airflow}"
 readonly RETENTION="${AIRFLOW__LOG_RETENTION_DAYS:-15}"
+readonly ABS_RETENTION=$(( RETENTION < 0 ? -RETENTION : RETENTION ))
 
 trap "exit" INT TERM
 
@@ -32,7 +33,7 @@ while true; do
   echo "Trimming airflow logs to ${RETENTION} days."
   find "${DIRECTORY}"/logs \
     -type d -name 'lost+found' -prune -o \
-    -type f -mtime +"${RETENTION}" -name '*.log' -print0 | \
+    -type f -mtime -"${ABS_RETENTION}" -name '*.log' -print0 | \
     xargs -0 rm -f || true
 
   find "${DIRECTORY}"/logs -type d -empty -delete || true


### PR DESCRIPTION
Fix find args for clean log . Retention is a positive number. `find` command needs a negative modify day for modified files in the past.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
