### PR TITLE
Refactor DAG.dataset_triggers into the timetable class

### DIFF
--- a/airflow/datasets/__init__.py
+++ b/airflow/datasets/__init__.py
@@ -124,12 +124,15 @@ class BaseDataset:
     :meta private:
     """
 
-    def __or__(self, other: BaseDataset) -> DatasetAny:
+    def __bool__(self) -> bool:
+        return True
+
+    def __or__(self, other: BaseDataset) -> BaseDataset:
         if not isinstance(other, BaseDataset):
             return NotImplemented
         return DatasetAny(self, other)
 
-    def __and__(self, other: BaseDataset) -> DatasetAll:
+    def __and__(self, other: BaseDataset) -> BaseDataset:
         if not isinstance(other, BaseDataset):
             return NotImplemented
         return DatasetAll(self, other)
@@ -216,7 +219,7 @@ class DatasetAny(_DatasetBooleanCondition):
 
     agg_func = any
 
-    def __or__(self, other: BaseDataset) -> DatasetAny:
+    def __or__(self, other: BaseDataset) -> BaseDataset:
         if not isinstance(other, BaseDataset):
             return NotImplemented
         # Optimization: X | (Y | Z) is equivalent to X | Y | Z.
@@ -238,7 +241,7 @@ class DatasetAll(_DatasetBooleanCondition):
 
     agg_func = all
 
-    def __and__(self, other: BaseDataset) -> DatasetAll:
+    def __and__(self, other: BaseDataset) -> BaseDataset:
         if not isinstance(other, BaseDataset):
             return NotImplemented
         # Optimization: X & (Y & Z) is equivalent to X & Y & Z.

--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -148,10 +148,6 @@
             { "$ref": "#/definitions/typed_relativedelta" }
           ]
         },
-        "dataset_triggers": {
-        "$ref": "#/definitions/typed_dataset_cond"
-
-},
         "owner_links": { "type": "object" },
         "timetable": {
           "type": "object",

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -37,7 +37,7 @@ from pendulum.tz.timezone import FixedTimezone, Timezone
 
 from airflow.compat.functools import cache
 from airflow.configuration import conf
-from airflow.datasets import Dataset, DatasetAll, DatasetAny
+from airflow.datasets import BaseDataset, Dataset, DatasetAll, DatasetAny
 from airflow.exceptions import AirflowException, RemovedInAirflow3Warning, SerializationError, TaskDeferred
 from airflow.jobs.job import Job
 from airflow.models.baseoperator import BaseOperator
@@ -226,6 +226,35 @@ class _PriorityWeightStrategyNotRegistered(AirflowException):
             "you have a top level database access that disrupted the session. "
             "Please check the airflow best practices documentation."
         )
+
+
+def encode_dataset_condition(var: BaseDataset) -> dict[str, Any]:
+    """Encode a dataset condition.
+
+    :meta private:
+    """
+    if isinstance(var, Dataset):
+        return {"__type": DAT.DATASET, "uri": var.uri, "extra": var.extra}
+    if isinstance(var, DatasetAll):
+        return {"__type": DAT.DATASET_ALL, "objects": [encode_dataset_condition(x) for x in var.objects]}
+    if isinstance(var, DatasetAny):
+        return {"__type": DAT.DATASET_ANY, "objects": [encode_dataset_condition(x) for x in var.objects]}
+    raise ValueError(f"serialization not implemented for {type(var).__name__!r}")
+
+
+def decode_dataset_condition(var: dict[str, Any]) -> BaseDataset:
+    """Decode a previously serialized dataset condition.
+
+    :meta private:
+    """
+    dat = var["__type"]
+    if dat == DAT.DATASET:
+        return Dataset(var["uri"], extra=var["extra"])
+    if dat == DAT.DATASET_ALL:
+        return DatasetAll(*(decode_dataset_condition(x) for x in var["objects"]))
+    if dat == DAT.DATASET_ANY:
+        return DatasetAny(*(decode_dataset_condition(x) for x in var["objects"]))
+    raise ValueError(f"deserialization not implemented for DAT {dat!r}")
 
 
 def encode_timetable(var: Timetable) -> dict[str, Any]:
@@ -488,8 +517,6 @@ class BaseSerialization:
                 serialized_object[key] = encode_timetable(value)
             elif key == "weight_rule" and value is not None:
                 serialized_object[key] = encode_priority_weight_strategy(value)
-            elif key == "dataset_triggers":
-                serialized_object[key] = cls.serialize(value)
             else:
                 value = cls.serialize(value)
                 if isinstance(value, dict) and Encoding.TYPE in value:
@@ -607,24 +634,9 @@ class BaseSerialization:
             return cls._encode(cls._serialize_param(var), type_=DAT.PARAM)
         elif isinstance(var, XComArg):
             return cls._encode(serialize_xcom_arg(var), type_=DAT.XCOM_REF)
-        elif isinstance(var, Dataset):
-            return cls._encode({"uri": var.uri, "extra": var.extra}, type_=DAT.DATASET)
-        elif isinstance(var, DatasetAll):
-            return cls._encode(
-                [
-                    cls.serialize(x, strict=strict, use_pydantic_models=use_pydantic_models)
-                    for x in var.objects
-                ],
-                type_=DAT.DATASET_ALL,
-            )
-        elif isinstance(var, DatasetAny):
-            return cls._encode(
-                [
-                    cls.serialize(x, strict=strict, use_pydantic_models=use_pydantic_models)
-                    for x in var.objects
-                ],
-                type_=DAT.DATASET_ANY,
-            )
+        elif isinstance(var, BaseDataset):
+            serialized_dataset = encode_dataset_condition(var)
+            return cls._encode(serialized_dataset, type_=serialized_dataset.pop("__type"))
         elif isinstance(var, SimpleTaskInstance):
             return cls._encode(
                 cls.serialize(var.__dict__, strict=strict, use_pydantic_models=use_pydantic_models),
@@ -740,9 +752,9 @@ class BaseSerialization:
         elif type_ == DAT.DATASET:
             return Dataset(**var)
         elif type_ == DAT.DATASET_ANY:
-            return DatasetAny(*(cls.deserialize(x) for x in var))
+            return DatasetAny(*(decode_dataset_condition(x) for x in var["objects"]))
         elif type_ == DAT.DATASET_ALL:
-            return DatasetAll(*(cls.deserialize(x) for x in var))
+            return DatasetAll(*(decode_dataset_condition(x) for x in var["objects"]))
         elif type_ == DAT.SIMPLE_TASK_INSTANCE:
             return SimpleTaskInstance(**cls.deserialize(var))
         elif type_ == DAT.CONNECTION:
@@ -914,9 +926,7 @@ class DependencyDetector:
         """Detect dependencies set directly on the DAG object."""
         if not dag:
             return
-        if not dag.dataset_triggers:
-            return
-        for uri, _ in dag.dataset_triggers.iter_datasets():
+        for uri, _ in dag.timetable.dataset_condition.iter_datasets():
             yield DagDependency(
                 source="dataset",
                 target=dag.dag_id,
@@ -1562,8 +1572,6 @@ class SerializedDAG(DAG, BaseSerialization):
                 v = cls.deserialize(v)
             elif k == "params":
                 v = cls._deserialize_params_dict(v)
-            elif k == "dataset_triggers":
-                v = cls.deserialize(v)
             # else use v as it is
 
             setattr(dag, k, v)

--- a/airflow/timetables/datasets.py
+++ b/airflow/timetables/datasets.py
@@ -44,9 +44,9 @@ class DatasetOrTimeSchedule(DatasetTriggeredSchedule):
     ) -> None:
         self.timetable = timetable
         if isinstance(datasets, BaseDataset):
-            self.datasets = datasets
+            self.dataset_condition = datasets
         else:
-            self.datasets = DatasetAll(*datasets)
+            self.dataset_condition = DatasetAll(*datasets)
 
         self.description = f"Triggered by datasets or {timetable.description}"
         self.periodic = timetable.periodic
@@ -55,25 +55,25 @@ class DatasetOrTimeSchedule(DatasetTriggeredSchedule):
 
     @classmethod
     def deserialize(cls, data: dict[str, typing.Any]) -> Timetable:
-        from airflow.serialization.serialized_objects import decode_timetable
+        from airflow.serialization.serialized_objects import decode_dataset_condition, decode_timetable
 
         return cls(
+            datasets=decode_dataset_condition(data["dataset_condition"]),
             timetable=decode_timetable(data["timetable"]),
-            # don't need the datasets after deserialization
-            # they are already stored on dataset_triggers attr on DAG
-            # and this is what scheduler looks at
-            datasets=[],
         )
 
     def serialize(self) -> dict[str, typing.Any]:
-        from airflow.serialization.serialized_objects import encode_timetable
+        from airflow.serialization.serialized_objects import encode_dataset_condition, encode_timetable
 
-        return {"timetable": encode_timetable(self.timetable)}
+        return {
+            "dataset_condition": encode_dataset_condition(self.dataset_condition),
+            "timetable": encode_timetable(self.timetable),
+        }
 
     def validate(self) -> None:
         if isinstance(self.timetable, DatasetTriggeredSchedule):
             raise AirflowTimetableInvalid("cannot nest dataset timetables")
-        if not isinstance(self.datasets, BaseDataset):
+        if not isinstance(self.dataset_condition, BaseDataset):
             raise AirflowTimetableInvalid("all elements in 'datasets' must be datasets")
 
     @property

--- a/airflow/timetables/simple.py
+++ b/airflow/timetables/simple.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from pendulum import DateTime
     from sqlalchemy import Session
 
+    from airflow.datasets import BaseDataset
     from airflow.models.dataset import DatasetEvent
     from airflow.timetables.base import TimeRestriction
     from airflow.utils.types import DagRunType
@@ -156,9 +157,24 @@ class DatasetTriggeredTimetable(_TrivialTimetable):
 
     description: str = "Triggered by datasets"
 
+    def __init__(self, datasets: BaseDataset) -> None:
+        super().__init__()
+        self.dataset_condition = datasets
+
+    @classmethod
+    def deserialize(cls, data: dict[str, Any]) -> Timetable:
+        from airflow.serialization.serialized_objects import decode_dataset_condition
+
+        return cls(decode_dataset_condition(data["dataset_condition"]))
+
     @property
     def summary(self) -> str:
         return "Dataset"
+
+    def serialize(self) -> dict[str, Any]:
+        from airflow.serialization.serialized_objects import encode_dataset_condition
+
+        return {"dataset_condition": encode_dataset_condition(self.dataset_condition)}
 
     def generate_run_id(
         self,

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -970,7 +970,7 @@ class TestCliDags:
         mock_render_dag.assert_has_calls([mock.call(mock_get_dag.return_value, tis=[])])
         assert "SOURCE" in output
 
-    @mock.patch("workday.AfterWorkdayTimetable")
+    @mock.patch("workday.AfterWorkdayTimetable", side_effect=lambda: mock.MagicMock(active_runs_limit=None))
     @mock.patch("airflow.models.dag._get_or_create_dagrun")
     def test_dag_test_with_custom_timetable(self, mock__get_or_create_dagrun, _):
         """

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -258,22 +258,21 @@ def test_dataset_trigger_setup_and_serialization(session, dag_maker, create_test
     with dag_maker(schedule=DatasetAny(*datasets)) as dag:
         EmptyOperator(task_id="hello")
 
-    # Verify dataset triggers are set up correctly
+    # Verify datasets are set up correctly
     assert isinstance(
-        dag.dataset_triggers, DatasetAny
-    ), "DAG dataset triggers should be an instance of DatasetAny"
+        dag.timetable.dataset_condition, DatasetAny
+    ), "DAG datasets should be an instance of DatasetAny"
 
