### PR TITLE
Simplify `airflow_version` imports

### DIFF
--- a/airflow/providers/airbyte/__init__.py
+++ b/airflow/providers/airbyte/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.8.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/airbyte/__init__.py
+++ b/airflow/providers/airbyte/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.8.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/alibaba/__init__.py
+++ b/airflow/providers/alibaba/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "2.8.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/alibaba/__init__.py
+++ b/airflow/providers/alibaba/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "2.8.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/amazon/__init__.py
+++ b/airflow/providers/amazon/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "8.21.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/amazon/__init__.py
+++ b/airflow/providers/amazon/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "8.21.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/apache/beam/__init__.py
+++ b/airflow/providers/apache/beam/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "5.7.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/apache/beam/__init__.py
+++ b/airflow/providers/apache/beam/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "5.7.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/apache/cassandra/__init__.py
+++ b/airflow/providers/apache/cassandra/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.5.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/apache/cassandra/__init__.py
+++ b/airflow/providers/apache/cassandra/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.5.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/apache/drill/__init__.py
+++ b/airflow/providers/apache/drill/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "2.7.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/apache/drill/__init__.py
+++ b/airflow/providers/apache/drill/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "2.7.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/apache/druid/__init__.py
+++ b/airflow/providers/apache/druid/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.10.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/apache/druid/__init__.py
+++ b/airflow/providers/apache/druid/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.10.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/apache/flink/__init__.py
+++ b/airflow/providers/apache/flink/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "1.4.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/apache/flink/__init__.py
+++ b/airflow/providers/apache/flink/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "1.4.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/apache/hdfs/__init__.py
+++ b/airflow/providers/apache/hdfs/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "4.4.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/apache/hdfs/__init__.py
+++ b/airflow/providers/apache/hdfs/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "4.4.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/apache/hive/__init__.py
+++ b/airflow/providers/apache/hive/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "8.1.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/apache/hive/__init__.py
+++ b/airflow/providers/apache/hive/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "8.1.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/apache/impala/__init__.py
+++ b/airflow/providers/apache/impala/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "1.4.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/apache/impala/__init__.py
+++ b/airflow/providers/apache/impala/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "1.4.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/apache/kafka/__init__.py
+++ b/airflow/providers/apache/kafka/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "1.4.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/apache/kafka/__init__.py
+++ b/airflow/providers/apache/kafka/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "1.4.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/apache/kylin/__init__.py
+++ b/airflow/providers/apache/kylin/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.6.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/apache/kylin/__init__.py
+++ b/airflow/providers/apache/kylin/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.6.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/apache/livy/__init__.py
+++ b/airflow/providers/apache/livy/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.8.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/apache/livy/__init__.py
+++ b/airflow/providers/apache/livy/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.8.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/apache/pig/__init__.py
+++ b/airflow/providers/apache/pig/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "4.4.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/apache/pig/__init__.py
+++ b/airflow/providers/apache/pig/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "4.4.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/apache/pinot/__init__.py
+++ b/airflow/providers/apache/pinot/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "4.4.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/apache/pinot/__init__.py
+++ b/airflow/providers/apache/pinot/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "4.4.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/apache/spark/__init__.py
+++ b/airflow/providers/apache/spark/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "4.8.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/apache/spark/__init__.py
+++ b/airflow/providers/apache/spark/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "4.8.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/apprise/__init__.py
+++ b/airflow/providers/apprise/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "1.3.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/apprise/__init__.py
+++ b/airflow/providers/apprise/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "1.3.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/arangodb/__init__.py
+++ b/airflow/providers/arangodb/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "2.5.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/arangodb/__init__.py
+++ b/airflow/providers/arangodb/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "2.5.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/asana/__init__.py
+++ b/airflow/providers/asana/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "2.5.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/asana/__init__.py
+++ b/airflow/providers/asana/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "2.5.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/atlassian/jira/__init__.py
+++ b/airflow/providers/atlassian/jira/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "2.6.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/atlassian/jira/__init__.py
+++ b/airflow/providers/atlassian/jira/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "2.6.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/celery/__init__.py
+++ b/airflow/providers/celery/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.7.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/celery/__init__.py
+++ b/airflow/providers/celery/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.7.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/celery/executors/__init__.py
+++ b/airflow/providers/celery/executors/__init__.py
@@ -18,12 +18,8 @@ from __future__ import annotations
 
 import packaging.version
 
