### PR TITLE
Increase Health Check parameters for mssql integration

### DIFF
--- a/scripts/ci/docker-compose/integration-mssql.yml
+++ b/scripts/ci/docker-compose/integration-mssql.yml
@@ -34,9 +34,9 @@ services:
     healthcheck:
       test: /opt/mssql-tools/bin/sqlcmd -S localhost,1433 -U sa -P "airflow123" -Q "SELECT 1" -b -o /dev/null
       interval: 10s
-      timeout: 3s
-      retries: 30
-      start_period: 10s
+      timeout: 20s
+      retries: 20
+      start_period: 20s
   airflow:
     depends_on:
       mssql:


### PR DESCRIPTION
The values for mssql integration were too low, particularly the timeout of 3s was far too low. Per documentation:
https://github.com/docker/cli/blob/5bf86c198488c7f78f2ffd05a8a2441f719d3b98/docs/reference/builder.md#healthcheck

Increasing the values shoudl bring stability back.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
