### PR TITLE
Use correct prefixes for distribution packages in provider documentation

### DIFF
--- a/dev/breeze/src/airflow_breeze/templates/PROVIDER_INDEX_TEMPLATE.rst.jinja2
+++ b/dev/breeze/src/airflow_breeze/templates/PROVIDER_INDEX_TEMPLATE.rst.jinja2
@@ -94,8 +94,8 @@ Downloading official packages
 You can download officially released packages and verify their checksums and signatures from the
 `Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
 
-* `The {{ PACKAGE_PIP_NAME }} {{ RELEASE }}{{ VERSION_SUFFIX }} sdist package <https://downloads.apache.org/airflow/providers/{{ PACKAGE_PIP_NAME }}-{{ RELEASE }}{{ VERSION_SUFFIX }}.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/{{ PACKAGE_PIP_NAME }}-{{ RELEASE }}{{ VERSION_SUFFIX }}.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/{{ PACKAGE_PIP_NAME }}-{{ RELEASE }}{{ VERSION_SUFFIX }}.tar.gz.sha512>`__)
-* `The {{ PACKAGE_PIP_NAME }} {{ RELEASE }}{{ VERSION_SUFFIX }} wheel package <https://downloads.apache.org/airflow/providers/{{ PACKAGE_WHEEL_NAME }}-{{ RELEASE }}{{ VERSION_SUFFIX }}-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/{{ PACKAGE_WHEEL_NAME }}-{{ RELEASE }}{{ VERSION_SUFFIX }}-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/{{ PACKAGE_WHEEL_NAME }}-{{ RELEASE }}{{ VERSION_SUFFIX }}-py3-none-any.whl.sha512>`__)
+* `The {{ PACKAGE_PIP_NAME }} {{ RELEASE }}{{ VERSION_SUFFIX }} sdist package <https://downloads.apache.org/airflow/providers/{{ PACKAGE_DIST_PREFIX }}-{{ RELEASE }}{{ VERSION_SUFFIX }}.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/{{ PACKAGE_DIST_PREFIX }}-{{ RELEASE }}{{ VERSION_SUFFIX }}.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/{{ PACKAGE_DIST_PREFIX }}-{{ RELEASE }}{{ VERSION_SUFFIX }}.tar.gz.sha512>`__)
+* `The {{ PACKAGE_PIP_NAME }} {{ RELEASE }}{{ VERSION_SUFFIX }} wheel package <https://downloads.apache.org/airflow/providers/{{ PACKAGE_DIST_PREFIX }}-{{ RELEASE }}{{ VERSION_SUFFIX }}-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/{{ PACKAGE_DIST_PREFIX }}-{{ RELEASE }}{{ VERSION_SUFFIX }}-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/{{ PACKAGE_DIST_PREFIX }}-{{ RELEASE }}{{ VERSION_SUFFIX }}-py3-none-any.whl.sha512>`__)
 
 
 

--- a/dev/breeze/src/airflow_breeze/utils/packages.py
+++ b/dev/breeze/src/airflow_breeze/utils/packages.py
@@ -398,7 +398,7 @@ def get_pip_package_name(provider_id: str) -> str:
     return "apache-airflow-providers-" + provider_id.replace(".", "-")
 
 
-def get_wheel_package_name(provider_id: str) -> str:
+def get_dist_package_name_prefix(provider_id: str) -> str:
     """
     Returns Wheel package name prefix for the package id.
 
@@ -585,7 +585,7 @@ def get_provider_jinja_context(
     context: dict[str, Any] = {
         "PROVIDER_ID": provider_details.provider_id,
         "PACKAGE_PIP_NAME": get_pip_package_name(provider_details.provider_id),
-        "PACKAGE_WHEEL_NAME": get_wheel_package_name(provider_details.provider_id),
+        "PACKAGE_DIST_PREFIX": get_dist_package_name_prefix(provider_details.provider_id),
         "FULL_PACKAGE_NAME": provider_details.full_package_name,
         "RELEASE": current_release_version,
         "RELEASE_NO_LEADING_ZEROS": release_version_no_leading_zeros,

--- a/dev/breeze/tests/test_packages.py
+++ b/dev/breeze/tests/test_packages.py
@@ -29,6 +29,7 @@ from airflow_breeze.utils.packages import (
     find_matching_long_package_names,
     get_available_packages,
     get_cross_provider_dependent_packages,
+    get_dist_package_name_prefix,
     get_documentation_package_path,
     get_install_requirements,
     get_long_package_name,
@@ -44,7 +45,6 @@ from airflow_breeze.utils.packages import (
     get_source_package_path,
     get_suspended_provider_folders,
     get_suspended_provider_ids,
-    get_wheel_package_name,
     validate_provider_info_with_runtime_schema,
 )
 from airflow_breeze.utils.path_utils import AIRFLOW_PROVIDERS_ROOT, AIRFLOW_SOURCES_ROOT, DOCS_ROOT
@@ -336,14 +336,14 @@ def test_get_pip_package_name(provider_id: str, pip_package_name: str):
 
 
 @pytest.mark.parametrize(
-    "provider_id, wheel_package_name",
+    "provider_id, expected_package_name",
     [
         ("asana", "apache_airflow_providers_asana"),
         ("apache.hdfs", "apache_airflow_providers_apache_hdfs"),
     ],
 )
-def test_get_wheel_package_name(provider_id: str, wheel_package_name: str):
-    assert get_wheel_package_name(provider_id) == wheel_package_name
+def test_get_dist_package_name_prefix(provider_id: str, expected_package_name: str):
+    assert get_dist_package_name_prefix(provider_id) == expected_package_name
 
 
 @pytest.mark.parametrize(
@@ -481,7 +481,7 @@ def test_provider_jinja_context():
     expected = {
         "PROVIDER_ID": "amazon",
         "PACKAGE_PIP_NAME": "apache-airflow-providers-amazon",
-        "PACKAGE_WHEEL_NAME": "apache_airflow_providers_amazon",
+        "PACKAGE_DIST_PREFIX": "apache_airflow_providers_amazon",
         "FULL_PACKAGE_NAME": "airflow.providers.amazon",
         "RELEASE": version,
         "RELEASE_NO_LEADING_ZEROS": version,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Since we change build packages to hatch it also affects name of distribution packages,
previously it use `-` in sdist package prefix, however now it use `_` for both `sdist` and `wheel` distributions
- `apache_airflow_providers_apache_flink-1.3.0.dev0.tar.gz`
- `apache_airflow_providers_apache_flink-1.3.0.dev0-py3-none-any.whl`

More generic solution rather than: https://github.com/apache/airflow/pull/39305


diff after local run `breeze release-management prepare-provider-documentation apache.flink --reapply-templates-only`

```diff
124c124
< * `The apache-airflow-providers-apache-flink 1.3.0 sdist package <https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-flink-1.3.0.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-flink-1.3.0.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache-airflow-providers-apache-flink-1.3.0.tar.gz.sha512>`__)
---
> * `The apache-airflow-providers-apache-flink 1.3.0 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_flink-1.3.0.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_flink-1.3.0.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_flink-1.3.0.tar.gz.sha512>`__)
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
