### PR TITLE
Faster airflow_version import for iceberg provider init

### DIFF
--- a/airflow/providers/apache/iceberg/__init__.py
+++ b/airflow/providers/apache/iceberg/__init__.py
@@ -23,15 +23,13 @@
 #
 from __future__ import annotations
 
-import importlib.metadata
-
 import packaging.version
+
+from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
 __version__ = "1.0.0"
-
-airflow_version = importlib.metadata.version("apache-airflow")
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"


### PR DESCRIPTION
This was simply missed in #39552.