### PR TITLE
Log info about task instance clearing/marking as succcess/failure

### DIFF
--- a/airflow/api/common/mark_tasks.py
+++ b/airflow/api/common/mark_tasks.py
@@ -160,7 +160,7 @@ def set_state(
             tis_altered += session.scalars(qry_sub_dag.with_for_update()).all()
         logger = TaskContextLogger("webserver")
         for task_instance in tis_altered:
-            logger.info("Task marked as %s from the UI", state, ti=task_instance, session=session)
+            logger.info("Task was manually marked as %s", state, ti=task_instance, session=session)
             task_instance.set_state(state, session=session)
         session.flush()
     else:

--- a/airflow/api/common/mark_tasks.py
+++ b/airflow/api/common/mark_tasks.py
@@ -29,6 +29,7 @@ from airflow.models.taskinstance import TaskInstance
 from airflow.operators.subdag import SubDagOperator
 from airflow.utils import timezone
 from airflow.utils.helpers import exactly_one
+from airflow.utils.log.task_context_logger import TaskContextLogger
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.types import DagRunType
@@ -157,7 +158,9 @@ def set_state(
         if sub_dag_run_ids:
             qry_sub_dag = all_subdag_tasks_query(sub_dag_run_ids, session, state, confirmed_dates)
             tis_altered += session.scalars(qry_sub_dag.with_for_update()).all()
+        logger = TaskContextLogger("webserver")
         for task_instance in tis_altered:
+            logger.info("Task marked as %s from the UI", state, ti=task_instance, session=session)
             task_instance.set_state(state, session=session)
         session.flush()
     else:

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -776,7 +776,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     "Executor reports task instance %s finished (%s) although the "
                     "task says it's %s. (Info: %s) Was the task killed externally?"
                 )
-                self._task_context_logger.error(msg, ti, state, ti.state, info, ti=ti)
+                self._task_context_logger.error(msg, ti, state, ti.state, info, ti=ti, session=session)
 
                 # Get task from the Serialized DAG
                 try:
@@ -1577,6 +1577,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                         "If the task instance has available retries, it will be retried.",
                         ti,
                         ti=ti,
+                        session=session,
                     )
         except NotImplementedError:
             self.log.debug("Executor doesn't support cleanup of stuck queued tasks. Skipping.")
@@ -1750,7 +1751,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 "(See https://airflow.apache.org/docs/apache-airflow/"
                 "stable/core-concepts/tasks.html#zombie-undead-tasks)"
             )
-            self._task_context_logger.error(log_message, ti=ti)
+            self._task_context_logger.error(log_message, ti=ti, session=session)
             self.job.executor.send_callback(request)
             Stats.incr("zombies_killed", tags={"dag_id": ti.dag_id, "task_id": ti.task_id})
 

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -273,7 +273,7 @@ def clear_task_instances(
         if ti.state == TaskInstanceState.RUNNING:
             if ti.job_id:
                 logger.info(
-                    "Manually clearing a running task instance, state set to RESTARTING",
+                    "Manually cleared a running task",
                     ti=ti,
                     session=session,
                 )
@@ -283,6 +283,7 @@ def clear_task_instances(
                 job_ids.append(ti.job_id)
                 # Log this on the start of the next run
                 logger.info("Task was manually cleared, rerunning", ti=ti, session=session)
+                session.merge(ti)
 
         else:
             logger.info("Task was manually cleared, rerunning", ti=ti, session=session)

--- a/airflow/providers/alibaba/cloud/log/oss_task_handler.py
+++ b/airflow/providers/alibaba/cloud/log/oss_task_handler.py
@@ -27,6 +27,7 @@ from airflow.configuration import conf
 from airflow.providers.alibaba.cloud.hooks.oss import OSSHook
 from airflow.utils.log.file_task_handler import FileTaskHandler
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.session import provide_session
 
 
 class OSSTaskHandler(FileTaskHandler, LoggingMixin):
@@ -63,7 +64,8 @@ class OSSTaskHandler(FileTaskHandler, LoggingMixin):
                 remote_conn_id,
             )
 
-    def set_context(self, ti):
+    @provide_session
+    def set_context(self, ti, **kwargs):
         """Set the context of the handler."""
         super().set_context(ti)
         # Local location and remote location is needed to open and

--- a/airflow/providers/alibaba/cloud/log/oss_task_handler.py
+++ b/airflow/providers/alibaba/cloud/log/oss_task_handler.py
@@ -27,7 +27,6 @@ from airflow.configuration import conf
 from airflow.providers.alibaba.cloud.hooks.oss import OSSHook
 from airflow.utils.log.file_task_handler import FileTaskHandler
 from airflow.utils.log.logging_mixin import LoggingMixin
-from airflow.utils.session import provide_session
 
 
 class OSSTaskHandler(FileTaskHandler, LoggingMixin):
@@ -64,7 +63,6 @@ class OSSTaskHandler(FileTaskHandler, LoggingMixin):
                 remote_conn_id,
             )
 
