### PR TITLE
Remove colon from notes header to make headlines in UI consistent

### DIFF
--- a/airflow/www/static/js/dag/details/NotesAccordion.tsx
+++ b/airflow/www/static/js/dag/details/NotesAccordion.tsx
@@ -120,7 +120,7 @@ const NotesAccordion = ({
           <AccordionButton p={0} pb={2} fontSize="inherit">
             <Box flex="1" textAlign="left" onClick={toggleNotesPanel}>
               <Text as="strong" size="lg">
-                {objectIdentifier} Notes:
+                {objectIdentifier} Notes
               </Text>
             </Box>
             <AccordionIcon />


### PR DESCRIPTION
As I was reviewing the PR #39899 of @tirkarthi I complianed about the colon... and realized that I always wanted to remove the one from the "Notes" section for DAG Runs and Task Instances.

This PR now only removes the colon from the headline in Grid view to be consistent:
![image](https://github.com/apache/airflow/assets/95105677/a7d87c89-4eee-47a3-950f-b798b72f1835)
