### PR TITLE
Simplify action name retrieval in FAB auth manager

### DIFF
--- a/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -272,10 +272,7 @@ class FabAuthManager(BaseAuthManager):
     ):
         if not user:
             user = self.get_user()
-        if method in get_fab_action_from_method_map():
-            fab_action_name = get_fab_action_from_method_map()[method]
-        else:
-            fab_action_name = method
+        fab_action_name = get_fab_action_from_method_map().get(method, method)
         return (fab_action_name, resource_name) in self._get_user_permissions(user)
 
     @provide_session


### PR DESCRIPTION
@vincbeck I was looking at the recent changes for custom actions and noticed this can be simplified.