### PR TITLE
Add possibility to collect all provider tests for compatibility testing

### DIFF
--- a/contributing-docs/testing/unit_tests.rst
+++ b/contributing-docs/testing/unit_tests.rst
@@ -1167,10 +1167,25 @@ are not part of the public API. We deal with it in one of the following ways:
   def test_plugin():
      pass
 
+5) Sometimes Pytest collection fails to work, when certain imports used by the tests either do not exist
+   or fail with RuntimeError about compatibility ("minimum Airflow version is required") or because they
+   raise AirflowOptionalProviderFeatureException. In such case you should wrap the imports in
+   ``ignore_provider_compatibility_error`` context manager adding the ``__file__``
+   module name as parameter.  This will stop failing pytest collection and automatically skip the whole
+   module from tests.
+
+   For example:
+
+.. code-block::python
+
+   with ignore_provider_compatibility_error("2.8.0", __file__):
+       from airflow.providers.common.io.xcom.backend import XComObjectStorageBackend
+
+6) In some cases in order to enable collection of pytest on older airflow version you might need to convert
+   top-level import into a local import, so that Pytest parser does not fail on collection.
 
 Running provider compatibility tests in CI
 ------------------------------------------
-
 
 In CI those tests are run in a slightly more complex way because we want to run them against the build
 provider packages, rather than mounted from sources.

--- a/tests/providers/amazon/aws/auth_manager/security_manager/test_aws_security_manager_override.py
+++ b/tests/providers/amazon/aws/auth_manager/security_manager/test_aws_security_manager_override.py
@@ -21,9 +21,12 @@ from unittest.mock import Mock, patch
 import pytest
 from flask import Flask
 
-from airflow.providers.amazon.aws.auth_manager.security_manager.aws_security_manager_override import (
-    AwsSecurityManagerOverride,
-)
+from tests.test_utils.compat import ignore_provider_compatibility_error
+
+with ignore_provider_compatibility_error("2.8.0", __file__):
+    from airflow.providers.amazon.aws.auth_manager.security_manager.aws_security_manager_override import (
+        AwsSecurityManagerOverride,
+    )
 from airflow.www.extensions.init_appbuilder import init_appbuilder
 
 

--- a/tests/providers/amazon/aws/auth_manager/test_aws_auth_manager.py
+++ b/tests/providers/amazon/aws/auth_manager/test_aws_auth_manager.py
@@ -23,16 +23,27 @@ import pytest
 from flask import Flask, session
 from flask_appbuilder.menu import MenuItem
 
-from airflow.auth.managers.models.resource_details import (
-    AccessView,
-    ConfigurationDetails,
-    ConnectionDetails,
-    DagAccessEntity,
-    DagDetails,
-    DatasetDetails,
-    PoolDetails,
-    VariableDetails,
-)
+from tests.test_utils.compat import AIRFLOW_V_2_8_PLUS
+
+try:
+    from airflow.auth.managers.models.resource_details import (
+        AccessView,
+        ConfigurationDetails,
+        ConnectionDetails,
+        DagAccessEntity,
+        DagDetails,
+        DatasetDetails,
+        PoolDetails,
+        VariableDetails,
+    )
+except ImportError:
+    if not AIRFLOW_V_2_8_PLUS:
+        pytest.skip(
+            "Skipping tests that require AwsSecurityManagerOverride for Airflow < 2.8.0",
+            allow_module_level=True,
+        )
+    else:
+        raise
 from airflow.providers.amazon.aws.auth_manager.avp.entities import AvpEntities
 from airflow.providers.amazon.aws.auth_manager.avp.facade import AwsAuthManagerAmazonVerifiedPermissionsFacade
 from airflow.providers.amazon.aws.auth_manager.aws_auth_manager import AwsAuthManager

--- a/tests/providers/common/io/operators/test_file_transfer.py
+++ b/tests/providers/common/io/operators/test_file_transfer.py
@@ -21,7 +21,10 @@ from unittest import mock
 
 from openlineage.client.run import Dataset
 
