### PR TITLE
Fix MyPy checks in CI to cover also tests folders

### DIFF
--- a/scripts/ci/pre_commit/mypy_folder.py
+++ b/scripts/ci/pre_commit/mypy_folder.py
@@ -44,7 +44,31 @@ if mypy_folder not in ALLOWED_FOLDERS:
 
 arguments = [mypy_folder]
 if mypy_folder == "airflow/providers":
-    arguments.append("--namespace-packages")
+    arguments.extend(
+        [
+            "tests/providers",
+            "tests/system/providers",
+            "tests/integration/providers",
+            "--namespace-packages",
+        ]
+    )
+
+if mypy_folder == "airflow":
+    arguments.extend(
+        [
+            "tests",
+            "--exclude",
+            "airflow/providers",
+            "--exclude",
+            "tests/providers",
+            "--exclude",
+            "tests/system/providers",
+            "--exclude",
+            "tests/integration/providers",
+        ]
+    )
+
+print("Running /opt/airflow/scripts/in_container/run_mypy.sh with arguments: ", arguments)
 
 res = run_command_via_breeze_shell(
     [


### PR DESCRIPTION
To speed up the checks In CI we run mypy checks in parallel, so we split it by folder rather than by files letting mypy to discover or pass all files.

This is done via `manual` stage of the mypy-* checks.

However we have not included / excluded tests in the checks between airflow and providers.

This PR should fix the problem where some of the tests might have typing errors and if the user did not run it manually, they could go undetected.

We also explicitly exclude all "providers" related tests. While the regular providers do not need to be skipped because there was no `--namespace-packages` added as mypy flag, test packages are regular packages and they should be excluded explicitly.

Finally the command to run is printed in the output of the mypy check.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
