### PR TITLE
fix: DynamoDBToS3Operator - remove process_func from templated_fields

### DIFF
--- a/airflow/providers/amazon/aws/transfers/dynamodb_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/dynamodb_to_s3.py
@@ -105,7 +105,6 @@ class DynamoDBToS3Operator(AwsToAwsBaseOperator):
         "file_size",
         "dynamodb_scan_kwargs",
         "s3_key_prefix",
-        "process_func",
         "export_time",
         "export_format",
         "check_interval",


### PR DESCRIPTION
following [discussion](https://github.com/apache/airflow/pull/37028/commits/48560f73dccb4bb69a5d5e56899a49644bdea915#r1620974798)