### PR TITLE
Remove explicitly specified folders when they are already ignored

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/testing_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/testing_commands.py
@@ -206,6 +206,9 @@ def _run_test(
         )
     )
     run_cmd.extend(list(extra_pytest_args))
+    # Skip "FOLDER" in case "--ignore=FOLDER" is passed as an argument
+    # Which might be the case if we are ignoring some providers during compatibility checks
+    run_cmd = [arg for arg in run_cmd if f"--ignore={arg}" not in run_cmd]
     try:
         remove_docker_networks(networks=[f"{compose_project_name}_default"])
         result = run_command(


### PR DESCRIPTION
When we are running compatibility tests, some providers might be explicitly selected because PRs are running selective checks and the provider is seen as "affected" by the change. However, when we are runing compatibility tests, we sometimes want to exclude providers via `--skip-providers` flag because those providers might be incompatible with the version of Airflow we test.

In case both - selective checks selects a provider and --skip-providers is set for those providers we now remove the explicitly specified provider from the list of pytest args.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
