### PR TITLE
Updated kuberentes pod operator to find pods only in running state

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -532,7 +532,7 @@ class KubernetesPodOperator(BaseOperator):
         ).items
 
         pod = None
-        running_pods = [pod for pod in pod_list if pod.status.phase == "Running"]
+        running_pods = [pod for pod in pod_list if pod.status.phase in {"Running", "Pending"}]
         num_pods = len(running_pods)
         if num_pods > 1:
             raise AirflowException(f"More than one pod running with labels {label_selector}")

--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -598,14 +598,13 @@ class KubernetesPodOperator(BaseOperator):
             ti.xcom_push(key="pod_name", value=self.pod.metadata.name)
             ti.xcom_push(key="pod_namespace", value=self.pod.metadata.namespace)
 
+            # get remote pod for use in cleanup methods
+            self.remote_pod = self.find_pod(self.pod.metadata.namespace, context=context)
             if self.callbacks:
                 self.callbacks.on_pod_creation(
                     pod=self.remote_pod, client=self.client, mode=ExecutionMode.SYNC
                 )
             self.await_pod_start(pod=self.pod)
-
-            # get remote pod for use in cleanup methods
-            self.remote_pod = self.find_pod(self.pod.metadata.namespace, context=context)
             if self.callbacks:
                 self.callbacks.on_pod_starting(
                     pod=self.find_pod(self.pod.metadata.namespace, context=context),


### PR DESCRIPTION
The proposed changes to the [find_pod](https://github.com/apache/airflow/blob/2.8.3/airflow/providers/cncf/kubernetes/operators/pod.py#L535) method will ensure it selects only pods that are in the running state, effectively ignoring pods that are in the terminating state. This adjustment addresses the issue of pods remaining in the terminating state for an extended period.

closes: https://github.com/apache/airflow/issues/39096
related: https://github.com/apache/airflow/issues/39096

---