### PR TITLE
Add pattern for split Log to independent messages

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -850,6 +850,13 @@ logging:
       type: string
       example: ~
       default: (?<=\n)(?=(?:|[ \t]+?)(?:\[.+?\]) (?:{{.+?:[0-9]+}}) (?:CRITICAL|ERROR|WARNING|INFO|DEBUG) - (?:.+?)(?:\n|$))
+    log_format_dedupe_logs:
+      description: |
+        Flag to enable/disable deduplication between log messages
+      version_added: 2.9.2
+      type: boolean
+      example: ~
+      default: "True"
     simple_log_format:
       description: |
         Defines the format of log messages for simple logging configuration

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -850,7 +850,7 @@ logging:
       type: string
       example: ~
       default: (?<=\n)(?=(?:|[ \t]+?)(?:\[.+?\]) (?:{{.+?:[0-9]+}}) (?:CRITICAL|ERROR|WARNING|INFO|DEBUG) - (?:.+?)(?:\n|$))
-    log_format_dedupe_logs:
+    log_format_deduplicate_logs:
       description: |
         Flag to enable/disable deduplication between log messages
       version_added: 2.9.2

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -849,7 +849,7 @@ logging:
       version_added: 2.9.2
       type: string
       example: ~
-      default: (?<=\n)(?=(?:|[ \t]+?)(?:\[.+?\]) (?:{{.+?:[0-9]+}}) (?:CRITICAL|ERROR|WARNING|INFO|DEBUG) - (?:.+?)(?:\n|$))
+      default: (\s*?\[.+?\] {{.+?:[0-9]+}} \w+ - )
     log_format_deduplicate_logs:
       description: |
         Flag to enable/disable deduplication between log messages

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -843,6 +843,13 @@ logging:
       type: string
       example: ~
       default: "[%%(asctime)s] {{%%(filename)s:%%(lineno)d}} %%(levelname)s - %%(message)s"
+    log_format_re_pattern:
+      description: |
+        Defines the pattern for split Log to independent messages
+      version_added: 2.9.2
+      type: string
+      example: ~
+      default: (?<=\n)(?=(?:|[ \t]+?)(?:\[.+?\]) (?:{{.+?:[0-9]+}}) (?:CRITICAL|ERROR|WARNING|INFO|DEBUG) - (?:.+?)(?:\n|$))
     simple_log_format:
       description: |
         Defines the format of log messages for simple logging configuration

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -80,6 +80,7 @@ GUNICORN_WORKER_READY_PREFIX = "[ready] "
 
 LOG_FORMAT = conf.get("logging", "log_format")
 SIMPLE_LOG_FORMAT = conf.get("logging", "simple_log_format")
+LOG_FORMAT_RE_PATTERN = conf.get("logging", "log_format_re_pattern")
 
 SQL_ALCHEMY_CONN: str | None = None
 PLUGINS_FOLDER: str | None = None

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -81,6 +81,7 @@ GUNICORN_WORKER_READY_PREFIX = "[ready] "
 LOG_FORMAT = conf.get("logging", "log_format")
 SIMPLE_LOG_FORMAT = conf.get("logging", "simple_log_format")
 LOG_FORMAT_RE_PATTERN = conf.get("logging", "log_format_re_pattern")
+LOG_FORMAT_DEDUPE_LOGS = conf.getboolean("logging", "log_format_dedupe_logs")
 
 SQL_ALCHEMY_CONN: str | None = None
 PLUGINS_FOLDER: str | None = None

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -81,7 +81,7 @@ GUNICORN_WORKER_READY_PREFIX = "[ready] "
 LOG_FORMAT = conf.get("logging", "log_format")
 SIMPLE_LOG_FORMAT = conf.get("logging", "simple_log_format")
 LOG_FORMAT_RE_PATTERN = conf.get("logging", "log_format_re_pattern")
-LOG_FORMAT_DEDUPE_LOGS = conf.getboolean("logging", "log_format_dedupe_logs")
+LOG_FORMAT_DEDUPLICATE_LOGS = conf.getboolean("logging", "log_format_deduplicate_logs")
 
 SQL_ALCHEMY_CONN: str | None = None
 PLUGINS_FOLDER: str | None = None

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -22,6 +22,7 @@ import functools
 import json
 import logging
 import os
