### PR TITLE
Aip-61: Add validation on task `executor` field 

### DIFF
--- a/airflow/executors/executor_loader.py
+++ b/airflow/executors/executor_loader.py
@@ -25,7 +25,7 @@ from contextlib import suppress
 from typing import TYPE_CHECKING
 
 from airflow.api_internal.internal_api_call import InternalApiConfig
-from airflow.exceptions import AirflowConfigException, AirflowException
+from airflow.exceptions import AirflowConfigException
 from airflow.executors.executor_constants import (
     CELERY_EXECUTOR,
     CELERY_KUBERNETES_EXECUTOR,
@@ -202,7 +202,7 @@ class ExecutorLoader:
         elif executor_name := _module_to_executors.get(executor_name_str):
             return executor_name
         else:
-            raise AirflowException(f"Unknown executor being loaded: {executor_name_str}")
+            raise ValueError(f"Unknown executor being loaded: {executor_name_str}")
 
     @classmethod
     def load_executor(cls, executor_name: ExecutorName | str | None) -> BaseExecutor:

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -94,6 +94,7 @@ from airflow.exceptions import (
     TaskDeferred,
     TaskNotFound,
 )
+from airflow.executors.executor_loader import ExecutorLoader
 from airflow.jobs.job import run_job
 from airflow.models.abstractoperator import AbstractOperator, TaskStateChangeCallback
 from airflow.models.base import Base, StringID
@@ -800,9 +801,20 @@ class DAG(LoggingMixin):
                 f"inconsistent schedule: timetable {self.timetable.summary!r} "
                 f"does not match schedule_interval {self.schedule_interval!r}",
             )
+        self.validate_executor_field()
         self.validate_schedule_and_params()
         self.timetable.validate()
         self.validate_setup_teardown()
+
+    def validate_executor_field(self):
+        for task in self.tasks:
+            if task.executor:
+                try:
+                    ExecutorLoader.lookup_executor_name_by_str(task.executor)
+                except AirflowException:
+                    raise ValueError(
+                        f"The specified executor {task.executor} for task {task.task_id} is not configured"
+                    )
 
     def validate_setup_teardown(self):
         """

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -811,9 +811,11 @@ class DAG(LoggingMixin):
             if task.executor:
                 try:
                     ExecutorLoader.lookup_executor_name_by_str(task.executor)
-                except AirflowException:
+                except ValueError:
                     raise ValueError(
-                        f"The specified executor {task.executor} for task {task.task_id} is not configured"
+                        f"The specified executor {task.executor} for task {task.task_id} is not "
+                        "configured. Review the core.executors Airflow configuration to add it or "
+                        "update the executor configuration for this task."
                     )
 
     def validate_setup_teardown(self):

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -2637,13 +2637,12 @@ my_postgres_conn:
             dag.validate()
 
     def test_validate_executor_field(self):
-        with patch.object(ExecutorLoader, "lookup_executor_name_by_str") as mock_get_executor_names:
+        with patch.object(ExecutorLoader, "lookup_executor_name_by_str"):
             dag = DAG(
                 "test-dag",
                 schedule=None,
             )
 
-            mock_get_executor_names.return_value = None
             EmptyOperator(task_id="t1", dag=dag, executor="test.custom.executor")
             dag.validate()
 


### PR DESCRIPTION
Add validation on tasks to check if the executor a Task is assigned is configured. This prevents DAGs that have tasks configured with incorrect executors from being run. 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
