### PR TITLE
remove deprecation jdbc

### DIFF
--- a/docs/apache-airflow-providers-jdbc/operators.rst
+++ b/docs/apache-airflow-providers-jdbc/operators.rst
@@ -24,6 +24,10 @@ Java Database Connectivity (JDBC) is an application programming interface
 (API) for the programming language Java, which defines how a client may
 access a database.
 
+.. warning::
+    Previously, JdbcOperator was used to perform this kind of operation. But at the moment JdbcOperator is deprecated and will be removed in future versions of the provider. Please consider to switch to SQLExecuteQueryOperator as soon as possible.
+
+
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
@@ -63,11 +67,11 @@ database is listening for new connections.
 
 Usage
 ^^^^^
-Use the :class:`~airflow.providers.jdbc.operators.jdbc` to execute
+Use the :class:`~airflow.providers.common.sql.operators.SQLExecuteQueryOperator` to execute
 commands against a database (or data storage) accessible via a JDBC driver.
 
 The :doc:`JDBC Connection <connections/jdbc>` must be passed as
-``jdbc_conn_id``.
+``conn_id``.
 
 .. exampleinclude:: /../../tests/system/providers/jdbc/example_jdbc_queries.py
     :language: python

--- a/tests/always/test_example_dags.py
+++ b/tests/always/test_example_dags.py
@@ -65,7 +65,6 @@ IGNORE_AIRFLOW_PROVIDER_DEPRECATION_WARNING: tuple[str, ...] = (
     "tests/system/providers/google/marketing_platform/example_analytics.py",
     # Deprecated Operators/Hooks, which replaced by common.sql Operators/Hooks
     "tests/system/providers/apache/drill/example_drill_dag.py",
-    "tests/system/providers/jdbc/example_jdbc_queries.py",
     "tests/system/providers/microsoft/mssql/example_mssql.py",
     "tests/system/providers/mysql/example_mysql.py",
     "tests/system/providers/postgres/example_postgres.py",

--- a/tests/system/providers/jdbc/example_jdbc_queries.py
+++ b/tests/system/providers/jdbc/example_jdbc_queries.py
@@ -24,7 +24,7 @@ from datetime import datetime, timedelta
 
 from airflow import DAG
 from airflow.operators.empty import EmptyOperator
-from airflow.providers.jdbc.operators.jdbc import JdbcOperator
+from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID")
 DAG_ID = "example_jdbc_operator"
@@ -40,19 +40,19 @@ with DAG(
     run_this_last = EmptyOperator(task_id="run_this_last")
 
     # [START howto_operator_jdbc_template]
-    delete_data = JdbcOperator(
+    delete_data = SQLExecuteQueryOperator(
         task_id="delete_data",
         sql="delete from my_schema.my_table where dt = {{ ds }}",
-        jdbc_conn_id="my_jdbc_connection",
+        conn_id="my_jdbc_connection",
         autocommit=True,
     )
     # [END howto_operator_jdbc_template]
 
     # [START howto_operator_jdbc]
-    insert_data = JdbcOperator(
+    insert_data = SQLExecuteQueryOperator(
         task_id="insert_data",
         sql="insert into my_schema.my_table select dt, value from my_schema.source_data",
-        jdbc_conn_id="my_jdbc_connection",
+        conn_id="my_jdbc_connection",
         autocommit=True,
     )
     # [END howto_operator_jdbc]


### PR DESCRIPTION
Related: #39485
Removing deprecated JdbcOperator from docs and tests and replacing with SQLExecuteQueryOperator

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
