### PR TITLE
Return rendered value and renderer for syntax highlighting in UI.

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3863,6 +3863,12 @@ components:
 
             *New in version 2.3.0*
           type: object
+        template_fields_renderers:
+          description: |
+            JSON object describing renderer mapping for task template fields.
+
+            *New in version 2.10.0*
+          type: object
         trigger:
           $ref: "#/components/schemas/Trigger"
         triggerer_job:

--- a/airflow/www/static/js/api/index.ts
+++ b/airflow/www/static/js/api/index.ts
@@ -66,7 +66,12 @@ axios.interceptors.request.use((config) => {
 });
 
 axios.interceptors.response.use((res: AxiosResponse) =>
-  res.data ? camelcaseKeys(res.data, { deep: true }) : res
+  // Don't convert case for rendered_fields whose keys should remain the same.
+  res.data
+    ? camelcaseKeys(res.data, {
+        deep: res.data.rendered_fields === undefined,
+      })
+    : res
 );
 
 axios.defaults.headers.common.Accept = "application/json";

--- a/airflow/www/static/js/dag/details/taskInstance/Details.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Details.tsx
@@ -355,13 +355,10 @@ const Details = ({ gridInstance, taskInstance, group }: Props) => {
                 >;
 
                 const templateFieldsRenderers =
-                  taskInstance.templateFieldsRenderers as Record<
-                    string,
-                    string
-                  >;
+                  instance.templateFieldsRenderers as Record<string, string>;
 
-                  const field = renderedFields[key];
-		  let validJSON = false;
+                const field = renderedFields[key];
+                let validJSON = false;
                 let fieldString = field as unknown as string;
                 const renderer = templateFieldsRenderers[key] || null;
                 const language: string = renderer
@@ -371,8 +368,8 @@ const Details = ({ gridInstance, taskInstance, group }: Props) => {
                 if (field) {
                   if (typeof field !== "string") {
                     try {
-			fieldString = JSON.stringify(field, null, 4);
-			validJSON = true;
+                      fieldString = JSON.stringify(field, null, 4);
+                      validJSON = true;
                     } catch (e) {
                       // skip
                     }
@@ -382,29 +379,30 @@ const Details = ({ gridInstance, taskInstance, group }: Props) => {
                     <Tr key={key}>
                       <Td>{key}</Td>
                       <Td>
-		      if (validJSON) {
+                        {validJSON && (
                           <RenderedJsonField content={fieldString} />
-		      } else {
-                        <Flex alignItems="right">
-                          <SyntaxHighlighter
-                            customStyle={{
-                              fontSize: theme.fontSizes.md,
-                              font: theme.fonts.mono,
-                            }}
-                            language={language}
-                            style={oneLight}
-                            wrapLongLines
-                          >
-                            {fieldString}
-                          </SyntaxHighlighter>
-                          <ClipboardButton
-                            ml={2}
-                            mt={2}
-                            iconOnly
-                            value={fieldString}
-                          />
-                              </Flex>
-		      }
+                        )}
+                        {!validJSON && (
+                          <Flex alignItems="right">
+                            <SyntaxHighlighter
+                              customStyle={{
+                                fontSize: theme.fontSizes.md,
+                                font: theme.fonts.mono,
+                              }}
+                              language={language}
+                              style={oneLight}
+                              wrapLongLines
+                            >
+                              {fieldString}
+                            </SyntaxHighlighter>
+                            <ClipboardButton
+                              ml={2}
+                              mt={2}
+                              iconOnly
+                              value={fieldString}
+                            />
+                          </Flex>
+                        )}
                       </Td>
                     </Tr>
                   );

--- a/airflow/www/static/js/dag/details/taskInstance/Details.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Details.tsx
@@ -18,7 +18,17 @@
  */
 
 import React, { useEffect, useState } from "react";
-import { Text, Flex, Table, Tbody, Tr, Td, Code, Box } from "@chakra-ui/react";
+import {
+  Text,
+  Flex,
+  Table,
+  Tbody,
+  Tr,
+  Td,
+  Code,
+  Box,
+  useTheme,
+} from "@chakra-ui/react";
 import { snakeCase } from "lodash";
 
 import { useTIHistory } from "src/api";
@@ -62,6 +72,7 @@ const dagId = getMetaValue("dag_id");
 const Details = ({ gridInstance, taskInstance, group }: Props) => {
   const isGroup = !!group?.children;
   const summary: React.ReactNode[] = [];
+  const theme = useTheme();
 
   const { runId, taskId } = gridInstance || {};
 
@@ -376,7 +387,10 @@ const Details = ({ gridInstance, taskInstance, group }: Props) => {
 		      } else {
                         <Flex alignItems="right">
                           <SyntaxHighlighter
-                            fontSize="md"
+                            customStyle={{
+                              fontSize: theme.fontSizes.md,
+                              font: theme.fonts.mono,
+                            }}
                             language={language}
                             style={oneLight}
                             wrapLongLines

--- a/airflow/www/static/js/dag/details/taskInstance/Details.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Details.tsx
@@ -343,9 +343,16 @@ const Details = ({ gridInstance, taskInstance, group }: Props) => {
                   Record<string, string | null>
                 >;
 
-                let { value: field } = renderedFields[key];
-		let validJSON = false;
-                const { renderer } = renderedFields[key];
+                const templateFieldsRenderers =
+                  taskInstance.templateFieldsRenderers as Record<
+                    string,
+                    string
+                  >;
+
+                  const field = renderedFields[key];
+		  let validJSON = false;
+                let fieldString = field as unknown as string;
+                const renderer = templateFieldsRenderers[key] || null;
                 const language: string = renderer
                   ? languageMapping[renderer] ?? "plaintext"
                   : "plaintext";
@@ -353,7 +360,7 @@ const Details = ({ gridInstance, taskInstance, group }: Props) => {
                 if (field) {
                   if (typeof field !== "string") {
                     try {
-			field = JSON.stringify(field, null, 4);
+			fieldString = JSON.stringify(field, null, 4);
 			validJSON = true;
                     } catch (e) {
                       // skip
@@ -365,7 +372,7 @@ const Details = ({ gridInstance, taskInstance, group }: Props) => {
                       <Td>{key}</Td>
                       <Td>
 		      if (validJSON) {
-                          <RenderedJsonField content={field as string} />
+                          <RenderedJsonField content={fieldString} />
 		      } else {
                         <Flex alignItems="right">
                           <SyntaxHighlighter
@@ -374,13 +381,13 @@ const Details = ({ gridInstance, taskInstance, group }: Props) => {
                             style={oneLight}
                             wrapLongLines
                           >
-                            {field as string}
+                            {fieldString}
                           </SyntaxHighlighter>
                           <ClipboardButton
                             ml={2}
                             mt={2}
                             iconOnly
-                            value={field as string}
+                            value={fieldString}
                           />
                               </Flex>
 		      }

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1540,6 +1540,12 @@ export interface components {
        * *New in version 2.3.0*
        */
       rendered_fields?: { [key: string]: unknown };
+      /**
+       * @description JSON object describing renderer mapping for task template fields.
+       *
+       * *New in version 2.10.0*
+       */
+      template_fields_renderers?: { [key: string]: unknown };
       trigger?: components["schemas"]["Trigger"];
       triggerer_job?: components["schemas"]["Job"];
       /**

--- a/tests/api_connexion/endpoints/test_mapped_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_mapped_task_instance_endpoint.py
@@ -245,6 +245,7 @@ class TestGetMappedTaskInstance(TestMappedTaskInstanceEndpoint):
             "unixname": getuser(),
             "trigger": None,
             "triggerer_job": None,
+            "template_fields_renderers": {},
         }
 
     def test_should_raises_401_unauthenticated(self):

--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -265,6 +265,11 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "rendered_map_index": None,
             "trigger": None,
             "triggerer_job": None,
+            "template_fields_renderers": {
+                "op_args": "py",
+                "op_kwargs": "py",
+                "templates_dict": "json",
+            },
         }
 
     def test_should_respond_200_with_task_state_in_deferred(self, session):
@@ -333,6 +338,11 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
                 "state": "running",
                 "unixname": getuser(),
             },
+            "template_fields_renderers": {
+                "op_args": "py",
+                "op_kwargs": "py",
+                "templates_dict": "json",
+            },
         }
 
     def test_should_respond_200_with_task_state_in_removed(self, session):
@@ -372,6 +382,11 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "rendered_map_index": None,
             "trigger": None,
             "triggerer_job": None,
+            "template_fields_renderers": {
+                "op_args": "py",
+                "op_kwargs": "py",
+                "templates_dict": "json",
+            },
         }
 
     def test_should_respond_200_task_instance_with_sla_and_rendered(self, session):
@@ -431,6 +446,11 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "rendered_map_index": None,
             "trigger": None,
             "triggerer_job": None,
+            "template_fields_renderers": {
+                "op_args": "py",
+                "op_kwargs": "py",
+                "templates_dict": "json",
+            },
         }
 
     def test_should_respond_200_mapped_task_instance_with_rtif(self, session):
@@ -484,6 +504,11 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
                 "rendered_map_index": None,
                 "trigger": None,
                 "triggerer_job": None,
+                "template_fields_renderers": {
+                    "op_args": "py",
+                    "op_kwargs": "py",
+                    "templates_dict": "json",
+                },
             }
 
     def test_should_raises_401_unauthenticated(self):
@@ -2447,6 +2472,11 @@ class TestSetTaskInstanceNote(TestTaskInstanceEndpoint):
             "rendered_map_index": None,
             "trigger": None,
             "triggerer_job": None,
+            "template_fields_renderers": {
+                "op_args": "py",
+                "op_kwargs": "py",
+                "templates_dict": "json",
+            },
         }
         ti = session.scalars(select(TaskInstance).where(TaskInstance.task_id == "print_the_context")).one()
         assert ti.task_instance_note.user_id is not None
@@ -2507,6 +2537,11 @@ class TestSetTaskInstanceNote(TestTaskInstanceEndpoint):
                 "rendered_map_index": None,
                 "trigger": None,
                 "triggerer_job": None,
+                "template_fields_renderers": {
+                    "op_args": "py",
+                    "op_kwargs": "py",
+                    "templates_dict": "json",
+                },
             }
 
     def test_should_respond_200_when_note_is_empty(self, session):


### PR DESCRIPTION
closes: #39527
related: #39527

This PR is like POC of the approach. The main point is to return the renderer information for the template field to UI and let react syntax highlighter module use the info to apply appropriate language syntax highlighting. There are four changes

1. To get the renderers the task needs to be retrieved from dagbag which in turn needs the existing session attached to be passed to get_dag or else the new session created will commit and cause the one attached to task_instance during serialization to become stale.
2. Earlier the rendered_fields will return only the value and now it will return {"value": value, "renderer": renderer} which though defined as a dictionary without structure might break scripts using it. 
3. Since configuration.query.query which is also a rendered field previously it was not returned in API but visible in the legacy page. Such nested paths are also now returned in the API.
4. Rendered template fields should be rendered as it is and not converted to camelcase which is also fixed here by excluding nested keys when rendered_fields key is present in response.

Thoughts welcome on the change and possible approaches.

Before PR : 

```
  "rendered_fields": {
    "configuration": {
        "query": {
          "query": "INSERT INTO `mylong_table_name`\n            (id,\n             name,\n             age)\nSELECT id,\n       name,\n       age\nFROM   users;"
        }
    },
    "project_id": 1
  },
```

With PR : 

```
  "rendered_fields": {
    "configuration": {
      "renderer": "json",
      "value": {
        "query": {
          "query": "INSERT INTO `mylong_table_name`\n            (id,\n             name,\n             age)\nSELECT id,\n       name,\n       age\nFROM   users;"
        }
      }
    },
    "configuration.query.query": {
      "renderer": "sql",
      "value": "INSERT INTO `mylong_table_name`\n            (id,\n             name,\n             age)\nSELECT id,\n       name,\n       age\nFROM   users;"
    },
    "project_id": {
      "renderer": null,
      "value": 1
    }
  },
```
Screenshot : 

![image](https://github.com/apache/airflow/assets/3972343/2927ae44-0407-45ce-9bc0-92b6e582a4c7)