+from airflow import __version__ as airflow_version
 from airflow.exceptions import AirflowOptionalProviderFeatureException
-
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
 
 base_version = packaging.version.parse(airflow_version).base_version
 

--- a/airflow/providers/celery/executors/__init__.py
+++ b/airflow/providers/celery/executors/__init__.py
@@ -16,11 +16,13 @@
 # under the License.
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
-from airflow import __version__ as airflow_version
 from airflow.exceptions import AirflowOptionalProviderFeatureException
 
+airflow_version = importlib.metadata.version("apache-airflow")
 base_version = packaging.version.parse(airflow_version).base_version
 
 if packaging.version.parse(base_version) < packaging.version.parse("2.7.0"):

--- a/airflow/providers/celery/executors/celery_executor.py
+++ b/airflow/providers/celery/executors/celery_executor.py
@@ -52,11 +52,13 @@ try:
         lazy_load_command,
     )
 except ImportError:
+    import importlib.metadata
+
     import packaging.version
 
-    from airflow import __version__ as airflow_version
     from airflow.exceptions import AirflowOptionalProviderFeatureException
 
+    airflow_version = importlib.metadata.version("apache-airflow")
     base_version = packaging.version.parse(airflow_version).base_version
 
     if packaging.version.parse(base_version) < packaging.version.parse("2.7.0"):

--- a/airflow/providers/celery/executors/celery_executor.py
+++ b/airflow/providers/celery/executors/celery_executor.py
@@ -52,13 +52,9 @@ try:
         lazy_load_command,
     )
 except ImportError:
-    try:
-        from airflow import __version__ as airflow_version
-    except ImportError:
-        from airflow.version import version as airflow_version
-
     import packaging.version
 
+    from airflow import __version__ as airflow_version
     from airflow.exceptions import AirflowOptionalProviderFeatureException
 
     base_version = packaging.version.parse(airflow_version).base_version

--- a/airflow/providers/cloudant/__init__.py
+++ b/airflow/providers/cloudant/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.5.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/cloudant/__init__.py
+++ b/airflow/providers/cloudant/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.5.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/cncf/kubernetes/__init__.py
+++ b/airflow/providers/cncf/kubernetes/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "8.2.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/cncf/kubernetes/__init__.py
+++ b/airflow/providers/cncf/kubernetes/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "8.2.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -55,11 +55,13 @@ try:
         positive_int,
     )
 except ImportError:
+    import importlib.metadata
+
     import packaging.version
 
-    from airflow import __version__ as airflow_version
     from airflow.exceptions import AirflowOptionalProviderFeatureException
 
+    airflow_version = importlib.metadata.version("apache-airflow")
     base_version = packaging.version.parse(airflow_version).base_version
 
     if packaging.version.parse(base_version) < packaging.version.parse("2.7.0"):

--- a/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -55,13 +55,9 @@ try:
         positive_int,
     )
 except ImportError:
-    try:
-        from airflow import __version__ as airflow_version
-    except ImportError:
-        from airflow.version import version as airflow_version
-
     import packaging.version
 
+    from airflow import __version__ as airflow_version
     from airflow.exceptions import AirflowOptionalProviderFeatureException
 
     base_version = packaging.version.parse(airflow_version).base_version

--- a/airflow/providers/cohere/__init__.py
+++ b/airflow/providers/cohere/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "1.2.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/cohere/__init__.py
+++ b/airflow/providers/cohere/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "1.2.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/common/io/__init__.py
+++ b/airflow/providers/common/io/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "1.3.1"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.8.0"

--- a/airflow/providers/common/io/__init__.py
+++ b/airflow/providers/common/io/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "1.3.1"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.8.0"

--- a/airflow/providers/common/io/xcom/__init__.py
+++ b/airflow/providers/common/io/xcom/__init__.py
@@ -18,12 +18,8 @@ from __future__ import annotations
 
 import packaging.version
 
+from airflow import __version__ as airflow_version
 from airflow.exceptions import AirflowOptionalProviderFeatureException
-
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.9.0"

