### PR TITLE
Fix static file caching is disabled in Airflow Webserver.

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -120,7 +120,7 @@ def create_app(config=None, testing=False):
         )
         cookie_samesite_config = "Lax"
     flask_app.config["SESSION_COOKIE_SAMESITE"] = cookie_samesite_config
-    
+
     # Above Flask 2.0.x, default value of SEND_FILE_MAX_AGE_DEFAULT changed 12 hours to None.
     # for static file caching, it needs to set value explicitly.
     flask_app.config["SEND_FILE_MAX_AGE_DEFAULT"] = timedelta(seconds=43200)

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -120,7 +120,6 @@ def create_app(config=None, testing=False):
         )
         cookie_samesite_config = "Lax"
     flask_app.config["SESSION_COOKIE_SAMESITE"] = cookie_samesite_config
-    flask_app.config["SEND_FILE_MAX_AGE_DEFAULT"] = timedelta(seconds=43200)
     
     # Above Flask 2.0.x, default value of SEND_FILE_MAX_AGE_DEFAULT changed 12 hours to None.
     # for static file caching, it needs to set value explicitly.

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -120,6 +120,11 @@ def create_app(config=None, testing=False):
         )
         cookie_samesite_config = "Lax"
     flask_app.config["SESSION_COOKIE_SAMESITE"] = cookie_samesite_config
+    flask_app.config["SEND_FILE_MAX_AGE_DEFAULT"] = timedelta(seconds=43200)
+    
+    # Above Flask 2.0.x, default value of SEND_FILE_MAX_AGE_DEFAULT changed 12 hours to None.
+    # for static file caching, it needs to set value explicitly.
+    flask_app.config["SEND_FILE_MAX_AGE_DEFAULT"] = timedelta(seconds=43200)
 
     if config:
         flask_app.config.from_mapping(config)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
close #39344 

Above Airflow 2.3.0, webserver's static file caching is disabled because of major updated Flask's breaking change. In Flask 2.0.x, default value of `SEND_FILE_MAX_AGE_DEFAULT` is changed from 12 hours to None on that version.
`SEND_FILE_MAX_AGE_DEFAULT` affects `Expires` Field in HTTP response header.
if it is None, `Expires` Field in HTTP response header is removed.

this pr add `SEND_FILE_MAX_AGE_DEFAULT` config for Flask explicitly in `/airflow/www/app.py`.
It enables static file caching in Airflow webserver.

I checked Airflow configuration references and searched `SEND_FILE_MAX_AGE_DEFAULT` in Airflow codebase, but there's no way to enable static file caching for airflow webserver's Flask.

## Airflow 2.9.0: As-Is
<img width="960" alt="image" src="https://github.com/apache/airflow/assets/37045096/ecb58aca-93e9-483f-8e14-d0dc3ce3df6f">

## Airflow 2.9.0: To-Be (Caching Worked)
![290_with_caching](https://github.com/apache/airflow/assets/37045096/be05516e-31e4-4c2d-bf79-173ad28e0d58)

## Local test in /tests/www
![image](https://github.com/apache/airflow/assets/37045096/6e2e39d9-2e7e-458e-b870-6de99fbc7955)


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
