### PR TITLE
Use `upload_files_v2` Slack SDK method by default in Slack Operators

### DIFF
--- a/airflow/providers/slack/CHANGELOG.rst
+++ b/airflow/providers/slack/CHANGELOG.rst
@@ -27,6 +27,23 @@
 Changelog
 ---------
 
+.. note::
+  Due to future discontinue of `files.upload <https://api.slack.com/changelog/2024-04-a-better-way-to-upload-files-is-here-to-stay>`__
+  Slack API method the default value of ``SlackAPIFileOperator.method_version`` and ``SqlToSlackApiFileOperator.slack_method_version``
+  changed from ``v1`` to ``v2``
+
+  If you previously use ``v1`` you should check that your application has appropriate scopes:
+
+  * **files:write** - for write files.
+  * **files:read** - for read files (not required if you use Slack SDK >= 3.23.0).
+  * **channels:read** - get list of public channels, for convert Channel Name to Channel ID.
+  * **groups:read** - get list of private channels, for convert Channel Name to Channel ID
+  * **mpim:read** - additional permission for API method **conversations.list**
+  * **im:read** - additional permission for API method **conversations.list**
+
+  If you use ``SlackHook.send_file`` please consider switch to ``SlackHook.send_file_v2``
+  or ``SlackHook.send_file_v1_to_v2`` methods.
+
 8.6.2
 .....
 

--- a/airflow/providers/slack/hooks/slack.py
+++ b/airflow/providers/slack/hooks/slack.py
@@ -23,11 +23,12 @@ from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Sequence, TypedDict
 
+from deprecated import deprecated
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 from typing_extensions import NotRequired
 
-from airflow.exceptions import AirflowNotFoundException
+from airflow.exceptions import AirflowNotFoundException, AirflowProviderDeprecationWarning
 from airflow.hooks.base import BaseHook
 from airflow.providers.slack.utils import ConnectionExtraConfig
 from airflow.utils.helpers import exactly_one