+import re2
 import sys
 import traceback
 import warnings
@@ -81,6 +82,7 @@ GUNICORN_WORKER_READY_PREFIX = "[ready] "
 LOG_FORMAT = conf.get("logging", "log_format")
 SIMPLE_LOG_FORMAT = conf.get("logging", "simple_log_format")
 LOG_FORMAT_RE_PATTERN = conf.get("logging", "log_format_re_pattern")
+LOG_FORMAT_RE_PATTERN_COMPILED = re2.compile(LOG_FORMAT_RE_PATTERN)
 LOG_FORMAT_DEDUPLICATE_LOGS = conf.getboolean("logging", "log_format_deduplicate_logs")
 
 SQL_ALCHEMY_CONN: str | None = None

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -22,7 +22,6 @@ import functools
 import json
 import logging
 import os
-import re2
 import sys
 import traceback
 import warnings
@@ -30,6 +29,7 @@ from importlib import metadata
 from typing import TYPE_CHECKING, Any, Callable
 
 import pluggy
+import re2
 from packaging.version import Version
 from sqlalchemy import create_engine, exc, text
 from sqlalchemy.orm import scoped_session, sessionmaker

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -172,7 +172,7 @@ def _interleave_logs(*logs):
     for _, _, v in sorted(
         records, key=lambda x: (x[0], x[1]) if x[0] else (pendulum.datetime(2000, 1, 1), x[1])
     ):
-        if settings.LOG_FORMAT_DEDUPE_LOGS:
+        if settings.LOG_FORMAT_DEDUPLICATE_LOGS:
             if v != last:  # dedupe
                 yield v
             last = v

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -131,7 +131,7 @@ def _parse_timestamps_in_log_file(lines: Iterable[str]):
 
 
 def split_log_to_messages(log: str):
-    if settings_LOG_FORMAT_RE_PATTERN == "\n":
+    if settings.LOG_FORMAT_RE_PATTERN == "\n":
         return log.splitlines()
     
     log_messages = re.split(settings.LOG_FORMAT_RE_PATTERN, log)

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -172,9 +172,12 @@ def _interleave_logs(*logs):
     for _, _, v in sorted(
         records, key=lambda x: (x[0], x[1]) if x[0] else (pendulum.datetime(2000, 1, 1), x[1])
     ):
-        if v != last:  # dedupe
+        if settings.LOG_FORMAT_DEDUPE_LOGS:
+            if v != last:  # dedupe
+                yield v
+            last = v
+        else:
             yield v
-        last = v
 
 
 def _ensure_ti(ti: TaskInstanceKey | TaskInstance | TaskInstancePydantic, session) -> TaskInstance:

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -22,13 +22,12 @@ from __future__ import annotations
 import inspect
 import logging
 import os
-import re
 import warnings
 from contextlib import suppress
 from enum import Enum
 from functools import cached_property
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Iterable, List
+from typing import TYPE_CHECKING, Any, Callable, Iterable
 from urllib.parse import urljoin
 
 import pendulum
@@ -130,12 +129,11 @@ def _parse_timestamps_in_log_file(lines: Iterable[str]):
             yield timestamp, idx, line
 
 
-def split_log_to_messages(log: str) -> List[str]:
-    lines = log.split("\n")  # do not remove \r symbols
-    log_messages = []
+def split_log_to_messages(log: str) -> list[str]:
+    log_messages: list[str] = []
 
-    msg = []
-    for line in lines:
+    msg: list[str] = []
+    for line in log.split("\n"):  # do not remove \r symbols
         if settings.LOG_FORMAT_RE_PATTERN_COMPILED.match(line) is not None:
             if len(msg) != 0:
                 log_messages.append("\n".join(msg))

--- a/tests/providers/amazon/aws/log/test_s3_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_s3_task_handler.py
@@ -125,7 +125,7 @@ class TestS3TaskHandler:
         mock_open().write.assert_not_called()
 
     def test_read(self):
