### PR TITLE
Deprecate AutoML Tables operators

### DIFF
--- a/airflow/providers/google/CHANGELOG.rst
+++ b/airflow/providers/google/CHANGELOG.rst
@@ -27,6 +27,21 @@
 Changelog
 ---------
 
+Main
+.......
+
+.. note::
+  Several AutoML operators have stopped being supported following the shutdown of a legacy version of
+  AutoML Natural Language, Tables, Vision, and Video Intelligence services. This includes
+  ``AutoMLDeployModelOperator``, ``AutoMLTablesUpdateDatasetOperator``, ``AutoMLTablesListTableSpecsOperator``
+  and ``AutoMLTablesListColumnSpecsOperator``. Please refer to the operator documentation to find out
+  about available alternatives, if any. For additional information regarding the AutoML shutdown see:
+
+* `AutoML Natural Language <https://cloud.google.com/natural-language/automl/docs/deprecations>`_
+* `AutoML Tables <https://cloud.google.com/automl-tables/docs/deprecations>`_
+* `AutoML Vision <https://cloud.google.com/vision/automl/docs/deprecations>`_
+* `AutoML Video Intelligence <https://cloud.google.com/video-intelligence/automl/docs/deprecations>`_
+
 10.18.0
 .......
 

--- a/airflow/providers/google/cloud/operators/automl.py
+++ b/airflow/providers/google/cloud/operators/automl.py
@@ -24,7 +24,6 @@ import warnings
 from functools import cached_property
 from typing import TYPE_CHECKING, Sequence, Tuple
 
