### PR TITLE
Remove FAB test side effects

### DIFF
--- a/tests/providers/fab/auth_manager/api_endpoints/test_user_endpoint.py
+++ b/tests/providers/fab/auth_manager/api_endpoints/test_user_endpoint.py
@@ -26,7 +26,7 @@ from airflow.providers.fab.auth_manager.models import User
 from airflow.security import permissions
 from airflow.utils import timezone
 from airflow.utils.session import create_session
-from tests.test_utils.api_connexion_utils import assert_401, create_user, delete_user
+from tests.test_utils.api_connexion_utils import assert_401, create_user, delete_role, delete_user
 from tests.test_utils.config import conf_vars
 
 pytestmark = pytest.mark.db_test
@@ -54,6 +54,7 @@ def configured_app(minimal_app_for_auth_api):
 
     delete_user(app, username="test")  # type: ignore
     delete_user(app, username="test_no_permissions")  # type: ignore
+    delete_role(app, name="TestNoPermissions")
 
 
 class TestUserEndpoint:

--- a/tests/providers/fab/auth_manager/cli_commands/test_role_command.py
+++ b/tests/providers/fab/auth_manager/cli_commands/test_role_command.py
@@ -44,18 +44,18 @@ class TestCliRoles:
         self.parser = cli_parser.get_parser()
         with get_application_builder() as appbuilder:
             self.appbuilder = appbuilder
-            self.clear_roles_and_roles()
+            self.clear_users_and_roles()
             yield
-            self.clear_roles_and_roles()
+            self.clear_users_and_roles()
 
-    def clear_roles_and_roles(self):
-        for email in [TEST_USER1_EMAIL, TEST_USER2_EMAIL]:
-            test_user = self.appbuilder.sm.find_user(email=email)
-            if test_user:
-                self.appbuilder.sm.del_register_user(test_user)
+    def clear_users_and_roles(self):
+        session = self.appbuilder.get_session
+        for user in self.appbuilder.sm.get_all_users():
+            session.delete(user)
         for role_name in ["FakeTeamA", "FakeTeamB", "FakeTeamC"]:
             if self.appbuilder.sm.find_role(role_name):
                 self.appbuilder.sm.delete_role(role_name)
+        session.commit()
 
     def test_cli_create_roles(self):
         assert self.appbuilder.sm.find_role("FakeTeamA") is None

--- a/tests/providers/fab/auth_manager/cli_commands/test_user_command.py
+++ b/tests/providers/fab/auth_manager/cli_commands/test_user_command.py
@@ -61,10 +61,10 @@ class TestCliUsers:
             self.clear_users()
 
     def clear_users(self):
