### PR TITLE
Fix BigQuery jobs Label Regex

### DIFF
--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -68,7 +68,7 @@ if TYPE_CHECKING:
 
 BIGQUERY_JOB_DETAILS_LINK_FMT = "https://console.cloud.google.com/bigquery?j={job_id}"
 
-LABEL_REGEX = re.compile(r"^[a-z][\w-]{0,63}$")
+LABEL_REGEX = re.compile(r"^[a-z][\w-]{0,62}$")
 
 
 class BigQueryUIColors(enum.Enum):

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -1878,7 +1878,7 @@ class TestBigQueryInsertJobOperator:
             },
         }
         op = BigQueryInsertJobOperator(
-            task_id="insert_query_job_except_this_task_id_is_really_really_really_really_long",
+            task_id="insert_query_job_except_this_task_id_is_64_chars_or_more_xxxxxxx",
             configuration=configuration,
             location=TEST_DATASET_LOCATION,
             project_id=TEST_GCP_PROJECT_ID,
@@ -1893,7 +1893,7 @@ class TestBigQueryInsertJobOperator:
                 "useLegacySql": False,
             },
         }
-        with dag_maker("adhoc_airflow_except_this_task_id_is_really_really_really_really_long"):
+        with dag_maker("adhoc_airflow_except_this_dag_id_is_64_chars_or_more_xxxxxxxxxxx"):
             op = BigQueryInsertJobOperator(
                 task_id="insert_query_job",
                 configuration=configuration,


### PR DESCRIPTION
#37736 Add label DAG ID and Task ID to BigQuery jobs.
However, the maximum label length is 63 characters (see: https://cloud.google.com/bigquery/docs/labels-intro#requirements). Therefore, if the DAG ID or Task ID length is 64, this causes an invalid label exception.
This PR fixes that issue.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
