### PR TITLE
[openlineage] typo: wrong OpenLineage facet key in spec

### DIFF
--- a/airflow/providers/google/cloud/openlineage/BigQueryErrorRunFacet.json
+++ b/airflow/providers/google/cloud/openlineage/BigQueryErrorRunFacet.json
@@ -23,7 +23,7 @@
     },
     "type": "object",
     "properties": {
-      "bigQueryJob": {
+      "bigQuery_error": {
         "$ref": "#/$defs/BigQueryErrorRunFacet"
       }
     }

--- a/airflow/providers/google/cloud/openlineage/utils.py
+++ b/airflow/providers/google/cloud/openlineage/utils.py
@@ -269,7 +269,7 @@ class _BigQueryOpenLineageMixin:
             if hasattr(self, "log"):
                 self.log.warning("Cannot retrieve job details from BigQuery.Client. %s", e, exc_info=True)
             exception_msg = traceback.format_exc()
-            # TODO: remove ErrorMessageRunFacet in next release
+            # TODO: remove BigQueryErrorRunFacet in next release
             run_facets.update(
                 {
                     "errorMessage": ErrorMessageRunFacet(
@@ -282,10 +282,6 @@ class _BigQueryOpenLineageMixin:
                 }
             )
         deduplicated_outputs = self._deduplicate_outputs(outputs)
-        # For complex scripts there can be multiple outputs - in that case keep them all in `outputs` and
-        # leave the `output` empty to avoid providing misleading information. When the script has a single
-        # output (f.e. a single statement with some variable declarations), treat it as a regular non-script
-        # job and put the output in `output` as an addition to new `outputs`. `output` is deprecated.
         return inputs, deduplicated_outputs, run_facets
 
     def _deduplicate_outputs(self, outputs: list[Dataset | None]) -> list[Dataset]:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Correcting a typo. Removing comment that relates to a previous behaviour, when returning an object with `output` and `outputs` attributes.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
