### PR TITLE
Bump docker version to 7.1.0

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1007,12 +1007,9 @@ function check_boto_upgrade() {
     ${PACKAGING_TOOL_CMD} uninstall ${EXTRA_UNINSTALL_FLAGS} aiobotocore s3fs || true
     # We need to include oss2 as dependency as otherwise jmespath will be bumped and it will not pass
     # the pip check test, Similarly gcloud-aio-auth limit is needed to be included as it bumps cryptography
-    # Also until docker-py compatibility with requests 2.32 is fixed we need to limit requests version
-    # Should be removed after  https://github.com/docker/docker-py/issues/3256 together with removal of similar
-    # limitation in providers/docker/pyproject.toml
     # shellcheck disable=SC2086
     ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} --upgrade boto3 botocore \
-       "oss2>=2.14.0" "gcloud-aio-auth>=4.0.0,<5.0.0" "requests<2.32.0"
+       "oss2>=2.14.0" "gcloud-aio-auth>=4.0.0,<5.0.0"
     pip check
 }
 

--- a/airflow/providers/docker/provider.yaml
+++ b/airflow/providers/docker/provider.yaml
@@ -68,13 +68,8 @@ versions:
 
 dependencies:
   - apache-airflow>=2.7.0
-  - docker>=6
+  - docker>=7.1.0
   - python-dotenv>=0.21.0
-  # requests 2.32.0 has an incompatibility with python lib docker
-  # https://github.com/psf/requests/issues/6707 and https://github.com/docker/docker-py/issues/3256
-  # once resolved remove this dependency and bump docker-py version
-  # !!!!! Make sure to also remove it from the scripts/docker/entrypoint_ci.sh !!!!!
-  - requests>=2.27.0,<2.32.0
 
 integrations:
   - integration-name: Docker

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -479,9 +479,8 @@
   "docker": {
     "deps": [
       "apache-airflow>=2.7.0",
-      "docker>=6",
-      "python-dotenv>=0.21.0",
-      "requests>=2.27.0,<2.32.0"
+      "docker>=7.1.0",
+      "python-dotenv>=0.21.0"
     ],
     "devel-deps": [],
     "plugins": [],

--- a/scripts/docker/entrypoint_ci.sh
+++ b/scripts/docker/entrypoint_ci.sh
@@ -227,12 +227,9 @@ function check_boto_upgrade() {
     ${PACKAGING_TOOL_CMD} uninstall ${EXTRA_UNINSTALL_FLAGS} aiobotocore s3fs || true
     # We need to include oss2 as dependency as otherwise jmespath will be bumped and it will not pass
     # the pip check test, Similarly gcloud-aio-auth limit is needed to be included as it bumps cryptography
-    # Also until docker-py compatibility with requests 2.32 is fixed we need to limit requests version
-    # Should be removed after  https://github.com/docker/docker-py/issues/3256 together with removal of similar
-    # limitation in providers/docker/pyproject.toml
     # shellcheck disable=SC2086
     ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} --upgrade boto3 botocore \
-       "oss2>=2.14.0" "gcloud-aio-auth>=4.0.0,<5.0.0" "requests<2.32.0"
+       "oss2>=2.14.0" "gcloud-aio-auth>=4.0.0,<5.0.0"
     pip check
 }
 


### PR DESCRIPTION
[docker 7.1.0](https://github.com/docker/docker-py/releases/tag/7.1.0) is released with the needed bugfix to update request package

> Fixed an issue due to an update in the [requests](https://github.com/psf/requests) package breaking docker-py by applying the https://github.com/psf/requests/pull/6710