### PR TITLE
add missing conn_id to string representation of ObjectStoragePath

### DIFF
--- a/airflow/io/path.py
+++ b/airflow/io/path.py
@@ -361,3 +361,9 @@ class ObjectStoragePath(CloudPath):
         conn_id = data.pop("conn_id", None)
 
         return ObjectStoragePath(path, conn_id=conn_id, **_kwargs)
+
+    def __str__(self):
+        conn_id = self.storage_options.get("conn_id")
+        if self._protocol and conn_id:
+            return f"{self._protocol}://{conn_id}@{self.path}"
+        return super().__str__()

--- a/tests/io/test_path.py
+++ b/tests/io/test_path.py
@@ -403,3 +403,8 @@ class TestFs:
 
         assert o.fs is not None
         assert o._fs_cached
+
+    @pytest.mark.parametrize("input_str", ("file:///tmp/foo", "s3://conn_id@bucket/test.txt"))
+    def test_str(self, input_str):
+        o = ObjectStoragePath(input_str)
+        assert str(o) == input_str


### PR DESCRIPTION
As stated in [apache-airflow-providers-common-io - Object Storage XCom Backend](https://airflow.apache.org/docs/apache-airflow-providers-common-io/stable/xcom_backend.html), we'll need to set `xcom_objectstorage_path` to something like `s3://conn_id@mybucket/key` to use customized xcom backend. As the string representation of `ObjectStoragePath` does not contain `conn_id`, [this serialization](https://github.com/apache/airflow/blob/6112745b8f2ac7b0eeaf909a9f3209ff2819cc8b/airflow/providers/common/io/xcom/backend.py#L148) will lost this information which cause [this comparison](https://github.com/apache/airflow/blob/6112745b8f2ac7b0eeaf909a9f3209ff2819cc8b/airflow/providers/common/io/xcom/backend.py#L110) to fail.


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
