### PR TITLE
Remove unused `copy_into_postifx` param from docstring

### DIFF
--- a/airflow/providers/snowflake/transfers/copy_into_snowflake.py
+++ b/airflow/providers/snowflake/transfers/copy_into_snowflake.py
@@ -42,8 +42,6 @@ class CopyFromExternalStageToSnowflakeOperator(BaseOperator):
     :param prefix: cloud storage location specified to limit the set of files to load
     :param files: files to load into table
     :param pattern: pattern to load files from external location to table
-    :param copy_into_postifx: optional sql postfix for INSERT INTO query
-           such as `formatTypeOptions` and `copyOptions`
     :param snowflake_conn_id:  Reference to :ref:`Snowflake connection id<howto/connection:snowflake>`
     :param account: snowflake account name
     :param warehouse: name of snowflake warehouse


### PR DESCRIPTION
The param is present in the docstring for CopyFromExternalStageToSnowflakeOperator, but was never implemented. This is misleading when reading the Python API docs for this operator.
