### PR TITLE
Document `extraContainers` and `extraInitContainers` that are templated

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1864,7 +1864,7 @@
                     "default": true
                 },
                 "extraContainers": {
-                    "description": "Launch additional containers into workers. Note, if used with KubernetesExecutor, you are responsible for signaling sidecars to exit when the main container finishes so Airflow can continue the worker shutdown process!",
+                    "description": "Launch additional containers into workers (templated). Note, if used with KubernetesExecutor, you are responsible for signaling sidecars to exit when the main container finishes so Airflow can continue the worker shutdown process!",
                     "type": "array",
                     "default": [],
                     "items": {
@@ -1872,7 +1872,7 @@
                     }
                 },
                 "extraInitContainers": {
-                    "description": "Add additional init containers into workers.",
+                    "description": "Add additional init containers into workers (templated).",
                     "items": {
                         "$ref": "#/definitions/io.k8s.api.core.v1.Container"
                     },
@@ -2442,7 +2442,7 @@
                     "default": true
                 },
                 "extraContainers": {
-                    "description": "Launch additional containers into scheduler.",
+                    "description": "Launch additional containers into scheduler (templated).",
                     "type": "array",
                     "default": [],
                     "items": {
@@ -2450,7 +2450,7 @@
                     }
                 },
                 "extraInitContainers": {
-                    "description": "Add additional init containers into scheduler.",
+                    "description": "Add additional init containers into scheduler (templated).",
                     "type": "array",
                     "default": [],
                     "items": {
@@ -2908,7 +2908,7 @@
                     "default": true
                 },
                 "extraContainers": {
-                    "description": "Launch additional containers into triggerer.",
+                    "description": "Launch additional containers into triggerer (templated).",
                     "type": "array",
                     "default": [],
                     "items": {
@@ -2916,7 +2916,7 @@
                     }
                 },
                 "extraInitContainers": {
-                    "description": "Add additional init containers into triggerer.",
+                    "description": "Add additional init containers into triggerer (templated).",
                     "type": "array",
                     "default": [],
                     "items": {
@@ -3399,7 +3399,7 @@
                     "default": true
                 },
                 "extraContainers": {
-                    "description": "Launch additional containers into dag processor.",
+                    "description": "Launch additional containers into dag processor (templated).",
                     "type": "array",
                     "default": [],
                     "items": {
@@ -3407,7 +3407,7 @@
                     }
                 },
                 "extraInitContainers": {
-                    "description": "Add additional init containers into dag processor.",
+                    "description": "Add additional init containers into dag processor (templated).",
                     "type": "array",
                     "default": [],
                     "items": {
@@ -4677,7 +4677,7 @@
                     }
                 },
                 "extraContainers": {
-                    "description": "Launch additional containers into webserver.",
+                    "description": "Launch additional containers into webserver (templated).",
                     "type": "array",
                     "default": [],
                     "items": {
@@ -4685,7 +4685,7 @@
                     }
                 },
                 "extraInitContainers": {
-                    "description": "Add additional init containers into webserver.",
+                    "description": "Add additional init containers into webserver (templated).",
                     "type": "array",
                     "default": [],
                     "items": {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -678,11 +678,11 @@ workers:
   # when it wants to scale a node down.
   safeToEvict: true
 
-  # Launch additional containers into worker.
+  # Launch additional containers into worker (templated).
   # Note: If used with KubernetesExecutor, you are responsible for signaling sidecars to exit when the main
   # container finishes so Airflow can continue the worker shutdown process!
   extraContainers: []
-  # Add additional init containers into workers.
+  # Add additional init containers into workers (templated).
   extraInitContainers: []
 
   # Mount additional volumes into worker. It can be templated like in the following example:
@@ -887,9 +887,9 @@ scheduler:
   # when it wants to scale a node down.
   safeToEvict: true
 
-  # Launch additional containers into scheduler.
+  # Launch additional containers into scheduler (templated).
   extraContainers: []
-  # Add additional init containers into scheduler.
+  # Add additional init containers into scheduler (templated).
   extraInitContainers: []
 
   # Mount additional volumes into scheduler. It can be templated like in the following example:
@@ -1270,9 +1270,9 @@ webserver:
     lastName: user
     password: admin
 
-  # Launch additional containers into webserver.
+  # Launch additional containers into webserver (templated).
   extraContainers: []
-  # Add additional init containers into webserver.
+  # Add additional init containers into webserver (templated).
   extraInitContainers: []
 
   # Mount additional volumes into webserver. It can be templated like in the following example:
@@ -1456,9 +1456,9 @@ triggerer:
   # when it wants to scale a node down.
   safeToEvict: true
 
-  # Launch additional containers into triggerer.
+  # Launch additional containers into triggerer (templated).
   extraContainers: []
-  # Add additional init containers into triggerers.
+  # Add additional init containers into triggerers (templated).
   extraInitContainers: []
 
   # Mount additional volumes into triggerer. It can be templated like in the following example:
@@ -1639,9 +1639,9 @@ dagProcessor:
   # when it wants to scale a node down.
   safeToEvict: true
 
-  # Launch additional containers into dag processor.
+  # Launch additional containers into dag processor (templated).
   extraContainers: []
-  # Add additional init containers into dag processors.
+  # Add additional init containers into dag processors (templated).
   extraInitContainers: []
 
   # Mount additional volumes into dag processor. It can be templated like in the following example:


### PR DESCRIPTION
Most of the Airflow pods have templated `extraContainers` and `extraInitContainers`, but were missed being documented as such.