### PR TITLE
remove deprecation sqlite

### DIFF
--- a/docs/apache-airflow-providers-sqlite/operators.rst
+++ b/docs/apache-airflow-providers-sqlite/operators.rst
@@ -19,17 +19,19 @@
 
 .. _howto/operator:SqliteOperator:
 
-SqliteOperator
-==============
+SQLExecuteQueryOperator to connect to Sqlite
+============================================
 
-Use the :class:`~airflow.providers.sqlite.operators.sqlite.SqliteOperator` to execute
+Use the :class:`SQLExecuteQueryOperator<airflow.providers.common.sql.operators.sql>` to execute
 Sqlite commands in a `Sqlite <https://sqlite.org/lang.html>`__ database.
 
+.. warning::
+    Previously, SqliteOperator was used to perform this kind of operation. But at the moment SqliteOperator is deprecated and will be removed in future versions of the provider. Please consider to switch to SQLExecuteQueryOperator as soon as possible.
 
 Using the Operator
 ^^^^^^^^^^^^^^^^^^
 
-Use the ``sqlite_conn_id`` argument to connect to your Sqlite instance where
+Use the ``conn_id`` argument to connect to your Sqlite instance where
 the connection metadata is structured as follows:
 
 .. list-table:: Sqlite Airflow Connection Metadata
@@ -41,7 +43,7 @@ the connection metadata is structured as follows:
    * - Host: string
      - Sqlite database file
 
-An example usage of the SqliteOperator is as follows:
+An example usage of the SQLExecuteQueryOperator to connect to Sqlite is as follows:
 
 .. exampleinclude:: /../../tests/system/providers/sqlite/example_sqlite.py
     :language: python
@@ -63,5 +65,5 @@ For further information, look at:
 
 .. note::
 
-  Parameters given via SqliteOperator() are given first-place priority
+  Parameters given via SQLExecuteQueryOperator() are given first-place priority
   relative to parameters set via Airflow connection metadata (such as ``schema``, ``login``, ``password`` etc).

--- a/tests/always/test_example_dags.py
+++ b/tests/always/test_example_dags.py
@@ -70,7 +70,6 @@ IGNORE_AIRFLOW_PROVIDER_DEPRECATION_WARNING: tuple[str, ...] = (
     "tests/system/providers/mysql/example_mysql.py",
     "tests/system/providers/postgres/example_postgres.py",
     "tests/system/providers/snowflake/example_snowflake.py",
-    "tests/system/providers/sqlite/example_sqlite.py",
     "tests/system/providers/trino/example_trino.py",
 )
 

--- a/tests/system/providers/sqlite/example_sqlite.py
+++ b/tests/system/providers/sqlite/example_sqlite.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """
-This is an example DAG for the use of the SqliteOperator.
+This is an example DAG for the use of the SQLExecuteQueryOperator with Sqlite.
 In this example, we create two tasks that execute in sequence.
 The first task calls an sql command, defined in the SQLite operator,
 which when triggered, is performed on the connected sqlite database.
@@ -29,8 +29,8 @@ import os
 from datetime import datetime
 
 from airflow import DAG
+from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 from airflow.providers.sqlite.hooks.sqlite import SqliteHook
-from airflow.providers.sqlite.operators.sqlite import SqliteOperator
 
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID")
 DAG_ID = "example_sqlite"
@@ -45,7 +45,7 @@ with DAG(
     # [START howto_operator_sqlite]
 
     # Example of creating a task that calls a common CREATE TABLE sql command.
-    create_table_sqlite_task = SqliteOperator(
+    create_table_sqlite_task = SQLExecuteQueryOperator(
         task_id="create_table_sqlite",
         sql=r"""
         CREATE TABLE Customers (
@@ -77,7 +77,7 @@ with DAG(
     # [START howto_operator_sqlite_external_file]
 
     # Example of creating a task that calls an sql command from an external file.
-    external_create_table_sqlite_task = SqliteOperator(
+    external_create_table_sqlite_task = SQLExecuteQueryOperator(
         task_id="create_table_sqlite_external_file",
         sql="create_table.sql",
     )


### PR DESCRIPTION
Related: #39485
Removing deprecated SqliteOperator from docs and tests and replacing with SQLExecuteQueryOperator
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
