### PR TITLE
Fix side effects in DBT Cloud tests

### DIFF
--- a/tests/providers/dbt/cloud/hooks/test_dbt.py
+++ b/tests/providers/dbt/cloud/hooks/test_dbt.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import json
+from datetime import timedelta
 from typing import Any
 from unittest.mock import patch
 
@@ -32,7 +33,7 @@ from airflow.providers.dbt.cloud.hooks.dbt import (
     TokenAuth,
     fallback_to_default_account,
 )
-from airflow.utils import db
+from airflow.utils import db, timezone
 
 pytestmark = pytest.mark.db_test
 
@@ -551,11 +552,20 @@ class TestDbtCloudHook:
             for argval in wait_for_job_run_status_test_args
         ],
     )
-    def test_wait_for_job_run_status(hook, job_run_status, expected_status, expected_output):
+    def test_wait_for_job_run_status(self, job_run_status, expected_status, expected_output, time_machine):
         config = {"run_id": RUN_ID, "timeout": 3, "check_interval": 1, "expected_statuses": expected_status}
         hook = DbtCloudHook(ACCOUNT_ID_CONN)
 
-        with patch.object(DbtCloudHook, "get_job_run_status") as mock_job_run_status:
+        # Freeze time for avoid real clock side effects
+        time_machine.move_to(timezone.datetime(1970, 1, 1), tick=False)
+
+        def fake_sleep(seconds):
+            # Shift frozen time every time we call a ``time.sleep`` during this test case.
+            time_machine.shift(timedelta(seconds=seconds))
+
+        with patch.object(DbtCloudHook, "get_job_run_status") as mock_job_run_status, patch(
+            "airflow.providers.dbt.cloud.hooks.dbt.time.sleep", side_effect=fake_sleep
+        ):
             mock_job_run_status.return_value = job_run_status
 
             if expected_output != "timeout":

--- a/tests/providers/dbt/cloud/operators/test_dbt.py
+++ b/tests/providers/dbt/cloud/operators/test_dbt.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import os
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -208,7 +209,7 @@ class TestDbtCloudRunJobOperator:
         ids=["default_account", "explicit_account"],
     )
     def test_execute_wait_for_termination(
-        self, mock_run_job, conn_id, account_id, job_run_status, expected_output
+        self, mock_run_job, conn_id, account_id, job_run_status, expected_output, time_machine
     ):
         operator = DbtCloudRunJobOperator(
             task_id=TASK_ID, dbt_cloud_conn_id=conn_id, account_id=account_id, dag=self.dag, **self.config
@@ -224,7 +225,19 @@ class TestDbtCloudRunJobOperator:
         assert operator.schema_override == self.config["schema_override"]
         assert operator.additional_run_config == self.config["additional_run_config"]
 
-        with patch.object(DbtCloudHook, "get_job_run") as mock_get_job_run:
+        # Freeze time for avoid real clock side effects
+        time_machine.move_to(timezone.datetime(1970, 1, 1), tick=False)
+
+        def fake_sleep(seconds):
+            # Shift frozen time every time we call a ``time.sleep`` during this test case.
+            # Because we freeze a time, we also need to add a small shift
+            # which is emulating time which we spent in a loop
+            overall_delta = timedelta(seconds=seconds) + timedelta(microseconds=42)
+            time_machine.shift(overall_delta)
+
+        with patch.object(DbtCloudHook, "get_job_run") as mock_get_job_run, patch(
+            "airflow.providers.dbt.cloud.hooks.dbt.time.sleep", side_effect=fake_sleep
+        ):
             mock_get_job_run.return_value.json.return_value = {
                 "data": {"status": job_run_status, "id": RUN_ID}
             }
@@ -445,7 +458,7 @@ class TestDbtCloudGetJobRunArtifactOperator:
         [(ACCOUNT_ID_CONN, None), (NO_ACCOUNT_ID_CONN, ACCOUNT_ID)],
         ids=["default_account", "explicit_account"],
     )
