### PR TITLE
Adding Glue Data Quality Rule Recommendation Run 

### DIFF
--- a/airflow/providers/amazon/aws/hooks/glue.py
+++ b/airflow/providers/amazon/aws/hooks/glue.py
@@ -535,14 +535,14 @@ class GlueDataQualityHook(AwsBaseHook):
         """
         Print the outcome of recommendation run, recommendation run generates multiple rules against a data source (Glue table) in Data Quality Definition Language (DQDL) format.
 
-        Ex:
         Rules = [
-                IsComplete "NAME",
-                ColumnLength "EMP_ID" between 1 and 12,
-                IsUnique "EMP_ID",
-                ColumnValues "INCOME" > 50000
-                ]
+        IsComplete "NAME",
+        ColumnLength "EMP_ID" between 1 and 12,
+        IsUnique "EMP_ID",
+        ColumnValues "INCOME" > 50000
+        ]
         """
+
         result = self.conn.get_data_quality_rule_recommendation_run(RunId=run_id)
 
         if result.get("RecommendedRuleset"):

--- a/airflow/providers/amazon/aws/hooks/glue.py
+++ b/airflow/providers/amazon/aws/hooks/glue.py
@@ -530,3 +530,27 @@ class GlueDataQualityHook(AwsBaseHook):
             raise AirflowException(
                 "AWS Glue data quality ruleset evaluation run failed for one or more rules"
             )
+
+    def log_recommendation_results(self, run_id: str) -> None:
+        """
+        Print the outcome of recommendation run, recommendation run generates multiple rules against a data source (Glue table) in Data Quality Definition Language (DQDL) format.
+
+        Ex:
+        Rules = [
+                IsComplete "NAME",
+                ColumnLength "EMP_ID" between 1 and 12,
+                IsUnique "EMP_ID",
+                ColumnValues "INCOME" > 50000
+                ]
+        """
+        result = self.conn.get_data_quality_rule_recommendation_run(RunId=run_id)
+
+        if result.get("RecommendedRuleset"):
+            self.log.info(
+                "AWS Glue data quality recommended rules for DatabaseName: %s TableName: %s",
+                result["DataSource"]["GlueTable"]["DatabaseName"],
+                result["DataSource"]["GlueTable"]["TableName"],
+            )
+            self.log.info(result["RecommendedRuleset"])
+        else:
+            self.log.info("AWS Glue data quality, no recommended rules available for RunId: %s", run_id)

