### PR TITLE
openlineage: notify that logged exception was caught

### DIFF
--- a/airflow/providers/openlineage/utils/utils.py
+++ b/airflow/providers/openlineage/utils/utils.py
@@ -367,6 +367,9 @@ def print_warning(log):
             try:
                 return f(*args, **kwargs)
             except Exception as e:
+                log.warning(
+                    "Note: exception below is being caught: it's printed for visibility. However OpenLineage events aren't being emitted. If you see that, task has completed successfully despite not getting OL events."
+                )
                 log.warning(e)
 
         return wrapper


### PR DESCRIPTION
As part of OL listener we catch any exceptions generated by OL implementation: most important feature of OL integration should be to not impact user code. However, we log any potential exceptions. 

There's a common issue of people looking at some errors, for example overloaded or buggy OL backend 502ing, which causes the exception stack trace to be written, and assuming it impacts their jobs. 

This PR adds warning explaining it's not the case.