### PR TITLE
Support failing tasks stuck in queued for hybrid executors

### DIFF
--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1566,22 +1566,22 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 TI.queued_by_job_id == self.job.id,
             )
         ).all()
-        try:
-            cleaned_up_task_instances = self.job.executor.cleanup_stuck_queued_tasks(
-                tis=tasks_stuck_in_queued
-            )
-            cleaned_up_task_instances = set(cleaned_up_task_instances)
-            for ti in tasks_stuck_in_queued:
-                if repr(ti) in cleaned_up_task_instances:
-                    self._task_context_logger.warning(
-                        "Marking task instance %s stuck in queued as failed. "
-                        "If the task instance has available retries, it will be retried.",
-                        ti,
-                        ti=ti,
-                    )
-        except NotImplementedError:
-            self.log.debug("Executor doesn't support cleanup of stuck queued tasks. Skipping.")
-            ...
+
+        for executor, stuck_tis in self._executor_to_tis(tasks_stuck_in_queued).items():
+            try:
+                cleaned_up_task_instances = set(executor.cleanup_stuck_queued_tasks(tis=stuck_tis))
+                for ti in stuck_tis:
+                    if repr(ti) in cleaned_up_task_instances:
+                        # TODO: Update this message to include the executor?
+                        self._task_context_logger.warning(
+                            "Marking task instance %s stuck in queued as failed. "
+                            "If the task instance has available retries, it will be retried.",
+                            ti,
+                            ti=ti,
+                        )
+            except NotImplementedError:
+                self.log.debug("Executor doesn't support cleanup of stuck queued tasks. Skipping.")
+                ...
 
     @provide_session
     def _emit_pool_metrics(self, session: Session = NEW_SESSION) -> None:

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1572,7 +1572,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 cleaned_up_task_instances = set(executor.cleanup_stuck_queued_tasks(tis=stuck_tis))
                 for ti in stuck_tis:
                     if repr(ti) in cleaned_up_task_instances:
-                        # TODO: Update this message to include the executor?
                         self._task_context_logger.warning(
                             "Marking task instance %s stuck in queued as failed. "
                             "If the task instance has available retries, it will be retried.",
@@ -1581,7 +1580,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                         )
             except NotImplementedError:
                 self.log.debug("Executor doesn't support cleanup of stuck queued tasks. Skipping.")
-                ...
 
     @provide_session
     def _emit_pool_metrics(self, session: Session = NEW_SESSION) -> None:

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -1809,26 +1809,7 @@ class TestSchedulerJob:
         # Second executor called for ti3
         mock_executors[1].try_adopt_task_instances.assert_called_once_with([ti3])
 
-    def test_fail_stuck_queued_tasks(self, dag_maker, session):
-        with dag_maker("test_fail_stuck_queued_tasks"):
-            op1 = EmptyOperator(task_id="op1")
-
-        dr = dag_maker.create_dagrun()
-        ti = dr.get_task_instance(task_id=op1.task_id, session=session)
-        ti.state = State.QUEUED
-        ti.queued_dttm = timezone.utcnow() - timedelta(minutes=15)
-        session.commit()
-        executor = MagicMock()
-        executor.cleanup_stuck_queued_tasks = mock.MagicMock()
-        scheduler_job = Job(executor=executor)
-        job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=0)
-        job_runner._task_queued_timeout = 300
-
-        job_runner._fail_tasks_stuck_in_queued()
-
-        job_runner.job.executor.cleanup_stuck_queued_tasks.assert_called_once()
-
-    def test_fail_stuck_queued_tasks_multiple_executors(self, dag_maker, session, mock_executors):
+    def test_fail_stuck_queued_tasks(self, dag_maker, session, mock_executors):
         with dag_maker("test_fail_stuck_queued_tasks_multiple_executors"):
             op1 = EmptyOperator(task_id="op1")
             op2 = EmptyOperator(task_id="op2", executor="default_exec")


### PR DESCRIPTION
Sort the set of tasks that are up for failing for being queued too long and send them to the appropriate executor for cleanup.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
