### PR TITLE
Refresh properties on KubernetesPodOperator on token expiration also when logging

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -612,16 +612,7 @@ class KubernetesPodOperator(BaseOperator):
                     mode=ExecutionMode.SYNC,
                 )
 
-            if self.get_logs:
-                self.pod_manager.fetch_requested_container_logs(
-                    pod=self.pod,
-                    containers=self.container_logs,
-                    follow_logs=True,
-                )
-            if not self.get_logs or (
-                self.container_logs is not True and self.base_container_name not in self.container_logs
-            ):
-                self.await_container_completion(pod=self.pod, container_name=self.base_container_name)
+            self.await_container_completion(pod=self.pod)
             if self.callbacks:
                 self.callbacks.on_pod_completion(
                     pod=self.find_pod(self.pod.metadata.namespace, context=context),
@@ -654,9 +645,18 @@ class KubernetesPodOperator(BaseOperator):
         retry=tenacity.retry_if_exception(lambda exc: check_exception_is_kubernetes_api_unauthorized(exc)),
         reraise=True,
     )
-    def await_container_completion(self, pod: k8s.V1Pod, container_name: str):
+    def await_container_completion(self, pod: k8s.V1Pod):
         try:
-            self.pod_manager.await_container_completion(pod=pod, container_name=container_name)
+            if self.get_logs:
+                self.pod_manager.fetch_requested_container_logs(
+                    pod=pod,
+                    containers=self.container_logs,
+                    follow_logs=True,
+                )
+            if not self.get_logs or (
+                self.container_logs is not True and self.base_container_name not in self.container_logs
+            ):
+                self.pod_manager.await_container_completion(pod=pod, container_name=self.base_container_name)
         except kubernetes.client.exceptions.ApiException as exc:
             if exc.status and str(exc.status) == "401":
                 self.log.warning(

--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -612,7 +612,7 @@ class KubernetesPodOperator(BaseOperator):
                     mode=ExecutionMode.SYNC,
                 )
 
-            self.await_container_completion(pod=self.pod)
+            self.await_pod_completion(pod=self.pod)
             if self.callbacks:
                 self.callbacks.on_pod_completion(
                     pod=self.find_pod(self.pod.metadata.namespace, context=context),
@@ -645,7 +645,7 @@ class KubernetesPodOperator(BaseOperator):
         retry=tenacity.retry_if_exception(lambda exc: check_exception_is_kubernetes_api_unauthorized(exc)),
         reraise=True,
     )
-    def await_container_completion(self, pod: k8s.V1Pod):
+    def await_pod_completion(self, pod: k8s.V1Pod):
         try:
             if self.get_logs:
                 self.pod_manager.fetch_requested_container_logs(

--- a/tests/providers/cncf/kubernetes/operators/test_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_pod.py
@@ -1621,29 +1621,38 @@ class TestKubernetesPodOperator:
             "pod": remote_pod_mock,
         }
 
+    @pytest.mark.parametrize("get_logs", [True, False])
+    @patch(f"{POD_MANAGER_CLASS}.fetch_requested_container_logs")
     @patch(f"{POD_MANAGER_CLASS}.await_container_completion")
     def test_await_container_completion_refreshes_properties_on_exception(
-        self, mock_await_container_completion
+        self, mock_await_container_completion, fetch_requested_container_logs, get_logs
     ):
-        container_name = "base"
         k = KubernetesPodOperator(
             task_id="task",
+            get_logs=get_logs
         )
         pod = self.run_pod(k)
         client, hook, pod_manager = k.client, k.hook, k.pod_manager
 
         # no exception doesn't update properties
-        k.await_container_completion(pod, container_name=container_name)
+        k.await_container_completion(pod)
         assert client == k.client
         assert hook == k.hook
         assert pod_manager == k.pod_manager
 
         # exception refreshes properties
         mock_await_container_completion.side_effect = [ApiException(status=401), mock.DEFAULT]
-        k.await_container_completion(pod, container_name=container_name)
-        mock_await_container_completion.assert_has_calls(
-            [mock.call(pod=pod, container_name=container_name)] * 3
-        )
+        fetch_requested_container_logs.side_effect = [ApiException(status=401), mock.DEFAULT]
+        k.await_container_completion(pod)
+
+        if get_logs:
+            fetch_requested_container_logs.assert_has_calls(
+                [mock.call(pod=pod, containers=k.container_logs, follow_logs=True)] * 3
+            )
+        else:
+            mock_await_container_completion.assert_has_calls(
+                [mock.call(pod=pod, container_name=k.base_container_name)] * 3
+            )
         assert client != k.client
         assert hook != k.hook
         assert pod_manager != k.pod_manager
