### PR TITLE
local task job: add overtime mechanism, to not kill task prematurely when auxiliary processes are running

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -341,6 +341,14 @@ core:
       type: string
       example: ~
       default: "downstream"
+    task_success_overtime:
+      description: |
+        Maximum possible time (in seconds) that task will have for execution of auxiliary processes
+        (like listeners, mini scheduler...) after task is marked as success..
+      version_added: 2.10.0
+      type: integer
+      example: ~
+      default: "20"
     default_task_execution_timeout:
       description: |
         The default task execution_timeout value for the operators. Expected an integer value to

--- a/airflow/providers/openlineage/plugins/listener.py
+++ b/airflow/providers/openlineage/plugins/listener.py
@@ -134,7 +134,6 @@ class OpenLineageListener:
                 dagrun.data_interval_start.isoformat() if dagrun.data_interval_start else None
             )
             data_interval_end = dagrun.data_interval_end.isoformat() if dagrun.data_interval_end else None
-
             redacted_event = self.adapter.start_task(
                 run_id=task_uuid,
                 job_name=get_job_name(task),

--- a/tests/dags/test_mark_state.py
+++ b/tests/dags/test_mark_state.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import time
 from datetime import datetime
 from time import sleep
 
@@ -24,6 +25,7 @@ from airflow.models.dag import DAG
 from airflow.operators.python import PythonOperator
 from airflow.utils.session import create_session
 from airflow.utils.state import State
+from airflow.utils.timezone import utcnow
 
 DEFAULT_DATE = datetime(2016, 1, 1)
 
@@ -41,11 +43,22 @@ def success_callback(context):
     assert context["dag_run"].dag_id == dag_id
 
 
+def sleep_execution():
+    time.sleep(1)
+
+
+def slow_execution():
+    import re
+
+    re.match(r"(a?){30}a{30}", "a" * 30)
+
+
 def test_mark_success_no_kill(ti):
     assert ti.state == State.RUNNING
     # Simulate marking this successful in the UI
     with create_session() as session:
         ti.state = State.SUCCESS
+        ti.end_date = utcnow()
         session.merge(ti)
         session.commit()
         # The below code will not run as heartbeat will detect change of state
@@ -103,3 +116,7 @@ def test_mark_skipped_externally(ti):
 PythonOperator(task_id="test_mark_skipped_externally", python_callable=test_mark_skipped_externally, dag=dag)
 
 PythonOperator(task_id="dummy", python_callable=lambda: True, dag=dag)
+
+PythonOperator(task_id="slow_execution", python_callable=slow_execution, dag=dag)
+
+PythonOperator(task_id="sleep_execution", python_callable=sleep_execution, dag=dag)

--- a/tests/listeners/slow_listener.py
+++ b/tests/listeners/slow_listener.py
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import time
+
+from airflow.listeners import hookimpl
+
+
+@hookimpl
+def on_task_instance_success(previous_state, task_instance, session):
+    time.sleep(3)

--- a/tests/listeners/very_slow_listener.py
+++ b/tests/listeners/very_slow_listener.py
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import time
+
+from airflow.listeners import hookimpl
+
+
+@hookimpl
+def on_task_instance_success(previous_state, task_instance, session):
+    time.sleep(10)


### PR DESCRIPTION
Currently, `LocalTaskJobRunner` kills worker processes after they have their state set to `SUCCESS` and are still running. This can happen in few ways - most common are either state is set externally, or there are relatively slow listeners or other processes (mini scheduler) running. 

This PR introduces mechanism in which  we give the task some additional to finish their job - by default 20 seconds, configurable - after which the process is terminated. 