### PR TITLE
Fix stacklevel for _log_state helper

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1217,6 +1217,7 @@ def _log_state(*, task_instance: TaskInstance | TaskInstancePydantic, lead_msg: 
         _date_or_empty(task_instance=task_instance, attr="execution_date"),
         _date_or_empty(task_instance=task_instance, attr="start_date"),
         _date_or_empty(task_instance=task_instance, attr="end_date"),
+        stacklevel=2,
     )
 
 


### PR DESCRIPTION
This is necessary to show what line the helper was invoked from.
