### PR TITLE
Fix `xmlsec` version pin

### DIFF
--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -99,10 +99,6 @@ dependencies:
   - sqlalchemy_redshift>=0.8.6
   - asgiref
   - PyAthena>=3.0.10
-  # XML sec 1.3.14 breaks Amazon's authentication with `lxml & xmlsec libxml2 library version mismatch`
-  # We should investigate if we can upgrade to a newer version of lxml and xmlsec
-  # Tracked in https://github.com/apache/airflow/issues/39103
-  - xmlsec<1.3.14
   - jmespath
 
 additional-extras:
@@ -128,6 +124,10 @@ additional-extras:
   - name: python3-saml
     dependencies:
       - python3-saml>=1.16.0
+      # XML sec 1.3.14 breaks Amazon's authentication with `lxml & xmlsec libxml2 library version mismatch`
+      # We should investigate if we can upgrade to a newer version of lxml and xmlsec
+      # Tracked in https://github.com/apache/airflow/issues/39103
+      - xmlsec<1.3.14
 
 devel-dependencies:
   - aiobotocore>=2.7.0

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -37,8 +37,7 @@
       "jsonpath_ng>=1.5.3",
       "redshift_connector>=2.0.918",
       "sqlalchemy_redshift>=0.8.6",
-      "watchtower>=2.0.1,<4",
-      "xmlsec<1.3.14"
+      "watchtower>=2.0.1,<4"
     ],
     "devel-deps": [
       "aiobotocore>=2.7.0",


### PR DESCRIPTION
`xmlsec` is only used when the `python3-saml` additional extra is used in the Amazon provider. We don't need it as a requirement for the Amazon provider in general.

Related: #39103
Closes: #39437