### PR TITLE
Fetch served logs also when task attempt is up for retry and no remote logs available

### DIFF
--- a/tests/utils/test_log_handlers.py
+++ b/tests/utils/test_log_handlers.py
@@ -313,55 +313,57 @@ class TestFileTaskLogHandler:
         else:
             mock_k8s_get_task_log.assert_not_called()
 
-    def test__read_for_celery_executor_fallbacks_to_worker(self, create_task_instance):
+    @pytest.mark.parametrize(
+        "state", [TaskInstanceState.RUNNING, TaskInstanceState.DEFERRED, TaskInstanceState.UP_FOR_RETRY]
+    )
+    def test__read_for_celery_executor_fallbacks_to_worker(self, state, create_task_instance):
         """Test for executors which do not have `get_task_log` method, it fallbacks to reading
         log from worker if and only if remote logs aren't found"""
         executor_name = "CeleryExecutor"
         # Reading logs from worker should occur when the task is either running, deferred, or up for retry.
-        for state in (TaskInstanceState.RUNNING, TaskInstanceState.DEFERRED, TaskInstanceState.UP_FOR_RETRY):
-            ti = create_task_instance(
-                dag_id=f"dag_for_testing_celery_executor_log_read_{state}",
-                task_id="task_for_testing_celery_executor_log_read",
-                run_type=DagRunType.SCHEDULED,
-                execution_date=DEFAULT_DATE,
+        ti = create_task_instance(
+            dag_id=f"dag_for_testing_celery_executor_log_read_{state}",
+            task_id="task_for_testing_celery_executor_log_read",
+            run_type=DagRunType.SCHEDULED,
+            execution_date=DEFAULT_DATE,
+        )
+        ti.try_number = 2
+        ti.state = state
+        with conf_vars({("core", "executor"): executor_name}):
+            reload(executor_loader)
+            fth = FileTaskHandler("")
+            fth._read_from_logs_server = mock.Mock()
+            fth._read_from_logs_server.return_value = ["this message"], ["this\nlog\ncontent"]
+            actual = fth._read(ti=ti, try_number=2)
+            fth._read_from_logs_server.assert_called_once()
+            # If we are in the up for retry state, the log has ended.
+            expected_end_of_log = state in (TaskInstanceState.UP_FOR_RETRY)
+            assert actual == (
+                "*** this message\nthis\nlog\ncontent",
+                {"end_of_log": expected_end_of_log, "log_pos": 16},
             )
-            ti.try_number = 2
-            ti.state = state
-            with conf_vars({("core", "executor"): executor_name}):
-                reload(executor_loader)
-                fth = FileTaskHandler("")
-                fth._read_from_logs_server = mock.Mock()
-                fth._read_from_logs_server.return_value = ["this message"], ["this\nlog\ncontent"]
-                actual = fth._read(ti=ti, try_number=2)
-                fth._read_from_logs_server.assert_called_once()
-                # If we are in the up for retry state, the log has ended.
-                expected_end_of_log = state in (TaskInstanceState.UP_FOR_RETRY)
-                assert actual == (
-                    "*** this message\nthis\nlog\ncontent",
-                    {"end_of_log": expected_end_of_log, "log_pos": 16},
-                )
 
-                # Previous try_number should return served logs when remote logs aren't implemented
-                fth._read_from_logs_server = mock.Mock()
-                fth._read_from_logs_server.return_value = ["served logs try_number=1"], ["this\nlog\ncontent"]
-                actual = fth._read(ti=ti, try_number=1)
-                fth._read_from_logs_server.assert_called_once()
-                assert actual == (
-                    "*** served logs try_number=1\nthis\nlog\ncontent",
-                    {"end_of_log": True, "log_pos": 16},
-                )
+            # Previous try_number should return served logs when remote logs aren't implemented
+            fth._read_from_logs_server = mock.Mock()
+            fth._read_from_logs_server.return_value = ["served logs try_number=1"], ["this\nlog\ncontent"]
+            actual = fth._read(ti=ti, try_number=1)
+            fth._read_from_logs_server.assert_called_once()
+            assert actual == (
+                "*** served logs try_number=1\nthis\nlog\ncontent",
+                {"end_of_log": True, "log_pos": 16},
+            )
 
-                # When remote_logs is implemented, previous try_number is from remote logs without reaching worker server
-                fth._read_from_logs_server.reset_mock()
-                fth._read_remote_logs = mock.Mock()
-                fth._read_remote_logs.return_value = ["remote logs"], ["remote\nlog\ncontent"]
-                actual = fth._read(ti=ti, try_number=1)
-                fth._read_remote_logs.assert_called_once()
-                fth._read_from_logs_server.assert_not_called()
-                assert actual == (
-                    "*** remote logs\nremote\nlog\ncontent",
-                    {"end_of_log": True, "log_pos": 18},
-                )
+            # When remote_logs is implemented, previous try_number is from remote logs without reaching worker server
+            fth._read_from_logs_server.reset_mock()
+            fth._read_remote_logs = mock.Mock()
+            fth._read_remote_logs.return_value = ["remote logs"], ["remote\nlog\ncontent"]
+            actual = fth._read(ti=ti, try_number=1)
+            fth._read_remote_logs.assert_called_once()
+            fth._read_from_logs_server.assert_not_called()
+            assert actual == (
+                "*** remote logs\nremote\nlog\ncontent",
+                {"end_of_log": True, "log_pos": 18},
+            )
 
     @pytest.mark.parametrize(
         "remote_logs, local_logs, served_logs_checked",

--- a/tests/utils/test_log_handlers.py
+++ b/tests/utils/test_log_handlers.py
@@ -317,43 +317,51 @@ class TestFileTaskLogHandler:
         """Test for executors which do not have `get_task_log` method, it fallbacks to reading
         log from worker if and only if remote logs aren't found"""
         executor_name = "CeleryExecutor"
-
-        ti = create_task_instance(
-            dag_id="dag_for_testing_celery_executor_log_read",
-            task_id="task_for_testing_celery_executor_log_read",
-            run_type=DagRunType.SCHEDULED,
-            execution_date=DEFAULT_DATE,
-        )
-        ti.state = TaskInstanceState.RUNNING
-        ti.try_number = 2
-        with conf_vars({("core", "executor"): executor_name}):
-            reload(executor_loader)
-            fth = FileTaskHandler("")
-
-            fth._read_from_logs_server = mock.Mock()
-            fth._read_from_logs_server.return_value = ["this message"], ["this\nlog\ncontent"]
-            actual = fth._read(ti=ti, try_number=2)
-            fth._read_from_logs_server.assert_called_once()
-            assert actual == ("*** this message\nthis\nlog\ncontent", {"end_of_log": False, "log_pos": 16})
-
-            # Previous try_number should return served logs when remote logs aren't implemented
-            fth._read_from_logs_server = mock.Mock()
-            fth._read_from_logs_server.return_value = ["served logs try_number=1"], ["this\nlog\ncontent"]
-            actual = fth._read(ti=ti, try_number=1)
-            fth._read_from_logs_server.assert_called_once()
-            assert actual == (
-                "*** served logs try_number=1\nthis\nlog\ncontent",
-                {"end_of_log": True, "log_pos": 16},
+        # Reading logs from worker should occur when the task is either running, deferred, or up for retry.
+        for state in (TaskInstanceState.RUNNING, TaskInstanceState.DEFERRED, TaskInstanceState.UP_FOR_RETRY):
+            ti = create_task_instance(
+                dag_id=f"dag_for_testing_celery_executor_log_read_{state}",
+                task_id="task_for_testing_celery_executor_log_read",
+                run_type=DagRunType.SCHEDULED,
+                execution_date=DEFAULT_DATE,
             )
+            ti.try_number = 2
+            ti.state = state
+            with conf_vars({("core", "executor"): executor_name}):
+                reload(executor_loader)
+                fth = FileTaskHandler("")
+                fth._read_from_logs_server = mock.Mock()
+                fth._read_from_logs_server.return_value = ["this message"], ["this\nlog\ncontent"]
+                actual = fth._read(ti=ti, try_number=2)
+                fth._read_from_logs_server.assert_called_once()
+                # If we are in the up for retry state, the log has ended.
+                expected_end_of_log = state in (TaskInstanceState.UP_FOR_RETRY)
+                assert actual == (
+                    "*** this message\nthis\nlog\ncontent",
+                    {"end_of_log": expected_end_of_log, "log_pos": 16},
+                )
 
-            # When remote_logs is implemented, previous try_number is from remote logs without reaching worker server
-            fth._read_from_logs_server.reset_mock()
-            fth._read_remote_logs = mock.Mock()
-            fth._read_remote_logs.return_value = ["remote logs"], ["remote\nlog\ncontent"]
-            actual = fth._read(ti=ti, try_number=1)
-            fth._read_remote_logs.assert_called_once()
-            fth._read_from_logs_server.assert_not_called()
-            assert actual == ("*** remote logs\nremote\nlog\ncontent", {"end_of_log": True, "log_pos": 18})
+                # Previous try_number should return served logs when remote logs aren't implemented
+                fth._read_from_logs_server = mock.Mock()
+                fth._read_from_logs_server.return_value = ["served logs try_number=1"], ["this\nlog\ncontent"]
+                actual = fth._read(ti=ti, try_number=1)
+                fth._read_from_logs_server.assert_called_once()
+                assert actual == (
+                    "*** served logs try_number=1\nthis\nlog\ncontent",
+                    {"end_of_log": True, "log_pos": 16},
+                )
+
+                # When remote_logs is implemented, previous try_number is from remote logs without reaching worker server
+                fth._read_from_logs_server.reset_mock()
+                fth._read_remote_logs = mock.Mock()
+                fth._read_remote_logs.return_value = ["remote logs"], ["remote\nlog\ncontent"]
+                actual = fth._read(ti=ti, try_number=1)
+                fth._read_remote_logs.assert_called_once()
+                fth._read_from_logs_server.assert_not_called()
+                assert actual == (
+                    "*** remote logs\nremote\nlog\ncontent",
+                    {"end_of_log": True, "log_pos": 18},
+                )
 
     @pytest.mark.parametrize(
         "remote_logs, local_logs, served_logs_checked",


### PR DESCRIPTION
This PR is a continuation of #39177, as while testing it noticed that when the task's state is in `TaskInstanceState.UP_FOR_RETRY`, the logs for all attempts is unavailable, when the source is served logs.

Also noticed that the tests previously only covered the `TaskInstanceState.RUNNING` situation, whereas there was also `TaskInstanceState.DEFERRED` (and now `TaskInstanceState.UP_FOR_RETRY`). Changed the test to cover all three cases.

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
