### PR TITLE
Bump `colorlog` to `>=6.8.2`

### DIFF
--- a/airflow/utils/log/colored_log.py
+++ b/airflow/utils/log/colored_log.py
@@ -23,7 +23,7 @@ import sys
 from typing import TYPE_CHECKING, Any
 
 import re2
-from colorlog import TTYColoredFormatter
+from colorlog import ColoredFormatter
 from colorlog.escape_codes import esc, escape_codes
 
 from airflow.utils.log.timezone_aware import TimezoneAware
@@ -40,14 +40,14 @@ DEFAULT_COLORS = {
 }
 
 BOLD_ON = escape_codes["bold"]
-BOLD_OFF = esc("22")
+BOLD_OFF = esc(22)
 
 
-class CustomTTYColoredFormatter(TTYColoredFormatter, TimezoneAware):
+class CustomTTYColoredFormatter(ColoredFormatter, TimezoneAware):
     """
     Custom log formatter.
 
-    Extends `colored.TTYColoredFormatter` by adding attributes
+    Extends `colored.ColoredFormatter` by adding attributes
     to message arguments and coloring error traceback.
     """
 
@@ -91,7 +91,9 @@ class CustomTTYColoredFormatter(TTYColoredFormatter, TimezoneAware):
 
             if record.exc_text:
                 record.exc_text = (
-                    self.color(self.log_colors, record.levelname) + record.exc_text + escape_codes["reset"]
+                    self._get_escape_code(self.log_colors, record.levelname)
+                    + record.exc_text
+                    + escape_codes["reset"]
                 )
 
         return record

--- a/airflow/utils/log/colored_log.py
+++ b/airflow/utils/log/colored_log.py
@@ -100,7 +100,7 @@ class CustomTTYColoredFormatter(ColoredFormatter, TimezoneAware):
 
     def format(self, record: LogRecord) -> str:
         try:
-            if self.stream.isatty():
+            if self.stream is not None and self.stream.isatty():
                 record = self._color_record_args(record)
                 record = self._color_record_traceback(record)
             return super().format(record)

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -418,9 +418,7 @@ DEPENDENCIES = [
     # Blinker use for signals in Flask, this is an optional dependency in Flask 2.2 and lower.
     # In Flask 2.3 it becomes a mandatory dependency, and flask signals are always available.
     "blinker>=1.6.2",
-    # Colorlog 6.x merges TTYColoredFormatter into ColoredFormatter, breaking backwards compatibility with 4.x
-    # Update CustomTTYColoredFormatter to remove
-    "colorlog>=4.0.2, <5.0",
+    "colorlog>=6.8.2",
     "configupdater>=3.1.1",
     # `airflow/www/extensions/init_views` imports `connexion.decorators.validation.RequestBodyValidator`
     # connexion v3 has refactored the entire module to middleware, see: /spec-first/connexion/issues/1525


### PR DESCRIPTION
Fixed the needed breaking changes: https://github.com/borntyping/python-colorlog/compare/v5.0.0...v6.8.2 🤞 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
