### PR TITLE
Fix Pod Number Exception in the sync mode if reattach_on_restart parameter is False

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -469,7 +469,9 @@ class KubernetesPodOperator(BaseOperator):
         """
         Generate labels for the pod to track the pod in case of Operator crash.
 
-        :param context: task context provided by airflow DAG
+        :param context: task context provided by airflow DAG.
+        :param include_try_number: if set to True will add the try number
+            from the task context to the pod labels.
         :return: dict
         """
         if not context:
@@ -534,24 +536,31 @@ class KubernetesPodOperator(BaseOperator):
 
         pod = None
         num_pods = len(pod_list)
-        if num_pods > 1:
-            raise AirflowException(f"More than one pod running with labels {label_selector}")
-        elif num_pods == 1:
+
+        if num_pods == 1:
             pod = pod_list[0]
-            self.log.info("Found matching pod %s with labels %s", pod.metadata.name, pod.metadata.labels)
-            self.log.info("`try_number` of task_instance: %s", context["ti"].try_number)
-            self.log.info("`try_number` of pod: %s", pod.metadata.labels["try_number"])
+            self.log_matching_pod(pod=pod, context=context)
+        elif num_pods > 1:
+            if self.reattach_on_restart:
+                raise AirflowException(f"More than one pod running with labels {label_selector}")
+            self.log.warning("Found more than one pod running with labels %s, resolving ...", label_selector)
+            pod = self.process_duplicate_label_pods(pod_list)
+            self.log_matching_pod(pod=pod, context=context)
+
         return pod
+
+    def log_matching_pod(self, pod: k8s.V1Pod, context: Context) -> None:
+        self.log.info("Found matching pod %s with labels %s", pod.metadata.name, pod.metadata.labels)
+        self.log.info("`try_number` of task_instance: %s", context["ti"].try_number)
+        self.log.info("`try_number` of pod: %s", pod.metadata.labels["try_number"])
 
     def get_or_create_pod(self, pod_request_obj: k8s.V1Pod, context: Context) -> k8s.V1Pod:
         if self.reattach_on_restart:
             pod = self.find_pod(self.namespace or pod_request_obj.metadata.namespace, context=context)
             if pod:
                 return pod
-
         self.log.debug("Starting pod:\n%s", yaml.safe_dump(pod_request_obj.to_dict()))
         self.pod_manager.create_pod(pod=pod_request_obj)
-
         return pod_request_obj
 
     def await_pod_start(self, pod: k8s.V1Pod) -> None:
@@ -1137,6 +1146,36 @@ class KubernetesPodOperator(BaseOperator):
     @deprecated(reason="use `trigger_reentry` instead.", category=AirflowProviderDeprecationWarning)
     def execute_complete(self, context: Context, event: dict, **kwargs):
         return self.trigger_reentry(context=context, event=event)
+
+    def process_duplicate_label_pods(self, pod_list: list[k8s.V1Pod]) -> k8s.V1Pod:
+        """
+        Patch or delete the existing pod with duplicate labels.
+
+        This is to handle an edge case that can happen only if reattach_on_restart
+        flag is False, and the previous run attempt has failed because the task
+        process has been killed externally by the cluster or another process.
+
+        If the task process is killed externally, it breaks the code execution and
+        immediately exists the task. As a result the pod created in the previous attempt
+        will not be properly deleted or patched by cleanup() method.
+
+        Return the newly created pod to be used for the next run attempt.
+        """
+        new_pod = pod_list.pop(self._get_most_recent_pod_index(pod_list))
+        old_pod = pod_list[0]
+        self.patch_already_checked(old_pod, reraise=False)
+        if self.on_finish_action == OnFinishAction.DELETE_POD:
+            self.process_pod_deletion(old_pod)
+        return new_pod
+
+    @staticmethod
+    def _get_most_recent_pod_index(pod_list: list[k8s.V1Pod]) -> int:
+        """Loop through a list of V1Pod objects and get the index of the most recent one."""
+        pod_start_times: list[datetime.datetime] = [
+            pod.to_dict().get("status").get("start_time") for pod in pod_list
+        ]
+        most_recent_start_time = max(pod_start_times)
+        return pod_start_times.index(most_recent_start_time)
 
 
 class _optionally_suppress(AbstractContextManager):

--- a/tests/providers/cncf/kubernetes/operators/test_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_pod.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import datetime
 import re
 from contextlib import contextmanager, nullcontext
 from io import BytesIO
@@ -1683,6 +1684,74 @@ class TestKubernetesPodOperator:
         mock_await_container_completion.assert_has_calls(
             [mock.call(pod=pod, container_name=k.base_container_name)] * expected_call_count
         )
