### PR TITLE
Home: filter running/failed and active/paused dags

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -133,27 +133,31 @@
     <div class="dags-table-header">
       <div class="form-group btn-group">
         <a
-          href="{{ url_for('Airflow.index', status='all', search=request.args.get('search', None), tags=request.args.getlist('tags', None)) }}"
+          href="{{ url_for('Airflow.index', status='all', lastrun=request.args.get('lastrun', 'all_states'), search=request.args.get('search', None), tags=request.args.getlist('tags', None)) }}"
           class="btn {{ 'btn-primary' if status_filter == 'all' else 'btn-default' }}"
           title="Show active and paused DAGs">All <span class="badge">{{ "{:,}".format(status_count_all) }}</span></a>
         <a
-          href="{{ url_for('Airflow.index', status='active', search=request.args.get('search', None), tags=request.args.getlist('tags', None)) }}"
+          href="{{ url_for('Airflow.index', status='active', lastrun=request.args.get('lastrun', 'all_states'), search=request.args.get('search', None), tags=request.args.getlist('tags', None)) }}"
           class="btn {{ 'btn-primary' if status_filter == 'active' else 'btn-default' }}"
           title="Show only active DAGs">Active <span class="badge">{{ "{:,}".format(status_count_active) }}</span></a>
         <a
-          href="{{ url_for('Airflow.index', status='paused', search=request.args.get('search', None), tags=request.args.getlist('tags', None)) }}"
+          href="{{ url_for('Airflow.index', status='paused', lastrun=request.args.get('lastrun', 'all_states'), search=request.args.get('search', None), tags=request.args.getlist('tags', None)) }}"
           class="btn {{ 'btn-primary' if status_filter == 'paused' else 'btn-default' }}"
           title="Show only paused DAGs">Paused <span class="badge">{{ "{:,}".format(status_count_paused) }}</span></a>
       </div>
       <div class="form-group btn-group p-2">
         <a
-          href="{{ url_for('Airflow.index', status='running', search=request.args.get('search', None), tags=request.args.getlist('tags', None)) }}"
-          class="btn {{ 'btn-primary' if status_filter == 'running' else 'btn-default' }}"
-          title="Show currently running DAG runs">Running <span class="badge">{{ "{:,}".format(status_count_running) }}</span></a>
+          href="{{ url_for('Airflow.index', lastrun='all_states', status=request.args.get('status', 'all'), search=request.args.get('search', None), tags=request.args.getlist('tags', None)) }}"
+          class="btn {{ 'btn-primary' if lastrun_filter == 'all_states' else 'btn-default' }}"
+          title="Show DAG runs in any state">All states <span class="badge">{{ "{:,}".format(lastrun_count_all) }}</span></a>
         <a
-          href="{{ url_for('Airflow.index', status='failed', search=request.args.get('search', None), tags=request.args.getlist('tags', None)) }}"
-          class="btn {{ 'btn-primary' if status_filter == 'failed' else 'btn-default' }}"
-          title="Show DAGs with failed latest DAG run">Failed <span class="badge">{{ "{:,}".format(status_count_failed) }}</span></a>
+          href="{{ url_for('Airflow.index', lastrun='running', status=request.args.get('status', 'all'), search=request.args.get('search', None), tags=request.args.getlist('tags', None)) }}"
+          class="btn {{ 'btn-primary' if lastrun_filter == 'running' else 'btn-default' }}"
+          title="Show currently running DAG runs">Running <span class="badge">{{ "{:,}".format(lastrun_count_running) }}</span></a>
+        <a
+          href="{{ url_for('Airflow.index', lastrun='failed', status=request.args.get('status', 'all'), search=request.args.get('search', None), tags=request.args.getlist('tags', None)) }}"
+          class="btn {{ 'btn-primary' if lastrun_filter == 'failed' else 'btn-default' }}"
+          title="Show DAGs with failed latest DAG run">Failed <span class="badge">{{ "{:,}".format(lastrun_count_failed) }}</span></a>
       </div>
       <div style="min-width: 200px; padding: 0 10px;">
         <form id="tags_form">

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -133,25 +133,25 @@
     <div class="dags-table-header">
       <div class="form-group btn-group">
         <a
