### PR TITLE
Refactor tests re sensor reschedule mode and try_number

### DIFF
--- a/tests/sensors/test_base.py
+++ b/tests/sensors/test_base.py
@@ -334,7 +334,7 @@ class TestBaseSensor:
         self._run(sensor)
         sensor_ti, dummy_ti = _get_tis()
         assert sensor_ti.state == State.SKIPPED
-        dummy_ti.state == State.NONE
+        assert dummy_ti.state == State.NONE
 
     def test_ok_with_reschedule_and_retry(self, make_sensor, time_machine, task_reschedules_for_ti, session):
         sensor, dr = make_sensor(

--- a/tests/sensors/test_base.py
+++ b/tests/sensors/test_base.py
@@ -356,8 +356,6 @@ class TestBaseSensor:
         # first poke returns False and task is re-scheduled
         date1 = timezone.utcnow()
         time_machine.move_to(date1, tick=False)
-        sensor_ti, dummy_ti = _get_tis()
-        session.commit()
         self._run(sensor)
         sensor_ti, dummy_ti = _get_tis()
         assert sensor_ti.state == State.UP_FOR_RESCHEDULE

--- a/tests/sensors/test_base.py
+++ b/tests/sensors/test_base.py
@@ -300,11 +300,6 @@ class TestBaseSensor:
         assert dummy_ti.state == State.NONE
         assert sensor_ti.state == State.NONE
 
-        # prepare for first run
-        sensor_ti.state = State.SCHEDULED
-
-        session.commit()
-
         self._run(sensor, session=session)
 
         sensor_ti, dummy_ti = _get_tis()

--- a/tests/sensors/test_base.py
+++ b/tests/sensors/test_base.py
@@ -284,62 +284,69 @@ class TestBaseSensor:
             if ti.task_id == DUMMY_OP:
                 assert ti.state == State.NONE
 
-    def test_fail_with_reschedule(self, make_sensor, time_machine):
+    def test_fail_with_reschedule(self, make_sensor, time_machine, session):
         sensor, dr = make_sensor(return_value=False, poke_interval=10, timeout=5, mode="reschedule")
+
+        def _get_tis():
+            tis = dr.get_task_instances(session=session)
+            yield next(x for x in tis if x.task_id == SENSOR_OP)
+            yield next(x for x in tis if x.task_id == DUMMY_OP)
 
         # first poke returns False and task is re-scheduled
         date1 = timezone.utcnow()
         time_machine.move_to(date1, tick=False)
-        self._run(sensor)
-        tis = dr.get_task_instances()
-        assert len(tis) == 2
-        for ti in tis:
-            if ti.task_id == SENSOR_OP:
-                assert ti.state == State.UP_FOR_RESCHEDULE
-            if ti.task_id == DUMMY_OP:
-                assert ti.state == State.NONE
+
+        sensor_ti, dummy_ti = _get_tis()
+        assert dummy_ti.state == State.NONE
+        assert sensor_ti.state == State.NONE
+
+        # prepare for first run
+        sensor_ti.state = State.SCHEDULED
+
+        session.commit()
+
+        self._run(sensor, session=session)
+
+        sensor_ti, dummy_ti = _get_tis()
+        assert sensor_ti.state == State.UP_FOR_RESCHEDULE
+        assert dummy_ti.state == State.NONE
 
         # second poke returns False, timeout occurs
         time_machine.coordinates.shift(sensor.poke_interval)
-        with pytest.raises(AirflowSensorTimeout):
-            self._run(sensor)
-        tis = dr.get_task_instances()
-        assert len(tis) == 2
-        for ti in tis:
-            if ti.task_id == SENSOR_OP:
-                assert ti.state == State.FAILED
-            if ti.task_id == DUMMY_OP:
-                assert ti.state == State.NONE
 
-    def test_soft_fail_with_reschedule(self, make_sensor, time_machine):
+        with pytest.raises(AirflowSensorTimeout):
+            self._run(sensor, session=session)
+
+        sensor_ti, dummy_ti = _get_tis()
+        assert sensor_ti.state == State.FAILED
+        assert dummy_ti.state == State.NONE
+
+    def test_soft_fail_with_reschedule(self, make_sensor, time_machine, session):
         sensor, dr = make_sensor(
             return_value=False, poke_interval=10, timeout=5, soft_fail=True, mode="reschedule"
         )
 
+        def _get_tis():
+            tis = dr.get_task_instances(session=session)
+            yield next(x for x in tis if x.task_id == SENSOR_OP)
+            yield next(x for x in tis if x.task_id == DUMMY_OP)
+
         # first poke returns False and task is re-scheduled
         date1 = timezone.utcnow()
         time_machine.move_to(date1, tick=False)
         self._run(sensor)
-        tis = dr.get_task_instances()
-        assert len(tis) == 2
-        for ti in tis:
-            if ti.task_id == SENSOR_OP:
-                assert ti.state == State.UP_FOR_RESCHEDULE
-            if ti.task_id == DUMMY_OP:
-                assert ti.state == State.NONE
+        sensor_ti, dummy_ti = _get_tis()
+        assert sensor_ti.state == State.UP_FOR_RESCHEDULE
+        assert dummy_ti.state == State.NONE
 
         # second poke returns False, timeout occurs
         time_machine.coordinates.shift(sensor.poke_interval)
         self._run(sensor)
-        tis = dr.get_task_instances()
-        assert len(tis) == 2
-        for ti in tis:
-            if ti.task_id == SENSOR_OP:
-                assert ti.state == State.SKIPPED
-            if ti.task_id == DUMMY_OP:
-                assert ti.state == State.NONE
+        sensor_ti, dummy_ti = _get_tis()
+        assert sensor_ti.state == State.SKIPPED
+        dummy_ti.state == State.NONE
 
-    def test_ok_with_reschedule_and_retry(self, make_sensor, time_machine, task_reschedules_for_ti):
+    def test_ok_with_reschedule_and_retry(self, make_sensor, time_machine, task_reschedules_for_ti, session):
         sensor, dr = make_sensor(
             return_value=None,
             poke_interval=10,
@@ -348,71 +355,67 @@ class TestBaseSensor:
             retry_delay=timedelta(seconds=10),
             mode="reschedule",
         )
+
+        def _get_tis():
+            tis = dr.get_task_instances(session=session)
+            yield next(x for x in tis if x.task_id == SENSOR_OP)
+            yield next(x for x in tis if x.task_id == DUMMY_OP)
+
         sensor.poke = Mock(side_effect=[False, False, False, True])
 
         # first poke returns False and task is re-scheduled
         date1 = timezone.utcnow()
         time_machine.move_to(date1, tick=False)
+        sensor_ti, dummy_ti = _get_tis()
+        session.commit()
         self._run(sensor)
-        tis = dr.get_task_instances()
-        assert len(tis) == 2
-        for ti in tis:
-            if ti.task_id == SENSOR_OP:
-                assert ti.state == State.UP_FOR_RESCHEDULE
-                # verify one row in task_reschedule table
-                task_reschedules = task_reschedules_for_ti(ti)
-                assert len(task_reschedules) == 1
-                assert task_reschedules[0].start_date == date1
-                assert task_reschedules[0].reschedule_date == date1 + timedelta(seconds=sensor.poke_interval)
-                assert task_reschedules[0].try_number == 1
-            if ti.task_id == DUMMY_OP:
-                assert ti.state == State.NONE
+        sensor_ti, dummy_ti = _get_tis()
+        assert sensor_ti.state == State.UP_FOR_RESCHEDULE
+        # verify one row in task_reschedule table
+        task_reschedules = task_reschedules_for_ti(sensor_ti)
+        assert len(task_reschedules) == 1
+        assert task_reschedules[0].start_date == date1
+        assert task_reschedules[0].reschedule_date == date1 + timedelta(seconds=sensor.poke_interval)
+        assert task_reschedules[0].try_number == 1
+        assert dummy_ti.state == State.NONE
 
         # second poke timesout and task instance is failed
         time_machine.coordinates.shift(sensor.poke_interval)
         with pytest.raises(AirflowSensorTimeout):
             self._run(sensor)
-        tis = dr.get_task_instances()
-        assert len(tis) == 2
-        for ti in tis:
-            if ti.task_id == SENSOR_OP:
-                assert ti.state == State.FAILED
-            if ti.task_id == DUMMY_OP:
-                assert ti.state == State.NONE
+
+        sensor_ti, dummy_ti = _get_tis()
+        assert sensor_ti.state == State.FAILED
+        assert dummy_ti.state == State.NONE
 
         # Task is cleared
         sensor.clear()
+        sensor_ti, dummy_ti = _get_tis()
+        assert sensor_ti.try_number == 2
+        assert sensor_ti.max_tries == 2
 
         # third poke returns False and task is rescheduled again
         date3 = date1 + timedelta(seconds=sensor.poke_interval) * 2 + sensor.retry_delay
         time_machine.coordinates.shift(sensor.poke_interval + sensor.retry_delay.total_seconds())
         self._run(sensor)
-        tis = dr.get_task_instances()
-        assert len(tis) == 2
-        for ti in tis:
-            if ti.task_id == SENSOR_OP:
-                assert ti.state == State.UP_FOR_RESCHEDULE
-                # verify one row in task_reschedule table
-                task_reschedules = task_reschedules_for_ti(ti)
-                assert len(task_reschedules) == 1
-                assert task_reschedules[0].start_date == date3
-                assert task_reschedules[0].reschedule_date == date3 + timedelta(seconds=sensor.poke_interval)
-                assert task_reschedules[0].try_number == 2
-            if ti.task_id == DUMMY_OP:
-                assert ti.state == State.NONE
+        sensor_ti, dummy_ti = _get_tis()
+        assert sensor_ti.state == State.UP_FOR_RESCHEDULE
+        # verify one row in task_reschedule table
+        task_reschedules = task_reschedules_for_ti(sensor_ti)
+        assert len(task_reschedules) == 1
+        assert task_reschedules[0].start_date == date3
+        assert task_reschedules[0].reschedule_date == date3 + timedelta(seconds=sensor.poke_interval)
+        assert task_reschedules[0].try_number == 2
+        assert dummy_ti.state == State.NONE
 
         # fourth poke return True and task succeeds
 
         time_machine.coordinates.shift(sensor.poke_interval)
         self._run(sensor)
 
-        tis = dr.get_task_instances()
-        assert len(tis) == 2
-        for ti in tis:
-            if ti.task_id == SENSOR_OP:
-                assert ti.state == State.SUCCESS
-            if ti.task_id == DUMMY_OP:
-                assert ti.state == State.NONE
+        sensor_ti, dummy_ti = _get_tis()
+        assert sensor_ti.state == State.SUCCESS
+        assert dummy_ti.state == State.NONE
 
     @pytest.mark.parametrize("mode", ["poke", "reschedule"])
     def test_should_include_ready_to_reschedule_dep(self, mode):
@@ -652,7 +655,7 @@ class TestBaseSensor:
             "since it is over MySQL's TIMESTAMP storage limit."
         )
 
