### PR TITLE
[openlineage] Update conf retrieval docstring and adjust pool_size

### DIFF
--- a/tests/providers/openlineage/test_conf.py
+++ b/tests/providers/openlineage/test_conf.py
@@ -23,8 +23,10 @@ import pytest
 
 from airflow.providers.openlineage.conf import (
     _is_true,
+    _safe_int_convert,
     config_path,
     custom_extractors,
+    dag_state_change_process_pool_size,
     disabled_operators,
     is_disabled,
     is_source_enabled,
@@ -49,6 +51,7 @@ _VAR_DISABLED = "OPENLINEAGE_DISABLED"
 _CONFIG_OPTION_DISABLED = "disabled"
 _VAR_URL = "OPENLINEAGE_URL"
 _CONFIG_OPTION_SELECTIVE_ENABLE = "selective_enable"
+_CONFIG_OPTION_DAG_STATE_CHANGE_PROCESS_POOL_SIZE = "dag_state_change_process_pool_size"
 
 _BOOL_PARAMS = (
     ("1", True),
@@ -76,6 +79,7 @@ def clear_cache():
     transport.cache_clear()
     is_disabled.cache_clear()
     selective_enable.cache_clear()
+    dag_state_change_process_pool_size.cache_clear()
     try:
         yield
     finally:
@@ -87,6 +91,7 @@ def clear_cache():
         transport.cache_clear()
         is_disabled.cache_clear()
         selective_enable.cache_clear()
+        dag_state_change_process_pool_size.cache_clear()
 
 
 @pytest.mark.parametrize(
@@ -101,6 +106,35 @@ def clear_cache():
 )
 def test_is_true(var_string, expected):
     assert _is_true(var_string) is expected
+
+
+@pytest.mark.parametrize(
+    "input_value, expected",
+    [
+        ("123", 123),
+        (456, 456),
+        ("789", 789),
+        (0, 0),
+        ("0", 0),
+    ],
+)
+def test_safe_int_convert(input_value, expected):
+    assert _safe_int_convert(input_value, default=1) == expected
+
+
+@pytest.mark.parametrize(
+    "input_value, default",
+    [
+        ("abc", 1),
+        ("", 2),
+        (None, 3),
+        ("123abc", 4),
+        ([], 5),
+        ("1.2", 6),
+    ],
+)
+def test_safe_int_convert_erroneous_values(input_value, default):
+    assert _safe_int_convert(input_value, default) == default
 
 
 @env_vars({_VAR_CONFIG_PATH: "env_var_path"})
@@ -456,3 +490,25 @@ def test_is_disabled_empty_conf_option():
 )
 def test_is_disabled_do_not_fail_if_conf_option_missing():
     assert is_disabled() is True
+
+
+@pytest.mark.parametrize(
+    ("var_string", "expected"),
+    (
+        ("1", 1),
+        ("2   ", 2),
+        ("  3", 3),
+        ("4.56", 1),  # default
+        ("asdf", 1),  # default
+        ("true", 1),  # default
+        ("false", 1),  # default
+        ("None", 1),  # default
+        ("", 1),  # default
+        (" ", 1),  # default
+        (None, 1),  # default
+    ),
+)
+def test_dag_state_change_process_pool_size(var_string, expected):
+    with conf_vars({(_CONFIG_SECTION, _CONFIG_OPTION_DAG_STATE_CHANGE_PROCESS_POOL_SIZE): var_string}):
+        result = dag_state_change_process_pool_size()
+        assert result == expected


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Adding a docstring to conf.py describing how we should retrieve OL configuration. Adjusting `dag_state_change_process_pool_size` to match that logic.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
