### PR TITLE
Add start execution from triggerer support to dynamic task mapping

### DIFF
--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -551,7 +551,7 @@ class DecoratedMappedOperator(MappedOperator):
         XComArg.apply_upstream_relationship(self, self.op_kwargs_expand_input.value)
 
     def _expand_mapped_kwargs(
-        self, context: Context, session: Session, *, include_xcom: bool = True
+        self, context: Context, session: Session, *, include_xcom: bool
     ) -> tuple[Mapping[str, Any], set[int]]:
         # We only use op_kwargs_expand_input so this must always be empty.
         if self.expand_input is not EXPAND_INPUT_EMPTY:

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -550,11 +550,13 @@ class DecoratedMappedOperator(MappedOperator):
         super(DecoratedMappedOperator, DecoratedMappedOperator).__attrs_post_init__(self)
         XComArg.apply_upstream_relationship(self, self.op_kwargs_expand_input.value)
 
-    def _expand_mapped_kwargs(self, context: Context, session: Session) -> tuple[Mapping[str, Any], set[int]]:
+    def _expand_mapped_kwargs(
+        self, context: Context, session: Session, *, include_xcom: bool = True
+    ) -> tuple[Mapping[str, Any], set[int]]:
         # We only use op_kwargs_expand_input so this must always be empty.
         if self.expand_input is not EXPAND_INPUT_EMPTY:
             raise AssertionError(f"unexpected expand_input: {self.expand_input}")
-        op_kwargs, resolved_oids = super()._expand_mapped_kwargs(context, session)
+        op_kwargs, resolved_oids = super()._expand_mapped_kwargs(context, session, include_xcom=include_xcom)
         return {"op_kwargs": op_kwargs}, resolved_oids
 
     def _get_unmap_kwargs(self, mapped_kwargs: Mapping[str, Any], *, strict: bool) -> dict[str, Any]:

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -55,6 +55,7 @@ if TYPE_CHECKING:
     from airflow.models.operator import Operator
     from airflow.models.taskinstance import TaskInstance
     from airflow.task.priority_strategy import PriorityWeightStrategy
+    from airflow.triggers.base import StartTriggerArgs
     from airflow.utils.task_group import TaskGroup
 
 DEFAULT_OWNER: str = conf.get_mandatory_value("operators", "default_owner")
@@ -433,6 +434,16 @@ class AbstractOperator(Templater, DAGNode):
 
         MappedOperator uses this to unmap start_from_trigger to decide whether to start the task
         execution directly from triggerer.
+
+        :meta private:
+        """
+        raise NotImplementedError()
+
+    def expand_start_trigger_args(self, *, context: Context, session: Session) -> StartTriggerArgs | None:
+        """
+        Get the start_trigger_args value of the current abstract operator.
+
+        MappedOperator uses this to unmap start_trigger_args to decide how to start a task from triggerer.
 
         :meta private:
         """

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -427,6 +427,17 @@ class AbstractOperator(Templater, DAGNode):
         """
         raise NotImplementedError()
 
+    def expand_start_from_trigger(self, *, context: Context, session: Session) -> bool:
+        """
+        Get the start_from_trigger value of the current abstract operator.
+
+        MappedOperator uses this to unmap start_from_trigger to decide whether to start the task
+        execution directly from triggerer.
+
+        :meta private:
+        """
+        raise NotImplementedError()
+
     @property
     def priority_weight_total(self) -> int:
         """

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1795,6 +1795,19 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         """
         return self
 
+    def expand_start_from_trigger(self, *, context: Context, session: Session) -> bool:
+        """
+        Get the start_from_trigger value of the current abstract operator.
+
+        Since a BaseOperator is not mapped to begin with, this simply returns
+        the original value of start_from_trigger.
+        MappedOperator uses this to unmap start_from_trigger to decide whether to start the task
+        execution directly from triggerer.
+
+        :meta private:
+        """
+        return self.start_from_trigger
+
 
 # TODO: Deprecate for Airflow 3.0
 Chainable = Union[DependencyMixin, Sequence[DependencyMixin]]

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1801,12 +1801,21 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
 
         Since a BaseOperator is not mapped to begin with, this simply returns
         the original value of start_from_trigger.
