### PR TITLE
Configure `back_populates` between `DagScheduleDatasetReference.dag` and `DagModel.schedule_dataset_references`

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -3668,6 +3668,7 @@ class DagModel(Base):
     )
     schedule_dataset_references = relationship(
         "DagScheduleDatasetReference",
+        back_populates="dag",
         cascade="all, delete, delete-orphan",
     )
     schedule_datasets = association_proxy("schedule_dataset_references", "dataset")

--- a/airflow/models/dataset.py
+++ b/airflow/models/dataset.py
@@ -112,7 +112,7 @@ class DagScheduleDatasetReference(Base):
     updated_at = Column(UtcDateTime, default=timezone.utcnow, onupdate=timezone.utcnow, nullable=False)
 
     dataset = relationship("DatasetModel", back_populates="consuming_dags")
-    dag = relationship("DagModel")
+    dag = relationship("DagModel", back_populates="schedule_dataset_references")
 
     queue_records = relationship(
         "DatasetDagRunQueue",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

We have an annoying warning about conflicts with relationship between `DagScheduleDatasetReference.dag` and `DagModel.schedule_dataset_references`

```console
Resetting the DB

DB: postgresql+psycopg2://postgres:***@postgres/airflow
[2024-05-03T09:37:44.023+0000] {db.py:1651} INFO - Dropping tables that exist
[2024-05-03T09:37:44.399+0000] {migration.py:216} INFO - Context impl PostgresqlImpl.
[2024-05-03T09:37:44.399+0000] {migration.py:219} INFO - Will assume transactional DDL.
[2024-05-03T09:37:44.422+0000] {migration.py:216} INFO - Context impl PostgresqlImpl.
[2024-05-03T09:37:44.422+0000] {migration.py:219} INFO - Will assume transactional DDL.
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running stamp_revision  -> 677fdbb7fc54
/opt/airflow/airflow/utils/db.py:133 SAWarning: relationship 'DagModel.schedule_dataset_references' will copy column dag.dag_id to column dag_schedule_dataset_reference.dag_id, which conflicts with relationship(s): 'DagScheduleDatasetReference.dag' (copies dag.dag_id to dag_schedule_dataset_reference.dag_id). If this is not the intention, consider if these relationships should be linked with back_populates, or if viewonly=True should be applied to one or more if they are read-only. For the less common case that foreign key constraints are partially overlapping, the orm.foreign() annotation can be used to isolate the columns that should be written towards.   To silence this warning, add the parameter 'overlaps="dag"' to the 'DagModel.schedule_dataset_references' relationship. (Background on this error at: https://sqlalche.me/e/14/qzyx)
WARNI [airflow.models.crypto] empty cryptography key - values will not be stored encrypted.

Database has been reset
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
