### PR TITLE
Load Provider Plugins in Development

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -5,6 +5,7 @@
       "apache-airflow>=2.7.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "http"
     ],
@@ -19,6 +20,7 @@
       "oss2>=2.14.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -47,10 +49,11 @@
       "mypy-boto3-rds>=1.33.0",
       "mypy-boto3-redshift-data>=1.33.0",
       "mypy-boto3-s3>=1.33.0",
-      "s3fs>=2023.10.0",
       "openapi-schema-validator>=0.6.2",
-      "openapi-spec-validator>=0.7.1"
+      "openapi-spec-validator>=0.7.1",
+      "s3fs>=2023.10.0"
     ],
+    "plugins": [],
     "cross-providers-deps": [
       "apache.hive",
       "cncf.kubernetes",
@@ -76,6 +79,7 @@
       "pyarrow>=14.0.1"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "google"
     ],
@@ -90,6 +94,7 @@
       "cassandra-driver>=3.29.1"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -101,6 +106,7 @@
       "sqlalchemy-drill>=1.1.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "common.sql"
     ],
@@ -114,6 +120,7 @@
       "pydruid>=0.4.1"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "apache.hive",
       "common.sql"
@@ -128,6 +135,7 @@
       "cryptography>=2.0.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "cncf.kubernetes"
     ],
@@ -140,6 +148,7 @@
       "hdfs[avro,dataframe,kerberos]>=2.0.4"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -154,6 +163,12 @@
       "thrift>=0.9.2"
     ],
     "devel-deps": [],
+    "plugins": [
+      {
+        "name": "hive",
+        "plugin-class": "airflow.providers.apache.hive.plugins.hive.HivePlugin"
+      }
+    ],
     "cross-providers-deps": [
       "amazon",
       "common.sql",
@@ -173,6 +188,7 @@
     "devel-deps": [
       "pyiceberg>=0.5.0"
     ],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -183,6 +199,7 @@
       "impyla>=0.18.0,<1.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "common.sql"
     ],
@@ -196,6 +213,7 @@
       "confluent-kafka>=1.8.2"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -206,6 +224,7 @@
       "kylinpy>=2.6"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -218,6 +237,7 @@
       "asgiref"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "http"
     ],
@@ -229,6 +249,7 @@
       "apache-airflow>=2.7.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -240,6 +261,7 @@
       "pinotdb>=5.1.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "common.sql"
     ],
@@ -253,6 +275,7 @@
       "pyspark"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "cncf.kubernetes"
     ],
@@ -265,6 +288,7 @@
       "apprise>=1.8.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -275,6 +299,7 @@
       "python-arango>=7.3.2"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -285,6 +310,7 @@
       "asana>=0.10,<4.0.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -295,6 +321,7 @@
       "atlassian-python-api>3.41.10"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -307,6 +334,7 @@
       "google-re2>=1.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "cncf.kubernetes"
     ],
@@ -319,6 +347,7 @@
       "cloudant>=2.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -334,6 +363,7 @@
       "kubernetes_asyncio>=28.1.0,<=29.0.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -344,6 +374,7 @@
       "cohere>=4.37,<5"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -353,6 +384,7 @@
       "apache-airflow>=2.8.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "openlineage"
     ],
@@ -366,6 +398,7 @@
       "sqlparse>=0.4.2"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "openlineage"
     ],
@@ -383,6 +416,7 @@
     "devel-deps": [
       "deltalake>=0.12.0"
     ],
+    "plugins": [],
     "cross-providers-deps": [
       "common.sql"
     ],
@@ -395,6 +429,7 @@
       "datadog>=0.14.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -407,6 +442,7 @@
       "asgiref"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "http",
       "openlineage"
@@ -420,6 +456,7 @@
       "apache-airflow>=2.7.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "http"
     ],
@@ -432,6 +469,7 @@
       "apache-airflow>=2.7.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "http"
     ],
@@ -446,6 +484,7 @@
       "requests>=2.27.0,<2.32.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -457,6 +496,7 @@
       "elasticsearch>=8.10,<9"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "common.sql"
     ],
@@ -471,6 +511,7 @@
       "pyexasol>=0.5.1"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "common.sql"
     ],