-    @provide_session
     def set_context(self, ti, **kwargs):
         """Set the context of the handler."""
         super().set_context(ti)

--- a/airflow/providers/amazon/aws/log/s3_task_handler.py
+++ b/airflow/providers/amazon/aws/log/s3_task_handler.py
@@ -28,8 +28,11 @@ from airflow.configuration import conf
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.utils.log.file_task_handler import FileTaskHandler
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.session import provide_session
 
 if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
     from airflow.models.taskinstance import TaskInstance
 
 
@@ -63,11 +66,14 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
             aws_conn_id=conf.get("logging", "REMOTE_LOG_CONN_ID"), transfer_config_args={"use_threads": False}
         )
 
-    def set_context(self, ti: TaskInstance, *, identifier: str | None = None) -> None:
+    @provide_session
+    def set_context(
+        self, ti: TaskInstance, *, identifier: str | None = None, session: Session = None
+    ) -> None:
         # todo: remove-at-min-airflow-version-2.8
         #   after Airflow 2.8 can always pass `identifier`
         if getattr(super(), "supports_task_context_logging", False):
-            super().set_context(ti, identifier=identifier)
+            super().set_context(ti, identifier=identifier, session=session)
         else:
             super().set_context(ti)
         # Local location and remote location is needed to open and

--- a/airflow/providers/apache/hdfs/log/hdfs_task_handler.py
+++ b/airflow/providers/apache/hdfs/log/hdfs_task_handler.py
@@ -50,7 +50,7 @@ class HdfsTaskHandler(FileTaskHandler, LoggingMixin):
         """Returns WebHDFSHook."""
         return WebHDFSHook(webhdfs_conn_id=conf.get("logging", "REMOTE_LOG_CONN_ID"))
 
-    def set_context(self, ti):
+    def set_context(self, ti, **kwargs):
         super().set_context(ti)
         # Local location and remote location is needed to open and
         # upload local log file to HDFS storage.

--- a/airflow/providers/google/cloud/log/gcs_task_handler.py
+++ b/airflow/providers/google/cloud/log/gcs_task_handler.py
@@ -35,8 +35,11 @@ from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import PROVIDE_PROJECT_ID
 from airflow.utils.log.file_task_handler import FileTaskHandler
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.session import provide_session
 
 if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
     from airflow.models.taskinstance import TaskInstance
 
 _DEFAULT_SCOPESS = frozenset(
@@ -129,11 +132,14 @@ class GCSTaskHandler(FileTaskHandler, LoggingMixin):
             project=self.project_id if self.project_id else project_id,
         )
 
-    def set_context(self, ti: TaskInstance, *, identifier: str | None = None) -> None:
+    @provide_session
+    def set_context(
+        self, ti: TaskInstance, *, identifier: str | None = None, session: Session = None
+    ) -> None:
         # todo: remove-at-min-airflow-version-2.8
         #   after Airflow 2.8 can always pass `identifier`
         if getattr(super(), "supports_task_context_logging", False):
-            super().set_context(ti, identifier=identifier)
+            super().set_context(ti, identifier=identifier, session=session)
         else:
             super().set_context(ti)
         # Log relative path is used to construct local and remote

--- a/airflow/providers/microsoft/azure/log/wasb_task_handler.py
+++ b/airflow/providers/microsoft/azure/log/wasb_task_handler.py
@@ -28,9 +28,12 @@ from azure.core.exceptions import HttpResponseError
 from airflow.configuration import conf
 from airflow.utils.log.file_task_handler import FileTaskHandler
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.session import provide_session
 
 if TYPE_CHECKING:
     import logging
+
+    from sqlalchemy.orm import Session
 
     from airflow.models.taskinstance import TaskInstance
 
@@ -82,11 +85,14 @@ class WasbTaskHandler(FileTaskHandler, LoggingMixin):
             )
             return None
 