-        """"Write with \n at the end of log"""
+        """Write with \n at the end of log"""
         self.conn.put_object(Bucket="bucket", Key=self.remote_log_key, Body=b"Log line\n")
         ti = copy.copy(self.ti)
         ti.state = TaskInstanceState.SUCCESS

--- a/tests/utils/log/test_log_reader.py
+++ b/tests/utils/log/test_log_reader.py
@@ -178,7 +178,7 @@ class TestLogView:
             "localhost\n*** Found local files:\n"
             f"***   * {self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/1.log\n"
             "try_number=1.\n"
-            "\n" # read_log_stream add \n after each try file
+            "\n"  # read_log_stream add \n after each try file
         ]
 
     def test_test_test_read_log_stream_should_read_all_logs(self):

--- a/tests/utils/log/test_log_reader.py
+++ b/tests/utils/log/test_log_reader.py
@@ -130,10 +130,10 @@ class TestLogView:
                 "localhost",
                 "*** Found local files:\n"
                 f"***   * {self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/1.log\n"
-                "try_number=1.",
+                "try_number=1.\n",
             )
         ]
-        assert metadatas == {"end_of_log": True, "log_pos": 13}
+        assert metadatas == {"end_of_log": True, "log_pos": 14}
 
     def test_test_read_log_chunks_should_read_all_files(self):
         task_log_reader = TaskLogReader()
@@ -147,7 +147,7 @@ class TestLogView:
                     "localhost",
                     "*** Found local files:\n"
                     f"***   * {self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/1.log\n"
-                    "try_number=1.",
+                    "try_number=1.\n",
                 )
             ],
             [
@@ -155,7 +155,7 @@ class TestLogView:
                     "localhost",
                     "*** Found local files:\n"
                     f"***   * {self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/2.log\n"
-                    f"try_number=2.",
+                    f"try_number=2.\n",
                 )
             ],
             [
@@ -163,11 +163,11 @@ class TestLogView:
                     "localhost",
                     "*** Found local files:\n"
                     f"***   * {self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/3.log\n"
-                    f"try_number=3.",
+                    f"try_number=3.\n",
                 )
             ],
         ]
-        assert metadatas == {"end_of_log": True, "log_pos": 13}
+        assert metadatas == {"end_of_log": True, "log_pos": 14}
 
     def test_test_test_read_log_stream_should_read_one_try(self):
         task_log_reader = TaskLogReader()
@@ -178,24 +178,26 @@ class TestLogView:
             "localhost\n*** Found local files:\n"
             f"***   * {self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/1.log\n"
             "try_number=1.\n"
+            "\n" # read_log_stream add \n after each try file
         ]
 
     def test_test_test_read_log_stream_should_read_all_logs(self):
         task_log_reader = TaskLogReader()
         self.ti.state = TaskInstanceState.SUCCESS  # Ensure mocked instance is completed to return stream
         stream = task_log_reader.read_log_stream(ti=self.ti, try_number=None, metadata={})
+        # read_log_stream add \n after each try file
         assert list(stream) == [
             "localhost\n*** Found local files:\n"
             f"***   * {self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/1.log\n"
-            "try_number=1."
+            "try_number=1.\n"
             "\n",
             "localhost\n*** Found local files:\n"
             f"***   * {self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/2.log\n"
-            "try_number=2."
+            "try_number=2.\n"
             "\n",
             "localhost\n*** Found local files:\n"
             f"***   * {self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/3.log\n"
-            "try_number=3."
+            "try_number=3.\n"
             "\n",
         ]
 

--- a/tests/utils/test_log_handlers.py
+++ b/tests/utils/test_log_handlers.py
@@ -763,6 +763,26 @@ def test_interleave_logs_correct_ordering():
 
     assert sample_with_dupe == "\n".join(_interleave_logs(sample_with_dupe, "", sample_with_dupe))
 
