### PR TITLE
Replace non-functional TOC directive with explanation where to look

### DIFF
--- a/COMMITTERS.rst
+++ b/COMMITTERS.rst
@@ -22,7 +22,7 @@ Before reading this document, you should be familiar with `Contributors' guide <
 This document assumes that you are a bit familiar how Airflow's community work, but you would like to learn more
 about the rules by which we add new members.
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Committers vs. Maintainers
 --------------------------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -18,7 +18,7 @@
 Contributing
 ============
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Contributions are welcome and are greatly appreciated! Every little bit helps, and credit will always be given.
 

--- a/PROVIDERS.rst
+++ b/PROVIDERS.rst
@@ -19,7 +19,7 @@
 Apache Airflow Providers
 ************************
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 What is a provider?
 ===================

--- a/airflow/providers/MANAGING_PROVIDERS_LIFECYCLE.rst
+++ b/airflow/providers/MANAGING_PROVIDERS_LIFECYCLE.rst
@@ -16,7 +16,7 @@
     under the License.
 
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Creating a new community provider
 =================================

--- a/contributing-docs/01_roles_in_airflow_project.rst
+++ b/contributing-docs/01_roles_in_airflow_project.rst
@@ -22,7 +22,7 @@ There are several roles within the Airflow Open-Source community.
 
 For detailed information for each role, see: `Committers and PMC members <../COMMITTERS.rst>`__.
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 PMC Member
 ----------

--- a/contributing-docs/02_how_to_communicate.rst
+++ b/contributing-docs/02_how_to_communicate.rst
@@ -26,7 +26,7 @@ This means that communication plays a big role in it, and this chapter is all ab
 
 In our communication, everyone is expected to follow the `ASF Code of Conduct <https://www.apache.org/foundation/policies/conduct>`_.
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Various Communication channels
 ------------------------------

--- a/contributing-docs/03_contributors_quick_start.rst
+++ b/contributing-docs/03_contributors_quick_start.rst
@@ -19,7 +19,7 @@
 Contributor's Quick Start
 *************************
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Note to Starters
 ################

--- a/contributing-docs/04_how_to_contribute.rst
+++ b/contributing-docs/04_how_to_contribute.rst
@@ -21,7 +21,7 @@ How to contribute
 There are various ways how you can contribute to Apache Airflow. Here is a short overview of
 some of those ways that involve creating issues and pull requests on GitHub.
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Report Bugs
 -----------

--- a/contributing-docs/05_pull_requests.rst
+++ b/contributing-docs/05_pull_requests.rst
@@ -22,7 +22,7 @@ Pull Requests
 This document describes how you can create Pull Requests and describes coding standards we use when
 implementing them.
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Pull Request guidelines
 -----------------------

--- a/contributing-docs/06_development_environments.rst
+++ b/contributing-docs/06_development_environments.rst
@@ -21,7 +21,7 @@ Development Environments
 There are two environments, available on Linux and macOS, that you can use to
 develop Apache Airflow.
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Local virtualenv Development Environment
 ----------------------------------------

--- a/contributing-docs/07_local_virtualenv.rst
+++ b/contributing-docs/07_local_virtualenv.rst
@@ -26,7 +26,7 @@ harder to debug the tests and to use your IDE to run them.
 
 That's why we recommend using local virtualenv for development and testing.
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Installation in local virtualenv
 --------------------------------

--- a/contributing-docs/08_static_code_checks.rst
+++ b/contributing-docs/08_static_code_checks.rst
@@ -26,7 +26,7 @@ for the first time. See the table below to identify which pre-commit checks requ
 
 You can also run the checks via `Breeze <../dev/breeze/doc/README.rst>`_ environment.
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Pre-commit hooks
 ----------------

--- a/contributing-docs/10_working_with_git.rst
+++ b/contributing-docs/10_working_with_git.rst
@@ -22,7 +22,7 @@ Working with Git
 In this document you can learn basics of how you should use Git in Airflow project. It explains branching model and stresses
 that we are using rebase workflow. It also explains how to sync your fork with the main repository.
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Airflow Git Branches
 ====================

--- a/contributing-docs/11_provider_packages.rst
+++ b/contributing-docs/11_provider_packages.rst
@@ -23,7 +23,7 @@ Airflow 2.0 is split into core and providers. They are delivered as separate pac
 * ``apache-airflow`` - core of Apache Airflow
 * ``apache-airflow-providers-*`` - More than 70 provider packages to communicate with external services
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Where providers are kept in our repository
 ------------------------------------------