--- a/airflow/providers/amazon/aws/hooks/glue.py
+++ b/airflow/providers/amazon/aws/hooks/glue.py
@@ -542,7 +542,6 @@ class GlueDataQualityHook(AwsBaseHook):
         ColumnValues "INCOME" > 50000
         ]
         """
-
         result = self.conn.get_data_quality_rule_recommendation_run(RunId=run_id)
 
         if result.get("RecommendedRuleset"):

--- a/airflow/providers/amazon/aws/operators/glue.py
+++ b/airflow/providers/amazon/aws/operators/glue.py
@@ -33,7 +33,7 @@ from airflow.providers.amazon.aws.links.glue import GlueJobRunDetailsLink
 from airflow.providers.amazon.aws.operators.base_aws import AwsBaseOperator
 from airflow.providers.amazon.aws.triggers.glue import (
     GlueDataQualityRuleSetEvaluationRunCompleteTrigger,
-    GlueJobCompleteTrigger,
+    GlueJobCompleteTrigger, GlueDataQualityRuleRecommendationRunCompleteTrigger,
 )
 from airflow.providers.amazon.aws.utils import validate_execute_complete_event
 
@@ -499,3 +499,149 @@ class GlueDataQualityRuleSetEvaluationRunOperator(AwsBaseOperator[GlueDataQualit
         )
 
         return event["evaluation_run_id"]
+
+
+class GlueDataQualityRuleRecommendationRunOperator(AwsBaseOperator[GlueDataQualityHook]):
+    """
+    Starts a recommendation run that is used to generate rules, Glue Data Quality analyzes the data and comes up with recommendations for a potential ruleset.
+
+    Recommendation runs are automatically deleted after 90 days.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:GlueDataQualityRuleRecommendationRunOperator`
+
+    :param datasource: The data source (Glue table) associated with this run. (templated)
+    :param role: IAM role supplied for job execution. (templated)
+    :param number_of_workers: The number of G.1X workers to be used in the run. (default: 5)
+    :param timeout: The timeout for a run in minutes. This is the maximum time that a run can consume resources
+        before it is terminated and enters TIMEOUT status. (default: 2,880)
+    :param show_results: Displays the recommended ruleset (a set of rules), when recommendation run completes. (default: True)
+    :param recommendation_run_kwargs: Extra arguments for recommendation run. (templated)
+    :param wait_for_completion: Whether to wait for job to stop. (default: True)
+    :param waiter_delay: Time in seconds to wait between status checks. (default: 60)
+    :param waiter_max_attempts: Maximum number of attempts to check for job completion. (default: 20)
+    :param deferrable: If True, the operator will wait asynchronously for the job to stop.
+        This implies waiting for completion. This mode requires aiobotocore module to be installed.
+        (default: False)
+
+    :param aws_conn_id: The Airflow connection used for AWS credentials.
+        If this is ``None`` or empty then the default boto3 behaviour is used. If
+        running Airflow in a distributed manner and aws_conn_id is None or
+        empty, then default boto3 configuration would be used (and must be
+        maintained on each worker node).
+    :param region_name: AWS region_name. If not specified then the default boto3 behaviour is used.
+    :param verify: Whether or not to verify SSL certificates. See:
+        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
+    :param botocore_config: Configuration dictionary (key-values) for botocore client. See:
+        https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html
+    """
+
+    aws_hook_class = GlueDataQualityHook
+    template_fields: Sequence[str] = (
+        "datasource",
+        "role",
+        "recommendation_run_kwargs",
+    )
+
+    template_fields_renderers = {"datasource": "json", "recommendation_run_kwargs": "json"}
+
+    ui_color = "#ededed"
+
+    def __init__(
+        self,
+        *,
+        datasource: dict,
+        role: str,
+        number_of_workers: int = 5,
+        timeout: int = 2880,
+        show_results: bool = True,
+        recommendation_run_kwargs: dict[str, Any] | None = None,
+        wait_for_completion: bool = True,
+        waiter_delay: int = 60,
+        waiter_max_attempts: int = 20,
+        deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
+        aws_conn_id: str | None = "aws_default",
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.datasource = datasource
+        self.role = role
+        self.number_of_workers = number_of_workers
+        self.timeout = timeout
+        self.show_results = show_results
+        self.recommendation_run_kwargs = recommendation_run_kwargs or {}
+        self.wait_for_completion = wait_for_completion
+        self.waiter_delay = waiter_delay
+        self.waiter_max_attempts = waiter_max_attempts
+        self.deferrable = deferrable
+        self.aws_conn_id = aws_conn_id
+
+    def execute(self, context: Context) -> str:
+        glue_table = self.datasource.get("GlueTable", {})
+
+        if not glue_table.get("DatabaseName") or not glue_table.get("TableName"):
+            raise AttributeError("DataSource glue table must have DatabaseName and TableName")
+
+        self.log.info("Submitting AWS Glue data quality recommendation run with %s", self.datasource)
+
+        try:
+            response = self.hook.conn.start_data_quality_rule_recommendation_run(
+                DataSource=self.datasource,
+                Role=self.role,
+                NumberOfWorkers=self.number_of_workers,
+                Timeout=self.timeout,
+                **self.recommendation_run_kwargs,
+            )
+        except ClientError as error:
+            print(error)
+            raise AirflowException(
+                f"AWS Glue data quality recommendation run failed: {error.response['Error']['Message']}"
+            )
+
+        recommendation_run_id = response["RunId"]
+
+        message_description = (
+            f"AWS Glue data quality recommendation run RunId: {recommendation_run_id} to complete."
+        )
+        if self.deferrable:
+            self.log.info("Deferring %s", message_description)
+            self.defer(
+                trigger=GlueDataQualityRuleRecommendationRunCompleteTrigger(
+                    recommendation_run_id=recommendation_run_id,
+                    waiter_delay=self.waiter_delay,
+                    waiter_max_attempts=self.waiter_max_attempts,
+                    aws_conn_id=self.aws_conn_id,
+                ),
+                method_name="execute_complete",
+            )
+
+        elif self.wait_for_completion:
+            self.log.info("Waiting for %s", message_description)
+
+            self.hook.get_waiter("data_quality_rule_recommendation_run_complete").wait(
+                RunId=recommendation_run_id,
+                WaiterConfig={"Delay": self.waiter_delay, "MaxAttempts": self.waiter_max_attempts},
+            )
+            self.log.info(
+                "AWS Glue data quality recommendation run completed RunId: %s", recommendation_run_id
+            )
+
+            if self.show_results:
+                self.hook.log_recommendation_results(run_id=recommendation_run_id)
+
+        else:
+            self.log.info("AWS Glue data quality recommendation run runId: %s.", recommendation_run_id)
+
+        return recommendation_run_id
+
+    def execute_complete(self, context: Context, event: dict[str, Any] | None = None) -> str:
+        event = validate_execute_complete_event(event)
+
+        if event["status"] != "success":
+            raise AirflowException(f"Error: AWS Glue data quality rule recommendation run: {event}")
+
+        if self.show_results:
+            self.hook.log_recommendation_results(run_id=event["recommendation_run_id"])
+
+        return event["recommendation_run_id"]

--- a/airflow/providers/amazon/aws/operators/glue.py
+++ b/airflow/providers/amazon/aws/operators/glue.py
@@ -595,7 +595,6 @@ class GlueDataQualityRuleRecommendationRunOperator(AwsBaseOperator[GlueDataQuali
                 **self.recommendation_run_kwargs,
             )
         except ClientError as error:
-            print(error)
             raise AirflowException(
                 f"AWS Glue data quality recommendation run failed: {error.response['Error']['Message']}"
             )
@@ -632,7 +631,7 @@ class GlueDataQualityRuleRecommendationRunOperator(AwsBaseOperator[GlueDataQuali
                 self.hook.log_recommendation_results(run_id=recommendation_run_id)
 
         else:
-            self.log.info("AWS Glue data quality recommendation run runId: %s.", recommendation_run_id)
+            self.log.info(message_description)
 
         return recommendation_run_id
 

--- a/airflow/providers/amazon/aws/operators/glue.py
+++ b/airflow/providers/amazon/aws/operators/glue.py
@@ -32,8 +32,9 @@ from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.amazon.aws.links.glue import GlueJobRunDetailsLink
 from airflow.providers.amazon.aws.operators.base_aws import AwsBaseOperator
 from airflow.providers.amazon.aws.triggers.glue import (
+    GlueDataQualityRuleRecommendationRunCompleteTrigger,
     GlueDataQualityRuleSetEvaluationRunCompleteTrigger,
-    GlueJobCompleteTrigger, GlueDataQualityRuleRecommendationRunCompleteTrigger,
+    GlueJobCompleteTrigger,
 )
 from airflow.providers.amazon.aws.utils import validate_execute_complete_event
 

--- a/airflow/providers/amazon/aws/sensors/glue.py
+++ b/airflow/providers/amazon/aws/sensors/glue.py
@@ -24,8 +24,10 @@ from airflow.configuration import conf
 from airflow.exceptions import AirflowException, AirflowSkipException
 from airflow.providers.amazon.aws.hooks.glue import GlueDataQualityHook, GlueJobHook
 from airflow.providers.amazon.aws.sensors.base_aws import AwsBaseSensor
-from airflow.providers.amazon.aws.triggers.glue import GlueDataQualityRuleSetEvaluationRunCompleteTrigger, \
-    GlueDataQualityRuleRecommendationRunCompleteTrigger
+from airflow.providers.amazon.aws.triggers.glue import (
+    GlueDataQualityRuleRecommendationRunCompleteTrigger,
+    GlueDataQualityRuleSetEvaluationRunCompleteTrigger,
+)
 from airflow.providers.amazon.aws.utils import validate_execute_complete_event
 from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.sensors.base import BaseSensorOperator

--- a/airflow/providers/amazon/aws/sensors/glue.py
+++ b/airflow/providers/amazon/aws/sensors/glue.py
@@ -24,7 +24,8 @@ from airflow.configuration import conf
 from airflow.exceptions import AirflowException, AirflowSkipException
 from airflow.providers.amazon.aws.hooks.glue import GlueDataQualityHook, GlueJobHook
 from airflow.providers.amazon.aws.sensors.base_aws import AwsBaseSensor
-from airflow.providers.amazon.aws.triggers.glue import GlueDataQualityRuleSetEvaluationRunCompleteTrigger
+from airflow.providers.amazon.aws.triggers.glue import GlueDataQualityRuleSetEvaluationRunCompleteTrigger, \
+    GlueDataQualityRuleRecommendationRunCompleteTrigger
 from airflow.providers.amazon.aws.utils import validate_execute_complete_event
 from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.sensors.base import BaseSensorOperator
@@ -216,6 +217,126 @@ class GlueDataQualityRuleSetEvaluationRunSensor(AwsBaseSensor[GlueDataQualityHoo
         elif status in self.FAILURE_STATES:
             job_error_message = (
                 f"Error: AWS Glue data quality ruleset evaluation run RunId: {self.evaluation_run_id} Run "
+                f"Status: {status}"
+                f": {response.get('ErrorString')}"
+            )
+            self.log.info(job_error_message)
+            # TODO: remove this if block when min_airflow_version is set to higher than 2.7.1
+            if self.soft_fail:
+                raise AirflowSkipException(job_error_message)
+            raise AirflowException(job_error_message)
+        else:
+            return False
+
+
+class GlueDataQualityRuleRecommendationRunSensor(AwsBaseSensor[GlueDataQualityHook]):
+    """
+    Waits for an AWS Glue data quality recommendation run to reach any of the status below.
+
+    'FAILED', 'STOPPED', 'STOPPING', 'TIMEOUT', 'SUCCEEDED'
+
+    .. seealso::
+        For more information on how to use this sensor, take a look at the guide:
+        :ref:`howto/sensor:GlueDataQualityRuleRecommendationRunSensor`
+
+    :param recommendation_run_id: The AWS Glue data quality rule recommendation run identifier.
+    :param show_results: Displays the recommended ruleset (a set of rules), when recommendation run completes. (default: True)
+    :param deferrable: If True, the sensor will operate in deferrable mode. This mode requires aiobotocore
+        module to be installed.
+        (default: False, but can be overridden in config file by setting default_deferrable to True)
+    :param poke_interval: Polling period in seconds to check for the status of the job. (default: 120)
+    :param max_retries: Number of times before returning the current state. (default: 60)
+
+    :param aws_conn_id: The Airflow connection used for AWS credentials.
+        If this is ``None`` or empty then the default boto3 behaviour is used. If
+        running Airflow in a distributed manner and aws_conn_id is None or
+        empty, then default boto3 configuration would be used (and must be
+        maintained on each worker node).
+    :param region_name: AWS region_name. If not specified then the default boto3 behaviour is used.
+    :param verify: Whether to verify SSL certificates. See:
+        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
+    :param botocore_config: Configuration dictionary (key-values) for botocore client. See:
+        https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html
+    """
+
+    SUCCESS_STATES = ("SUCCEEDED",)
+
+    FAILURE_STATES = ("FAILED", "STOPPED", "STOPPING", "TIMEOUT")
+
+    aws_hook_class = GlueDataQualityHook
+    template_fields: Sequence[str] = aws_template_fields("recommendation_run_id")
+
+    def __init__(
+        self,
+        *,
+        recommendation_run_id: str,
+        show_results: bool = True,
+        deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
+        poke_interval: int = 120,
+        max_retries: int = 60,
+        aws_conn_id: str | None = "aws_default",
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.recommendation_run_id = recommendation_run_id
+        self.show_results = show_results
+        self.deferrable = deferrable
+        self.poke_interval = poke_interval
+        self.max_retries = max_retries
+        self.aws_conn_id = aws_conn_id
+
+    def execute(self, context: Context) -> Any:
+        if self.deferrable:
+            self.defer(
+                trigger=GlueDataQualityRuleRecommendationRunCompleteTrigger(
+                    recommendation_run_id=self.recommendation_run_id,
+                    waiter_delay=int(self.poke_interval),
+                    waiter_max_attempts=self.max_retries,
+                    aws_conn_id=self.aws_conn_id,
+                ),
+                method_name="execute_complete",
+            )
+        else:
+            super().execute(context=context)
+
+    def execute_complete(self, context: Context, event: dict[str, Any] | None = None) -> None:
+        event = validate_execute_complete_event(event)
+
+        if event["status"] != "success":
+            message = f"Error: AWS Glue data quality recommendation run: {event}"
+            if self.soft_fail:
+                raise AirflowSkipException(message)
+            raise AirflowException(message)
+
+        if self.show_results:
+            self.hook.log_recommendation_results(run_id=self.recommendation_run_id)
+
+        self.log.info("AWS Glue data quality recommendation run completed.")
+
+    def poke(self, context: Context) -> bool:
+        self.log.info(
+            "Poking for AWS Glue data quality recommendation run RunId: %s", self.recommendation_run_id
+        )
+
+        response = self.hook.conn.get_data_quality_rule_recommendation_run(RunId=self.recommendation_run_id)
+
+        status = response.get("Status")
+
+        if status in self.SUCCESS_STATES:
+            if self.show_results:
+                self.hook.log_recommendation_results(run_id=self.recommendation_run_id)
+
+            self.log.info(
+                "AWS Glue data quality recommendation run completed RunId: %s Run State: %s",
+                self.recommendation_run_id,
+                response["Status"],
+            )
+
+            return True
+
+        elif status in self.FAILURE_STATES:
+            job_error_message = (
+                f"Error: AWS Glue data quality recommendation run RunId: {self.recommendation_run_id} Run "
                 f"Status: {status}"
                 f": {response.get('ErrorString')}"
             )

--- a/airflow/providers/amazon/aws/triggers/glue.py
+++ b/airflow/providers/amazon/aws/triggers/glue.py
@@ -187,3 +187,38 @@ class GlueDataQualityRuleSetEvaluationRunCompleteTrigger(AwsBaseWaiterTrigger):
 
     def hook(self) -> AwsGenericHook:
         return GlueDataQualityHook(aws_conn_id=self.aws_conn_id)
+
+
+class GlueDataQualityRuleRecommendationRunCompleteTrigger(AwsBaseWaiterTrigger):
+    """
+    Trigger when a AWS Glue data quality recommendation run complete.
+
+    :param recommendation_run_id: The AWS Glue data quality rule recommendation run identifier.
+    :param waiter_delay: The amount of time in seconds to wait between attempts. (default: 60)
+    :param waiter_max_attempts: The maximum number of attempts to be made. (default: 75)
+    :param aws_conn_id: The Airflow connection used for AWS credentials.
+    """
+
+    def __init__(
+        self,
+        recommendation_run_id: str,
+        waiter_delay: int = 60,
+        waiter_max_attempts: int = 75,
+        aws_conn_id: str | None = "aws_default",
+    ):
+        super().__init__(
+            serialized_fields={"recommendation_run_id": recommendation_run_id},
+            waiter_name="data_quality_rule_recommendation_run_complete",
+            waiter_args={"RunId": recommendation_run_id},
+            failure_message="AWS Glue data quality recommendation run failed.",
+            status_message="Status of AWS Glue data quality recommendation run is",
+            status_queries=["Status"],
+            return_key="recommendation_run_id",
+            return_value=recommendation_run_id,
+            waiter_delay=waiter_delay,
+            waiter_max_attempts=waiter_max_attempts,
+            aws_conn_id=aws_conn_id,
+        )
+
+    def hook(self) -> AwsGenericHook:
+        return GlueDataQualityHook(aws_conn_id=self.aws_conn_id)

--- a/airflow/providers/amazon/aws/waiters/glue.json
+++ b/airflow/providers/amazon/aws/waiters/glue.json
@@ -74,6 +74,55 @@
                     "state": "success"
                 }
             ]
+        },
+        "data_quality_rule_recommendation_run_complete": {
+            "operation": "GetDataQualityRuleRecommendationRun",
+            "delay": 60,
+            "maxAttempts": 75,
+            "acceptors": [
+                {
+                    "matcher": "path",
+                    "argument": "Status",
+                    "expected": "STARTING",
+                    "state": "retry"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "Status",
+                    "expected": "RUNNING",
+                    "state": "retry"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "Status",
+                    "expected": "STOPPING",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "Status",
+                    "expected": "STOPPED",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "Status",
+                    "expected": "FAILED",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "Status",
+                    "expected": "TIMEOUT",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "path",
+                    "argument": "Status",
+                    "expected": "SUCCEEDED",
+                    "state": "success"
+                }
+            ]
         }
     }
 }

--- a/docs/apache-airflow-providers-amazon/operators/glue.rst
+++ b/docs/apache-airflow-providers-amazon/operators/glue.rst
@@ -99,6 +99,20 @@ To start a AWS Glue Data Quality ruleset evaluation run you can use
     :start-after: [START howto_operator_glue_data_quality_ruleset_evaluation_run_operator]
     :end-before: [END howto_operator_glue_data_quality_ruleset_evaluation_run_operator]
 
+.. _howto/operator:GlueDataQualityRuleRecommendationRunOperator:
+
+Start a AWS Glue Data Quality Recommendation Run
+=================================================
+
+To start a AWS Glue Data Quality rule recommendation run you can use
+:class:`~airflow.providers.amazon.aws.operators.glue.GlueDataQualityRuleRecommendationRunOperator`.
+
+.. exampleinclude:: /../../tests/system/providers/amazon/aws/example_glue_data_quality_with_recommendation.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_glue_data_quality_rule_recommendation_run]
+    :end-before: [END howto_operator_glue_data_quality_rule_recommendation_run]
+
 Sensors
 -------
 
@@ -143,6 +157,20 @@ reaches a terminal state you can use :class:`~airflow.providers.amazon.aws.senso
     :dedent: 4
     :start-after: [START howto_sensor_glue_data_quality_ruleset_evaluation_run]
     :end-before: [END howto_sensor_glue_data_quality_ruleset_evaluation_run]
