### PR TITLE
retry for failure in the queue

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -5351,6 +5351,7 @@ components:
         - success
         - running
         - failed
+        - failed_in_queue
         - upstream_failed
         - skipped
         - up_for_retry

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -424,6 +424,15 @@ class BaseExecutor(LoggingMixin):
                 self.log.debug("Could not find key: %s", key)
         self.event_buffer[key] = state, info
 
+    def failed_in_queue(self, key: TaskInstanceKey, info=None) -> None:
+        """
+        Set failed in queue state for the event.
+
+        :param info: Executor information for the task instance
+        :param key: Unique key for the task instance
+        """
+        self.change_state(key, TaskInstanceState.FAILED_IN_QUEUE, info)
+
     def fail(self, key: TaskInstanceKey, info=None) -> None:
         """
         Set fail state for the event.

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -733,6 +733,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 TaskInstanceState.SUCCESS,
                 TaskInstanceState.QUEUED,
                 TaskInstanceState.RUNNING,
+                TaskInstanceState.FAILED_IN_QUEUE,
             ):
                 tis_with_right_state.append(ti_key)
 

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1934,7 +1934,11 @@ class DAG(LoggingMixin):
         """
         state: list[TaskInstanceState] = []
         if only_failed:
-            state += [TaskInstanceState.FAILED, TaskInstanceState.UPSTREAM_FAILED]
+            state += [
+                TaskInstanceState.FAILED,
+                TaskInstanceState.UPSTREAM_FAILED,
+                TaskInstanceState.FAILED_IN_QUEUE,
+            ]
         if only_running:
             # Yes, having `+=` doesn't make sense, but this was the existing behaviour
             state += [TaskInstanceState.RUNNING]

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -414,6 +414,7 @@ def _stop_remaining_tasks(*, task_instance: TaskInstance | TaskInstancePydantic,
         if ti.task_id == task_instance.task_id or ti.state in (
             TaskInstanceState.SUCCESS,
             TaskInstanceState.FAILED,
+            TaskInstanceState.FAILED_IN_QUEUE,
         ):
             continue
         task = task_instance.task.dag.task_dict[ti.task_id]

--- a/airflow/providers/celery/executors/celery_executor.py
+++ b/airflow/providers/celery/executors/celery_executor.py
@@ -453,7 +453,7 @@ class CeleryExecutor(BaseExecutor):
         for ti in tis:
             readable_tis.append(repr(ti))
             task_instance_key = ti.key
-            self.fail(task_instance_key, None)
+            self.failed_in_queue(task_instance_key, None)
             celery_async_result = self.tasks.pop(task_instance_key, None)
             if celery_async_result:
                 try:

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -106,6 +106,7 @@ json = json
 STATE_COLORS = {
     "deferred": "mediumpurple",
     "failed": "red",
+    "failed_in_queue": "reddishorange",
     "queued": "gray",
     "removed": "lightgrey",
     "restarting": "violet",

--- a/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -49,6 +49,7 @@ class _UpstreamTIStates(NamedTuple):
     success: int
     skipped: int
     failed: int
+    failed_in_queue: int
     upstream_failed: int
     removed: int
     done: int
@@ -79,6 +80,7 @@ class _UpstreamTIStates(NamedTuple):
             success=counter.get(TaskInstanceState.SUCCESS, 0),
             skipped=counter.get(TaskInstanceState.SKIPPED, 0),
             failed=counter.get(TaskInstanceState.FAILED, 0),
+            failed_in_queue=counter.get(TaskInstanceState.FAILED_IN_QUEUE, 0),
             upstream_failed=counter.get(TaskInstanceState.UPSTREAM_FAILED, 0),
             removed=counter.get(TaskInstanceState.REMOVED, 0),
             done=sum(counter.values()),

--- a/airflow/utils/state.py
+++ b/airflow/utils/state.py
@@ -53,6 +53,7 @@ class TaskInstanceState(str, Enum):
     SUCCESS = "success"  # Task completed
     RESTARTING = "restarting"  # External request to restart (e.g. cleared when running)
     FAILED = "failed"  # Task errored out
+    FAILED_IN_QUEUE = "failed_in_queue"  # Task failed due to queue timeout
     UP_FOR_RETRY = "up_for_retry"  # Task failed but has retries left
     UP_FOR_RESCHEDULE = "up_for_reschedule"  # A waiting `reschedule` sensor
     UPSTREAM_FAILED = "upstream_failed"  # One or more upstream deps failed
@@ -89,6 +90,7 @@ class State:
     SUCCESS = TaskInstanceState.SUCCESS
     RUNNING = TaskInstanceState.RUNNING
     FAILED = TaskInstanceState.FAILED
+    FAILED_IN_QUEUE = TaskInstanceState.FAILED_IN_QUEUE
 
     # These are TaskState only
     NONE = None
@@ -121,6 +123,7 @@ class State:
         TaskInstanceState.SUCCESS: "green",
         TaskInstanceState.RESTARTING: "violet",
         TaskInstanceState.FAILED: "red",
+        TaskInstanceState.FAILED_IN_QUEUE: "coral",
         TaskInstanceState.UP_FOR_RETRY: "gold",
         TaskInstanceState.UP_FOR_RESCHEDULE: "turquoise",
         TaskInstanceState.UPSTREAM_FAILED: "orange",
@@ -147,6 +150,7 @@ class State:
         [
             TaskInstanceState.SUCCESS,
             TaskInstanceState.FAILED,
+            TaskInstanceState.FAILED_IN_QUEUE,
             TaskInstanceState.SKIPPED,
             TaskInstanceState.UPSTREAM_FAILED,
             TaskInstanceState.REMOVED,
@@ -179,7 +183,7 @@ class State:
     """
 
     failed_states: frozenset[TaskInstanceState] = frozenset(
-        [TaskInstanceState.FAILED, TaskInstanceState.UPSTREAM_FAILED]
+        [TaskInstanceState.FAILED, TaskInstanceState.UPSTREAM_FAILED, TaskInstanceState.FAILED_IN_QUEUE]
     )
     """
     A list of states indicating that a task or dag is a failed state.

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -2393,6 +2393,7 @@ export interface components {
           | "success"
           | "running"
           | "failed"
+          | "failed_in_queue"
           | "upstream_failed"
           | "skipped"
           | "up_for_retry"

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -100,6 +100,7 @@ def get_instance_with_map(task_instance, session):
 priority: list[None | TaskInstanceState] = [
     TaskInstanceState.FAILED,
     TaskInstanceState.UPSTREAM_FAILED,
+    TaskInstanceState.FAILED_IN_QUEUE,
     TaskInstanceState.UP_FOR_RETRY,
     TaskInstanceState.UP_FOR_RESCHEDULE,
     TaskInstanceState.QUEUED,


### PR DESCRIPTION
related: #38304 

I think to have a retry option specifically for the failure happening in queue, we need to have a separate state where we need to indicate that failure is happening due to longer queue timeout and then segregate the retry for it there. Please let me know if I am going in right direction or do you think I have to think this in different approach? 
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
