### PR TITLE
Use `back_populates` instead of `sqlalchemy.orm.backref` in bidirectional relationships

### DIFF
--- a/airflow/jobs/job.py
+++ b/airflow/jobs/job.py
@@ -99,6 +99,7 @@ class Job(Base, LoggingMixin):
         "TaskInstance",
         back_populates="queued_by_job",
         primaryjoin="Job.id == foreign(TaskInstance.queued_by_job_id)",
+        uselist=False,
     )
 
     dag_runs = relationship(  # Only makes sense for SchedulerJob and BackfillJob instances.

--- a/airflow/jobs/job.py
+++ b/airflow/jobs/job.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Callable, NoReturn
 
 from sqlalchemy import Column, Index, Integer, String, case, select
 from sqlalchemy.exc import OperationalError
-from sqlalchemy.orm import backref, foreign, relationship
+from sqlalchemy.orm import foreign, relationship
 from sqlalchemy.orm.session import make_transient
 
 from airflow.api_internal.internal_api_call import internal_api_call
@@ -103,8 +103,8 @@ class Job(Base, LoggingMixin):
 
     task_instances_enqueued = relationship(
         "TaskInstance",
+        back_populates="queued_by_job",
         primaryjoin="Job.id == foreign(TaskInstance.queued_by_job_id)",
-        backref=backref("queued_by_job", uselist=False),
     )
 
     dag_runs = relationship(

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -74,7 +74,7 @@ from sqlalchemy import (
     update,
 )
 from sqlalchemy.ext.associationproxy import association_proxy
-from sqlalchemy.orm import backref, joinedload, load_only, relationship
+from sqlalchemy.orm import joinedload, load_only, relationship
 from sqlalchemy.sql import Select, expression
 
 import airflow.templates
@@ -3555,6 +3555,8 @@ class DagTag(Base):
         primary_key=True,
     )
 
+    dag = relationship("DagModel", back_populates="tags")
+
     __table_args__ = (Index("idx_dag_tag_dag_id", dag_id),)
 
     def __repr__(self):
@@ -3577,6 +3579,8 @@ class DagOwnerAttributes(Base):
     )
     owner = Column(String(500), primary_key=True, nullable=False)
     link = Column(String(500), nullable=False)
+
+    dag = relationship("DagModel", back_populates="dag_owner_links")
 
     def __repr__(self):
         return f"<DagOwnerAttributes: dag_id={self.dag_id}, owner={self.owner}, link={self.link}>"
@@ -3639,10 +3643,12 @@ class DagModel(Base):
     # Dataset expression based on dataset triggers
     dataset_expression = Column(sqlalchemy_jsonfield.JSONField(json=json), nullable=True)
     # Tags for view filter
-    tags = relationship("DagTag", cascade="all, delete, delete-orphan", backref=backref("dag"))
+    tags = relationship("DagTag", back_populates="dag", cascade="all, delete, delete-orphan")
     # Dag owner links for DAGs view
     dag_owner_links = relationship(
-        "DagOwnerAttributes", cascade="all, delete, delete-orphan", backref=backref("dag")
+        "DagOwnerAttributes",
+        back_populates="dag",
+        cascade="all, delete, delete-orphan",
     )
 
     max_active_tasks = Column(Integer, nullable=False)

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -3667,6 +3667,13 @@ class DagModel(Base):
         Index("idx_next_dagrun_create_after", next_dagrun_create_after, unique=False),
     )
 
+    serialized_dag = relationship(
+        "SerializedDagModel",
+        back_populates="dag_model",
+        primaryjoin="DagModel.dag_id == foreign(SerializedDagModel.dag_id)",
+        uselist=False,
+        innerjoin=True,
+    )
     parent_dag = relationship(
         "DagModel", remote_side=[dag_id], primaryjoin=root_dag_id == dag_id, foreign_keys=[root_dag_id]
     )
@@ -4110,15 +4117,6 @@ def dag(
         return factory
 
     return wrapper
-
-
-STATICA_HACK = True
-globals()["kcah_acitats"[::-1].upper()] = False
-if STATICA_HACK:  # pragma: no cover
-    from airflow.models.serialized_dag import SerializedDagModel
-
-    DagModel.serialized_dag = relationship(SerializedDagModel)
-    """:sphinx-autoapi-skip:"""
 
 
 class DagContext:

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -195,6 +195,13 @@ class DagRun(Base, LoggingMixin):
     )
     note = association_proxy("dag_run_note", "content", creator=_creator_note)
 
+    creating_job = relationship(
+        "Job",
+        back_populates="dag_runs",
+        uselist=False,
+        primaryjoin="Job.id == foreign(DagRun.creating_job_id)",
+    )
+
     DEFAULT_DAGRUNS_TO_EXAMINE = airflow_conf.getint(
         "scheduler",
         "max_dagruns_per_loop_to_schedule",

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -201,6 +201,13 @@ class DagRun(Base, LoggingMixin):
         uselist=False,
         primaryjoin="Job.id == foreign(DagRun.creating_job_id)",
     )
