### PR TITLE
docs: fix environment variable names when section name has dot in it

### DIFF
--- a/docs/exts/includes/sections-and-options.rst
+++ b/docs/exts/includes/sections-and-options.rst
@@ -63,13 +63,13 @@
     :Default: ``{{ "''" if option["default"] == "" else option["default"] }}``
         {% if option.get("sensitive") %}
     :Environment Variables:
-      ``AIRFLOW__{{ section_name | replace(".","_") | upper }}__{{ option_name | upper }}``
+      ``AIRFLOW__{{ section_name | replace(".", "_") | upper }}__{{ option_name | upper }}``
 
-      ``AIRFLOW__{{ section_name | replace(".","_") | upper }}__{{ option_name | upper }}_CMD``
+      ``AIRFLOW__{{ section_name | replace(".", "_") | upper }}__{{ option_name | upper }}_CMD``
 
-      ``AIRFLOW__{{ section_name | replace(".","_") | upper }}__{{ option_name | upper }}_SECRET``
+      ``AIRFLOW__{{ section_name | replace(".", "_") | upper }}__{{ option_name | upper }}_SECRET``
         {% else %}
-    :Environment Variable: ``AIRFLOW__{{ section_name | replace(".","_") | upper }}__{{ option_name | upper }}``
+    :Environment Variable: ``AIRFLOW__{{ section_name | replace(".", "_") | upper }}__{{ option_name | upper }}``
         {% endif %}
         {% if option["example"] %}
     :Example:

--- a/docs/exts/includes/sections-and-options.rst
+++ b/docs/exts/includes/sections-and-options.rst
@@ -63,13 +63,13 @@
     :Default: ``{{ "''" if option["default"] == "" else option["default"] }}``
         {% if option.get("sensitive") %}
     :Environment Variables:
-      ``AIRFLOW__{{ section_name | upper }}__{{ option_name | upper }}``
+      ``AIRFLOW__{{ section_name | replace(".","_") | upper }}__{{ option_name | upper }}``
 
-      ``AIRFLOW__{{ section_name | upper }}__{{ option_name | upper }}_CMD``
+      ``AIRFLOW__{{ section_name | replace(".","_") | upper }}__{{ option_name | upper }}_CMD``
 
-      ``AIRFLOW__{{ section_name | upper }}__{{ option_name | upper }}_SECRET``
+      ``AIRFLOW__{{ section_name | replace(".","_") | upper }}__{{ option_name | upper }}_SECRET``
         {% else %}
-    :Environment Variable: ``AIRFLOW__{{ section_name | upper }}__{{ option_name | upper }}``
+    :Environment Variable: ``AIRFLOW__{{ section_name | replace(".","_") | upper }}__{{ option_name | upper }}``
         {% endif %}
         {% if option["example"] %}
     :Example:


### PR DESCRIPTION
When the configuration section name has a dot in it, the environment variable variants of variables need to replace the dots with underscores. See https://airflow.apache.org/docs/apache-airflow/stable/howto/set-config.html

Closes: #39311