-from deprecated import deprecated
 from google.api_core.gapic_v1.method import DEFAULT, _MethodDefault
 from google.cloud.automl_v1beta1 import (
     BatchPredictResult,
@@ -35,7 +34,7 @@ from google.cloud.automl_v1beta1 import (
     TableSpec,
 )
 
-from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.automl import CloudAutoMLHook
 from airflow.providers.google.cloud.hooks.vertex_ai.prediction_service import PredictionServiceHook
 from airflow.providers.google.cloud.links.translate import (
@@ -685,6 +684,10 @@ class AutoMLTablesListColumnSpecsOperator(GoogleCloudBaseOperator):
     """
     Lists column specs in a table.
 
+    Operator AutoMLTablesListColumnSpecsOperator has been deprecated due to shutdown of
+    a legacy version of AutoML Tables on March 31, 2024. For additional information
+    see: https://cloud.google.com/automl-tables/docs/deprecations.
+
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
         :ref:`howto/operator:AutoMLTablesListColumnSpecsOperator`
@@ -759,6 +762,11 @@ class AutoMLTablesListColumnSpecsOperator(GoogleCloudBaseOperator):
         self.retry = retry
         self.gcp_conn_id = gcp_conn_id
         self.impersonation_chain = impersonation_chain
+        raise AirflowException(
+            "Operator AutoMLTablesListColumnSpecsOperator has been deprecated due to shutdown of "
+            "a legacy version of AutoML Tables on March 31, 2024. "
+            "For additional information see: https://cloud.google.com/automl-tables/docs/deprecations."
+        )
 
     def execute(self, context: Context):
         hook = CloudAutoMLHook(
@@ -791,20 +799,14 @@ class AutoMLTablesListColumnSpecsOperator(GoogleCloudBaseOperator):
         return result
 
 
-@deprecated(
-    reason=(
-        "Class `AutoMLTablesUpdateDatasetOperator` has been deprecated and no longer available. "
-        "Please use `UpdateDatasetOperator` instead"
-    ),
-    category=AirflowProviderDeprecationWarning,
-    action="error",
-)
 class AutoMLTablesUpdateDatasetOperator(GoogleCloudBaseOperator):
     """
     Updates a dataset.
 
-    AutoMLTablesUpdateDatasetOperator has been deprecated and no longer available. Please use
-    :class:`airflow.providers.google.cloud.operators.vertex_ai.dataset.UpdateDatasetOperator`
+    Operator AutoMLTablesUpdateDatasetOperator has been deprecated due to shutdown of
+    a legacy version of AutoML Tables on March 31, 2024. For additional information
+    see: https://cloud.google.com/automl-tables/docs/deprecations.
+    Please use :class:`airflow.providers.google.cloud.operators.vertex_ai.dataset.UpdateDatasetOperator`
     instead.
 
     .. seealso::
@@ -864,6 +866,12 @@ class AutoMLTablesUpdateDatasetOperator(GoogleCloudBaseOperator):
         self.retry = retry
         self.gcp_conn_id = gcp_conn_id
         self.impersonation_chain = impersonation_chain
+        raise AirflowException(
+            "Operator AutoMLTablesUpdateDatasetOperator has been deprecated due to shutdown of "
+            "a legacy version of AutoML Tables on March 31, 2024. "
+            "For additional information see: https://cloud.google.com/automl-tables/docs/deprecations. "
+            "Please use UpdateDatasetOperator from Vertex AI instead."
+        )
 
     def execute(self, context: Context):
         hook = CloudAutoMLHook(
@@ -1074,14 +1082,6 @@ class AutoMLDeleteModelOperator(GoogleCloudBaseOperator):
         self.log.info("Deletion is completed")
 
 
-@deprecated(
-    reason=(
-        "Class `AutoMLDeployModelOperator` has been deprecated and no longer available. Please use "
-        "`DeployModelOperator` instead"
-    ),
-    category=AirflowProviderDeprecationWarning,
-    action="error",
-)
 class AutoMLDeployModelOperator(GoogleCloudBaseOperator):
     """
     Deploys a model; if a model is already deployed, deploying it with the same parameters has no effect.
@@ -1092,8 +1092,10 @@ class AutoMLDeployModelOperator(GoogleCloudBaseOperator):
     Only applicable for Text Classification, Image Object Detection and Tables; all other
     domains manage deployment automatically.
 
-    AutoMLDeployModelOperator has been deprecated and no longer available. Please use
-    :class:`airflow.providers.google.cloud.operators.vertex_ai.endpoint_service.DeployModelOperator`
+    Operator AutoMLDeployModelOperator has been deprecated due to shutdown of a legacy version
+    of AutoML Natural Language, Vision, Video Intelligence on March 31, 2024.
+    For additional information see: https://cloud.google.com/vision/automl/docs/deprecations .
+    Please use :class:`airflow.providers.google.cloud.operators.vertex_ai.endpoint_service.DeployModelOperator`
     instead.
 
     .. seealso::
@@ -1156,24 +1158,20 @@ class AutoMLDeployModelOperator(GoogleCloudBaseOperator):
         self.retry = retry
         self.gcp_conn_id = gcp_conn_id
         self.impersonation_chain = impersonation_chain
+        raise AirflowException(
+            "Operator AutoMLDeployModelOperator has been deprecated due to shutdown of "
+            "a legacy version of AutoML AutoML Natural Language, Vision, Video Intelligence "
+            "on March 31, 2024. "
+            "For additional information see: https://cloud.google.com/vision/automl/docs/deprecations. "
+            "Please use DeployModelOperator from Vertex AI instead."
+        )
 
     def execute(self, context: Context):
         hook = CloudAutoMLHook(
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.impersonation_chain,
         )
-        model = hook.get_model(
-            model_id=self.model_id,
-            location=self.location,
-            project_id=self.project_id,
-            retry=self.retry,
-            timeout=self.timeout,
-            metadata=self.metadata,
-        )
-        if not hasattr(model, "translation_model_metadata"):
-            _raise_exception_for_deprecated_operator(self.__class__.__name__, "DeployModelOperator")
         self.log.info("Deploying model_id %s", self.model_id)
-
         operation = hook.deploy_model(
             model_id=self.model_id,
             location=self.location,
@@ -1190,6 +1188,10 @@ class AutoMLDeployModelOperator(GoogleCloudBaseOperator):
 class AutoMLTablesListTableSpecsOperator(GoogleCloudBaseOperator):
     """
     Lists table specs in a dataset.
+
+    Operator AutoMLTablesListTableSpecsOperator has been deprecated due to shutdown of
+    a legacy version of AutoML Tables on March 31, 2024. For additional information
+    see: https://cloud.google.com/automl-tables/docs/deprecations.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
@@ -1256,6 +1258,11 @@ class AutoMLTablesListTableSpecsOperator(GoogleCloudBaseOperator):
         self.retry = retry
         self.gcp_conn_id = gcp_conn_id
         self.impersonation_chain = impersonation_chain
+        raise AirflowException(
+            "Operator AutoMLTablesListTableSpecsOperator has been deprecated due to shutdown of "
+            "a legacy version of AutoML Tables on March 31, 2024. "
+            "For additional information see: https://cloud.google.com/automl-tables/docs/deprecations. "
+        )
 
     def execute(self, context: Context):
         hook = CloudAutoMLHook(

--- a/scripts/in_container/run_provider_yaml_files_check.py
+++ b/scripts/in_container/run_provider_yaml_files_check.py
@@ -57,6 +57,8 @@ DEPRECATED_MODULES = [
 
 KNOWN_DEPRECATED_CLASSES = [
     "airflow.providers.google.cloud.links.dataproc.DataprocLink",
+    "airflow.providers.google.cloud.operators.automl.AutoMLTablesListColumnSpecsOperator",
+    "airflow.providers.google.cloud.operators.automl.AutoMLTablesListTableSpecsOperator",
     "airflow.providers.google.cloud.operators.automl.AutoMLTablesUpdateDatasetOperator",
     "airflow.providers.google.cloud.operators.automl.AutoMLDeployModelOperator",
 ]

--- a/tests/always/test_project_structure.py
+++ b/tests/always/test_project_structure.py
@@ -363,6 +363,8 @@ class TestGoogleProviderProjectStructure(ExampleCoverageTest, AssetsCoverageTest
         ".CloudDataTransferServiceS3ToGCSOperator",
         "airflow.providers.google.cloud.operators.cloud_storage_transfer_service"
         ".CloudDataTransferServiceGCSToGCSOperator",
+        "airflow.providers.google.cloud.operators.automl.AutoMLTablesListColumnSpecsOperator",
+        "airflow.providers.google.cloud.operators.automl.AutoMLTablesListTableSpecsOperator",
         "airflow.providers.google.cloud.operators.automl.AutoMLTablesUpdateDatasetOperator",
         "airflow.providers.google.cloud.operators.automl.AutoMLDeployModelOperator",
         "airflow.providers.google.cloud.operators.dataproc.DataprocSubmitHadoopJobOperator",

--- a/tests/system/providers/google/cloud/automl/example_automl_translation.py
+++ b/tests/system/providers/google/cloud/automl/example_automl_translation.py
@@ -15,9 +15,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""
-Example Airflow DAG that uses Google AutoML services.
-"""
+
+"""Example Airflow DAG that uses Google AutoML Translation services."""
 
 from __future__ import annotations
 
@@ -31,7 +30,6 @@ from google.cloud import storage  # type: ignore[attr-defined]
 from airflow.decorators import task
 from airflow.models.dag import DAG
 from airflow.models.xcom_arg import XComArg
-from airflow.providers.google.cloud.hooks.automl import CloudAutoMLHook
 from airflow.providers.google.cloud.operators.automl import (
     AutoMLCreateDatasetOperator,
     AutoMLDeleteDatasetOperator,
@@ -43,7 +41,7 @@ from airflow.providers.google.cloud.operators.gcs import GCSCreateBucketOperator
 from airflow.providers.google.cloud.transfers.gcs_to_gcs import GCSToGCSOperator
 from airflow.utils.trigger_rule import TriggerRule
 
-DAG_ID = "example_automl_translate"
+DAG_ID = "automl_translate"
 GCP_PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT", "default")
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID", "default")
 GCP_AUTOML_LOCATION = "us-central1"
@@ -57,7 +55,7 @@ MODEL = {
     "translation_model_metadata": {},
 }
 
-DATASET_NAME = f"ds_translate_{ENV_ID}".replace("-", "_")
+DATASET_NAME = f"ds_{DAG_ID}_{ENV_ID}".replace("-", "_")
 DATASET = {
     "display_name": DATASET_NAME,
     "translation_dataset_metadata": {
@@ -72,8 +70,6 @@ GCS_FILE_PATH = f"automl/datasets/translate/{CSV_FILE_NAME}"
 AUTOML_DATASET_BUCKET = f"gs://{DATA_SAMPLE_GCS_BUCKET_NAME}/automl/{CSV_FILE_NAME}"
 IMPORT_INPUT_CONFIG = {"gcs_source": {"input_uris": [AUTOML_DATASET_BUCKET]}}
 
-extract_object_id = CloudAutoMLHook.extract_object_id
-
 
 # Example DAG for AutoML Translation
 with DAG(
@@ -81,7 +77,6 @@ with DAG(
     schedule="@once",
     start_date=datetime(2021, 1, 1),
     catchup=False,
-    user_defined_macros={"extract_object_id": extract_object_id},
     tags=["example", "automl", "translate"],
 ) as dag:
     create_bucket = GCSCreateBucketOperator(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Deprecate AutoML Tables operators:
- `AutoMLTablesListTableSpecsOperator` 
- `AutoMLTablesListColumnSpecsOperator`
- `AutoMLTablesUpdateDatasetOperator`

and 
`AutoMLDeployModelOperator`.

The Cloud AutoML platform has gone through several deprecations in the recent months. Some features were moved to Cloud Translation and Vertex AI, and some just stopped being supported. 

The AutoML Tables operators are trying to make operations on AutoML datasets, such as getting specs of the tables contained within the datasets or updating the datasets. However after its deprecation, the only available functionality for AutoML is AutoML Translation, which is integrated into Cloud Translation and does not support tabular datasets. So we can query the datasets with the operators, but no tables or their columns will be found, making these operators useless and prone to errors.

Tabular datasets are available in Vertex AI, but unfortunately at this moment only `AutoMLTablesUpdateDatasetOperator` has a substitute  Vertex AI operator with similar functions.  `AutoMLTablesListTableSpecsOperator`  and `AutoMLTablesListColumnSpecsOperator` have no substitutes.

The functionality of `AutoMLDeployModelOperator` is also not supported by Cloud AutoML anymore. Instead  the `DeployModelOperator` from Vertex AI should be used.

This PR is a continuation of #38673 .


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
