### PR TITLE
removed stale code

### DIFF
--- a/airflow/providers/google/cloud/log/stackdriver_task_handler.py
+++ b/airflow/providers/google/cloud/log/stackdriver_task_handler.py
@@ -180,8 +180,7 @@ class StackdriverTaskHandler(logging.Handler):
         """
         message = self.format(record)
         ti = None
-        # todo: remove ctx_indiv_trigger is not None check when min airflow version >= 2.6
-        if ctx_indiv_trigger is not None and getattr(record, ctx_indiv_trigger.name, None):
+        if getattr(record, ctx_indiv_trigger.name, None):
             ti = getattr(record, "task_instance", None)  # trigger context
         labels = self._get_labels(ti)
         self._transport.send(record, message, resource=self.resource, labels=labels)


### PR DESCRIPTION
The current google provider airflow min version is 2.7.0, ctx_indiv_trigger is not None check is marked for deletion when min airflow version 2.6. This PR removed that stale function.
<img width="511" alt="image" src="https://github.com/apache/airflow/assets/41102134/705cb721-2b84-451a-8b17-f947711e4810">
