### PR TITLE
Add a warning message to KPO to warn of one second interval logs duplication

### DIFF
--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -516,7 +516,7 @@ class PodManager(LoggingMixin):
                 # a timeout is a normal thing and we ignore it and resume following logs
                 if not isinstance(exc, TimeoutError):
                     self.log.warning(
-                        "Pod %s log read interrupted but container %s still running",
+                        "Pod %s log read interrupted but container %s still running. Logs generated in the last one second might get duplicated.",
                         pod.metadata.name,
                         container_name,
                     )


### PR DESCRIPTION
Add a warning message to KPO to warn of one second interval logs duplication.

The KubernetesPodOperator is duplicating the last one second logs when a pod is interrupted, and this is because the logs reading method in the Kubernetes python client takes a since_seconds parameter, and doesn't support passing a finer-grained time representation (See [here](https://github.com/kubernetes-client/python/issues/1351) for context). The optimal fix requires a change in Kubernetes Python client.
As a quick win, we added a warning message to warn users that logs that the last second logs before the container was interrupted might get duplicated.

closes: #39236
related: #33500 