--- a/airflow/providers/common/io/xcom/__init__.py
+++ b/airflow/providers/common/io/xcom/__init__.py
@@ -16,10 +16,13 @@
 # under the License.
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
-from airflow import __version__ as airflow_version
 from airflow.exceptions import AirflowOptionalProviderFeatureException
+
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.9.0"

--- a/airflow/providers/common/sql/__init__.py
+++ b/airflow/providers/common/sql/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "1.13.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/common/sql/__init__.py
+++ b/airflow/providers/common/sql/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "1.13.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/databricks/__init__.py
+++ b/airflow/providers/databricks/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "6.4.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/databricks/__init__.py
+++ b/airflow/providers/databricks/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "6.4.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/datadog/__init__.py
+++ b/airflow/providers/datadog/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.6.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/datadog/__init__.py
+++ b/airflow/providers/datadog/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.6.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/dbt/cloud/__init__.py
+++ b/airflow/providers/dbt/cloud/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.8.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/dbt/cloud/__init__.py
+++ b/airflow/providers/dbt/cloud/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.8.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/dingding/__init__.py
+++ b/airflow/providers/dingding/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.5.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/dingding/__init__.py
+++ b/airflow/providers/dingding/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.5.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/discord/__init__.py
+++ b/airflow/providers/discord/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.7.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/discord/__init__.py
+++ b/airflow/providers/discord/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.7.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/docker/__init__.py
+++ b/airflow/providers/docker/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.11.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/docker/__init__.py
+++ b/airflow/providers/docker/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.11.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/elasticsearch/__init__.py
+++ b/airflow/providers/elasticsearch/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "5.4.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/elasticsearch/__init__.py
+++ b/airflow/providers/elasticsearch/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "5.4.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/exasol/__init__.py
+++ b/airflow/providers/exasol/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "4.5.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/exasol/__init__.py
+++ b/airflow/providers/exasol/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "4.5.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/fab/__init__.py
+++ b/airflow/providers/fab/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "1.1.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.9.0"

--- a/airflow/providers/fab/__init__.py
+++ b/airflow/providers/fab/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "1.1.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.9.0"

