### PR TITLE
Resolve DbtCloudJobRunAsyncSensor deprecation in system tests

### DIFF
--- a/docs/apache-airflow-providers-dbt-cloud/operators.rst
+++ b/docs/apache-airflow-providers-dbt-cloud/operators.rst
@@ -97,27 +97,15 @@ the ``account_id`` for the task is referenced within the ``default_args`` of the
     :start-after: [START howto_operator_dbt_cloud_run_job_sensor]
     :end-before: [END howto_operator_dbt_cloud_run_job_sensor]
 
-Also you can use deferrable mode in this sensor if you would like to free up the worker slots while the sensor is running.
+Also, you can poll for status of the job run asynchronously using ``deferrable`` mode. In this mode, worker
+slots are freed up while the sensor is running.
 
 .. exampleinclude:: /../../tests/system/providers/dbt/cloud/example_dbt_cloud.py
     :language: python
     :dedent: 4
-    :start-after: [START howto_operator_dbt_cloud_run_job_sensor_defered]
-    :end-before: [END howto_operator_dbt_cloud_run_job_sensor_defered]
+    :start-after: [START howto_operator_dbt_cloud_run_job_sensor_deferred]
+    :end-before: [END howto_operator_dbt_cloud_run_job_sensor_deferred]
 
-.. _howto/operator:DbtCloudJobRunAsyncSensor:
-
-Poll for status of a dbt Cloud Job run asynchronously
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. note::
-    :class:`~airflow.providers.dbt.cloud.sensors.dbt.DbtCloudJobRunAsyncSensor` is deprecated and will be removed in a future release. Please use :class:`~airflow.providers.dbt.cloud.sensors.dbt.DbtCloudJobRunSensor` and use the deferrable mode in that operator.
-
-.. exampleinclude:: /../../tests/system/providers/dbt/cloud/example_dbt_cloud.py
-    :language: python
-    :dedent: 4
-    :start-after: [START howto_operator_dbt_cloud_run_job_async_sensor]
-    :end-before: [END howto_operator_dbt_cloud_run_job_async_sensor]
 
 .. _howto/operator:DbtCloudGetJobRunArtifactOperator:
 

--- a/tests/always/test_example_dags.py
+++ b/tests/always/test_example_dags.py
@@ -51,7 +51,6 @@ IGNORE_AIRFLOW_PROVIDER_DEPRECATION_WARNING: tuple[str, ...] = (
     "tests/system/providers/amazon/aws/example_eks_with_nodegroups.py",
     "tests/system/providers/amazon/aws/example_emr.py",
     "tests/system/providers/amazon/aws/example_emr_notebook_execution.py",
-    "tests/system/providers/dbt/cloud/example_dbt_cloud.py",
     "tests/system/providers/google/cloud/azure/example_azure_fileshare_to_gcs.py",
     "tests/system/providers/google/cloud/bigquery/example_bigquery_operations.py",
     "tests/system/providers/google/cloud/bigquery/example_bigquery_sensors.py",

--- a/tests/system/providers/dbt/cloud/example_dbt_cloud.py
+++ b/tests/system/providers/dbt/cloud/example_dbt_cloud.py
@@ -25,7 +25,7 @@ from airflow.providers.dbt.cloud.operators.dbt import (
     DbtCloudListJobsOperator,
     DbtCloudRunJobOperator,
 )
-from airflow.providers.dbt.cloud.sensors.dbt import DbtCloudJobRunAsyncSensor, DbtCloudJobRunSensor
+from airflow.providers.dbt.cloud.sensors.dbt import DbtCloudJobRunSensor
 from airflow.utils.edgemodifier import Label
 from tests.system.utils import get_test_env_id
 
@@ -72,17 +72,11 @@ with DAG(
     )
     # [END howto_operator_dbt_cloud_run_job_sensor]
 
-    # [START howto_operator_dbt_cloud_run_job_sensor_defered]
-    job_run_sensor_defered = DbtCloudJobRunSensor(
-        task_id="job_run_sensor_defered", run_id=trigger_job_run2.output, timeout=20, deferrable=True
+    # [START howto_operator_dbt_cloud_run_job_sensor_deferred]
+    job_run_sensor_deferred = DbtCloudJobRunSensor(
+        task_id="job_run_sensor_deferred", run_id=trigger_job_run2.output, timeout=20, deferrable=True
     )
-    # [END howto_operator_dbt_cloud_run_job_sensor_defered]
-
-    # [START howto_operator_dbt_cloud_run_job_async_sensor]
-    job_run_async_sensor = DbtCloudJobRunAsyncSensor(
-        task_id="job_run_async_sensor", run_id=trigger_job_run2.output, timeout=20
-    )
-    # [END howto_operator_dbt_cloud_run_job_async_sensor]
+    # [END howto_operator_dbt_cloud_run_job_sensor_deferred]
 
     # [START howto_operator_dbt_cloud_list_jobs]
     list_dbt_jobs = DbtCloudListJobsOperator(task_id="list_dbt_jobs", account_id=106277, project_id=160645)
@@ -95,6 +89,7 @@ with DAG(
     # Task dependency created via `XComArgs`:
     # trigger_job_run1 >> get_run_results_artifact
     # trigger_job_run2 >> job_run_sensor
+    # trigger_job_run2 >> job_run_sensor_deferred
 
     from tests.system.utils.watcher import watcher
 


### PR DESCRIPTION
Related: #39485

The DbtCloudJobRunAsyncSensor is deprecated in favor of using DbtCloudJobRunSensor with `deferrable=True` set. Removing this sensor from the dbt Cloud system test and updating documentation accordingly.