@@ -487,6 +528,7 @@
       "jmespath"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -497,6 +539,7 @@
       "facebook-business>=6.0.2"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -506,6 +549,7 @@
       "apache-airflow>=2.7.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "openlineage"
     ],
@@ -518,6 +562,7 @@
       "apache-airflow>=2.7.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -587,6 +632,7 @@
       "sqlalchemy-spanner>=1.6.2"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "amazon",
       "apache.beam",
@@ -617,6 +663,7 @@
       "grpcio>=1.15.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -627,6 +674,7 @@
       "hvac>=1.1.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "google"
     ],
@@ -642,6 +690,7 @@
       "requests_toolbelt"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -651,6 +700,7 @@
       "apache-airflow>=2.7.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -662,6 +712,7 @@
       "requests>=2.27.0,<3"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -673,6 +724,7 @@
       "jaydebeapi>=1.1.1"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "common.sql"
     ],
@@ -685,6 +737,7 @@
       "python-jenkins>=1.0.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -718,6 +771,7 @@
     "devel-deps": [
       "pywinrm"
     ],
+    "plugins": [],
     "cross-providers-deps": [
       "google",
       "oracle",
@@ -733,6 +787,7 @@
       "pymssql>=2.1.8"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "common.sql"
     ],
@@ -745,6 +800,7 @@
       "pypsrp>=0.8.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -755,6 +811,7 @@
       "pywinrm>=0.4"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -768,6 +825,7 @@
     "devel-deps": [
       "mongomock"
     ],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -780,6 +838,7 @@
       "mysqlclient>=1.3.6"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "amazon",
       "common.sql",
@@ -797,6 +856,7 @@
       "neo4j>=4.2.1"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -808,6 +868,7 @@
       "pyodbc"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "common.sql"
     ],
@@ -820,6 +881,7 @@
       "openai[datalib]>=1.23"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -829,6 +891,7 @@
       "apache-airflow>=2.7.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -842,6 +905,12 @@
       "openlineage-python>=0.28.0"
     ],
     "devel-deps": [],
+    "plugins": [
+      {
+        "name": "openlineage",
+        "plugin-class": "airflow.providers.openlineage.plugins.openlineage.OpenLineageProviderPlugin"
+      }
+    ],
     "cross-providers-deps": [
       "common.sql"
     ],
@@ -854,6 +923,7 @@
       "opensearch-py>=2.2.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -864,6 +934,7 @@
       "opsgenie-sdk>=2.1.5"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -875,6 +946,7 @@
       "oracledb>=1.0.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "common.sql"
     ],
@@ -887,6 +959,7 @@
       "pdpyras>=4.1.2"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -899,6 +972,7 @@
       "scrapbook[all]"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [
       "3.12"
@@ -912,6 +986,7 @@
       "pgvector>=0.2.3"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "common.sql",
       "postgres"
@@ -925,6 +1000,7 @@
       "pinecone-client>=3.0.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -936,6 +1012,7 @@
       "psycopg2-binary>=2.8.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "amazon",
       "common.sql",
@@ -952,6 +1029,7 @@
       "presto-python-client>=0.8.4"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "common.sql",
       "google"
@@ -965,6 +1043,7 @@
       "qdrant_client>=1.9.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -975,6 +1054,7 @@
       "redis>=4.5.2,!=4.5.5,!=5.0.2"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -986,6 +1066,7 @@
       "simple-salesforce>=1.0.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -996,6 +1077,7 @@
       "smbprotocol>=1.5.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "google"
     ],
@@ -1008,6 +1090,7 @@
       "apache-airflow>=2.7.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -1018,6 +1101,7 @@
       "sendgrid>=6.0.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -1030,6 +1114,7 @@
       "paramiko>=2.8.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "openlineage",
       "ssh"
@@ -1043,6 +1128,7 @@
       "spython>=0.0.56"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -1054,6 +1140,7 @@
       "slack_sdk>=3.19.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "common.sql"
     ],
@@ -1065,6 +1152,7 @@
       "apache-airflow>=2.7.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -1077,6 +1165,7 @@
       "snowflake-sqlalchemy>=1.1.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "common.sql",
       "openlineage"
@@ -1090,6 +1179,7 @@
       "apache-airflow>=2.7.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "common.sql"
     ],
