### PR TITLE
Reroute AutoML operator links to Google Translation links

### DIFF
--- a/airflow/providers/google/cloud/links/automl.py
+++ b/airflow/providers/google/cloud/links/automl.py
@@ -21,6 +21,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from deprecated import deprecated
+
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.google.cloud.links.base import BaseGoogleLink
 
 if TYPE_CHECKING:
@@ -44,6 +47,13 @@ AUTOML_MODEL_PREDICT_LINK = (
 )
 
 
+@deprecated(
+    reason=(
+        "Class `AutoMLDatasetLink` has been deprecated and will be removed after 31.12.2024. "
+        "Please use `TranslationLegacyDatasetLink` from `airflow/providers/google/cloud/links/translate.py` instead."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class AutoMLDatasetLink(BaseGoogleLink):
     """Helper class for constructing AutoML Dataset link."""
 
@@ -65,6 +75,13 @@ class AutoMLDatasetLink(BaseGoogleLink):
         )
 
 
+@deprecated(
+    reason=(
+        "Class `AutoMLDatasetListLink` has been deprecated and will be removed after 31.12.2024. "
+        "Please use `TranslationDatasetListLink` from `airflow/providers/google/cloud/links/translate.py` instead."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class AutoMLDatasetListLink(BaseGoogleLink):
     """Helper class for constructing AutoML Dataset List link."""
 
@@ -87,6 +104,13 @@ class AutoMLDatasetListLink(BaseGoogleLink):
         )
 
 
+@deprecated(
+    reason=(
+        "Class `AutoMLModelLink` has been deprecated and will be removed after 31.12.2024. "
+        "Please use `TranslationLegacyModelLink` from `airflow/providers/google/cloud/links/translate.py` instead."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class AutoMLModelLink(BaseGoogleLink):
     """Helper class for constructing AutoML Model link."""
 
@@ -114,6 +138,13 @@ class AutoMLModelLink(BaseGoogleLink):
         )
 
 
+@deprecated(
+    reason=(
+        "Class `AutoMLModelTrainLink` has been deprecated and will be removed after 31.12.2024. "
+        "Please use `TranslationLegacyModelTrainLink` from `airflow/providers/google/cloud/links/translate.py` instead."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class AutoMLModelTrainLink(BaseGoogleLink):
     """Helper class for constructing AutoML Model Train link."""
 
@@ -138,6 +169,13 @@ class AutoMLModelTrainLink(BaseGoogleLink):
         )
 
 
+@deprecated(
+    reason=(
+        "Class `AutoMLModelPredictLink` has been deprecated and will be removed after 31.12.2024. "
+        "Please use `TranslationLegacyModelPredictLink` from `airflow/providers/google/cloud/links/translate.py` instead."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class AutoMLModelPredictLink(BaseGoogleLink):
     """Helper class for constructing AutoML Model Predict link."""
 

--- a/airflow/providers/google/cloud/links/translate.py
+++ b/airflow/providers/google/cloud/links/translate.py
@@ -1,0 +1,180 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""This module contains Google Translate links."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from airflow.providers.google.cloud.links.base import BASE_LINK, BaseGoogleLink
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
+
+
+TRANSLATION_BASE_LINK = BASE_LINK + "/translation"
+TRANSLATION_LEGACY_DATASET_LINK = (
+    TRANSLATION_BASE_LINK + "/locations/{location}/datasets/{dataset_id}/sentences?project={project_id}"
+)
+TRANSLATION_DATASET_LIST_LINK = TRANSLATION_BASE_LINK + "/datasets?project={project_id}"
+TRANSLATION_LEGACY_MODEL_LINK = (
+    TRANSLATION_BASE_LINK
+    + "/locations/{location}/datasets/{dataset_id}/evaluate;modelId={model_id}?project={project_id}"
+)
+TRANSLATION_LEGACY_MODEL_TRAIN_LINK = (
+    TRANSLATION_BASE_LINK + "/locations/{location}/datasets/{dataset_id}/train?project={project_id}"
+)
+TRANSLATION_LEGACY_MODEL_PREDICT_LINK = (
+    TRANSLATION_BASE_LINK
+    + "/locations/{location}/datasets/{dataset_id}/predict;modelId={model_id}?project={project_id}"
+)
+
+
+class TranslationLegacyDatasetLink(BaseGoogleLink):
+    """
+    Helper class for constructing Legacy Translation Dataset link.
+
+    Legacy Datasets are created and managed by AutoML API.
+    """
+
+    name = "Translation Legacy Dataset"
+    key = "translation_legacy_dataset"
+    format_str = TRANSLATION_LEGACY_DATASET_LINK
+
+    @staticmethod
+    def persist(
+        context: Context,
+        task_instance,
+        dataset_id: str,
+        project_id: str,
+    ):
+        task_instance.xcom_push(
+            context,
+            key=TranslationLegacyDatasetLink.key,
+            value={"location": task_instance.location, "dataset_id": dataset_id, "project_id": project_id},
+        )
+
+
+class TranslationDatasetListLink(BaseGoogleLink):
+    """Helper class for constructing Translation Dataset List link."""
+
+    name = "Translation Dataset List"
+    key = "translation_dataset_list"
+    format_str = TRANSLATION_DATASET_LIST_LINK
+
+    @staticmethod
+    def persist(
+        context: Context,
+        task_instance,
+        project_id: str,
+    ):
+        task_instance.xcom_push(
+            context,
+            key=TranslationDatasetListLink.key,
+            value={
+                "project_id": project_id,
+            },
+        )
+
+
+class TranslationLegacyModelLink(BaseGoogleLink):
+    """
+    Helper class for constructing Translation Legacy Model link.
+
+    Legacy Models are created and managed by AutoML API.
+    """
+
+    name = "Translation Legacy Model"
+    key = "translation_legacy_model"
+    format_str = TRANSLATION_LEGACY_MODEL_LINK
+
+    @staticmethod
+    def persist(
+        context: Context,
+        task_instance,
+        dataset_id: str,
+        model_id: str,
+        project_id: str,
+    ):
+        task_instance.xcom_push(
+            context,
+            key=TranslationLegacyModelLink.key,
+            value={
+                "location": task_instance.location,
+                "dataset_id": dataset_id,
+                "model_id": model_id,
+                "project_id": project_id,
+            },
+        )
+
+
+class TranslationLegacyModelTrainLink(BaseGoogleLink):
+    """
+    Helper class for constructing Translation Legacy Model Train link.
+
+    Legacy Models are created and managed by AutoML API.
+    """
+
+    name = "Translation Legacy Model Train"
+    key = "translation_legacy_model_train"
+    format_str = TRANSLATION_LEGACY_MODEL_TRAIN_LINK
+
+    @staticmethod
+    def persist(
+        context: Context,
+        task_instance,
+        project_id: str,
+    ):
+        task_instance.xcom_push(
+            context,
+            key=TranslationLegacyModelTrainLink.key,
+            value={
+                "location": task_instance.location,
+                "dataset_id": task_instance.model["dataset_id"],
+                "project_id": project_id,
+            },
+        )
+
+
+class TranslationLegacyModelPredictLink(BaseGoogleLink):
+    """
+    Helper class for constructing Translation Legacy Model Predict link.
+
+    Legacy Models are created and managed by AutoML API.
+    """
+
+    name = "Translation Legacy Model Predict"
+    key = "translation_legacy_model_predict"
+    format_str = TRANSLATION_LEGACY_MODEL_PREDICT_LINK
+
+    @staticmethod
+    def persist(
+        context: Context,
+        task_instance,
+        model_id: str,
+        project_id: str,
+    ):
+        task_instance.xcom_push(
+            context,
+            key=TranslationLegacyModelPredictLink.key,
+            value={
+                "location": task_instance.location,
+                "dataset_id": task_instance.model.dataset_id,
+                "model_id": model_id,
+                "project_id": project_id,
+            },
+        )

--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -1274,6 +1274,12 @@ extra-links:
   - airflow.providers.google.common.links.storage.StorageLink
   - airflow.providers.google.common.links.storage.FileDetailsLink
   - airflow.providers.google.marketing_platform.links.analytics_admin.GoogleAnalyticsPropertyLink
+  - airflow.providers.google.cloud.links.translate.TranslationLegacyDatasetLink
+  - airflow.providers.google.cloud.links.translate.TranslationDatasetListLink
+  - airflow.providers.google.cloud.links.translate.TranslationLegacyModelLink
+  - airflow.providers.google.cloud.links.translate.TranslationLegacyModelTrainLink
+  - airflow.providers.google.cloud.links.translate.TranslationLegacyModelPredictLink
+
 
 secrets-backends:
   - airflow.providers.google.cloud.secrets.secret_manager.CloudSecretManagerBackend

--- a/tests/providers/google/cloud/links/__init__.py
+++ b/tests/providers/google/cloud/links/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/providers/google/cloud/links/test_translate.py
+++ b/tests/providers/google/cloud/links/test_translate.py
@@ -1,0 +1,150 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+from google.cloud.automl_v1beta1 import Model
+
+from airflow.providers.google.cloud.links.translate import (
+    TRANSLATION_BASE_LINK,
+    TranslationDatasetListLink,
+    TranslationLegacyDatasetLink,
+    TranslationLegacyModelLink,
+    TranslationLegacyModelPredictLink,
+    TranslationLegacyModelTrainLink,
+)
+from airflow.providers.google.cloud.operators.automl import (
+    AutoMLBatchPredictOperator,
+    AutoMLCreateDatasetOperator,
+    AutoMLListDatasetOperator,
+    AutoMLTrainModelOperator,
+)
+
+GCP_LOCATION = "test-location"
+GCP_PROJECT_ID = "test-project"
+DATASET = "test-dataset"
+MODEL = "test-model"
+
+
+class TestTranslationLegacyDatasetLink:
+    @pytest.mark.db_test
+    def test_get_link(self, create_task_instance_of_operator):
+        expected_url = f"{TRANSLATION_BASE_LINK}/locations/{GCP_LOCATION}/datasets/{DATASET}/sentences?project={GCP_PROJECT_ID}"
+        link = TranslationLegacyDatasetLink()
+        ti = create_task_instance_of_operator(
+            AutoMLCreateDatasetOperator,
+            dag_id="test_legacy_dataset_link_dag",
+            task_id="test_legacy_dataset_link_task",
+            dataset=DATASET,
+            location=GCP_LOCATION,
+        )
+        link.persist(context={"ti": ti}, task_instance=ti.task, dataset_id=DATASET, project_id=GCP_PROJECT_ID)
+        actual_url = link.get_link(operator=ti.task, ti_key=ti.key)
+        assert actual_url == expected_url
+
+
+class TestTranslationDatasetListLink:
+    @pytest.mark.db_test
+    def test_get_link(self, create_task_instance_of_operator):
+        expected_url = f"{TRANSLATION_BASE_LINK}/datasets?project={GCP_PROJECT_ID}"
+        link = TranslationDatasetListLink()
+        ti = create_task_instance_of_operator(
+            AutoMLListDatasetOperator,
+            dag_id="test_dataset_list_link_dag",
+            task_id="test_dataset_list_link_task",
+            location=GCP_LOCATION,
+        )
+        link.persist(context={"ti": ti}, task_instance=ti.task, project_id=GCP_PROJECT_ID)
+        actual_url = link.get_link(operator=ti.task, ti_key=ti.key)
+        assert actual_url == expected_url
+
+
+class TestTranslationLegacyModelLink:
+    @pytest.mark.db_test
+    def test_get_link(self, create_task_instance_of_operator):
+        expected_url = (
+            f"{TRANSLATION_BASE_LINK}/locations/{GCP_LOCATION}/datasets/{DATASET}/"
+            f"evaluate;modelId={MODEL}?project={GCP_PROJECT_ID}"
+        )
+        link = TranslationLegacyModelLink()
+        ti = create_task_instance_of_operator(
+            AutoMLTrainModelOperator,
+            dag_id="test_legacy_model_link_dag",
+            task_id="test_legacy_model_link_task",
+            model=MODEL,
+            project_id=GCP_PROJECT_ID,
+            location=GCP_LOCATION,
+        )
+        link.persist(
+            context={"ti": ti},
+            task_instance=ti.task,
+            dataset_id=DATASET,
+            model_id=MODEL,
+            project_id=GCP_PROJECT_ID,
+        )
+        actual_url = link.get_link(operator=ti.task, ti_key=ti.key)
+        assert actual_url == expected_url
+
+
+class TestTranslationLegacyModelTrainLink:
+    @pytest.mark.db_test
+    def test_get_link(self, create_task_instance_of_operator):
+        expected_url = (
+            f"{TRANSLATION_BASE_LINK}/locations/{GCP_LOCATION}/datasets/{DATASET}/"
+            f"train?project={GCP_PROJECT_ID}"
+        )
+        link = TranslationLegacyModelTrainLink()
+        ti = create_task_instance_of_operator(
+            AutoMLTrainModelOperator,
+            dag_id="test_legacy_model_train_link_dag",
+            task_id="test_legacy_model_train_link_task",
+            model={"dataset_id": DATASET},
+            project_id=GCP_PROJECT_ID,
+            location=GCP_LOCATION,
+        )
+        link.persist(
+            context={"ti": ti},
+            task_instance=ti.task,
+            project_id=GCP_PROJECT_ID,
+        )
+        actual_url = link.get_link(operator=ti.task, ti_key=ti.key)
+        assert actual_url == expected_url
+
+
+class TestTranslationLegacyModelPredictLink:
+    @pytest.mark.db_test
+    def test_get_link(self, create_task_instance_of_operator):
+        expected_url = (
+            f"{TRANSLATION_BASE_LINK}/locations/{GCP_LOCATION}/datasets/{DATASET}/"
+            f"predict;modelId={MODEL}?project={GCP_PROJECT_ID}"
+        )
+        link = TranslationLegacyModelPredictLink()
+        ti = create_task_instance_of_operator(
+            AutoMLBatchPredictOperator,
+            dag_id="test_legacy_model_predict_link_dag",
+            task_id="test_legacy_model_predict_link_task",
+            model_id=MODEL,
+            project_id=GCP_PROJECT_ID,
+            location=GCP_LOCATION,
+            input_config="input_config",
+            output_config="input_config",
+        )
+        ti.task.model = Model(dataset_id=DATASET, display_name=MODEL)
+        link.persist(context={"ti": ti}, task_instance=ti.task, model_id=MODEL, project_id=GCP_PROJECT_ID)
+        actual_url = link.get_link(operator=ti.task, ti_key=ti.key)
+        assert actual_url == expected_url


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Update deprecated AutoML operators with new links. Due to its future deprecation AutoML's URLs have been divided between Google Translation and Vertex AI services. This PR updates the operators that are going to be used only with Google Translation services. 

I opted to create a new module `airflow/providers/google/cloud/links/translate.py` and put the new links there instead of updating the existing AutoML links in `airflow/providers/google/cloud/links/automl.py` because:
- The links are leading to Google Translation URLs anyway;
- Corresponding AutoML URLs are no longer accessible and will be deprecated in the future;
- There is no module for the Google Translation links yet even though Google Translation operators exist.

This PR is dependent on and should not be merged before https://github.com/apache/airflow/pull/38673 .

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