-    def set_context(self, ti: TaskInstance, *, identifier: str | None = None) -> None:
+    @provide_session
+    def set_context(
+        self, ti: TaskInstance, *, identifier: str | None = None, session: Session = None
+    ) -> None:
         # todo: remove-at-min-airflow-version-2.8
         #   after Airflow 2.8 can always pass `identifier`
         if getattr(super(), "supports_task_context_logging", False):
-            super().set_context(ti, identifier=identifier)
+            super().set_context(ti, identifier=identifier, session=session)
         else:
             super().set_context(ti)
         # Local location and remote location is needed to open and

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -45,6 +45,7 @@ from airflow.utils.state import State, TaskInstanceState
 
 if TYPE_CHECKING:
     from pendulum import DateTime
+    from sqlalchemy.orm import Session
 
     from airflow.models import DagRun
     from airflow.models.taskinstance import TaskInstance, TaskInstanceKey
@@ -209,7 +210,7 @@ class FileTaskHandler(logging.Handler):
 
     @provide_session
     def set_context(
-        self, ti: TaskInstance, *, identifier: str | None = None, session=None
+        self, ti: TaskInstance, *, identifier: str | None = None, session: Session = None
     ) -> None | SetContextPropagate:
         """
         Provide task_instance context to airflow task handler.
@@ -223,6 +224,7 @@ class FileTaskHandler(logging.Handler):
         :param ti: task instance object
         :param identifier: if set, adds suffix to log file. For use when relaying exceptional messages
             to task logs from a context other than task or trigger run
+        :param session: the database session to use
         """
         local_loc = self._init_file(ti, identifier=identifier, session=session)
         self.handler = NonCachingFileHandler(local_loc, encoding="utf-8")

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -207,7 +207,10 @@ class FileTaskHandler(logging.Handler):
         Some handlers emit "end of log" markers, and may not wish to do so when task defers.
         """
 
-    def set_context(self, ti: TaskInstance, *, identifier: str | None = None) -> None | SetContextPropagate:
+    @provide_session
+    def set_context(
+        self, ti: TaskInstance, *, identifier: str | None = None, session=None
+    ) -> None | SetContextPropagate:
         """
         Provide task_instance context to airflow task handler.
 
@@ -221,7 +224,7 @@ class FileTaskHandler(logging.Handler):
         :param identifier: if set, adds suffix to log file. For use when relaying exceptional messages
             to task logs from a context other than task or trigger run
         """
-        local_loc = self._init_file(ti, identifier=identifier)
+        local_loc = self._init_file(ti, identifier=identifier, session=session)
         self.handler = NonCachingFileHandler(local_loc, encoding="utf-8")
         if self.formatter:
             self.handler.setFormatter(self.formatter)
@@ -280,11 +283,14 @@ class FileTaskHandler(logging.Handler):
             filename = render_template_to_string(jinja_tpl, context)
         return dag_run, ti, str_tpl, filename
 
+    @provide_session
     def _render_filename(
-        self, ti: TaskInstance | TaskInstanceKey | TaskInstancePydantic, try_number: int
+        self, ti: TaskInstance | TaskInstanceKey | TaskInstancePydantic, try_number: int, session=None
     ) -> str:
         """Return the worker log filename."""
-        dag_run, ti, str_tpl, filename = self._render_filename_db_access(ti=ti, try_number=try_number)
+        dag_run, ti, str_tpl, filename = self._render_filename_db_access(
+            ti=ti, try_number=try_number, session=session
+        )
         if filename:
             return filename
         if str_tpl:
@@ -504,7 +510,8 @@ class FileTaskHandler(logging.Handler):
             parent.mkdir(mode=new_folder_permissions, exist_ok=True)
         directory.mkdir(mode=new_folder_permissions, exist_ok=True)
 
-    def _init_file(self, ti, *, identifier: str | None = None):
+    @provide_session
+    def _init_file(self, ti, *, identifier: str | None = None, session=None):
         """
         Create log directory and give it permissions that are configured.
 
@@ -516,7 +523,7 @@ class FileTaskHandler(logging.Handler):
         new_file_permissions = int(
             conf.get("logging", "file_task_handler_new_file_permissions", fallback="0o664"), 8
         )
-        local_relative_path = self._render_filename(ti, ti.try_number)
+        local_relative_path = self._render_filename(ti, ti.try_number, session=session)
         full_path = os.path.join(self.local_base, local_relative_path)
         if identifier:
             full_path += f".{identifier}.log"