-        MappedOperator uses this to unmap start_from_trigger to decide whether to start the task
-        execution directly from triggerer.
 
         :meta private:
         """
         return self.start_from_trigger
+
+    def expand_start_trigger_args(self, *, context: Context, session: Session) -> StartTriggerArgs | None:
+        """
+        Get the start_trigger_args value of the current abstract operator.
+
+        Since a BaseOperator is not mapped to begin with, this simply returns
+        the original value of start_trigger_args.
+
+        :meta private:
+        """
+        return self.start_trigger_args
 
 
 # TODO: Deprecate for Airflow 3.0

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -1582,7 +1582,6 @@ class DagRun(Base, LoggingMixin):
             # this task.
             # if not, we'll add this "ti" into "schedulable_ti_ids" and later execute it to run in the worker
             elif ti.task.start_trigger_args is not None:
-
                 context = ti.get_template_context()
                 start_from_trigger = ti.task.expand_start_from_trigger(context=context, session=session)
 

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -1582,13 +1582,9 @@ class DagRun(Base, LoggingMixin):
             # this task.
             # if not, we'll add this "ti" into "schedulable_ti_ids" and later execute it to run in the worker
             elif ti.task.start_trigger_args is not None:
-                from airflow.models.mappedoperator import MappedOperator
 
-                if isinstance(ti.task, MappedOperator):
-                    context = ti.get_template_context()
-                    start_from_trigger = ti.task._expand_start_from_trigger(context=context, session=session)
-                else:
-                    start_from_trigger = ti.task.start_from_trigger
+                context = ti.get_template_context()
+                start_from_trigger = ti.task.expand_start_from_trigger(context=context, session=session)
 
                 if start_from_trigger:
                     ti.start_date = timezone.utcnow()

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -1585,7 +1585,7 @@ class DagRun(Base, LoggingMixin):
                     context = ti.get_template_context()
                     ti.task._expand_start_trigger(context=context, session=session)
 
-                if ti.task.start_from_trigger is True:
+                if ti.task.start_from_trigger:
                     ti.start_date = timezone.utcnow()
                     if ti.state != TaskInstanceState.UP_FOR_RESCHEDULE:
                         ti.try_number += 1

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -1577,7 +1577,10 @@ class DagRun(Base, LoggingMixin):
                 and not ti.task.outlets
             ):
                 dummy_ti_ids.append((ti.task_id, ti.map_index))
-            # check whether the operator supports start execution from triggerer
+            # check "start_trigger_args" to see whether the operator supports start execution from triggerer
+            # if so, we'll then check "start_from_trigger" to see whether this feature is turned on and defer
+            # this task.
+            # if not, we'll add this "ti" into "schedulable_ti_ids" and later execute it to run in the worker
             elif ti.task.start_trigger_args is not None:
                 from airflow.models.mappedoperator import MappedOperator
 

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -1583,9 +1583,11 @@ class DagRun(Base, LoggingMixin):
 
                 if isinstance(ti.task, MappedOperator):
                     context = ti.get_template_context()
-                    ti.task._expand_start_trigger(context=context, session=session)
+                    start_from_trigger = ti.task._expand_start_from_trigger(context=context, session=session)
+                else:
+                    start_from_trigger = ti.task.start_from_trigger
 
-                if ti.task.start_from_trigger:
+                if start_from_trigger:
                     ti.start_date = timezone.utcnow()
                     if ti.state != TaskInstanceState.UP_FOR_RESCHEDULE:
                         ti.try_number += 1

--- a/airflow/models/expandinput.py
+++ b/airflow/models/expandinput.py
@@ -69,7 +69,7 @@ class MappedArgument(ResolveMixin):
         yield from self._input.iter_references()
 
     @provide_session
-    def resolve(self, context: Context, *, session: Session = NEW_SESSION, include_xcom: bool = True) -> Any:
+    def resolve(self, context: Context, *, include_xcom: bool, session: Session = NEW_SESSION) -> Any:
         data, _ = self._input.resolve(context, session=session, include_xcom=include_xcom)
         return data[self._key]
 
@@ -166,10 +166,10 @@ class DictOfListsExpandInput(NamedTuple):
         return functools.reduce(operator.mul, (lengths[name] for name in self.value), 1)
 
     def _expand_mapped_field(
-        self, key: str, value: Any, context: Context, *, session: Session, include_xcom: bool = True
+        self, key: str, value: Any, context: Context, *, session: Session, include_xcom: bool
     ) -> Any:
         if include_xcom and _needs_run_time_resolution(value):
-            value = value.resolve(context, session=session)
+            value = value.resolve(context, session=session, include_xcom=include_xcom)
         map_index = context["ti"].map_index
         if map_index < 0:
             raise RuntimeError("can't resolve task-mapping argument without expanding")
@@ -206,9 +206,12 @@ class DictOfListsExpandInput(NamedTuple):
                 yield from x.iter_references()
 
     def resolve(
-        self, context: Context, session: Session, *, include_xcom: bool = True
+        self, context: Context, session: Session, *, include_xcom: bool
     ) -> tuple[Mapping[str, Any], set[int]]:
-        data = {k: self._expand_mapped_field(k, v, context, session=session) for k, v in self.value.items()}
+        data = {
+            k: self._expand_mapped_field(k, v, context, session=session, include_xcom=include_xcom)
+            for k, v in self.value.items()
+        }
         literal_keys = {k for k, _ in self._iter_parse_time_resolved_kwargs()}
         resolved_oids = {id(v) for k, v in data.items() if k not in literal_keys}
         return data, resolved_oids
@@ -253,7 +256,7 @@ class ListOfDictsExpandInput(NamedTuple):
                     yield from x.iter_references()
 
     def resolve(
-        self, context: Context, session: Session, *, include_xcom: bool = True
+        self, context: Context, session: Session, *, include_xcom: bool
     ) -> tuple[Mapping[str, Any], set[int]]:
         map_index = context["ti"].map_index
         if map_index < 0:
@@ -263,9 +266,9 @@ class ListOfDictsExpandInput(NamedTuple):
         if isinstance(self.value, collections.abc.Sized):
             mapping = self.value[map_index]
             if not isinstance(mapping, collections.abc.Mapping):
-                mapping = mapping.resolve(context, session)
+                mapping = mapping.resolve(context, session, include_xcom=include_xcom)
         elif include_xcom:
-            mappings = self.value.resolve(context, session)
+            mappings = self.value.resolve(context, session, include_xcom=include_xcom)
             if not isinstance(mappings, collections.abc.Sequence):
                 raise ValueError(f"expand_kwargs() expects a list[dict], not {_describe_type(mappings)}")
             mapping = mappings[map_index]

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -689,7 +689,7 @@ class MappedOperator(AbstractOperator):
         return DagAttributeTypes.OP, self.task_id
 
     def _expand_mapped_kwargs(
-        self, context: Context, session: Session, *, include_xcom: bool = True
+        self, context: Context, session: Session, *, include_xcom: bool
     ) -> tuple[Mapping[str, Any], set[int]]:
         """
         Get the kwargs to create the unmapped operator.
