### PR TITLE
Fix logic to cancel the external job if the TaskInstance is not in a running or deferred state for DataprocCreateClusterOperator

### DIFF
--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -810,9 +810,6 @@ class DataprocCreateClusterOperator(GoogleCloudBaseOperator):
                 else:
                     self.defer(
                         trigger=DataprocClusterTrigger(
-                            dag_id=self.dag_id,
-                            task_id=self.task_id,
-                            run_id=context.get("run_id"),
                             cluster_name=self.cluster_name,
                             project_id=self.project_id,
                             region=self.region,
@@ -2751,9 +2748,6 @@ class DataprocUpdateClusterOperator(GoogleCloudBaseOperator):
             if cluster.status.state != cluster.status.State.RUNNING:
                 self.defer(
                     trigger=DataprocClusterTrigger(
-                        dag_id=self.dag_id,
-                        task_id=self.task_id,
-                        run_id=context.get("run_id"),
                         cluster_name=self.cluster_name,
                         project_id=self.project_id,
                         region=self.region,

--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -810,6 +810,9 @@ class DataprocCreateClusterOperator(GoogleCloudBaseOperator):
                 else:
                     self.defer(
                         trigger=DataprocClusterTrigger(
+                            dag_id=self.dag_id,
+                            task_id=self.task_id,
+                            run_id=context.get("run_id"),
                             cluster_name=self.cluster_name,
                             project_id=self.project_id,
                             region=self.region,
@@ -2748,6 +2751,9 @@ class DataprocUpdateClusterOperator(GoogleCloudBaseOperator):
             if cluster.status.state != cluster.status.State.RUNNING:
                 self.defer(
                     trigger=DataprocClusterTrigger(
+                        dag_id=self.dag_id,
+                        task_id=self.task_id,
+                        run_id=context.get("run_id"),
                         cluster_name=self.cluster_name,
                         project_id=self.project_id,
                         region=self.region,

--- a/airflow/providers/google/cloud/triggers/dataproc.py
+++ b/airflow/providers/google/cloud/triggers/dataproc.py
@@ -195,7 +195,7 @@ class DataprocClusterTrigger(DataprocBaseTrigger):
         task_instance = query.one_or_none()
         if task_instance is None:
             raise AirflowException(
-                "TaskInstance dag_id: %s,task_id: %s, run_id: %s and map_index: %s not found",
+                "TaskInstance with dag_id: %s,task_id: %s, run_id: %s and map_index: %s is not found.",
                 self.task_instance.dag_id,
                 self.task_instance.task_id,
                 self.task_instance.run_id,

--- a/airflow/providers/google/cloud/triggers/dataproc.py
+++ b/airflow/providers/google/cloud/triggers/dataproc.py
@@ -22,16 +22,22 @@ from __future__ import annotations
 import asyncio
 import re
 import time
-from typing import Any, AsyncIterator, Sequence
+from typing import TYPE_CHECKING, Any, AsyncIterator, Sequence
 
 from google.api_core.exceptions import NotFound
 from google.cloud.dataproc_v1 import Batch, Cluster, ClusterStatus, JobStatus
 
 from airflow.exceptions import AirflowException
+from airflow.models.taskinstance import TaskInstance
 from airflow.providers.google.cloud.hooks.dataproc import DataprocAsyncHook, DataprocHook
 from airflow.providers.google.cloud.utils.dataproc import DataprocOperationType
 from airflow.providers.google.common.hooks.base_google import PROVIDE_PROJECT_ID
 from airflow.triggers.base import BaseTrigger, TriggerEvent
+from airflow.utils.session import provide_session
+from airflow.utils.state import TaskInstanceState
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
 
 
 class DataprocBaseTrigger(BaseTrigger):
@@ -160,14 +166,20 @@ class DataprocClusterTrigger(DataprocBaseTrigger):
     :param polling_interval_seconds: polling period in seconds to check for the status
     """
 
-    def __init__(self, cluster_name: str, **kwargs):
+    def __init__(self, dag_id: str, task_id: str, run_id: str | None, cluster_name: str, **kwargs):
         super().__init__(**kwargs)
+        self.dag_id = dag_id
+        self.task_id = task_id
+        self.run_id = run_id
         self.cluster_name = cluster_name
 
     def serialize(self) -> tuple[str, dict[str, Any]]:
         return (
             "airflow.providers.google.cloud.triggers.dataproc.DataprocClusterTrigger",
             {
+                "dag_id": self.dag_id,
+                "task_id": self.task_id,
+                "run_id": self.run_id,
                 "cluster_name": self.cluster_name,
                 "project_id": self.project_id,
                 "region": self.region,
@@ -177,6 +189,38 @@ class DataprocClusterTrigger(DataprocBaseTrigger):
                 "delete_on_error": self.delete_on_error,
             },
         )
+
+    @provide_session
+    def get_task_instance(self, session: Session) -> TaskInstance:
+        """
+        Get the task instance for the current task.
+
+        :param session: Sqlalchemy session
+        """
+        query = session.query(TaskInstance).filter(
+            TaskInstance.dag_id == self.dag_id,
+            TaskInstance.task_id == self.task_id,
+            TaskInstance.run_id == self.run_id,
+        )
+        task_instance = query.one_or_none()
+        if task_instance is None:
+            raise AirflowException(
+                f"TaskInstance {self.dag_id}.{self.task_id} with run_id {self.run_id} not found"
+            )
+        return task_instance
+
+    def safe_to_cancel(self) -> bool:
+        """
+        Whether it is safe to cancel the external job which is being executed by this trigger.
+
+        This is to avoid the case that `asyncio.CancelledError` is called because the trigger itself is stopped.
+        Because in those cases, we should NOT cancel the external job.
+        """
+        task_instance = self.get_task_instance()  # type: ignore[call-arg]
+        return task_instance.state not in {
+            TaskInstanceState.RUNNING,
+            TaskInstanceState.DEFERRED,
+        }
 
     async def run(self) -> AsyncIterator[TriggerEvent]:
         try:
@@ -207,7 +251,7 @@ class DataprocClusterTrigger(DataprocBaseTrigger):
                 await asyncio.sleep(self.polling_interval_seconds)
         except asyncio.CancelledError:
             try:
-                if self.delete_on_error:
+                if self.delete_on_error and self.safe_to_cancel():
                     self.log.info("Deleting cluster %s.", self.cluster_name)
                     # The synchronous hook is utilized to delete the cluster when a task is cancelled.
                     # This is because the asynchronous hook deletion is not awaited when the trigger task

--- a/airflow/providers/google/cloud/triggers/dataproc.py
+++ b/airflow/providers/google/cloud/triggers/dataproc.py
@@ -22,17 +22,22 @@ from __future__ import annotations
 import asyncio
 import re
 import time
-from typing import Any, AsyncIterator, Sequence
+from typing import TYPE_CHECKING, Any, AsyncIterator, Sequence
 
 from google.api_core.exceptions import NotFound
 from google.cloud.dataproc_v1 import Batch, Cluster, ClusterStatus, JobStatus
 
 from airflow.exceptions import AirflowException
+from airflow.models.taskinstance import TaskInstance
 from airflow.providers.google.cloud.hooks.dataproc import DataprocAsyncHook, DataprocHook
 from airflow.providers.google.cloud.utils.dataproc import DataprocOperationType
 from airflow.providers.google.common.hooks.base_google import PROVIDE_PROJECT_ID
 from airflow.triggers.base import BaseTrigger, TriggerEvent
+from airflow.utils.session import provide_session
 from airflow.utils.state import TaskInstanceState
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm.session import Session
 
 
 class DataprocBaseTrigger(BaseTrigger):
@@ -179,6 +184,25 @@ class DataprocClusterTrigger(DataprocBaseTrigger):
             },
         )
 
+    @provide_session
+    def get_task_instance(self, session: Session) -> TaskInstance:
+        query = session.query(TaskInstance).filter(
+            TaskInstance.dag_id == self.task_instance.dag_id,
+            TaskInstance.task_id == self.task_instance.task_id,
+            TaskInstance.run_id == self.task_instance.run_id,
+            TaskInstance.map_index == self.task_instance.map_index,
+        )
+        task_instance = query.one_or_none()
+        if task_instance is None:
+            raise AirflowException(
+                "TaskInstance dag_id: %s,task_id: %s, run_id: %s and map_index: %s not found",
+                self.task_instance.dag_id,
+                self.task_instance.task_id,
+                self.task_instance.run_id,
+                self.task_instance.map_index,
+            )
+        return task_instance
+
     def safe_to_cancel(self) -> bool:
         """
         Whether it is safe to cancel the external job which is being executed by this trigger.
@@ -186,10 +210,9 @@ class DataprocClusterTrigger(DataprocBaseTrigger):
         This is to avoid the case that `asyncio.CancelledError` is called because the trigger itself is stopped.
         Because in those cases, we should NOT cancel the external job.
         """
-        return self.task_instance not in {
-            TaskInstanceState.RUNNING,
-            TaskInstanceState.DEFERRED,
-        }
+        # Database query is needed to get the latest state of the task instance.
+        task_instance = self.get_task_instance()  # type: ignore[call-arg]
+        return task_instance.state != TaskInstanceState.DEFERRED
 
     async def run(self) -> AsyncIterator[TriggerEvent]:
         try:
@@ -221,6 +244,10 @@ class DataprocClusterTrigger(DataprocBaseTrigger):
         except asyncio.CancelledError:
             try:
                 if self.delete_on_error and self.safe_to_cancel():
+                    self.log.info(
+                        "Deleting the cluster as it is safe to delete as the airflow TaskInstance is not in "
+                        "deferred state."
+                    )
                     self.log.info("Deleting cluster %s.", self.cluster_name)
                     # The synchronous hook is utilized to delete the cluster when a task is cancelled.
                     # This is because the asynchronous hook deletion is not awaited when the trigger task

--- a/tests/providers/google/cloud/triggers/test_dataproc.py
+++ b/tests/providers/google/cloud/triggers/test_dataproc.py
@@ -49,17 +49,11 @@ TEST_POLL_INTERVAL = 5
 TEST_GCP_CONN_ID = "google_cloud_default"
 TEST_OPERATION_NAME = "name"
 TEST_JOB_ID = "test-job-id"
-TEST_DAG_ID = "test_dag_id"
-TEST_TASK_ID = "test_task_id"
-TEST_RUN_ID = "test_run_id"
 
 
 @pytest.fixture
 def cluster_trigger():
     return DataprocClusterTrigger(
-        dag_id=TEST_DAG_ID,
-        task_id=TEST_TASK_ID,
-        run_id=TEST_RUN_ID,
         cluster_name=TEST_CLUSTER_NAME,
         project_id=TEST_PROJECT_ID,
         region=TEST_REGION,
@@ -162,9 +156,6 @@ class TestDataprocClusterTrigger:
         classpath, kwargs = cluster_trigger.serialize()
         assert classpath == "airflow.providers.google.cloud.triggers.dataproc.DataprocClusterTrigger"
         assert kwargs == {
-            "dag_id": TEST_DAG_ID,
-            "task_id": TEST_TASK_ID,
-            "run_id": TEST_RUN_ID,
             "cluster_name": TEST_CLUSTER_NAME,
             "project_id": TEST_PROJECT_ID,
             "region": TEST_REGION,
@@ -267,9 +258,6 @@ class TestDataprocClusterTrigger:
         mock_get_sync_hook.return_value.delete_cluster = mock_delete_cluster
 
         cluster_trigger = DataprocClusterTrigger(
-            dag_id="dag_id",
-            task_id="task_id",
-            run_id="run_id",
             cluster_name="cluster_name",
             project_id="project-id",
             region="region",

--- a/tests/providers/google/cloud/triggers/test_dataproc.py
+++ b/tests/providers/google/cloud/triggers/test_dataproc.py
@@ -49,11 +49,17 @@ TEST_POLL_INTERVAL = 5
 TEST_GCP_CONN_ID = "google_cloud_default"
 TEST_OPERATION_NAME = "name"
 TEST_JOB_ID = "test-job-id"
+TEST_DAG_ID = "test_dag_id"
+TEST_TASK_ID = "test_task_id"
+TEST_RUN_ID = "test_run_id"
 
 
 @pytest.fixture
 def cluster_trigger():
     return DataprocClusterTrigger(
+        dag_id=TEST_DAG_ID,
+        task_id=TEST_TASK_ID,
+        run_id=TEST_RUN_ID,
         cluster_name=TEST_CLUSTER_NAME,
         project_id=TEST_PROJECT_ID,
         region=TEST_REGION,
@@ -156,6 +162,9 @@ class TestDataprocClusterTrigger:
         classpath, kwargs = cluster_trigger.serialize()
         assert classpath == "airflow.providers.google.cloud.triggers.dataproc.DataprocClusterTrigger"
         assert kwargs == {
+            "dag_id": TEST_DAG_ID,
+            "task_id": TEST_TASK_ID,
+            "run_id": TEST_RUN_ID,
             "cluster_name": TEST_CLUSTER_NAME,
             "project_id": TEST_PROJECT_ID,
             "region": TEST_REGION,
@@ -258,6 +267,9 @@ class TestDataprocClusterTrigger:
         mock_get_sync_hook.return_value.delete_cluster = mock_delete_cluster
 
         cluster_trigger = DataprocClusterTrigger(
+            dag_id="dag_id",
+            task_id="task_id",
+            run_id="run_id",
             cluster_name="cluster_name",
             project_id="project-id",
             region="region",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

[PR #39130](https://github.com/apache/airflow/pull/39130) introduces a method for handling asyncio.CancelledError in a try/except block. However, this method is deemed unsafe, and it affects `DataprocCreateClusterOperator` operators, which enables external job cancellation if the triggerer restarts or crashes. This can cause weird behaviour like rescheduling deferred operators, as Airflow remains unaware of job cancellations. 

As a workaround, capturing `asyncio.CancelledError` cancels the job only if the TaskInstance is not in a running or deferred state. This prevents premature external job termination.

More details at: https://github.com/apache/airflow/issues/36090#issuecomment-2094972855
<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