--- a/airflow/utils/log/task_context_logger.py
+++ b/airflow/utils/log/task_context_logger.py
@@ -24,7 +24,7 @@ from logging import Logger
 from typing import TYPE_CHECKING
 
 from airflow.configuration import conf
-from airflow.utils.session import NEW_SESSION, provide_session
+from airflow.utils.session import provide_session
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -82,7 +82,7 @@ class TaskContextLogger:
         return h
 
     @provide_session
-    def _log(self, level: int, msg: str, *args, ti: TaskInstance, session: Session = NEW_SESSION):
+    def _log(self, level: int, msg: str, *args, ti: TaskInstance, session: Session = None):
         """
         Emit a log message to the task instance logs.
 
@@ -114,81 +114,89 @@ class TaskContextLogger:
             task_handler.close()
 
     @provide_session
-    def critical(self, msg: str, *args, ti: TaskInstance, session: Session = NEW_SESSION):
+    def critical(self, msg: str, *args, ti: TaskInstance, session: Session = None):
         """
         Emit a log message with level CRITICAL to the task instance logs.
 
         :param msg: the message to relay to task context log
         :param ti: the task instance
+        :param session: the database session to use
         """
         self._log(logging.CRITICAL, msg, *args, ti=ti, session=session)
 
     @provide_session
-    def fatal(self, msg: str, *args, ti: TaskInstance, session: Session = NEW_SESSION):
+    def fatal(self, msg: str, *args, ti: TaskInstance, session: Session = None):
         """
         Emit a log message with level FATAL to the task instance logs.
 
         :param msg: the message to relay to task context log
         :param ti: the task instance
+        :param session: the database session to use
         """
         self._log(logging.FATAL, msg, *args, ti=ti, session=session)
 
     @provide_session
-    def error(self, msg: str, *args, ti: TaskInstance, session: Session = NEW_SESSION):
+    def error(self, msg: str, *args, ti: TaskInstance, session: Session = None):
         """
         Emit a log message with level ERROR to the task instance logs.
 
         :param msg: the message to relay to task context log
         :param ti: the task instance
+        :param session: the database session to use
         """
         self._log(logging.ERROR, msg, *args, ti=ti, session=session)
 
     @provide_session
-    def warn(self, msg: str, *args, ti: TaskInstance, session: Session = NEW_SESSION):
+    def warn(self, msg: str, *args, ti: TaskInstance, session: Session = None):
         """
         Emit a log message with level WARN to the task instance logs.
 
         :param msg: the message to relay to task context log
         :param ti: the task instance
+        :param session: the database session to use
         """
         self._log(logging.WARNING, msg, *args, ti=ti, session=session)
 
     @provide_session
-    def warning(self, msg: str, *args, ti: TaskInstance, session: Session = NEW_SESSION):
+    def warning(self, msg: str, *args, ti: TaskInstance, session: Session = None):
         """
         Emit a log message with level WARNING to the task instance logs.
 
         :param msg: the message to relay to task context log
         :param ti: the task instance
+        :param session: the database session to use
         """
         self._log(logging.WARNING, msg, *args, ti=ti, session=session)
 
     @provide_session
-    def info(self, msg: str, *args, ti: TaskInstance, session: Session = NEW_SESSION):
+    def info(self, msg: str, *args, ti: TaskInstance, session: Session = None):
         """
         Emit a log message with level INFO to the task instance logs.
 
         :param msg: the message to relay to task context log
         :param ti: the task instance
+        :param session: the database session to use
         """
         self._log(logging.INFO, msg, *args, ti=ti, session=session)
 
     @provide_session
-    def debug(self, msg: str, *args, ti: TaskInstance, session: Session = NEW_SESSION):
+    def debug(self, msg: str, *args, ti: TaskInstance, session: Session = None):
         """
         Emit a log message with level DEBUG to the task instance logs.
 
         :param msg: the message to relay to task context log
         :param ti: the task instance
+        :param session: the database session to use
         """
         self._log(logging.DEBUG, msg, *args, ti=ti, session=session)
 
     @provide_session
-    def notset(self, msg: str, *args, ti: TaskInstance, session: Session = NEW_SESSION):
+    def notset(self, msg: str, *args, ti: TaskInstance, session: Session = None):
         """
         Emit a log message with level NOTSET to the task instance logs.
 
         :param msg: the message to relay to task context log
         :param ti: the task instance
