### PR TITLE
Add support for external IdP OIDC token retrieval for Google Cloud Operators.

### DIFF
--- a/airflow/providers/google/cloud/utils/credentials_provider.py
+++ b/airflow/providers/google/cloud/utils/credentials_provider.py
@@ -461,7 +461,9 @@ def _get_project_id_from_service_account_email(service_account_email: str) -> st
         )
 
 
-def _get_info_from_credential_configuration_file(credential_configuration_file: str | dict[str, str]) -> dict[str, str]:
+def _get_info_from_credential_configuration_file(
+    credential_configuration_file: str | dict[str, str],
+) -> dict[str, str]:
     """
     Extract the Credential Configuration File information, either from a json file, json string or dictionary.
 
@@ -472,20 +474,23 @@ def _get_info_from_credential_configuration_file(credential_configuration_file: 
     # if it's already a dict, just return it
     if isinstance(credential_configuration_file, dict):
         return credential_configuration_file
-    
-    if not isinstance(credential_configuration_file, str):
-        raise AirflowException("Invalid argument type, expected str or dict, got {}.".format(type(credential_configuration_file)))
 
-    if os.path.exists(credential_configuration_file): # attempts to load from json file 
+    if not isinstance(credential_configuration_file, str):
+        raise AirflowException(
+            f"Invalid argument type, expected str or dict, got {type(credential_configuration_file)}."
+        )
+
+    if os.path.exists(credential_configuration_file):  # attempts to load from json file
         with open(credential_configuration_file) as file_obj:
             try:
                 return json.load(file_obj)
             except ValueError:
-                raise AirflowException("Credential Configuration File '{}' is not a valid json file.".format(credential_configuration_file))
+                raise AirflowException(
+                    f"Credential Configuration File '{credential_configuration_file}' is not a valid json file."
+                )
 
-    # if not a file, attempt to load it from a json string 
+    # if not a file, attempt to load it from a json string
     try:
         return json.loads(credential_configuration_file)
     except ValueError:
         raise AirflowException("Credential Configuration File is not a valid json string.")
-    

--- a/airflow/providers/google/cloud/utils/credentials_provider.py
+++ b/airflow/providers/google/cloud/utils/credentials_provider.py
@@ -35,6 +35,9 @@ from google.auth.environment_vars import CREDENTIALS, LEGACY_PROJECT, PROJECT
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud._internal_client.secret_manager_client import _SecretManagerClient
+from airflow.providers.google.cloud.utils.external_token_supplier import (
+    ClientCredentialsGrantFlowTokenSupplier,
+)
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.process_utils import patch_environ
 
@@ -210,6 +213,10 @@ class _CredentialProvider(LoggingMixin):
         target_principal: str | None = None,
         delegates: Sequence[str] | None = None,
         is_anonymous: bool | None = None,
+        idp_issuer_url: str | None = None,
+        client_id: str | None = None,
+        client_secret: str | None = None,
+        idp_extra_params_dict: dict[str, str] | None = None,
     ) -> None:
         super().__init__()
         key_options = [key_path, keyfile_dict, credential_config_file, key_secret_name, is_anonymous]
@@ -229,6 +236,10 @@ class _CredentialProvider(LoggingMixin):
         self.target_principal = target_principal
         self.delegates = delegates
         self.is_anonymous = is_anonymous
+        self.idp_issuer_url = idp_issuer_url
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.idp_extra_params_dict = idp_extra_params_dict
 
     def get_credentials_and_project(self) -> tuple[Credentials, str]:
         """
@@ -248,6 +259,10 @@ class _CredentialProvider(LoggingMixin):
                 credentials, project_id = self._get_credentials_using_key_secret_name()
             elif self.keyfile_dict:
                 credentials, project_id = self._get_credentials_using_keyfile_dict()
+            elif self.idp_issuer_url:
+                credentials, project_id = (
+                    self._get_credentials_using_credential_config_file_and_token_supplier()
+                )
             elif self.credential_config_file:
                 credentials, project_id = self._get_credentials_using_credential_config_file()
             else:
