### PR TITLE
Fix mocking in kerberos integration test

### DIFF
--- a/tests/integration/api_experimental/auth/backend/test_kerberos_auth.py
+++ b/tests/integration/api_experimental/auth/backend/test_kerberos_auth.py
@@ -62,8 +62,9 @@ class TestApiKerberos:
     def test_trigger_dag(self):
         with self.app.test_client() as client:
             url_template = "/api/experimental/dags/{}/dag_runs"
+            url_path = url_template.format("example_bash_operator")
             response = client.post(
-                url_template.format("example_bash_operator"),
+                url_path,
                 data=json.dumps(dict(run_id="my_run" + datetime.now().isoformat())),
                 content_type="application/json",
             )
@@ -79,6 +80,8 @@ class TestApiKerberos:
             response.raw = mock.MagicMock()
             response.connection = mock.MagicMock()
             response.connection.send = mock.MagicMock()
+            response.connection.send.return_value = mock.MagicMock()
+            response.connection.send.return_value.url = url_path
 
             # disable mutual authentication for testing
             CLIENT_AUTH.mutual_authentication = 3


### PR DESCRIPTION
The new requests-kerberos has a slightly different approach for parsing urls and extracting hostname from url causes a problem with "mock cannot be compared to int" when mock is returned as URL.

This PR fixes it by hard-coding returned URL in the mock that is being returned in this case.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