-    def test_get_json_artifact(self, mock_get_artifact, conn_id, account_id):
+    def test_get_json_artifact(self, mock_get_artifact, conn_id, account_id, tmp_path, monkeypatch):
         operator = DbtCloudGetJobRunArtifactOperator(
             task_id=TASK_ID,
             dbt_cloud_conn_id=conn_id,
@@ -456,7 +469,11 @@ class TestDbtCloudGetJobRunArtifactOperator:
         )
 
         mock_get_artifact.return_value.json.return_value = {"data": "file contents"}
-        return_value = operator.execute(context={})
+        with monkeypatch.context() as ctx:
+            # Let's change current working directory to temp,
+            # otherwise the output file will be created in the current working directory
+            ctx.chdir(tmp_path)
+            return_value = operator.execute(context={})
 
         mock_get_artifact.assert_called_once_with(
             run_id=RUN_ID,
@@ -466,7 +483,7 @@ class TestDbtCloudGetJobRunArtifactOperator:
         )
 
         assert operator.output_file_name == f"{RUN_ID}_path-to-my-manifest.json"
-        assert os.path.exists(operator.output_file_name)
+        assert os.path.exists(tmp_path / operator.output_file_name)
         assert return_value == operator.output_file_name
 
     @patch("airflow.providers.dbt.cloud.hooks.dbt.DbtCloudHook.get_job_run_artifact")
@@ -475,7 +492,7 @@ class TestDbtCloudGetJobRunArtifactOperator:
         [(ACCOUNT_ID_CONN, None), (NO_ACCOUNT_ID_CONN, ACCOUNT_ID)],
         ids=["default_account", "explicit_account"],
     )
-    def test_get_json_artifact_with_step(self, mock_get_artifact, conn_id, account_id):
+    def test_get_json_artifact_with_step(self, mock_get_artifact, conn_id, account_id, tmp_path, monkeypatch):
         operator = DbtCloudGetJobRunArtifactOperator(
             task_id=TASK_ID,
             dbt_cloud_conn_id=conn_id,
@@ -487,7 +504,11 @@ class TestDbtCloudGetJobRunArtifactOperator:
         )
 
         mock_get_artifact.return_value.json.return_value = {"data": "file contents"}
-        return_value = operator.execute(context={})
+        with monkeypatch.context() as ctx:
+            # Let's change current working directory to temp,
+            # otherwise the output file will be created in the current working directory
+            ctx.chdir(tmp_path)
+            return_value = operator.execute(context={})
 
         mock_get_artifact.assert_called_once_with(
             run_id=RUN_ID,
@@ -497,7 +518,7 @@ class TestDbtCloudGetJobRunArtifactOperator:
         )
 
         assert operator.output_file_name == f"{RUN_ID}_path-to-my-manifest.json"
-        assert os.path.exists(operator.output_file_name)
+        assert os.path.exists(tmp_path / operator.output_file_name)
         assert return_value == operator.output_file_name
 
     @patch("airflow.providers.dbt.cloud.hooks.dbt.DbtCloudHook.get_job_run_artifact")
@@ -506,7 +527,7 @@ class TestDbtCloudGetJobRunArtifactOperator:
         [(ACCOUNT_ID_CONN, None), (NO_ACCOUNT_ID_CONN, ACCOUNT_ID)],
         ids=["default_account", "explicit_account"],
     )
-    def test_get_text_artifact(self, mock_get_artifact, conn_id, account_id):
+    def test_get_text_artifact(self, mock_get_artifact, conn_id, account_id, tmp_path, monkeypatch):
         operator = DbtCloudGetJobRunArtifactOperator(
             task_id=TASK_ID,
             dbt_cloud_conn_id=conn_id,
@@ -517,7 +538,11 @@ class TestDbtCloudGetJobRunArtifactOperator:
         )
 
         mock_get_artifact.return_value.text = "file contents"
-        return_value = operator.execute(context={})
+        with monkeypatch.context() as ctx:
+            # Let's change current working directory to temp,
+            # otherwise the output file will be created in the current working directory
+            ctx.chdir(tmp_path)
+            return_value = operator.execute(context={})
 
         mock_get_artifact.assert_called_once_with(
             run_id=RUN_ID,
@@ -527,7 +552,7 @@ class TestDbtCloudGetJobRunArtifactOperator:
         )
 
         assert operator.output_file_name == f"{RUN_ID}_path-to-my-model.sql"