@@ -812,7 +812,7 @@ class MappedOperator(AbstractOperator):
             if isinstance(resolve, collections.abc.Mapping):
                 kwargs = resolve
             elif resolve is not None:
-                kwargs, _ = self._expand_mapped_kwargs(*resolve)
+                kwargs, _ = self._expand_mapped_kwargs(*resolve, include_xcom=True)
             else:
                 raise RuntimeError("cannot unmap a non-serialized operator without context")
             kwargs = self._get_unmap_kwargs(kwargs, strict=self._disallow_kwargs_override)
@@ -907,7 +907,7 @@ class MappedOperator(AbstractOperator):
         # set_current_task_session context manager to store the session in the current task.
         session = get_current_task_instance_session()
 
-        mapped_kwargs, seen_oids = self._expand_mapped_kwargs(context, session)
+        mapped_kwargs, seen_oids = self._expand_mapped_kwargs(context, session, include_xcom=True)
         unmapped_task = self.unmap(mapped_kwargs)
         context_update_for_unmapped(context, unmapped_task)
 

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -731,12 +731,16 @@ class MappedOperator(AbstractOperator):
             "params": params,
         }
 
-    def _expand_start_from_trigger(self, *, context: Context, session: Session) -> bool:
+    def expand_start_from_trigger(self, *, context: Context, session: Session) -> bool:
         """
-        Get the kwargs to create the unmapped start_from_trigger.
+        Get the start_from_trigger value of the current abstract operator.
 
-        This method is for allowing mapped operator to start execution from triggerer.
+        MappedOperator uses this to unmap start_from_trigger to decide whether to start the task
+        execution directly from triggerer.
+
+        :meta private:
         """