+
+    @pytest.mark.parametrize(
+        "on_finish_action", [OnFinishAction.KEEP_POD, OnFinishAction.DELETE_SUCCEEDED_POD]
+    )
+    @patch(KUB_OP_PATH.format("patch_already_checked"))
+    @patch(KUB_OP_PATH.format("process_pod_deletion"))
+    def test_process_duplicate_label_pods__label_patched_if_action_is_not_delete_pod(
+        self,
+        process_pod_deletion_mock,
+        patch_already_checked_mock,
+        on_finish_action,
+    ):
+        now = datetime.datetime.now()
+        k = KubernetesPodOperator(
+            namespace="default",
+            image="ubuntu:22.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo 12"],
+            name="test",
+            task_id="task",
+            do_xcom_push=False,
+            reattach_on_restart=False,
+            on_finish_action=on_finish_action,
+        )
+        context = create_context(k)
+        pod_1 = k.get_or_create_pod(pod_request_obj=k.build_pod_request_obj(context), context=context)
+        pod_2 = k.get_or_create_pod(pod_request_obj=k.build_pod_request_obj(context), context=context)
+
+        pod_1.status = {"start_time": now}
+        pod_2.status = {"start_time": now + datetime.timedelta(seconds=60)}
+        pod_2.metadata.labels.update({"try_number": "2"})
+
+        result = k.process_duplicate_label_pods([pod_1, pod_2])
+
+        patch_already_checked_mock.assert_called_once_with(pod_1, reraise=False)
+        process_pod_deletion_mock.assert_not_called()
+        assert result.metadata.name == pod_2.metadata.name
+
+    @patch(KUB_OP_PATH.format("patch_already_checked"))
+    @patch(KUB_OP_PATH.format("process_pod_deletion"))
+    def test_process_duplicate_label_pods__pod_removed_if_delete_pod(
+        self, process_pod_deletion_mock, patch_already_checked_mock
+    ):
+        now = datetime.datetime.now()
+        k = KubernetesPodOperator(
+            namespace="default",
+            image="ubuntu:22.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo 12"],
+            name="test",
+            task_id="task",
+            do_xcom_push=False,
+            reattach_on_restart=False,
+            on_finish_action=OnFinishAction.DELETE_POD,
+        )
+        context = create_context(k)
+        pod_1 = k.get_or_create_pod(pod_request_obj=k.build_pod_request_obj(context), context=context)
+        pod_2 = k.get_or_create_pod(pod_request_obj=k.build_pod_request_obj(context), context=context)
+
+        pod_1.status = {"start_time": now}
+        pod_2.status = {"start_time": now + datetime.timedelta(seconds=60)}
+        pod_2.metadata.labels.update({"try_number": "2"})
+
+        result = k.process_duplicate_label_pods([pod_1, pod_2])
+
+        patch_already_checked_mock.assert_called_once_with(pod_1, reraise=False)
+        process_pod_deletion_mock.assert_called_once_with(pod_1)
+        assert result.metadata.name == pod_2.metadata.name
 
 
 class TestSuppress:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Prevent **KubernetesPodOperator**  from raising an exception in a rare scenario, wherein the task is running in the sync mode with parameter `reattach_on_restart` equal to *False*, and the first task attempt fails because the task process is killed externally by the Kubernetes cluster or another process.

If the task is killed externally, it breaks the execution flow (including any try/except blocks) and immediately exists the task, resulting in a situation where the pod created for the first task run try is not properly deleted / updated, and consequently in the pod number exception, which will repeat in the next task tries until the dag will fail completely.

**Behavior before the fix**:
1. `KubernetesPodOperator` starts a new task.
2. A k8s pod is created to process the task.
3.  For some reason the task in the pod is killed externally and exits with some code (-9 for example).
4. Since the `reattach_on_restart` parameter is set to False, the operator does not try to restart the task in the same pod for the next attempt, and tries to create a new one while the original pod still exists with the same labels.
5. The new pod is created. 
6. Before continuing the task, `KubernetesPodOperator` tries to find the pod using the pod labels stored in the task context. 
7. 2 pods with such labels are found, resulting in the exception (*"More than one pod running with labels"*).
8. The exception continues to be raised on the next tries.

**Behavior after the fix**:
1-6. Same behavior.
7. 2 pods with such labels are found.
9. If `reattach_on_restart` is False, then we loop through the pods and pick the one that was created last and assign it to be used for the next attempt.  
10.  We will update the labels of the previous pod and, depending on the value of the `on_finish_action` parameter, either keep or remove it.
11. The task will continue without the exception.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