-        assert os.path.exists(operator.output_file_name)
+        assert os.path.exists(tmp_path / operator.output_file_name)
         assert return_value == operator.output_file_name
 
     @patch("airflow.providers.dbt.cloud.hooks.dbt.DbtCloudHook.get_job_run_artifact")
@@ -536,7 +561,7 @@ class TestDbtCloudGetJobRunArtifactOperator:
         [(ACCOUNT_ID_CONN, None), (NO_ACCOUNT_ID_CONN, ACCOUNT_ID)],
         ids=["default_account", "explicit_account"],
     )
-    def test_get_text_artifact_with_step(self, mock_get_artifact, conn_id, account_id):
+    def test_get_text_artifact_with_step(self, mock_get_artifact, conn_id, account_id, tmp_path, monkeypatch):
         operator = DbtCloudGetJobRunArtifactOperator(
             task_id=TASK_ID,
             dbt_cloud_conn_id=conn_id,
@@ -548,7 +573,11 @@ class TestDbtCloudGetJobRunArtifactOperator:
         )
 
         mock_get_artifact.return_value.text = "file contents"
-        return_value = operator.execute(context={})
+        with monkeypatch.context() as ctx:
+            # Let's change current working directory to temp,
+            # otherwise the output file will be created in the current working directory
+            ctx.chdir(tmp_path)
+            return_value = operator.execute(context={})
 
         mock_get_artifact.assert_called_once_with(
             run_id=RUN_ID,
@@ -558,7 +587,7 @@ class TestDbtCloudGetJobRunArtifactOperator:
         )
 
         assert operator.output_file_name == f"{RUN_ID}_path-to-my-model.sql"
-        assert os.path.exists(operator.output_file_name)
+        assert os.path.exists(tmp_path / operator.output_file_name)
         assert return_value == operator.output_file_name
 
     @patch("airflow.providers.dbt.cloud.hooks.dbt.DbtCloudHook.get_job_run_artifact")
@@ -568,6 +597,7 @@ class TestDbtCloudGetJobRunArtifactOperator:
         ids=["default_account", "explicit_account"],
     )
     def test_get_artifact_with_specified_output_file(self, mock_get_artifact, conn_id, account_id, tmp_path):
+        specified_output_file = (tmp_path / "run_results.json").as_posix()
         operator = DbtCloudGetJobRunArtifactOperator(
             task_id=TASK_ID,
             dbt_cloud_conn_id=conn_id,
@@ -575,7 +605,7 @@ class TestDbtCloudGetJobRunArtifactOperator:
             account_id=account_id,
             path="run_results.json",
             dag=self.dag,
-            output_file_name=tmp_path / "run_results.json",
+            output_file_name=specified_output_file,
         )
 
         mock_get_artifact.return_value.json.return_value = {"data": "file contents"}
@@ -588,7 +618,7 @@ class TestDbtCloudGetJobRunArtifactOperator:
             step=None,
         )
 
-        assert operator.output_file_name == tmp_path / "run_results.json"
+        assert operator.output_file_name == specified_output_file
         assert os.path.exists(operator.output_file_name)
         assert return_value == operator.output_file_name
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Fixup flakey test `tests/providers/dbt/cloud/operators/test_dbt.py::TestDbtCloudRunJobOperator::test_execute_wait_for_termination` which depends on a system time. As a bonus test run time is reduced

```console
            else:
                # When the job run status is not in a terminal status or "Success", the operator will
                # continue to call ``get_job_run()`` until a ``timeout`` number of seconds has passed
                # (3 seconds for this test).  Therefore, there should be 4 calls of this function: one
                # initially and 3 for each check done at a 1 second interval.
>               assert mock_get_job_run.call_count == 4
E               AssertionError: assert 3 == 4
E                +  where 3 = <MagicMock name='get_job_run' id='140043051658976'>.call_count

tests/providers/dbt/cloud/operators/test_dbt.py:264: AssertionError
```

In addition changed current directory in tests where we provide relative paths, otherwise this is a matter of time when we accidentally merge in main branch files test-generated 


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
