### PR TITLE
Print stderr from helm test failures

### DIFF
--- a/tests/charts/helm_template_generator.py
+++ b/tests/charts/helm_template_generator.py
@@ -102,6 +102,11 @@ def validate_k8s_object(instance, kubernetes_version):
     validate.validate(instance)
 
 
+class HelmFailedError(subprocess.CalledProcessError):
+    def __str__(self):
+        return f"Helm command failed. Args: {self.args}\nStderr: \n{self.stderr.decode('utf-8')}"
+
+
 def render_chart(
     name="release-name",
     values=None,
@@ -135,15 +140,9 @@ def render_chart(
         if show_only:
             for i in show_only:
                 command.extend(["--show-only", i])
-        result = subprocess.run(command, stderr=subprocess.PIPE, stdout=subprocess.PIPE, cwd=chart_dir)
-        if result.returncode != 0:
-            try:
-                result.check_returncode()
-            except Exception as e:
-                raise RuntimeError(
-                    "Helm command failed.  Stderr: \n%s" % result.stderr.decode("utf-8")
-                ) from e
-
+        result = subprocess.run(command, capture_output=True, cwd=chart_dir)
+        if result.returncode:
+            raise HelmFailedError(result.returncode, result.args, result.stdout, result.stderr)
         templates = result.stdout
         k8s_objects = yaml.full_load_all(templates)
         k8s_objects = [k8s_object for k8s_object in k8s_objects if k8s_object]  # type: ignore


### PR DESCRIPTION
Previously you would not see the error message; you'd only see that the command failed.  Now you'll see it.

Here's an example of what it looks like now:
```
test_basic_helm_chart.py:551: in test_invalid_pull_policy
    render_chart(
../../tests/charts/helm_template_generator.py:145: in render_chart
    raise HelmFailedError(result.returncode, result.args, result.stdout, result.stderr)
E   tests.charts.helm_template_generator.HelmFailedError: Helm command failed. Args: (1, ['helm', 'template', 'test-basic', '/Users/dstandish/code/airflow/chart', '--values', '/var/folders/9c/tknx7xx10qx92983y1r5djb40000gn/T/tmpbmxoj2yj', '--kube-version', '1.29.1', '--namespace', 'default'], b'', b'Error: values don\'t meet the specifications of the schema(s) in the following chart(s):\nairflow:\n- images.flower.pullPolicy: images.flower.pullPolicy must be one of the following: "Always", "Never", "IfNotPresent"\n\n')
E   Stderr: 
E   Error: values don't meet the specifications of the schema(s) in the following chart(s):
E   airflow:
E   - images.flower.pullPolicy: images.flower.pullPolicy must be one of the following: "Always", "Never", "IfNotPresent"
FAILED [ 50%]
helm_tests/airflow_aux/test_basic_helm_chart.py:544 (TestBaseChartTest.test_invalid_pull_policy[statsd])
```

Before you would only have seen something like this:

```
helm_tests/airflow_core/test_rpc_server.py:578 (TestRPCServerDeployment.test_rpc_server_security_context_legacy)
../../tests/charts/helm_template_generator.py:141: in render_chart
    result.check_returncode()
../../../../.pyenv/versions/3.11.3/lib/python3.11/subprocess.py:502: in check_returncode
    raise CalledProcessError(self.returncode, self.args, self.stdout,
E   subprocess.CalledProcessError: Command '['helm', 'template', 'release-name', '/Users/dstandish/code/airflow/chart', '--values', '/var/folders/9c/tknx7xx10qx92983y1r5djb40000gn/T/tmpcbo2q6kz', '--kube-version', '1.29.1', '--namespace', 'default', '--show-only', 'templates/rpc-server/rpc-server-deployment.yaml']' returned non-zero exit status 1.
```
