### PR TITLE
s3togcs operator objects list compress

### DIFF
--- a/airflow/providers/google/cloud/transfers/s3_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/s3_to_gcs.py
@@ -108,6 +108,10 @@ class S3ToGCSOperator(S3ListOperator):
     :param deferrable: Run operator in the deferrable mode
     :param poll_interval: time in seconds between polling for job completion.
         The value is considered only when running in deferrable mode. Must be greater than 0.
+    :param num_element : number of times option to compression list.
+        If num_element < 1 : If num_element are negative, return s3_objects ( default )
+        Elif num_element = 0 : return []
+        Elif len(s3 list) <= 2 * num_element
 
     **Example**:
 
@@ -121,6 +125,7 @@ class S3ToGCSOperator(S3ListOperator):
            dest_gcs="gs://my.gcs.bucket/some/customers/",
            replace=False,
            gzip=True,
+           num_element=-1,
            dag=my_dag,
        )
 
@@ -154,6 +159,7 @@ class S3ToGCSOperator(S3ListOperator):
         google_impersonation_chain: str | Sequence[str] | None = None,
         deferrable=conf.getboolean("operators", "default_deferrable", fallback=False),
         poll_interval: int = 10,
+        num_element: int = -1,
         **kwargs,
     ):
         super().__init__(bucket=bucket, prefix=prefix, delimiter=delimiter, aws_conn_id=aws_conn_id, **kwargs)
@@ -168,6 +174,7 @@ class S3ToGCSOperator(S3ListOperator):
         if poll_interval <= 0:
             raise ValueError("Invalid value for poll_interval. Expected value greater than 0")
         self.poll_interval = poll_interval
+        self.num_element = num_element
 
     def _check_inputs(self) -> None:
         if self.dest_gcs and not gcs_object_is_directory(self.dest_gcs):
@@ -180,7 +187,7 @@ class S3ToGCSOperator(S3ListOperator):
                 'The destination Google Cloud Storage path must end with a slash "/" or be empty.'
             )
 
-    def execute(self, context: Context):
+    def execute(self, context: Context) -> list[str]:
         self._check_inputs()
         # use the super method to list all the files in an S3 bucket/key
         s3_objects = super().execute(context)
@@ -199,6 +206,7 @@ class S3ToGCSOperator(S3ListOperator):
             self.transfer_files_async(s3_objects, gcs_hook, s3_hook)
         else:
             self.transfer_files(s3_objects, gcs_hook, s3_hook)
+        s3_objects = self.compress_s3_object_list(s3_objects, self.num_element)
 
         return s3_objects
 
@@ -343,3 +351,16 @@ class S3ToGCSOperator(S3ListOperator):
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.google_impersonation_chain,
         )
+
+    def compress_s3_object_list(self, s3_objects: list[str], num: int) -> list[str]:
+        """s3 object list compression"""
+        if num < 0:
+            return s3_objects
+        elif num == 0:
+            return []
+        elif len(s3_objects) <= 2 * num:
+            return s3_objects
+        half = (num - 1) // 2
+
+        return s3_objects[:half] + ["..."] + s3_objects[-half:]
+


### PR DESCRIPTION
When using MySQL as a metadata database, while transferring thousands of S3 data files to GCS, the files are moved successfully, but when recording the paths of these files in the metadata (XCom), the length of the list of paths exceeds the MySQL BLOB length limit