### PR TITLE
Refresh properties on KubernetesPodOperator when k8s fails due to token expiration

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -78,6 +78,7 @@ from airflow.providers.cncf.kubernetes.utils.pod_manager import (
     PodNotFoundException,
     PodOperatorHookProtocol,
     PodPhase,
+    check_exception_is_kubernetes_api_unauthorized,
     container_is_succeeded,
     get_container_termination_message,
 )
@@ -97,12 +98,6 @@ if TYPE_CHECKING:
 alphanum_lower = string.ascii_lowercase + string.digits
 
 KUBE_CONFIG_ENV_VAR = "KUBECONFIG"
-
-
-def check_exception_is_kubernetes_api_unauthorized(exc: BaseException):
-    return (
-        isinstance(exc, kubernetes.client.exceptions.ApiException) and exc.status and str(exc.status) == "401"
-    )
 
 
 class PodEventType(Enum):

--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -99,7 +99,7 @@ alphanum_lower = string.ascii_lowercase + string.digits
 KUBE_CONFIG_ENV_VAR = "KUBECONFIG"
 
 
-def check_exception_is_kubernetes_api_unauthorized(exc: Exception):
+def check_exception_is_kubernetes_api_unauthorized(exc: BaseException):
     return (
         isinstance(exc, kubernetes.client.exceptions.ApiException) and exc.status and str(exc.status) == "401"
     )

--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -35,7 +35,8 @@ from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence
 import kubernetes
 import tenacity
 from deprecated import deprecated
