### PR TITLE
Add `retry_args` parameter to `HttpOperator`

### DIFF
--- a/airflow/providers/http/operators/http.py
+++ b/airflow/providers/http/operators/http.py
@@ -89,6 +89,8 @@ class HttpOperator(BaseOperator):
     :param tcp_keep_alive_interval: The TCP Keep Alive interval parameter (corresponds to
         ``socket.TCP_KEEPINTVL``)
     :param deferrable: Run operator in the deferrable mode
+    :param retry_args: Arguments which define the retry behaviour.
+        See Tenacity documentation at https://github.com/jd/tenacity
     """
 
     conn_id_field = "http_conn_id"
@@ -120,6 +122,7 @@ class HttpOperator(BaseOperator):
         tcp_keep_alive_count: int = 20,
         tcp_keep_alive_interval: int = 30,
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
+        retry_args: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -139,6 +142,7 @@ class HttpOperator(BaseOperator):
         self.tcp_keep_alive_count = tcp_keep_alive_count
         self.tcp_keep_alive_interval = tcp_keep_alive_interval
         self.deferrable = deferrable
+        self.retry_args = retry_args
 
     @property
     def hook(self) -> HttpHook:
@@ -167,7 +171,12 @@ class HttpOperator(BaseOperator):
 
     def execute_sync(self, context: Context) -> Any:
         self.log.info("Calling HTTP method")
-        response = self.hook.run(self.endpoint, self.data, self.headers, self.extra_options)
+        if self.retry_args:
+            response = self.hook.run_with_advanced_retry(
+                self.retry_args, self.endpoint, self.data, self.headers, self.extra_options
+            )
+        else:
+            response = self.hook.run(self.endpoint, self.data, self.headers, self.extra_options)
         response = self.paginate_sync(response=response)
         return self.process_response(context=context, response=response)
 
@@ -180,6 +189,12 @@ class HttpOperator(BaseOperator):
             next_page_params = self.pagination_function(response)
             if not next_page_params:
                 break
+            if self.retry_args:
+                response = self.hook.run_with_advanced_retry(
+                    self.retry_args, **self._merge_next_page_parameters(next_page_params)
+                )
+            else:
+                response = self.hook.run(**self._merge_next_page_parameters(next_page_params))
             response = self.hook.run(**self._merge_next_page_parameters(next_page_params))
             all_responses.append(response)
         return all_responses

--- a/airflow/providers/http/operators/http.py
+++ b/airflow/providers/http/operators/http.py
@@ -195,7 +195,6 @@ class HttpOperator(BaseOperator):
                 )
             else:
                 response = self.hook.run(**self._merge_next_page_parameters(next_page_params))
-            response = self.hook.run(**self._merge_next_page_parameters(next_page_params))
             all_responses.append(response)
         return all_responses
 


### PR DESCRIPTION
This PR adds `retry_args` parameter to `HttpOperator`.

closes: #39247
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
