### PR TITLE
weaviate remove deprecations

### DIFF
--- a/tests/always/test_example_dags.py
+++ b/tests/always/test_example_dags.py
@@ -63,9 +63,6 @@ IGNORE_AIRFLOW_PROVIDER_DEPRECATION_WARNING: tuple[str, ...] = (
     "tests/system/providers/google/cloud/kubernetes_engine/example_kubernetes_engine_resource.py",
     "tests/system/providers/google/cloud/life_sciences/example_life_sciences.py",
     "tests/system/providers/google/marketing_platform/example_analytics.py",
-    "tests/system/providers/weaviate/example_weaviate_cohere.py",
-    "tests/system/providers/weaviate/example_weaviate_openai.py",
-    "tests/system/providers/weaviate/example_weaviate_operator.py",
     # Deprecated Operators/Hooks, which replaced by common.sql Operators/Hooks
     "tests/system/providers/apache/drill/example_drill_dag.py",
     "tests/system/providers/jdbc/example_jdbc_queries.py",

--- a/tests/system/providers/weaviate/example_weaviate_cohere.py
+++ b/tests/system/providers/weaviate/example_weaviate_cohere.py
@@ -82,7 +82,7 @@ def example_weaviate_cohere():
         task_id="perform_ingestion",
         conn_id="weaviate_default",
         class_name="Weaviate_example_class",
-        input_json=update_vector_data_in_json["return_value"],
+        input_data=update_vector_data_in_json["return_value"],
     )
 
     embed_query = CohereEmbeddingOperator(

--- a/tests/system/providers/weaviate/example_weaviate_openai.py
+++ b/tests/system/providers/weaviate/example_weaviate_openai.py
@@ -80,7 +80,7 @@ def example_weaviate_openai():
         task_id="perform_ingestion",
         conn_id="weaviate_default",
         class_name="Weaviate_example_class",
-        input_json=update_vector_data_in_json["return_value"],
+        input_data=update_vector_data_in_json["return_value"],
     )
 
     embed_query = OpenAIEmbeddingOperator(

--- a/tests/system/providers/weaviate/example_weaviate_operator.py
+++ b/tests/system/providers/weaviate/example_weaviate_operator.py
@@ -121,7 +121,7 @@ def example_weaviate_using_operator():
         task_id="batch_data_with_vectors_xcom_data",
         conn_id="weaviate_default",
         class_name="QuestionWithoutVectorizerUsingOperator",
-        input_json=store_data_with_vectors_in_xcom(),
+        input_data=store_data_with_vectors_in_xcom(),
         trigger_rule="all_done",
     )
     # [END howto_operator_weaviate_embedding_and_ingest_xcom_data_with_vectors]
@@ -131,7 +131,7 @@ def example_weaviate_using_operator():
         task_id="batch_data_with_vectors_callable_data",
         conn_id="weaviate_default",
         class_name="QuestionWithoutVectorizerUsingOperator",
-        input_json=get_data_with_vectors(),
+        input_data=get_data_with_vectors(),
         trigger_rule="all_done",
     )
     # [END howto_operator_weaviate_embedding_and_ingest_callable_data_with_vectors]
@@ -231,7 +231,7 @@ def example_weaviate_using_operator():
         task_id="batch_data_without_vectors_xcom_data",
         conn_id="weaviate_default",
         class_name="QuestionWithOpenAIVectorizerUsingOperator",
-        input_json=xcom_data_without_vectors["return_value"],
+        input_data=xcom_data_without_vectors["return_value"],
         trigger_rule="all_done",
     )
     # [END howto_operator_weaviate_ingest_xcom_data_without_vectors]
@@ -241,7 +241,7 @@ def example_weaviate_using_operator():
         task_id="batch_data_without_vectors_callable_data",
         conn_id="weaviate_default",
         class_name="QuestionWithOpenAIVectorizerUsingOperator",
-        input_json=get_data_without_vectors(),
+        input_data=get_data_without_vectors(),
         trigger_rule="all_done",
     )
     # [END howto_operator_weaviate_ingest_callable_data_without_vectors]


### PR DESCRIPTION
Related: #39485
Passing 'input_json' to WeaviateIngestOperator is deprecated. Using 'input_data' instead
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
