### PR TITLE
Skip `tests/providers/google/cloud/links/test_translate.py` module in no-pydantic environment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -394,6 +394,7 @@ combine-as-imports = true
 "tests/providers/google/cloud/hooks/vertex_ai/test_model_service.py" = ["E402"]
 "tests/providers/google/cloud/hooks/vertex_ai/test_pipeline_job.py" = ["E402"]
 "tests/providers/google/cloud/hooks/vertex_ai/test_prediction_service.py" = ["E402"]
+"tests/providers/google/cloud/links/test_translate.py" = ["E402"]
 "tests/providers/google/cloud/operators/test_automl.py"= ["E402"]
 "tests/providers/google/cloud/operators/test_vertex_ai.py" = ["E402"]
 "tests/providers/google/cloud/operators/vertex_ai/test_generative_model.py" = ["E402"]

--- a/tests/providers/google/cloud/links/test_translate.py
+++ b/tests/providers/google/cloud/links/test_translate.py
@@ -18,6 +18,10 @@
 from __future__ import annotations
 
 import pytest
+
+# For no Pydantic environment, we need to skip the tests
+pytest.importorskip("google.cloud.aiplatform_v1")
+
 from google.cloud.automl_v1beta1 import Model
 
 from airflow.providers.google.cloud.links.translate import (


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Fix in main and full tests needed PR's

```console
____ ERROR collecting tests/providers/google/cloud/links/test_translate.py _____
ImportError while importing test module '/opt/airflow/tests/providers/google/cloud/links/test_translate.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/local/lib/python3.8/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/providers/google/cloud/links/test_translate.py:31: in <module>
    from airflow.providers.google.cloud.operators.automl import (
airflow/providers/google/cloud/operators/automl.py:40: in <module>
    from airflow.providers.google.cloud.hooks.vertex_ai.prediction_service import PredictionServiceHook
airflow/providers/google/cloud/hooks/vertex_ai/prediction_service.py:24: in <module>
    from google.cloud.aiplatform_v1 import PredictionServiceClient
E   ModuleNotFoundError: No module named 'google.cloud.aiplatform_v1'
----- generated xml file: /files/test_result-providers_google-postgres.xml -----
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
