### PR TITLE
Simpler error message when trying to offline migrate with sqlite

### DIFF
--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -1535,7 +1535,7 @@ def _revisions_above_min_for_offline(config, revisions) -> None:
     """
     dbname = settings.engine.dialect.name
     if dbname == "sqlite":
-        raise AirflowException("Offline migration not supported for SQLite.")
+        raise SystemExit("Offline migration not supported for SQLite.")
     min_version, min_revision = ("2.2.0", "7b2661a43ba3") if dbname == "mssql" else ("2.0.0", "e959f08ac86c")
 
     # Check if there is history between the revisions and the start revision

--- a/tests/utils/test_db.py
+++ b/tests/utils/test_db.py
@@ -34,7 +34,6 @@ from alembic.script import ScriptDirectory
 from sqlalchemy import MetaData, Table
 from sqlalchemy.sql import Select
 
-from airflow.exceptions import AirflowException
 from airflow.models import Base as airflow_base
 from airflow.settings import engine
 from airflow.utils.db import (
@@ -180,7 +179,7 @@ class TestDb:
     def test_sqlite_offline_upgrade_raises_with_revision(self):
         with mock.patch("airflow.utils.db.settings.engine.dialect") as dialect:
             dialect.name = "sqlite"
-            with pytest.raises(AirflowException, match="Offline migration not supported for SQLite"):
+            with pytest.raises(SystemExit, match="Offline migration not supported for SQLite"):
                 upgradedb(from_revision="e1a11ece99cc", to_revision="54bebd308c5f", show_sql_only=True)
 
     def test_offline_upgrade_fails_for_migration_less_than_2_2_0_head_for_mssql(self):


### PR DESCRIPTION
Before:

```
$ airflow db migrate --show-sql-only --from-version 2.8.0 --to-version 2.9.0
DB: sqlite:////root/airflow/sqlite/airflow.db
Generating sql for upgrade -- upgrade commands will *not* be submitted.
Traceback (most recent call last):
  File "/usr/local/bin/airflow", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/opt/airflow/airflow/__main__.py", line 58, in main
    args.func(args)
  File "/opt/airflow/airflow/cli/cli_config.py", line 49, in command
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/airflow/airflow/utils/cli.py", line 115, in wrapper
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/opt/airflow/airflow/utils/providers_configuration_loader.py", line 55, in wrapped_function
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/airflow/airflow/cli/commands/db_command.py", line 140, in migratedb
    db.upgradedb(
  File "/opt/airflow/airflow/utils/session.py", line 84, in wrapper
    return func(*args, session=session, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/airflow/airflow/utils/db.py", line 1603, in upgradedb
    _revisions_above_min_for_offline(config=config, revisions=[from_revision, to_revision])
  File "/opt/airflow/airflow/utils/db.py", line 1538, in _revisions_above_min_for_offline
    raise AirflowException("Offline migration not supported for SQLite.")
airflow.exceptions.AirflowException: Offline migration not supported for SQLite.
```

After:

```
$ airflow db migrate --show-sql-only --from-version 2.8.0 --to-version 2.9.0
DB: sqlite:////root/airflow/sqlite/airflow.db
Generating sql for upgrade -- upgrade commands will *not* be submitted.
Offline migration not supported for SQLite.
```