### PR TITLE
Bump Snowflake client driver versions per support policy

### DIFF
--- a/airflow/providers/snowflake/provider.yaml
+++ b/airflow/providers/snowflake/provider.yaml
@@ -75,8 +75,8 @@ versions:
 dependencies:
   - apache-airflow>=2.7.0
   - apache-airflow-providers-common-sql>=1.10.0
-  - snowflake-connector-python>=2.7.8
-  - snowflake-sqlalchemy>=1.1.0
+  - snowflake-connector-python>=2.7.11
+  - snowflake-sqlalchemy>=1.4.0
 
 integrations:
   - integration-name: Snowflake

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -1160,8 +1160,8 @@
     "deps": [
       "apache-airflow-providers-common-sql>=1.10.0",
       "apache-airflow>=2.7.0",
-      "snowflake-connector-python>=2.7.8",
-      "snowflake-sqlalchemy>=1.1.0"
+      "snowflake-connector-python>=2.7.11",
+      "snowflake-sqlalchemy>=1.4.0"
     ],
     "devel-deps": [],
     "plugins": [],


### PR DESCRIPTION
Snowflake will stop supporting `snowflake-connector-python < 2.7.11` and `snowflake-sqlalchemy < 1.4.0` drivers starting in August 2024 per their [support policy](https://docs.snowflake.com/en/release-notes/requirements?mkt_tok=MjUyLVJGTy0yMjcAAAGS9G-6LwxqoiEDdP7gW8LVuqIOZBVZYD7tBBBXJwLgxN-eRMQk6RRZbEZXCRl2R2GkOvK3m4KXivhOgGlJRFSCAhmEvJVSU8CR9cAR2qyf7IHMW7mTQQ#client-support-policy). This PR bumps the driver versions to align with said policy to get ahead of dropped support.
