### PR TITLE
Fix HTTP 500 Internal Server Error if DAG is triggered with bad params

### DIFF
--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -59,6 +59,7 @@ from airflow.api_connexion.schemas.task_instance_schema import (
     task_instance_reference_collection_schema,
 )
 from airflow.auth.managers.models.resource_details import DagAccessEntity
+from airflow.exceptions import ParamValidationError
 from airflow.models import DagModel, DagRun
 from airflow.timetables.base import DataInterval
 from airflow.utils.airflow_flask_app import get_airflow_app
@@ -356,7 +357,7 @@ def post_dag_run(*, dag_id: str, session: Session = NEW_SESSION) -> APIResponse:
                 current_user_id = get_auth_manager().get_user_id()
                 dag_run.note = (dag_run_note, current_user_id)
             return dagrun_schema.dump(dag_run)
-        except ValueError as ve:
+        except (ValueError, ParamValidationError) as ve:
             raise BadRequest(detail=str(ve))
 
     if dagrun_instance.execution_date == logical_date:


### PR DESCRIPTION
We have noticed that if you attempt to trigger a DAG via stable API with invalid parameters (e.g. bad values not mathcing to model/schema, missing required fields) that a HTTP 500 with "Uuups" text is returned.

The API endpoint did not check for ParamValidationError - which is fixed with this PR. Now with this PR applied a correct HTTP 400 with details is returned.

Swagger test looks like this - but added a test on API as well:
![image](https://github.com/apache/airflow/assets/95105677/134a4fd2-65a1-4d89-b275-3e4e112e03bd)
