### PR TITLE
Limit yandex provider to avoid mypy errors

### DIFF
--- a/airflow/providers/yandex/provider.yaml
+++ b/airflow/providers/yandex/provider.yaml
@@ -53,7 +53,10 @@ dependencies:
   - apache-airflow>=2.7.0
   # The 0.289 and 0.290 versions have broken dataproc support
   # See https://github.com/yandex-cloud/python-sdk/issues/103
-  - yandexcloud>=0.278.0,!=0.289.0,!=0.290.0
+  # the 0.291.0 version of yandex provider introduced mypy typing
+  # that conflicts with the way yandex provider uses it and should be fixed
+  # See https://github.com/yandex-cloud/python-sdk/issues/106
+  - yandexcloud>=0.278.0,!=0.289.0,!=0.290.0,<0.292.0
   - yandex-query-client>=0.1.4
 
 integrations:

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -1299,7 +1299,7 @@
     "deps": [
       "apache-airflow>=2.7.0",
       "yandex-query-client>=0.1.4",
-      "yandexcloud>=0.278.0,!=0.289.0,!=0.290.0"
+      "yandexcloud>=0.278.0,!=0.289.0,!=0.290.0,<0.292.0"
     ],
     "devel-deps": [],
     "plugins": [],


### PR DESCRIPTION
The 0.291.0 version of yandex provider introduced mypy typing that conflicts with the way yandex provider uses it and should be fixed See https://github.com/yandex-cloud/python-sdk/issues/106

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
