### PR TITLE
Fix deprecated calls in `cncf.kubernetes` provider

### DIFF
--- a/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_utils.py
+++ b/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_utils.py
@@ -32,7 +32,7 @@ from airflow.providers.cncf.kubernetes.kube_client import get_kube_client
 from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import (
     annotations_for_logging_task_metadata,
     annotations_to_key,
-    create_pod_id,
+    create_unique_id,
 )
 from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -413,7 +413,7 @@ class AirflowKubernetesScheduler(LoggingMixin):
         pod = PodGenerator.construct_pod(
             namespace=self.namespace,
             scheduler_job_id=self.scheduler_job_id,
-            pod_id=create_pod_id(dag_id, task_id),
+            pod_id=create_unique_id(dag_id, task_id),
             dag_id=dag_id,
             task_id=task_id,
             kube_image=self.kube_config.kube_image,

--- a/airflow/providers/cncf/kubernetes/kubernetes_helper_functions.py
+++ b/airflow/providers/cncf/kubernetes/kubernetes_helper_functions.py
@@ -19,10 +19,10 @@ from __future__ import annotations
 import logging
 import secrets
 import string
-import warnings
 from typing import TYPE_CHECKING
 
 import pendulum
+from deprecated import deprecated
 from slugify import slugify
 
 from airflow.compat.functools import cache
@@ -59,6 +59,10 @@ def add_unique_suffix(*, name: str, rand_len: int = 8, max_len: int = POD_NAME_M
     return name[: max_len - len(suffix)].strip("-.") + suffix
 
 
+@deprecated(
+    reason="This function is deprecated. Please use `add_unique_suffix`",
+    category=AirflowProviderDeprecationWarning,
+)
 def add_pod_suffix(*, pod_name: str, rand_len: int = 8, max_len: int = POD_NAME_MAX_LENGTH) -> str:
     """Add random string to pod name while staying under max length.
 
@@ -67,14 +71,7 @@ def add_pod_suffix(*, pod_name: str, rand_len: int = 8, max_len: int = POD_NAME_
     :param max_len: maximum length of the pod name
     :meta private:
     """
-    warnings.warn(
-        "This function is deprecated. Please use `add_unique_suffix`.",
-        AirflowProviderDeprecationWarning,
-        stacklevel=2,
-    )
-
-    suffix = "-" + rand_str(rand_len)
-    return pod_name[: max_len - len(suffix)].strip("-.") + suffix
+    return add_unique_suffix(name=pod_name, rand_len=rand_len, max_len=max_len)
 
 
 def create_unique_id(
@@ -109,6 +106,10 @@ def create_unique_id(
         return base_name
 
 
+@deprecated(
+    reason="This function is deprecated. Please use `create_unique_id`.",
+    category=AirflowProviderDeprecationWarning,
+)
 def create_pod_id(
     dag_id: str | None = None,
     task_id: str | None = None,
@@ -125,26 +126,7 @@ def create_pod_id(
     :param unique: whether a random string suffix should be added
     :return: A valid identifier for a kubernetes pod name
     """
-    warnings.warn(
-        "This function is deprecated. Please use `create_unique_id`.",
-        AirflowProviderDeprecationWarning,
-        stacklevel=2,
-    )
-
-    if not (dag_id or task_id):
-        raise ValueError("Must supply either dag_id or task_id.")
-    name = ""
-    if dag_id:
-        name += dag_id
-    if task_id:
-        if name:
-            name += "-"
-        name += task_id
-    base_name = slugify(name, lowercase=True)[:max_length].strip(".-")
-    if unique:
-        return add_pod_suffix(pod_name=base_name, rand_len=8, max_len=max_length)
-    else:
-        return base_name
+    return create_unique_id(dag_id=dag_id, task_id=task_id, max_length=max_length, unique=unique)
 
 
 def annotations_to_key(annotations: dict[str, str]) -> TaskInstanceKey:

--- a/airflow/providers/cncf/kubernetes/pod_generator.py
+++ b/airflow/providers/cncf/kubernetes/pod_generator.py
@@ -45,7 +45,6 @@ from airflow.exceptions import (
 )
 from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import (
     POD_NAME_MAX_LENGTH,
-    add_pod_suffix,
     add_unique_suffix,
     rand_str,
 )
@@ -156,12 +155,15 @@ class PodGenerator:
         # Attach sidecar
         self.extract_xcom = extract_xcom
 
-    @deprecated(reason="This function is deprecated.", category=AirflowProviderDeprecationWarning)
+    @deprecated(
+        reason="This method is deprecated and will be removed in the future releases",
+        category=AirflowProviderDeprecationWarning,
+    )
     def gen_pod(self) -> k8s.V1Pod:
         """Generate pod."""
         result = self.ud_pod
 
-        result.metadata.name = add_pod_suffix(pod_name=result.metadata.name)
+        result.metadata.name = add_unique_suffix(name=result.metadata.name)
 
         if self.extract_xcom:
             result = self.add_xcom_sidecar(result)
@@ -210,8 +212,8 @@ class PodGenerator:
             return k8s_object
         elif isinstance(k8s_legacy_object, dict):
             warnings.warn(
-                "Using a dictionary for the executor_config is deprecated and will soon be removed."
-                'please use a `kubernetes.client.models.V1Pod` class with a "pod_override" key'
+                "Using a dictionary for the executor_config is deprecated and will soon be removed. "
+                'Please use a `kubernetes.client.models.V1Pod` class with a "pod_override" key'
                 " instead. ",
                 category=AirflowProviderDeprecationWarning,
                 stacklevel=2,
@@ -575,7 +577,7 @@ class PodGenerator:
 
     @staticmethod
     @deprecated(
-        reason="This function is deprecated. Use `add_pod_suffix` in `kubernetes_helper_functions`.",
+        reason="This method is deprecated. Use `add_pod_suffix` in `kubernetes_helper_functions`.",
         category=AirflowProviderDeprecationWarning,
     )
     def make_unique_pod_id(pod_id: str) -> str | None:
@@ -595,12 +597,6 @@ class PodGenerator:
         :param pod_id: requested pod name
         :return: ``str`` valid Pod name of appropriate length
         """
-        warnings.warn(
-            "This function is deprecated. Use `add_pod_suffix` in `kubernetes_helper_functions`.",
-            AirflowProviderDeprecationWarning,
-            stacklevel=2,
-        )
-
         if not pod_id:
             return None
 

--- a/airflow/providers/cncf/kubernetes/template_rendering.py
+++ b/airflow/providers/cncf/kubernetes/template_rendering.py
@@ -24,9 +24,7 @@ from kubernetes.client.api_client import ApiClient
 
 from airflow.exceptions import AirflowException
 from airflow.providers.cncf.kubernetes.kube_config import KubeConfig
-from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import (
-    create_pod_id,
-)
+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import create_unique_id
 from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
 from airflow.utils.session import NEW_SESSION, provide_session
 
@@ -43,7 +41,7 @@ def render_k8s_pod_yaml(task_instance: TaskInstance) -> dict | None:
         task_id=task_instance.task_id,
         map_index=task_instance.map_index,
         date=None,
-        pod_id=create_pod_id(task_instance.dag_id, task_instance.task_id),
+        pod_id=create_unique_id(task_instance.dag_id, task_instance.task_id),
         try_number=task_instance.try_number,
         kube_image=kube_config.kube_image,
         args=task_instance.command_as_list(),

--- a/tests/deprecations_ignore.yml
+++ b/tests/deprecations_ignore.yml
@@ -54,6 +54,7 @@
 
 
 # CLI
+# https://github.com/apache/airflow/issues/39199
 - tests/cli/commands/test_kubernetes_command.py::TestGenerateDagYamlCommand::test_generate_dag_yaml
 
 
@@ -456,34 +457,6 @@
 - tests/providers/atlassian/jira/operators/test_jira.py::TestJiraOperator::test_project_issue_count
 - tests/providers/atlassian/jira/operators/test_jira.py::TestJiraOperator::test_update_issue
 - tests/providers/atlassian/jira/sensors/test_jira.py::TestJiraSensor::test_issue_label_set
-- tests/providers/cncf/kubernetes/executors/test_kubernetes_executor.py::TestAirflowKubernetesScheduler::test_create_pod_id
-- tests/providers/cncf/kubernetes/executors/test_kubernetes_executor.py::TestKubernetesExecutor::test_pod_template_file_override_in_executor_config
-- tests/providers/cncf/kubernetes/executors/test_kubernetes_executor.py::TestKubernetesExecutor::test_run_next_exception_requeue
-- tests/providers/cncf/kubernetes/executors/test_kubernetes_executor.py::TestKubernetesExecutor::test_run_next_pmh_error
-- tests/providers/cncf/kubernetes/executors/test_kubernetes_executor.py::TestKubernetesExecutor::test_run_next_pod_reconciliation_error
-- tests/providers/cncf/kubernetes/operators/test_pod.py::TestKubernetesPodOperator::test_execute_async_callbacks
-- tests/providers/cncf/kubernetes/operators/test_pod.py::TestKubernetesPodOperator::test_mark_checked_if_not_deleted
-- tests/providers/cncf/kubernetes/operators/test_pod.py::TestKubernetesPodOperator::test_pod_delete_after_await_container_error
-- tests/providers/cncf/kubernetes/operators/test_pod.py::TestKubernetesPodOperatorAsync::test_async_create_pod_should_throw_exception
-- tests/providers/cncf/kubernetes/operators/test_pod.py::TestKubernetesPodOperatorAsync::test_async_create_pod_with_skip_on_exit_code_should_skip
-- tests/providers/cncf/kubernetes/operators/test_pod.py::TestKubernetesPodOperatorAsync::test_async_create_pod_xcom_push_should_execute_successfully
-- tests/providers/cncf/kubernetes/operators/test_pod.py::TestKubernetesPodOperatorAsync::test_async_get_logs_should_execute_successfully
-- tests/providers/cncf/kubernetes/operators/test_pod.py::TestKubernetesPodOperatorAsync::test_async_write_logs_should_execute_successfully
-- tests/providers/cncf/kubernetes/operators/test_pod.py::test_async_kpo_wait_termination_before_cleanup_on_failure
-- tests/providers/cncf/kubernetes/operators/test_pod.py::test_async_kpo_wait_termination_before_cleanup_on_success
-- tests/providers/cncf/kubernetes/operators/test_pod.py::test_async_skip_kpo_wait_termination_with_timeout_event
-- tests/providers/cncf/kubernetes/operators/test_spark_kubernetes.py::TestSparkKubernetesOperator::test_create_application_from_yaml_json
-- tests/providers/cncf/kubernetes/test_kubernetes_helper_functions.py::TestCreatePodId::test_create_pod_id
-- tests/providers/cncf/kubernetes/test_kubernetes_helper_functions.py::TestCreatePodId::test_create_pod_id_dag_and_task
-- tests/providers/cncf/kubernetes/test_kubernetes_helper_functions.py::TestCreatePodId::test_create_pod_id_dag_only
-- tests/providers/cncf/kubernetes/test_kubernetes_helper_functions.py::TestCreatePodId::test_create_pod_id_dag_too_long_non_unique
-- tests/providers/cncf/kubernetes/test_kubernetes_helper_functions.py::TestCreatePodId::test_create_pod_id_dag_too_long_with_suffix
-- tests/providers/cncf/kubernetes/test_kubernetes_helper_functions.py::TestCreatePodId::test_create_pod_id_task_only
-- tests/providers/cncf/kubernetes/test_pod_generator.py::TestPodGenerator::test_from_obj
-- tests/providers/cncf/kubernetes/test_pod_generator.py::TestPodGenerator::test_gen_pod_extract_xcom
-- tests/providers/cncf/kubernetes/test_pod_generator.py::TestPodGenerator::test_pod_name_confirm_to_max_length
-- tests/providers/cncf/kubernetes/test_pod_generator.py::TestPodGenerator::test_pod_name_is_valid
-- tests/providers/cncf/kubernetes/test_template_rendering.py::test_render_k8s_pod_yaml
 - tests/providers/common/sql/hooks/test_dbapi.py::TestDbApiHook::test_insert_rows_executemany
 - tests/providers/common/sql/hooks/test_dbapi.py::TestDbApiHook::test_insert_rows_replace_executemany_hana_dialect
 - tests/providers/common/sql/hooks/test_dbapi.py::TestDbApiHook::test_instance_check_works_for_legacy_db_api_hook

--- a/tests/providers/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/tests/providers/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -28,39 +28,35 @@ from kubernetes.client import models as k8s
 from kubernetes.client.rest import ApiException
 from urllib3 import HTTPResponse
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.models.taskinstancekey import TaskInstanceKey
 from airflow.operators.bash import BashOperator
 from airflow.operators.empty import EmptyOperator
+from airflow.providers.cncf.kubernetes import pod_generator
+from airflow.providers.cncf.kubernetes.executors.kubernetes_executor import (
+    KubernetesExecutor,
+    PodReconciliationError,
+)
+from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import (
+    ADOPTED,
+    POD_EXECUTOR_DONE_KEY,
+)
+from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils import (
+    AirflowKubernetesScheduler,
+    KubernetesJobWatcher,
+    ResourceVersion,
+    get_base_pod_from_template,
+)
+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import (
+    annotations_for_logging_task_metadata,
+    annotations_to_key,
+    create_unique_id,
+    get_logs_task_metadata,
+)
+from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
 from airflow.utils import timezone
 from airflow.utils.state import State, TaskInstanceState
 from tests.test_utils.config import conf_vars
-
-try:
-    from airflow.providers.cncf.kubernetes import pod_generator
-    from airflow.providers.cncf.kubernetes.executors.kubernetes_executor import (
-        KubernetesExecutor,
-        PodReconciliationError,
-    )
-    from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import (
-        ADOPTED,
-        POD_EXECUTOR_DONE_KEY,
-    )
-    from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils import (
-        AirflowKubernetesScheduler,
-        KubernetesJobWatcher,
-        ResourceVersion,
-        create_pod_id,
-        get_base_pod_from_template,
-    )
-    from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import (
-        annotations_for_logging_task_metadata,
-        annotations_to_key,
-        get_logs_task_metadata,
-    )
-    from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
-except ImportError:
-    AirflowKubernetesScheduler = None  # type: ignore
 
 
 class TestAirflowKubernetesScheduler:
@@ -100,17 +96,12 @@ class TestAirflowKubernetesScheduler:
         regex = r"^[^a-z0-9A-Z]*|[^a-zA-Z0-9_\-\.]|[^a-z0-9A-Z]*$"
         return len(value) <= 63 and re.match(regex, value)
 
-    @pytest.mark.skipif(
-        AirflowKubernetesScheduler is None, reason="kubernetes python package is not installed"
-    )
     def test_create_pod_id(self):
         for dag_id, task_id in self._cases():
-            pod_name = PodGenerator.make_unique_pod_id(create_pod_id(dag_id, task_id))
-            assert self._is_valid_pod_id(pod_name)
+            with pytest.warns(AirflowProviderDeprecationWarning, match=r"deprecated\. Use `add_pod_suffix`"):
+                pod_name = PodGenerator.make_unique_pod_id(create_unique_id(dag_id, task_id))
+            assert self._is_valid_pod_id(pod_name), f"dag_id={dag_id!r}, task_id={task_id!r}"
 
-    @pytest.mark.skipif(
-        AirflowKubernetesScheduler is None, reason="kubernetes python package is not installed"
-    )
     @mock.patch("airflow.providers.cncf.kubernetes.pod_generator.PodGenerator")
     @mock.patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor.KubeConfig")
     def test_get_base_pod_from_template(self, mock_kubeconfig, mock_generator, data_file):
@@ -144,14 +135,16 @@ class TestAirflowKubernetesScheduler:
 
     def test_make_safe_label_value(self):
         for dag_id, task_id in self._cases():
+            case = f"dag_id={dag_id!r}, task_id={task_id!r}"
             safe_dag_id = pod_generator.make_safe_label_value(dag_id)
-            assert self._is_safe_label_value(safe_dag_id)
+            assert self._is_safe_label_value(safe_dag_id), case
             safe_task_id = pod_generator.make_safe_label_value(task_id)
-            assert self._is_safe_label_value(safe_task_id)
-            dag_id = "my_dag_id"
-            assert dag_id == pod_generator.make_safe_label_value(dag_id)
-            dag_id = "my_dag_id_" + "a" * 64
-            assert "my_dag_id_" + "a" * 43 + "-0ce114c45" == pod_generator.make_safe_label_value(dag_id)
+            assert self._is_safe_label_value(safe_task_id), case
+
+        dag_id = "my_dag_id"
+        assert dag_id == pod_generator.make_safe_label_value(dag_id)
+        dag_id = "my_dag_id_" + "a" * 64
+        assert "my_dag_id_" + "a" * 43 + "-0ce114c45" == pod_generator.make_safe_label_value(dag_id)
 
     def test_execution_date_serialize_deserialize(self):
         datetime_obj = datetime.now()

--- a/tests/providers/cncf/kubernetes/operators/test_spark_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/operators/test_spark_kubernetes.py
@@ -192,10 +192,8 @@ def create_context(task):
 @patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.await_pod_start")
 @patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.create_pod")
 @patch("airflow.providers.cncf.kubernetes.operators.spark_kubernetes.SparkKubernetesOperator.client")
-@patch(
-    "airflow.providers.cncf.kubernetes.operators.spark_kubernetes.SparkKubernetesOperator.create_job_name"
-)  # , return_value='default')
-@patch("airflow.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperator.cleanup")
+@patch("airflow.providers.cncf.kubernetes.operators.spark_kubernetes.SparkKubernetesOperator.create_job_name")
+@patch("airflow.providers.cncf.kubernetes.operators.pod.KubernetesPodOperator.cleanup")
 @patch("kubernetes.client.api.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object_status")
 @patch("kubernetes.client.api.custom_objects_api.CustomObjectsApi.create_namespaced_custom_object")
 class TestSparkKubernetesOperator:

--- a/tests/providers/cncf/kubernetes/test_client.py
+++ b/tests/providers/cncf/kubernetes/test_client.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import socket
 from unittest import mock
 
+import pytest
 from kubernetes.client import Configuration
 from urllib3.connection import HTTPConnection, HTTPSConnection
 
@@ -61,6 +62,7 @@ class TestClient:
         conf.get.assert_called_with("kubernetes_executor", "ssl_ca_cert")
         assert client.api_client.configuration.ssl_ca_cert == "/path/to/ca.crt"
 
+    @pytest.mark.platform("linux")
     def test_enable_tcp_keepalive(self):
         socket_options = [
             (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),

--- a/tests/providers/cncf/kubernetes/test_kubernetes_helper_functions.py
+++ b/tests/providers/cncf/kubernetes/test_kubernetes_helper_functions.py
@@ -18,15 +18,17 @@
 from __future__ import annotations
 
 import re
+from unittest import mock
 
 import pytest
 
-from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import create_pod_id
+from airflow.exceptions import AirflowProviderDeprecationWarning
+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import create_pod_id, create_unique_id
 
 pod_name_regex = r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
 
 
-class TestCreatePodId:
+class TestCreateUniqueId:
     @pytest.mark.parametrize(
         "val, expected",
         [
@@ -40,7 +42,7 @@ class TestCreatePodId:
         ],
     )
     def test_create_pod_id_task_only(self, val, expected):
-        actual = create_pod_id(task_id=val, unique=False)
+        actual = create_unique_id(task_id=val, unique=False)
         assert actual == expected
         assert re.match(pod_name_regex, actual)
 
@@ -57,7 +59,7 @@ class TestCreatePodId:
         ],
     )
     def test_create_pod_id_dag_only(self, val, expected):
-        actual = create_pod_id(dag_id=val, unique=False)
+        actual = create_unique_id(dag_id=val, unique=False)
         assert actual == expected
         assert re.match(pod_name_regex, actual)
 
@@ -74,18 +76,18 @@ class TestCreatePodId:
         ],
     )
     def test_create_pod_id_dag_and_task(self, dag_id, task_id, expected):
-        actual = create_pod_id(dag_id=dag_id, task_id=task_id, unique=False)
+        actual = create_unique_id(dag_id=dag_id, task_id=task_id, unique=False)
         assert actual == expected
         assert re.match(pod_name_regex, actual)
 
     def test_create_pod_id_dag_too_long_with_suffix(self):
-        actual = create_pod_id("0" * 254)
+        actual = create_unique_id("0" * 254)
         assert len(actual) == 63
         assert re.match(r"0{54}-[a-z0-9]{8}", actual)
         assert re.match(pod_name_regex, actual)
 
     def test_create_pod_id_dag_too_long_non_unique(self):
-        actual = create_pod_id("0" * 254, unique=False)
+        actual = create_unique_id("0" * 254, unique=False)
         assert len(actual) == 63
         assert re.match(r"0{63}", actual)
         assert re.match(pod_name_regex, actual)
@@ -96,7 +98,7 @@ class TestCreatePodId:
         """Test behavior of max_length and unique."""
         dag_id = "dag-dag-dag-dag-dag-dag-dag-dag-dag-dag-dag-dag-dag-dag-dag-dag-"
         task_id = "task-task-task-task-task-task-task-task-task-task-task-task-task-task-task-task-task-"
-        actual = create_pod_id(
+        actual = create_unique_id(
             dag_id=dag_id,
             task_id=task_id,
             max_length=length,
@@ -108,3 +110,20 @@ class TestCreatePodId:
             assert re.match(r"-[a-z0-9]{8}", actual[-9:])
         else:
             assert actual == base[:length]
+
+    @pytest.mark.parametrize("dag_id", ["fake-dag", None])
+    @pytest.mark.parametrize("task_id", ["fake-task", None])
+    @pytest.mark.parametrize("max_length", [10, 42, None])
+    @pytest.mark.parametrize("unique", [True, False])
+    def test_back_compat_create_pod_id(self, dag_id, task_id, max_length, unique):
+        with mock.patch(
+            "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.create_unique_id"
+        ) as mocked_create_unique_id:
+            with pytest.warns(
+                AirflowProviderDeprecationWarning, match=r"deprecated. Please use `create_unique_id`"
+            ):
+                create_pod_id(dag_id, task_id, max_length=max_length, unique=unique)
+
+        mocked_create_unique_id.assert_called_once_with(
+            dag_id=dag_id, task_id=task_id, max_length=max_length, unique=unique
+        )

--- a/tests/providers/cncf/kubernetes/test_pod_generator.py
+++ b/tests/providers/cncf/kubernetes/test_pod_generator.py
@@ -26,7 +26,7 @@ from dateutil import parser
 from kubernetes.client import ApiClient, models as k8s
 
 from airflow import __version__
-from airflow.exceptions import AirflowConfigException
+from airflow.exceptions import AirflowConfigException, AirflowProviderDeprecationWarning
 from airflow.providers.cncf.kubernetes.executors.kubernetes_executor import PodReconciliationError
 from airflow.providers.cncf.kubernetes.pod_generator import (
     PodDefaultsDeprecated,
@@ -170,7 +170,8 @@ class TestPodGenerator:
         template_file = data_file("pods/generator_base_with_secrets.yaml").as_posix()
 
         pod_generator = PodGenerator(pod_template_file=template_file, extract_xcom=True)
-        result = pod_generator.gen_pod()
+        with pytest.warns(AirflowProviderDeprecationWarning, match="deprecated and will be removed"):
+            result = pod_generator.gen_pod()
         container_two = {
             "name": "airflow-xcom-sidecar",
             "image": "alpine",
@@ -194,37 +195,34 @@ class TestPodGenerator:
         expected_dict = self.k8s_client.sanitize_for_serialization(self.expected)
         assert result_dict == expected_dict
 
-    def test_from_obj(self):
-        result = PodGenerator.from_obj(
-            {
-                "pod_override": k8s.V1Pod(
-                    api_version="v1",
-                    kind="Pod",
-                    metadata=k8s.V1ObjectMeta(name="foo", annotations={"test": "annotation"}),
-                    spec=k8s.V1PodSpec(
-                        containers=[
-                            k8s.V1Container(
-                                name="base",
-                                volume_mounts=[
-                                    k8s.V1VolumeMount(
-                                        mount_path="/foo/", name="example-kubernetes-test-volume"
-                                    )
-                                ],
-                            )
-                        ],
-                        volumes=[
-                            k8s.V1Volume(
-                                name="example-kubernetes-test-volume",
-                                host_path=k8s.V1HostPathVolumeSource(path="/tmp/"),
-                            )
-                        ],
-                    ),
-                )
-            }
-        )
-        result = self.k8s_client.sanitize_for_serialization(result)
+    def test_from_obj_pod_override_object(self):
+        obj = {
+            "pod_override": k8s.V1Pod(
+                api_version="v1",
+                kind="Pod",
+                metadata=k8s.V1ObjectMeta(name="foo", annotations={"test": "annotation"}),
+                spec=k8s.V1PodSpec(
+                    containers=[
+                        k8s.V1Container(
+                            name="base",
+                            volume_mounts=[
+                                k8s.V1VolumeMount(mount_path="/foo/", name="example-kubernetes-test-volume")
+                            ],
+                        )
+                    ],
+                    volumes=[
+                        k8s.V1Volume(
+                            name="example-kubernetes-test-volume",
+                            host_path=k8s.V1HostPathVolumeSource(path="/tmp/"),
+                        )
+                    ],
+                ),
+            )
+        }
 
-        assert {
+        result = PodGenerator.from_obj(obj)
+
+        assert self.k8s_client.sanitize_for_serialization(result) == {
             "apiVersion": "v1",
             "kind": "Pod",
             "metadata": {
@@ -240,67 +238,33 @@ class TestPodGenerator:
                 ],
                 "volumes": [{"hostPath": {"path": "/tmp/"}, "name": "example-kubernetes-test-volume"}],
             },
-        } == result
-        result = PodGenerator.from_obj(
-            {
-                "KubernetesExecutor": {
-                    "annotations": {"test": "annotation"},
-                    "volumes": [
-                        {
-                            "name": "example-kubernetes-test-volume",
-                            "hostPath": {"path": "/tmp/"},
-                        },
-                    ],
-                    "volume_mounts": [
-                        {
-                            "mountPath": "/foo/",
-                            "name": "example-kubernetes-test-volume",
-                        },
-                    ],
-                }
-            }
-        )
-
-        result_from_pod = PodGenerator.from_obj(
-            {
-                "pod_override": k8s.V1Pod(
-                    metadata=k8s.V1ObjectMeta(annotations={"test": "annotation"}),
-                    spec=k8s.V1PodSpec(
-                        containers=[
-                            k8s.V1Container(
-                                name="base",
-                                volume_mounts=[
-                                    k8s.V1VolumeMount(
-                                        name="example-kubernetes-test-volume", mount_path="/foo/"
-                                    )
-                                ],
-                            )
-                        ],
-                        volumes=[k8s.V1Volume(name="example-kubernetes-test-volume", host_path="/tmp/")],
-                    ),
-                )
-            }
-        )
-
-        result = self.k8s_client.sanitize_for_serialization(result)
-        result_from_pod = self.k8s_client.sanitize_for_serialization(result_from_pod)
-        expected_from_pod = {
-            "metadata": {"annotations": {"test": "annotation"}},
-            "spec": {
-                "containers": [
-                    {
-                        "name": "base",
-                        "volumeMounts": [{"mountPath": "/foo/", "name": "example-kubernetes-test-volume"}],
-                    }
-                ],
-                "volumes": [{"hostPath": "/tmp/", "name": "example-kubernetes-test-volume"}],
-            },
         }
-        assert (
-            result_from_pod == expected_from_pod
-        ), "There was a discrepancy between KubernetesExecutor and pod_override"
 
-        assert {
+    def test_from_obj_legacy(self):
+        obj = {
+            "KubernetesExecutor": {
+                "annotations": {"test": "annotation"},
+                "volumes": [
+                    {
+                        "name": "example-kubernetes-test-volume",
+                        "hostPath": {"path": "/tmp/"},
+                    },
+                ],
+                "volume_mounts": [
+                    {
+                        "mountPath": "/foo/",
+                        "name": "example-kubernetes-test-volume",
+                    },
+                ],
+            }
+        }
+        with pytest.warns(
+            AirflowProviderDeprecationWarning,
+            match="Using a dictionary for the executor_config is deprecated and will soon be removed",
+        ):
+            result = PodGenerator.from_obj(obj)
+
+        assert self.k8s_client.sanitize_for_serialization(result) == {
             "apiVersion": "v1",
             "kind": "Pod",
             "metadata": {
@@ -322,7 +286,32 @@ class TestPodGenerator:
                 "imagePullSecrets": [],
                 "volumes": [{"hostPath": {"path": "/tmp/"}, "name": "example-kubernetes-test-volume"}],
             },
-        } == result
+        }
+
+    def test_from_obj_both(self):
+        obj = {
+            "pod_override": k8s.V1Pod(
+                api_version="v1",
+                kind="Pod",
+            ),
+            "KubernetesExecutor": {
+                "annotations": {"test": "annotation"},
+                "volumes": [
+                    {
+                        "name": "example-kubernetes-test-volume",
+                        "hostPath": {"path": "/tmp/"},
+                    },
+                ],
+                "volume_mounts": [
+                    {
+                        "mountPath": "/foo/",
+                        "name": "example-kubernetes-test-volume",
+                    },
+                ],
+            },
+        }
+        with pytest.raises(AirflowConfigException, match="Can not have both a legacy and new"):
+            PodGenerator.from_obj(obj)
 
     def test_reconcile_pods_empty_mutator_pod(self, data_file):
         template_file = data_file("pods/generator_base_with_secrets.yaml").as_posix()
@@ -736,7 +725,10 @@ class TestPodGenerator:
         ),
     )
     def test_pod_name_confirm_to_max_length(self, input):
-        actual = PodGenerator.make_unique_pod_id(input)
+        with pytest.warns(
+            AirflowProviderDeprecationWarning, match="Use `add_pod_suffix` in `kubernetes_helper_functions`"
+        ):
+            actual = PodGenerator.make_unique_pod_id(input)
         assert len(actual) <= 100
         actual_base, actual_suffix = actual.rsplit("-", maxsplit=1)
         # we limit pod id length to 100
@@ -767,7 +759,10 @@ class TestPodGenerator:
         `make_unique_pod_id` doesn't actually guarantee that the regex passes for any input.
         But I guess this test verifies that an otherwise valid pod_id doesn't get _screwed up_.
         """
-        actual = PodGenerator.make_unique_pod_id(pod_id)
+        with pytest.warns(
+            AirflowProviderDeprecationWarning, match="Use `add_pod_suffix` in `kubernetes_helper_functions`"
+        ):
+            actual = PodGenerator.make_unique_pod_id(pod_id)
         assert len(actual) <= 253
         assert actual == actual.lower(), "not lowercase"
         # verify using official k8s regex


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #39356
related: #38642

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