-          href="{{ url_for('Airflow.index', status='all', lastrun=request.args.get('lastrun', 'all_states'), search=request.args.get('search', None), tags=request.args.getlist('tags', None)) }}"
+          href="{{ url_for('Airflow.index', status='all', lastrun=request.args.get('lastrun', None), search=request.args.get('search', None), tags=request.args.getlist('tags', None)) }}"
           class="btn {{ 'btn-primary' if status_filter == 'all' else 'btn-default' }}"
           title="Show active and paused DAGs">All <span class="badge">{{ "{:,}".format(status_count_all) }}</span></a>
         <a
-          href="{{ url_for('Airflow.index', status='active', lastrun=request.args.get('lastrun', 'all_states'), search=request.args.get('search', None), tags=request.args.getlist('tags', None)) }}"
+          href="{{ url_for('Airflow.index', status='active', lastrun=request.args.get('lastrun', None), search=request.args.get('search', None), tags=request.args.getlist('tags', None)) }}"
           class="btn {{ 'btn-primary' if status_filter == 'active' else 'btn-default' }}"
           title="Show only active DAGs">Active <span class="badge">{{ "{:,}".format(status_count_active) }}</span></a>
         <a
-          href="{{ url_for('Airflow.index', status='paused', lastrun=request.args.get('lastrun', 'all_states'), search=request.args.get('search', None), tags=request.args.getlist('tags', None)) }}"
+          href="{{ url_for('Airflow.index', status='paused', lastrun=request.args.get('lastrun', None), search=request.args.get('search', None), tags=request.args.getlist('tags', None)) }}"
           class="btn {{ 'btn-primary' if status_filter == 'paused' else 'btn-default' }}"
           title="Show only paused DAGs">Paused <span class="badge">{{ "{:,}".format(status_count_paused) }}</span></a>
       </div>
       <div class="form-group btn-group p-2">
         <a
-          href="{{ url_for('Airflow.index', lastrun='all' if lastrun_filter == 'running' else 'running', status=request.args.get('status', 'all'), search=request.args.get('search', None), tags=request.args.getlist('tags', None)) }}"
+          href="{{ url_for('Airflow.index', lastrun='reset_filter' if lastrun_filter == 'running' else 'running', status=request.args.get('status', None), search=request.args.get('search', None), tags=request.args.getlist('tags', None)) }}"
           class="btn {{ 'btn-primary' if lastrun_filter == 'running' else 'btn-default' }}"
           title="Show currently running DAG runs">Running <span class="badge">{{ "{:,}".format(lastrun_count_running) }}</span></a>
         <a
-          href="{{ url_for('Airflow.index', lastrun='all' if lastrun_filter == 'failed' else 'failed', status=request.args.get('status', 'all'), search=request.args.get('search', None), tags=request.args.getlist('tags', None)) }}"
+          href="{{ url_for('Airflow.index', lastrun='reset_filter' if lastrun_filter == 'failed' else 'failed', status=request.args.get('status', None), search=request.args.get('search', None), tags=request.args.getlist('tags', None)) }}"
           class="btn {{ 'btn-primary' if lastrun_filter == 'failed' else 'btn-default' }}"
           title="Show DAGs with failed latest DAG run">Failed <span class="badge">{{ "{:,}".format(lastrun_count_failed) }}</span></a>
       </div>

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -147,15 +147,11 @@
       </div>
       <div class="form-group btn-group p-2">
         <a
-          href="{{ url_for('Airflow.index', lastrun='all_states', status=request.args.get('status', 'all'), search=request.args.get('search', None), tags=request.args.getlist('tags', None)) }}"
-          class="btn {{ 'btn-primary' if lastrun_filter == 'all_states' else 'btn-default' }}"
-          title="Show DAG runs in any state">All states <span class="badge">{{ "{:,}".format(lastrun_count_all) }}</span></a>
-        <a
-          href="{{ url_for('Airflow.index', lastrun='running', status=request.args.get('status', 'all'), search=request.args.get('search', None), tags=request.args.getlist('tags', None)) }}"
+          href="{{ url_for('Airflow.index', lastrun='all' if lastrun_filter == 'running' else 'running', status=request.args.get('status', 'all'), search=request.args.get('search', None), tags=request.args.getlist('tags', None)) }}"
           class="btn {{ 'btn-primary' if lastrun_filter == 'running' else 'btn-default' }}"
           title="Show currently running DAG runs">Running <span class="badge">{{ "{:,}".format(lastrun_count_running) }}</span></a>
         <a
