### PR TITLE
Fix example_branch_operator failing in python 3.12

### DIFF
--- a/airflow/example_dags/example_branch_operator.py
+++ b/airflow/example_dags/example_branch_operator.py
@@ -141,7 +141,7 @@ if is_venv_installed():
 
         branching_venv = BranchPythonVirtualenvOperator(
             task_id="branching_venv",
-            requirements=["numpy~=1.24.4"],
+            requirements=["numpy~=1.26.0"],
             venv_cache_path=VENV_CACHE_PATH,
             python_callable=branch_with_venv,
             op_args=[options],
@@ -162,7 +162,7 @@ if is_venv_installed():
         for option in options:
             t = PythonVirtualenvOperator(
                 task_id=f"venv_{option}",
-                requirements=["numpy~=1.24.4"],
+                requirements=["numpy~=1.26.0"],
                 venv_cache_path=VENV_CACHE_PATH,
                 python_callable=hello_world_with_venv,
             )


### PR DESCRIPTION
Recently, this dag started failing due to python 3.12 removal of some deprecated symbols. The fix here was moving to a higher version of numpy as the old version uses pinned setuptools