+
+.. _howto/sensor:GlueDataQualityRuleRecommendationRunSensor:
+
+Wait on an AWS Glue Data Quality Recommendation Run
+====================================================
+
+To wait on the state of an AWS Glue Data Quality recommendation run until it
+reaches a terminal state you can use :class:`~airflow.providers.amazon.aws.sensors.glue.GlueDataQualityRuleRecommendationRunSensor`
+
+.. exampleinclude:: /../../tests/system/providers/amazon/aws/example_glue_data_quality_with_recommendation.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_sensor_glue_data_quality_rule_recommendation_run]
+    :end-before: [END howto_sensor_glue_data_quality_rule_recommendation_run]
 
 Reference
 ---------

--- a/tests/providers/amazon/aws/operators/test_glue.py
+++ b/tests/providers/amazon/aws/operators/test_glue.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Generator
 from unittest import mock
 
+import boto3
 import pytest
 from boto3 import client
 from moto import mock_aws
@@ -30,7 +31,7 @@ from airflow.providers.amazon.aws.links.glue import GlueJobRunDetailsLink
 from airflow.providers.amazon.aws.operators.glue import (
     GlueDataQualityOperator,
     GlueDataQualityRuleSetEvaluationRunOperator,
-    GlueJobOperator,
+    GlueJobOperator, GlueDataQualityRuleRecommendationRunOperator,
 )
 
 if TYPE_CHECKING:
