### PR TITLE
Skip get_current_task_instance_session if use_internal_api

### DIFF
--- a/airflow/utils/task_instance_session.py
+++ b/airflow/utils/task_instance_session.py
@@ -35,6 +35,8 @@ log = logging.getLogger(__name__)
 def get_current_task_instance_session() -> Session:
     global __current_task_instance_session
     if not __current_task_instance_session:
+        if InternalApiConfig.get_use_internal_api():
+            return __current_task_instance_session
         log.warning("No task session set for this task. Continuing but this likely causes a resource leak.")
         log.warning("Please report this and stacktrace below to https://github.com/apache/airflow/issues")
         for filename, line_number, name, line in traceback.extract_stack():

--- a/airflow/utils/task_instance_session.py
+++ b/airflow/utils/task_instance_session.py
@@ -23,6 +23,7 @@ import traceback
 from typing import TYPE_CHECKING
 
 from airflow import settings
+from airflow.api_internal.internal_api_call import InternalApiConfig
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session


### PR DESCRIPTION
We don't need a session when configured to use the internal API.
