### PR TITLE
Don't pass auth to opensearch client with empty login and password

### DIFF
--- a/airflow/providers/opensearch/hooks/opensearch.py
+++ b/airflow/providers/opensearch/hooks/opensearch.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import json
 from functools import cached_property
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict
 
 from opensearchpy import OpenSearch, RequestsHttpConnection
 
@@ -29,6 +29,16 @@ if TYPE_CHECKING:
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 from airflow.utils.strings import to_boolean
+
+
+class OpenSearchClientArguments(TypedDict, total=False):
+    """Typed arguments to the open search client."""
+
+    hosts: str | list[dict] | None
+    use_ssl: bool
+    verify_certs: bool
+    connection_class: type[OpenSearchConnectionClass] | None
+    http_auth: tuple[str, str]
 
 
 class OpenSearchHook(BaseHook):
@@ -67,7 +77,7 @@ class OpenSearchHook(BaseHook):
     @cached_property
     def client(self) -> OpenSearch:
         """This function is intended for Operators that forward high level client objects."""
-        client_args = dict(
+        client_args: OpenSearchClientArguments = dict(
             hosts=[{"host": self.conn.host, "port": self.conn.port}],
             use_ssl=self.use_ssl,
             verify_certs=self.verify_certs,

--- a/airflow/providers/opensearch/hooks/opensearch.py
+++ b/airflow/providers/opensearch/hooks/opensearch.py
@@ -67,14 +67,15 @@ class OpenSearchHook(BaseHook):
     @cached_property
     def client(self) -> OpenSearch:
         """This function is intended for Operators that forward high level client objects."""
-        auth = (self.conn.login, self.conn.password)
-        client = OpenSearch(
+        client_args = dict(
             hosts=[{"host": self.conn.host, "port": self.conn.port}],
-            http_auth=auth,
             use_ssl=self.use_ssl,
             verify_certs=self.verify_certs,
             connection_class=self.connection_class,
         )
+        if self.conn.login and self.conn.password:
+            client_args["http_auth"] = (self.conn.login, self.conn.password)
+        client = OpenSearch(**client_args)
         return client
 
     def search(self, query: dict, index_name: str, **kwargs: Any) -> Any:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This updates the opensearch hook to only pass the http_auth argument to the opensearch client if a login and password are part of the connection.

closes: #39979

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