@@ -525,6 +526,112 @@ class TestGlueDataQualityRuleSetEvaluationRunOperator:
         self, _, wait_for_completion, deferrable, mock_conn, glue_data_quality_hook
     ):
         mock_conn.get_data_quality_ruleset.return_value = {"Name": "TestRuleSet"}
+        self.operator.wait_for_completion = wait_for_completion
+        self.operator.deferrable = deferrable
+
+        response = self.operator.execute({})
+
+        assert response == self.RUN_ID
+        assert glue_data_quality_hook.get_waiter.call_count == wait_for_completion
+        assert self.operator.defer.call_count == deferrable
+
+
+class TestGlueDataQualityRuleRecommendationRunOperator:
+    RUN_ID = "1234567890"
+    DATA_SOURCE = {"GlueTable": {"DatabaseName": "TestDB", "TableName": "TestTable"}}
+    ROLE = "role_arn"
+
+    @pytest.fixture
+    def mock_conn(self) -> Generator[BaseAwsConnection, None, None]:
+        with mock.patch.object(GlueDataQualityHook, "conn") as _conn:
+            _conn.start_data_quality_rule_recommendation_run.return_value = {"RunId": self.RUN_ID}
+            yield _conn
+
+    @pytest.fixture
+    def glue_data_quality_hook(self) -> Generator[GlueDataQualityHook, None, None]:
+        with mock_aws():
+            hook = GlueDataQualityHook(aws_conn_id="aws_default")
+            yield hook
+
+    def setup_method(self):
+        self.operator = GlueDataQualityRuleRecommendationRunOperator(
+            task_id="start_recommendation_run",
+            datasource=self.DATA_SOURCE,
+            role=self.ROLE,
+            show_results=False,
+            recommendation_run_kwargs={"CreatedRulesetName": "test-ruleset"}
+        )
+        self.operator.defer = mock.MagicMock()
+
+    def test_init(self):
+        assert self.operator.datasource == self.DATA_SOURCE
+        assert self.operator.role == self.ROLE
+        assert self.operator.show_results is False
+        assert self.operator.recommendation_run_kwargs == {"CreatedRulesetName": "test-ruleset"}
+
+    @mock.patch.object(GlueDataQualityHook, "conn")
+    def test_start_data_quality_rule_recommendation_run(self, glue_data_quality_mock_conn):
+        self.op = GlueDataQualityRuleRecommendationRunOperator(
+            task_id="start_recommendation_run",
+            datasource=self.DATA_SOURCE,
+            role=self.ROLE,
+            number_of_workers=10,
+            timeout=1000,
+            recommendation_run_kwargs={"CreatedRulesetName": "test-ruleset"},
+        )
+
+        self.op.wait_for_completion = False
+        self.op.execute({})
+
+        glue_data_quality_mock_conn.start_data_quality_rule_recommendation_run.assert_called_once_with(
+            DataSource=self.DATA_SOURCE,
+            Role=self.ROLE,
+            NumberOfWorkers=10,
+            Timeout=1000,
+            CreatedRulesetName="test-ruleset",
+        )
+
+    @mock.patch.object(GlueDataQualityHook, "conn")
+    def test_start_data_quality_rule_recommendation_run_failed(self, glue_data_quality_mock_conn):
+        created_ruleset_name = "test-ruleset"
+        error_message = f"Ruleset {created_ruleset_name} already exists"
+
+        err_response = {"Error": {"Code": "InvalidInputException", "Message": error_message}}
+
+        exception = boto3.client("glue").exceptions.ClientError(
+            err_response, "StartDataQualityRuleRecommendationRun"
+        )
+        returned_exception = type(exception)
+
+        glue_data_quality_mock_conn.exceptions.InvalidInputException = returned_exception
+        glue_data_quality_mock_conn.start_data_quality_rule_recommendation_run.side_effect = exception
+
+        operator = GlueDataQualityRuleRecommendationRunOperator(
+            task_id="stat_evaluation_run",
+            datasource=self.DATA_SOURCE,
+            role=self.ROLE,
+            recommendation_run_kwargs={"CreatedRulesetName": created_ruleset_name},
+        )
+        operator.wait_for_completion = False
+
+        with pytest.raises(
+            AirflowException,
+            match=f"AWS Glue data quality recommendation run failed: Ruleset {created_ruleset_name} already exists",
+        ):
+            operator.execute({})
+
+    @pytest.mark.parametrize(
+        "wait_for_completion, deferrable",
+        [
+            pytest.param(False, False, id="no_wait"),
+            pytest.param(True, False, id="wait"),
+            pytest.param(False, True, id="defer"),
+        ],
+    )
+    @mock.patch.object(GlueDataQualityHook, "get_waiter")
+    def test_start_data_quality_rule_recommendation_run_wait_combinations(
+        self, _, wait_for_completion, deferrable, mock_conn, glue_data_quality_hook
+    ):
         self.operator.wait_for_completion = wait_for_completion
         self.operator.deferrable = deferrable
 

