### PR TITLE
Use TracebackSession when internal API configured and getting current session

### DIFF
--- a/airflow/utils/task_instance_session.py
+++ b/airflow/utils/task_instance_session.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING
 
 from airflow import settings
 from airflow.api_internal.internal_api_call import InternalApiConfig
+from airflow.settings import TracebackSession
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -37,6 +38,7 @@ def get_current_task_instance_session() -> Session:
     global __current_task_instance_session
     if not __current_task_instance_session:
         if InternalApiConfig.get_use_internal_api():
+            __current_task_instance_session = TracebackSession()
             return __current_task_instance_session
         log.warning("No task session set for this task. Continuing but this likely causes a resource leak.")
         log.warning("Please report this and stacktrace below to https://github.com/apache/airflow/issues")


### PR DESCRIPTION
We shouldn't use this session; this class will tell you where it came from.
