### PR TITLE
[openlineage] fix: OpenLineage in FileTransferOperator for Airflow 2.8

### DIFF
--- a/tests/providers/common/io/operators/test_file_transfer.py
+++ b/tests/providers/common/io/operators/test_file_transfer.py
@@ -69,3 +69,30 @@ def test_get_openlineage_facets_on_start():
     assert len(lineage.outputs) == 1
     assert lineage.inputs[0] == expected_input
     assert lineage.outputs[0] == expected_output
+
+
+def test_get_openlineage_facets_on_start_without_namespace():
+    mock_src = mock.MagicMock(key="/src_key", protocol="s3", bucket="src_bucket", sep="/")
+    mock_dst = mock.MagicMock(key="dst_key", protocol="gcs", bucket="", sep="/")
+
+    # Ensure the `namespace` attribute does not exist
+    if hasattr(mock_src, "namespace"):
+        delattr(mock_src, "namespace")
+    if hasattr(mock_dst, "namespace"):
+        delattr(mock_dst, "namespace")
+
+    operator = FileTransferOperator(
+        task_id="task",
+        src=mock_src,
+        dst=mock_dst,
+        source_conn_id="source_conn_id",
+        dest_conn_id="dest_conn_id",
+    )
+    # Make sure the _get_path method returns the mock objects
+    operator._get_path = mock.Mock(side_effect=[mock_src, mock_dst])
+
+    lineage = operator.get_openlineage_facets_on_start()
+    assert len(lineage.inputs) == 1
+    assert len(lineage.outputs) == 1
+    assert lineage.inputs[0] == Dataset(namespace="s3://src_bucket", name="src_key")
+    assert lineage.outputs[0] == Dataset(namespace="gcs", name="dst_key")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

As discussed in #39606, there is an issue with OpenLineage in FileTransferOperator when running Airflow 2.8.

Namespace property has been added in core Airflow `io.path.ObjectStoragePath` with #36410 (Airflow 2.9) so when running Airflow 2.8 we should re-create this behaviour manually inside the provider based on what was available in 2.8.0

There is no need for any action for Airflow <2.8 as the `apache-airflow-providers-common-io` requires at least 2.8.0


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