-          href="{{ url_for('Airflow.index', lastrun='failed', status=request.args.get('status', 'all'), search=request.args.get('search', None), tags=request.args.getlist('tags', None)) }}"
+          href="{{ url_for('Airflow.index', lastrun='all' if lastrun_filter == 'failed' else 'failed', status=request.args.get('status', 'all'), search=request.args.get('search', None), tags=request.args.getlist('tags', None)) }}"
           class="btn {{ 'btn-primary' if lastrun_filter == 'failed' else 'btn-default' }}"
           title="Show DAGs with failed latest DAG run">Failed <span class="badge">{{ "{:,}".format(lastrun_count_failed) }}</span></a>
       </div>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -155,6 +155,7 @@ if TYPE_CHECKING:
 PAGE_SIZE = conf.getint("webserver", "page_size")
 FILTER_TAGS_COOKIE = "tags_filter"
 FILTER_STATUS_COOKIE = "dag_status_filter"
+FILTER_LASTRUN_COOKIE = "last_run_filter"
 LINECHART_X_AXIS_TICKFORMAT = (
     "function (d, i) { let xLabel;"
     "if (i === undefined) {xLabel = d3.time.format('%H:%M, %d %b %Y')(new Date(parseInt(d)));"
@@ -780,6 +781,7 @@ class Airflow(AirflowBaseView):
         arg_search_query = request.args.get("search")
         arg_tags_filter = request.args.getlist("tags")
         arg_status_filter = request.args.get("status")
+        arg_lastrun_filter = request.args.get("lastrun")
         arg_sorting_key = request.args.get("sorting_key", "dag_id")
         arg_sorting_direction = request.args.get("sorting_direction", default="asc")
 
@@ -806,6 +808,18 @@ class Airflow(AirflowBaseView):
             status = arg_status_filter.strip().lower()
             flask_session[FILTER_STATUS_COOKIE] = status
             arg_status_filter = status
+
+        if arg_lastrun_filter is None:
+            cookie_val = flask_session.get(FILTER_LASTRUN_COOKIE)
+            if cookie_val:
+                arg_lastrun_filter = cookie_val
+            else:
+                arg_lastrun_filter = "all_states"
+                flask_session[FILTER_LASTRUN_COOKIE] = arg_lastrun_filter
+        else:
+            last_run = arg_lastrun_filter.strip().lower()
+            flask_session[FILTER_LASTRUN_COOKIE] = last_run
+            arg_lastrun_filter = last_run
 
         dags_per_page = PAGE_SIZE
 
@@ -842,14 +856,19 @@ class Airflow(AirflowBaseView):
                 flask_session[FILTER_TAGS_COOKIE] = None
                 return redirect(url_for("Airflow.index"))
 
-            all_dags = dags_query
-            active_dags = dags_query.where(~DagModel.is_paused)
-            paused_dags = dags_query.where(DagModel.is_paused)
-
             # find DAGs which have a RUNNING DagRun
             running_dags = dags_query.join(DagRun, DagModel.dag_id == DagRun.dag_id).where(
-                DagRun.state == DagRunState.RUNNING
+                (DagRun.state == DagRunState.RUNNING) | (DagRun.state == DagRunState.QUEUED)
             )
+
+            lastrun_running_is_paused = session.execute(
+                running_dags.with_only_columns(DagModel.dag_id, DagModel.is_paused).distinct(DagModel.dag_id)
+            ).all()
+
+            lastrun_running_count_active = len(
+                list(filter(lambda x: not x.is_paused, lastrun_running_is_paused))
+            )
+            lastrun_running_count_paused = len(list(filter(lambda x: x.is_paused, lastrun_running_is_paused)))
 
             # find DAGs for which the latest DagRun is FAILED
             subq_all = (
@@ -876,34 +895,56 @@ class Airflow(AirflowBaseView):
             )
             failed_dags = dags_query.join(subq_join, DagModel.dag_id == subq_join.c.dag_id)
 
-            is_paused_count = dict(
+            lastrun_failed_is_paused_count = dict(
                 session.execute(
-                    all_dags.with_only_columns(DagModel.is_paused, func.count()).group_by(DagModel.is_paused)
+                    failed_dags.with_only_columns(DagModel.is_paused, func.count()).group_by(
+                        DagModel.is_paused
+                    )
                 ).all()
             )
 
-            status_count_active = is_paused_count.get(False, 0)
-            status_count_paused = is_paused_count.get(True, 0)
+            lastrun_failed_count_active = lastrun_failed_is_paused_count.get(False, 0)
+            lastrun_failed_count_paused = lastrun_failed_is_paused_count.get(True, 0)
 
-            status_count_running = get_query_count(running_dags, session=session)
-            status_count_failed = get_query_count(failed_dags, session=session)
+            lastrun_allstates_active = get_query_count(dags_query.where(~DagModel.is_paused), session=session)
+            lastrun_allstates_paused = get_query_count(dags_query.where(DagModel.is_paused), session=session)
+            lastrun_allstates_all = get_query_count(dags_query, session=session)
 
+            if arg_lastrun_filter == "running":
+                dags_query = running_dags
+            elif arg_lastrun_filter == "failed":
+                dags_query = failed_dags
+
+            all_dags = dags_query
+            active_dags = dags_query.where(~DagModel.is_paused)
+            paused_dags = dags_query.where(DagModel.is_paused)
+
+            status_is_paused = session.execute(
+                all_dags.with_only_columns(DagModel.dag_id, DagModel.is_paused).distinct(DagModel.dag_id)
+            ).all()
+
+            status_count_active = len(list(filter(lambda x: not x.is_paused, status_is_paused)))
+            status_count_paused = len(list(filter(lambda x: x.is_paused, status_is_paused)))
             all_dags_count = status_count_active + status_count_paused
+
             if arg_status_filter == "active":
                 current_dags = active_dags
                 num_of_all_dags = status_count_active
+                lastrun_count_all = lastrun_allstates_active
+                lastrun_count_running = lastrun_running_count_active
+                lastrun_count_failed = lastrun_failed_count_active
             elif arg_status_filter == "paused":
                 current_dags = paused_dags
                 num_of_all_dags = status_count_paused
-            elif arg_status_filter == "running":
-                current_dags = running_dags
-                num_of_all_dags = status_count_running
-            elif arg_status_filter == "failed":
-                current_dags = failed_dags
-                num_of_all_dags = status_count_failed
+                lastrun_count_all = lastrun_allstates_paused
+                lastrun_count_running = lastrun_running_count_paused
+                lastrun_count_failed = lastrun_failed_count_paused
             else:
                 current_dags = all_dags
                 num_of_all_dags = all_dags_count
+                lastrun_count_all = lastrun_allstates_all
+                lastrun_count_running = lastrun_running_count_active + lastrun_running_count_paused
+                lastrun_count_failed = lastrun_failed_count_active + lastrun_failed_count_paused
 
             if arg_sorting_key == "dag_id":
                 if arg_sorting_direction == "desc":
@@ -1105,8 +1146,10 @@ class Airflow(AirflowBaseView):
             status_count_all=all_dags_count,
             status_count_active=status_count_active,
             status_count_paused=status_count_paused,
-            status_count_running=status_count_running,
-            status_count_failed=status_count_failed,
+            lastrun_filter=arg_lastrun_filter,
+            lastrun_count_all=lastrun_count_all,
+            lastrun_count_running=lastrun_count_running,
+            lastrun_count_failed=lastrun_count_failed,
             tags_filter=arg_tags_filter,
             sorting_key=arg_sorting_key,
             sorting_direction=arg_sorting_direction,

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -814,7 +814,7 @@ class Airflow(AirflowBaseView):
             if cookie_val:
                 arg_lastrun_filter = cookie_val
             else:
-                arg_lastrun_filter = "all_states"
+                arg_lastrun_filter = "all"
                 flask_session[FILTER_LASTRUN_COOKIE] = arg_lastrun_filter
         else:
             last_run = arg_lastrun_filter.strip().lower()
@@ -906,10 +906,6 @@ class Airflow(AirflowBaseView):
             lastrun_failed_count_active = lastrun_failed_is_paused_count.get(False, 0)
             lastrun_failed_count_paused = lastrun_failed_is_paused_count.get(True, 0)
 
-            lastrun_allstates_active = get_query_count(dags_query.where(~DagModel.is_paused), session=session)
-            lastrun_allstates_paused = get_query_count(dags_query.where(DagModel.is_paused), session=session)
-            lastrun_allstates_all = get_query_count(dags_query, session=session)
-
             if arg_lastrun_filter == "running":
                 dags_query = running_dags
             elif arg_lastrun_filter == "failed":
@@ -930,19 +926,16 @@ class Airflow(AirflowBaseView):
             if arg_status_filter == "active":
                 current_dags = active_dags
                 num_of_all_dags = status_count_active
-                lastrun_count_all = lastrun_allstates_active
                 lastrun_count_running = lastrun_running_count_active
                 lastrun_count_failed = lastrun_failed_count_active
             elif arg_status_filter == "paused":
                 current_dags = paused_dags
                 num_of_all_dags = status_count_paused
-                lastrun_count_all = lastrun_allstates_paused
                 lastrun_count_running = lastrun_running_count_paused
                 lastrun_count_failed = lastrun_failed_count_paused
             else:
                 current_dags = all_dags
                 num_of_all_dags = all_dags_count
-                lastrun_count_all = lastrun_allstates_all
                 lastrun_count_running = lastrun_running_count_active + lastrun_running_count_paused
                 lastrun_count_failed = lastrun_failed_count_active + lastrun_failed_count_paused
 
@@ -1147,7 +1140,6 @@ class Airflow(AirflowBaseView):
             status_count_active=status_count_active,
             status_count_paused=status_count_paused,
             lastrun_filter=arg_lastrun_filter,
-            lastrun_count_all=lastrun_count_all,
             lastrun_count_running=lastrun_count_running,
             lastrun_count_failed=lastrun_count_failed,
             tags_filter=arg_tags_filter,

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -794,25 +794,25 @@ class Airflow(AirflowBaseView):
             flask_session[FILTER_LASTRUN_COOKIE] = None
             return redirect(url_for("Airflow.index"))
 
-        cookie_val = flask_session.get(FILTER_TAGS_COOKIE)
+        filter_tags_cookie_val = flask_session.get(FILTER_TAGS_COOKIE)
         if arg_tags_filter:
             flask_session[FILTER_TAGS_COOKIE] = ",".join(arg_tags_filter)
-        elif cookie_val:
+        elif filter_tags_cookie_val:
             # If tags exist in cookie, but not URL, add them to the URL
-            return redirect(url_for("Airflow.index", tags=cookie_val.split(",")))
+            return redirect(url_for("Airflow.index", tags=filter_tags_cookie_val.split(",")))
 
-        cookie_val = flask_session.get(FILTER_LASTRUN_COOKIE)
+        filter_lastrun_cookie_val = flask_session.get(FILTER_LASTRUN_COOKIE)
         if arg_lastrun_filter:
             arg_lastrun_filter = arg_lastrun_filter.strip().lower()
             flask_session[FILTER_LASTRUN_COOKIE] = arg_lastrun_filter
-        elif cookie_val:
+        elif filter_lastrun_cookie_val:
             # If tags exist in cookie, but not URL, add them to the URL
-            return redirect(url_for("Airflow.index", lastrun=cookie_val))
+            return redirect(url_for("Airflow.index", lastrun=filter_lastrun_cookie_val))
 
         if arg_status_filter is None:
-            cookie_val = flask_session.get(FILTER_STATUS_COOKIE)
-            if cookie_val:
-                arg_status_filter = cookie_val
+            filter_status_cookie_val = flask_session.get(FILTER_STATUS_COOKIE)
+            if filter_status_cookie_val:
+                arg_status_filter = filter_status_cookie_val
             else:
                 arg_status_filter = "active" if hide_paused_dags_by_default else "all"
                 flask_session[FILTER_STATUS_COOKIE] = arg_status_filter

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -790,12 +790,24 @@ class Airflow(AirflowBaseView):
             # Remove the reset_tags=reset from the URL
             return redirect(url_for("Airflow.index"))
 
+        if arg_lastrun_filter == "reset_filter":
+            flask_session[FILTER_LASTRUN_COOKIE] = None
+            return redirect(url_for("Airflow.index"))
+
         cookie_val = flask_session.get(FILTER_TAGS_COOKIE)
         if arg_tags_filter:
             flask_session[FILTER_TAGS_COOKIE] = ",".join(arg_tags_filter)
         elif cookie_val:
             # If tags exist in cookie, but not URL, add them to the URL
             return redirect(url_for("Airflow.index", tags=cookie_val.split(",")))
+
+        cookie_val = flask_session.get(FILTER_LASTRUN_COOKIE)
+        if arg_lastrun_filter:
+            arg_lastrun_filter = arg_lastrun_filter.strip().lower()
+            flask_session[FILTER_LASTRUN_COOKIE] = arg_lastrun_filter
+        elif cookie_val:
+            # If tags exist in cookie, but not URL, add them to the URL
+            return redirect(url_for("Airflow.index", lastrun=cookie_val))
 
         if arg_status_filter is None:
             cookie_val = flask_session.get(FILTER_STATUS_COOKIE)
@@ -808,18 +820,6 @@ class Airflow(AirflowBaseView):
             status = arg_status_filter.strip().lower()
             flask_session[FILTER_STATUS_COOKIE] = status
             arg_status_filter = status
-
-        if arg_lastrun_filter is None:
-            cookie_val = flask_session.get(FILTER_LASTRUN_COOKIE)
-            if cookie_val:
-                arg_lastrun_filter = cookie_val
-            else:
-                arg_lastrun_filter = "all"
-                flask_session[FILTER_LASTRUN_COOKIE] = arg_lastrun_filter
-        else:
-            last_run = arg_lastrun_filter.strip().lower()
-            flask_session[FILTER_LASTRUN_COOKIE] = last_run
-            arg_lastrun_filter = last_run
 
         dags_per_page = PAGE_SIZE
 

--- a/tests/www/views/test_views_base.py
+++ b/tests/www/views/test_views_base.py
@@ -44,7 +44,7 @@ def test_index_redirect(admin_client):
 
 
 def test_homepage_query_count(admin_client):
-    with assert_queries_count(17):
+    with assert_queries_count(20):
         resp = admin_client.get("/home")
     check_content_in_response("DAGs", resp)
 

--- a/tests/www/views/test_views_home.py
+++ b/tests/www/views/test_views_home.py
@@ -27,7 +27,7 @@ from airflow.security import permissions
 from airflow.utils.session import create_session
 from airflow.utils.state import State
 from airflow.www.utils import UIAlert
-from airflow.www.views import FILTER_STATUS_COOKIE, FILTER_TAGS_COOKIE
+from airflow.www.views import FILTER_LASTRUN_COOKIE, FILTER_STATUS_COOKIE, FILTER_TAGS_COOKIE
 from tests.test_utils.api_connexion_utils import create_user
 from tests.test_utils.db import clear_db_dags, clear_db_import_errors, clear_db_serialized_dags
 from tests.test_utils.www import check_content_in_response, check_content_not_in_response, client_with_login
@@ -101,14 +101,17 @@ def test_home_status_filter_cookie(admin_client):
         admin_client.get("home?status=paused", follow_redirects=True)
         assert "paused" == flask.session[FILTER_STATUS_COOKIE]
 
-        admin_client.get("home?status=running", follow_redirects=True)
-        assert "running" == flask.session[FILTER_STATUS_COOKIE]
-
-        admin_client.get("home?status=failed", follow_redirects=True)
-        assert "failed" == flask.session[FILTER_STATUS_COOKIE]
-
         admin_client.get("home?status=all", follow_redirects=True)
         assert "all" == flask.session[FILTER_STATUS_COOKIE]
+
+        admin_client.get("home?lastrun=running", follow_redirects=True)
+        assert "running" == flask.session[FILTER_LASTRUN_COOKIE]
+
+        admin_client.get("home?lastrun=failed", follow_redirects=True)
+        assert "failed" == flask.session[FILTER_LASTRUN_COOKIE]
+
+        admin_client.get("home?lastrun=all_states", follow_redirects=True)
+        assert "all_states" == flask.session[FILTER_LASTRUN_COOKIE]
 
 
 @pytest.fixture(scope="module")
@@ -305,8 +308,9 @@ def test_home_no_importerrors_perm(broken_dags, client_no_importerror):
         "home?status=all",
         "home?status=active",
         "home?status=paused",
-        "home?status=running",
-        "home?status=failed",
+        "home?lastrun=running",
+        "home?lastrun=failed",
+        "home?lastrun=all_states",
     ],
 )
 def test_home_importerrors_filtered_singledag_user(broken_dags_with_read_perm, client_single_dag, page):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Closes: #39675

Now, on the home page, the two sets of buttons (filter DAG states and DAG Run states work together). I have had to add a new button on the home page to view all states:

<img width="646" alt="image" src="https://github.com/apache/airflow/assets/41503039/6ac8c577-eb42-4250-b874-29e2180bdd2f">

I've had to add a few SQL queries to ensure that the number next to each label is correct. Without them, if a DAG has multiple running DAG Runs, it counts them all. For example: we have 1 DAG with 3 running DAG runs --> without the new queries, a (3) appears, instead of a (1).

Moreover, the numbers next to the label may seem strange at first, since they change continuously according to the applied filters.

I initially thought of making this work as the TAGs filter, but it is nice to see the count next to the label.

@PApostol since you developed this initially: what do you think? 

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