+        :param session: the database session to use
         """
         self._log(logging.NOTSET, msg, *args, ti=ti, session=session)

--- a/airflow/utils/log/task_context_logger.py
+++ b/airflow/utils/log/task_context_logger.py
@@ -24,8 +24,11 @@ from logging import Logger
 from typing import TYPE_CHECKING
 
 from airflow.configuration import conf
+from airflow.utils.session import NEW_SESSION, provide_session
 
 if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
     from airflow.models.taskinstance import TaskInstance
     from airflow.utils.log.file_task_handler import FileTaskHandler
 
@@ -78,7 +81,8 @@ class TaskContextLogger:
             assert isinstance(h, FileTaskHandler)
         return h
 
-    def _log(self, level: int, msg: str, *args, ti: TaskInstance):
+    @provide_session
+    def _log(self, level: int, msg: str, *args, ti: TaskInstance, session: Session = NEW_SESSION):
         """
         Emit a log message to the task instance logs.
 
@@ -98,7 +102,7 @@ class TaskContextLogger:
 
         task_handler = copy(self.task_handler)
         try:
-            task_handler.set_context(ti, identifier=self.component_name)
+            task_handler.set_context(ti, identifier=self.component_name, session=session)
             if hasattr(task_handler, "mark_end_on_close"):
                 task_handler.mark_end_on_close = False
             filename, lineno, func, stackinfo = logger.findCaller(stacklevel=3)
@@ -109,74 +113,82 @@ class TaskContextLogger:
         finally:
             task_handler.close()
 
-    def critical(self, msg: str, *args, ti: TaskInstance):
+    @provide_session
+    def critical(self, msg: str, *args, ti: TaskInstance, session: Session = NEW_SESSION):
         """
         Emit a log message with level CRITICAL to the task instance logs.
 
         :param msg: the message to relay to task context log
         :param ti: the task instance
         """
-        self._log(logging.CRITICAL, msg, *args, ti=ti)
+        self._log(logging.CRITICAL, msg, *args, ti=ti, session=session)
 
-    def fatal(self, msg: str, *args, ti: TaskInstance):
+    @provide_session
+    def fatal(self, msg: str, *args, ti: TaskInstance, session: Session = NEW_SESSION):
         """
         Emit a log message with level FATAL to the task instance logs.
 
         :param msg: the message to relay to task context log
         :param ti: the task instance
         """
-        self._log(logging.FATAL, msg, *args, ti=ti)
+        self._log(logging.FATAL, msg, *args, ti=ti, session=session)
 
-    def error(self, msg: str, *args, ti: TaskInstance):
+    @provide_session
+    def error(self, msg: str, *args, ti: TaskInstance, session: Session = NEW_SESSION):
         """
         Emit a log message with level ERROR to the task instance logs.
 
         :param msg: the message to relay to task context log
         :param ti: the task instance
         """
-        self._log(logging.ERROR, msg, *args, ti=ti)
+        self._log(logging.ERROR, msg, *args, ti=ti, session=session)
 
-    def warn(self, msg: str, *args, ti: TaskInstance):
+    @provide_session
+    def warn(self, msg: str, *args, ti: TaskInstance, session: Session = NEW_SESSION):
         """
         Emit a log message with level WARN to the task instance logs.
 
         :param msg: the message to relay to task context log
         :param ti: the task instance
         """
-        self._log(logging.WARNING, msg, *args, ti=ti)
+        self._log(logging.WARNING, msg, *args, ti=ti, session=session)
 
-    def warning(self, msg: str, *args, ti: TaskInstance):
+    @provide_session
+    def warning(self, msg: str, *args, ti: TaskInstance, session: Session = NEW_SESSION):
         """
         Emit a log message with level WARNING to the task instance logs.
 
         :param msg: the message to relay to task context log
         :param ti: the task instance
         """
-        self._log(logging.WARNING, msg, *args, ti=ti)
+        self._log(logging.WARNING, msg, *args, ti=ti, session=session)
 
-    def info(self, msg: str, *args, ti: TaskInstance):
+    @provide_session
+    def info(self, msg: str, *args, ti: TaskInstance, session: Session = NEW_SESSION):
         """
         Emit a log message with level INFO to the task instance logs.
 
         :param msg: the message to relay to task context log
         :param ti: the task instance
         """
