### PR TITLE
Passing `external_task_group_id` to `WorkflowTrigger`

### DIFF
--- a/airflow/sensors/external_task.py
+++ b/airflow/sensors/external_task.py
@@ -351,6 +351,7 @@ class ExternalTaskSensor(BaseSensorOperator):
                 timeout=self.execution_timeout,
                 trigger=WorkflowTrigger(
                     external_dag_id=self.external_dag_id,
+                    external_task_group_id=self.external_task_group_id,
                     external_task_ids=self.external_task_ids,
                     execution_dates=self._get_dttm_filter(context),
                     allowed_states=self.allowed_states,


### PR DESCRIPTION
Fixes an issue where deferred ExternalTaskSensors are not correctly waiting on a TaskGroup

closes: #39616 