@@ -357,6 +372,24 @@ class _CredentialProvider(LoggingMixin):
 
         return credentials, project_id
 
+    def _get_credentials_using_credential_config_file_and_token_supplier(self):
+        self._log_info(
+            "Getting connection using credential configuration file and external Identity Provider."
+        )
+
+        if not self.credential_config_file:
+            raise AirflowException(
+                "Credential configuration is needed to use authentication by External Identity Provider."
+            )
+
+        info = _get_info_from_credential_configuration_file(self.credential_config_file)
+        info["subject_token_supplier"] = ClientCredentialsGrantFlowTokenSupplier(
+            oidc_issuer_url=self.idp_issuer_url, client_id=self.client_id, client_secret=self.client_secret
+        )
+
+        credentials, project_id = google.auth.load_credentials_from_dict(info=info, scopes=self.scopes)
+        return credentials, project_id
+
     def _get_credentials_using_adc(self) -> tuple[Credentials, str]:
         self._log_info(
             "Getting connection using `google.auth.default()` since no explicit credentials are provided."
@@ -426,3 +459,18 @@ def _get_project_id_from_service_account_email(service_account_email: str) -> st
         raise AirflowException(
             f"Could not extract project_id from service account's email: {service_account_email}."
         )
+
+
+def _get_info_from_credential_configuration_file(credential_configuration_file):
+    if isinstance(credential_configuration_file, str) and os.path.exists(credential_configuration_file):
+        with open(credential_configuration_file) as file_obj:
+            try:
+                info = json.load(file_obj)
+            except ValueError:
+                raise AirflowException("Credentials Configuration File is not a valid json file.")
+    else:
+        try:
+            info = json.loads(credential_configuration_file)
+        except json.decoder.JSONDecodeError:
+            raise AirflowException("Invalid JSON.")
+    return info

--- a/airflow/providers/google/cloud/utils/external_token_supplier.py
+++ b/airflow/providers/google/cloud/utils/external_token_supplier.py
@@ -1,0 +1,146 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import time
+from functools import wraps
+from typing import TYPE_CHECKING, Any
+
+import requests
+from google.auth.exceptions import RefreshError
+from google.auth.identity_pool import SubjectTokenSupplier
+
+if TYPE_CHECKING:
+    from google.auth.external_account import SupplierContext
+    from google.auth.transport import Request
+
+from airflow.utils.log.logging_mixin import LoggingMixin
+
+
+def cache_token_decorator(get_subject_token_method):
+    """Cache calls to ``SubjectTokenSupplier`` instances' ``get_token_supplier`` methods.
+
+    Different instances of a same SubjectTokenSupplier class with the same credentials and oidc issuer url
+    share access tokens.
+
+    :param get_subject_token_method: A method that returns both a token and an integer specifying
+        the time in seconds until the token expires
+
+    See also:
+        https://googleapis.dev/python/google-auth/latest/reference/google.auth.identity_pool.html#google.auth.identity_pool.SubjectTokenSupplier.get_subject_token
+    """
+    cache = {}
+
+    @wraps(get_subject_token_method)
+    def wrapper(supplier_instance: SubjectTokenSupplier, *args, **kwargs) -> str:
+        """Obeys the interface set by ``SubjectTokenSupplier`` for ``get_subject_token`` methods.
+
+        :param supplier_instance: the SubjectTokenSupplier instance whose get_subject_token method is being decorated
+        :return: The token string
+        """
+        nonlocal cache
+
+        cache_key = (
+            supplier_instance.oidc_issuer_url
+            + supplier_instance.client_id
+            + supplier_instance.client_secret
+            + ",".join(sorted(supplier_instance.extra_params_kwargs))
+        )
+        token: dict[str, str | float] = {}
+
+        if cache_key not in cache or cache[cache_key]["expiration_time"] < time.monotonic():
+            supplier_instance.log.info("OIDC token missing or expired")
+            try:
+                access_token, expires_in = get_subject_token_method(supplier_instance, *args, **kwargs)
+                if not isinstance(expires_in, int) or not isinstance(access_token, str):
+                    raise RefreshError  # assume error if strange values are provided
+
+            except RefreshError:
+                supplier_instance.log.error("Failed retrieving new OIDC Token from IdP")
+                raise
+
+            expiration_time = time.monotonic() + float(expires_in)
+            token["access_token"] = access_token
+            token["expiration_time"] = expiration_time
+            cache[cache_key] = token
+
+            supplier_instance.log.info("New OIDC token retrieved, expires in %s seconds.", expires_in)
+
+        return cache[cache_key]["access_token"]
+
+    return wrapper
+
+
+class ClientCredentialsGrantFlowTokenSupplier(LoggingMixin, SubjectTokenSupplier):
+    """
+    Class that retrieves an OIDC token from an external IdP using OAuth2.0 Client Credentials Grant flow.
+
+    This class implements the ``SubjectTokenSupplier`` interface class used by ``google.auth.identity_pool.Credentials``
+
+    :params oidc_issuer_url: URL of the IdP that performs OAuth2.0 Client Credentials Grant flow and returns an OIDC token.
+    :params client_id: Client ID of the application requesting the token
+    :params client_secret: Client secret of the application requesting the token
+    :params extra_params_kwargs: Extra parameters to be passed in the payload of the POST request to the `oidc_issuer_url`
+
+    See also:
+        https://googleapis.dev/python/google-auth/latest/reference/google.auth.identity_pool.html#google.auth.identity_pool.SubjectTokenSupplier
+    """
+
+    def __init__(
+        self,
+        oidc_issuer_url: str,
+        client_id: str,
+        client_secret: str,
+        **extra_params_kwargs: Any,
+    ) -> None:
+        super().__init__()
+        self.oidc_issuer_url = oidc_issuer_url
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.extra_params_kwargs = extra_params_kwargs
+
+    @cache_token_decorator
+    def get_subject_token(self, context: SupplierContext, request: Request) -> tuple[str, int]:
+        """Perform Client Credentials Grant flow with IdP and retrieves an OIDC token and expiration time."""
+        self.log.info("Requesting new OIDC token from external IdP.")
+        try:
+            response = requests.post(
+                self.oidc_issuer_url,
+                data={
+                    "grant_type": "client_credentials",
+                    "client_id": self.client_id,
+                    "client_secret": self.client_secret,
+                    **self.extra_params_kwargs,
+                },
+            )
+            response.raise_for_status()
+        except requests.HTTPError as e:
+            raise RefreshError(str(e))
+        except requests.ConnectionError as e:
+            raise RefreshError(str(e))
+
+        try:
+            response_dict = response.json()
+        except requests.JSONDecodeError:
+            raise RefreshError(f"Didn't get a json response from {self.oidc_issuer_url}")
+
+        # These fields are required
+        if {"access_token", "expires_in"} - set(response_dict.keys()):
+            # TODO more information about the error can be provided in the exception by inspecting the response
+            raise RefreshError(f"No access token returned from {self.oidc_issuer_url}")
+
+        return response_dict["access_token"], response_dict["expires_in"]

--- a/airflow/providers/google/cloud/utils/external_token_supplier.py
+++ b/airflow/providers/google/cloud/utils/external_token_supplier.py
@@ -34,8 +34,8 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 def cache_token_decorator(get_subject_token_method):
     """Cache calls to ``SubjectTokenSupplier`` instances' ``get_token_supplier`` methods.
 
-    Different instances of a same SubjectTokenSupplier class with the same credentials and oidc issuer url
-    share access tokens.
+    Different instances of a same SubjectTokenSupplier class with the same attributes
+    share the OIDC token cache.
 
     :param get_subject_token_method: A method that returns both a token and an integer specifying
         the time in seconds until the token expires

--- a/tests/providers/google/cloud/utils/test_external_token_supplier.py
+++ b/tests/providers/google/cloud/utils/test_external_token_supplier.py
@@ -1,0 +1,135 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest.mock import ANY
+
+import pytest
+import requests_mock
+from google.auth.exceptions import RefreshError
+
+from airflow.providers.google.cloud.utils.external_token_supplier import (
+    ClientCredentialsGrantFlowTokenSupplier,
+)
+
+MOCK_URL1 = "http://mock-idp/token1"
+MOCK_URL2 = "http://mock-idp/token2"
+MOCK_URL3 = "http://mock-idp/token3"
+MOCK_URL4 = "http://mock-idp/token4"
+CLIENT_ID = "test-client-id"
+CLIENT_ID2 = "test-client-id2"
+CLIENT_ID3 = "test-client-id3"
+CLIENT_SECRET = "test-client-secret"
+CLIENT_SECRET2 = "test-client-secret2"
+
+
+class TestClientCredentialsGrantFlowTokenSupplier:
+    def test_get_subject_token_success(self):
+        token_supplier = ClientCredentialsGrantFlowTokenSupplier(
+            oidc_issuer_url=MOCK_URL1,
+            client_id=CLIENT_ID,
+            client_secret=CLIENT_SECRET,
+        )
+
+        with requests_mock.Mocker() as m:
+            m.post(MOCK_URL1, json={"access_token": "mock-token", "expires_in": 3600})
+            token = token_supplier.get_subject_token(ANY, ANY)
+
+        assert token == "mock-token"
+
+    def test_cache_token_decorator(self):
+        token_supplier = ClientCredentialsGrantFlowTokenSupplier(
+            oidc_issuer_url=MOCK_URL2,
+            client_id=CLIENT_ID,
+            client_secret=CLIENT_SECRET,
+        )
+
+        with requests_mock.Mocker() as m:
+            m.post(MOCK_URL2, json={"access_token": "mock-token", "expires_in": 3600})
+            token = token_supplier.get_subject_token(ANY, ANY)
+
+        assert token == "mock-token"
+
+        # instances with same credentials and url should get previous token
+        token_supplier2 = ClientCredentialsGrantFlowTokenSupplier(
+            oidc_issuer_url=MOCK_URL2,
+            client_id=CLIENT_ID,
+            client_secret=CLIENT_SECRET,
+        )
+
+        with requests_mock.Mocker() as m2:
+            m2.post(MOCK_URL2, json={"access_token": "mock-token2", "expires_in": 3600})
+            token = token_supplier2.get_subject_token(ANY, ANY)
+
+        assert token == "mock-token"
+
+    def test_cache_token_decorator_diff_credentials(self):
+        token_supplier = ClientCredentialsGrantFlowTokenSupplier(
+            oidc_issuer_url=MOCK_URL3,
+            client_id=CLIENT_ID,
+            client_secret=CLIENT_SECRET,
+        )
+
+        with requests_mock.Mocker() as m:
+            m.post(MOCK_URL3, json={"access_token": "mock-token", "expires_in": 3600})
+            token = token_supplier.get_subject_token(ANY, ANY)
+
+        assert token == "mock-token"
+
+        # instances with different credentials and same url should get different tokens
+        token_supplier2 = ClientCredentialsGrantFlowTokenSupplier(
+            oidc_issuer_url=MOCK_URL3,
+            client_id=CLIENT_ID2,
+            client_secret=CLIENT_SECRET2,
+        )
+
+        with requests_mock.Mocker() as m2:
+            m2.post(MOCK_URL3, json={"access_token": "mock-token2", "expires_in": 3600})
+            token = token_supplier2.get_subject_token(ANY, ANY)
+
+        assert token == "mock-token2"
+
+    def test_cache_token_expiration_date(self):
+        token_supplier = ClientCredentialsGrantFlowTokenSupplier(
+            oidc_issuer_url=MOCK_URL4,
+            client_id=CLIENT_ID,
+            client_secret=CLIENT_SECRET,
+        )
+
+        with requests_mock.Mocker() as m:
+            m.post(MOCK_URL4, json={"access_token": "mock-token", "expires_in": -1})
+            token = token_supplier.get_subject_token(ANY, ANY)
+
+        assert token == "mock-token"
+
+        with requests_mock.Mocker() as m2:
+            m2.post(MOCK_URL4, json={"access_token": "mock-token2", "expires_in": 3600})
+            token = token_supplier.get_subject_token(ANY, ANY)
+
+        assert token == "mock-token2"
+
+    def test_get_subject_token_failure(self):
+        token_supplier = ClientCredentialsGrantFlowTokenSupplier(
+            oidc_issuer_url=MOCK_URL4,
+            client_id=CLIENT_ID3,
+            client_secret=CLIENT_SECRET,
+        )
+        with requests_mock.Mocker() as m:
+            m.post(MOCK_URL4, status_code=400)
+
+        with pytest.raises(RefreshError):
+            token_supplier.get_subject_token(ANY, ANY)

--- a/tests/providers/google/common/hooks/test_base_google.py
+++ b/tests/providers/google/common/hooks/test_base_google.py
@@ -413,6 +413,10 @@ class TestGoogleBaseHook:
             target_principal=None,
             delegates=None,
             is_anonymous=None,
+            idp_issuer_url=None,
+            client_id=None,
+            client_secret=None,
+            idp_extra_params_dict=None,
         )
         assert ("CREDENTIALS", "PROJECT_ID") == result
 
@@ -451,6 +455,10 @@ class TestGoogleBaseHook:
             target_principal=None,
             delegates=None,
             is_anonymous=None,
+            idp_issuer_url=None,
+            client_id=None,
+            client_secret=None,
+            idp_extra_params_dict=None,
         )
         assert (mock_credentials, "PROJECT_ID") == result
 
@@ -482,6 +490,10 @@ class TestGoogleBaseHook:
             target_principal=None,
             delegates=None,
             is_anonymous=None,
+            idp_issuer_url=None,
+            client_id=None,
+            client_secret=None,
+            idp_extra_params_dict=None,
         )
         assert (mock_credentials, "PROJECT_ID") == result
 
@@ -503,6 +515,10 @@ class TestGoogleBaseHook:
             target_principal=None,
             delegates=None,
             is_anonymous=None,
+            idp_issuer_url=None,
+            client_id=None,
+            client_secret=None,
+            idp_extra_params_dict=None,
         )
         assert (mock_credentials, "PROJECT_ID") == result
 
@@ -540,6 +556,10 @@ class TestGoogleBaseHook:
             target_principal=None,
             delegates=None,
             is_anonymous=None,
+            idp_issuer_url=None,
+            client_id=None,
+            client_secret=None,
+            idp_extra_params_dict=None,
         )
         assert ("CREDENTIALS", "SECOND_PROJECT_ID") == result
 
@@ -576,6 +596,10 @@ class TestGoogleBaseHook:
             target_principal=None,
             delegates=None,
             is_anonymous=True,
+            idp_issuer_url=None,
+            client_id=None,
+            client_secret=None,
+            idp_extra_params_dict=None,
         )
 
     @pytest.mark.skipif(
@@ -784,6 +808,10 @@ class TestGoogleBaseHook:
             target_principal=target_principal,
             delegates=delegates,
             is_anonymous=None,
+            idp_issuer_url=None,
+            client_id=None,
+            client_secret=None,
+            idp_extra_params_dict=None,
         )
         assert (mock_credentials, PROJECT_ID) == result
 


### PR DESCRIPTION
This feature enables OIDC token retrieval from any generic Identity Provider (IdP) that uses the OAuth 2.0 Credentials Grant Flow. Additionally, it lays the groundwork for integrating other custom OIDC token retrieval methods.

Google SDK supports defining custom classes for retrieving OIDC tokens for authentication via Workload Identity Federation. This pull request introduces a class that implements this functionality using Credentials Grant Flow and implements a caching mechanism, which can be extended to new classes.

related: #35899


Co-authored-by: @gazev
