### PR TITLE
sftp_sensor: fixing resource management with sensor

### DIFF
--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -549,7 +549,7 @@ class SFTPHookAsync(BaseHook):
         matched_files = [file for file in files_list if fnmatch(str(file.filename), fnmatch_pattern)]
         return matched_files
 
-    async def get_mod_time(self, path: str) -> str | None:  # type: ignore[return]
+    async def get_mod_time(self, path: str) -> str:  # type: ignore[return]
         """
         Make SFTP async connection.
 

--- a/airflow/providers/sftp/sensors/sftp.py
+++ b/airflow/providers/sftp/sensors/sftp.py
@@ -111,6 +111,19 @@ class SFTPSensor(BaseSensorOperator):
                 _newer_than = convert_to_utc(self.newer_than)
                 if _newer_than <= _mod_time:
                     files_found.append(actual_file_to_check)
+                    self.log.info(
+                        "File %s has modification time: '%s', which is newer than: '%s'",
+                        actual_file_to_check,
+                        str(_mod_time),
+                        str(_newer_than),
+                    )
+                else:
+                    self.log.info(
+                        "File %s has modification time: '%s', which is older than: '%s'",
+                        actual_file_to_check,
+                        str(_mod_time),
+                        str(_newer_than),
+                    )
             else:
                 files_found.append(actual_file_to_check)
 


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/39922

## Summary
When a user tries to use the SFTPSensor operator with `deferrable=True`, using path/newer_than, it will open a connection and remain open, the reason is because of method `get_mod_time` in opening a sftp connection but not closing it afterward.

As part of this change, we are closing the connection.