@@ -184,6 +185,14 @@ class SlackHook(BaseHook):
         """
         return self.client.api_call(api_method, **kwargs)
 
+    @deprecated(
+        reason=(
+            "This method utilise `files.upload` Slack API method which is being sunset on March 11, 2025. "
+            "Beginning May 8, 2024, newly-created apps will be unable to 'files.upload' Slack API. "
+            "Please use `send_file_v2` or `send_file_v1_to_v2` instead."
+        ),
+        category=AirflowProviderDeprecationWarning,
+    )
     def send_file(
         self,
         *,

--- a/airflow/providers/slack/operators/slack.py
+++ b/airflow/providers/slack/operators/slack.py
@@ -226,7 +226,7 @@ class SlackAPIFileOperator(SlackAPIOperator):
         filetype: str | None = None,
         content: str | None = None,
         title: str | None = None,
-        method_version: Literal["v1", "v2"] = "v1",
+        method_version: Literal["v1", "v2"] = "v2",
         channel: str | Sequence[str] | None | ArgNotSet = NOTSET,
         **kwargs,
     ) -> None:

--- a/airflow/providers/slack/transfers/sql_to_slack.py
+++ b/airflow/providers/slack/transfers/sql_to_slack.py
@@ -90,7 +90,7 @@ class SqlToSlackApiFileOperator(BaseSqlToSlackOperator):
         slack_initial_comment: str | None = None,
         slack_title: str | None = None,
         slack_base_url: str | None = None,
-        slack_method_version: Literal["v1", "v2"] = "v1",
+        slack_method_version: Literal["v1", "v2"] = "v2",
         df_kwargs: dict | None = None,
         action_on_empty_df: Literal["send", "skip", "error"] = "send",
         **kwargs,

--- a/docs/apache-airflow-providers-slack/operators/slack_api.rst
+++ b/docs/apache-airflow-providers-slack/operators/slack_api.rst
@@ -60,9 +60,12 @@ Using the Operator
 
 .. note::
     Operator supports two methods for upload files, which controlled by ``method_version``,
-    by default it use Slack SDK method ``upload_files`` however this might impact a performance and cause random API errors.
-    It is recommended to switch to Slack SDK method ``upload_files_v2`` by set ``v2`` to ``method_version``,
-    however this action required to add additional scope to your application:
+    by default it use Slack SDK method ``upload_files_v2`` it is possible to use legacy ``upload_files``
+    method by set ``v1`` to ``method_version`` however this not recommended because it
+    might impact a performance, cause random API errors and is being sunset on March 11, 2025 in addition
+    beginning May 8, 2024, newly-created apps will be unable to use this API method.
+
+    If you previously use ``v1`` you should check that your application has appropriate scopes:
 
     * **files:write** - for write files.
     * **files:read** - for read files (not required if you use Slack SDK >= 3.23.0).
@@ -74,6 +77,7 @@ Using the Operator
     .. seealso::
         - `Slack SDK 3.19.0 Release Notes <https://github.com/slackapi/python-slack-sdk/releases/tag/v3.19.0>`_
         - `conversations.list API <https://api.slack.com/methods/conversations.list>`_
+        - `files.upload retires in March 2025 <https://api.slack.com/changelog/2024-04-a-better-way-to-upload-files-is-here-to-stay>`_
 
 You could send file attachment by specifying file path
 

--- a/docs/apache-airflow-providers-slack/operators/sql_to_slack.rst
+++ b/docs/apache-airflow-providers-slack/operators/sql_to_slack.rst
@@ -28,9 +28,12 @@ Using the Operator
 
 .. note::
     Operator supports two methods for upload files, which controlled by ``slack_method_version``,
-    by default it use Slack SDK method ``upload_files`` however this might impact a performance and cause random API errors.
-    It is recommended to switch to Slack SDK method ``upload_files_v2`` by set ``v2`` to ``slack_method_version``,
-    however this action required to add additional scope to your application:
+    by default it use Slack SDK method ``upload_files_v2`` it is possible to use legacy ``upload_files``
+    method by set ``v1`` to ``slack_method_version`` however this not recommended because it
+    might impact a performance, cause random API errors and is being sunset on March 11, 2025 in addition
+    beginning May 8, 2024, newly-created apps will be unable to use this API method.
+
+    If you previously use ``v1`` you should check that your application has appropriate scopes:
 
     * **files:write** - for write files.
     * **files:read** - for read files (not required if you use Slack SDK >= 3.23.0).
@@ -42,7 +45,7 @@ Using the Operator
     .. seealso::
         - `Slack SDK 3.19.0 Release Notes <https://github.com/slackapi/python-slack-sdk/releases/tag/v3.19.0>`_
         - `conversations.list API <https://api.slack.com/methods/conversations.list>`_
-
+        - `files.upload retires in March 2025 <https://api.slack.com/changelog/2024-04-a-better-way-to-upload-files-is-here-to-stay>`_
 
 This operator will execute a custom query in the provided SQL connection and publish a file to Slack channel(s).
 

--- a/tests/providers/slack/hooks/test_slack.py
+++ b/tests/providers/slack/hooks/test_slack.py
@@ -26,7 +26,7 @@ from slack_sdk.errors import SlackApiError
 from slack_sdk.http_retry.builtin_handlers import ConnectionErrorRetryHandler, RateLimitErrorRetryHandler
 from slack_sdk.web.slack_response import SlackResponse
 
-from airflow.exceptions import AirflowNotFoundException
+from airflow.exceptions import AirflowNotFoundException, AirflowProviderDeprecationWarning
 from airflow.models.connection import Connection
 from airflow.providers.slack.hooks.slack import SlackHook
 
@@ -307,9 +307,11 @@ class TestSlackHook:
     )
     def test_send_file_wrong_parameters(self, file, content):
         hook = SlackHook(slack_conn_id=SLACK_API_DEFAULT_CONN_ID)
+        warning_message = "use `send_file_v2` or `send_file_v1_to_v2"
         error_message = r"Either `file` or `content` must be provided, not both\."
-        with pytest.raises(ValueError, match=error_message):
-            hook.send_file(file=file, content=content)
+        with pytest.warns(AirflowProviderDeprecationWarning, match=warning_message):
+            with pytest.raises(ValueError, match=error_message):
+                hook.send_file(file=file, content=content)
 
     @pytest.mark.parametrize("initial_comment", [None, "test comment"])
     @pytest.mark.parametrize("title", [None, "test title"])
@@ -324,14 +326,16 @@ class TestSlackHook:
         file.write_text('{"foo": "bar"}')
 
         hook = SlackHook(slack_conn_id=SLACK_API_DEFAULT_CONN_ID)
-        hook.send_file(
-            channels=channels,
-            file=file,
-            filename="filename.mock",
-            initial_comment=initial_comment,
-            title=title,
-            filetype=filetype,
-        )
+        warning_message = "use `send_file_v2` or `send_file_v1_to_v2"
+        with pytest.warns(AirflowProviderDeprecationWarning, match=warning_message):
+            hook.send_file(
+                channels=channels,
+                file=file,
+                filename="filename.mock",
+                initial_comment=initial_comment,
+                title=title,
+                filetype=filetype,
+            )
 
         mocked_client.files_upload.assert_called_once_with(
             channels=channels,
@@ -355,7 +359,9 @@ class TestSlackHook:
         file.write_text('{"foo": "bar"}')
 
         hook = SlackHook(slack_conn_id=SLACK_API_DEFAULT_CONN_ID)
-        hook.send_file(file=file)
+        warning_message = "use `send_file_v2` or `send_file_v1_to_v2"
+        with pytest.warns(AirflowProviderDeprecationWarning, match=warning_message):
+            hook.send_file(file=file)
 
         assert mocked_client.files_upload.call_count == 1
         call_args = mocked_client.files_upload.call_args.kwargs
@@ -370,14 +376,16 @@ class TestSlackHook:
     def test_send_file_content(self, mocked_client, initial_comment, title, filetype, channels, filename):
         """Test send file by providing content."""
         hook = SlackHook(slack_conn_id=SLACK_API_DEFAULT_CONN_ID)
-        hook.send_file(
-            channels=channels,
-            content='{"foo": "bar"}',
-            filename=filename,
-            initial_comment=initial_comment,
-            title=title,
-            filetype=filetype,
-        )
+        warning_message = "use `send_file_v2` or `send_file_v1_to_v2"
+        with pytest.warns(AirflowProviderDeprecationWarning, match=warning_message):
+            hook.send_file(
+                channels=channels,
+                content='{"foo": "bar"}',
+                filename=filename,
+                initial_comment=initial_comment,
+                title=title,
+                filetype=filetype,
+            )
         mocked_client.files_upload.assert_called_once_with(
             channels=channels,
             content='{"foo": "bar"}',

--- a/tests/system/providers/slack/example_slack.py
+++ b/tests/system/providers/slack/example_slack.py
@@ -83,7 +83,6 @@ with DAG(
         task_id="slack_file_upload_2",
         channels=SLACK_CHANNEL,
         content="file content in txt",
-        method_version="v2",
     )
     # [END slack_api_file_operator_content_howto_guide]
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Couple days ago Slack sent auto message to my my email which informed me that ``files.upload`` discontinued soon

> Hello Andrey Anshin,
> 
> A workspace that you administer contains apps or integrations that recently used the [files.upload web API method](https://api.slack.com/methods/files.upload). We want to inform you about two important changes coming to support for the files.upload API.
>	
> **May 8, 2024**
> Newly created Slack apps will no longer be able to access the files.upload API. Existing applications will be able to continue using files.upload until support is discontinued.
>	
> **March 11, 2025**
> Support for the files.upload API for all apps will be discontinued.

Link for more details about upcoming changes: https://api.slack.com/changelog/2024-04-a-better-way-to-upload-files-is-here-to-stay

Recently we add support of `v2` method https://github.com/apache/airflow/pull/36757, and also add `SlackHook.send_file_v1_to_v2` for smooth transition between `v1` and `v2` which used in operators under the hood

So I would propose to switch by default to `v2`:
- Users who create Slack Apps after the **May 8, 2024** has not affected and could use Slack Operators which intends to send files into the slack
- Users who use Slack Apps which created before **May 8, 2024** should grant additional scopes for the application, no mandatory changes required in existed tasks

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
