### PR TITLE
Fix typo in console message for static checks on last commit

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/developer_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/developer_commands.py
@@ -859,9 +859,7 @@ def static_checks(
     if show_diff_on_failure:
         command_to_execute.append("--show-diff-on-failure")
     if last_commit:
-        get_console().print(
-            "\n[info]Running checks for last commit in the current branch current branch: HEAD^..HEAD\n"
-        )
+        get_console().print("\n[info]Running checks for last commit in the current branch: HEAD^..HEAD\n")
         command_to_execute.extend(["--from-ref", "HEAD^", "--to-ref", "HEAD"])
     if commit_ref:
         get_console().print(f"\n[info]Running checks for selected commit: {commit_ref}\n")


### PR DESCRIPTION
There is a duplication of "current branch" in the console message that gets printed during `breeze static-checks --last-commit`.
