### PR TITLE
Add support for cancelling job when deferrable Databricks operator is killed

### DIFF
--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -511,6 +511,15 @@ class DatabricksHook(BaseDatabricksHook):
         json = {"run_id": run_id}
         self._do_api_call(CANCEL_RUN_ENDPOINT, json)
 
+    async def a_cancel_run(self, run_id: int) -> None:
+        """
+        Async version of `cancel_run`.
+
+        :param run_id: id of the run
+        """
+        json = {"run_id": run_id}
+        await self._a_do_api_call(CANCEL_RUN_ENDPOINT, json)
+
     def cancel_all_runs(self, job_id: int) -> None:
         """
         Cancel all active runs of a job asynchronously.

--- a/airflow/providers/databricks/triggers/databricks.py
+++ b/airflow/providers/databricks/triggers/databricks.py
@@ -86,7 +86,7 @@ class DatabricksExecutionTrigger(BaseTrigger):
                 "repair_run": self.repair_run,
             },
         )
-    
+
     @provide_session
     def get_task_instance(self, session: Session) -> TaskInstance:
         query = session.query(TaskInstance).filter(
@@ -105,7 +105,7 @@ class DatabricksExecutionTrigger(BaseTrigger):
                 self.task_instance.map_index,
             )
         return task_instance
-    
+
     def safe_to_cancel(self) -> bool:
         """
         Defermines whether it's safe to cancel the external job which is being executed by this trigger.
@@ -113,7 +113,7 @@ class DatabricksExecutionTrigger(BaseTrigger):
         This is to avoid the case that `asyncio.CancelledError` is called because the trigger itself is stopped
         In these cases, we should NOT cancel the external job.
         """
-        task_instance = self.get_task_instance()
+        task_instance = self.get_task_instance()  # type: ignore[call-arg]
         return task_instance.state != TaskInstanceState.DEFERRED
 
     async def run(self):

--- a/airflow/providers/databricks/triggers/databricks.py
+++ b/airflow/providers/databricks/triggers/databricks.py
@@ -108,7 +108,7 @@ class DatabricksExecutionTrigger(BaseTrigger):
 
     def safe_to_cancel(self) -> bool:
         """
-        Defermines whether it's safe to cancel the external job which is being executed by this trigger.
+        Determines whether it's safe to cancel the external job which is being executed by this trigger.
 
         This is to avoid the case that `asyncio.CancelledError` is called because the trigger itself is stopped
         In these cases, we should NOT cancel the external job.

--- a/tests/providers/databricks/triggers/test_databricks.py
+++ b/tests/providers/databricks/triggers/test_databricks.py
@@ -17,11 +17,10 @@
 # under the License.
 from __future__ import annotations
 
+import asyncio
 from unittest import mock
 
-import asyncio
 import pytest
-
 
 from airflow.models import Connection
 from airflow.providers.databricks.hooks.databricks import RunState


### PR DESCRIPTION
This pull request updates the behaviour of deferrable Databricks operators to handle manual terminations more gracefully when a Databricks operator running in deferrable mode is terminated (generally by a user manually restarting or failing a task).

To handle this scenario, we catch `asyncio.CancelledError` that's thrown, check if the job is in a non-terminal state and then proceed with cancelling it if it is. This takes a similar approach as other providers ([1], [2]) to gracefully terminate these jobs as the standard `on_kill` method on the operator doesn't work. 

Unlike other operators, an explicit `cancel_on_kill` input hasn't been added here, but happy to include a new parameter for the trigger based on feedback.

See https://github.com/apache/airflow/issues/36090 for the general issue around this.

[1] https://github.com/apache/airflow/pull/38912
[2] https://github.com/apache/airflow/blob/main/airflow/providers/google/cloud/triggers/dataproc.py#L125-L138

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