--- a/contributing-docs/12_airflow_dependencies_and_extras.rst
+++ b/contributing-docs/12_airflow_dependencies_and_extras.rst
@@ -33,7 +33,7 @@ you are developing your own operators and DAGs.
 
 This - seemingly unsolvable - puzzle is solved by having pinned constraints files.
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Pinned constraint files
 -----------------------

--- a/contributing-docs/14_node_environment_setup.rst
+++ b/contributing-docs/14_node_environment_setup.rst
@@ -27,7 +27,7 @@ found with node\>=8.11.3 and yarn\>=1.19.1. The pre-commit framework of ours ins
 node and yarn automatically when installed - if you use ``breeze`` you do not need to install
 neither node nor yarn.
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Installing yarn and its packages manually
 -----------------------------------------

--- a/contributing-docs/16_contribution_workflow.rst
+++ b/contributing-docs/16_contribution_workflow.rst
@@ -18,7 +18,7 @@
 Contribution Workflow
 =====================
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Typically, you start your first contribution by reviewing open tickets
 at `GitHub issues <https://github.com/apache/airflow/issues>`__.

--- a/contributing-docs/README.rst
+++ b/contributing-docs/README.rst
@@ -25,7 +25,7 @@ This index of linked documents aims to explain the subject of contributions if y
 any Open Source project, but it will also help people who have contributed to other projects learn about the
 rules of that community.
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 New Contributor
 ---------------

--- a/contributing-docs/quick-start-ide/contributors_quick_start_gitpod.rst
+++ b/contributing-docs/quick-start-ide/contributors_quick_start_gitpod.rst
@@ -15,7 +15,7 @@
     specific language governing permissions and limitations
     under the License.
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Connect your project to Gitpod
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/contributing-docs/quick-start-ide/contributors_quick_start_pycharm.rst
+++ b/contributing-docs/quick-start-ide/contributors_quick_start_pycharm.rst
@@ -15,7 +15,7 @@
     specific language governing permissions and limitations
     under the License.
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Setup your project
 ##################

--- a/contributing-docs/quick-start-ide/contributors_quick_start_vscode.rst
+++ b/contributing-docs/quick-start-ide/contributors_quick_start_vscode.rst
@@ -15,7 +15,7 @@
     specific language governing permissions and limitations
     under the License.
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Setup your project
 ##################

--- a/contributing-docs/testing/docker_compose_tests.rst
+++ b/contributing-docs/testing/docker_compose_tests.rst
@@ -20,7 +20,7 @@ Airflow Docker Compose Tests
 
 This document describes how to run tests for Airflow Docker Compose deployment.
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Running Docker Compose Tests with Breeze
 ----------------------------------------

--- a/contributing-docs/testing/integration_tests.rst
+++ b/contributing-docs/testing/integration_tests.rst
@@ -22,7 +22,7 @@ Some of the tests in Airflow are integration tests. These tests require ``airflo
 image and extra images with integrations (such as ``celery``, ``mongodb``, etc.).
 The integration tests are all stored in the ``tests/integration`` folder.
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Enabling Integrations
 ---------------------

--- a/contributing-docs/testing/k8s_tests.rst
+++ b/contributing-docs/testing/k8s_tests.rst
@@ -25,7 +25,7 @@ deploy and run the cluster tests in our repository and into Breeze development e
 KinD has a really nice ``kind`` tool that you can use to interact with the cluster. Run ``kind --help`` to
 learn more.
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 K8S test environment
 --------------------

--- a/contributing-docs/testing/system_tests.rst
+++ b/contributing-docs/testing/system_tests.rst
@@ -21,7 +21,7 @@ Airflow System Tests
 System tests need to communicate with external services/systems that are available
 if you have appropriate credentials configured for your tests.
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Purpose of System Tests
 -----------------------

--- a/contributing-docs/testing/testing_packages.rst
+++ b/contributing-docs/testing/testing_packages.rst
@@ -22,7 +22,7 @@ Breeze can be used to test new release candidates of packages - both Airflow and
 configure the CI image of Breeze to install and start Airflow for both Airflow and provider packages, whether they
 are built from sources or downloaded from PyPI as release candidates.
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Prerequisites
 -------------

