### PR TITLE
Allow passing labels to FAB Views registered via Plugins

### DIFF
--- a/airflow/www/extensions/init_views.py
+++ b/airflow/www/extensions/init_views.py
@@ -142,16 +142,15 @@ def init_plugins(app):
     appbuilder = app.appbuilder
 
     for view in plugins_manager.flask_appbuilder_views:
-        if view.get("name"):
-            # Shallow copy the view to avoid modifying the original view
-            # since Plugins are global objects
-            view_copy = view.copy()
-
-            name = view_copy.pop("name")
-            baseview = view_copy.pop("view")
-
+        name = view.get("name")
+        if name:
+            filtered_view_kwargs = {k: v for k, v in view.items() if k not in ["view"]}
             log.debug("Adding view %s with menu", name)
-            appbuilder.add_view(baseview, name, **view_copy)
+            baseview = view.get("view")
+            if baseview:
+                appbuilder.add_view(baseview, **filtered_view_kwargs)
+            else:
+                log.error("'view' key is missing for the named view: %s", name)
         else:
             # if 'name' key is missing, intent is to add view without menu
             log.debug("Adding view %s without menu", str(type(view["view"])))

--- a/airflow/www/extensions/init_views.py
+++ b/airflow/www/extensions/init_views.py
@@ -142,10 +142,11 @@ def init_plugins(app):
     appbuilder = app.appbuilder
 
     for view in plugins_manager.flask_appbuilder_views:
-        name = view.get("name")
+        name = view.pop("name", None)
         if name:
             log.debug("Adding view %s with menu", name)
-            appbuilder.add_view(view["view"], name, category=view["category"])
+            baseview = view.pop("view")
+            appbuilder.add_view(baseview, name, **view)
         else:
             # if 'name' key is missing, intent is to add view without menu
             log.debug("Adding view %s without menu", str(type(view["view"])))

--- a/airflow/www/extensions/init_views.py
+++ b/airflow/www/extensions/init_views.py
@@ -142,11 +142,16 @@ def init_plugins(app):
     appbuilder = app.appbuilder
 
     for view in plugins_manager.flask_appbuilder_views:
-        name = view.pop("name", None)
-        if name:
+        if view.get("name"):
+            # Shallow copy the view to avoid modifying the original view
+            # since Plugins are global objects
+            view_copy = view.copy()
+
+            name = view_copy.pop("name")
+            baseview = view_copy.pop("view")
+
             log.debug("Adding view %s with menu", name)
-            baseview = view.pop("view")
-            appbuilder.add_view(baseview, name, **view)
+            appbuilder.add_view(baseview, name, **view_copy)
         else:
             # if 'name' key is missing, intent is to add view without menu
             log.debug("Adding view %s without menu", str(type(view["view"])))

--- a/tests/cli/commands/test_plugins_command.py
+++ b/tests/cli/commands/test_plugins_command.py
@@ -72,6 +72,7 @@ class TestPluginsCommand:
                     {
                         "name": "Test View",
                         "category": "Test Plugin",
+                        "label": "Test Label",
                         "view": "tests.plugins.test_plugin.PluginTestAppBuilderBaseView",
                     }
                 ],

--- a/tests/plugins/test_plugin.py
+++ b/tests/plugins/test_plugin.py
@@ -79,7 +79,12 @@ class PluginTestAppBuilderBaseView(AppBuilderBaseView):
 
 
 v_appbuilder_view = PluginTestAppBuilderBaseView()
-v_appbuilder_package = {"name": "Test View", "category": "Test Plugin", "view": v_appbuilder_view}
+v_appbuilder_package = {
+    "name": "Test View",
+    "category": "Test Plugin",
+    "view": v_appbuilder_view,
+    "label": "Test Label",
+}
 
 v_nomenu_appbuilder_package = {"view": v_appbuilder_view}
 

--- a/tests/plugins/test_plugins_manager.py
+++ b/tests/plugins/test_plugins_manager.py
@@ -103,6 +103,7 @@ class TestPluginsRBAC:
         link = links[0]
         assert link.name == v_appbuilder_package["category"]
         assert link.childs[0].name == v_appbuilder_package["name"]
+        assert link.childs[0].label == v_appbuilder_package["label"]
 
     def test_flaskappbuilder_menu_links(self):
         from tests.plugins.test_plugin import appbuilder_mitem, appbuilder_mitem_toplevel


### PR DESCRIPTION
Currently, we only allow passing "name" and "category" for any FAB View when registering via Airflow plugin.

However, we do allow the same for the Menu Link as shown below:

https://github.com/apache/airflow/blob/a74b5f069481e1a2339cfd95e137619b16390906/airflow/www/extensions/init_views.py#L154-L158

This PR makes it consistent so we can pass more info that is available in FAB's [`add_view`](https://github.com/dpgaspar/Flask-AppBuilder/blob/c65e067f09e741c00322221263c8599b8e8811d5/flask_appbuilder/base.py#L361-L372) method like `href`, `label`, `category_icons`, `icon` etc

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
