### PR TITLE
Resolve timestamp deprecations in tests

### DIFF
--- a/tests/deprecations_ignore.yml
+++ b/tests/deprecations_ignore.yml
@@ -122,8 +122,6 @@
 - tests/models/test_taskinstance.py::TestTaskInstance::test_template_with_custom_timetable_deprecated_context
 - tests/models/test_taskinstance.py::TestTaskInstance::test_xcom_pull
 - tests/models/test_taskinstance.py::TestTaskInstance::test_xcom_pull_different_execution_date
-- tests/models/test_timestamp.py::test_timestamp_behaviour
-- tests/models/test_timestamp.py::test_timestamp_behaviour_with_timezone
 - tests/models/test_xcom.py::TestXCom::test_set_serialize_call_old_signature
 - tests/ti_deps/deps/test_prev_dagrun_dep.py::TestPrevDagrunDep::test_first_task_run_of_new_task
 

--- a/tests/models/test_timestamp.py
+++ b/tests/models/test_timestamp.py
@@ -40,8 +40,8 @@ def clear_db():
 def add_log(execdate, session, dag_maker, timezone_override=None):
     with dag_maker(dag_id="logging", default_args={"start_date": execdate}):
         task = EmptyOperator(task_id="dummy")
-    dag_maker.create_dagrun()
-    task_instance = TaskInstance(task=task, execution_date=execdate, state="success")
+    dag_run = dag_maker.create_dagrun()
+    task_instance = TaskInstance(task=task, run_id=dag_run.run_id, state="success")
     session.merge(task_instance)
     log = Log(State.RUNNING, task_instance)
     if timezone_override:


### PR DESCRIPTION
Resolve timestamp deprecations in tests
related: https://github.com/apache/airflow/issues/38642