--- a/tests/providers/amazon/aws/operators/test_glue.py
+++ b/tests/providers/amazon/aws/operators/test_glue.py
@@ -608,7 +608,7 @@ class TestGlueDataQualityRuleRecommendationRunOperator:
         glue_data_quality_mock_conn.start_data_quality_rule_recommendation_run.side_effect = exception
 
         operator = GlueDataQualityRuleRecommendationRunOperator(
-            task_id="stat_evaluation_run",
+            task_id="stat_recommendation_run",
             datasource=self.DATA_SOURCE,
             role=self.ROLE,
             recommendation_run_kwargs={"CreatedRulesetName": created_ruleset_name},

--- a/tests/providers/amazon/aws/operators/test_glue.py
+++ b/tests/providers/amazon/aws/operators/test_glue.py
@@ -30,8 +30,9 @@ from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.amazon.aws.links.glue import GlueJobRunDetailsLink
 from airflow.providers.amazon.aws.operators.glue import (
     GlueDataQualityOperator,
+    GlueDataQualityRuleRecommendationRunOperator,
     GlueDataQualityRuleSetEvaluationRunOperator,
-    GlueJobOperator, GlueDataQualityRuleRecommendationRunOperator,
+    GlueJobOperator,
 )
 
 if TYPE_CHECKING:
@@ -559,7 +560,7 @@ class TestGlueDataQualityRuleRecommendationRunOperator:
             datasource=self.DATA_SOURCE,
             role=self.ROLE,
             show_results=False,
-            recommendation_run_kwargs={"CreatedRulesetName": "test-ruleset"}
+            recommendation_run_kwargs={"CreatedRulesetName": "test-ruleset"},
         )
         self.operator.defer = mock.MagicMock()
 

--- a/tests/providers/amazon/aws/sensors/test_glue_data_quality.py
+++ b/tests/providers/amazon/aws/sensors/test_glue_data_quality.py
@@ -22,7 +22,8 @@ import pytest
 
 from airflow.exceptions import AirflowException, AirflowSkipException, TaskDeferred
 from airflow.providers.amazon.aws.hooks.glue import GlueDataQualityHook
-from airflow.providers.amazon.aws.sensors.glue import GlueDataQualityRuleSetEvaluationRunSensor
+from airflow.providers.amazon.aws.sensors.glue import GlueDataQualityRuleSetEvaluationRunSensor, \
+    GlueDataQualityRuleRecommendationRunSensor
 
 SAMPLE_RESPONSE_GET_DATA_QUALITY_EVALUATION_RUN_SUCCEEDED = {
     "RunId": "12345",
@@ -64,6 +65,27 @@ SAMPLE_RESPONSE_GET_DATA_QUALITY_RESULT = {
         }
     ],
 }
+
+RULES = """
+        Rules = [
+                RowCount between 2 and 8,
+                IsComplete "name"
+             ]
+        """
+
+SAMPLE_RESPONSE_GET_DATA_RULE_RECOMMENDATION_RUN_SUCCEEDED = {
+    "RunId": "12345",
+    "Status": "SUCCEEDED",
+    "DataSource": {
+        "GlueTable": {
+            "DatabaseName": "TestDB",
+            "TableName": "TestTable"
+        }
+    },
+    "RecommendedRuleset": RULES,
+}
+
+SAMPLE_RESPONSE_DATA_RULE_RECOMMENDATION_RUN_RUNNING = {"RunId": "12345", "Status": "RUNNING"}
 
 
 class TestGlueDataQualityRuleSetEvaluationRunSensor:
@@ -180,3 +202,122 @@ class TestGlueDataQualityRuleSetEvaluationRunSensor:
         event = {"status": "failure"}
         with pytest.raises(AirflowException):
             op.execute_complete(context={}, event=event)
