### PR TITLE
Add `job_id` parameter to `BigQueryGetDataOperator`

### DIFF
--- a/airflow/providers/google/cloud/triggers/bigquery.py
+++ b/airflow/providers/google/cloud/triggers/bigquery.py
@@ -205,9 +205,10 @@ class BigQueryGetDataTrigger(BigQueryInsertJobTrigger):
         (default: False).
     """
 
-    def __init__(self, as_dict: bool = False, **kwargs):
+    def __init__(self, as_dict: bool = False, selected_fields: str | None = None, **kwargs):
         super().__init__(**kwargs)
         self.as_dict = as_dict
+        self.selected_fields = selected_fields
 
     def serialize(self) -> tuple[str, dict[str, Any]]:
         """Serialize BigQueryInsertJobTrigger arguments and classpath."""
@@ -223,6 +224,7 @@ class BigQueryGetDataTrigger(BigQueryInsertJobTrigger):
                 "poll_interval": self.poll_interval,
                 "impersonation_chain": self.impersonation_chain,
                 "as_dict": self.as_dict,
+                "selected_fields": self.selected_fields,
             },
         )
 
@@ -235,7 +237,11 @@ class BigQueryGetDataTrigger(BigQueryInsertJobTrigger):
                 job_status = await hook.get_job_status(job_id=self.job_id, project_id=self.project_id)
                 if job_status["status"] == "success":
                     query_results = await hook.get_job_output(job_id=self.job_id, project_id=self.project_id)
-                    records = hook.get_records(query_results=query_results, as_dict=self.as_dict)
+                    records = hook.get_records(
+                        query_results=query_results,
+                        as_dict=self.as_dict,
+                        selected_fields=self.selected_fields,
+                    )
                     self.log.debug("Response from hook: %s", job_status["status"])
                     yield TriggerEvent(
                         {

--- a/tests/providers/google/cloud/triggers/test_bigquery.py
+++ b/tests/providers/google/cloud/triggers/test_bigquery.py
@@ -64,6 +64,7 @@ TEST_GCP_CONN_ID = "TEST_GCP_CONN_ID"
 TEST_IMPERSONATION_CHAIN = "TEST_SERVICE_ACCOUNT"
 TEST_HOOK_PARAMS: dict[str, Any] = {}
 TEST_PARTITION_ID = "1234"
+TEST_SELECTED_FIELDS = "f0_,f1_"
 
 
 @pytest.fixture
@@ -91,6 +92,7 @@ def get_data_trigger():
         location=None,
         poll_interval=POLLING_PERIOD_SECONDS,
         impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        selected_fields=TEST_SELECTED_FIELDS,
     )
 
 
@@ -285,6 +287,7 @@ class TestBigQueryGetDataTrigger:
             "project_id": TEST_GCP_PROJECT_ID,
             "table_id": TEST_TABLE_ID,
             "location": None,
+            "selected_fields": TEST_SELECTED_FIELDS,
             "poll_interval": POLLING_PERIOD_SECONDS,
         }
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

solves: #39127

This PR adds the `job_id` parameter to `BigQueryGetDataOperator` to fetch data from the results of selection queries executed by `BigQueryInsertJobOperator` (or any other querying interfaces). The new parameter is mutually exclusive with `table_id` and its related parameters (`dataset_id` and `use_legacy_sql`).

After merging this PR, the original issue of fetching results from complex queries (for example, queries with `ORDER BY` clauses) will be solved by running two operators sequentially: 
- Running the complex selection query with `BigQueryInsertJobOperator`
- Running `BigQueryGetDataOperator` while providing `job_id` from the previous step (templated):
   `job_id = "{{ task_instance.xcom_pull(task_ids='insert_job_op', key='return_value') }}"`

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