-    # Serialize and deserialize DAG dataset triggers
-    serialized_trigger = SerializedDAG.serialize(dag.dataset_triggers)
-    deserialized_trigger = SerializedDAG.deserialize(serialized_trigger)
+    # Round-trip the DAG through serialization
+    deserialized_dag = SerializedDAG.deserialize_dag(SerializedDAG.serialize_dag(dag))
 
     # Verify serialization and deserialization integrity
     assert isinstance(
-        deserialized_trigger, DatasetAny
-    ), "Deserialized trigger should maintain type DatasetAny"
+        deserialized_dag.timetable.dataset_condition, DatasetAny
+    ), "Deserialized datasets should maintain type DatasetAny"
     assert (
-        deserialized_trigger.objects == dag.dataset_triggers.objects
-    ), "Deserialized trigger objects should match original"
+        deserialized_dag.timetable.dataset_condition.objects == dag.timetable.dataset_condition.objects
+    ), "Deserialized datasets should match original"
 
 
 @pytest.mark.db_test
@@ -303,12 +302,13 @@ def test_dataset_dag_run_queue_processing(session, clear_datasets, dag_maker, cr
     for (serialized_dag,) in serialized_dags:
         dag = SerializedDAG.deserialize(serialized_dag.data)
         for dataset_uri, status in dag_statuses[dag.dag_id].items():
-            assert dag.dataset_triggers.evaluate({dataset_uri: status}), "DAG trigger evaluation failed"
+            cond = dag.timetable.dataset_condition
+            assert cond.evaluate({dataset_uri: status}), "DAG trigger evaluation failed"
 
 
 @pytest.mark.db_test
 @pytest.mark.usefixtures("clear_datasets")
-def test_dag_with_complex_dataset_triggers(session, dag_maker):
+def test_dag_with_complex_dataset_condition(session, dag_maker):
     # Create Dataset instances
     d1 = Dataset(uri="hello1")
     d2 = Dataset(uri="hello2")
@@ -324,13 +324,13 @@ def test_dag_with_complex_dataset_triggers(session, dag_maker):
         EmptyOperator(task_id="hello")
 
     assert isinstance(
-        dag.dataset_triggers, DatasetAny
+        dag.timetable.dataset_condition, DatasetAny
     ), "DAG's dataset trigger should be an instance of DatasetAny"
     assert any(
-        isinstance(trigger, DatasetAll) for trigger in dag.dataset_triggers.objects
+        isinstance(trigger, DatasetAll) for trigger in dag.timetable.dataset_condition.objects
     ), "DAG's dataset trigger should include DatasetAll"
 
-    serialized_triggers = SerializedDAG.serialize(dag.dataset_triggers)
+    serialized_triggers = SerializedDAG.serialize(dag.timetable.dataset_condition)
 
     deserialized_triggers = SerializedDAG.deserialize(serialized_triggers)
 
@@ -341,11 +341,13 @@ def test_dag_with_complex_dataset_triggers(session, dag_maker):
         isinstance(trigger, DatasetAll) for trigger in deserialized_triggers.objects
     ), "Deserialized triggers should include DatasetAll"
 