+
+
+class TestGlueDataQualityRuleRecommendationRunSensor:
+    SENSOR = GlueDataQualityRuleRecommendationRunSensor
+
+    def setup_method(self):
+        self.default_args = dict(
+            task_id="test_data_quality_rule_recommendation_sensor",
+            recommendation_run_id="12345",
+            poke_interval=5,
+            max_retries=0,
+        )
+        self.sensor = self.SENSOR(**self.default_args, aws_conn_id=None)
+
+    def test_base_aws_op_attributes(self):
+        op = self.SENSOR(**self.default_args)
+        assert op.hook.aws_conn_id == "aws_default"
+        assert op.hook._region_name is None
+        assert op.hook._verify is None
+        assert op.hook._config is None
+
+        op = self.SENSOR(
+            **self.default_args,
+            aws_conn_id="aws-test-custom-conn",
+            region_name="eu-west-1",
+            verify=False,
+            botocore_config={"read_timeout": 42},
+        )
+        assert op.hook.aws_conn_id == "aws-test-custom-conn"
+        assert op.hook._region_name == "eu-west-1"
+        assert op.hook._verify is False
+        assert op.hook._config is not None
+        assert op.hook._config.read_timeout == 42
+
+    @mock.patch.object(GlueDataQualityHook, "conn")
+    def test_poke_success_state(self, mock_conn):
+        mock_conn.get_data_quality_rule_recommendation_run.return_value = (
+            SAMPLE_RESPONSE_GET_DATA_RULE_RECOMMENDATION_RUN_SUCCEEDED
+        )
+        assert self.sensor.poke({}) is True
+
+    @mock.patch.object(GlueDataQualityHook, "conn")
+    def test_poke_intermediate_state(self, mock_conn):
+        mock_conn.get_data_quality_rule_recommendation_run.return_value = (
+            SAMPLE_RESPONSE_DATA_RULE_RECOMMENDATION_RUN_RUNNING
+        )
+        assert self.sensor.poke({}) is False
+
+    @pytest.mark.parametrize(
+        "soft_fail, expected_exception",
+        [
+            pytest.param(False, AirflowException, id="not-soft-fail"),
+            pytest.param(True, AirflowSkipException, id="soft-fail"),
+        ],
+    )
+    @pytest.mark.parametrize("state", SENSOR.FAILURE_STATES)
+    @mock.patch.object(GlueDataQualityHook, "conn")
+    def test_poke_failure_states(self, mock_conn, state, soft_fail, expected_exception):
+        mock_conn.get_data_quality_rule_recommendation_run.return_value = {
+            "RunId": "12345",
+            "Status": state,
+            "ErrorString": "unknown error",
+        }
+
+        sensor = self.SENSOR(**self.default_args, aws_conn_id=None, soft_fail=soft_fail)
+
+        message = (
+            f"Error: AWS Glue data quality recommendation run RunId: 12345 Run Status: {state}: unknown error"
+        )
+
+        with pytest.raises(expected_exception, match=message):
+            sensor.poke({})
+
+        mock_conn.get_data_quality_rule_recommendation_run.assert_called_once_with(RunId="12345")
+
+    def test_sensor_defer(self):
+        """Test the execute method raise TaskDeferred if running sensor in deferrable mode"""
+        sensor = GlueDataQualityRuleRecommendationRunSensor(
+            task_id="test_task",
+            poke_interval=0,
+            recommendation_run_id="12345",
+            aws_conn_id="aws_default",
+            deferrable=True,
+        )
+
+        with pytest.raises(TaskDeferred):
+            sensor.execute(context=None)
+
+    @mock.patch.object(GlueDataQualityHook, "conn")
+    def test_execute_complete_succeeds_if_status_in_succeeded_states(self, mock_conn, caplog):
+        mock_conn.get_data_quality_rule_recommendation_run.return_value = (
+            SAMPLE_RESPONSE_GET_DATA_RULE_RECOMMENDATION_RUN_SUCCEEDED
+        )
+
+        op = GlueDataQualityRuleRecommendationRunSensor(
+            task_id="test_data_quality_rule_recommendation_run_sensor",
+            recommendation_run_id="12345",
+            poke_interval=0,
+            aws_conn_id="aws_default",
+            deferrable=True,
+        )
+        event = {"status": "success", "recommendation_run_id": "12345"}
+        op.execute_complete(context={}, event=event)
+        assert "AWS Glue data quality recommendation run completed." in caplog.messages
+
+    def test_execute_complete_fails_if_status_in_failure_states(self):
+        op = GlueDataQualityRuleRecommendationRunSensor(
+            task_id="test_data_quality_rule_recommendation_run_sensor",
+            recommendation_run_id="12345",
+            poke_interval=0,
+            aws_conn_id="aws_default",
+            deferrable=True,
+        )
+        event = {"status": "failure"}
+
+        with pytest.raises(AirflowException):
+            op.execute_complete(context={}, event=event)
+
+

--- a/tests/providers/amazon/aws/sensors/test_glue_data_quality.py
+++ b/tests/providers/amazon/aws/sensors/test_glue_data_quality.py
@@ -22,8 +22,10 @@ import pytest
 
 from airflow.exceptions import AirflowException, AirflowSkipException, TaskDeferred
 from airflow.providers.amazon.aws.hooks.glue import GlueDataQualityHook
