### PR TITLE
Change `httpx` to `requests` in `file_task_handler`

### DIFF
--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -86,7 +86,7 @@ def _set_task_deferred_context_var():
 
 def _fetch_logs_from_service(url, log_relative_path):
     # Import occurs in function scope for perf. Ref: https://github.com/apache/airflow/pull/21438
-    import httpx
+    import requests
 
     from airflow.utils.jwt_signer import JWTSigner
 
@@ -96,7 +96,7 @@ def _fetch_logs_from_service(url, log_relative_path):
         expiration_time_in_seconds=conf.getint("webserver", "log_request_clock_grace", fallback=30),
         audience="task-instance-logs",
     )
-    response = httpx.get(
+    response = requests.get(
         url,
         timeout=timeout,
         headers={"Authorization": signer.generate_signed_token({"filename": log_relative_path})},
@@ -574,9 +574,9 @@ class FileTaskHandler(logging.Handler):
                 messages.append(f"Found logs served from host {url}")
                 logs.append(response.text)
         except Exception as e:
-            from httpx import UnsupportedProtocol
+            from requests.exceptions import InvalidSchema
 
-            if isinstance(e, UnsupportedProtocol) and ti.task.inherits_from_empty_operator is True:
+            if isinstance(e, InvalidSchema) and ti.task.inherits_from_empty_operator is True:
                 messages.append(self.inherits_from_empty_operator_log_message)
             else:
                 messages.append(f"Could not read served logs: {e}")

--- a/tests/utils/test_log_handlers.py
+++ b/tests/utils/test_log_handlers.py
@@ -789,29 +789,10 @@ log_location = "dag_id=sample/run_id=manual__2024-05-23T07:18:59.298882+00:00/ta
 log_url = f"{worker_url}/log/{log_location}"
 
 
-@pytest.fixture
-def http_proxy():
-    _origin_http_proxy = os.getenv("http_proxy") or ""
-    os.environ["http_proxy"] = "http://proxy.example.com"
-    yield
-    os.environ["http_proxy"] = _origin_http_proxy
-
-
-@pytest.fixture
-def no_proxy():
-    _origin_no_proxy = os.getenv("no_proxy") or ""
-
-    def _set_no_proxy(values):
-        os.environ["no_proxy"] = values
-
-    yield _set_no_proxy
-    os.environ["no_proxy"] = _origin_no_proxy
-
-
 @mock.patch("requests.adapters.HTTPAdapter.send")
-@pytest.mark.usefixtures("http_proxy")
-def test_fetch_logs_from_service_with_not_matched_no_proxy(mock_send, no_proxy):
-    no_proxy("localhost")
+def test_fetch_logs_from_service_with_not_matched_no_proxy(mock_send, monkeypatch):
+    monkeypatch.setenv("http_proxy", "http://proxy.example.com")
+    monkeypatch.setenv("no_proxy", "localhost")
 
     response = Response()
     response.status_code = HTTPStatus.OK
@@ -828,9 +809,9 @@ def test_fetch_logs_from_service_with_not_matched_no_proxy(mock_send, no_proxy):
 
 
 @mock.patch("requests.adapters.HTTPAdapter.send")
-@pytest.mark.usefixtures("http_proxy")
-def test_fetch_logs_from_service_with_cidr_no_proxy(mock_send, no_proxy):
-    no_proxy("10.0.0.0/8")
+def test_fetch_logs_from_service_with_cidr_no_proxy(mock_send, monkeypatch):
+    monkeypatch.setenv("http_proxy", "http://proxy.example.com")
+    monkeypatch.setenv("no_proxy", "10.0.0.0/8")
 
     response = Response()
     response.status_code = HTTPStatus.OK


### PR DESCRIPTION
closes: #39794 

- httpx does not support CIDRs in NO_PROXY
- simply, it is fixed by converting `httpx` to `requests`
- related issue: https://github.com/apache/airflow/issues/39794

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
