### PR TITLE
Image used for k8s tests copies airflow sources with airflow user

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
@@ -596,17 +596,19 @@ def _rebuild_k8s_image(
         f"airflow base image: {params.airflow_image_name_with_tag}\n"
     )
     if copy_local_sources:
-        extra_copy_command = "COPY . /opt/airflow/"
+        extra_copy_command = "COPY --chown=airflow:0 . /opt/airflow/"
     else:
         extra_copy_command = ""
     docker_image_for_kubernetes_tests = f"""
 FROM {params.airflow_image_name_with_tag}
 
+USER airflow
+
 {extra_copy_command}
 
-COPY airflow/example_dags/ /opt/airflow/dags/
+COPY --chown=airflow:0 airflow/example_dags/ /opt/airflow/dags/
 
-COPY airflow/providers/cncf/kubernetes/kubernetes_executor_templates/ /opt/airflow/pod_templates/
+COPY --chown=airflow:0 airflow/providers/cncf/kubernetes/kubernetes_executor_templates/ /opt/airflow/pod_templates/
 
 ENV GUNICORN_CMD_ARGS='--preload' AIRFLOW__WEBSERVER__WORKER_REFRESH_INTERVAL=0
 """


### PR DESCRIPTION
When you have localy umask set to 077 or similar (disallowing group access), the PROD image used to run k8s tests was not working properly. The files copied to k8s image when preparing k8s image for local testing were copied using `root` user. This worked with no problems when group read access was set (umask 022 or 002 is usually set by defailt). But when someone had umask set to disable group read access when checking out the repository (077 or similar) then the files copied to the K8s image had no group read access and airflow failed with strange "import error".

This PR adds `--chown airflow:0` to all files copied when k8s image is prepared and makes sure that airflow user is set by default. This should work regardless of the umask setting (as long as the host owner has read access to checked out repository).

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