-from airflow.providers.common.io.operators.file_transfer import FileTransferOperator
+from tests.test_utils.compat import ignore_provider_compatibility_error
+
+with ignore_provider_compatibility_error("2.8.0", __file__):
+    from airflow.providers.common.io.operators.file_transfer import FileTransferOperator
 
 
 def test_file_transfer_copy():

--- a/tests/providers/common/io/xcom/test_backend.py
+++ b/tests/providers/common/io/xcom/test_backend.py
@@ -19,8 +19,7 @@ from __future__ import annotations
 
 import pytest
 
-from airflow.exceptions import AirflowOptionalProviderFeatureException
-from tests.test_utils.compat import AIRFLOW_V_2_9_PLUS
+from tests.test_utils.compat import AIRFLOW_V_2_9_PLUS, ignore_provider_compatibility_error
 
 pytestmark = [
     pytest.mark.db_test,
@@ -32,10 +31,9 @@ import airflow.models.xcom
 from airflow.models.xcom import BaseXCom, resolve_xcom_backend
 from airflow.operators.empty import EmptyOperator
 
-try:
+with ignore_provider_compatibility_error("2.8.0", __file__):
     from airflow.providers.common.io.xcom.backend import XComObjectStorageBackend
-except AirflowOptionalProviderFeatureException:
-    pass
+
 from airflow.utils import timezone
 from airflow.utils.xcom import XCOM_RETURN_KEY
 from tests.test_utils import db

--- a/tests/providers/fab/auth_manager/api/auth/backend/test_basic_auth.py
+++ b/tests/providers/fab/auth_manager/api/auth/backend/test_basic_auth.py
@@ -24,6 +24,11 @@ from flask_appbuilder.const import AUTH_LDAP
 
 from airflow.api.auth.backend.basic_auth import requires_authentication
 from airflow.www import app as application
+from tests.test_utils.compat import AIRFLOW_V_2_9_PLUS
+
+pytestmark = [
+    pytest.mark.skipif(not AIRFLOW_V_2_9_PLUS, reason="Tests for Airflow 2.9.0+ only"),
+]
 
 
 @pytest.fixture

--- a/tests/providers/fab/auth_manager/api/auth/backend/test_kerberos_auth.py
+++ b/tests/providers/fab/auth_manager/api/auth/backend/test_kerberos_auth.py
@@ -19,7 +19,10 @@ from __future__ import annotations
 from airflow.api.auth.backend.kerberos_auth import (
     init_app as base_init_app,
 )
-from airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth import init_app
+from tests.test_utils.compat import ignore_provider_compatibility_error
+
+with ignore_provider_compatibility_error("2.9.0+", __file__):
+    from airflow.providers.fab.auth_manager.api.auth.backend.kerberos_auth import init_app
 
 
 class TestKerberosAuth:

--- a/tests/providers/fab/auth_manager/api_endpoints/test_role_and_permission_endpoint.py
+++ b/tests/providers/fab/auth_manager/api_endpoints/test_role_and_permission_endpoint.py
@@ -19,8 +19,13 @@ from __future__ import annotations
 import pytest
 
 from airflow.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
-from airflow.providers.fab.auth_manager.models import Role
-from airflow.providers.fab.auth_manager.security_manager.override import EXISTING_ROLES
+from tests.test_utils.compat import ignore_provider_compatibility_error
+
+with ignore_provider_compatibility_error("2.9.0+", __file__):
+    from airflow.providers.fab.auth_manager.models import Role
+    from airflow.providers.fab.auth_manager.security_manager.override import EXISTING_ROLES
+
+
 from airflow.security import permissions
 from tests.test_utils.api_connexion_utils import (
     assert_401,

--- a/tests/providers/fab/auth_manager/api_endpoints/test_user_endpoint.py
+++ b/tests/providers/fab/auth_manager/api_endpoints/test_user_endpoint.py
@@ -22,14 +22,19 @@ import pytest
 from sqlalchemy.sql.functions import count
 
 from airflow.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
-from airflow.providers.fab.auth_manager.models import User
 from airflow.security import permissions
 from airflow.utils import timezone
 from airflow.utils.session import create_session
+from tests.test_utils.compat import ignore_provider_compatibility_error
+
+with ignore_provider_compatibility_error("2.9.0+", __file__):
+    from airflow.providers.fab.auth_manager.models import User
+
 from tests.test_utils.api_connexion_utils import assert_401, create_user, delete_role, delete_user
 from tests.test_utils.config import conf_vars
 
 pytestmark = pytest.mark.db_test
+
 
 DEFAULT_TIME = "2020-06-11T18:00:00+00:00"
 

--- a/tests/providers/fab/auth_manager/api_endpoints/test_user_schema.py
+++ b/tests/providers/fab/auth_manager/api_endpoints/test_user_schema.py
@@ -18,14 +18,19 @@ from __future__ import annotations
 
 import pytest
 
-from airflow.api_connexion.schemas.user_schema import user_collection_item_schema, user_schema
-from airflow.providers.fab.auth_manager.models import User
+from tests.test_utils.compat import ignore_provider_compatibility_error
+
+with ignore_provider_compatibility_error("2.9.0+", __file__):
+    from airflow.api_connexion.schemas.user_schema import user_collection_item_schema, user_schema
+    from airflow.providers.fab.auth_manager.models import User
+
 from airflow.utils import timezone
-from tests.test_utils.api_connexion_utils import create_role, delete_role
 
 TEST_EMAIL = "test@example.org"
 
 DEFAULT_TIME = "2021-01-09T13:59:56.336000+00:00"
+
+from tests.test_utils.api_connexion_utils import create_role, delete_role  # noqa: E402
 
 pytestmark = pytest.mark.db_test
 

--- a/tests/providers/fab/auth_manager/cli_commands/test_definition.py
+++ b/tests/providers/fab/auth_manager/cli_commands/test_definition.py
@@ -16,11 +16,14 @@
 # under the License.
 from __future__ import annotations
 
-from airflow.providers.fab.auth_manager.cli_commands.definition import (
-    ROLES_COMMANDS,
-    SYNC_PERM_COMMAND,
-    USERS_COMMANDS,
-)
+from tests.test_utils.compat import ignore_provider_compatibility_error
+
+with ignore_provider_compatibility_error("2.9.0+", __file__):
+    from airflow.providers.fab.auth_manager.cli_commands.definition import (
+        ROLES_COMMANDS,
+        SYNC_PERM_COMMAND,
+        USERS_COMMANDS,
+    )
 
 
 class TestCliDefinition:

--- a/tests/providers/fab/auth_manager/cli_commands/test_role_command.py
+++ b/tests/providers/fab/auth_manager/cli_commands/test_role_command.py
@@ -25,11 +25,16 @@ from typing import TYPE_CHECKING
 import pytest
 
 from airflow.cli import cli_parser
-from airflow.providers.fab.auth_manager.cli_commands import role_command
-from airflow.providers.fab.auth_manager.cli_commands.utils import get_application_builder
+from tests.test_utils.compat import ignore_provider_compatibility_error
+
+with ignore_provider_compatibility_error("2.9.0+", __file__):
+    from airflow.providers.fab.auth_manager.cli_commands import role_command
+    from airflow.providers.fab.auth_manager.cli_commands.utils import get_application_builder
+
 from airflow.security import permissions
 
 pytestmark = pytest.mark.db_test
+
 
 if TYPE_CHECKING:
     from airflow.providers.fab.auth_manager.models import Role

--- a/tests/providers/fab/auth_manager/cli_commands/test_sync_perm_command.py
+++ b/tests/providers/fab/auth_manager/cli_commands/test_sync_perm_command.py
@@ -22,7 +22,10 @@ from unittest import mock
 import pytest
 
 from airflow.cli import cli_parser
-from airflow.providers.fab.auth_manager.cli_commands import sync_perm_command
+from tests.test_utils.compat import ignore_provider_compatibility_error
+
+with ignore_provider_compatibility_error("2.9.0+", __file__):
+    from airflow.providers.fab.auth_manager.cli_commands import sync_perm_command
 
 pytestmark = pytest.mark.db_test
 

--- a/tests/providers/fab/auth_manager/cli_commands/test_user_command.py
+++ b/tests/providers/fab/auth_manager/cli_commands/test_user_command.py
@@ -26,8 +26,11 @@ from io import StringIO
 import pytest
 
 from airflow.cli import cli_parser
-from airflow.providers.fab.auth_manager.cli_commands import user_command
-from airflow.providers.fab.auth_manager.cli_commands.utils import get_application_builder
+from tests.test_utils.compat import ignore_provider_compatibility_error
+
+with ignore_provider_compatibility_error("2.9.0+", __file__):
+    from airflow.providers.fab.auth_manager.cli_commands import user_command
+    from airflow.providers.fab.auth_manager.cli_commands.utils import get_application_builder
 
 pytestmark = pytest.mark.db_test
 

--- a/tests/providers/fab/auth_manager/cli_commands/test_utils.py
+++ b/tests/providers/fab/auth_manager/cli_commands/test_utils.py
@@ -18,11 +18,16 @@ from __future__ import annotations
 
 import pytest
 
-from airflow.providers.fab.auth_manager.cli_commands.utils import get_application_builder
+from tests.test_utils.compat import ignore_provider_compatibility_error
+
+with ignore_provider_compatibility_error("2.9.0+", __file__):
+    from airflow.providers.fab.auth_manager.cli_commands.utils import get_application_builder
+
 from airflow.www.extensions.init_appbuilder import AirflowAppBuilder
 
+pytestmark = pytest.mark.db_test
 
-@pytest.mark.db_test
+
 class TestCliUtils:
     def test_get_application_builder(self):
         with get_application_builder() as appbuilder:

--- a/tests/providers/fab/auth_manager/decorators/test_auth.py
+++ b/tests/providers/fab/auth_manager/decorators/test_auth.py
@@ -20,10 +20,16 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from airflow.api_connexion.exceptions import PermissionDenied
-from airflow.providers.fab.auth_manager.decorators.auth import _has_access_fab, _requires_access_fab
 from airflow.security.permissions import ACTION_CAN_READ, RESOURCE_DAG
-from airflow.www import app as application
+from tests.test_utils.compat import ignore_provider_compatibility_error
+
+permissions = [(ACTION_CAN_READ, RESOURCE_DAG)]
+
+with ignore_provider_compatibility_error("2.9.0+", __file__):
+    from airflow.api_connexion.exceptions import PermissionDenied
+    from airflow.providers.fab.auth_manager.decorators.auth import _has_access_fab, _requires_access_fab
+
+from airflow.www import app as application  # noqa: E402
 
 
 @pytest.fixture(scope="module")

--- a/tests/providers/fab/auth_manager/models/test_anonymous_user.py
+++ b/tests/providers/fab/auth_manager/models/test_anonymous_user.py
@@ -17,7 +17,10 @@
 # under the License.
 from __future__ import annotations
 
-from airflow.providers.fab.auth_manager.models.anonymous_user import AnonymousUser
+from tests.test_utils.compat import ignore_provider_compatibility_error
+
+with ignore_provider_compatibility_error("2.9.0+", __file__):
+    from airflow.providers.fab.auth_manager.models.anonymous_user import AnonymousUser
 
 
 class TestAnonymousUser:

--- a/tests/providers/fab/auth_manager/security_manager/test_constants.py
+++ b/tests/providers/fab/auth_manager/security_manager/test_constants.py
@@ -16,7 +16,10 @@
 # under the License.
 from __future__ import annotations
 
-from airflow.providers.fab.auth_manager.security_manager.constants import EXISTING_ROLES
+from tests.test_utils.compat import ignore_provider_compatibility_error
+
+with ignore_provider_compatibility_error("2.9.0+", __file__):
+    from airflow.providers.fab.auth_manager.security_manager.constants import EXISTING_ROLES
 
 
 class TestFbSecurityManagerConstants:

--- a/tests/providers/fab/auth_manager/security_manager/test_override.py
+++ b/tests/providers/fab/auth_manager/security_manager/test_override.py
@@ -19,7 +19,10 @@ from __future__ import annotations
 from unittest import mock
 from unittest.mock import Mock
 
-from airflow.providers.fab.auth_manager.security_manager.override import FabAirflowSecurityManagerOverride
+from tests.test_utils.compat import ignore_provider_compatibility_error
+
+with ignore_provider_compatibility_error("2.9.0+", __file__):
+    from airflow.providers.fab.auth_manager.security_manager.override import FabAirflowSecurityManagerOverride
 
 
 class EmptySecurityManager(FabAirflowSecurityManagerOverride):

--- a/tests/providers/fab/auth_manager/test_fab_auth_manager.py
+++ b/tests/providers/fab/auth_manager/test_fab_auth_manager.py
@@ -24,11 +24,20 @@ from unittest.mock import Mock
 import pytest
 from flask import Flask
 
-from airflow.auth.managers.models.resource_details import AccessView, DagAccessEntity, DagDetails
 from airflow.exceptions import AirflowConfigException, AirflowException
-from airflow.providers.fab.auth_manager.fab_auth_manager import FabAuthManager
-from airflow.providers.fab.auth_manager.models import User
-from airflow.providers.fab.auth_manager.security_manager.override import FabAirflowSecurityManagerOverride
+
+try:
+    from airflow.auth.managers.models.resource_details import AccessView, DagAccessEntity, DagDetails
+except ImportError:
+    pass
+
+from tests.test_utils.compat import ignore_provider_compatibility_error
+
+with ignore_provider_compatibility_error("2.9.0+", __file__):
+    from airflow.providers.fab.auth_manager.fab_auth_manager import FabAuthManager
+    from airflow.providers.fab.auth_manager.models import User
+    from airflow.providers.fab.auth_manager.security_manager.override import FabAirflowSecurityManagerOverride
+
 from airflow.security.permissions import (
     ACTION_CAN_ACCESS_MENU,
     ACTION_CAN_CREATE,

--- a/tests/providers/fab/auth_manager/test_models.py
+++ b/tests/providers/fab/auth_manager/test_models.py
@@ -20,10 +20,13 @@ from unittest import mock
 
 from sqlalchemy import Column, MetaData, String, Table
 
-from airflow.providers.fab.auth_manager.models import (
-    add_index_on_ab_register_user_username_postgres,
-    add_index_on_ab_user_username_postgres,
-)
+from tests.test_utils.compat import ignore_provider_compatibility_error
+
+with ignore_provider_compatibility_error("2.9.0+", __file__):
+    from airflow.providers.fab.auth_manager.models import (
+        add_index_on_ab_register_user_username_postgres,
+        add_index_on_ab_user_username_postgres,
+    )
 
 _mock_conn = mock.MagicMock()
 _mock_conn.dialect = mock.MagicMock()

--- a/tests/providers/fab/auth_manager/test_security.py
+++ b/tests/providers/fab/auth_manager/test_security.py
@@ -31,15 +31,18 @@ from flask_appbuilder import SQLA, Model, expose, has_access
 from flask_appbuilder.views import BaseView, ModelView
 from sqlalchemy import Column, Date, Float, Integer, String
 
-from airflow.auth.managers.models.resource_details import DagDetails
 from airflow.configuration import initialize_config
 from airflow.exceptions import AirflowException
 from airflow.models import DagModel
 from airflow.models.base import Base
 from airflow.models.dag import DAG
-from airflow.providers.fab.auth_manager.fab_auth_manager import FabAuthManager
-from airflow.providers.fab.auth_manager.models import User, assoc_permission_role
-from airflow.providers.fab.auth_manager.models.anonymous_user import AnonymousUser
+from tests.test_utils.compat import ignore_provider_compatibility_error
+
+with ignore_provider_compatibility_error("2.9.0+", __file__):
+    from airflow.providers.fab.auth_manager.fab_auth_manager import FabAuthManager
+    from airflow.providers.fab.auth_manager.models import User, assoc_permission_role
+    from airflow.providers.fab.auth_manager.models.anonymous_user import AnonymousUser
+
 from airflow.security import permissions
 from airflow.security.permissions import ACTION_CAN_READ
 from airflow.www import app as application
@@ -125,14 +128,20 @@ def _delete_dag_model(dag_model, session, security_manager):
 
 
 def _can_read_dag(dag_id: str, user) -> bool:
+    from airflow.auth.managers.models.resource_details import DagDetails
+
     return get_auth_manager().is_authorized_dag(method="GET", details=DagDetails(id=dag_id), user=user)
 
 
 def _can_edit_dag(dag_id: str, user) -> bool:
+    from airflow.auth.managers.models.resource_details import DagDetails
+
     return get_auth_manager().is_authorized_dag(method="PUT", details=DagDetails(id=dag_id), user=user)
 
 
 def _can_delete_dag(dag_id: str, user) -> bool:
+    from airflow.auth.managers.models.resource_details import DagDetails
+
     return get_auth_manager().is_authorized_dag(method="DELETE", details=DagDetails(id=dag_id), user=user)
 
 
@@ -229,6 +238,8 @@ def sample_dags(security_manager):
 @pytest.fixture(scope="module")
 def has_dag_perm(security_manager):
     def _has_dag_perm(perm, dag_id, user):
+        from airflow.auth.managers.models.resource_details import DagDetails
+
         root_dag_id = security_manager._get_root_dag_id(dag_id)
         return get_auth_manager().is_authorized_dag(
             method=perm, details=DagDetails(id=root_dag_id), user=user

--- a/tests/providers/fab/auth_manager/views/test_permissions.py
+++ b/tests/providers/fab/auth_manager/views/test_permissions.py
@@ -22,7 +22,12 @@ import pytest
 from airflow.security import permissions
 from airflow.www import app as application
 from tests.test_utils.api_connexion_utils import create_user, delete_user
+from tests.test_utils.compat import AIRFLOW_V_2_9_PLUS
 from tests.test_utils.www import client_with_login
+
+pytestmark = [
+    pytest.mark.skipif(not AIRFLOW_V_2_9_PLUS, reason="Tests for Airflow 2.9.0+ only"),
+]
 
 
 @pytest.fixture(scope="module")

--- a/tests/providers/fab/auth_manager/views/test_roles_list.py
+++ b/tests/providers/fab/auth_manager/views/test_roles_list.py
@@ -22,7 +22,12 @@ import pytest
 from airflow.security import permissions
 from airflow.www import app as application
 from tests.test_utils.api_connexion_utils import create_user, delete_user
+from tests.test_utils.compat import AIRFLOW_V_2_9_PLUS
 from tests.test_utils.www import client_with_login
+
+pytestmark = [
+    pytest.mark.skipif(not AIRFLOW_V_2_9_PLUS, reason="Tests for Airflow 2.9.0+ only"),
+]
 
 
 @pytest.fixture(scope="module")

--- a/tests/providers/fab/auth_manager/views/test_user.py
+++ b/tests/providers/fab/auth_manager/views/test_user.py
@@ -22,7 +22,12 @@ import pytest
 from airflow.security import permissions
 from airflow.www import app as application
 from tests.test_utils.api_connexion_utils import create_user, delete_user
+from tests.test_utils.compat import AIRFLOW_V_2_9_PLUS
 from tests.test_utils.www import client_with_login
+
+pytestmark = [
+    pytest.mark.skipif(not AIRFLOW_V_2_9_PLUS, reason="Tests for Airflow 2.9.0+ only"),
+]
 
 
 @pytest.fixture(scope="module")

--- a/tests/providers/fab/auth_manager/views/test_user_edit.py
+++ b/tests/providers/fab/auth_manager/views/test_user_edit.py
@@ -22,7 +22,12 @@ import pytest
 from airflow.security import permissions
 from airflow.www import app as application
 from tests.test_utils.api_connexion_utils import create_user, delete_user
+from tests.test_utils.compat import AIRFLOW_V_2_9_PLUS
 from tests.test_utils.www import client_with_login
+
+pytestmark = [
+    pytest.mark.skipif(not AIRFLOW_V_2_9_PLUS, reason="Tests for Airflow 2.9.0+ only"),
+]
 
 
 @pytest.fixture(scope="module")

--- a/tests/providers/fab/auth_manager/views/test_user_stats.py
+++ b/tests/providers/fab/auth_manager/views/test_user_stats.py
@@ -22,7 +22,12 @@ import pytest
 from airflow.security import permissions
 from airflow.www import app as application
 from tests.test_utils.api_connexion_utils import create_user, delete_user
+from tests.test_utils.compat import AIRFLOW_V_2_9_PLUS
 from tests.test_utils.www import client_with_login
+
+pytestmark = [
+    pytest.mark.skipif(not AIRFLOW_V_2_9_PLUS, reason="Tests for Airflow 2.9.0+ only"),
+]
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_utils/api_connexion_utils.py
+++ b/tests/test_utils/api_connexion_utils.py
@@ -19,7 +19,10 @@ from __future__ import annotations
 from contextlib import contextmanager
 
 from airflow.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
-from airflow.providers.fab.auth_manager.security_manager.override import EXISTING_ROLES
+from tests.test_utils.compat import ignore_provider_compatibility_error
+
+with ignore_provider_compatibility_error("2.9.0+", __file__):
+    from airflow.providers.fab.auth_manager.security_manager.override import EXISTING_ROLES
 
 
 @contextmanager

--- a/tests/test_utils/db.py
+++ b/tests/test_utils/db.py
@@ -46,16 +46,6 @@ from airflow.models.dataset import (
     TaskOutletDatasetReference,
 )
 from airflow.models.serialized_dag import SerializedDagModel
-
-try:
-    from airflow.providers.fab.auth_manager.models import Permission, Resource, assoc_permission_role
-except ImportError:
-    # Handle Pre-airflow 2.9 case where FAB was part of the core airflow
-    from airflow.auth.managers.fab.models import (  # type: ignore[no-redef]
-        Permission,
-        Resource,
-        assoc_permission_role,
-    )
 from airflow.security.permissions import RESOURCE_DAG_PREFIX
 from airflow.utils.db import add_default_pool_if_not_exists, create_default_connections, reflect_tables
 from airflow.utils.session import create_session
@@ -186,6 +176,25 @@ def clear_db_dag_parsing_requests():
 
 
 def clear_dag_specific_permissions():
+    try:
+        from airflow.providers.fab.auth_manager.models import Permission, Resource, assoc_permission_role
+    except ImportError:
+        # Handle Pre-airflow 2.9 case where FAB was part of the core airflow
+        from airflow.auth.managers.fab.models import (  # type: ignore[no-redef]
+            Permission,
+            Resource,
+            assoc_permission_role,
+        )
+    except RuntimeError as e:
+        # Handle case where FAB provider is not even usable
+        if "needs Apache Airflow 2.9.0" in str(e):
+            from airflow.auth.managers.fab.models import (  # type: ignore[no-redef]
+                Permission,
+                Resource,
+                assoc_permission_role,
+            )
+        else:
+            raise
     with create_session() as session:
         dag_resources = session.query(Resource).filter(Resource.name.like(f"{RESOURCE_DAG_PREFIX}%")).all()
         dag_resource_ids = [d.id for d in dag_resources]

--- a/tests/test_utils/mock_security_manager.py
+++ b/tests/test_utils/mock_security_manager.py
@@ -16,7 +16,10 @@
 # under the License.
 from __future__ import annotations
 
-from airflow.providers.fab.auth_manager.security_manager.override import FabAirflowSecurityManagerOverride
+from tests.test_utils.compat import ignore_provider_compatibility_error
+
+with ignore_provider_compatibility_error("2.9.0", __file__):
+    from airflow.providers.fab.auth_manager.security_manager.override import FabAirflowSecurityManagerOverride
 
 
 class MockSecurityManager(FabAirflowSecurityManagerOverride):


### PR DESCRIPTION
Some of the provider tests fail to be collected by Pytest if they are run on older airlfow releases - because of problematic imports or runtime errors returned by provider initialization code.

This PR adds test_utils compatibility context manager to allow to handle it in the way that the tests are automatically skipped in such cases.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
