### PR TITLE
standardizes template fields for `BaseSQLOperator` and adds `database` as a templated field

### DIFF
--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -141,7 +141,7 @@ class BaseSQLOperator(BaseOperator):
         super().__init__(**kwargs)
         self.conn_id = conn_id
         self.database = database
-        self.hook_params = {} if hook_params is None else hook_params
+        self.hook_params = hook_params or {}
         self.retry_on_failure = retry_on_failure
 
     @cached_property

--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -127,6 +127,8 @@ class BaseSQLOperator(BaseOperator):
 
     conn_id_field = "conn_id"
 
+    template_fields: Sequence[str] = ("conn_id", "database", "hook_params")
+
     def __init__(
         self,
         *,
@@ -220,7 +222,7 @@ class SQLExecuteQueryOperator(BaseSQLOperator):
         :ref:`howto/operator:SQLExecuteQueryOperator`
     """
 
-    template_fields: Sequence[str] = ("conn_id", "sql", "parameters", "hook_params")
+    template_fields: Sequence[str] = ("sql", "parameters", *BaseSQLOperator.template_fields)
     template_ext: Sequence[str] = (".sql", ".json")
     template_fields_renderers = {"sql": "sql", "parameters": "json"}
     ui_color = "#cdaaed"
@@ -425,7 +427,7 @@ class SQLColumnCheckOperator(BaseSQLOperator):
         :ref:`howto/operator:SQLColumnCheckOperator`
     """
 
-    template_fields: Sequence[str] = ("partition_clause", "table", "sql", "hook_params")
+    template_fields: Sequence[str] = ("table", "partition_clause", "sql", *BaseSQLOperator.template_fields)
     template_fields_renderers = {"sql": "sql"}
 
     sql_check_template = """
@@ -653,7 +655,7 @@ class SQLTableCheckOperator(BaseSQLOperator):
         :ref:`howto/operator:SQLTableCheckOperator`
     """
 
-    template_fields: Sequence[str] = ("partition_clause", "table", "sql", "conn_id", "hook_params")
+    template_fields: Sequence[str] = ("table", "partition_clause", "sql", *BaseSQLOperator.template_fields)
 
     template_fields_renderers = {"sql": "sql"}
 
@@ -769,7 +771,7 @@ class SQLCheckOperator(BaseSQLOperator):
     :param parameters: (optional) the parameters to render the SQL query with.
     """
 
-    template_fields: Sequence[str] = ("sql", "hook_params")
+    template_fields: Sequence[str] = ("sql", *BaseSQLOperator.template_fields)
     template_ext: Sequence[str] = (
         ".hql",
         ".sql",
@@ -815,11 +817,7 @@ class SQLValueCheckOperator(BaseSQLOperator):
     """
 
     __mapper_args__ = {"polymorphic_identity": "SQLValueCheckOperator"}
-    template_fields: Sequence[str] = (
-        "sql",
-        "pass_value",
-        "hook_params",
-    )
+    template_fields: Sequence[str] = ("sql", "pass_value", *BaseSQLOperator.template_fields)
     template_ext: Sequence[str] = (
         ".hql",
         ".sql",
@@ -916,7 +914,7 @@ class SQLIntervalCheckOperator(BaseSQLOperator):
     """
 
     __mapper_args__ = {"polymorphic_identity": "SQLIntervalCheckOperator"}
-    template_fields: Sequence[str] = ("sql1", "sql2", "hook_params")
+    template_fields: Sequence[str] = ("sql1", "sql2", *BaseSQLOperator.template_fields)
     template_ext: Sequence[str] = (
         ".hql",
         ".sql",
@@ -1044,7 +1042,12 @@ class SQLThresholdCheckOperator(BaseSQLOperator):
     :param max_threshold: numerical value or max threshold sql to be executed (templated)
     """
 
-    template_fields: Sequence[str] = ("sql", "min_threshold", "max_threshold", "hook_params")
+    template_fields: Sequence[str] = (
+        "sql",
+        "min_threshold",
+        "max_threshold",
+        *BaseSQLOperator.template_fields,
+    )
     template_ext: Sequence[str] = (
         ".hql",
         ".sql",
@@ -1142,7 +1145,7 @@ class BranchSQLOperator(BaseSQLOperator, SkipMixin):
     :param parameters: (optional) the parameters to render the SQL query with.
     """
 
-    template_fields: Sequence[str] = ("sql",)
+    template_fields: Sequence[str] = ("sql", *BaseSQLOperator.template_fields)
     template_ext: Sequence[str] = (".sql",)
     template_fields_renderers = {"sql": "sql"}
     ui_color = "#a22034"

--- a/airflow/providers/common/sql/operators/sql.pyi
+++ b/airflow/providers/common/sql/operators/sql.pyi
@@ -54,6 +54,7 @@ def parse_boolean(val: str) -> str | bool: ...
 
 class BaseSQLOperator(BaseOperator):
     conn_id_field: str
+    template_fields: Sequence[str]
     conn_id: Incomplete
     database: Incomplete
     hook_params: Incomplete

--- a/tests/providers/common/sql/operators/test_sql.py
+++ b/tests/providers/common/sql/operators/test_sql.py
@@ -29,6 +29,7 @@ from airflow.models import Connection, DagRun, TaskInstance as TI, XCom
 from airflow.operators.empty import EmptyOperator
 from airflow.providers.common.sql.hooks.sql import fetch_all_handler
 from airflow.providers.common.sql.operators.sql import (
+    BaseSQLOperator,
     BranchSQLOperator,
     SQLCheckOperator,
     SQLColumnCheckOperator,
@@ -57,6 +58,28 @@ class MockHook:
 
 def _get_mock_db_hook():
     return MockHook()
+
+
+class TestBaseSQLOperator:
+    def _construct_operator(self, **kwargs):
+        dag = DAG("test_dag", start_date=datetime.datetime(2017, 1, 1), render_template_as_native_obj=True)
+        return BaseSQLOperator(
+            task_id="test_task",
+            conn_id="{{ conn_id }}",
+            database="{{ database }}",
+            hook_params="{{ hook_params }}",
+            **kwargs,
+            dag=dag,
+        )
+
+    def test_templated_fields(self):
+        operator = self._construct_operator()
+        operator.render_template_fields(
+            {"conn_id": "my_conn_id", "database": "my_database", "hook_params": {"key": "value"}}
+        )
+        assert operator.conn_id == "my_conn_id"
+        assert operator.database == "my_database"
+        assert operator.hook_params == {"key": "value"}
 
 
 class TestSQLExecuteQueryOperator:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This pull request standardizes the template fields for the `BaseSQLOperator` and the operators that inherit from it. It also makes the `database` argument as a templated field so that this example DAG can work.

```python


from airflow.models import DAG
from airflow.operators.python import PythonOperator
from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator

with DAG(
    dag_id="sql_query",
    description="Makes an SQL query to a database",
    schedule_interval=None,
    catchup=False,
) as dag:
    get_database = PythonOperator(
        task_id="get_database",
        python_callable=lambda: "postgres",
    )

    make_sql_query = SQLExecuteQueryOperator(
        task_id="make_sql_query",
        conn_id="my_conn_id",
        sql="SELECT datname FROM pg_database;",
        database=get_database.output,
    )

    get_database >> make_sql_query
```



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
