### PR TITLE
Improve trigger UI for string array format validation

### DIFF
--- a/airflow/www/templates/airflow/trigger.html
+++ b/airflow/www/templates/airflow/trigger.html
@@ -86,7 +86,7 @@
         {% endfor -%}
       </select>
     {% elif form_details.schema and "array" in form_details.schema.type %}
-      {% if "items" in form_details.schema and form_details.schema.items %}
+      {% if "items" in form_details.schema and form_details.schema["items"] and ("type" not in form_details.schema["items"] or "string" not in form_details.schema["items"]["type"]) %}
       <textarea class="form-control" name="element_{{ form_key }}" id="element_{{ form_key }}" valuetype="advancedarray" rows="6"
         {%- if not "null" in form_details.schema.type %} required=""{% endif -%}>
         {%- if form_details.value is sequence %}

--- a/docs/apache-airflow/core-concepts/params.rst
+++ b/docs/apache-airflow/core-concepts/params.rst
@@ -271,13 +271,17 @@ The following features are supported in the Trigger UI Form:
               | For multi-value selects ``examples`` you can add
               | the attribute ``values_display`` with a dict and
               | map data values to display labels.
-            * | If you add the attribute ``items``, a JSON entry
+            * | If you add the attribute ``items`` with a
+              | dictionary that contains a field ``type``
+              | with a value other than "string", a JSON entry
               | field will be generated for more array types and
               | additional type validation as described in
               | `JSON Schema Array Items <https://json-schema.org/understanding-json-schema/reference/array.html#items>`_.
           - ``Param(["a", "b", "c"], type="array")``
 
             ``Param(["two", "three"], type="array", examples=["one", "two", "three", "four", "five"])``
+
+            ``Param(["one@example.com", "two@example.com"], type="array", items={"type": "string", "format": "idn-email"})``
 
         * - ``object``
           - | Generates a JSON entry field with


### PR DESCRIPTION
closes: #39972

The schema argument in a Param definition is used to detemine the
relevant UI element. When the type of a Param is `array` a simple
textarea is rendered. When additionally a schema for the items of
the array is provided, the UI element previously switched to a
CodeMirror box that expects pure JSON inputs. For strings a textarea
is presented now, to keep the same behaviour than without a format
definition.

Besides that the jinja template now accesses the `items` member of the schema correctly to avoid problems with empty `items` arrays.