-    def test_reschedule_and_retry_timeout(self, make_sensor, time_machine):
+    def test_reschedule_and_retry_timeout(self, make_sensor, time_machine, session):
         """
         Test mode="reschedule", retries and timeout configurations interact correctly.
 
@@ -689,60 +692,72 @@ class TestBaseSensor:
 
         sensor.poke = Mock(side_effect=[False, RuntimeError, False, False, False, False, False, False])
 
-        def assert_ti_state(try_number, max_tries, state):
-            tis = dr.get_task_instances()
-
-            assert len(tis) == 2
-
-            for ti in tis:
-                if ti.task_id == SENSOR_OP:
-                    assert ti.try_number == try_number
-                    assert ti.max_tries == max_tries
-                    assert ti.state == state
-                    break
-            else:
-                self.fail("sensor not found")
+        def _get_sensor_ti():
+            tis = dr.get_task_instances(session=session)
+            return next(x for x in tis if x.task_id == SENSOR_OP)
 
         # first poke returns False and task is re-scheduled
         date1 = timezone.utcnow()
         time_machine.move_to(date1, tick=False)
         self._run(sensor)
-        assert_ti_state(1, 2, State.UP_FOR_RESCHEDULE)
+        sensor_ti = _get_sensor_ti()
+        assert sensor_ti.try_number == 1
+        assert sensor_ti.max_tries == 2
+        assert sensor_ti.state == State.UP_FOR_RESCHEDULE
 
         # second poke raises RuntimeError and task instance retries
         time_machine.coordinates.shift(sensor.poke_interval)
         with pytest.raises(RuntimeError):
             self._run(sensor)
-        assert_ti_state(2, 2, State.UP_FOR_RETRY)
+        sensor_ti = _get_sensor_ti()
+        assert sensor_ti.try_number == 2
+        assert sensor_ti.max_tries == 2
+        assert sensor_ti.state == State.UP_FOR_RETRY
 
         # third poke returns False and task is rescheduled again
         time_machine.coordinates.shift(sensor.retry_delay + timedelta(seconds=1))
         self._run(sensor)
-        assert_ti_state(2, 2, State.UP_FOR_RESCHEDULE)
+        sensor_ti = _get_sensor_ti()
+        assert sensor_ti.try_number == 2
+        assert sensor_ti.max_tries == 2
+        assert sensor_ti.state == State.UP_FOR_RESCHEDULE
 
         # fourth poke times out and raises AirflowSensorTimeout
         time_machine.coordinates.shift(sensor.poke_interval)
         with pytest.raises(AirflowSensorTimeout):
             self._run(sensor)
-        assert_ti_state(3, 2, State.FAILED)
+        sensor_ti = _get_sensor_ti()
+        assert sensor_ti.try_number == 3
+        assert sensor_ti.max_tries == 2
+        assert sensor_ti.state == State.FAILED
 
         # Clear the failed sensor
         sensor.clear()
+        sensor_ti = _get_sensor_ti()
+        assert sensor_ti.try_number == 3
+        assert sensor_ti.max_tries == 4
+        assert sensor_ti.state is None
 
         time_machine.coordinates.shift(20)
 
         for _ in range(3):
             time_machine.coordinates.shift(sensor.poke_interval)
             self._run(sensor)
-            assert_ti_state(3, 4, State.UP_FOR_RESCHEDULE)
+            sensor_ti = _get_sensor_ti()
+            assert sensor_ti.try_number == 3
+            assert sensor_ti.max_tries == 4
+            assert sensor_ti.state == State.UP_FOR_RESCHEDULE
 
         # Last poke times out and raises AirflowSensorTimeout
         time_machine.coordinates.shift(sensor.poke_interval)
         with pytest.raises(AirflowSensorTimeout):
             self._run(sensor)
-        assert_ti_state(4, 4, State.FAILED)
+        sensor_ti = _get_sensor_ti()
+        assert sensor_ti.try_number == 4
+        assert sensor_ti.max_tries == 4
+        assert sensor_ti.state == State.FAILED
 
-    def test_reschedule_and_retry_timeout_and_silent_fail(self, make_sensor, time_machine):
+    def test_reschedule_and_retry_timeout_and_silent_fail(self, make_sensor, time_machine, session):
         """
         Test mode="reschedule", silent_fail=True then retries and timeout configurations interact correctly.
 
