### PR TITLE
Fix custom actions in security manager `has_access`

### DIFF
--- a/airflow/www/security_manager.py
+++ b/airflow/www/security_manager.py
@@ -337,7 +337,7 @@ class AirflowSecurityManagerV2(LoggingMixin):
             # The user is trying to access a page specific to the auth manager
             # (e.g. the user list view in FabAuthManager) or a page defined in a plugin
             return lambda action, resource_pk, user: get_auth_manager().is_authorized_custom_view(
-                method=get_method_from_fab_action_map()[action],
+                method=get_method_from_fab_action_map().get(action, action),
                 resource_name=fab_resource_name,
                 user=user,
             )


### PR DESCRIPTION
Closes: #39144

#39167 was an incomplete fix, as `has_access` in the security manager was also failing with custom actions.