### PR TITLE
Add possibility to override the conn type for Druid

### DIFF
--- a/airflow/providers/apache/druid/hooks/druid.py
+++ b/airflow/providers/apache/druid/hooks/druid.py
@@ -86,7 +86,10 @@ class DruidHook(BaseHook):
         """Get Druid connection url."""
         host = self.conn.host
         port = self.conn.port
-        conn_type = self.conn.conn_type or "http"
+        if self.conn.schema:
+            conn_type = self.conn.schema
+        else:
+            conn_type = self.conn.conn_type or "http"
         if ingestion_type == IngestionType.BATCH:
             endpoint = self.conn.extra_dejson.get("endpoint", "")
         else:

--- a/tests/providers/apache/druid/hooks/test_druid.py
+++ b/tests/providers/apache/druid/hooks/test_druid.py
@@ -39,9 +39,14 @@ class TestDruidSubmitHook:
             self.is_sql_based_ingestion = False
 
             def get_conn_url(self, ingestion_type: IngestionType = IngestionType.BATCH):
+                if self.conn.schema:
+                    conn_type = self.conn.schema
+                else:
+                    conn_type = "http"
+
                 if ingestion_type == IngestionType.MSQ:
-                    return "http://druid-overlord:8081/druid/v2/sql/task"
-                return "http://druid-overlord:8081/druid/indexer/v1/task"
+                    return f"{conn_type}//druid-overlord:8081/druid/v2/sql/task"
+                return f"{conn_type}://druid-overlord:8081/druid/indexer/v1/task"
 
         self.db_hook = TestDRuidhook()
 
@@ -254,7 +259,7 @@ class TestDruidHook:
     def test_conn_property(self, mock_get_connection):
         get_conn_value = MagicMock()
         get_conn_value.host = "test_host"
-        get_conn_value.conn_type = "https"
+        get_conn_value.conn_type = "http"
         get_conn_value.port = "1"
         get_conn_value.extra_dejson = {"endpoint": "ingest"}
         mock_get_connection.return_value = get_conn_value
@@ -265,8 +270,20 @@ class TestDruidHook:
     def test_get_conn_url(self, mock_get_connection):
         get_conn_value = MagicMock()
         get_conn_value.host = "test_host"
-        get_conn_value.conn_type = "https"
+        get_conn_value.conn_type = "http"
         get_conn_value.port = "1"
+        get_conn_value.extra_dejson = {"endpoint": "ingest"}
+        mock_get_connection.return_value = get_conn_value
+        hook = DruidHook(timeout=1, max_ingestion_time=5)
+        assert hook.get_conn_url() == "http://test_host:1/ingest"
+
+    @patch("airflow.providers.apache.druid.hooks.druid.DruidHook.get_connection")
+    def test_get_conn_url_with_schema(self, mock_get_connection):
+        get_conn_value = MagicMock()
+        get_conn_value.host = "test_host"
+        get_conn_value.conn_type = "http"
+        get_conn_value.port = "1"
+        get_conn_value.schema = "https"
         get_conn_value.extra_dejson = {"endpoint": "ingest"}
         mock_get_connection.return_value = get_conn_value
         hook = DruidHook(timeout=1, max_ingestion_time=5)
@@ -276,8 +293,20 @@ class TestDruidHook:
     def test_get_conn_url_with_ingestion_type(self, mock_get_connection):
         get_conn_value = MagicMock()
         get_conn_value.host = "test_host"
-        get_conn_value.conn_type = "https"
+        get_conn_value.conn_type = "http"
         get_conn_value.port = "1"
+        get_conn_value.extra_dejson = {"endpoint": "ingest", "msq_endpoint": "sql_ingest"}
+        mock_get_connection.return_value = get_conn_value
+        hook = DruidHook(timeout=1, max_ingestion_time=5)
+        assert hook.get_conn_url(IngestionType.MSQ) == "http://test_host:1/sql_ingest"
+
+    @patch("airflow.providers.apache.druid.hooks.druid.DruidHook.get_connection")
+    def test_get_conn_url_with_ingestion_type_and_schema(self, mock_get_connection):
+        get_conn_value = MagicMock()
+        get_conn_value.host = "test_host"
+        get_conn_value.conn_type = "http"
+        get_conn_value.port = "1"
+        get_conn_value.schema = "https"
         get_conn_value.extra_dejson = {"endpoint": "ingest", "msq_endpoint": "sql_ingest"}
         mock_get_connection.return_value = get_conn_value
         hook = DruidHook(timeout=1, max_ingestion_time=5)


### PR DESCRIPTION
Minor fix, which allows to use the schema which are specified in theschema rather than `http` as default. In the same time it doesn't changethe logic as any conn_type can be selected. Intuitevely it's expectedthat anything specified in `schema` field will actually take precedencein the building the desired url.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
