### PR TITLE
Amazon Bedrock system test - Skip Provisioned Throughput workflow

### DIFF
--- a/tests/system/providers/amazon/aws/example_bedrock.py
+++ b/tests/system/providers/amazon/aws/example_bedrock.py
@@ -59,7 +59,7 @@ SKIP_LONG_TASKS = environ.get("SKIP_LONG_SYSTEM_TEST_TASKS", default=True)
 # No-commitment Provisioned Throughput is currently restricted to external
 # customers only and will fail with a ServiceQuotaExceededException if run
 # on the AWS System Test stack.
-SKIP_RESTRICTED_TASKS = environ.get("SKIP_RESTRICTED_SYSTEM_TEST_TASKS", default=True)
+SKIP_PROVISION_THROUGHPUT = environ.get("SKIP_RESTRICTED_SYSTEM_TEST_TASKS", default=True)
 
 
 LLAMA_SHORT_MODEL_ID = "meta.llama2-13b-chat-v1"
@@ -137,7 +137,7 @@ def provision_throughput_workflow():
 
     @task.branch
     def run_or_skip():
-        return end_workflow.task_id if SKIP_RESTRICTED_TASKS else provision_throughput.task_id
+        return end_workflow.task_id if SKIP_PROVISION_THROUGHPUT else provision_throughput.task_id
 
     run_or_skip = run_or_skip()
     end_workflow = EmptyOperator(task_id="end_workflow", trigger_rule=TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS)

--- a/tests/system/providers/amazon/aws/example_bedrock.py
+++ b/tests/system/providers/amazon/aws/example_bedrock.py
@@ -56,6 +56,12 @@ DAG_ID = "example_bedrock"
 # the code snippets for docs, and we can manually run the full tests.
 SKIP_LONG_TASKS = environ.get("SKIP_LONG_SYSTEM_TEST_TASKS", default=True)
 
+# No-commitment Provisioned Throughput is currently restricted to external
+# customers only and will fail with a ServiceQuotaExceededException if run
+# on the AWS System Test stack.
+SKIP_RESTRICTED_TASKS = environ.get("SKIP_RESTRICTED_SYSTEM_TEST_TASKS", default=True)
+
+
 LLAMA_SHORT_MODEL_ID = "meta.llama2-13b-chat-v1"
 TITAN_MODEL_ID = "amazon.titan-text-express-v1:0:8k"
 TITAN_SHORT_MODEL_ID = TITAN_MODEL_ID.split(":")[0]
@@ -107,9 +113,43 @@ def customize_model_workflow():
     chain(run_or_skip, customize_model, await_custom_model_job, delete_custom_model(), end_workflow)
 
 
-@task
-def delete_provision_throughput(provisioned_model_id: str):
-    BedrockHook().conn.delete_provisioned_model_throughput(provisionedModelId=provisioned_model_id)
+@task_group
+def provision_throughput_workflow():
+    # [START howto_operator_provision_throughput]
+    provision_throughput = BedrockCreateProvisionedModelThroughputOperator(
+        task_id="provision_throughput",
+        model_units=1,
+        provisioned_model_name=provisioned_model_name,
+        model_id=f"{model_arn_prefix}{TITAN_MODEL_ID}",
+    )
+    # [END howto_operator_provision_throughput]
+
+    # [START howto_sensor_provision_throughput]
+    await_provision_throughput = BedrockProvisionModelThroughputCompletedSensor(
+        task_id="await_provision_throughput",
+        model_id=provision_throughput.output,
+    )
+    # [END howto_sensor_provision_throughput]
+
+    @task
+    def delete_provision_throughput(provisioned_model_id: str):
+        BedrockHook().conn.delete_provisioned_model_throughput(provisionedModelId=provisioned_model_id)
+
+    @task.branch
+    def run_or_skip():
+        return end_workflow.task_id if SKIP_RESTRICTED_TASKS else provision_throughput.task_id
+
+    run_or_skip = run_or_skip()
+    end_workflow = EmptyOperator(task_id="end_workflow", trigger_rule=TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS)
+
+    chain(run_or_skip, Label("Quota-restricted tasks skipped"), end_workflow)
+    chain(
+        run_or_skip,
+        provision_throughput,
+        await_provision_throughput,
+        delete_provision_throughput(provision_throughput.output),
+        end_workflow,
+    )
 
 
 with DAG(
@@ -157,23 +197,6 @@ with DAG(
     )
     # [END howto_operator_invoke_titan_model]
 
-    # [START howto_operator_provision_throughput]
-    provision_throughput = BedrockCreateProvisionedModelThroughputOperator(
-        task_id="provision_throughput",
-        model_units=1,
-        provisioned_model_name=provisioned_model_name,
-        model_id=f"{model_arn_prefix}{TITAN_MODEL_ID}",
-    )
-    # [END howto_operator_provision_throughput]
-    provision_throughput.wait_for_completion = False
-
-    # [START howto_sensor_provision_throughput]
-    await_provision_throughput = BedrockProvisionModelThroughputCompletedSensor(
-        task_id="await_provision_throughput",
-        model_id=provision_throughput.output,
-    )
-    # [END howto_sensor_provision_throughput]
-
     delete_bucket = S3DeleteBucketOperator(
         task_id="delete_bucket",
         trigger_rule=TriggerRule.ALL_DONE,
@@ -189,10 +212,8 @@ with DAG(
         # TEST BODY
         [invoke_llama_model, invoke_titan_model],
         customize_model_workflow(),
-        provision_throughput,
-        await_provision_throughput,
+        provision_throughput_workflow(),
         # TEST TEARDOWN
-        delete_provision_throughput(provision_throughput.output),
         delete_bucket,
     )
 


### PR DESCRIPTION
The Bedrock team recently implemented a restriction against internal teams creating no-commitment throughput in order to reserve that capacity for public users.  That change causes this test to fail with a ServiceQuotaExceededException when run in our internal team system test dashboard stack.  Skipping that block of the test will allow us to retain the sample code snippets and get the test passing again, albeit without actually testing that API call anymore.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