--- a/contributing-docs/testing/unit_tests.rst
+++ b/contributing-docs/testing/unit_tests.rst
@@ -20,7 +20,7 @@ Airflow Unit Tests
 
 All unit tests for Apache Airflow are run using `pytest <http://doc.pytest.org/en/latest/>`_ .
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Writing Unit Tests
 ------------------

--- a/dev/breeze/doc/01_installation.rst
+++ b/dev/breeze/doc/01_installation.rst
@@ -21,7 +21,7 @@ Installation
 
 This document describes prerequisites for running Breeze and installation process.
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Docker Desktop
 --------------

--- a/dev/breeze/doc/02_customizing.rst
+++ b/dev/breeze/doc/02_customizing.rst
@@ -23,7 +23,7 @@ Customizing breeze environment
 
 Breeze can be customized in a number of ways. You can read about those ways in this document.
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 
 Customizing Breeze startup

--- a/dev/breeze/doc/03_developer_tasks.rst
+++ b/dev/breeze/doc/03_developer_tasks.rst
@@ -22,7 +22,7 @@ The regular Breeze development tasks are available as top-level commands. Those 
 used during the development, that's why they are available without any sub-command. More advanced
 commands are separated to sub-commands.
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Entering Breeze shell
 ---------------------

--- a/dev/breeze/doc/04_troubleshooting.rst
+++ b/dev/breeze/doc/04_troubleshooting.rst
@@ -19,7 +19,7 @@
 Troubleshooting
 ===============
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Basic troubleshooting of breeze command
 ---------------------------------------

--- a/dev/breeze/doc/05_test_commands.rst
+++ b/dev/breeze/doc/05_test_commands.rst
@@ -22,7 +22,7 @@ Airflow Breeze is a Python script serving as a "swiss-army-knife" of Airflow tes
 hood it uses other scripts that you can also run manually if you have problem with running the Breeze
 environment. Breeze script allows performing the following tasks:
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Running tests
 -------------

--- a/dev/breeze/doc/06_managing_docker_images.rst
+++ b/dev/breeze/doc/06_managing_docker_images.rst
@@ -22,7 +22,7 @@ Managing Docker images
 This document describes how to manage Breeze images CI and PROD - used to run containerized
 Airflow development environment and tests.
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 CI Image tasks
 --------------

--- a/dev/breeze/doc/07_breeze_maintenance_tasks.rst
+++ b/dev/breeze/doc/07_breeze_maintenance_tasks.rst
@@ -21,7 +21,7 @@ Breeze maintenance tasks
 This document describes Breeze maintenance tasks, that are mostly useful when you are
 modifying Breeze itself.
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Regenerating documentation SVG screenshots
 ..........................................

--- a/dev/breeze/doc/08_ci_tasks.rst
+++ b/dev/breeze/doc/08_ci_tasks.rst
@@ -21,7 +21,7 @@ CI tasks
 Breeze hase a number of commands that are mostly used in CI environment to perform cleanup.
 Detailed description of the CI design can be found in `CI design <ci/README.md>`_.
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Those are all the commands available in the ``ci`` group:
 

--- a/dev/breeze/doc/09_release_management_tasks.rst
+++ b/dev/breeze/doc/09_release_management_tasks.rst
@@ -21,7 +21,7 @@ Release management tasks
 Maintainers also can use Breeze for other purposes (those are commands that regular contributors likely
 do not need or have no access to run). Those are usually connected with releasing Airflow:
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Those are all of the available release management commands:
 

--- a/dev/breeze/doc/10_advanced_breeze_topics.rst
+++ b/dev/breeze/doc/10_advanced_breeze_topics.rst
@@ -21,7 +21,7 @@ Advanced Breeze topics
 This document describes advanced topics related to Breeze. It is intended for people who already
 know how to use Breeze and want to learn more about it and understand how it works under the hood.
 
-.. contents:: :local:
+**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Debugging/developing Breeze
 ---------------------------


### PR DESCRIPTION
GitHub stopped rendering .. contents:: :local: in their UI and instead opt for expandable table of content that can be shown by clicking an "index" button at the top-right of the page. It's really nice when you know it but it's not easily discoverable. Seems that this is a deliberate choice and there is no going back, so best approach we can do is to explain it to the users by replacing the index with explanation where to look for it.

More details here: https://github.com/github/markup/issues/1798

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
