### PR TITLE
Added get_extra_dejson method with nested parameter in Connection

### DIFF
--- a/tests/models/test_connection.py
+++ b/tests/models/test_connection.py
@@ -250,3 +250,26 @@ class TestConnection:
     # string works as expected.
     def test_sanitize_conn_id(self, connection, expected_conn_id):
         assert connection.conn_id == expected_conn_id
+
+    def test_extra_dejson(self):
+        extra = (
+            '{"trust_env": false, "verify": false, "stream": true, "headers":'
+            '{\r\n "Content-Type": "application/json",\r\n  "X-Requested-By": "Airflow"\r\n}}'
+        )
+        connection = Connection(
+            conn_id="pokeapi",
+            conn_type="http",
+            login="user",
+            password="pass",
+            host="https://pokeapi.co/",
+            port=100,
+            schema="https",
+            extra=extra,
+        )
+
+        assert connection.extra_dejson == {
+            "trust_env": False,
+            "verify": False,
+            "stream": True,
+            "headers": {"Content-Type": "application/json", "X-Requested-By": "Airflow"},
+        }


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: [#35591](https://github.com/apache/airflow/pull/35591/)

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This new method allows you to specify if you want the nested json as string to be also deserialized.  The already existing extra_dejson property delegates to this method with nested set to False, as this is the default behaviour (nested json strings don't get deserialized by default).  This is a PR in preparation of [#35591](https://github.com/apache/airflow/pull/35591/), as it has become to big, we're going to split it up in smaller ones.  This is one of them.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
