### PR TITLE
Remove transitional package apt-transport-https from dependencies.rst

### DIFF
--- a/docs/apache-airflow/installation/dependencies.rst
+++ b/docs/apache-airflow/installation/dependencies.rst
@@ -82,7 +82,7 @@ for development and testing as well as production use.
 
 .. code-block:: bash
 
-  sudo apt install -y --no-install-recommends apt-transport-https apt-utils ca-certificates \
+  sudo apt install -y --no-install-recommends apt-utils ca-certificates \
     curl dumb-init freetds-bin krb5-user libgeos-dev \
     ldap-utils libsasl2-2 libsasl2-modules libxmlsec1 locales libffi8 libldap-2.5-0 libssl3 netcat-openbsd \
     lsb-release openssh-client python3-selinux rsync sasl2-bin sqlite3 sudo unixodbc
@@ -97,7 +97,7 @@ for Bullseye and we will only build images and explain system level dependencies
 
 .. code-block:: bash
 
-  sudo apt install -y --no-install-recommends apt-transport-https apt-utils ca-certificates \
+  sudo apt install -y --no-install-recommends apt-utils ca-certificates \
     curl dumb-init freetds-bin krb5-user libgeos-dev \
     ldap-utils libsasl2-2 libsasl2-modules libxmlsec1 locales libffi7 libldap-2.4-2 libssl1.1 netcat \
     lsb-release openssh-client python3-selinux rsync sasl2-bin sqlite3 sudo unixodbc


### PR DESCRIPTION
Remove apt-transport-https because It is a dummy transitional package.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
