### PR TITLE
use `sqlalchemy_url` property in `get_uri` for sqlite provider

### DIFF
--- a/airflow/providers/sqlite/hooks/sqlite.py
+++ b/airflow/providers/sqlite/hooks/sqlite.py
@@ -18,7 +18,8 @@
 from __future__ import annotations
 
 import sqlite3
-from urllib.parse import unquote
+
+from sqlalchemy.engine import URL
 
 from airflow.providers.common.sql.hooks.sql import DbApiHook
 
@@ -35,6 +36,14 @@ class SqliteHook(DbApiHook):
         super().__init__(*args, **kwargs)
         self._placeholder: str = "?"
 
+    @property
+    def sqlalchemy_url(self) -> URL:
+        airflow_conn = self.get_connection(getattr(self, self.conn_name_attr))
+        database = airflow_conn.host
+        if not database:
+            database = ":memory:"
+        return URL.create(drivername="sqlite+pysqlite", database=database, query=airflow_conn.extra_dejson)
+
     def get_conn(self) -> sqlite3.dbapi2.Connection:
         """Return SQLite connection object."""
         sqlalchemy_uri = self.get_uri()
@@ -46,14 +55,4 @@ class SqliteHook(DbApiHook):
 
     def get_uri(self) -> str:
         """Override DbApiHook get_uri method for get_sqlalchemy_engine()."""
-        conn_id = getattr(self, self.conn_name_attr)
-        airflow_conn = self.get_connection(conn_id)
-        if airflow_conn.conn_type is None:
-            airflow_conn.conn_type = self.conn_type
-        airflow_uri = unquote(airflow_conn.get_uri())
-        # For sqlite, there is no schema in the connection URI. So we need to drop the trailing slash.
-        airflow_sqlite_uri = airflow_uri.replace("/?", "?")
-        # The sqlite connection has one more slash for path specification.
-        # See https://docs.sqlalchemy.org/en/14/dialects/sqlite.html#connect-strings for details.
-        sqlalchemy_uri = airflow_sqlite_uri.replace("sqlite://", "sqlite:///")
-        return sqlalchemy_uri
+        return self.sqlalchemy_url.render_as_string()


### PR DESCRIPTION
Related: #38195 

use `sqlalchemy_url` property to form uri in `get_uri` in  sqlite hook