-    serialized_dag_dict = SerializedDAG.to_dict(dag)["dag"]
-    assert "dataset_triggers" in serialized_dag_dict, "Serialized DAG should contain 'dataset_triggers'"
+    serialized_timetable_dict = SerializedDAG.to_dict(dag)["dag"]["timetable"]["__var"]
+    assert (
+        "dataset_condition" in serialized_timetable_dict
+    ), "Serialized timetable should contain 'dataset_condition'"
     assert isinstance(
-        serialized_dag_dict["dataset_triggers"], dict
-    ), "Serialized 'dataset_triggers' should be a dict"
+        serialized_timetable_dict["dataset_condition"], dict
+    ), "Serialized 'dataset_condition' should be a dict"
 
 
 def datasets_equal(d1: BaseDataset, d2: BaseDataset) -> bool:

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -1968,7 +1968,7 @@ class TestDag:
 
     def test_timetable_and_description_from_dataset(self):
         dag = DAG("test_schedule_interval_arg", schedule=[Dataset(uri="hello")], start_date=TEST_DATE)
-        assert dag.timetable == DatasetTriggeredTimetable()
+        assert dag.timetable == DatasetTriggeredTimetable(Dataset(uri="hello"))
         assert dag.schedule_interval == "Dataset"
         assert dag.timetable.description == "Triggered by datasets"
 

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -591,16 +591,10 @@ class TestStringifiedDAGs:
             "params",
             "_processor_dags_folder",
         }
