### PR TITLE
Add `parameters` as template field for SqlSensor

### DIFF
--- a/airflow/providers/common/sql/sensors/sql.py
+++ b/airflow/providers/common/sql/sensors/sql.py
@@ -51,7 +51,7 @@ class SqlSensor(BaseSensorOperator):
             Should match the desired hook constructor params.
     """
 
-    template_fields: Sequence[str] = ("sql", "hook_params")
+    template_fields: Sequence[str] = ("sql", "hook_params", "parameters")
     template_ext: Sequence[str] = (
         ".hql",
         ".sql",


### PR DESCRIPTION
Since `params` really shouldn't be used for parameterizing SQL, it would be helpful if `parameters` could access Airflow Context, user-defined macros, etc. via Jinja templating in SqlSensor.