### PR TITLE
Fix: Reuse ProcessPoolExecutor in CeleryExecutor

### DIFF
--- a/airflow/providers/celery/executors/celery_executor.py
+++ b/airflow/providers/celery/executors/celery_executor.py
@@ -267,6 +267,7 @@ class CeleryExecutor(BaseExecutor):
         self.tasks = {}
         self.task_publish_retries: Counter[TaskInstanceKey] = Counter()
         self.task_publish_max_retries = conf.getint("celery", "task_publish_max_retries")
+        self.send_pool = ProcessPoolExecutor(max_workers=self._sync_parallelism)
 
     def start(self) -> None:
         self.log.debug("Starting Celery Executor using %s processes for syncing", self._sync_parallelism)
@@ -336,12 +337,10 @@ class CeleryExecutor(BaseExecutor):
         # Use chunks instead of a work queue to reduce context switching
         # since tasks are roughly uniform in size
         chunksize = self._num_tasks_per_send_process(len(task_tuples_to_send))
-        num_processes = min(len(task_tuples_to_send), self._sync_parallelism)
 
-        with ProcessPoolExecutor(max_workers=num_processes) as send_pool:
-            key_and_async_results = list(
-                send_pool.map(send_task_to_executor, task_tuples_to_send, chunksize=chunksize)
-            )
+        key_and_async_results = list(
+            self.send_pool.map(send_task_to_executor, task_tuples_to_send, chunksize=chunksize)
+        )
         return key_and_async_results
 
     def sync(self) -> None:


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/39482

When the scheduler send task to celery, if there is only 1 task in the current cycle, the task will be sent to the main thread; if there are multiple tasks, a thread pool will be created based on the number of CPU cores, and then all tasks will be consumed by the thread pool.
There are some problems with the current implementation. The scheduler creates a thread pool every time it schedules, which will bring a very large performance overhead. In fact, the thread pool can be reused.
![image](https://github.com/apache/airflow/assets/28948186/069fed0f-2140-4779-8901-ebd2af29a415)

When I tested, sometimes it would take almost 4 seconds to consume 32 tasks.
![image](https://github.com/apache/airflow/assets/28948186/868b6046-35a0-42ba-a897-167dc42fdcfb)



If the thread pool is reused, it only takes 10 milliseconds.
![image](https://github.com/apache/airflow/assets/28948186/f86839c2-61bb-4a37-ad77-0b1bd3805f2b)
![image](https://github.com/apache/airflow/assets/28948186/6ee0f090-6f73-4a13-8059-830074e1d6a2)
