### PR TITLE
Unify lazy db sequence implementations

### DIFF
--- a/airflow/lineage/__init__.py
+++ b/airflow/lineage/__init__.py
@@ -130,10 +130,10 @@ def prepare_lineage(func: T) -> T:
             # Remove auto and task_ids
             self.inlets = [i for i in self.inlets if not isinstance(i, str)]
 
-            # We manually create a session here since xcom_pull returns a LazyXComAccess iterator.
-            # If we do not pass a session a new session will be created, however that session will not be
-            # properly closed and will remain open. After we are done iterating we can safely close this
-            # session.
+            # We manually create a session here since xcom_pull returns a
+            # LazySelectSequence proxy. If we do not pass a session, a new one
+            # will be created, but that session will not be properly closed.
+            # After we are done iterating, we can safely close this session.
             with create_session() as session:
                 _inlets = self.xcom_pull(
                     context, task_ids=task_ids, dag_id=self.dag_id, key=PIPELINE_OUTLETS, session=session

--- a/airflow/models/base.py
+++ b/airflow/models/base.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import Column, Integer, MetaData, String, text
 from sqlalchemy.orm import registry
@@ -48,7 +48,10 @@ metadata = MetaData(schema=_get_schema(), naming_convention=naming_convention)
 mapper_registry = registry(metadata=metadata)
 _sentinel = object()
 
-Base: Any = mapper_registry.generate_base()
+if TYPE_CHECKING:
+    Base = Any
+else:
+    Base = mapper_registry.generate_base()
 
 ID_LEN = 250
 

--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -17,18 +17,14 @@
 # under the License.
 from __future__ import annotations
 
-import collections.abc
-import contextlib
 import inspect
-import itertools
 import json
 import logging
 import pickle
 import warnings
-from functools import cached_property, wraps
-from typing import TYPE_CHECKING, Any, Generator, Iterable, cast, overload
+from functools import wraps
+from typing import TYPE_CHECKING, Any, Iterable, cast, overload
 
-import attr
 from sqlalchemy import (
     Column,
     ForeignKeyConstraint,
@@ -38,6 +34,7 @@ from sqlalchemy import (
     PrimaryKeyConstraint,
     String,
     delete,
+    select,
     text,
 )
 from sqlalchemy.dialects.mysql import LONGBLOB
@@ -45,12 +42,12 @@ from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import Query, reconstructor, relationship
 from sqlalchemy.orm.exc import NoResultFound
 
-from airflow import settings
 from airflow.api_internal.internal_api_call import internal_api_call
 from airflow.configuration import conf
 from airflow.exceptions import RemovedInAirflow3Warning
 from airflow.models.base import COLLATION_ARGS, ID_LEN, TaskInstanceDependencies
 from airflow.utils import timezone
+from airflow.utils.db import LazySelectSequence
 from airflow.utils.helpers import exactly_one, is_container
 from airflow.utils.json import XComDecoder, XComEncoder
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -70,7 +67,9 @@ if TYPE_CHECKING:
     import datetime
 
     import pendulum
+    from sqlalchemy.engine import Row
     from sqlalchemy.orm import Session
+    from sqlalchemy.sql.expression import Select, TextClause
 
     from airflow.models.taskinstancekey import TaskInstanceKey
 
@@ -222,11 +221,11 @@ class BaseXCom(TaskInstanceDependencies, LoggingMixin):
             if dag_run_id is None:
                 raise ValueError(f"DAG run not found on DAG {dag_id!r} with ID {run_id!r}")
 
-        # Seamlessly resolve LazyXComAccess to a list. This is intended to work
+        # Seamlessly resolve LazySelectSequence to a list. This intends to work
         # as a "lazy list" to avoid pulling a ton of XComs unnecessarily, but if
         # it's pushed into XCom, the user should be aware of the performance
         # implications, and this avoids leaking the implementation detail.
-        if isinstance(value, LazyXComAccess):
+        if isinstance(value, LazySelectSequence):
             warning_message = (
                 "Coercing mapped lazy proxy %s from task %s (DAG %s, run %s) "
                 "to list, which may degrade performance. Review resource "
@@ -716,111 +715,19 @@ class BaseXCom(TaskInstanceDependencies, LoggingMixin):
         return BaseXCom._deserialize_value(self, True)
 
 
-class _LazyXComAccessIterator(collections.abc.Iterator):
-    def __init__(self, cm: contextlib.AbstractContextManager[Query]) -> None:
-        self._cm = cm
-        self._entered = False
-
-    def __del__(self) -> None:
-        if self._entered:
-            self._cm.__exit__(None, None, None)
-
-    def __iter__(self) -> collections.abc.Iterator:
-        return self
-
-    def __next__(self) -> Any:
-        return XCom.deserialize_value(next(self._it))
-
-    @cached_property
-    def _it(self) -> collections.abc.Iterator:
-        self._entered = True
-        return iter(self._cm.__enter__())
-
-
-@attr.define(slots=True)
-class LazyXComAccess(collections.abc.Sequence):
-    """Wrapper to lazily pull XCom with a sequence-like interface.
-
-    Note that since the session bound to the parent query may have died when we
-    actually access the sequence's content, we must create a new session
-    for every function call with ``with_session()``.
+class LazyXComSelectSequence(LazySelectSequence[Any]):
+    """List-like interface to lazily access XCom values.
 
     :meta private:
     """
 
-    _query: Query
-    _len: int | None = attr.ib(init=False, default=None)
+    @staticmethod
+    def _rebuild_select(stmt: TextClause) -> Select:
+        return select(XCom.value).from_statement(stmt)
 
-    @classmethod
-    def build_from_xcom_query(cls, query: Query) -> LazyXComAccess:
-        return cls(query=query.with_entities(XCom.value))
-
-    def __repr__(self) -> str:
-        return f"LazyXComAccess([{len(self)} items])"
-
-    def __str__(self) -> str:
-        return str(list(self))
-
-    def __eq__(self, other: Any) -> bool:
-        if isinstance(other, (list, LazyXComAccess)):
-            z = itertools.zip_longest(iter(self), iter(other), fillvalue=object())
-            return all(x == y for x, y in z)
-        return NotImplemented
-
-    def __getstate__(self) -> Any:
-        # We don't want to go to the trouble of serializing the entire Query
-        # object, including its filters, hints, etc. (plus SQLAlchemy does not
-        # provide a public API to inspect a query's contents). Converting the
-        # query into a SQL string is the best we can get. Theoratically we can
-        # do the same for count(), but I think it should be performant enough to
-        # calculate only that eagerly.
-        with self._get_bound_query() as query:
-            statement = query.statement.compile(
-                query.session.get_bind(),
-                # This inlines all the values into the SQL string to simplify
-                # cross-process commuinication as much as possible.
-                compile_kwargs={"literal_binds": True},
-            )
-            return (str(statement), query.count())
-
-    def __setstate__(self, state: Any) -> None:
-        statement, self._len = state
-        self._query = Query(XCom.value).from_statement(text(statement))
-
-    def __len__(self):
-        if self._len is None:
-            with self._get_bound_query() as query:
-                self._len = query.count()
-        return self._len
-
-    def __iter__(self):
-        return _LazyXComAccessIterator(self._get_bound_query())
-
-    def __getitem__(self, key):
-        if not isinstance(key, int):
-            raise ValueError("only support index access for now")
-        try:
-            with self._get_bound_query() as query:
-                r = query.offset(key).limit(1).one()
-        except NoResultFound:
-            raise IndexError(key) from None
-        return XCom.deserialize_value(r)
-
-    @contextlib.contextmanager
-    def _get_bound_query(self) -> Generator[Query, None, None]:
-        # Do we have a valid session already?
-        if self._query.session and self._query.session.is_active:
-            yield self._query
-            return
-
-        Session = getattr(settings, "Session", None)
-        if Session is None:
-            raise RuntimeError("Session must be set before!")
-        session = Session()
-        try:
-            yield self._query.with_session(session)
-        finally:
-            session.close()
+    @staticmethod
+    def _process_row(row: Row) -> Any:
+        return XCom.deserialize_value(row)
 
 
 def _patch_outdated_serializer(clazz: type[BaseXCom], params: Iterable[str]) -> None:

--- a/airflow/typing_compat.py
+++ b/airflow/typing_compat.py
@@ -23,6 +23,7 @@ __all__ = [
     "Literal",
     "ParamSpec",
     "Protocol",
+    "Self",
     "TypedDict",
     "TypeGuard",
     "runtime_checkable",
@@ -45,3 +46,8 @@ if sys.version_info >= (3, 10):
     from typing import ParamSpec, TypeGuard
 else:
     from typing_extensions import ParamSpec, TypeGuard
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self

--- a/airflow/utils/context.py
+++ b/airflow/utils/context.py
@@ -32,25 +32,26 @@ from typing import (
     KeysView,
     Mapping,
     MutableMapping,
-    Sequence,
     SupportsIndex,
     ValuesView,
-    overload,
 )
 
 import attrs
 import lazy_object_proxy
+from sqlalchemy import select
 
 from airflow.datasets import Dataset, coerce_to_uri
 from airflow.exceptions import RemovedInAirflow3Warning
+from airflow.models.dataset import DatasetEvent, DatasetModel
+from airflow.utils.db import LazySelectSequence
 from airflow.utils.types import NOTSET
 
 if TYPE_CHECKING:
+    from sqlalchemy.engine import Row
     from sqlalchemy.orm import Session
-    from sqlalchemy.sql.expression import Select
+    from sqlalchemy.sql.expression import Select, TextClause
 
     from airflow.models.baseoperator import BaseOperator
-    from airflow.models.dataset import DatasetEvent
 
 # NOTE: Please keep this in sync with the following:
 # * Context in airflow/utils/context.pyi.
@@ -187,57 +188,23 @@ class OutletEventAccessors(Mapping[str, OutletEventAccessor]):
         return self._dict[uri]
 
 
-@attrs.define()
-class InletEventsAccessor(Sequence["DatasetEvent"]):
-    """Lazy sequence to access inlet dataset events.
+class LazyDatasetEventSelectSequence(LazySelectSequence[DatasetEvent]):
+    """List-like interface to lazily access DatasetEvent rows.
 
     :meta private:
     """
 
-    _uri: str
-    _session: Session
+    @staticmethod
+    def _rebuild_select(stmt: TextClause) -> Select:
+        return select(DatasetEvent).from_statement(stmt)
 
-    def _get_select_stmt(self, *, reverse: bool = False) -> Select:
-        from sqlalchemy import select
-
-        from airflow.models.dataset import DatasetEvent, DatasetModel
-
-        stmt = select(DatasetEvent).join(DatasetEvent.dataset).where(DatasetModel.uri == self._uri)
-        if reverse:
-            return stmt.order_by(DatasetEvent.timestamp.desc())
-        return stmt.order_by(DatasetEvent.timestamp.asc())
-
-    def __reversed__(self) -> Iterator[DatasetEvent]:
-        return iter(self._session.scalar(self._get_select_stmt(reverse=True)))
-
-    def __iter__(self) -> Iterator[DatasetEvent]:
-        return iter(self._session.scalar(self._get_select_stmt()))
-
-    @overload
-    def __getitem__(self, key: int) -> DatasetEvent: ...
-
-    @overload
-    def __getitem__(self, key: slice) -> Sequence[DatasetEvent]: ...
-
-    def __getitem__(self, key: int | slice) -> DatasetEvent | Sequence[DatasetEvent]:
-        if not isinstance(key, int):
-            raise ValueError("non-index access is not supported")
-        if key >= 0:
-            stmt = self._get_select_stmt().offset(key)
-        else:
-            stmt = self._get_select_stmt(reverse=True).offset(-1 - key)
-        if (event := self._session.scalar(stmt.limit(1))) is not None:
-            return event
-        raise IndexError(key)
-
-    def __len__(self) -> int:
-        from sqlalchemy import func, select
-
-        return self._session.scalar(select(func.count()).select_from(self._get_select_stmt()))
+    @staticmethod
+    def _process_row(row: Row) -> DatasetEvent:
+        return row[0]
 
 
 @attrs.define(init=False)
-class InletEventsAccessors(Mapping[str, InletEventsAccessor]):
+class InletEventsAccessors(Mapping[str, LazyDatasetEventSelectSequence]):
     """Lazy mapping for inlet dataset events accessors.
 
     :meta private:
@@ -258,14 +225,18 @@ class InletEventsAccessors(Mapping[str, InletEventsAccessor]):
     def __len__(self) -> int:
         return len(self._inlets)
 
-    def __getitem__(self, key: int | str | Dataset) -> InletEventsAccessor:
+    def __getitem__(self, key: int | str | Dataset) -> LazyDatasetEventSelectSequence:
         if isinstance(key, int):  # Support index access; it's easier for trivial cases.
             dataset = self._inlets[key]
             if not isinstance(dataset, Dataset):
                 raise IndexError(key)
         else:
             dataset = self._datasets[coerce_to_uri(key)]
-        return InletEventsAccessor(dataset.uri, session=self._session)
+        return LazyDatasetEventSelectSequence.from_select(
+            select(DatasetEvent).join(DatasetEvent.dataset).where(DatasetModel.uri == dataset.uri),
+            order_by=[DatasetEvent.timestamp],
+            session=self._session,
+        )
 
 
 class AirflowContextDeprecationWarning(RemovedInAirflow3Warning):

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -1914,7 +1914,7 @@ def get_query_count(query_stmt: Select, *, session: Session) -> int:
     return session.scalar(count_stmt)
 
 
-def get_query_exists(query_stmt: Select, *, session: Session) -> bool:
+def check_query_exists(query_stmt: Select, *, session: Session) -> bool:
     """Check whether there is at least one row matching a query.
 
     A SELECT 1 FROM is issued against the subquery built from the given
@@ -2020,7 +2020,7 @@ class LazySelectSequence(Sequence[T]):
         self._session = get_current_task_instance_session()
 
     def __bool__(self) -> bool:
-        return get_query_exists(self._select_asc, session=self._session)
+        return check_query_exists(self._select_asc, session=self._session)
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, collections.abc.Sequence):

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -2000,7 +2000,7 @@ class LazySelectSequence(Sequence[T]):
 
     def __str__(self) -> str:
         counter = "item" if (length := len(self)) == 1 else "items"
-        return f"[... {length} {counter} ...]"
+        return f"LazySelectSequence([{length} {counter}])"
 
     def __getstate__(self) -> Any:
         # We don't want to go to the trouble of serializing SQLAlchemy objects.

--- a/airflow/utils/task_instance_session.py
+++ b/airflow/utils/task_instance_session.py
@@ -22,7 +22,7 @@ import logging
 import traceback
 from typing import TYPE_CHECKING
 
-from airflow.utils.session import create_session
+from airflow import settings
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -41,7 +41,7 @@ def get_current_task_instance_session() -> Session:
             log.warning('File: "%s", %s , in %s', filename, line_number, name)
             if line:
                 log.warning("  %s", line.strip())
-        __current_task_instance_session = create_session()
+        __current_task_instance_session = settings.Session()
     return __current_task_instance_session
 
 

--- a/docs/apache-airflow/authoring-and-scheduling/dynamic-task-mapping.rst
+++ b/docs/apache-airflow/authoring-and-scheduling/dynamic-task-mapping.rst
@@ -53,7 +53,7 @@ The grid view also provides visibility into your mapped tasks in the details pan
 
     In the above example, ``values`` received by ``sum_it`` is an aggregation of all values returned by each mapped instance of ``add_one``. However, since it is impossible to know how many instances of ``add_one`` we will have in advance, ``values`` is not a normal list, but a "lazy sequence" that retrieves each individual value only when asked. Therefore, if you run ``print(values)`` directly, you would get something like this::
 
-        LazyXComAccess(dag_id='simple_mapping', run_id='test_run', task_id='add_one')
+        [... 15 items ...]
 
     You can use normal sequence syntax on this object (e.g. ``values[0]``), or iterate through it normally with a ``for`` loop. ``list(values)`` will give you a "real" ``list``, but since this would eagerly load values from *all* of the referenced upstream mapped tasks, you must be aware of the potential performance implications if the mapped number is large.
 

--- a/docs/apache-airflow/authoring-and-scheduling/dynamic-task-mapping.rst
+++ b/docs/apache-airflow/authoring-and-scheduling/dynamic-task-mapping.rst
@@ -53,7 +53,7 @@ The grid view also provides visibility into your mapped tasks in the details pan
 
     In the above example, ``values`` received by ``sum_it`` is an aggregation of all values returned by each mapped instance of ``add_one``. However, since it is impossible to know how many instances of ``add_one`` we will have in advance, ``values`` is not a normal list, but a "lazy sequence" that retrieves each individual value only when asked. Therefore, if you run ``print(values)`` directly, you would get something like this::
 
-        [... 15 items ...]
+        LazySelectSequence([15 items])
 
     You can use normal sequence syntax on this object (e.g. ``values[0]``), or iterate through it normally with a ``for`` loop. ``list(values)`` will give you a "real" ``list``, but since this would eagerly load values from *all* of the referenced upstream mapped tasks, you must be aware of the potential performance implications if the mapped number is large.
 


### PR DESCRIPTION
LazyXComAccessor and InletEventsAccessor are somewhat similar in purpose. A new LazySelectSequence is introduced with a more generic implementation that fits both use cases. This also implements the Sequence protocol a bit more efficiently in some places.

See #39367 for some context.