### PR TITLE
openlineage: isolate metadata extraction by executing OL methods in separate, forked process

### DIFF
--- a/airflow/providers/google/cloud/openlineage/utils.py
+++ b/airflow/providers/google/cloud/openlineage/utils.py
@@ -158,9 +158,13 @@ def get_from_nullable_chain(source: Any, chain: list[str]) -> Any | None:
         if not result:
             return None
     """
+    # chain.pop modifies passed list, this can be unexpected
+    chain = chain.copy()
     chain.reverse()
     try:
         while chain:
+            while isinstance(source, list) and len(source) == 1:
+                source = source[0]
             next_key = chain.pop()
             if isinstance(source, dict):
                 source = source.get(next_key)

--- a/airflow/providers/openlineage/conf.py
+++ b/airflow/providers/openlineage/conf.py
@@ -33,7 +33,15 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from airflow.compat.functools import cache
+# Disable caching if we're inside tests - this makes config easier to mock.
+if os.getenv("PYTEST_VERSION"):
+
+    def decorator(func):
+        return func
+
+    cache = decorator
+else:
+    from airflow.compat.functools import cache
 from airflow.configuration import conf
 
 _CONFIG_SECTION = "openlineage"
@@ -130,3 +138,10 @@ def dag_state_change_process_pool_size() -> int:
     """[openlineage] dag_state_change_process_pool_size."""
     option = conf.get(_CONFIG_SECTION, "dag_state_change_process_pool_size", fallback="")
     return _safe_int_convert(str(option).strip(), default=1)
+
+
+@cache
+def execution_timeout() -> int:
+    """[openlineage] execution_timeout."""
+    option = conf.get(_CONFIG_SECTION, "execution_timeout", fallback="")
+    return _safe_int_convert(str(option).strip(), default=10)

--- a/airflow/providers/openlineage/plugins/listener.py
+++ b/airflow/providers/openlineage/plugins/listener.py
@@ -17,12 +17,15 @@
 from __future__ import annotations
 
 import logging
+import os
 from concurrent.futures import ProcessPoolExecutor
 from datetime import datetime
 from typing import TYPE_CHECKING
 
+import psutil
 from openlineage.client.serde import Serde
 from packaging.version import Version
+from setproctitle import getproctitle, setproctitle
 
 from airflow import __version__ as AIRFLOW_VERSION, settings
 from airflow.listeners import hookimpl
@@ -38,6 +41,7 @@ from airflow.providers.openlineage.utils.utils import (
     is_selective_lineage_enabled,
     print_warning,
 )
+from airflow.settings import configure_orm
 from airflow.stats import Stats
 from airflow.utils.timeout import timeout
 
@@ -156,7 +160,7 @@ class OpenLineageListener:
                 len(Serde.to_json(redacted_event).encode("utf-8")),
             )
 
-        on_running()
+        self._execute(on_running, "on_running", use_fork=True)
 
     @hookimpl
     def on_task_instance_success(
@@ -223,7 +227,7 @@ class OpenLineageListener:
                 len(Serde.to_json(redacted_event).encode("utf-8")),
             )
 
-        on_success()
+        self._execute(on_success, "on_success", use_fork=True)
 
     if _IS_AIRFLOW_2_10_OR_HIGHER:
 
@@ -318,10 +322,51 @@ class OpenLineageListener:
                 len(Serde.to_json(redacted_event).encode("utf-8")),
             )
 
-        on_failure()
+        self._execute(on_failure, "on_failure", use_fork=True)
+
+    def _execute(self, callable, callable_name: str, use_fork: bool = False):
+        if use_fork:
+            self._fork_execute(callable, callable_name)
+        else:
+            callable()
+
+    def _terminate_with_wait(self, process: psutil.Process):
+        process.terminate()
+        try:
+            # Waiting for max 3 seconds to make sure process can clean up before being killed.
+            process.wait(timeout=3)
+        except psutil.TimeoutExpired:
+            # If it's not dead by then, then force kill.
+            process.kill()
+
+    def _fork_execute(self, callable, callable_name: str):
+        self.log.debug("Will fork to execute OpenLineage process.")
+        pid = os.fork()
+        if pid:
+            process = psutil.Process(pid)
+            try:
+                self.log.debug("Waiting for process %s", pid)
+                process.wait(conf.execution_timeout())
+            except psutil.TimeoutExpired:
+                self.log.warning(
+                    "OpenLineage process %s expired. This should not affect process execution.", pid
+                )
+                self._terminate_with_wait(process)
+            except BaseException:
+                # Kill the process directly.
+                self._terminate_with_wait(process)
+            self.log.warning("Process with pid %s finished - parent", pid)
+        else:
+            setproctitle(getproctitle() + " - OpenLineage - " + callable_name)
+            configure_orm(disable_connection_pool=True)
+            self.log.debug("Executing OpenLineage process - %s - pid %s", callable_name, os.getpid())
+            callable()
+            self.log.debug("Process with current pid finishes after %s", callable_name)
+            os._exit(0)
 
     @property
     def executor(self) -> ProcessPoolExecutor:
+        # Executor for dag_run listener
         def initializer():
             # Re-configure the ORM engine as there are issues with multiple processes
             # if process calls Airflow DB.

--- a/airflow/providers/openlineage/provider.yaml
+++ b/airflow/providers/openlineage/provider.yaml
@@ -45,8 +45,8 @@ dependencies:
   - apache-airflow>=2.7.0
   - apache-airflow-providers-common-sql>=1.6.0
   - attrs>=22.2
-  - openlineage-integration-common>=1.15.0
-  - openlineage-python>=1.15.0
+  - openlineage-integration-common>=1.16.0
+  - openlineage-python>=1.16.0
 
 integrations:
   - integration-name: OpenLineage
@@ -144,3 +144,10 @@ config:
         example: ~
         type: integer
         version_added: 1.8.0
+      execution_timeout:
+        description: |
+          Maximum amount of time (in seconds) that OpenLineage can spend executing metadata extraction.
+        default: "10"
+        example: ~
+        type: integer
+        version_added: 1.9.0

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -913,8 +913,8 @@
       "apache-airflow-providers-common-sql>=1.6.0",
       "apache-airflow>=2.7.0",
       "attrs>=22.2",
-      "openlineage-integration-common>=1.15.0",
-      "openlineage-python>=1.15.0"
+      "openlineage-integration-common>=1.16.0",
+      "openlineage-python>=1.16.0"
     ],
     "devel-deps": [],
     "plugins": [

--- a/tests/dags/test_openlineage_execution.py
+++ b/tests/dags/test_openlineage_execution.py
@@ -1,0 +1,60 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import datetime
+import time
+
+from openlineage.client.generated.base import Dataset
+
+from airflow.models.dag import DAG
+from airflow.models.operator import BaseOperator
+from airflow.providers.openlineage.extractors import OperatorLineage
+
+
+class OpenLineageExecutionOperator(BaseOperator):
+    def __init__(self, *, stall_amount=0, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.stall_amount = stall_amount
+
+    def execute(self, context):
+        self.log.error("STALL AMOUNT %s", self.stall_amount)
+        time.sleep(1)
+
+    def get_openlineage_facets_on_start(self):
+        return OperatorLineage(inputs=[Dataset(namespace="test", name="on-start")])
+
+    def get_openlineage_facets_on_complete(self, task_instance):
+        self.log.error("STALL AMOUNT %s", self.stall_amount)
+        time.sleep(self.stall_amount)
+        return OperatorLineage(inputs=[Dataset(namespace="test", name="on-complete")])
+
+
+with DAG(
+    dag_id="test_openlineage_execution",
+    default_args={"owner": "airflow", "retries": 3, "start_date": datetime.datetime(2022, 1, 1)},
+    schedule="0 0 * * *",
+    dagrun_timeout=datetime.timedelta(minutes=60),
+):
+    no_stall = OpenLineageExecutionOperator(task_id="execute_no_stall")
+
+    short_stall = OpenLineageExecutionOperator(task_id="execute_short_stall", stall_amount=5)
+
+    mid_stall = OpenLineageExecutionOperator(task_id="execute_mid_stall", stall_amount=15)
+
+    long_stall = OpenLineageExecutionOperator(task_id="execute_long_stall", stall_amount=30)

--- a/tests/providers/openlineage/plugins/test_adapter.py
+++ b/tests/providers/openlineage/plugins/test_adapter.py
@@ -44,13 +44,7 @@ from airflow.models.taskinstance import TaskInstance, TaskInstanceState
 from airflow.operators.bash import BashOperator
 from airflow.operators.empty import EmptyOperator
 from airflow.providers.openlineage.conf import (
-    config_path,
-    custom_extractors,
-    disabled_operators,
-    is_disabled,
-    is_source_enabled,
     namespace,
-    transport,
 )
 from airflow.providers.openlineage.extractors import OperatorLineage
 from airflow.providers.openlineage.plugins.adapter import _PRODUCER, OpenLineageAdapter
@@ -62,27 +56,6 @@ from airflow.utils.task_group import TaskGroup
 from tests.test_utils.config import conf_vars
 
 pytestmark = pytest.mark.db_test
-
-
-@pytest.fixture(autouse=True)
-def clear_cache():
-    config_path.cache_clear()
-    is_source_enabled.cache_clear()
-    disabled_operators.cache_clear()
-    custom_extractors.cache_clear()
-    namespace.cache_clear()
-    transport.cache_clear()
-    is_disabled.cache_clear()
-    try:
-        yield
-    finally:
-        config_path.cache_clear()
-        is_source_enabled.cache_clear()
-        disabled_operators.cache_clear()
-        custom_extractors.cache_clear()
-        namespace.cache_clear()
-        transport.cache_clear()
-        is_disabled.cache_clear()
 
 
 @patch.dict(
@@ -154,9 +127,6 @@ def test_create_client_overrides_env_vars():
 
         assert client.transport.kind == "http"
         assert client.transport.url == "http://localhost:5050"
-
-    transport.cache_clear()
-    config_path.cache_clear()
 
     with conf_vars({("openlineage", "transport"): '{"type": "console"}'}):
         client = OpenLineageAdapter().get_or_create_openlineage_client()
@@ -893,9 +863,6 @@ def test_configuration_precedence_when_creating_ol_client():
             assert client.transport.config.endpoint == "api/v1/lineage"
             assert client.transport.config.auth.api_key == "random_token"
 
-    config_path.cache_clear()
-    transport.cache_clear()
-
     # Second, check transport in Airflow configuration (airflow.cfg or env variable)
     with patch.dict(
         os.environ,
@@ -916,9 +883,6 @@ def test_configuration_precedence_when_creating_ol_client():
             assert client.transport.kind == "kafka"
             assert client.transport.kafka_config.topic == "test"
             assert client.transport.kafka_config.config == {"acks": "all"}
-
-    config_path.cache_clear()
-    transport.cache_clear()
 
     # Third, check legacy OPENLINEAGE_CONFIG env variable
     with patch.dict(
@@ -942,9 +906,6 @@ def test_configuration_precedence_when_creating_ol_client():
             assert client.transport.config.endpoint == "api/v1/lineage"
             assert client.transport.config.auth.api_key == "random_token"
 
-    config_path.cache_clear()
-    transport.cache_clear()
-
     # Fourth, check legacy OPENLINEAGE_URL env variable
     with patch.dict(
         os.environ,
@@ -966,9 +927,6 @@ def test_configuration_precedence_when_creating_ol_client():
             assert client.transport.config.url == "http://test.com"
             assert client.transport.config.endpoint == "api/v1/lineage"
             assert client.transport.config.auth.api_key == "test_api_key"
-
-    config_path.cache_clear()
-    transport.cache_clear()
 
     # If all else fails, use console transport
     with patch.dict(os.environ, {}, clear=True):

--- a/tests/providers/openlineage/plugins/test_execution.py
+++ b/tests/providers/openlineage/plugins/test_execution.py
@@ -1,0 +1,195 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import json
+import logging
+import os
+import random
+import shutil
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from airflow.jobs.job import Job
+from airflow.jobs.local_task_job_runner import LocalTaskJobRunner
+from airflow.listeners.listener import get_listener_manager
+from airflow.models import DagBag, TaskInstance
+from airflow.providers.google.cloud.openlineage.utils import get_from_nullable_chain
+from airflow.providers.openlineage.plugins.listener import OpenLineageListener
+from airflow.task.task_runner.standard_task_runner import StandardTaskRunner
+from airflow.utils import timezone
+from airflow.utils.state import State
+from tests.test_utils.compat import AIRFLOW_V_2_10_PLUS
+from tests.test_utils.config import conf_vars
+
+TEST_DAG_FOLDER = os.environ["AIRFLOW__CORE__DAGS_FOLDER"]
+DEFAULT_DATE = timezone.datetime(2016, 1, 1)
+
+
+log = logging.getLogger(__name__)
+
+
+def read_file_content(file_path: str) -> str:
+    with open(file_path) as file:
+        return file.read()
+
+
+def get_sorted_events(event_dir: str) -> list[str]:
+    event_paths = [os.path.join(event_dir, event_path) for event_path in sorted(os.listdir(event_dir))]
+    return [json.loads(read_file_content(event_path)) for event_path in event_paths]
+
+
+def has_value_in_events(events, chain, value):
+    x = [get_from_nullable_chain(event, chain) for event in events]
+    log.error(x)
+    y = [z == value for z in x]
+    return any(y)
+
+
+with tempfile.TemporaryDirectory(prefix="venv") as tmp_dir:
+    listener_path = Path(tmp_dir) / "event"
+
+    @pytest.mark.skipif(not AIRFLOW_V_2_10_PLUS, reason="Test requires Airflow 2.10+")
+    @pytest.mark.usefixtures("reset_logging_config")
+    class TestOpenLineageExecution:
+        @pytest.fixture(autouse=True)
+        def clean_listener_manager(self):
+            get_listener_manager().clear()
+            yield
+            get_listener_manager().clear()
+
+        def setup_job(self, task_name, run_id):
+            dirpath = Path(tmp_dir)
+            if dirpath.exists():
+                shutil.rmtree(dirpath)
+            dirpath.mkdir(exist_ok=True, parents=True)
+            lm = get_listener_manager()
+            lm.add_listener(OpenLineageListener())
+
+            dagbag = DagBag(
+                dag_folder=TEST_DAG_FOLDER,
+                include_examples=False,
+            )
+            dag = dagbag.dags.get("test_openlineage_execution")
+            task = dag.get_task(task_name)
+
+            dag.create_dagrun(
+                run_id=run_id,
+                data_interval=(DEFAULT_DATE, DEFAULT_DATE),
+                state=State.RUNNING,
+                start_date=DEFAULT_DATE,
+            )
+            ti = TaskInstance(task=task, run_id=run_id)
+            job = Job(id=random.randint(0, 23478197), dag_id=ti.dag_id)
+            job_runner = LocalTaskJobRunner(job=job, task_instance=ti, ignore_ti_state=True)
+            task_runner = StandardTaskRunner(job_runner)
+            with mock.patch("airflow.task.task_runner.get_task_runner", return_value=task_runner):
+                job_runner._execute()
+
+            return task_runner.return_code(timeout=60)
+
+        @pytest.mark.db_test
+        @conf_vars({("openlineage", "transport"): f'{{"type": "file", "log_file_path": "{listener_path}"}}'})
+        def test_not_stalled_task_emits_proper_lineage(self):
+            task_name = "execute_no_stall"
+            run_id = "test1"
+            self.setup_job(task_name, run_id)
+
+            events = get_sorted_events(tmp_dir)
+            assert has_value_in_events(events, ["inputs", "name"], "on-start")
+            assert has_value_in_events(events, ["inputs", "name"], "on-complete")
+
+        @conf_vars(
+            {
+                ("openlineage", "transport"): f'{{"type": "file", "log_file_path": "{listener_path}"}}',
+                ("openlineage", "execution_timeout"): "15",
+            }
+        )
+        @pytest.mark.db_test
+        def test_short_stalled_task_emits_proper_lineage(self):
+            self.setup_job("execute_short_stall", "test_short_stalled_task_emits_proper_lineage")
+            events = get_sorted_events(tmp_dir)
+            assert has_value_in_events(events, ["inputs", "name"], "on-start")
+            assert has_value_in_events(events, ["inputs", "name"], "on-complete")
+
+        @conf_vars(
+            {
+                ("openlineage", "transport"): f'{{"type": "file", "log_file_path": "{listener_path}"}}',
+                ("openlineage", "execution_timeout"): "3",
+            }
+        )
+        @pytest.mark.db_test
+        def test_short_stalled_task_extraction_with_low_execution_is_killed_by_ol_timeout(self):
+            self.setup_job(
+                "execute_short_stall",
+                "test_short_stalled_task_extraction_with_low_execution_is_killed_by_ol_timeout",
+            )
+            events = get_sorted_events(tmp_dir)
+            assert has_value_in_events(events, ["inputs", "name"], "on-start")
+            assert not has_value_in_events(events, ["inputs", "name"], "on-complete")
+
+        @conf_vars({("openlineage", "transport"): f'{{"type": "file", "log_file_path": "{listener_path}"}}'})
+        @pytest.mark.db_test
+        def test_mid_stalled_task_is_killed_by_ol_timeout(self):
+            self.setup_job("execute_mid_stall", "test_mid_stalled_task_is_killed_by_openlineage")
+            events = get_sorted_events(tmp_dir)
+            assert has_value_in_events(events, ["inputs", "name"], "on-start")
+            assert not has_value_in_events(events, ["inputs", "name"], "on-complete")
+
+        @conf_vars(
+            {
+                ("openlineage", "transport"): f'{{"type": "file", "log_file_path": "{listener_path}"}}',
+                ("openlineage", "execution_timeout"): "60",
+                ("core", "task_success_overtime"): "3",
+            }
+        )
+        @pytest.mark.db_test
+        def test_long_stalled_task_is_killed_by_listener_overtime_if_ol_timeout_long_enough(self):
+            dirpath = Path(tmp_dir)
+            if dirpath.exists():
+                shutil.rmtree(dirpath)
+            dirpath.mkdir(exist_ok=True, parents=True)
+            lm = get_listener_manager()
+            lm.add_listener(OpenLineageListener())
+
+            dagbag = DagBag(
+                dag_folder=TEST_DAG_FOLDER,
+                include_examples=False,
+            )
+            dag = dagbag.dags.get("test_openlineage_execution")
+            task = dag.get_task("execute_long_stall")
+
+            dag.create_dagrun(
+                run_id="test_long_stalled_task_is_killed_by_listener_overtime_if_ol_timeout_long_enough",
+                data_interval=(DEFAULT_DATE, DEFAULT_DATE),
+                state=State.RUNNING,
+                start_date=DEFAULT_DATE,
+            )
+            ti = TaskInstance(
+                task=task,
+                run_id="test_long_stalled_task_is_killed_by_listener_overtime_if_ol_timeout_long_enough",
+            )
+            job = Job(id="1", dag_id=ti.dag_id)
+            job_runner = LocalTaskJobRunner(job=job, task_instance=ti, ignore_ti_state=True)
+            job_runner._execute()
+
+            events = get_sorted_events(tmp_dir)
+            assert has_value_in_events(events, ["inputs", "name"], "on-start")
+            assert not has_value_in_events(events, ["inputs", "name"], "on-complete")

--- a/tests/providers/openlineage/plugins/test_openlineage.py
+++ b/tests/providers/openlineage/plugins/test_openlineage.py
@@ -23,7 +23,6 @@ from unittest.mock import patch
 
 import pytest
 
-from airflow.providers.openlineage.conf import config_path, is_disabled, transport
 from tests.conftest import RUNNING_TESTS_AGAINST_AIRFLOW_PACKAGES
 from tests.test_utils.config import conf_vars
 
@@ -33,18 +32,10 @@ from tests.test_utils.config import conf_vars
 )
 class TestOpenLineageProviderPlugin:
     def setup_method(self):
-        is_disabled.cache_clear()
-        transport.cache_clear()
-        config_path.cache_clear()
         # Remove module under test if loaded already before. This lets us
         # import the same source files for more than one test.
         if "airflow.providers.openlineage.plugins.openlineage" in sys.modules:
             del sys.modules["airflow.providers.openlineage.plugins.openlineage"]
-
-    def teardown_method(self):
-        is_disabled.cache_clear()
-        transport.cache_clear()
-        config_path.cache_clear()
 
     @pytest.mark.parametrize(
         "mocks, expected",

--- a/tests/providers/openlineage/test_conf.py
+++ b/tests/providers/openlineage/test_conf.py
@@ -69,31 +69,6 @@ _BOOL_PARAMS = (
 )
 
 
-@pytest.fixture(autouse=True)
-def clear_cache():
-    config_path.cache_clear()
-    is_source_enabled.cache_clear()
-    disabled_operators.cache_clear()
-    custom_extractors.cache_clear()
-    namespace.cache_clear()
-    transport.cache_clear()
-    is_disabled.cache_clear()
-    selective_enable.cache_clear()
-    dag_state_change_process_pool_size.cache_clear()
-    try:
-        yield
-    finally:
-        config_path.cache_clear()
-        is_source_enabled.cache_clear()
-        disabled_operators.cache_clear()
-        custom_extractors.cache_clear()
-        namespace.cache_clear()
-        transport.cache_clear()
-        is_disabled.cache_clear()
-        selective_enable.cache_clear()
-        dag_state_change_process_pool_size.cache_clear()
-
-
 @pytest.mark.parametrize(
     ("var_string", "expected"),
     (


### PR DESCRIPTION
This PR builds on https://github.com/apache/airflow/pull/39890 (already merged).

After this change, OpenLineage will execute metadata extraction in separate, forked process. 
It's a technique modeled to what interaction between `LocalTaskJobRunner` and `StandardTaskRunner` looks like - a process, in this case process of `StandardTaskRunner` watches over OpenLineage listener process during metadata extraction. 

This adds a layer of isolation between task execution and OpenLineage, adding a level of assurance that OpenLineage execution does not interfere with task execution in a way other than taking time.
Additionally, this allows us to add configurable timeout for OL execute methods.

The reason for that is, beyond configurability, that sometimes metadata extraction code can hang - for example, when dealing with Snowflake connection issue https://github.com/snowflakedb/snowflake-connector-python/pull/1898 - and we want to give as much guarantees that OL will not cause task to fail.