### PR TITLE
remove extra return in `get_conn` of  mssql provider

### DIFF
--- a/airflow/providers/microsoft/mssql/hooks/mssql.py
+++ b/airflow/providers/microsoft/mssql/hooks/mssql.py
@@ -103,7 +103,6 @@ class MsSqlHook(DbApiHook):
             database=self.schema or conn.schema,
             port=conn.port,
         )
-        return conn
 
     def set_autocommit(
         self,


### PR DESCRIPTION
forgot to remove an additional return in `get_conn` in the earlier PR(#39575). this PR fixes it.