### PR TITLE
Remove deprecated docker compose version field

### DIFF
--- a/scripts/ci/docker-compose/integration-cassandra.yml
+++ b/scripts/ci/docker-compose/integration-cassandra.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "3.8"
 services:
   cassandra:
     image: cassandra:3.0

--- a/scripts/ci/docker-compose/integration-celery.yml
+++ b/scripts/ci/docker-compose/integration-celery.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "3.8"
 services:
   rabbitmq:
     image: rabbitmq:3.7

--- a/scripts/ci/docker-compose/integration-drill.yml
+++ b/scripts/ci/docker-compose/integration-drill.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "3.8"
 services:
   drill:
     container_name: drill

--- a/scripts/ci/docker-compose/integration-kafka.yml
+++ b/scripts/ci/docker-compose/integration-kafka.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "3.8"
 services:
   broker:
     image: confluentinc/cp-kafka:7.3.0

--- a/scripts/ci/docker-compose/integration-kerberos.yml
+++ b/scripts/ci/docker-compose/integration-kerberos.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "3.8"
 services:
   kdc-server-example-com:
     image: ghcr.io/apache/airflow-krb5-kdc-server:2021.07.04

--- a/scripts/ci/docker-compose/integration-mongo.yml
+++ b/scripts/ci/docker-compose/integration-mongo.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "3.8"
 services:
   mongo:
     image: mongo:3

--- a/scripts/ci/docker-compose/integration-mssql.yml
+++ b/scripts/ci/docker-compose/integration-mssql.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "3.8"
 services:
   mssql:
     container_name: mssql

--- a/scripts/ci/docker-compose/integration-openlineage.yml
+++ b/scripts/ci/docker-compose/integration-openlineage.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "3.8"
 services:
   marquez:
     image: marquezproject/marquez:0.40.0

--- a/scripts/ci/docker-compose/integration-otel.yml
+++ b/scripts/ci/docker-compose/integration-otel.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "3.8"
 services:
   otel-collector:
     image: otel/opentelemetry-collector-contrib:0.70.0

--- a/scripts/ci/docker-compose/integration-pinot.yml
+++ b/scripts/ci/docker-compose/integration-pinot.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "3.8"
 services:
   pinot:
     image: apachepinot/pinot:0.8.0

--- a/scripts/ci/docker-compose/integration-qdrant.yml
+++ b/scripts/ci/docker-compose/integration-qdrant.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "3.8"
 services:
   qdrant:
     image: qdrant/qdrant:v1.9.0

--- a/scripts/ci/docker-compose/integration-statsd.yml
+++ b/scripts/ci/docker-compose/integration-statsd.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "3.8"
 services:
   statsd-exporter:
     image: quay.io/prometheus/statsd-exporter:v0.26.0

--- a/scripts/ci/docker-compose/integration-trino.yml
+++ b/scripts/ci/docker-compose/integration-trino.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "3.8"
 services:
   trino:
     image: ghcr.io/apache/airflow-trino:359-2021.07.04


### PR DESCRIPTION
I noticed a deprecation warning when launching breeze in my environment telling me:
`WARN[0000] /home/username/Workspace/airflow/scripts/ci/docker-compose/integration-celery.yml: `version` is obsolete`

It seems this field is not needed by docker-compose - this PR cleans all these version fields not needed anymore. Warning is gone after this change.