### PR TITLE
Reraise exception from strict dataset URI checks

### DIFF
--- a/airflow/datasets/__init__.py
+++ b/airflow/datasets/__init__.py
@@ -94,14 +94,13 @@ def _sanitize_uri(uri: str) -> str:
             parsed = normalizer(parsed)
         except ValueError as exception:
             if conf.getboolean("core", "strict_dataset_uri_validation", fallback=False):
-                raise exception
-            else:
-                warnings.warn(
-                    f"The dataset URI {uri} is not AIP-60 compliant. "
-                    f"In Airflow 3, this will raise an exception. More information: {repr(exception)}",
-                    UserWarning,
-                    stacklevel=3,
-                )
+                raise
+            warnings.warn(
+                f"The dataset URI {uri} is not AIP-60 compliant: {exception}. "
+                f"In Airflow 3, this will raise an exception.",
+                UserWarning,
+                stacklevel=3,
+            )
     return urllib.parse.urlunsplit(parsed)
 
 

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -457,11 +457,8 @@ def mock_get_uri_normalizer(normalized_scheme):
 def test__sanitize_uri_raises_warning(mock_warn):
     _sanitize_uri("postgres://localhost:5432/database.schema.table")
     msg = mock_warn.call_args.args[0]
-    assert "The dataset URI postgres://localhost:5432/database.schema.table is not AIP-60 compliant." in msg
-    assert (
-        "In Airflow 3, this will raise an exception. More information: ValueError('Incorrect URI format')"
-        in msg
-    )
+    assert "The dataset URI postgres://localhost:5432/database.schema.table is not AIP-60 compliant" in msg
+    assert "In Airflow 3, this will raise an exception." in msg
 
 
 @patch("airflow.datasets._get_uri_normalizer", mock_get_uri_normalizer)


### PR DESCRIPTION
Minor improvement from #39670. Instead of `raise exception`, re-raise the original exception instead to preserve the error stack. Code under the raise is unindented instead of using `else`.