### PR TITLE
Drop `xmlsec` pin

### DIFF
--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -99,10 +99,6 @@ dependencies:
   - sqlalchemy_redshift>=0.8.6
   - asgiref
   - PyAthena>=3.0.10
-  # XML sec 1.3.14 breaks Amazon's authentication with `lxml & xmlsec libxml2 library version mismatch`
-  # We should investigate if we can upgrade to a newer version of lxml and xmlsec
-  # Tracked in https://github.com/apache/airflow/issues/39103
-  - xmlsec<1.3.14
   - jmespath
 
 additional-extras:

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -37,8 +37,7 @@
       "jsonpath_ng>=1.5.3",
       "redshift_connector>=2.0.918",
       "sqlalchemy_redshift>=0.8.6",
-      "watchtower>=2.0.1,<4",
-      "xmlsec<1.3.14"
+      "watchtower>=2.0.1,<4"
     ],
     "devel-deps": [
       "aiobotocore>=2.7.0",


### PR DESCRIPTION
Testing out the theory that we may no longer need the pin: https://github.com/apache/airflow/issues/39437#issuecomment-2103372590