### PR TITLE
Fix Apprise mypy checks added in 1.8.0

### DIFF
--- a/airflow/providers/apprise/hooks/apprise.py
+++ b/airflow/providers/apprise/hooks/apprise.py
@@ -18,12 +18,15 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Iterable
+from typing import TYPE_CHECKING, Any, Iterable
 
 import apprise
 from apprise import AppriseConfig, NotifyFormat, NotifyType
 
 from airflow.hooks.base import BaseHook
+
+if TYPE_CHECKING:
+    from apprise import AppriseAttachment
 
 
 class AppriseHook(BaseHook):
@@ -72,7 +75,7 @@ class AppriseHook(BaseHook):
         notify_type: NotifyType = NotifyType.INFO,
         body_format: NotifyFormat = NotifyFormat.TEXT,
         tag: str | Iterable[str] | None = None,
-        attach: str | Iterable[str] | None = None,
+        attach: AppriseAttachment | None = None,
         interpret_escapes: bool | None = None,
         config: AppriseConfig | None = None,
     ):

--- a/airflow/providers/apprise/provider.yaml
+++ b/airflow/providers/apprise/provider.yaml
@@ -44,7 +44,7 @@ integrations:
 
 dependencies:
   - apache-airflow>=2.7.0
-  - apprise
+  - apprise>=1.8.0
 
 hooks:
   - integration-name: Apprise

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -262,7 +262,7 @@
   "apprise": {
     "deps": [
       "apache-airflow>=2.7.0",
-      "apprise"
+      "apprise>=1.8.0"
     ],
     "devel-deps": [],
     "cross-providers-deps": [],


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