-        compare_serialization_list = {
-            "dataset_triggers",
-        }
         fields_to_check = dag.get_serialized_fields() - exclusion_list
         for field in fields_to_check:
             actual = getattr(serialized_dag, field)
             expected = getattr(dag, field)
-            if field in compare_serialization_list:
-                actual = BaseSerialization.serialize(actual)
-                expected = BaseSerialization.serialize(expected)
             assert actual == expected, f"{dag.dag_id}.{field} does not match"
         # _processor_dags_folder is only populated at serialization time
         # it's only used when relying on serialized dag to determine a dag's relative path

--- a/tests/timetables/test_datasets_timetable.py
+++ b/tests/timetables/test_datasets_timetable.py
@@ -129,6 +129,10 @@ def test_serialization(dataset_timetable: DatasetOrTimeSchedule, monkeypatch: An
     serialized = dataset_timetable.serialize()
     assert serialized == {
         "timetable": "mock_serialized_timetable",
+        "dataset_condition": {
+            "__type": "dataset_all",
+            "objects": [{"__type": "dataset", "uri": "test_dataset", "extra": None}],
+        },
     }
 
 
@@ -141,7 +145,13 @@ def test_deserialization(monkeypatch: Any) -> None:
     monkeypatch.setattr(
         "airflow.serialization.serialized_objects.decode_timetable", lambda x: MockTimetable()
     )
-    mock_serialized_data = {"timetable": "mock_serialized_timetable", "datasets": [{"uri": "test_dataset"}]}
+    mock_serialized_data = {
+        "timetable": "mock_serialized_timetable",
+        "dataset_condition": {
+            "__type": "dataset_all",
+            "objects": [{"__type": "dataset", "uri": "test_dataset", "extra": None}],
+        },
+    }
     deserialized = DatasetOrTimeSchedule.deserialize(mock_serialized_data)
     assert isinstance(deserialized, DatasetOrTimeSchedule)
 


### PR DESCRIPTION
This allows us to remove a bunch of conditionals regarding whether a DAG is backed by a timetable or dataset condition, and a weird edge case in serialization where we don't actually deserialize datasets in a timetable.

Now datasets are always serialized as a part of the timetable, and we always evaluate the timetable and datasets. Timetables that do not actually contain datasets (most of them) simply always evaluate to False.