--- a/airflow/providers/facebook/__init__.py
+++ b/airflow/providers/facebook/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.5.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/facebook/__init__.py
+++ b/airflow/providers/facebook/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.5.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/ftp/__init__.py
+++ b/airflow/providers/ftp/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.9.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/ftp/__init__.py
+++ b/airflow/providers/ftp/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.9.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/github/__init__.py
+++ b/airflow/providers/github/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "2.6.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/github/__init__.py
+++ b/airflow/providers/github/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "2.6.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/google/__init__.py
+++ b/airflow/providers/google/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "10.18.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/google/__init__.py
+++ b/airflow/providers/google/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "10.18.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/grpc/__init__.py
+++ b/airflow/providers/grpc/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.5.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/grpc/__init__.py
+++ b/airflow/providers/grpc/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.5.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/hashicorp/__init__.py
+++ b/airflow/providers/hashicorp/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.7.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/hashicorp/__init__.py
+++ b/airflow/providers/hashicorp/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.7.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/http/__init__.py
+++ b/airflow/providers/http/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "4.11.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/http/__init__.py
+++ b/airflow/providers/http/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "4.11.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/imap/__init__.py
+++ b/airflow/providers/imap/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.6.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/imap/__init__.py
+++ b/airflow/providers/imap/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.6.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/influxdb/__init__.py
+++ b/airflow/providers/influxdb/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "2.5.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/influxdb/__init__.py
+++ b/airflow/providers/influxdb/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "2.5.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/jdbc/__init__.py
+++ b/airflow/providers/jdbc/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "4.3.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/jdbc/__init__.py
+++ b/airflow/providers/jdbc/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "4.3.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/jenkins/__init__.py
+++ b/airflow/providers/jenkins/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.6.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/jenkins/__init__.py
+++ b/airflow/providers/jenkins/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.6.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/microsoft/azure/__init__.py
+++ b/airflow/providers/microsoft/azure/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "10.1.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/microsoft/azure/__init__.py
+++ b/airflow/providers/microsoft/azure/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "10.1.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/microsoft/mssql/__init__.py
+++ b/airflow/providers/microsoft/mssql/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.7.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/microsoft/mssql/__init__.py
+++ b/airflow/providers/microsoft/mssql/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.7.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/microsoft/psrp/__init__.py
+++ b/airflow/providers/microsoft/psrp/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "2.7.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/microsoft/psrp/__init__.py
+++ b/airflow/providers/microsoft/psrp/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "2.7.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/microsoft/winrm/__init__.py
+++ b/airflow/providers/microsoft/winrm/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.5.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/microsoft/winrm/__init__.py
+++ b/airflow/providers/microsoft/winrm/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.5.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/mongo/__init__.py
+++ b/airflow/providers/mongo/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "4.1.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/mongo/__init__.py
+++ b/airflow/providers/mongo/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "4.1.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/mysql/__init__.py
+++ b/airflow/providers/mysql/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "5.6.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/mysql/__init__.py
+++ b/airflow/providers/mysql/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "5.6.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/neo4j/__init__.py
+++ b/airflow/providers/neo4j/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.6.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/neo4j/__init__.py
+++ b/airflow/providers/neo4j/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.6.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/odbc/__init__.py
+++ b/airflow/providers/odbc/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "4.6.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/odbc/__init__.py
+++ b/airflow/providers/odbc/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "4.6.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/openai/__init__.py
+++ b/airflow/providers/openai/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "1.2.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/openai/__init__.py
+++ b/airflow/providers/openai/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "1.2.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/openfaas/__init__.py
+++ b/airflow/providers/openfaas/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.5.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/openfaas/__init__.py
+++ b/airflow/providers/openfaas/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.5.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/openlineage/__init__.py
+++ b/airflow/providers/openlineage/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "1.7.1"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/openlineage/__init__.py
+++ b/airflow/providers/openlineage/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "1.7.1"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/opensearch/__init__.py
+++ b/airflow/providers/opensearch/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "1.2.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/opensearch/__init__.py
+++ b/airflow/providers/opensearch/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "1.2.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/opsgenie/__init__.py
+++ b/airflow/providers/opsgenie/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "5.6.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/opsgenie/__init__.py
+++ b/airflow/providers/opsgenie/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "5.6.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/oracle/__init__.py
+++ b/airflow/providers/oracle/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.10.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/oracle/__init__.py
+++ b/airflow/providers/oracle/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.10.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/pagerduty/__init__.py
+++ b/airflow/providers/pagerduty/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.7.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/pagerduty/__init__.py
+++ b/airflow/providers/pagerduty/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.7.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/papermill/__init__.py
+++ b/airflow/providers/papermill/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.7.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/papermill/__init__.py
+++ b/airflow/providers/papermill/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.7.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/pgvector/__init__.py
+++ b/airflow/providers/pgvector/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "1.2.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/pgvector/__init__.py
+++ b/airflow/providers/pgvector/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "1.2.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/pinecone/__init__.py
+++ b/airflow/providers/pinecone/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "2.0.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/pinecone/__init__.py
+++ b/airflow/providers/pinecone/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "2.0.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/postgres/__init__.py
+++ b/airflow/providers/postgres/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "5.11.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/postgres/__init__.py
+++ b/airflow/providers/postgres/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "5.11.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/presto/__init__.py
+++ b/airflow/providers/presto/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "5.5.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/presto/__init__.py
+++ b/airflow/providers/presto/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "5.5.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/qdrant/__init__.py
+++ b/airflow/providers/qdrant/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "1.1.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/qdrant/__init__.py
+++ b/airflow/providers/qdrant/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "1.1.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/redis/__init__.py
+++ b/airflow/providers/redis/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.7.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/redis/__init__.py
+++ b/airflow/providers/redis/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.7.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/salesforce/__init__.py
+++ b/airflow/providers/salesforce/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "5.7.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/salesforce/__init__.py
+++ b/airflow/providers/salesforce/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "5.7.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/samba/__init__.py
+++ b/airflow/providers/samba/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "4.7.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/samba/__init__.py
+++ b/airflow/providers/samba/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "4.7.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/segment/__init__.py
+++ b/airflow/providers/segment/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.5.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/segment/__init__.py
+++ b/airflow/providers/segment/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.5.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/sendgrid/__init__.py
+++ b/airflow/providers/sendgrid/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.5.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/sendgrid/__init__.py
+++ b/airflow/providers/sendgrid/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.5.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/sftp/__init__.py
+++ b/airflow/providers/sftp/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "4.10.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/sftp/__init__.py
+++ b/airflow/providers/sftp/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "4.10.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/singularity/__init__.py
+++ b/airflow/providers/singularity/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.5.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/singularity/__init__.py
+++ b/airflow/providers/singularity/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.5.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/slack/__init__.py
+++ b/airflow/providers/slack/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "8.7.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/slack/__init__.py
+++ b/airflow/providers/slack/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "8.7.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/smtp/__init__.py
+++ b/airflow/providers/smtp/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "1.7.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/smtp/__init__.py
+++ b/airflow/providers/smtp/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "1.7.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/snowflake/__init__.py
+++ b/airflow/providers/snowflake/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "5.5.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/snowflake/__init__.py
+++ b/airflow/providers/snowflake/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "5.5.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/sqlite/__init__.py
+++ b/airflow/providers/sqlite/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.8.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/sqlite/__init__.py
+++ b/airflow/providers/sqlite/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.8.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/ssh/__init__.py
+++ b/airflow/providers/ssh/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.11.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/ssh/__init__.py
+++ b/airflow/providers/ssh/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.11.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/tableau/__init__.py
+++ b/airflow/providers/tableau/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "4.5.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/tableau/__init__.py
+++ b/airflow/providers/tableau/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "4.5.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/tabular/__init__.py
+++ b/airflow/providers/tabular/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "1.5.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/tabular/__init__.py
+++ b/airflow/providers/tabular/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "1.5.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/telegram/__init__.py
+++ b/airflow/providers/telegram/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "4.5.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/telegram/__init__.py
+++ b/airflow/providers/telegram/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "4.5.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/teradata/__init__.py
+++ b/airflow/providers/teradata/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "2.1.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/teradata/__init__.py
+++ b/airflow/providers/teradata/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "2.1.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/trino/__init__.py
+++ b/airflow/providers/trino/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "5.7.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/trino/__init__.py
+++ b/airflow/providers/trino/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "5.7.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/vertica/__init__.py
+++ b/airflow/providers/vertica/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.8.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/vertica/__init__.py
+++ b/airflow/providers/vertica/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.8.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/weaviate/__init__.py
+++ b/airflow/providers/weaviate/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "1.4.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/weaviate/__init__.py
+++ b/airflow/providers/weaviate/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "1.4.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/yandex/__init__.py
+++ b/airflow/providers/yandex/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "3.11.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/yandex/__init__.py
+++ b/airflow/providers/yandex/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "3.11.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/zendesk/__init__.py
+++ b/airflow/providers/zendesk/__init__.py
@@ -29,10 +29,7 @@ __all__ = ["__version__"]
 
 __version__ = "4.7.0"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/zendesk/__init__.py