@@ -779,59 +794,71 @@ class TestBaseSensor:
             silent_fail=True,
         )
 
+        def _get_sensor_ti():
+            tis = dr.get_task_instances(session=session)
+            return next(x for x in tis if x.task_id == SENSOR_OP)
+
         sensor.poke = Mock(side_effect=[False, RuntimeError, False, False, False, False, False, False])
-
-        def assert_ti_state(try_number, max_tries, state):
-            tis = dr.get_task_instances()
-
-            assert len(tis) == 2
-
-            for ti in tis:
-                if ti.task_id == SENSOR_OP:
-                    assert ti.try_number == try_number
-                    assert ti.max_tries == max_tries
-                    assert ti.state == state
-                    break
-            else:
-                self.fail("sensor not found")
 
         # first poke returns False and task is re-scheduled
         date1 = timezone.utcnow()
         time_machine.move_to(date1, tick=False)
         self._run(sensor)
-        assert_ti_state(1, 2, State.UP_FOR_RESCHEDULE)
+        sensor_ti = _get_sensor_ti()
+        assert sensor_ti.try_number == 1
+        assert sensor_ti.max_tries == 2
+        assert sensor_ti.state == State.UP_FOR_RESCHEDULE
 
         # second poke raises RuntimeError and task instance is re-scheduled again
         time_machine.coordinates.shift(sensor.poke_interval)
         self._run(sensor)
