### PR TITLE
Move prohibited warnings detection in deferrable pytest plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -529,6 +529,14 @@ filterwarnings = [
     'ignore:jsonschema\.exceptions\.RefResolutionError:DeprecationWarning:connexion.json_schema',
     'ignore:Accessing jsonschema\.draft4_format_checker:DeprecationWarning:connexion.decorators.validation',
 ]
+# We cannot add warnings from the airflow package into `filterwarnings`,
+# because it invokes import airflow before we set up test environment which breaks the tests.
+# Instead of that, we use a separate parameter and dynamically add it into `filterwarnings` marker.
+forbidden_warnings = [
+    "airflow.exceptions.RemovedInAirflow3Warning",
+    "airflow.utils.context.AirflowContextDeprecationWarning",
+    "airflow.exceptions.AirflowProviderDeprecationWarning",
+]
 python_files = [
     "test_*.py",
     "example_*.py",

--- a/tests/_internals/forbidden_warnings.py
+++ b/tests/_internals/forbidden_warnings.py
@@ -1,0 +1,133 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+TESTS_DIR = Path(__file__).parents[1].resolve()
+
+
+class ForbiddenWarningsPlugin:
+    """Internal plugin for restricting warnings during the tests run."""
+
+    node_key: str = "forbidden_warnings_node"
+    deprecations_ignore: Path = (TESTS_DIR / "deprecations_ignore.yml").resolve(strict=True)
+
+    def __init__(self, config: pytest.Config, forbidden_warnings: tuple[str, ...]):
+        excluded_cases = {
+            # Skip: Integration and System Tests
+            "tests/integration/",
+            "tests/system/",
+            # Skip: DAGs for tests
+            "tests/dags/",
+            "tests/dags_corrupted/",
+            "tests/dags_with_system_exit/",
+        }
+        with self.deprecations_ignore.open() as fp:
+            excluded_cases.update(yaml.safe_load(fp))
+
+        self.config = config
+        self.forbidden_warnings = forbidden_warnings
+        self.is_worker_node = hasattr(config, "workerinput")
+        self.detected_cases: set[str] = set()
+        self.excluded_cases: tuple[str, ...] = tuple(sorted(excluded_cases))
+
+    @staticmethod
+    def prune_params_node_id(node_id: str) -> str:
+        """Remove parametrized parts from node id."""
+        return node_id.partition("[")[0]
+
+    def pytest_itemcollected(self, item: pytest.Item):
+        if item.nodeid.startswith(self.excluded_cases):
+            return
+        for fw in self.forbidden_warnings:
+            # Add marker at the beginning of the markers list. In this case, it does not conflict with
+            # filterwarnings markers, which are set explicitly in the test suite.
+            item.add_marker(pytest.mark.filterwarnings(f"error::{fw}"), append=False)
+
+    @pytest.hookimpl(hookwrapper=True, trylast=True)
+    def pytest_sessionfinish(self, session: pytest.Session, exitstatus: int):
+        """Save set of test node ids in the session finish on xdist worker node"""
+        yield
+        if self.is_worker_node and self.detected_cases and hasattr(self.config, "workeroutput"):
+            self.config.workeroutput[self.node_key] = frozenset(self.detected_cases)
+
+    @pytest.hookimpl(optionalhook=True)
+    def pytest_testnodedown(self, node, error):
+        """Get a set of test node ids from the xdist worker node."""
+        if not (workeroutput := getattr(node, "workeroutput", {})):
+            return
+
+        node_detected_cases: tuple[tuple[str, int]] = workeroutput.get(self.node_key)
+        if not node_detected_cases:
+            return
+
+        self.detected_cases |= node_detected_cases
+
+    def pytest_exception_interact(self, node: pytest.Item, call: pytest.CallInfo, report: pytest.TestReport):
+        if not call.excinfo or call.when not in ["setup", "call", "teardown"]:
+            # Skip analyze exception if there is no exception exists
+            # or exception happens outside of tests or fixtures
+            return
+
+        exc = call.excinfo.type
+        exception_qualname = exc.__name__
+        if (exception_module := exc.__module__) != "builtins":
+            exception_qualname = f"{exception_module}.{exception_qualname}"
+        if exception_qualname in self.forbidden_warnings:
+            self.detected_cases.add(node.nodeid)
+
+    @pytest.hookimpl(hookwrapper=True, tryfirst=True)
+    def pytest_terminal_summary(self, terminalreporter, exitstatus: int, config: pytest.Config):
+        yield
+        if not self.detected_cases or self.is_worker_node:  # No need to print report on worker node
+            return
+
+        total_cases = len(self.detected_cases)
+        uniq_tests_cases = len(set(map(self.prune_params_node_id, self.detected_cases)))
+        terminalreporter.section(f"{total_cases:,} prohibited warning(s) detected", red=True, bold=True)
+
+        report_message = "By default selected warnings are prohibited during tests runs:\n * "
+        report_message += "\n * ".join(self.forbidden_warnings)
+        report_message += "\n\n"
+        report_message += (
+            "Please make sure that you follow Airflow Unit test developer guidelines:\n"
+            "https://github.com/apache/airflow/blob/main/contributing-docs/testing/unit_tests.rst#handling-warnings"
+        )
+        if total_cases <= 20:
+            # Print tests node ids only if there is a small amount of it,
+            # otherwise it could turn into a mess in the terminal
+            report_message += "\n\nWarnings detected in test case(s):\n - "
+            report_message += "\n - ".join(sorted(self.detected_cases))
+        if uniq_tests_cases >= 15:
+            # If there are a lot of unique tests where this happens,
+            # we might suggest adding it into the exclusion list
+            report_message += (
+                "\n\nIf this is significant change in code base you might add tests cases ids into the "
+                f"{self.deprecations_ignore} file, please make sure that you also create "
+                "follow up Issue/Task in https://github.com/apache/airflow/issues"
+            )
+        terminalreporter.write_line(report_message.rstrip(), red=True)
+        terminalreporter.write_line(
+            "You could disable this check by provide the `--disable-forbidden-warnings` flag, "
+            "however this check always turned on in the Airflow's CI.",
+            white=True,
+        )

--- a/tests/deprecations_ignore.yml
+++ b/tests/deprecations_ignore.yml
@@ -16,15 +16,6 @@
 # under the License.
 ---
 
-# Skip: Integration and System Tests
-- tests/integration/
-- tests/system/
-# Skip: DAGs for tests
-- tests/dags/
-- tests/dags_corrupted/
-- tests/dags_with_system_exit/
-
-
 # API
 - tests/api_connexion/endpoints/test_connection_endpoint.py::TestGetConnection::test_should_respond_200
 - tests/api_connexion/endpoints/test_connection_endpoint.py::TestPatchConnection::test_patch_should_respond_200


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

related: https://github.com/apache/airflow/issues/38642

Move all logic around existed functionality into the separate plugin, which allow to do additional things without turned root `conftest.py` into the mess

- Allow to disable detect prohibited warnings locally: `--disable-forbidden-warnings` or set warnings to ignore `-W "ignore"`
- Move list of prohibited warnings into the `pyproject.toml`
- Analyse test failure and if it due to listed  prohibited warning show hint to the developer

![image](https://github.com/apache/airflow/assets/3998685/336ebfe0-3e5a-4047-8fe4-1d13e7eca402)


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