+    serialized_dag = relationship(
+        "SerializedDagModel",
+        back_populates="dag_runs",
+        primaryjoin="SerializedDagModel.dag_id == foreign(DagRun.dag_id)",
+        uselist=False,
+        innerjoin=True,
+    )
 
     DEFAULT_DAGRUNS_TO_EXAMINE = airflow_conf.getint(
         "scheduler",

--- a/airflow/models/serialized_dag.py
+++ b/airflow/models/serialized_dag.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, Collection
 
 import sqlalchemy_jsonfield
 from sqlalchemy import BigInteger, Column, Index, LargeBinary, String, and_, exc, or_, select
-from sqlalchemy.orm import backref, relationship
+from sqlalchemy.orm import relationship
 from sqlalchemy.sql.expression import func, literal
 
 from airflow.api_internal.internal_api_call import internal_api_call
@@ -93,12 +93,11 @@ class SerializedDagModel(Base):
     )
 
     dag_model = relationship(
-        DagModel,
-        primaryjoin=dag_id == DagModel.dag_id,  # type: ignore
-        foreign_keys=dag_id,
+        "DagModel",
+        back_populates="serialized_dag",
+        primaryjoin="DagModel.dag_id == foreign(SerializedDagModel.dag_id)",
         uselist=False,
         innerjoin=True,
-        backref=backref("serialized_dag", uselist=False, innerjoin=True),
     )
 
     load_op_links = True

--- a/airflow/models/serialized_dag.py
+++ b/airflow/models/serialized_dag.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, Collection
 
 import sqlalchemy_jsonfield
 from sqlalchemy import BigInteger, Column, Index, LargeBinary, String, and_, exc, or_, select
-from sqlalchemy.orm import backref, foreign, relationship
+from sqlalchemy.orm import backref, relationship
 from sqlalchemy.sql.expression import func, literal
 
 from airflow.api_internal.internal_api_call import internal_api_call
@@ -34,7 +34,6 @@ from airflow.exceptions import TaskNotFound
 from airflow.models.base import ID_LEN, Base
 from airflow.models.dag import DagModel
 from airflow.models.dagcode import DagCode
-from airflow.models.dagrun import DagRun
 from airflow.serialization.serialized_objects import DagDependency, SerializedDAG
 from airflow.settings import COMPRESS_SERIALIZED_DAGS, MIN_SERIALIZED_DAG_UPDATE_INTERVAL, json
 from airflow.utils import timezone
@@ -88,9 +87,9 @@ class SerializedDagModel(Base):
     __table_args__ = (Index("idx_fileloc_hash", fileloc_hash, unique=False),)
 
     dag_runs = relationship(
-        DagRun,
-        primaryjoin=dag_id == foreign(DagRun.dag_id),  # type: ignore
-        backref=backref("serialized_dag", uselist=False, innerjoin=True),
+        "DagRun",
+        back_populates="serialized_dag",
+        primaryjoin="SerializedDagModel.dag_id == foreign(DagRun.dag_id)",
     )
 
     dag_model = relationship(

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1786,6 +1786,11 @@ class TaskInstance(Base, LoggingMixin):
 
     trigger = relationship("Trigger", uselist=False, back_populates="task_instance")
     triggerer_job = association_proxy("trigger", "triggerer_job")
+    queued_by_job = relationship(
+        "Job",
+        back_populates="task_instances_enqueued",
+        primaryjoin="Job.id == foreign(TaskInstance.queued_by_job_id)",
+    )
     dag_run = relationship("DagRun", back_populates="task_instances", lazy="joined", innerjoin=True)
     rendered_task_instance_fields = relationship("RenderedTaskInstanceFields", lazy="noload", uselist=False)
     execution_date = association_proxy("dag_run", "execution_date")
@@ -4007,11 +4012,3 @@ class TaskInstanceNote(TaskInstanceDependencies):
         if self.map_index != -1:
             prefix += f" map_index={self.map_index}"
         return prefix + ">"
-
-
-STATICA_HACK = True
-globals()["kcah_acitats"[::-1].upper()] = False
-if STATICA_HACK:  # pragma: no cover
-    from airflow.jobs.job import Job
-
-    TaskInstance.queued_by_job = relationship(Job)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

[`backref`](https://docs.sqlalchemy.org/en/14/orm/backref.html) is a legacy approach for construct relationships, instead of that preferable way is use [`back_populates`](https://docs.sqlalchemy.org/en/14/orm/relationship_api.html#sqlalchemy.orm.relationship.params.back_populates) keyword argument in [`relationship`](https://docs.sqlalchemy.org/en/14/orm/relationship_api.html#sqlalchemy.orm.relationship) for built it explicitly

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