-from airflow.providers.amazon.aws.sensors.glue import GlueDataQualityRuleSetEvaluationRunSensor, \
-    GlueDataQualityRuleRecommendationRunSensor
+from airflow.providers.amazon.aws.sensors.glue import (
+    GlueDataQualityRuleRecommendationRunSensor,
+    GlueDataQualityRuleSetEvaluationRunSensor,
+)
 
 SAMPLE_RESPONSE_GET_DATA_QUALITY_EVALUATION_RUN_SUCCEEDED = {
     "RunId": "12345",
@@ -76,12 +78,7 @@ RULES = """
 SAMPLE_RESPONSE_GET_DATA_RULE_RECOMMENDATION_RUN_SUCCEEDED = {
     "RunId": "12345",
     "Status": "SUCCEEDED",
-    "DataSource": {
-        "GlueTable": {
-            "DatabaseName": "TestDB",
-            "TableName": "TestTable"
-        }
-    },
+    "DataSource": {"GlueTable": {"DatabaseName": "TestDB", "TableName": "TestTable"}},
     "RecommendedRuleset": RULES,
 }
 
@@ -319,5 +316,3 @@ class TestGlueDataQualityRuleRecommendationRunSensor:
 
         with pytest.raises(AirflowException):
             op.execute_complete(context={}, event=event)
-
-

--- a/tests/providers/amazon/aws/triggers/test_glue.py
+++ b/tests/providers/amazon/aws/triggers/test_glue.py
@@ -27,8 +27,9 @@ from airflow.providers.amazon.aws.hooks.glue import GlueDataQualityHook, GlueJob
 from airflow.providers.amazon.aws.hooks.glue_catalog import GlueCatalogHook
 from airflow.providers.amazon.aws.triggers.glue import (
     GlueCatalogPartitionTrigger,
+    GlueDataQualityRuleRecommendationRunCompleteTrigger,
     GlueDataQualityRuleSetEvaluationRunCompleteTrigger,
-    GlueJobCompleteTrigger, GlueDataQualityRuleRecommendationRunCompleteTrigger,
+    GlueJobCompleteTrigger,
 )
 from airflow.triggers.base import TriggerEvent
 from tests.providers.amazon.aws.utils.test_waiter import assert_expected_waiter_type
@@ -124,6 +125,7 @@ class TestGlueDataQualityEvaluationRunCompletedTrigger:
         assert response == TriggerEvent({"status": "success", "evaluation_run_id": self.RUN_ID})
         assert_expected_waiter_type(mock_get_waiter, self.EXPECTED_WAITER_NAME)
         mock_get_waiter().wait.assert_called_once()
+
 
 class TestGlueDataQualityRuleRecommendationRunCompleteTrigger:
     EXPECTED_WAITER_NAME = "data_quality_rule_recommendation_run_complete"

--- a/tests/providers/amazon/aws/triggers/test_glue.py
+++ b/tests/providers/amazon/aws/triggers/test_glue.py
@@ -28,7 +28,7 @@ from airflow.providers.amazon.aws.hooks.glue_catalog import GlueCatalogHook
 from airflow.providers.amazon.aws.triggers.glue import (
     GlueCatalogPartitionTrigger,
     GlueDataQualityRuleSetEvaluationRunCompleteTrigger,
-    GlueJobCompleteTrigger,
+    GlueJobCompleteTrigger, GlueDataQualityRuleRecommendationRunCompleteTrigger,
 )
 from airflow.triggers.base import TriggerEvent
 from tests.providers.amazon.aws.utils.test_waiter import assert_expected_waiter_type
@@ -122,5 +122,31 @@ class TestGlueDataQualityEvaluationRunCompletedTrigger:
         response = await generator.asend(None)
 
         assert response == TriggerEvent({"status": "success", "evaluation_run_id": self.RUN_ID})
+        assert_expected_waiter_type(mock_get_waiter, self.EXPECTED_WAITER_NAME)
+        mock_get_waiter().wait.assert_called_once()
+
+class TestGlueDataQualityRuleRecommendationRunCompleteTrigger:
+    EXPECTED_WAITER_NAME = "data_quality_rule_recommendation_run_complete"
+    RUN_ID = "1234567890abc"
+
+    def test_serialization(self):
+        """Assert that arguments and classpath are correctly serialized."""
+        trigger = GlueDataQualityRuleRecommendationRunCompleteTrigger(recommendation_run_id=self.RUN_ID)
+        classpath, kwargs = trigger.serialize()
+        assert classpath == BASE_TRIGGER_CLASSPATH + "GlueDataQualityRuleRecommendationRunCompleteTrigger"
+        assert kwargs.get("recommendation_run_id") == self.RUN_ID
+
+    @pytest.mark.asyncio
+    @mock.patch.object(GlueDataQualityHook, "get_waiter")
+    @mock.patch.object(GlueDataQualityHook, "async_conn")
+    async def test_run_success(self, mock_async_conn, mock_get_waiter):
+        mock_async_conn.__aenter__.return_value = mock.MagicMock()
+        mock_get_waiter().wait = AsyncMock()
+        trigger = GlueDataQualityRuleRecommendationRunCompleteTrigger(recommendation_run_id=self.RUN_ID)
+
+        generator = trigger.run()
+        response = await generator.asend(None)
+
+        assert response == TriggerEvent({"status": "success", "recommendation_run_id": self.RUN_ID})
         assert_expected_waiter_type(mock_get_waiter, self.EXPECTED_WAITER_NAME)
         mock_get_waiter().wait.assert_called_once()

--- a/tests/providers/amazon/aws/waiters/test_glue.py
+++ b/tests/providers/amazon/aws/waiters/test_glue.py
@@ -24,14 +24,16 @@ import pytest
 
 from airflow.providers.amazon.aws.hooks.glue import GlueDataQualityHook
 from airflow.providers.amazon.aws.sensors.glue import (
-    GlueDataQualityRuleSetEvaluationRunSensor,
+    GlueDataQualityRuleSetEvaluationRunSensor, GlueDataQualityRuleRecommendationRunSensor,
 )
 
 
 class TestGlueDataQualityCustomWaiters:
-    def test_service_waiters(self):
-        print(GlueDataQualityHook().list_waiters())
+    def test_evaluation_run_waiters(self):
         assert "data_quality_ruleset_evaluation_run_complete" in GlueDataQualityHook().list_waiters()
+
+    def test_recommendation_run_waiters(self):
+        assert "data_quality_rule_recommendation_run_complete" in GlueDataQualityHook().list_waiters()
 
 
 class TestGlueDataQualityCustomWaitersBase:
@@ -63,6 +65,37 @@ class TestGlueDataQualityRuleSetEvaluationRunCompleteWaiter(TestGlueDataQualityC
             GlueDataQualityHook().get_waiter(self.WAITER_NAME).wait(RunId="run_id")
 
     def test_data_quality_ruleset_evaluation_run_wait(self, mock_get_job):
+        wait = {"Status": "RUNNING"}
+        success = {"Status": "SUCCEEDED"}
+        mock_get_job.side_effect = [wait, wait, success]
+
+        GlueDataQualityHook().get_waiter(self.WAITER_NAME).wait(
+            RunIc="run_id", WaiterConfig={"Delay": 0.01, "MaxAttempts": 3}
+        )
+
+
+class TestGlueDataQualityRuleRecommendationRunCompleteWaiter(TestGlueDataQualityCustomWaitersBase):
+    WAITER_NAME = "data_quality_rule_recommendation_run_complete"
+
+    @pytest.fixture
+    def mock_get_job(self):
+        with mock.patch.object(self.client, "get_data_quality_rule_recommendation_run") as mock_getter:
+            yield mock_getter
+
+    @pytest.mark.parametrize("state", GlueDataQualityRuleRecommendationRunSensor.SUCCESS_STATES)
+    def test_data_quality_rule_recommendation_run_complete(self, state, mock_get_job):
+        mock_get_job.return_value = {"Status": state}
+
+        GlueDataQualityHook().get_waiter(self.WAITER_NAME).wait(RunId="run_id")
+
+    @pytest.mark.parametrize("state", GlueDataQualityRuleRecommendationRunSensor.FAILURE_STATES)
+    def test_data_quality_rule_recommendation_run_failed(self, state, mock_get_job):
+        mock_get_job.return_value = {"Status": state}
+
+        with pytest.raises(botocore.exceptions.WaiterError):
+            GlueDataQualityHook().get_waiter(self.WAITER_NAME).wait(RunId="run_id")
+
+    def test_data_quality_rule_recommendation_run_wait(self, mock_get_job):
         wait = {"Status": "RUNNING"}
         success = {"Status": "SUCCEEDED"}
         mock_get_job.side_effect = [wait, wait, success]

--- a/tests/providers/amazon/aws/waiters/test_glue.py
+++ b/tests/providers/amazon/aws/waiters/test_glue.py
@@ -24,7 +24,8 @@ import pytest
 
 from airflow.providers.amazon.aws.hooks.glue import GlueDataQualityHook
 from airflow.providers.amazon.aws.sensors.glue import (
-    GlueDataQualityRuleSetEvaluationRunSensor, GlueDataQualityRuleRecommendationRunSensor,
+    GlueDataQualityRuleRecommendationRunSensor,
+    GlueDataQualityRuleSetEvaluationRunSensor,
 )
 
 

--- a/tests/system/providers/amazon/aws/example_glue_data_quality_with_recommendation.py
+++ b/tests/system/providers/amazon/aws/example_glue_data_quality_with_recommendation.py
@@ -42,7 +42,7 @@ from tests.system.providers.amazon.aws.utils import SystemTestContextBuilder
 ROLE_ARN_KEY = "ROLE_ARN"
 sys_test_context_task = SystemTestContextBuilder().add_variable(ROLE_ARN_KEY).build()
 
-DAG_ID = "example_glue_data_quality_recommendation_run"
+DAG_ID = "example_glue_data_quality_with_recommendation"
 SAMPLE_DATA = """"Alice",20
     "Bob",25
     "Charlie",30

--- a/tests/system/providers/amazon/aws/example_glue_data_quality_with_recommendation.py
+++ b/tests/system/providers/amazon/aws/example_glue_data_quality_with_recommendation.py
@@ -24,7 +24,7 @@ from airflow.models.baseoperator import chain
 from airflow.providers.amazon.aws.hooks.glue import GlueDataQualityHook
 from airflow.providers.amazon.aws.operators.athena import AthenaOperator
 from airflow.providers.amazon.aws.operators.glue import (
-    GlueDataQualityOperator,
+    GlueDataQualityRuleRecommendationRunOperator,
     GlueDataQualityRuleSetEvaluationRunOperator,
 )
 from airflow.providers.amazon.aws.operators.s3 import (
@@ -32,48 +32,48 @@ from airflow.providers.amazon.aws.operators.s3 import (
     S3CreateObjectOperator,
     S3DeleteBucketOperator,
 )
-from airflow.providers.amazon.aws.sensors.glue import GlueDataQualityRuleSetEvaluationRunSensor
+from airflow.providers.amazon.aws.sensors.glue import (
+    GlueDataQualityRuleRecommendationRunSensor,
+    GlueDataQualityRuleSetEvaluationRunSensor,
+)
 from airflow.utils.trigger_rule import TriggerRule
 from tests.system.providers.amazon.aws.utils import SystemTestContextBuilder
 
 ROLE_ARN_KEY = "ROLE_ARN"
 sys_test_context_task = SystemTestContextBuilder().add_variable(ROLE_ARN_KEY).build()
 
-DAG_ID = "example_glue_data_quality"
+DAG_ID = "example_glue_data_quality_recommendation_run"
 SAMPLE_DATA = """"Alice",20
     "Bob",25
     "Charlie",30
     """
 SAMPLE_FILENAME = "airflow_sample.csv"
 
-RULE_SET = """
-Rules = [
-    RowCount between 2 and 8,
-    IsComplete "name",
-    Uniqueness "name" > 0.95,
-    ColumnLength "name" between 3 and 14,
-    ColumnValues "age" between 19 and 31
-]
-"""
-
 
 @task_group
-def glue_data_quality_workflow():
-    # [START howto_operator_glue_data_quality_operator]
-    create_rule_set = GlueDataQualityOperator(
-        task_id="create_rule_set",
-        name=rule_set_name,
-        ruleset=RULE_SET,
-        data_quality_ruleset_kwargs={
-            "TargetTable": {
+def glue_data_quality_recommendation_workflow():
+    # [START howto_operator_glue_data_quality_rule_recommendation_run]
+    recommendation_run = GlueDataQualityRuleRecommendationRunOperator(
+        task_id="recommendation_run",
+        datasource={
+            "GlueTable": {
                 "TableName": athena_table,
                 "DatabaseName": athena_database,
             }
         },
+        role=test_context[ROLE_ARN_KEY],
+        recommendation_run_kwargs={"CreatedRulesetName": rule_set_name},
     )
-    # [END howto_operator_glue_data_quality_operator]
+    # [END howto_operator_glue_data_quality_rule_recommendation_run]
+    recommendation_run.wait_for_completion = False
 
-    # [START howto_operator_glue_data_quality_ruleset_evaluation_run_operator]
+    # [START howto_sensor_glue_data_quality_rule_recommendation_run]
+    await_recommendation_run_sensor = GlueDataQualityRuleRecommendationRunSensor(
+        task_id="await_recommendation_run_sensor",
+        recommendation_run_id=recommendation_run.output,
+    )
+    # [END howto_sensor_glue_data_quality_rule_recommendation_run]
+
     start_evaluation_run = GlueDataQualityRuleSetEvaluationRunOperator(
         task_id="start_evaluation_run",
         datasource={
@@ -85,17 +85,16 @@ def glue_data_quality_workflow():
         role=test_context[ROLE_ARN_KEY],
         rule_set_names=[rule_set_name],
     )
-    # [END howto_operator_glue_data_quality_ruleset_evaluation_run_operator]
     start_evaluation_run.wait_for_completion = False
 
-    # [START howto_sensor_glue_data_quality_ruleset_evaluation_run]
     await_evaluation_run_sensor = GlueDataQualityRuleSetEvaluationRunSensor(
         task_id="await_evaluation_run_sensor",
         evaluation_run_id=start_evaluation_run.output,
     )
-    # [END howto_sensor_glue_data_quality_ruleset_evaluation_run]
 
-    chain(create_rule_set, start_evaluation_run, await_evaluation_run_sensor)
+    chain(
+        recommendation_run, await_recommendation_run_sensor, start_evaluation_run, await_evaluation_run_sensor
+    )
 
 
 @task(trigger_rule=TriggerRule.ALL_DONE)
@@ -114,7 +113,7 @@ with DAG(
     test_context = sys_test_context_task()
     env_id = test_context["ENV_ID"]
 
-    rule_set_name = f"{env_id}-system-test-ruleset"
+    rule_set_name = f"{env_id}-recommendation-ruleset"
     s3_bucket = f"{env_id}-glue-dq-athena-bucket"
     athena_table = f"{env_id}_test_glue_dq_table"
     athena_database = f"{env_id}_glue_dq_default"
@@ -190,7 +189,7 @@ with DAG(
         create_database,
         create_table,
         # TEST BODY
-        glue_data_quality_workflow(),
+        glue_data_quality_recommendation_workflow(),
         # TEST TEARDOWN
         delete_ruleset(rule_set_name),
         drop_table,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Adding Amazon Glue Data Quality Recommendation Run. Doc, Operator, Sensor, Trigger, Waiter, Unit Test, System Test.

Manually tested in Breeze with
 1. wait_for_completion=False with a Sensor
 2. deferrable=True. 
 3. wait_for_completion=True
 
Please Don't mind the first one failed due to wrong table i have provided.

<img width="432" alt="image" src="https://github.com/apache/airflow/assets/31437079/cb1dbe95-5a58-493b-8d68-cdb62281c8f1">


https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/glue/client/start_data_quality_rule_recommendation_run.html

Sample Dag for recommendation run:

```
from datetime import datetime

from airflow import DAG
from airflow.providers.amazon.aws.operators.glue import GlueDataQualityRuleRecommendationRunOperator

with DAG(
    dag_id="example_glue_data_quality",
    schedule="@once",
    start_date=datetime(2021, 1, 1),
    tags=["example_recommendation_test"],
    catchup=False,
) as dag:
    start_recommendation_run = GlueDataQualityRuleRecommendationRunOperator(
        task_id="start_recommendation_run",
        datasource={
            "GlueTable": {
                "TableName": "test_table",
                "DatabaseName": "test_default",
            }
        },
        role="arn:aws:iam::{ACCOUNT_ID}:role/GlueDataQuality",
        recommendation_run_kwargs={"CreatedRulesetName": "test-rule-set"},
    )

```


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
