### PR TITLE
Remove rawwar from triager

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -121,7 +121,6 @@ github:
     - vatsrahul1001
     - cmarteepants
     - romsharon98
-    - rawwar
 
 notifications:
   jobs: jobs@airflow.apache.org


### PR DESCRIPTION
I'm stepping down from the triage team as I won't be able to contribute actively for a few months.