### PR TITLE
Bedrock system test adjustment

### DIFF
--- a/tests/system/providers/amazon/aws/example_bedrock_retrieve_and_generate.py
+++ b/tests/system/providers/amazon/aws/example_bedrock_retrieve_and_generate.py
@@ -511,6 +511,11 @@ with DAG(
     )
     # [END howto_operator_bedrock_create_data_source]
 
+    # In this demo, delete_data_source and delete_cluster are both trying to delete
+    # the data from the S3 bucket and occasionally hitting a conflict.  This ensures that
+    # delete_data_source doesn't attempt to delete the files, leaving that duty to delete_bucket.
+    create_data_source.create_data_source_kwargs["dataDeletionPolicy"] = "RETAIN"
+
     # [START howto_operator_bedrock_ingest_data]
     ingest_data = BedrockIngestDataOperator(
         task_id="ingest_data",


### PR DESCRIPTION
This test occasionally fails.  On occasion, delete_data_source takes a little longer on the service side and it tries to delete files in the S3 Bucket **after** the delete_bucket operator already has.  This causes delete_data_source to fail which in turn causes delete_knowledge_base to fail, leaving stranded artifacts in the account.

Setting the Data Source retention policy to "RETAIN" means delete_data_source will not try to delete the files, and delete_bucket can safely do so.


@syedahsn - This is the bug I mentioned earlier, and the fix for it.

## Testing
Static checks pass and the system test passes when run locally.