+++ b/airflow/providers/zendesk/__init__.py
@@ -23,13 +23,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "4.7.0"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/dev/breeze/src/airflow_breeze/templates/PROVIDER__INIT__PY_TEMPLATE.py.jinja2
+++ b/dev/breeze/src/airflow_breeze/templates/PROVIDER__INIT__PY_TEMPLATE.py.jinja2
@@ -48,10 +48,7 @@ __all__ = ["__version__"]
 
 __version__ = "{{ RELEASE }}{{ VERSION_SUFFIX }}"
 
-try:
-    from airflow import __version__ as airflow_version
-except ImportError:
-    from airflow.version import version as airflow_version
+from airflow import __version__ as airflow_version
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "{{ MIN_AIRFLOW_VERSION }}"

--- a/dev/breeze/src/airflow_breeze/templates/PROVIDER__INIT__PY_TEMPLATE.py.jinja2
+++ b/dev/breeze/src/airflow_breeze/templates/PROVIDER__INIT__PY_TEMPLATE.py.jinja2
@@ -42,13 +42,15 @@
 #
 from __future__ import annotations
 
+import importlib.metadata
+
 import packaging.version
 
 __all__ = ["__version__"]
 
 __version__ = "{{ RELEASE }}{{ VERSION_SUFFIX }}"
 
-from airflow import __version__ as airflow_version
+airflow_version = importlib.metadata.version('apache-airflow')
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "{{ MIN_AIRFLOW_VERSION }}"


### PR DESCRIPTION
Use `importlib.metadata.version` to get `airflow_version`. This is a more standardized approach to getting the version.