@@ -1103,6 +1193,7 @@
       "sshtunnel>=0.3.2"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -1113,6 +1204,7 @@
       "tableauserverclient"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -1125,6 +1217,7 @@
     "devel-deps": [
       "pyiceberg>=0.5.0"
     ],
+    "plugins": [],
     "cross-providers-deps": [
       "apache.iceberg"
     ],
@@ -1137,6 +1230,7 @@
       "python-telegram-bot>=20.2"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -1149,6 +1243,7 @@
       "teradatasqlalchemy>=17.20.0.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "common.sql"
     ],
@@ -1163,6 +1258,7 @@
       "trino>=0.318.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "common.sql",
       "google",
@@ -1178,6 +1274,7 @@
       "vertica-python>=0.5.1"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [
       "common.sql"
     ],
@@ -1191,6 +1288,7 @@
       "weaviate-client>=3.24.2"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -1202,6 +1300,7 @@
       "yandexcloud>=0.278.0"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
@@ -1212,6 +1311,7 @@
       "zenpy>=2.0.40"
     ],
     "devel-deps": [],
+    "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -846,6 +846,17 @@ class CustomBuildHook(BuildHookInterface[BuilderConfig]):
         # field in core.metadata until this is possible
         self.metadata.core._optional_dependencies = self.optional_dependencies
 
