### PR TITLE
Remove DAG Run Add option from FAB view

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -4796,7 +4796,6 @@ class DagRunModelView(AirflowModelView):
 
     class_permission_name = permissions.RESOURCE_DAG_RUN
     method_permission_name = {
-        "add": "create",
         "delete": "delete",
         "edit": "edit",
         "list": "read",


### PR DESCRIPTION
I don't know from which time onwards it was possible to create a new DAG run from FAB UI but as reported in #39856 this is broken at least since notes can be added.

In my perspective I have never seen this option and can not imagine it is working anyway, therefore I propose the `/dagrun/add` to be removed. If a DAG should be triggered it should use the "play" button and run through the UI/API to trigger a new run.

closes: #39856
