### PR TITLE
Remove misplaced backquotes in faq.rst

### DIFF
--- a/docs/apache-airflow/faq.rst
+++ b/docs/apache-airflow/faq.rst
@@ -221,7 +221,7 @@ a global ``start_date`` for your tasks. This can be done by declaring your
 ``start_date`` directly in the ``DAG()`` object. A DAG's first
 DagRun will be created based on the first complete ``data_interval``
 after ``start_date``. For example, for a DAG with
-``start_date=``datetime(2024, 1, 1)`` and ``schedule="0 0 3 * *"``, the
+``start_date=datetime(2024, 1, 1)`` and ``schedule="0 0 3 * *"``, the
 first DAG run will be triggered at midnight on 2024-02-03 with
 ``data_interval_start=datetime(2024, 1, 3)`` and
 ``data_interval_end=datetime(2024, 2, 3)``. From that point on, the scheduler


### PR DESCRIPTION
closes: #39660 

In the [section 'What’s the deal with start_date?' of the FAQ](https://airflow.apache.org/docs/apache-airflow/stable/faq.html#what-s-the-deal-with-start-date), two back quotes (\`\`) are in the middle of an inline code (line 224 of `faq.rst`):

```rst
``start_date=``datetime(2024, 1, 1)``
```

This leads to a bad rendering where the two back quotes appears between `=` and `datetime(2024, 1, 1)`, like this: `start_date=``datetime(2024, 1, 1)` (or picture just bellow).

![Bad rendering of inline code](https://github.com/apache/airflow/assets/59126928/0026ded2-6cd7-465f-819d-c825691818b1)

I removed the two back quotes in the middle of the inline code, so now it renders without them.