+    sample_with_dupe_multiline = """[2023-01-17T12:46:55.868-0800] {temporal.py:62} INFO - trigger starting
+[2023-01-17T12:46:55.868-0800] {temporal.py:71} INFO - sleeping 1 second...
+[2023-01-17T12:47:09.882-0800] {temporal.py:71} INFO - sleeping 1 second...
+[2023-01-17T12:47:10.882-0800] {temporal.py:71} INFO - sleeping 1 second...
+[2023-01-17T12:47:10.980-0800] {temporal.py:71} INFO - multiline log message 1
+    
+1
+2
+2
+
+...
+[2023-01-17T12:47:10.981-0800] {temporal.py:71} INFO - multiline log message 2
+    
+*** test
+result
+[2023-01-17T12:47:11.883-0800] {temporal.py:74} INFO - yielding event with payload DateTime(2023, 1, 17, 20, 47, 11, 254388, tzinfo=Timezone('UTC'))
+[2023-01-17T12:47:11.883-0800] {triggerer_job.py:540} INFO - Trigger <airflow.triggers.temporal.DateTimeTrigger moment=2023-01-17T20:47:11.254388+00:00> (ID 1) fired: TriggerEvent<DateTime(2023, 1, 17, 20, 47, 11, 254388, tzinfo=Timezone('UTC'))>
+"""
+    assert sample_with_dupe_multiline == "\n".join(_interleave_logs(sample_with_dupe_multiline, "", sample_with_dupe_multiline))
+
 
 def test_permissions_for_new_directories(tmp_path):
     # Set umask to 0o027: owner rwx, group rx-w, other -rwx

--- a/tests/utils/test_log_handlers.py
+++ b/tests/utils/test_log_handlers.py
@@ -780,8 +780,11 @@ def test_interleave_logs_correct_ordering():
 result
 [2023-01-17T12:47:11.883-0800] {temporal.py:74} INFO - yielding event with payload DateTime(2023, 1, 17, 20, 47, 11, 254388, tzinfo=Timezone('UTC'))
 [2023-01-17T12:47:11.883-0800] {triggerer_job.py:540} INFO - Trigger <airflow.triggers.temporal.DateTimeTrigger moment=2023-01-17T20:47:11.254388+00:00> (ID 1) fired: TriggerEvent<DateTime(2023, 1, 17, 20, 47, 11, 254388, tzinfo=Timezone('UTC'))>
-"""
-    assert sample_with_dupe_multiline == "\n".join(_interleave_logs(sample_with_dupe_multiline, "", sample_with_dupe_multiline))
+""" # noqa
+
+    assert sample_with_dupe_multiline == "\n".join(
+        _interleave_logs(sample_with_dupe_multiline, "", sample_with_dupe_multiline)
+    )
 
 
 def test_permissions_for_new_directories(tmp_path):

--- a/tests/utils/test_log_handlers.py
+++ b/tests/utils/test_log_handlers.py
@@ -768,19 +768,19 @@ def test_interleave_logs_correct_ordering():
 [2023-01-17T12:47:09.882-0800] {temporal.py:71} INFO - sleeping 1 second...
 [2023-01-17T12:47:10.882-0800] {temporal.py:71} INFO - sleeping 1 second...
 [2023-01-17T12:47:10.980-0800] {temporal.py:71} INFO - multiline log message 1
-    
+{trailing-whitespace}
 1
 2
 2
 
 ...
 [2023-01-17T12:47:10.981-0800] {temporal.py:71} INFO - multiline log message 2
-    
+{trailing-whitespace}
 *** test
 result
 [2023-01-17T12:47:11.883-0800] {temporal.py:74} INFO - yielding event with payload DateTime(2023, 1, 17, 20, 47, 11, 254388, tzinfo=Timezone('UTC'))
 [2023-01-17T12:47:11.883-0800] {triggerer_job.py:540} INFO - Trigger <airflow.triggers.temporal.DateTimeTrigger moment=2023-01-17T20:47:11.254388+00:00> (ID 1) fired: TriggerEvent<DateTime(2023, 1, 17, 20, 47, 11, 254388, tzinfo=Timezone('UTC'))>
-""" # noqa
+""".replace("{trailing-whitespace}", "   ")  # pre-commit hook removes trailing-whitespace
 
     assert sample_with_dupe_multiline == "\n".join(
         _interleave_logs(sample_with_dupe_multiline, "", sample_with_dupe_multiline)


### PR DESCRIPTION
Add two ways to fix the difference between logs which stores in files and logs in UI:
1. Custom re.pattern which can split whole log into "real" messages
2. Disable deduplication of log lines

closes: #39686 
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
