### PR TITLE
update: remove RFC3896 `conn_type` warning

### DIFF
--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -271,12 +271,6 @@ class Connection(Base, LoggingMixin):
 
     def get_uri(self) -> str:
         """Return connection in URI format."""
-        if self.conn_type and "_" in self.conn_type:
-            self.log.warning(
-                "Connection schemes (type: %s) shall not contain '_' according to RFC3986.",
-                self.conn_type,
-            )
-
         if self.conn_type:
             uri = f"{self.conn_type.lower().replace('_', '-')}://"
         else:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Remove warning about underscores in `conn_type`.

When secrets backend is initially loaded using a URI a `Connection` object is created using the URI (e.g. [Vault](https://github.com/apache/airflow/blob/9284dc53914fc1b8b17399158de7b2c883519664/airflow/providers/hashicorp/secrets/vault.py#L215-L235)) part of which involves normalizing `conn_type` by replacing dashes with underscores (see [Connection._normalize_conn_type](https://github.com/apache/airflow/blob/9284dc53914fc1b8b17399158de7b2c883519664/airflow/models/connection.py#L226-L232)). Then when the connection is saved to secret cache (see [Connection.get_connection_from_secrets](https://github.com/apache/airflow/blob/9284dc53914fc1b8b17399158de7b2c883519664/airflow/models/connection.py#L507-L512)) the connection with a normalized `conn_type` is transformed back into a URI which causes the RFC3896 warning related to underscores appearing in `conn_type`.

For example, a google-cloud-platform connection in Vault defined as a URI (where `conn_type` is `google-cloud-platform`) will generate this warning about underscores in the `conn_type` when referenced by an Airflow component.
```json
{
    "conn_uri": "google-cloud-platform:..."
}
```

Another option could be to move this warning to `Connection._normalize_conn_type`.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
