### PR TITLE
Mark TestStandardTaskRunner::test_read_task_utilization as db test

### DIFF
--- a/tests/task/task_runner/test_standard_task_runner.py
+++ b/tests/task/task_runner/test_standard_task_runner.py
@@ -449,10 +449,11 @@ class TestStandardTaskRunner:
             "_AIRFLOW_PARSING_CONTEXT_TASK_ID=task1\n"
         )
 
+    @pytest.mark.db_test
     @mock.patch("airflow.task.task_runner.standard_task_runner.Stats.gauge")
     @patch("airflow.utils.log.file_task_handler.FileTaskHandler._init_file")
-    def test_read_task_utilization(self, mock_init, mock_stats):
-        mock_init.return_value = "/tmp/any"
+    def test_read_task_utilization(self, mock_init, mock_stats, tmp_path):
+        mock_init.return_value = (tmp_path / "test_read_task_utilization.log").as_posix()
         Job = mock.Mock()
         Job.job_type = None
         Job.task_instance = mock.MagicMock()


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Fix failing `main`

```console
❯ breeze shell --backend none

root@a2b2d941fc72:/opt/airflow# pytest tests --skip-db-tests tests/task/task_runner/test_standard_task_runner.py

======================================================= FAILURES ========================================================
___________________________________ TestStandardTaskRunner.test_read_task_utilization ___________________________________

self = <tests.task.task_runner.test_standard_task_runner.TestStandardTaskRunner object at 0xffff9b97e460>
mock_init = <MagicMock name='_init_file' id='281472688691328'>
mock_stats = <MagicMock name='gauge' id='281472686772336'>

    @mock.patch("airflow.task.task_runner.standard_task_runner.Stats.gauge")
    @patch("airflow.utils.log.file_task_handler.FileTaskHandler._init_file")
    def test_read_task_utilization(self, mock_init, mock_stats):
        mock_init.return_value = "/tmp/any"
        Job = mock.Mock()
        Job.job_type = None
        Job.task_instance = mock.MagicMock()
        Job.task_instance.task_id = "task_id"
        Job.task_instance.dag_id = "dag_id"
        Job.task_instance.run_as_user = None
        Job.task_instance.command_as_list.return_value = [
            "airflow",
            "tasks",
            "run",
            "test_on_kill",
            "task1",
            "2016-01-01",
        ]
        job_runner = LocalTaskJobRunner(job=Job, task_instance=Job.task_instance)
        task_runner = StandardTaskRunner(job_runner)
>       task_runner.start()

tests/task/task_runner/test_standard_task_runner.py:472: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
airflow/task/task_runner/standard_task_runner.py:55: in start
    self.process = self._start_by_fork()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <airflow.task.task_runner.standard_task_runner.StandardTaskRunner object at 0xffff7768c640>

    def _start_by_fork(self):
        pid = os.fork()
        if pid:
            self.log.info("Started process %d to run task", pid)
            return psutil.Process(pid)
        else:
            # Start a new process group
            set_new_process_group()
            import signal
    
            signal.signal(signal.SIGINT, signal.SIG_DFL)
            signal.signal(signal.SIGTERM, signal.SIG_DFL)
    
            from airflow import settings
            from airflow.cli.cli_parser import get_parser
            from airflow.sentry import Sentry
    
            if not InternalApiConfig.get_use_internal_api():
                # Force a new SQLAlchemy session. We can't share open DB handles
                # between process. The cli code will re-create this as part of its
                # normal startup
>               settings.engine.pool.dispose()
E               AttributeError: 'NoneType' object has no attribute 'pool'

airflow/task/task_runner/standard_task_runner.py:90: AttributeError
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