+        # start_from_trigger only makes sense when start_trigger_args exists.
         if not self.start_trigger_args:
             return False
 

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -738,13 +738,22 @@ class MappedOperator(AbstractOperator):
             return
 
         mapped_kwargs, _ = self._expand_mapped_kwargs(context, session)
-        self.start_from_trigger = mapped_kwargs.get("start_from_trigger", self.start_from_trigger)
+        if self._disallow_kwargs_override:
+            prevent_duplicates(
+                self.partial_kwargs,
+                mapped_kwargs,
+                fail_reason="unmappable or already specified",
+            )
 
-        self.start_trigger_args.trigger_kwargs = mapped_kwargs.get(
-            "trigger_kwargs", self.start_trigger_args.trigger_kwargs
+        self.start_from_trigger = self.partial_kwargs.get(
+            "start_from_trigger", mapped_kwargs.get("start_from_trigger", self.start_from_trigger)
         )
-        self.start_trigger_args.timeout = mapped_kwargs.get(
-            "trigger_timeout", self.start_trigger_args.timeout
+
+        self.start_trigger_args.trigger_kwargs = self.partial_kwargs.get(
+            "trigger_kwargs", mapped_kwargs.get("trigger_kwargs", self.start_trigger_args.trigger_kwargs)
+        )
+        self.start_trigger_args.timeout = self.partial_kwargs.get(
+            "trigger_timeout", mapped_kwargs.get("trigger_timeout", self.start_trigger_args.timeout)
         )
 
     def unmap(self, resolve: None | Mapping[str, Any] | tuple[Context, Session]) -> BaseOperator:

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -757,16 +757,14 @@ class MappedOperator(AbstractOperator):
             "start_from_trigger", self.partial_kwargs.get("start_from_trigger", self.start_from_trigger)
         )
 
-    def _expand_start_trigger_args(self, *, context: Context, session: Session) -> StartTriggerArgs:
+    def expand_start_trigger_args(self, *, context: Context, session: Session) -> StartTriggerArgs | None:
         """
         Get the kwargs to create the unmapped start_trigger_args.
 
         This method is for allowing mapped operator to start execution from triggerer.
         """
         if not self.start_trigger_args:
-            raise AirflowException(
-                "Cannot expand start_trigger_args for mapped operator without class level start_trigger_args"
-            )
+            return None
 
         mapped_kwargs, _ = self._expand_mapped_kwargs(context, session, include_xcom=False)
         if self._disallow_kwargs_override:

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -745,15 +745,18 @@ class MappedOperator(AbstractOperator):
                 fail_reason="unmappable or already specified",
             )
 
