### PR TITLE
Prepare docs 4th wave May 2024

### DIFF
--- a/airflow/providers/amazon/CHANGELOG.rst
+++ b/airflow/providers/amazon/CHANGELOG.rst
@@ -26,6 +26,20 @@
 Changelog
 ---------
 
+8.24.0
+......
+
+Features
+~~~~~~~~
+
+* ``ECS Overrides for AWS Batch submit_job (#39903)``
+* ``Add transfer operator S3ToDynamoDBOperator (#39654)``
+
+Misc
+~~~~
+
+* ``Resolving ECS fargate deprecated warnings (#39834)``
+
 8.23.0
 ......
 

--- a/airflow/providers/amazon/__init__.py
+++ b/airflow/providers/amazon/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "8.23.0"
+__version__ = "8.24.0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -22,9 +22,10 @@ description: |
   Amazon integration (including `Amazon Web Services (AWS) <https://aws.amazon.com/>`__).
 
 state: ready
-source-date-epoch: 1716286347
+source-date-epoch: 1717051501
 # note that those versions are maintained by release manager - do not update them manually
 versions:
+  - 8.24.0
   - 8.23.0
   - 8.22.0
   - 8.21.0

--- a/airflow/providers/cncf/kubernetes/CHANGELOG.rst
+++ b/airflow/providers/cncf/kubernetes/CHANGELOG.rst
@@ -40,6 +40,8 @@ Bug Fixes
 ~~~~~~~~~
 
 * ``Fix deprecated calls in 'cncf.kubernetes' provider (#39381)``
+* ``Handling exception getting logs when pods finish success (#39296)``
+* ``fix wrong arguments in read_namespaced_pod_log call (#39874)``
 
 Misc
 ~~~~
@@ -48,11 +50,13 @@ Misc
 * ``Remove compat code for 2.7.0 - its now the min Airflow version (#39591)``
 * ``Simplify 'airflow_version' imports (#39497)``
 * ``Replace pod_manager.read_pod_logs with client.read_namespaced_pod_log in KubernetesPodOperator._write_logs (#39112)``
+* ``Add a warning message to KPO to warn of one second interval logs duplication (#39861)``
 
 .. Below changes are excluded from the changelog. Move them to
    appropriate section above if needed. Do not delete the lines(!):
    * ``Reapply templates for all providers (#39554)``
    * ``Faster 'airflow_version' imports (#39552)``
+   * ``Prepare docs 3rd wave May 2024 (#39738)``
 
 8.2.0
 .....

--- a/airflow/providers/teradata/CHANGELOG.rst
+++ b/airflow/providers/teradata/CHANGELOG.rst
@@ -25,6 +25,22 @@
 Changelog
 ---------
 
+2.2.0
+.....
+
+Features
+~~~~~~~~
+
+.. note::
+  This release contains several new features including:
+  • Introduction of Stored Procedure Support in Teradata Hook
+  • Inclusion of the TeradataStoredProcedureOperator for executing stored procedures
+  • Integration of Azure Blob Storage to Teradata Transfer Operator
+  • Integration of Amazon S3 to Teradata Transfer Operator
+  • Provision of necessary documentation, along with unit and system tests, for the Teradata Provider modifications.
+
+* ``Updates to Teradata Provider (#39217)``
+
 2.1.1
 .....
 

--- a/airflow/providers/teradata/__init__.py
+++ b/airflow/providers/teradata/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "2.1.1"
+__version__ = "2.2.0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.7.0"

--- a/airflow/providers/teradata/provider.yaml
+++ b/airflow/providers/teradata/provider.yaml
@@ -22,9 +22,10 @@ description: |
     `Teradata <https://www.teradata.com/>`__
 
 state: ready
-source-date-epoch: 1716289161
+source-date-epoch: 1717051506
 # note that those versions are maintained by release manager - do not update them manually
 versions:
+  - 2.2.0
   - 2.1.1
   - 2.1.0
   - 2.0.0

--- a/docs/apache-airflow-providers-amazon/commits.rst
+++ b/docs/apache-airflow-providers-amazon/commits.rst
@@ -35,14 +35,28 @@ For high-level changelog, see :doc:`package information including changelog <ind
 
 
 
+8.24.0
+......
+
+Latest change: 2024-05-29
+
+=================================================================================================  ===========  ==============================================================
+Commit                                                                                             Committed    Subject
+=================================================================================================  ===========  ==============================================================
+`5f2ebb312b <https://github.com/apache/airflow/commit/5f2ebb312b08769b454a777280ddf5c43c38bb87>`_  2024-05-29   ``ECS Overrides for AWS Batch submit_job (#39903)``
+`53081cd342 <https://github.com/apache/airflow/commit/53081cd342098a2ab7be18a62f7b87e7c0b9e2e3>`_  2024-05-27   ``Implement amazon s3 to dynamodb transfer operator (#39654)``
+`8a35a6abdc <https://github.com/apache/airflow/commit/8a35a6abdcdcc2558048701adce82f2132e05884>`_  2024-05-26   ``Resolving ECS fargate deprecated warnings (#39834)``
+=================================================================================================  ===========  ==============================================================
+
 8.23.0
 ......
 
-Latest change: 2024-05-23
+Latest change: 2024-05-26
 
 =================================================================================================  ===========  ==============================================================================================================================
 Commit                                                                                             Committed    Subject
 =================================================================================================  ===========  ==============================================================================================================================
+`34500f3a2f <https://github.com/apache/airflow/commit/34500f3a2fa4652272bc831e3c18fd2a6a2da5ef>`_  2024-05-26   ``Prepare docs 3rd wave May 2024 (#39738)``
 `e565cea65c <https://github.com/apache/airflow/commit/e565cea65cb42e43387aa7fd135ac46e8ac25f65>`_  2024-05-23   ``Resolving EMR deprecated warnings (#39743)``
 `7b588b4dd9 <https://github.com/apache/airflow/commit/7b588b4dd97ee719b9574c2f9b948b7a5a837968>`_  2024-05-22   ``misc: add comment about remove unused code (#39748)``
 `a78ee74b6a <https://github.com/apache/airflow/commit/a78ee74b6a6d1774f7f248b14100eda8f87d9952>`_  2024-05-22   ``bugfix: handle invalid cluster states in NeptuneStopDbClusterOperator (#38287)``

--- a/docs/apache-airflow-providers-amazon/index.rst
+++ b/docs/apache-airflow-providers-amazon/index.rst
@@ -86,7 +86,7 @@ apache-airflow-providers-amazon package
 Amazon integration (including `Amazon Web Services (AWS) <https://aws.amazon.com/>`__).
 
 
-Release: 8.23.0
+Release: 8.24.0
 
 Provider package
 ----------------
@@ -161,5 +161,5 @@ Downloading official packages
 You can download officially released packages and verify their checksums and signatures from the
 `Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
 
-* `The apache-airflow-providers-amazon 8.23.0 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_amazon-8.23.0.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_amazon-8.23.0.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_amazon-8.23.0.tar.gz.sha512>`__)
-* `The apache-airflow-providers-amazon 8.23.0 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_amazon-8.23.0-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_amazon-8.23.0-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_amazon-8.23.0-py3-none-any.whl.sha512>`__)
+* `The apache-airflow-providers-amazon 8.24.0 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_amazon-8.24.0.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_amazon-8.24.0.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_amazon-8.24.0.tar.gz.sha512>`__)
+* `The apache-airflow-providers-amazon 8.24.0 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_amazon-8.24.0-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_amazon-8.24.0-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_amazon-8.24.0-py3-none-any.whl.sha512>`__)

--- a/docs/apache-airflow-providers-cncf-kubernetes/commits.rst
+++ b/docs/apache-airflow-providers-cncf-kubernetes/commits.rst
@@ -38,11 +38,15 @@ For high-level changelog, see :doc:`package information including changelog <ind
 8.3.0
 .....
 
-Latest change: 2024-05-15
+Latest change: 2024-05-28
 
 =================================================================================================  ===========  =======================================================================================================================
 Commit                                                                                             Committed    Subject
 =================================================================================================  ===========  =======================================================================================================================
+`53970a8d1f <https://github.com/apache/airflow/commit/53970a8d1f4d8337a6e9b9aeac25fde030432f98>`_  2024-05-28   ``Handling exception getting logs when pods finish success (#39296)``
+`e190cff272 <https://github.com/apache/airflow/commit/e190cff27299256df75b56e46e27e9932174805a>`_  2024-05-28   ``fix wrong arguments in read_namespaced_pod_log call (#39874)``
+`98c5a3a2c6 <https://github.com/apache/airflow/commit/98c5a3a2c6d1df722d56bb3748dfbc810d5952aa>`_  2024-05-27   ``Add a warning message to KPO to warn of one second interval logs duplication (#39861)``
+`34500f3a2f <https://github.com/apache/airflow/commit/34500f3a2fa4652272bc831e3c18fd2a6a2da5ef>`_  2024-05-26   ``Prepare docs 3rd wave May 2024 (#39738)``
 `610747d25a <https://github.com/apache/airflow/commit/610747d25a6153574c07624afaadcbf575aa2960>`_  2024-05-15   ``Add timeout when watching pod events in k8s executor (#39551)``
 `f57de6c183 <https://github.com/apache/airflow/commit/f57de6c1836199190ab02419aa2b9d5caee33002>`_  2024-05-14   ``Move Kubernetes cli to provider package (#39587)``
 `e3897dcbed <https://github.com/apache/airflow/commit/e3897dcbed0262b0cab7a357f8d7fbbb6c4f4eeb>`_  2024-05-13   ``Remove compat code for 2.7.0 - its now the min Airflow version (#39591)``

--- a/docs/apache-airflow-providers-teradata/commits.rst
+++ b/docs/apache-airflow-providers-teradata/commits.rst
@@ -35,14 +35,26 @@ For high-level changelog, see :doc:`package information including changelog <ind
 
 
 
+2.2.0
+.....
+
+Latest change: 2024-05-29
+
+=================================================================================================  ===========  =========================================
+Commit                                                                                             Committed    Subject
+=================================================================================================  ===========  =========================================
+`0b9232e54d <https://github.com/apache/airflow/commit/0b9232e54d61357930c71737fb51657c834fc6d7>`_  2024-05-29   ``Updates to Teradata Provider (#39217)``
+=================================================================================================  ===========  =========================================
+
 2.1.1
 .....
 
-Latest change: 2024-05-11
+Latest change: 2024-05-26
 
 =================================================================================================  ===========  ================================================
 Commit                                                                                             Committed    Subject
 =================================================================================================  ===========  ================================================
+`34500f3a2f <https://github.com/apache/airflow/commit/34500f3a2fa4652272bc831e3c18fd2a6a2da5ef>`_  2024-05-26   ``Prepare docs 3rd wave May 2024 (#39738)``
 `2b1a2f8d56 <https://github.com/apache/airflow/commit/2b1a2f8d561e569df194c4ee0d3a18930738886e>`_  2024-05-11   ``Reapply templates for all providers (#39554)``
 `2c05187b07 <https://github.com/apache/airflow/commit/2c05187b07baf7c41a32b18fabdbb3833acc08eb>`_  2024-05-10   ``Faster 'airflow_version' imports (#39552)``
 `73918925ed <https://github.com/apache/airflow/commit/73918925edaf1c94790a6ad8bec01dec60accfa1>`_  2024-05-08   ``Simplify 'airflow_version' imports (#39497)``

--- a/docs/apache-airflow-providers-teradata/index.rst
+++ b/docs/apache-airflow-providers-teradata/index.rst
@@ -77,7 +77,7 @@ apache-airflow-providers-teradata package
 `Teradata <https://www.teradata.com/>`__
 
 
-Release: 2.1.1
+Release: 2.2.0
 
 Provider package
 ----------------
@@ -116,14 +116,16 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-teradata[common.sql]
+    pip install apache-airflow-providers-teradata[amazon]
 
 
-============================================================================================================  ==============
-Dependent package                                                                                             Extra
-============================================================================================================  ==============
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_  ``common.sql``
-============================================================================================================  ==============
+======================================================================================================================  ===================
+Dependent package                                                                                                       Extra
+======================================================================================================================  ===================
+`apache-airflow-providers-amazon <https://airflow.apache.org/docs/apache-airflow-providers-amazon>`_                    ``amazon``
+`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_            ``common.sql``
+`apache-airflow-providers-microsoft-azure <https://airflow.apache.org/docs/apache-airflow-providers-microsoft-azure>`_  ``microsoft.azure``
+======================================================================================================================  ===================
 
 Downloading official packages
 -----------------------------
@@ -131,5 +133,5 @@ Downloading official packages
 You can download officially released packages and verify their checksums and signatures from the
 `Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
 
-* `The apache-airflow-providers-teradata 2.1.1 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_teradata-2.1.1.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_teradata-2.1.1.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_teradata-2.1.1.tar.gz.sha512>`__)
-* `The apache-airflow-providers-teradata 2.1.1 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_teradata-2.1.1-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_teradata-2.1.1-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_teradata-2.1.1-py3-none-any.whl.sha512>`__)
+* `The apache-airflow-providers-teradata 2.2.0 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_teradata-2.2.0.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_teradata-2.2.0.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_teradata-2.2.0.tar.gz.sha512>`__)
+* `The apache-airflow-providers-teradata 2.2.0 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_teradata-2.2.0-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_teradata-2.2.0-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_teradata-2.2.0-py3-none-any.whl.sha512>`__)


### PR DESCRIPTION
This is ad hoc release for: cncf.kubernetes, amazon and teradata providers