### PR TITLE
Allow FTPHook to change port number

### DIFF
--- a/airflow/providers/ftp/hooks/ftp.py
+++ b/airflow/providers/ftp/hooks/ftp.py
@@ -58,7 +58,11 @@ class FTPHook(BaseHook):
         if self.conn is None:
             params = self.get_connection(self.ftp_conn_id)
             pasv = params.extra_dejson.get("passive", True)
-            self.conn = ftplib.FTP(params.host, params.login, params.password)  # nosec: B321
+            self.conn = ftplib.FTP()  # nosec: B321
+            if params.host:
+                self.conn.connect(params.host, params.port)
+                if params.login:
+                    self.conn.login(params.login, params.password)
             self.conn.set_pasv(pasv)
 
         return self.conn

--- a/airflow/providers/ftp/hooks/ftp.py
+++ b/airflow/providers/ftp/hooks/ftp.py
@@ -17,13 +17,14 @@
 # under the License.
 from __future__ import annotations
 
-import logging
 import datetime
 import ftplib  # nosec: B402
+import logging
 from typing import Any, Callable
 
 from airflow.hooks.base import BaseHook
 
+logger = logging.getLogger(__name__)
 
 class FTPHook(BaseHook):
     """
@@ -64,7 +65,7 @@ class FTPHook(BaseHook):
                 port = ftplib.FTP_PORT
                 if params.port is not None:
                     port = params.port
-                logging.info(f"Connecting via FTP to {params.host}:{port}")
+                logger.info("Connecting via FTP to %s:%d" % (params.host, port))
                 self.conn.connect(params.host, port)
                 if params.login:
                     self.conn.login(params.login, params.password)

--- a/airflow/providers/ftp/hooks/ftp.py
+++ b/airflow/providers/ftp/hooks/ftp.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import logging
 import datetime
 import ftplib  # nosec: B402
 from typing import Any, Callable
@@ -63,6 +64,7 @@ class FTPHook(BaseHook):
                 port = ftplib.FTP_PORT
                 if params.port is not None:
                     port = params.port
+                logging.info(f"Connecting via FTP to {params.host}:{port}")
                 self.conn.connect(params.host, port)
                 if params.login:
                     self.conn.login(params.login, params.password)

--- a/airflow/providers/ftp/hooks/ftp.py
+++ b/airflow/providers/ftp/hooks/ftp.py
@@ -26,6 +26,7 @@ from airflow.hooks.base import BaseHook
 
 logger = logging.getLogger(__name__)
 
+
 class FTPHook(BaseHook):
     """
     Interact with FTP.

--- a/airflow/providers/ftp/hooks/ftp.py
+++ b/airflow/providers/ftp/hooks/ftp.py
@@ -60,7 +60,10 @@ class FTPHook(BaseHook):
             pasv = params.extra_dejson.get("passive", True)
             self.conn = ftplib.FTP()  # nosec: B321
             if params.host:
-                self.conn.connect(params.host, params.port)
+                port = ftplib.FTP_PORT
+                if params.port is not None:
+                    port = params.port
+                self.conn.connect(params.host, port)
                 if params.login:
                     self.conn.login(params.login, params.password)
             self.conn.set_pasv(pasv)

--- a/airflow/providers/ftp/hooks/ftp.py
+++ b/airflow/providers/ftp/hooks/ftp.py
@@ -66,7 +66,7 @@ class FTPHook(BaseHook):
                 port = ftplib.FTP_PORT
                 if params.port is not None:
                     port = params.port
-                logger.info("Connecting via FTP to %s:%d" % (params.host, port))
+                logger.info("Connecting via FTP to %s:%d", params.host, port)
                 self.conn.connect(params.host, port)
                 if params.login:
                     self.conn.login(params.login, params.password)

--- a/tests/providers/ftp/hooks/test_ftp.py
+++ b/tests/providers/ftp/hooks/test_ftp.py
@@ -171,8 +171,8 @@ class TestIntegrationFTPHook:
                 conn_type="ftp",
                 host="localhost",
                 port=10000,
-                login='user',
-                password='pass123',
+                login="user",
+                password="pass123",
                 extra='{"passive": true}',
             )
         )

