### PR TITLE
Remove webserver try_number adjustment

### DIFF
--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -96,12 +96,6 @@ def get_instance_with_map(task_instance, session):
     return get_mapped_summary(task_instance, mapped_instances)
 
 
-def get_try_count(try_number: int, state: State):
-    if state in (TaskInstanceState.DEFERRED, TaskInstanceState.UP_FOR_RESCHEDULE):
-        return try_number + 1
-    return try_number
-
-
 priority: list[None | TaskInstanceState] = [
     TaskInstanceState.FAILED,
     TaskInstanceState.UPSTREAM_FAILED,
@@ -147,7 +141,7 @@ def get_mapped_summary(parent_instance, task_instances):
         "start_date": group_start_date,
         "end_date": group_end_date,
         "mapped_states": mapped_states,
-        "try_number": get_try_count(parent_instance.try_number, parent_instance.state),
+        "try_number": parent_instance.try_number,
         "execution_date": parent_instance.execution_date,
     }
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -409,7 +409,7 @@ def dag_to_grid(dag: DagModel, dag_runs: Sequence[DagRun], session: Session) -> 
                         "queued_dttm": task_instance.queued_dttm,
                         "start_date": task_instance.start_date,
                         "end_date": task_instance.end_date,
-                        "try_number": wwwutils.get_try_count(task_instance.try_number, task_instance.state),
+                        "try_number": task_instance.try_number,
                         "note": task_instance.note,
                     }
                     for task_instance in grouped_tis[item.task_id]
@@ -1687,7 +1687,7 @@ class Airflow(AirflowBaseView):
 
         num_logs = 0
         if ti is not None:
-            num_logs = wwwutils.get_try_count(ti.try_number, ti.state)
+            num_logs = ti.try_number
         logs = [""] * num_logs
         root = request.args.get("root", "")
         return self.render_template(

--- a/tests/www/views/test_views_log.py
+++ b/tests/www/views/test_views_log.py
@@ -208,8 +208,8 @@ def log_admin_client(log_app):
     [
         (None, 0, 0),
         (TaskInstanceState.UP_FOR_RETRY, 2, 2),
-        (TaskInstanceState.UP_FOR_RESCHEDULE, 0, 1),
-        (TaskInstanceState.UP_FOR_RESCHEDULE, 1, 2),
+        (TaskInstanceState.UP_FOR_RESCHEDULE, 0, 0),
+        (TaskInstanceState.UP_FOR_RESCHEDULE, 1, 1),
         (TaskInstanceState.RUNNING, 1, 1),
         (TaskInstanceState.SUCCESS, 1, 1),
         (TaskInstanceState.FAILED, 3, 3),


### PR DESCRIPTION
Previously we had code to compensate for the fact that we were decrementing try_number when deferring or rescheduling.  We can remove this code now.  Just missed this in #39336.