-        assert_ti_state(1, 2, State.UP_FOR_RESCHEDULE)
+        sensor_ti = _get_sensor_ti()
+        assert sensor_ti.try_number == 1
+        assert sensor_ti.max_tries == 2
+        assert sensor_ti.state == State.UP_FOR_RESCHEDULE
 
         # third poke returns False and task is rescheduled again
         time_machine.coordinates.shift(sensor.retry_delay + timedelta(seconds=1))
         self._run(sensor)
-        assert_ti_state(1, 2, State.UP_FOR_RESCHEDULE)
+        sensor_ti = _get_sensor_ti()
+        assert sensor_ti.try_number == 1
+        assert sensor_ti.max_tries == 2
+        assert sensor_ti.state == State.UP_FOR_RESCHEDULE
 
         # fourth poke times out and raises AirflowSensorTimeout
         time_machine.coordinates.shift(sensor.poke_interval)
         with pytest.raises(AirflowSensorTimeout):
             self._run(sensor)
-        assert_ti_state(2, 2, State.FAILED)
+        sensor_ti = _get_sensor_ti()
+        assert sensor_ti.try_number == 2
+        assert sensor_ti.max_tries == 2
+        assert sensor_ti.state == State.FAILED
 
         # Clear the failed sensor
         sensor.clear()