-        for email in [TEST_USER1_EMAIL, TEST_USER2_EMAIL]:
-            test_user = self.appbuilder.sm.find_user(email=email)
-            if test_user:
-                self.appbuilder.sm.del_register_user(test_user)
+        session = self.appbuilder.get_session
+        for user in self.appbuilder.sm.get_all_users():
+            session.delete(user)
+        session.commit()
 
     def test_cli_create_user_random_password(self):
         args = self.parser.parse_args(

--- a/tests/providers/fab/auth_manager/views/test_permissions.py
+++ b/tests/providers/fab/auth_manager/views/test_permissions.py
@@ -21,7 +21,7 @@ import pytest
 
 from airflow.security import permissions
 from airflow.www import app as application
-from tests.test_utils.api_connexion_utils import create_user
+from tests.test_utils.api_connexion_utils import create_user, delete_user
 from tests.test_utils.www import client_with_login
 
 
@@ -32,7 +32,7 @@ def fab_app():
 
 @pytest.fixture(scope="module")
 def user_permissions_reader(fab_app):
-    return create_user(
+    yield create_user(
         fab_app,
         username="user_permissions",
         role_name="role_permissions",
@@ -43,6 +43,8 @@ def user_permissions_reader(fab_app):
             (permissions.ACTION_CAN_READ, permissions.RESOURCE_WEBSITE),
         ],
     )
+
+    delete_user(fab_app, "user_permissions")
 
 
 @pytest.fixture

--- a/tests/providers/fab/auth_manager/views/test_roles_list.py
+++ b/tests/providers/fab/auth_manager/views/test_roles_list.py
@@ -21,7 +21,7 @@ import pytest
 
 from airflow.security import permissions
 from airflow.www import app as application
-from tests.test_utils.api_connexion_utils import create_user
+from tests.test_utils.api_connexion_utils import create_user, delete_user
 from tests.test_utils.www import client_with_login
 
 
@@ -32,7 +32,7 @@ def fab_app():
 
 @pytest.fixture(scope="module")
 def user_roles_reader(fab_app):
-    return create_user(
+    yield create_user(
         fab_app,
         username="user_roles",
         role_name="role_roles",
@@ -41,6 +41,8 @@ def user_roles_reader(fab_app):
             (permissions.ACTION_CAN_READ, permissions.RESOURCE_WEBSITE),
         ],
     )
+
+    delete_user(fab_app, "user_roles")
 
 
 @pytest.fixture

--- a/tests/providers/fab/auth_manager/views/test_user.py
+++ b/tests/providers/fab/auth_manager/views/test_user.py
@@ -21,7 +21,7 @@ import pytest
 
 from airflow.security import permissions
 from airflow.www import app as application
-from tests.test_utils.api_connexion_utils import create_user
+from tests.test_utils.api_connexion_utils import create_user, delete_user
 from tests.test_utils.www import client_with_login
 
 
@@ -32,7 +32,7 @@ def fab_app():
 
 @pytest.fixture(scope="module")
 def user_user_reader(fab_app):
-    return create_user(
+    yield create_user(
         fab_app,
         username="user_user",
         role_name="role_user",
@@ -41,6 +41,8 @@ def user_user_reader(fab_app):
             (permissions.ACTION_CAN_READ, permissions.RESOURCE_WEBSITE),
         ],
     )
+
+    delete_user(fab_app, "user_user")
 
 
 @pytest.fixture

--- a/tests/providers/fab/auth_manager/views/test_user_edit.py
+++ b/tests/providers/fab/auth_manager/views/test_user_edit.py
@@ -21,7 +21,7 @@ import pytest
 
 from airflow.security import permissions
 from airflow.www import app as application
-from tests.test_utils.api_connexion_utils import create_user
+from tests.test_utils.api_connexion_utils import create_user, delete_user
 from tests.test_utils.www import client_with_login
 
 
@@ -32,7 +32,7 @@ def fab_app():
 
 @pytest.fixture(scope="module")
 def user_user_reader(fab_app):
-    return create_user(
+    yield create_user(
         fab_app,
         username="user_user",
         role_name="role_user",
@@ -41,6 +41,8 @@ def user_user_reader(fab_app):
             (permissions.ACTION_CAN_READ, permissions.RESOURCE_WEBSITE),
         ],
     )
+
+    delete_user(fab_app, "user_user")
 
 
 @pytest.fixture

--- a/tests/providers/fab/auth_manager/views/test_user_stats.py
+++ b/tests/providers/fab/auth_manager/views/test_user_stats.py
@@ -21,7 +21,7 @@ import pytest
 
 from airflow.security import permissions
 from airflow.www import app as application
-from tests.test_utils.api_connexion_utils import create_user
+from tests.test_utils.api_connexion_utils import create_user, delete_user
 from tests.test_utils.www import client_with_login
 
 
@@ -32,7 +32,7 @@ def fab_app():
 
 @pytest.fixture(scope="module")
 def user_user_stats_reader(fab_app):
-    return create_user(
+    yield create_user(
         fab_app,
         username="user_user_stats",
         role_name="role_user_stats",
@@ -41,6 +41,8 @@ def user_user_stats_reader(fab_app):
             (permissions.ACTION_CAN_READ, permissions.RESOURCE_WEBSITE),
         ],
     )
+
+    delete_user(fab_app, "user_user_stats")
 
 
 @pytest.fixture


### PR DESCRIPTION
These tests were leaving users around, which meant subsequent runs of the FAB tests would break.

I've also fixed one case where we left a role around, though this wasn't breaking other tests.