@@ -1662,20 +1671,20 @@ class TestKubernetesPodOperator:
     def test_await_container_completion_retries_on_specific_exception(
         self, mock_await_container_completion, side_effect, exception_type, expect_exc
     ):
-        container_name = "base"
         k = KubernetesPodOperator(
             task_id="task",
+            get_logs=False,
         )
         pod = self.run_pod(k)
         mock_await_container_completion.side_effect = side_effect
         if expect_exc:
-            k.await_container_completion(pod, container_name=container_name)
+            k.await_container_completion(pod)
         else:
             with pytest.raises(exception_type):
-                k.await_container_completion(pod, container_name=container_name)
+                k.await_container_completion(pod)
         expected_call_count = min(len(side_effect), 3)  # retry max 3 times
         mock_await_container_completion.assert_has_calls(
-            [mock.call(pod=pod, container_name=container_name)] * expected_call_count
+            [mock.call(pod=pod, container_name=k.base_container_name)] * expected_call_count
         )
 
 

--- a/tests/providers/cncf/kubernetes/operators/test_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_pod.py
@@ -1627,10 +1627,7 @@ class TestKubernetesPodOperator:
     def test_await_container_completion_refreshes_properties_on_exception(
         self, mock_await_container_completion, fetch_requested_container_logs, get_logs
     ):
-        k = KubernetesPodOperator(
-            task_id="task",
-            get_logs=get_logs
-        )
+        k = KubernetesPodOperator(task_id="task", get_logs=get_logs)
         pod = self.run_pod(k)
         client, hook, pod_manager = k.client, k.hook, k.pod_manager
 

--- a/tests/providers/cncf/kubernetes/operators/test_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_pod.py
@@ -1632,7 +1632,7 @@ class TestKubernetesPodOperator:
         client, hook, pod_manager = k.client, k.hook, k.pod_manager
 
         # no exception doesn't update properties
-        k.await_container_completion(pod)
+        k.await_pod_completion(pod)
         assert client == k.client
         assert hook == k.hook
         assert pod_manager == k.pod_manager
@@ -1640,7 +1640,7 @@ class TestKubernetesPodOperator:
         # exception refreshes properties
         mock_await_container_completion.side_effect = [ApiException(status=401), mock.DEFAULT]
         fetch_requested_container_logs.side_effect = [ApiException(status=401), mock.DEFAULT]
-        k.await_container_completion(pod)
+        k.await_pod_completion(pod)
 
         if get_logs:
             fetch_requested_container_logs.assert_has_calls(
@@ -1675,10 +1675,10 @@ class TestKubernetesPodOperator:
         pod = self.run_pod(k)
         mock_await_container_completion.side_effect = side_effect
         if expect_exc:
-            k.await_container_completion(pod)
+            k.await_pod_completion(pod)
         else:
             with pytest.raises(exception_type):
-                k.await_container_completion(pod)
+                k.await_pod_completion(pod)
         expected_call_count = min(len(side_effect), 3)  # retry max 3 times
         mock_await_container_completion.assert_has_calls(
             [mock.call(pod=pod, container_name=k.base_container_name)] * expected_call_count


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This is a follow-up on this pr: https://github.com/apache/airflow/pull/39325.

The above PR addressed [an issue](https://github.com/apache/airflow/issues/32718) for which `KubernetesPodOperator` properties were refreshed on auth-token expiration.

This PR covers also the `get_logs=True` case, which was not covered by the previous change, aiming at fixing this exception:

```
Traceback (most recent call last):
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/airflow/providers/cncf/kubernetes/operators/pod.py", line 615, in execute_sync
    self.pod_manager.fetch_requested_container_logs(
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/airflow/providers/cncf/kubernetes/utils/pod_manager.py", line 587, in fetch_requested_container_logs
    status = self.fetch_container_logs(pod=pod, container_name=c, follow=follow_logs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/airflow/providers/cncf/kubernetes/utils/pod_manager.py", line 511, in fetch_container_logs
    if not self.container_is_running(pod, container_name=container_name):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/airflow/providers/cncf/kubernetes/utils/pod_manager.py", line 645, in container_is_running
    remote_pod = self.read_pod(pod)
  [...]
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/kubernetes/client/api_client.py", line 180, in __call_api
    response_data = self.request(
                    ^^^^^^^^^^^^^
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/kubernetes/client/api_client.py", line 373, in request
    return self.rest_client.GET(url,
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/kubernetes/client/rest.py", line 244, in GET
    return self.request("GET", url,
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/airflow/.local/lib/python3.11/site-packages/kubernetes/client/rest.py", line 238, in request
    raise ApiException(http_resp=r)
kubernetes.client.exceptions.ApiException: (401)
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