--- a/tests/providers/ftp/hooks/test_ftp.py
+++ b/tests/providers/ftp/hooks/test_ftp.py
@@ -155,6 +155,16 @@ class TestIntegrationFTPHook:
             Connection(conn_id="ftp_active", conn_type="ftp", host="localhost", extra='{"passive": false}')
         )
 
+        db.merge_conn(
+            Connection(conn_id="ftp_custom_port", conn_type="ftp", host="localhost", port=10000,
+                       extra='{"passive": true}')
+        )
+
+        db.merge_conn(
+            Connection(conn_id="ftp_custom_port_and_login", conn_type="ftp", host="localhost", port=10000,
+                       login='user', password='pass123', extra='{"passive": true}')
+        )
+
     def _test_mode(self, hook_type, connection_id, expected_mode):
         hook = hook_type(connection_id)
         conn = hook.get_conn()
@@ -171,6 +181,26 @@ class TestIntegrationFTPHook:
         from airflow.providers.ftp.hooks.ftp import FTPHook
 
         self._test_mode(FTPHook, "ftp_active", False)
+
+    @mock.patch("ftplib.FTP")
+    def test_ftp_custom_port(self, mock_ftp):
+        from airflow.providers.ftp.hooks.ftp import FTPHook
+
+        hook = FTPHook("ftp_custom_port")
+        conn = hook.get_conn()
+        conn.connect.assert_called_once_with("localhost", 10000)
+        conn.login.assert_not_called()
+        conn.set_pasv.assert_called_once_with(True)
+
+    @mock.patch("ftplib.FTP")
+    def test_ftp_custom_port_and_login(self, mock_ftp):
+        from airflow.providers.ftp.hooks.ftp import FTPHook
+
+        hook = FTPHook("ftp_custom_port_and_login")
+        conn = hook.get_conn()
+        conn.connect.assert_called_once_with("localhost", 10000)
+        conn.login.assert_called_once_with("user", "pass123")
+        conn.set_pasv.assert_called_once_with(True)
 
     @mock.patch("ftplib.FTP_TLS")
     def test_ftps_passive_mode(self, mock_ftp):

--- a/tests/providers/ftp/hooks/test_ftp.py
+++ b/tests/providers/ftp/hooks/test_ftp.py
@@ -168,7 +168,8 @@ class TestIntegrationFTPHook:
         db.merge_conn(
             Connection(
                 conn_id="ftp_custom_port_and_login",
-                conn_type="ftp", host="localhost",
+                conn_type="ftp",
+                host="localhost",
                 port=10000,
                 login='user',
                 password='pass123',

--- a/tests/providers/ftp/hooks/test_ftp.py
+++ b/tests/providers/ftp/hooks/test_ftp.py
@@ -166,12 +166,13 @@ class TestIntegrationFTPHook:
         )
 
         db.merge_conn(
-            Connection(conn_id="ftp_custom_port_and_login",
-                       conn_type="ftp", host="localhost",
-                       port=10000,
-                       login='user',
-                       password='pass123',
-                       extra='{"passive": true}',
+            Connection(
+                conn_id="ftp_custom_port_and_login",
+                conn_type="ftp", host="localhost",
+                port=10000,
+                login='user',
+                password='pass123',
+                extra='{"passive": true}',
             )
         )
 

--- a/tests/providers/ftp/hooks/test_ftp.py
+++ b/tests/providers/ftp/hooks/test_ftp.py
@@ -156,13 +156,23 @@ class TestIntegrationFTPHook:
         )
 
         db.merge_conn(
-            Connection(conn_id="ftp_custom_port", conn_type="ftp", host="localhost", port=10000,
-                       extra='{"passive": true}')
+            Connection(
+                conn_id="ftp_custom_port",
+                conn_type="ftp",
+                host="localhost",
+                port=10000,
+                extra='{"passive": true}',
+            )
         )
 
         db.merge_conn(
-            Connection(conn_id="ftp_custom_port_and_login", conn_type="ftp", host="localhost", port=10000,
-                       login='user', password='pass123', extra='{"passive": true}')
+            Connection(conn_id="ftp_custom_port_and_login",
+                       conn_type="ftp", host="localhost",
+                       port=10000,
+                       login='user',
+                       password='pass123',
+                       extra='{"passive": true}',
+            )
         )
 
     def _test_mode(self, hook_type, connection_id, expected_mode):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Allow FTPHook to use a custom FTP port number

closes: #39308 

<!-- Please keep an empty line above the dashes. -->
