### PR TITLE
Update plugins.rst examples to use pyproject.toml over setup.py

### DIFF
--- a/docs/apache-airflow/authoring-and-scheduling/plugins.rst
+++ b/docs/apache-airflow/authoring-and-scheduling/plugins.rst
@@ -309,15 +309,12 @@ will automatically load the registered plugins from the entrypoint list.
         name = "my_namespace"
         flask_blueprints = [bp]
 
-.. code-block:: python
+Then inside pyproject.toml:
 
-    from setuptools import setup
+.. code-block:: toml
 
-    setup(
-        name="my-package",
-        # ...
-        entry_points={"airflow.plugins": ["my_plugin = my_package.my_plugin:MyAirflowPlugin"]},
-    )
+    [project.entry-points."airflow.plugins"]
+    my_plugin = "my_package.my_plugin:MyAirflowPlugin"
 
 Automatic reloading webserver
 -----------------------------

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1279,6 +1279,7 @@ pymysql
 pyodbc
 pypa
 PyPI
+pyproject
 pypsrp
 pyspark
 pytest
@@ -1655,6 +1656,7 @@ todo
 tokenization
 tokopedia
 tolerations
+toml
 toolchain
 Tooltip
 tooltip


### PR DESCRIPTION
pyproject.toml is the standard project description moving forward. Airflow has itself adopted this recently. Examples should follow this to ease using the latest standard for plugin authors.

https://packaging.python.org/en/latest/discussions/setup-py-deprecated/#is-pyproject-toml-mandatory
