### PR TITLE
Fix logic to cancel the external job if the TaskInstance is not in a running or deferred state for DataprocSubmitJobOperator

### DIFF
--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -1454,9 +1454,6 @@ class DataprocJobBaseOperator(GoogleCloudBaseOperator):
             if self.deferrable:
                 self.defer(
                     trigger=DataprocSubmitTrigger(
-                        dag_id=self.dag_id,
-                        task_id=self.task_id,
-                        run_id=context.get("run_id"),
                         job_id=job_id,
                         project_id=self.project_id,
                         region=self.region,

--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -1454,6 +1454,9 @@ class DataprocJobBaseOperator(GoogleCloudBaseOperator):
             if self.deferrable:
                 self.defer(
                     trigger=DataprocSubmitTrigger(
+                        dag_id=self.dag_id,
+                        task_id=self.task_id,
+                        run_id=context.get("run_id"),
                         job_id=job_id,
                         project_id=self.project_id,
                         region=self.region,
@@ -2586,6 +2589,9 @@ class DataprocSubmitJobOperator(GoogleCloudBaseOperator):
                 raise AirflowException(f"Job was cancelled:\n{job}")
             self.defer(
                 trigger=DataprocSubmitTrigger(
+                    dag_id=self.dag_id,
+                    task_id=self.task_id,
+                    run_id=context.get("run_id"),
                     job_id=self.job_id,
                     project_id=self.project_id,
                     region=self.region,

--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -2589,9 +2589,6 @@ class DataprocSubmitJobOperator(GoogleCloudBaseOperator):
                 raise AirflowException(f"Job was cancelled:\n{job}")
             self.defer(
                 trigger=DataprocSubmitTrigger(
-                    dag_id=self.dag_id,
-                    task_id=self.task_id,
-                    run_id=context.get("run_id"),
                     job_id=self.job_id,
                     project_id=self.project_id,
                     region=self.region,

--- a/tests/providers/google/cloud/triggers/test_dataproc.py
+++ b/tests/providers/google/cloud/triggers/test_dataproc.py
@@ -49,9 +49,6 @@ TEST_POLL_INTERVAL = 5
 TEST_GCP_CONN_ID = "google_cloud_default"
 TEST_OPERATION_NAME = "name"
 TEST_JOB_ID = "test-job-id"
-TEST_DAG_ID = "test_dag_id"
-TEST_TASK_ID = "test_task_id"
-TEST_RUN_ID = "test_run_id"
 
 
 @pytest.fixture
@@ -121,9 +118,6 @@ def async_get_cluster():
 @pytest.fixture
 def submit_trigger():
     return DataprocSubmitTrigger(
-        dag_id=TEST_DAG_ID,
-        task_id=TEST_TASK_ID,
-        run_id=TEST_RUN_ID,
         job_id=TEST_JOB_ID,
         project_id=TEST_PROJECT_ID,
         region=TEST_REGION,
@@ -500,9 +494,6 @@ class TestDataprocSubmitTrigger:
         classpath, kwargs = submit_trigger.serialize()
         assert classpath == "airflow.providers.google.cloud.triggers.dataproc.DataprocSubmitTrigger"
         assert kwargs == {
-            "dag_id": TEST_DAG_ID,
-            "task_id": TEST_TASK_ID,
-            "run_id": TEST_RUN_ID,
             "job_id": TEST_JOB_ID,
             "project_id": TEST_PROJECT_ID,
             "region": TEST_REGION,

--- a/tests/providers/google/cloud/triggers/test_dataproc.py
+++ b/tests/providers/google/cloud/triggers/test_dataproc.py
@@ -123,6 +123,7 @@ def submit_trigger():
         region=TEST_REGION,
         gcp_conn_id=TEST_GCP_CONN_ID,
         polling_interval_seconds=TEST_POLL_INTERVAL,
+        cancel_on_kill=True,
     )
 
 
@@ -536,14 +537,15 @@ class TestDataprocSubmitTrigger:
         assert event.payload == expected_event.payload
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("is_safe_to_cancel", [True, False])
     @mock.patch("airflow.providers.google.cloud.triggers.dataproc.DataprocSubmitTrigger.get_async_hook")
     @mock.patch("airflow.providers.google.cloud.triggers.dataproc.DataprocSubmitTrigger.get_sync_hook")
     @mock.patch("airflow.providers.google.cloud.triggers.dataproc.DataprocSubmitTrigger.safe_to_cancel")
     async def test_submit_trigger_run_cancelled(
-        self, mock_safe_to_cancel, mock_get_sync_hook, mock_get_async_hook, submit_trigger
+        self, mock_safe_to_cancel, mock_get_sync_hook, mock_get_async_hook, submit_trigger, is_safe_to_cancel
     ):
         """Test the trigger correctly handles an asyncio.CancelledError."""
-        mock_safe_to_cancel.return_value = True
+        mock_safe_to_cancel.return_value = is_safe_to_cancel
         mock_async_hook = mock_get_async_hook.return_value
         mock_async_hook.get_job.side_effect = asyncio.CancelledError
 
@@ -567,7 +569,7 @@ class TestDataprocSubmitTrigger:
             pytest.fail(f"Unexpected exception raised: {e}")
 
         # Check if cancel_job was correctly called
-        if submit_trigger.cancel_on_kill:
+        if submit_trigger.cancel_on_kill and is_safe_to_cancel:
             mock_sync_hook.cancel_job.assert_called_once_with(
                 job_id=submit_trigger.job_id,
                 project_id=submit_trigger.project_id,

--- a/tests/providers/google/cloud/triggers/test_dataproc.py
+++ b/tests/providers/google/cloud/triggers/test_dataproc.py
@@ -49,6 +49,9 @@ TEST_POLL_INTERVAL = 5
 TEST_GCP_CONN_ID = "google_cloud_default"
 TEST_OPERATION_NAME = "name"
 TEST_JOB_ID = "test-job-id"
+TEST_DAG_ID = "test_dag_id"
+TEST_TASK_ID = "test_task_id"
+TEST_RUN_ID = "test_run_id"
 
 
 @pytest.fixture
@@ -118,6 +121,9 @@ def async_get_cluster():
 @pytest.fixture
 def submit_trigger():
     return DataprocSubmitTrigger(
+        dag_id=TEST_DAG_ID,
+        task_id=TEST_TASK_ID,
+        run_id=TEST_RUN_ID,
         job_id=TEST_JOB_ID,
         project_id=TEST_PROJECT_ID,
         region=TEST_REGION,
@@ -494,6 +500,9 @@ class TestDataprocSubmitTrigger:
         classpath, kwargs = submit_trigger.serialize()
         assert classpath == "airflow.providers.google.cloud.triggers.dataproc.DataprocSubmitTrigger"
         assert kwargs == {
+            "dag_id": TEST_DAG_ID,
+            "task_id": TEST_TASK_ID,
+            "run_id": TEST_RUN_ID,
             "job_id": TEST_JOB_ID,
             "project_id": TEST_PROJECT_ID,
             "region": TEST_REGION,
@@ -538,10 +547,12 @@ class TestDataprocSubmitTrigger:
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.google.cloud.triggers.dataproc.DataprocSubmitTrigger.get_async_hook")
     @mock.patch("airflow.providers.google.cloud.triggers.dataproc.DataprocSubmitTrigger.get_sync_hook")
+    @mock.patch("airflow.providers.google.cloud.triggers.dataproc.DataprocSubmitTrigger.safe_to_cancel")
     async def test_submit_trigger_run_cancelled(
-        self, mock_get_sync_hook, mock_get_async_hook, submit_trigger
+        self, mock_safe_to_cancel, mock_get_sync_hook, mock_get_async_hook, submit_trigger
     ):
         """Test the trigger correctly handles an asyncio.CancelledError."""
+        mock_safe_to_cancel.return_value = True
         mock_async_hook = mock_get_async_hook.return_value
         mock_async_hook.get_job.side_effect = asyncio.CancelledError
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

[PR #39230](https://github.com/apache/airflow/pull/39230) introduces a method for handling asyncio.CancelledError in a try/except block. However, this method is deemed unsafe, and it affects `DataprocSubmitJobOperator` operators, which enables external job cancellation if the triggerer restarts or crashes. This can cause weird behaviour like rescheduling deferred operators, as Airflow remains unaware of job cancellations. 

As a workaround, capturing `asyncio.CancelledError` cancels the job only if the TaskInstance is not in a running or deferred state. This prevents premature external job termination.

More details at: https://github.com/apache/airflow/issues/36090#issuecomment-2094972855

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
