### PR TITLE
Remove 'legacy' definition for `CronDataIntervalTimetable`

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2495,17 +2495,16 @@ scheduler:
     create_cron_data_intervals:
       description: |
         Whether to create DAG runs that span an interval or one single point in time for cron schedules, when
-        a cron string is provided to `schedule` argument of a DAG. If True,
-        CronDataIntervalTimetable is used, which is the legacy Airflow behavior suitable
-        for DAGs with well-defined data_interval you get contiguous intervals from the end of the previous
-        interval up to the scheduled datetime. If False, CronTriggerTimetable is used,
-        which is closer to the behavior of cron itself.
+        a cron string is provided to ``schedule`` argument of a DAG.
 
-        Notably, for CronTriggerTimetable, the logical_date is the same as the time the DAG Run will try to
-        schedule, while for CronDataIntervalTimetable, the logical_date is the beginning of the data interval,
-        but the DAG Run will try to schedule at the end of the data interval. For more differences
-        between the two Timetables, see
-        https://airflow.apache.org/docs/apache-airflow/stable/authoring-and-scheduling/timetable.html#differences-between-the-two-cron-timetables
+        * ``True``: **CronDataIntervalTimetable** is used, which is suitable
+          for DAGs with well-defined data interval. You get contiguous intervals from the end of the previous
+          interval up to the scheduled datetime.
+        * ``False``: **CronTriggerTimetable** is used, which is closer to the behavior of cron itself.
+
+        Notably, for **CronTriggerTimetable**, the logical date is the same as the time the DAG Run will
+        try to schedule, while for **CronDataIntervalTimetable**, the logical date is the beginning of
+        the data interval, but the DAG Run will try to schedule at the end of the data interval.
       version_added: 2.9.0
       type: boolean
       example: ~


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

There is even no discussion / decision about default cron time table in Airflow 3, so use by default `CronDataIntervalTimetable` can't be considered to be a legacy behaviour


Also a bit reformat entire section and remove duplicate information which already exists in see also

**before**
![image](https://github.com/apache/airflow/assets/3998685/4bfab817-88f1-4670-bc81-156ee90c4386)

**after**
![image](https://github.com/apache/airflow/assets/3998685/f298fb45-2029-429d-a730-afcec433c773)


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