-from kubernetes.client import CoreV1Api, V1Pod, models as k8s
+from kubernetes.client import CoreV1Api, V1Pod
+from kubernetes.client import models as k8s
 
 from airflow.configuration import conf
 from airflow.exceptions import (
@@ -651,7 +652,7 @@ class KubernetesPodOperator(BaseOperator):
         except kubernetes.client.exceptions.ApiException as e:
             if str(e.status) == "401":
                 self._refresh_cached_properties()
-                raise e
+            raise e
 
     def _refresh_cached_properties(self):
         del self.hook

--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -35,8 +35,9 @@ from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence
 import kubernetes
 import tenacity
 from deprecated import deprecated
-from kubernetes.client import CoreV1Api, V1Pod
-from kubernetes.client import models as k8s
+from kubernetes.client import CoreV1Api, V1Pod, models as k8s
+from kubernetes.stream import stream
+from urllib3.exceptions import HTTPError
 
 from airflow.configuration import conf
 from airflow.exceptions import (

--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -190,6 +190,10 @@ def get_container_termination_message(pod: V1Pod, container_name: str):
         return container_status.state.terminated.message if container_status else None
 
 
+def check_exception_is_kubernetes_api_unauthorized(exc: BaseException):
+    return isinstance(exc, ApiException) and exc.status and str(exc.status) == "401"
+
+
 class PodLaunchTimeoutException(AirflowException):
     """When pod does not leave the ``Pending`` phase within specified timeout."""
 

--- a/tests/providers/cncf/kubernetes/operators/test_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_pod.py
@@ -24,8 +24,7 @@ from unittest.mock import MagicMock, patch
 
 import pendulum
 import pytest
-from kubernetes.client import ApiClient, V1Pod, V1PodSecurityContext, V1PodStatus
-from kubernetes.client import models as k8s
+from kubernetes.client import ApiClient, V1Pod, V1PodSecurityContext, V1PodStatus, models as k8s
 from kubernetes.client.rest import ApiException
 from urllib3 import HTTPResponse
 

--- a/tests/providers/cncf/kubernetes/operators/test_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_pod.py
@@ -24,8 +24,7 @@ from unittest.mock import MagicMock, patch
 
 import pendulum
 import pytest
-from kubernetes.client import ApiClient, V1Pod, V1PodSecurityContext, V1PodStatus
-from kubernetes.client import models as k8s
+from kubernetes.client import ApiClient, V1Pod, V1PodSecurityContext, V1PodStatus, models as k8s
 from kubernetes.client.rest import ApiException
 from urllib3 import HTTPResponse
 
@@ -38,10 +37,6 @@ from airflow.providers.cncf.kubernetes.operators.pod import (
     PodEventType,
     _optionally_suppress,
 )
-from airflow.providers.cncf.kubernetes.secret import Secret
-from airflow.providers.cncf.kubernetes.triggers.pod import KubernetesPodTrigger
-from airflow.providers.cncf.kubernetes.utils.pod_manager import PodLoggingStatus, PodPhase
-from airflow.providers.cncf.kubernetes.utils.xcom_sidecar import PodDefaults
 from airflow.utils import timezone
 from airflow.utils.session import create_session
 from airflow.utils.types import DagRunType

--- a/tests/providers/cncf/kubernetes/operators/test_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_pod.py
@@ -24,7 +24,8 @@ from unittest.mock import MagicMock, patch
 
 import pendulum
 import pytest
-from kubernetes.client import ApiClient, V1Pod, V1PodSecurityContext, V1PodStatus, models as k8s
+from kubernetes.client import ApiClient, V1Pod, V1PodSecurityContext, V1PodStatus
+from kubernetes.client import models as k8s
 from kubernetes.client.rest import ApiException
 from urllib3 import HTTPResponse
 
@@ -1622,49 +1623,52 @@ class TestKubernetesPodOperator:
         )
         pod = self.run_pod(k)
         client, hook, pod_manager = k.client, k.hook, k.pod_manager
+
+        # no exception doesn't update properties
+        k.await_container_completion(pod, container_name=container_name)
+        assert client == k.client
+        assert hook == k.hook
+        assert pod_manager == k.pod_manager
+
+        # exception refreshes properties
         mock_await_container_completion.side_effect = [ApiException(status=401), mock.DEFAULT]
         k.await_container_completion(pod, container_name=container_name)
         mock_await_container_completion.assert_has_calls(
-            [
-                mock.call(pod=pod, container_name=container_name),
-                mock.call(pod=pod, container_name=container_name),
-            ]
+            [mock.call(pod=pod, container_name=container_name)] * 3
         )
         assert client != k.client
         assert hook != k.hook
         assert pod_manager != k.pod_manager
 
     @pytest.mark.parametrize(
-        "side_effect, exception_type, expect_retry",
+        "side_effect, exception_type, expect_exc",
         [
-            (ApiException(401), ApiException, True),
-            (ApiException(402), ApiException, False),
-            (ApiException(500), ApiException, False),
-            (Exception, Exception, False),
+            ([ApiException(401), mock.DEFAULT], ApiException, True),  # works after one 401
+            ([ApiException(401)] * 10, ApiException, False),  # exc after 3 retries on 401
+            ([ApiException(402)], ApiException, False),  # exc on non-401
+            ([ApiException(500)], ApiException, False),  # exc on non-401
+            ([Exception], Exception, False),  # exc on different exception
         ],
     )
     @patch(f"{POD_MANAGER_CLASS}.await_container_completion")
     def test_await_container_completion_retries_on_specific_exception(
-        self, mock_await_container_completion, side_effect, exception_type, expect_retry
+        self, mock_await_container_completion, side_effect, exception_type, expect_exc
     ):
         container_name = "base"
         k = KubernetesPodOperator(
             task_id="task",
         )
         pod = self.run_pod(k)
-        mock_await_container_completion.side_effect = [side_effect, mock.DEFAULT]
-        if expect_retry:
+        mock_await_container_completion.side_effect = side_effect
+        if expect_exc:
             k.await_container_completion(pod, container_name=container_name)
-            mock_await_container_completion.assert_has_calls(
-                [
-                    mock.call(pod=pod, container_name=container_name),
-                    mock.call(pod=pod, container_name=container_name),
-                ]
-            )
         else:
             with pytest.raises(exception_type):
                 k.await_container_completion(pod, container_name=container_name)
-            mock_await_container_completion.assert_called_once_with(pod=pod, container_name=container_name)
+        expected_call_count = min(len(side_effect), 3)  # retry max 3 times
+        mock_await_container_completion.assert_has_calls(
+            [mock.call(pod=pod, container_name=container_name)] * expected_call_count
+        )
 
 
 class TestSuppress:

--- a/tests/providers/cncf/kubernetes/operators/test_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_pod.py
@@ -37,6 +37,10 @@ from airflow.providers.cncf.kubernetes.operators.pod import (
     PodEventType,
     _optionally_suppress,
 )
+from airflow.providers.cncf.kubernetes.secret import Secret
+from airflow.providers.cncf.kubernetes.triggers.pod import KubernetesPodTrigger
+from airflow.providers.cncf.kubernetes.utils.pod_manager import PodLoggingStatus, PodPhase
+from airflow.providers.cncf.kubernetes.utils.xcom_sidecar import PodDefaults
 from airflow.utils import timezone
 from airflow.utils.session import create_session
 from airflow.utils.types import DagRunType


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Closes: [#32718](https://github.com/apache/airflow/issues/32718)


<!-- Please keep an empty line above the dashes. -->
---
The `KubernetesPodOperator` caches the hook and client used to interact with K8S. This includes also the `kube config` and related secret auth token. For long running jobs, the token may expire during the execution, causing the job to fail:

```
Traceback (most recent call last):
  [...]
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/airflow/providers/cncf/kubernetes/utils/pod_manager.py", line 690, in read_pod
    return self._client.read_namespaced_pod(pod.metadata.name, pod.metadata.namespace)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/kubernetes/client/api/core_v1_api.py", line 23483, in read_namespaced_pod
    return self.read_namespaced_pod_with_http_info(name, namespace, **kwargs)  # noqa: E501
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/kubernetes/client/api/core_v1_api.py", line 23570, in read_namespaced_pod_with_http_info
    return self.api_client.call_api(
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/kubernetes/client/api_client.py", line 348, in call_api
    return self.__call_api(resource_path, method,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/kubernetes/client/api_client.py", line 180, in __call_api
    response_data = self.request(
                    ^^^^^^^^^^^^^
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/kubernetes/client/api_client.py", line 373, in request
    return self.rest_client.GET(url,
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/kubernetes/client/rest.py", line 240, in GET
    return self.request("GET", url,
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/kubernetes/client/rest.py", line 234, in request
    raise ApiException(http_resp=r)
kubernetes.client.exceptions.ApiException: (401)
Reason: Unauthorized
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Unauthorized","reason":"Unauthorized","code":401}
```

This PR builds on top of https://github.com/apache/airflow/pull/32719. Before adding more tests, I'd be happy to discuss this or other approaches to solve this issue.