+        # Add entrypoints dynamically for all provider packages, else they will not be found by
+        # plugin manager
+        entry_points = self.metadata.core._entry_points or {}
+        plugins = entry_points.get("airflow.plugins") or {}
+        for provider in PROVIDER_DEPENDENCIES.values():
+            for plugin in provider["plugins"]:
+                plugin_class: str = plugin["plugin-class"]
+                plugins[plugin["name"]] = plugin_class[::-1].replace(".", ":", 1)[::-1]
+        entry_points["airflow.plugins"] = plugins
+        self.metadata.core._entry_points = entry_points
+
     def _add_devel_ci_dependencies(self, deps: list[str], python_exclusion: str) -> None:
         """
         Add devel_ci_dependencies.

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -846,16 +846,17 @@ class CustomBuildHook(BuildHookInterface[BuilderConfig]):
         # field in core.metadata until this is possible
         self.metadata.core._optional_dependencies = self.optional_dependencies
 
-        # Add entrypoints dynamically for all provider packages, else they will not be found by
-        # plugin manager
-        entry_points = self.metadata.core._entry_points or {}
-        plugins = entry_points.get("airflow.plugins") or {}
-        for provider in PROVIDER_DEPENDENCIES.values():
-            for plugin in provider["plugins"]:
-                plugin_class: str = plugin["plugin-class"]
-                plugins[plugin["name"]] = plugin_class[::-1].replace(".", ":", 1)[::-1]
-        entry_points["airflow.plugins"] = plugins
-        self.metadata.core._entry_points = entry_points
+        # Add entrypoints dynamically for all provider packages, in editable build
+        # else they will not be found by plugin manager
+        if version != "standard":
+            entry_points = self.metadata.core._entry_points or {}
+            plugins = entry_points.get("airflow.plugins") or {}
+            for provider in PROVIDER_DEPENDENCIES.values():
+                for plugin in provider["plugins"]:
+                    plugin_class: str = plugin["plugin-class"]
+                    plugins[plugin["name"]] = plugin_class[::-1].replace(".", ":", 1)[::-1]
+            entry_points["airflow.plugins"] = plugins
+            self.metadata.core._entry_points = entry_points
 
     def _add_devel_ci_dependencies(self, deps: list[str], python_exclusion: str) -> None:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 
-dynamic = ["version", "optional-dependencies", "dependencies"]
+dynamic = ["version", "optional-dependencies", "dependencies", "entry-points"]
 
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # !!! YOU MIGHT BE SURPRISED NOT SEEING THE DEPENDENCIES AS `project.dependencies`     !!!!!!!!!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 
-dynamic = ["version", "optional-dependencies", "dependencies", "entry-points"]
+dynamic = ["version", "optional-dependencies", "dependencies"]
 
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # !!! YOU MIGHT BE SURPRISED NOT SEEING THE DEPENDENCIES AS `project.dependencies`     !!!!!!!!!

--- a/scripts/ci/pre_commit/update_providers_dependencies.py
+++ b/scripts/ci/pre_commit/update_providers_dependencies.py
@@ -185,12 +185,13 @@ if __name__ == "__main__":
     find_all_providers_and_provider_files()
     num_files = len(ALL_PROVIDER_FILES)
     num_providers = len(ALL_PROVIDERS)
-    console.print(f"Found {len(ALL_PROVIDERS)} providers with {len(ALL_PROVIDER_FILES)} Python files.")
+    console.print(f"Found {num_providers} providers with {num_files} Python files.")
     for file in ALL_PROVIDER_FILES:
         check_if_different_provider_used(file)
     for provider, provider_yaml_content in ALL_PROVIDERS.items():
         ALL_DEPENDENCIES[provider]["deps"].extend(provider_yaml_content["dependencies"])
         ALL_DEPENDENCIES[provider]["devel-deps"].extend(provider_yaml_content.get("devel-dependencies") or [])
+        ALL_DEPENDENCIES[provider]["plugins"].extend(provider_yaml_content.get("plugins") or [])
         STATES[provider] = provider_yaml_content["state"]
     if warnings:
         console.print("[yellow]Warnings!\n")
@@ -205,7 +206,8 @@ if __name__ == "__main__":
     unique_sorted_dependencies: dict[str, dict[str, list[str] | str]] = defaultdict(dict)
     for key in sorted(ALL_DEPENDENCIES.keys()):
         unique_sorted_dependencies[key]["deps"] = sorted(ALL_DEPENDENCIES[key]["deps"])
-        unique_sorted_dependencies[key]["devel-deps"] = ALL_DEPENDENCIES[key].get("devel-deps") or []
+        unique_sorted_dependencies[key]["devel-deps"] = sorted(ALL_DEPENDENCIES[key]["devel-deps"])
+        unique_sorted_dependencies[key]["plugins"] = sorted(ALL_DEPENDENCIES[key]["plugins"])
         unique_sorted_dependencies[key]["cross-providers-deps"] = sorted(
             set(ALL_DEPENDENCIES[key]["cross-providers-deps"])
         )

--- a/tests/providers/openlineage/plugins/test_openlineage.py
+++ b/tests/providers/openlineage/plugins/test_openlineage.py
@@ -36,16 +36,15 @@ class TestOpenLineageProviderPlugin:
         is_disabled.cache_clear()
         transport.cache_clear()
         config_path.cache_clear()
-        self.old_modules = dict(sys.modules)
+        # Remove module under test if loaded already before. This lets us
+        # import the same source files for more than one test.
+        if "airflow.providers.openlineage.plugins.openlineage" in sys.modules:
+            del sys.modules["airflow.providers.openlineage.plugins.openlineage"]
 
     def teardown_method(self):
         is_disabled.cache_clear()
         transport.cache_clear()
         config_path.cache_clear()
-        # Remove any new modules imported during the test run. This lets us
-        # import the same source files for more than one test.
-        for mod in [m for m in sys.modules if m not in self.old_modules]:
-            del sys.modules[mod]
 
     @pytest.mark.parametrize(
         "mocks, expected",


### PR DESCRIPTION
As I am starting to build a PoC and experience code in  and for AIP-69 I realized that provider packages from the mono-repo do not load plugins when starting the system via breeze. Plugins are correctly published via entry-point definition if packages are released but are missing in the global pyproject.toml. Mainly also because they should not be contained there.

Following a Slack discussion in https://apache-airflow.slack.com/archives/C06K9Q5G2UA/p1715545743922549 with @potiuk I attempted and succeeded in extending the `hatch_build.py`. With this PR the plugins defined in the provider packages are dynamically extended for the development setup, means that when starting Airflow with breeze, the included "hive" and "openlineage" plugin are loaded by default. (Any maybe if Romte Executor will bring nother also this...

How to test?
- Use the branch and start Airflow with `breeze start-airflow --answer y`
- In the tmux started run `airflow plugins` and see hive and openlineage are added from source automatically.

Note: Needed to extend the "provider_dependencies.json" to have the plugin information contained there as well as hatch loads the other details from there as well. First wanted to start another second JSON... but actually the provider dependencies is not cleanly a dependency, so added it there.

@mobuchowski FYI needed to adjust pytest as the openlineage provider plugin is now loaded before pytest and module needs to be un-loaded to make fixture for config working. This replaces the module-unloading post test.