-        self._log(logging.INFO, msg, *args, ti=ti)
+        self._log(logging.INFO, msg, *args, ti=ti, session=session)
 
-    def debug(self, msg: str, *args, ti: TaskInstance):
+    @provide_session
+    def debug(self, msg: str, *args, ti: TaskInstance, session: Session = NEW_SESSION):
         """
         Emit a log message with level DEBUG to the task instance logs.
 
         :param msg: the message to relay to task context log
         :param ti: the task instance
         """
-        self._log(logging.DEBUG, msg, *args, ti=ti)
+        self._log(logging.DEBUG, msg, *args, ti=ti, session=session)
 
-    def notset(self, msg: str, *args, ti: TaskInstance):
+    @provide_session
+    def notset(self, msg: str, *args, ti: TaskInstance, session: Session = NEW_SESSION):
         """
         Emit a log message with level NOTSET to the task instance logs.
 
         :param msg: the message to relay to task context log
         :param ti: the task instance
         """
-        self._log(logging.NOTSET, msg, *args, ti=ti)
+        self._log(logging.NOTSET, msg, *args, ti=ti, session=session)

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -125,6 +125,7 @@ from airflow.utils.docs import get_doc_url_for_provider, get_docs_url
 from airflow.utils.helpers import exactly_one
 from airflow.utils.log import secrets_masker
 from airflow.utils.log.log_reader import TaskLogReader
+from airflow.utils.log.task_context_logger import TaskContextLogger
 from airflow.utils.net import get_hostname
 from airflow.utils.session import NEW_SESSION, create_session, provide_session
 from airflow.utils.state import DagRunState, State, TaskInstanceState
@@ -5414,9 +5415,11 @@ class TaskInstanceModelView(AirflowModelView):
         session: Session = NEW_SESSION,
     ) -> None:
         """Set task instance state."""
+        logger = TaskContextLogger("Webserver")
         try:
             count = len(tis)
             for ti in tis:
+                logger.info("Task was manually marked as %s", target_state, ti=ti, session=session)
                 ti.set_state(target_state, session)
             session.commit()
             flash(f"{count} task instances were set to '{target_state}'")

--- a/tests/utils/log/test_task_context_logger.py
+++ b/tests/utils/log/test_task_context_logger.py
@@ -66,12 +66,12 @@ def test_task_handler_not_supports_task_context_logging(mock_handler, supported)
 
 @pytest.mark.db_test
 @pytest.mark.parametrize("supported", [True, False])
-def test_task_context_log_with_correct_arguments(ti, mock_handler, supported):
+def test_task_context_log_with_correct_arguments(ti, mock_handler, supported, session):
     mock_handler.supports_task_context_logging = supported
     t = TaskContextLogger(component_name="test_component")
-    t.info("test message with args %s, %s", "a", "b", ti=ti)
+    t.info("test message with args %s, %s", "a", "b", ti=ti, session=session)
     if supported:
-        mock_handler.set_context.assert_called_once_with(ti, identifier="test_component")
+        mock_handler.set_context.assert_called_once_with(ti, identifier="test_component", session=session)
         mock_handler.emit.assert_called_once()
     else:
         mock_handler.set_context.assert_not_called()

--- a/tests/utils/test_log_handlers.py
+++ b/tests/utils/test_log_handlers.py
@@ -496,6 +496,7 @@ class TestFileTaskLogHandler:
             session.add(t)
             ti.triggerer = t
             t.task_instance = ti
+            session.flush()
         h = FileTaskHandler(base_log_folder=os.fspath(tmp_path))
         h.set_context(ti)
         expected = "dag_id=test_fth/run_id=test/task_id=dummy/attempt=0.log"


### PR DESCRIPTION
When a task is cleared or marked as failed/successful, we do not have
much information other than that the state of the task instance has been
externally set to restarting, succes or failed.

This PR adds information about this clearing/marking as success or failed
in the log so that users can know exactly what happened.

To make this work, I had to introduce session to TaskContextLogger as
without it, when the log is sent, the task instance fails.


Clearing a task from the UI:
![Screenshot 2024-05-06 at 16 31 39](https://github.com/apache/airflow/assets/4122866/2217d17d-0536-4163-a909-4fe709df1da9)

Marking failed from the UI
![Screenshot 2024-05-06 at 16 16 47](https://github.com/apache/airflow/assets/4122866/9cef9162-4224-477c-93a1-448f4077fe10)