+        sensor_ti = _get_sensor_ti()
+        assert sensor_ti.try_number == 2
+        assert sensor_ti.max_tries == 3
+        assert sensor_ti.state == State.NONE
 
         time_machine.coordinates.shift(20)
 
         for _ in range(3):
             time_machine.coordinates.shift(sensor.poke_interval)
             self._run(sensor)
-            assert_ti_state(2, 3, State.UP_FOR_RESCHEDULE)
+            sensor_ti = _get_sensor_ti()
+            assert sensor_ti.try_number == 2
+            assert sensor_ti.max_tries == 3
+            assert sensor_ti.state == State.UP_FOR_RESCHEDULE
 
         # Last poke times out and raises AirflowSensorTimeout
         time_machine.coordinates.shift(sensor.poke_interval)
         with pytest.raises(AirflowSensorTimeout):
             self._run(sensor)
-        assert_ti_state(3, 3, State.FAILED)
+        sensor_ti = _get_sensor_ti()
+        assert sensor_ti.try_number == 3
+        assert sensor_ti.max_tries == 3
+        assert sensor_ti.state == State.FAILED
 
     def test_sensor_with_xcom(self, make_sensor):
         xcom_value = "TestValue"

--- a/tests/sensors/test_base.py
+++ b/tests/sensors/test_base.py
@@ -296,12 +296,7 @@ class TestBaseSensor:
         date1 = timezone.utcnow()
         time_machine.move_to(date1, tick=False)
 
-        sensor_ti, dummy_ti = _get_tis()
-        assert dummy_ti.state == State.NONE
-        assert sensor_ti.state == State.NONE
-
         self._run(sensor, session=session)
-
         sensor_ti, dummy_ti = _get_tis()
         assert sensor_ti.state == State.UP_FOR_RESCHEDULE
         assert dummy_ti.state == State.NONE

--- a/tests/sensors/test_base.py
+++ b/tests/sensors/test_base.py
@@ -289,6 +289,7 @@ class TestBaseSensor:
 
         def _get_tis():
             tis = dr.get_task_instances(session=session)
+            assert len(tis) == 2
             yield next(x for x in tis if x.task_id == SENSOR_OP)
             yield next(x for x in tis if x.task_id == DUMMY_OP)
 
@@ -318,6 +319,7 @@ class TestBaseSensor:
 
         def _get_tis():
             tis = dr.get_task_instances(session=session)
+            assert len(tis) == 2
             yield next(x for x in tis if x.task_id == SENSOR_OP)
             yield next(x for x in tis if x.task_id == DUMMY_OP)
 
@@ -348,6 +350,7 @@ class TestBaseSensor:
 
         def _get_tis():
             tis = dr.get_task_instances(session=session)
+            assert len(tis) == 2
             yield next(x for x in tis if x.task_id == SENSOR_OP)
             yield next(x for x in tis if x.task_id == DUMMY_OP)
 


### PR DESCRIPTION
It's a little clearer what's going on when we're not in a loop or behind an `assert...` helper function.

Additionally I add asserts immediately after calling `clear`.

This will make it easier to review changes when we attempt to fix try_number shenanigans.
