### PR TITLE
openlineage: improve spawned OpenLineage process in scheduler

### DIFF
--- a/tests/providers/openlineage/plugins/test_listener.py
+++ b/tests/providers/openlineage/plugins/test_listener.py
@@ -561,7 +561,7 @@ def test_listener_on_dag_run_state_changes_configure_process_pool_size(mock_exec
     try:
         with conf_vars({("openlineage", "dag_state_change_process_pool_size"): max_workers}):
             listener.on_dag_run_running(mock.MagicMock(), None)
-        mock_executor.assert_called_once_with(max_workers=expected)
+        mock_executor.assert_called_once_with(max_workers=expected, initializer=mock.ANY)
         mock_executor.return_value.submit.assert_called_once()
     finally:
         conf.dag_state_change_process_pool_size.cache_clear()


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Although there's no call made by OpenLineage Provider to Airflow database from the process(es) spawned with ProcessPoolExecutor in Airflow, in #39520 there would be added such. Not only because of that reason there should be ORM re-configured on initialization of the processes spawned.

Additionally, ProcessPoolExecutor catches all exceptions raised in its' workers and sets information about them in the result object. However, we're not waiting or checking the status of submitted jobs, therefore exceptions are _swallowed_ and logged anywhere.

I tried adding some tests for checking if logs land properly now from within OpenLineageListener's ProcessPoolExecutor jobs. Pytest seems not to like `multiprocessing` and I ended up giving up on the tests. 
Both changes, however, were tested in breeze and Astro Cloud with running 1000 concurrent DagRuns and gave expected results.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
