### PR TITLE
remove deprecation drill

### DIFF
--- a/airflow/providers/apache/drill/operators/drill.py
+++ b/airflow/providers/apache/drill/operators/drill.py
@@ -37,10 +37,6 @@ class DrillOperator(SQLExecuteQueryOperator):
 
     Please use :class:`airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`.
 
-    .. seealso::
-        For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:DrillOperator`
-
     :param sql: the SQL code to be executed as a single string, or
         a list of str (sql statements), or a reference to a template file.
         Template references are recognized by str ending in '.sql'

--- a/docs/apache-airflow-providers-apache-drill/operators.rst
+++ b/docs/apache-airflow-providers-apache-drill/operators.rst
@@ -16,19 +16,22 @@
     under the License.
 
 
-Apache Drill Operators
-======================
+Connect to Apache Drill via SQLExecuteQueryOperator
+===================================================
 
 Prerequisite
 ------------
 
-To use :class:`~airflow.providers.apache.drill.operators.drill.DrillOperator`,
-you must configure a :doc:`Drill Connection <connections/drill>`.
+Use :class:`~airflow.providers.common.sql.operators.SQLExecuteQueryOperator`,
+to execute SQL commands in  `Drill <https://drill.apache.org/>`__ query engine.
 
-.. _howto/operator:DrillOperator:
+To connect to Drill, you must configure a :doc:`Drill Connection <connections/drill>` and can pass that as ``conn_id`` to SQLExecuteQueryOperator.
 
-DrillOperator
--------------
+.. warning::
+    Previously, DrillOperator was used to perform this kind of operation. But at the moment DrillOperator is deprecated and will be removed in future versions of the provider. Please consider to switch to SQLExecuteQueryOperator as soon as possible.
+
+SQLExecuteQueryOperator
+-----------------------
 
 Executes one or more SQL queries on an Apache Drill server.
 The ``sql`` parameter can be templated and be an external ``.sql`` file.

--- a/tests/always/test_example_dags.py
+++ b/tests/always/test_example_dags.py
@@ -63,7 +63,7 @@ IGNORE_AIRFLOW_PROVIDER_DEPRECATION_WARNING: tuple[str, ...] = (
     "tests/system/providers/google/cloud/life_sciences/example_life_sciences.py",
     "tests/system/providers/google/marketing_platform/example_analytics.py",
     # Deprecated Operators/Hooks, which replaced by common.sql Operators/Hooks
-    "tests/system/providers/apache/drill/example_drill_dag.py",
+    "tests/system/providers/jdbc/example_jdbc_queries.py",
     "tests/system/providers/microsoft/mssql/example_mssql.py",
     "tests/system/providers/mysql/example_mysql.py",
     "tests/system/providers/snowflake/example_snowflake.py",

--- a/tests/system/providers/apache/drill/example_drill_dag.py
+++ b/tests/system/providers/apache/drill/example_drill_dag.py
@@ -25,7 +25,7 @@ import os
 from datetime import datetime
 
 from airflow.models import DAG
-from airflow.providers.apache.drill.operators.drill import DrillOperator
+from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID")
 DAG_ID = "example_drill_dag"
@@ -38,7 +38,7 @@ with DAG(
     tags=["example"],
 ) as dag:
     # [START howto_operator_drill]
-    sql_task = DrillOperator(
+    sql_task = SQLExecuteQueryOperator(
         task_id="json_to_parquet_table",
         sql="""
         drop table if exists dfs.tmp.employee;


### PR DESCRIPTION
Related: #39485
Removing deprecated DrillOperator from docs and tests and replacing with SQLExecuteQueryOperator
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
