### PR TITLE
Update example AzureContainerInstancesOperator

### DIFF
--- a/airflow/providers/microsoft/azure/operators/container_instances.py
+++ b/airflow/providers/microsoft/azure/operators/container_instances.py
@@ -117,7 +117,12 @@ class AzureContainerInstancesOperator(BaseOperator):
             memory_in_gb=14.0,
             cpu=4.0,
             gpu=GpuResource(count=1, sku="K80"),
-            dns_config=["10.0.0.10", "10.0.0.11"],
+            subnet_ids=[
+                {"id": "/subscriptions/00000000-0000-0000-0000-00000000000/resourceGroups/my_rg/providers/Microsoft.Network/virtualNetworks/my_vnet/subnets/my_subnet"}
+            ],
+            dns_config={
+                "name_servers": ["10.0.0.10", "10.0.0.11"]
+            },
             diagnostics={
                 "log_analytics": {
                     "workspaceId": "workspaceid",

--- a/airflow/providers/microsoft/azure/operators/container_instances.py
+++ b/airflow/providers/microsoft/azure/operators/container_instances.py
@@ -118,11 +118,11 @@ class AzureContainerInstancesOperator(BaseOperator):
             cpu=4.0,
             gpu=GpuResource(count=1, sku="K80"),
             subnet_ids=[
-                {"id": "/subscriptions/00000000-0000-0000-0000-00000000000/resourceGroups/my_rg/providers/Microsoft.Network/virtualNetworks/my_vnet/subnets/my_subnet"}
+                {
+                    "id": "/subscriptions/00000000-0000-0000-0000-00000000000/resourceGroups/my_rg/providers/Microsoft.Network/virtualNetworks/my_vnet/subnets/my_subnet"
+                }
             ],
-            dns_config={
-                "name_servers": ["10.0.0.10", "10.0.0.11"]
-            },
+            dns_config={"name_servers": ["10.0.0.10", "10.0.0.11"]},
             diagnostics={
                 "log_analytics": {
                     "workspaceId": "workspaceid",


### PR DESCRIPTION
Small documentation update found during testing of #39156 for release of microsoft.azure 10.1.0rc1 #39346.

#39156/microsoft.azure 10.1.0rc1 has been tested however the example above the code did not work and did not show users how to use the new available api configurations properly.