### PR TITLE
Resolve triggerer job logging deprecations in tests

### DIFF
--- a/tests/deprecations_ignore.yml
+++ b/tests/deprecations_ignore.yml
@@ -57,9 +57,6 @@
 - tests/jobs/test_backfill_job.py::TestBackfillJob::test_reset_orphaned_tasks_with_orphans
 - tests/jobs/test_backfill_job.py::TestBackfillJob::test_subdag_clear_parentdag_downstream_clear
 - tests/jobs/test_backfill_job.py::TestBackfillJob::test_update_counters
-- tests/jobs/test_triggerer_job_logging.py::test_configure_trigger_log_handler_fallback_task
-- tests/jobs/test_triggerer_job_logging.py::test_configure_trigger_log_handler_root_not_file_task
-- tests/jobs/test_triggerer_job_logging.py::test_configure_trigger_log_handler_root_old_file_task
 - tests/models/test_baseoperatormeta.py::TestExecutorSafeguard::test_executor_when_classic_operator_called_from_decorated_task_with_allow_nested_operators_false
 - tests/models/test_baseoperatormeta.py::TestExecutorSafeguard::test_executor_when_classic_operator_called_from_decorated_task_without_allow_nested_operators
 - tests/models/test_cleartasks.py::TestClearTasks::test_dags_clear

--- a/tests/jobs/test_triggerer_job_logging.py
+++ b/tests/jobs/test_triggerer_job_logging.py
@@ -218,7 +218,6 @@ fallback_task = {
             "class": "airflow.providers.amazon.aws.log.s3_task_handler.S3TaskHandler",
             "base_log_folder": "~/abc",
             "s3_log_folder": "s3://abc",
-            "filename_template": "blah",
         },
     },
     "loggers": {"airflow.task": {"handlers": ["task"]}},
@@ -318,7 +317,6 @@ root_not_file_task = {
             "class": "airflow.providers.amazon.aws.log.s3_task_handler.S3TaskHandler",
             "base_log_folder": "~/abc",
             "s3_log_folder": "s3://abc",
-            "filename_template": "blah",
         },
         "trigger": {"class": "logging.Handler"},
     },
@@ -379,7 +377,6 @@ root_logger_old_file_task = {
             "class": "airflow.providers.amazon.aws.log.s3_task_handler.S3TaskHandler",
             "base_log_folder": "~/abc",
             "s3_log_folder": "s3://abc",
-            "filename_template": "blah",
         },
         "trigger": {
             "class": "tests.jobs.test_triggerer_job_logging.OldFileTaskHandler",


### PR DESCRIPTION
Resolve triggerer job logging deprecations in tests
related: https://github.com/apache/airflow/issues/38642