-        self.start_from_trigger = self.partial_kwargs.get(
-            "start_from_trigger", mapped_kwargs.get("start_from_trigger", self.start_from_trigger)
+        # Ordering is significant; mapped kwargs should override partial ones.
+
+        self.start_from_trigger = mapped_kwargs.get(
+            "start_from_trigger", self.partial_kwargs.get("start_from_trigger", self.start_from_trigger)
         )
 
-        self.start_trigger_args.trigger_kwargs = self.partial_kwargs.get(
-            "trigger_kwargs", mapped_kwargs.get("trigger_kwargs", self.start_trigger_args.trigger_kwargs)
+        self.start_trigger_args.trigger_kwargs = mapped_kwargs.get(
+            "trigger_kwargs",
+            self.partial_kwargs.get("trigger_kwargs", self.start_trigger_args.trigger_kwargs),
         )
-        self.start_trigger_args.timeout = self.partial_kwargs.get(
-            "trigger_timeout", mapped_kwargs.get("trigger_timeout", self.start_trigger_args.timeout)
+        self.start_trigger_args.timeout = mapped_kwargs.get(
+            "trigger_timeout", self.partial_kwargs.get("trigger_timeout", self.start_trigger_args.timeout)
         )
 
     def unmap(self, resolve: None | Mapping[str, Any] | tuple[Context, Session]) -> BaseOperator:

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -729,6 +729,24 @@ class MappedOperator(AbstractOperator):
             "params": params,
         }
 
+    def _expand_start_trigger(self, *, context: Context, session: Session) -> None:
+        """Get the kwargs to create the unmapped start_from_trigger and start_trigger_args.
+
+        This method is for allowing mapped operator to start execution from triggerer.
+        """
+        if not self.start_trigger_args:
+            return
+
+        mapped_kwargs, _ = self._expand_mapped_kwargs(context, session)
+        self.start_from_trigger = mapped_kwargs.get("start_from_trigger", self.start_from_trigger)
+
+        self.start_trigger_args.trigger_kwargs = mapped_kwargs.get(
+            "trigger_kwargs", self.start_trigger_args.trigger_kwargs
+        )
+        self.start_trigger_args.timeout = mapped_kwargs.get(
+            "trigger_timeout", self.start_trigger_args.timeout
+        )
+
     def unmap(self, resolve: None | Mapping[str, Any] | tuple[Context, Session]) -> BaseOperator:
         """
         Get the "normal" Operator after applying the current mapping.

--- a/airflow/models/param.py
+++ b/airflow/models/param.py
@@ -329,7 +329,7 @@ class DagParam(ResolveMixin):
     def iter_references(self) -> Iterable[tuple[Operator, str]]:
         return ()
 
-    def resolve(self, context: Context) -> Any:
+    def resolve(self, context: Context, *, include_xcom: bool) -> Any:
         """Pull DagParam value from DagRun context. This method is run during ``op.execute()``."""
         with contextlib.suppress(KeyError):
             return context["dag_run"].conf[self._name]

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1634,7 +1634,7 @@ def _defer_task(
             kwargs=trigger_kwargs,
         )
     else:
-        raise AirflowException("exception and ti.task.start_trigger_args cannot both be None")
+        raise TaskDeferralError("exception and ti.task.start_trigger_args cannot both be None")
 
     # First, make the trigger entry
     session.add(trigger_row)

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -208,7 +208,7 @@ class XComArg(ResolveMixin, DependencyMixin):
         raise NotImplementedError()
 
     @provide_session
-    def resolve(self, context: Context, session: Session = NEW_SESSION) -> Any:
+    def resolve(self, context: Context, session: Session = NEW_SESSION, *, include_xcom: bool) -> Any:
         """
         Pull XCom value.
 
@@ -437,7 +437,7 @@ class PlainXComArg(XComArg):
         )
 
     @provide_session
-    def resolve(self, context: Context, session: Session = NEW_SESSION) -> Any:
+    def resolve(self, context: Context, session: Session = NEW_SESSION, *, include_xcom: bool) -> Any:
         ti = context["ti"]
         if TYPE_CHECKING:
             assert isinstance(ti, TaskInstance)
@@ -551,8 +551,8 @@ class MapXComArg(XComArg):
         return self.arg.get_task_map_length(run_id, session=session)
 
     @provide_session
-    def resolve(self, context: Context, session: Session = NEW_SESSION) -> Any:
-        value = self.arg.resolve(context, session=session)
+    def resolve(self, context: Context, session: Session = NEW_SESSION, *, include_xcom: bool) -> Any:
+        value = self.arg.resolve(context, session=session, include_xcom=include_xcom)
         if not isinstance(value, (Sequence, dict)):
             raise ValueError(f"XCom map expects sequence or dict, not {type(value).__name__}")
         return _MapResult(value, self.callables)
@@ -632,8 +632,8 @@ class ZipXComArg(XComArg):
         return max(ready_lengths)
 
     @provide_session
-    def resolve(self, context: Context, session: Session = NEW_SESSION) -> Any:
-        values = [arg.resolve(context, session=session) for arg in self.args]
+    def resolve(self, context: Context, session: Session = NEW_SESSION, *, include_xcom: bool) -> Any:
+        values = [arg.resolve(context, session=session, include_xcom=include_xcom) for arg in self.args]
         for value in values:
             if not isinstance(value, (Sequence, dict)):
                 raise ValueError(f"XCom zip expects sequence or dict, not {type(value).__name__}")
@@ -707,8 +707,8 @@ class ConcatXComArg(XComArg):
         return sum(ready_lengths)
 
     @provide_session
-    def resolve(self, context: Context, session: Session = NEW_SESSION) -> Any:
-        values = [arg.resolve(context, session=session) for arg in self.args]
+    def resolve(self, context: Context, session: Session = NEW_SESSION, *, include_xcom: bool) -> Any:
+        values = [arg.resolve(context, session=session, include_xcom=include_xcom) for arg in self.args]
         for value in values:
             if not isinstance(value, (Sequence, dict)):
                 raise ValueError(f"XCom concat expects sequence or dict, not {type(value).__name__}")

--- a/airflow/template/templater.py
+++ b/airflow/template/templater.py
@@ -46,7 +46,7 @@ class LiteralValue(ResolveMixin):
     def iter_references(self) -> Iterable[tuple[Operator, str]]:
         return ()
 
-    def resolve(self, context: Context) -> Any:
+    def resolve(self, context: Context, *, include_xcom: bool) -> Any:
         return self.value
 
 
@@ -172,7 +172,7 @@ class Templater(LoggingMixin):
         if isinstance(value, ObjectStoragePath):
             return self._render_object_storage_path(value, context, jinja_env)
         if isinstance(value, ResolveMixin):
-            return value.resolve(context)
+            return value.resolve(context, include_xcom=True)
 
         # Fast path for common built-in collections.
         if value.__class__ is tuple:

--- a/airflow/utils/mixins.py
+++ b/airflow/utils/mixins.py
@@ -64,7 +64,7 @@ class ResolveMixin:
         """
         raise NotImplementedError
 
-    def resolve(self, context: Context) -> typing.Any:
+    def resolve(self, context: Context, *, include_xcom: bool) -> typing.Any:
         """
         Resolve this value for runtime.
 

--- a/docs/apache-airflow/authoring-and-scheduling/deferring.rst
+++ b/docs/apache-airflow/authoring-and-scheduling/deferring.rst
@@ -245,7 +245,7 @@ To enable Dynamic Task Mapping support, you can define ``start_from_trigger`` an
             # We have no more work to do here. Mark as complete.
             return
 
-These parameters can be mapped using the ``expand`` and ``partial`` methods.
+These parameters can be mapped using the ``expand`` and ``partial`` methods. Note that XCom values won't be resolved at this stage.
 
 .. code-block:: python
 

--- a/docs/apache-airflow/authoring-and-scheduling/deferring.rst
+++ b/docs/apache-airflow/authoring-and-scheduling/deferring.rst
@@ -210,7 +210,7 @@ This is particularly useful when deferring is the only thing the ``execute`` met
             # We have no more work to do here. Mark as complete.
             return
 
-To enable Dynamic Task Mapping support, you can define ``start_from_trigger`` and ``trigger_kwargs`` in the parameter of "__init__". Note that you don't need to define both of them to use this feature, but you do need to use the exact same parameter name. For example, if you define an argument as ``t_kwargs`` and assign this value to ``self.start_trigger_args.trigger_kwargs``, it will not work.
+To enable Dynamic Task Mapping support, you can define ``start_from_trigger`` and ``trigger_kwargs`` in the parameter of "__init__". Note that you don't need to define both of them to use this feature, but you do need to use the exact same parameter name. For example, if you define an argument as ``t_kwargs`` and assign this value to ``self.start_trigger_args.trigger_kwargs``, it will not work. Note that this works different from mapping an operator without ``start_from_trigger`` support. The whole ``__init__`` method is skipped when mapping an operator whose ``start_from_trigger`` is set to True. Only argument ``trigger_kwargs`` is used and passed into ``trigger_cls``.
 
 .. code-block:: python
 

--- a/docs/apache-airflow/authoring-and-scheduling/deferring.rst
+++ b/docs/apache-airflow/authoring-and-scheduling/deferring.rst
@@ -249,7 +249,7 @@ These parameters can be mapped using the ``expand`` and ``partial`` methods.
 
 .. code-block:: python
 
-    WaitTwoHourSensor.partial(task_id="transform").partial(start_from_trigger=True).expand(
+    WaitTwoHourSensor.partial(task_id="transform", start_from_trigger=True).expand(
         trigger_kwargs=[{"moment": timedelta(hours=2)}, {"moment": timedelta(hours=2)}]
     )
 

--- a/docs/apache-airflow/authoring-and-scheduling/deferring.rst
+++ b/docs/apache-airflow/authoring-and-scheduling/deferring.rst
@@ -245,12 +245,12 @@ To enable Dynamic Task Mapping support, you can define ``start_from_trigger`` an
             # We have no more work to do here. Mark as complete.
             return
 
-These parameters can be mapped using the ``expand`` method.
+These parameters can be mapped using the ``expand`` and ``partial`` methods.
 
 .. code-block:: python
 
-    WaitTwoHourSensor.partial(task_id="transform").expand(
-        trigger_kwargs=[{"moment": timedelta(hours=1)}], start_from_trigger=True
+    WaitTwoHourSensor.partial(task_id="transform").partial(start_from_trigger=True).expand(
+        trigger_kwargs=[{"moment": timedelta(hours=2)}, {"moment": timedelta(hours=2)}]
     )
 
 Writing Triggers


### PR DESCRIPTION
This is a follow-up PR of https://github.com/apache/airflow/pull/39585, which enables the mapped operator to start execution from triggerer

## Why
Dynamic task mapping is not yet supported in https://github.com/apache/airflow/pull/38674 and https://github.com/apache/airflow/pull/39585.

## What
Allow DAG authors to provide argument `trigger_kwargs` and `start_from_trigger` in `__init__` which can be used in `expand`.


```python
from __future__ import annotations

from datetime import timedelta
from typing import Any

from airflow.models.baseoperator import BaseOperator, StartTriggerArgs
from airflow.triggers.temporal import TimeDeltaTrigger


class AsyncOperator(BaseOperator):
    start_trigger_args = StartTriggerArgs(
        trigger_cls="airflow.triggers.testing.SuccessTrigger",
        trigger_kwargs={},
        next_method="execute_complete",
        timeout=None,
    )
    start_from_trigger = True

    def __init__(self, *args, start_from_trigger: bool, trigger_kwargs=None, **kwargs):
        super().__init__(*args, **kwargs)
        self.start_from_trigger = start_from_trigger
        self.start_trigger_args.trigger_kwargs = trigger_kwargs

    def execute(self, context):
        self.log.info("execute")

    def execute_complete(self, context, event=None) -> None:
        self.log.info("execute complete")
```


```python
from __future__ import annotations

import datetime

import pendulum

from airflow import DAG
from airflow.operators.async_op import AsyncOperator

with DAG(
    dag_id="example_async_operator",
    schedule=None,
    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
    catchup=False,
    dagrun_timeout=datetime.timedelta(minutes=10),
) as dag:
    add_one_task = AsyncOperator.partial(task_id="add_one").expand(
        trigger_kwargs=[{}, {}], start_from_trigger=[True, False]
    )
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
