### PR TITLE
remove deprecation trino

### DIFF
--- a/docs/apache-airflow-providers-trino/operators/trino.rst
+++ b/docs/apache-airflow-providers-trino/operators/trino.rst
@@ -17,11 +17,14 @@
 
 .. _howto/operator:TrinoOperator:
 
-TrinoOperator
-=============
+Connect to Trino using SQLExecuteQueryOperator
+==============================================
 
-Use the :class:`TrinoOperator <airflow.providers.trino.operators.trino>` to execute
+Use the :class:`SQLExecuteQueryOperator <airflow.providers.common.sql.operators.sql>` to execute
 SQL commands in a `Trino <https://trino.io/>`__ query engine.
+
+.. warning::
+   TrinoOperator is deprecated in favor of SQLExecuteQueryOperator. If you are using TrinoOperator you should migrate as soon as possible.
 
 
 Using the Operator
@@ -29,7 +32,7 @@ Using the Operator
 
 Use the ``trino_conn_id`` argument to connect to your Trino instance
 
-An example usage of the TrinoOperator is as follows:
+An example usage of the SQLExecuteQueryOperator to connect to Trino is as follows:
 
 .. exampleinclude:: /../../tests/system/providers/trino/example_trino.py
     :language: python

--- a/tests/always/test_example_dags.py
+++ b/tests/always/test_example_dags.py
@@ -58,9 +58,6 @@ IGNORE_AIRFLOW_PROVIDER_DEPRECATION_WARNING: tuple[str, ...] = (
     "tests/system/providers/google/cloud/life_sciences/example_life_sciences.py",
     "tests/system/providers/google/marketing_platform/example_analytics.py",
     # Deprecated Operators/Hooks, which replaced by common.sql Operators/Hooks
-    "tests/system/providers/jdbc/example_jdbc_queries.py",
-    "tests/system/providers/snowflake/example_snowflake.py",
-    "tests/system/providers/trino/example_trino.py",
 )
 
 

--- a/tests/system/providers/trino/example_trino.py
+++ b/tests/system/providers/trino/example_trino.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """
-Example DAG using TrinoOperator.
+Example DAG using SQLExecuteQueryOperator to connect to Trino.
 """
 
 from __future__ import annotations
@@ -24,7 +24,7 @@ from __future__ import annotations
 from datetime import datetime
 
 from airflow import models
-from airflow.providers.trino.operators.trino import TrinoOperator
+from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 
 SCHEMA = "hive.cities"
 TABLE = "city"
@@ -40,12 +40,12 @@ with models.DAG(
     catchup=False,
     tags=["example"],
 ) as dag:
-    trino_create_schema = TrinoOperator(
+    trino_create_schema = SQLExecuteQueryOperator(
         task_id="trino_create_schema",
         sql=f"CREATE SCHEMA IF NOT EXISTS {SCHEMA} WITH (location = 's3://irisbkt/cities/');",
         handler=list,
     )
-    trino_create_table = TrinoOperator(
+    trino_create_table = SQLExecuteQueryOperator(
         task_id="trino_create_table",
         sql=f"""CREATE TABLE IF NOT EXISTS {SCHEMA}.{TABLE}(
         cityid bigint,
@@ -53,14 +53,12 @@ with models.DAG(
         )""",
         handler=list,
     )
-
-    trino_insert = TrinoOperator(
+    trino_insert = SQLExecuteQueryOperator(
         task_id="trino_insert",
         sql=f"""INSERT INTO {SCHEMA}.{TABLE} VALUES (1, 'San Francisco');""",
         handler=list,
     )
-
-    trino_multiple_queries = TrinoOperator(
+    trino_multiple_queries = SQLExecuteQueryOperator(
         task_id="trino_multiple_queries",
         sql=f"""CREATE TABLE IF NOT EXISTS {SCHEMA}.{TABLE1}(cityid bigint,cityname varchar);
         INSERT INTO {SCHEMA}.{TABLE1} VALUES (2, 'San Jose');
@@ -68,14 +66,13 @@ with models.DAG(
         INSERT INTO {SCHEMA}.{TABLE2} VALUES (3, 'San Diego');""",
         handler=list,
     )
-
-    trino_templated_query = TrinoOperator(
+    trino_templated_query = SQLExecuteQueryOperator(
         task_id="trino_templated_query",
         sql="SELECT * FROM {{ params.SCHEMA }}.{{ params.TABLE }}",
         handler=list,
         params={"SCHEMA": SCHEMA, "TABLE": TABLE1},
     )
-    trino_parameterized_query = TrinoOperator(
+    trino_parameterized_query = SQLExecuteQueryOperator(
         task_id="trino_parameterized_query",
         sql=f"select * from {SCHEMA}.{TABLE2} where cityname = ?",
         parameters=("San Diego",),


### PR DESCRIPTION
Related: #39485
Removing deprecated TrinoOperator from docs and tests and replacing with SQLExecuteQueryOperator

 
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
