### PR TITLE
Fix openai 1.32 breaking openai tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,8 @@ ARG AIRFLOW_VERSION="2.9.1"
 ARG PYTHON_BASE_IMAGE="python:3.8-slim-bookworm"
 
 ARG AIRFLOW_PIP_VERSION=24.0
-ARG AIRFLOW_UV_VERSION=0.2.9
+# until https://github.com/astral-sh/uv/issues/4136 is solved we limit UV to version 0.2.5
+ARG AIRFLOW_UV_VERSION=0.2.5
 ARG AIRFLOW_USE_UV="false"
 ARG UV_HTTP_TIMEOUT="300"
 ARG AIRFLOW_IMAGE_REPOSITORY="https://github.com/apache/airflow"

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1268,7 +1268,8 @@ ARG DEFAULT_CONSTRAINTS_BRANCH="constraints-main"
 ARG AIRFLOW_CI_BUILD_EPOCH="10"
 ARG AIRFLOW_PRE_CACHED_PIP_PACKAGES="true"
 ARG AIRFLOW_PIP_VERSION=24.0
-ARG AIRFLOW_UV_VERSION=0.2.9
+# until https://github.com/astral-sh/uv/issues/4136 is solved we limit UV to version 0.2.5
+ARG AIRFLOW_UV_VERSION=0.2.5
 ARG AIRFLOW_USE_UV="true"
 # Setup PIP
 # By default PIP install run without cache to make image smaller
@@ -1292,7 +1293,8 @@ ARG AIRFLOW_VERSION=""
 ARG ADDITIONAL_PIP_INSTALL_FLAGS=""
 
 ARG AIRFLOW_PIP_VERSION=24.0
-ARG AIRFLOW_UV_VERSION=0.2.9
+# until https://github.com/astral-sh/uv/issues/4136 is solved we limit UV to version 0.2.5
+ARG AIRFLOW_UV_VERSION=0.2.5
 ARG AIRFLOW_USE_UV="true"
 
 ENV AIRFLOW_REPO=${AIRFLOW_REPO}\

--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -162,9 +162,8 @@ dependencies:
   # https://pandas.pydata.org/docs/whatsnew/v2.2.0.html#increased-minimum-versions-for-dependencies
   # However Airflow not fully supports it yet: https://github.com/apache/airflow/issues/28723
   # In addition FAB also limit sqlalchemy to < 2.0
-  - pandas>=1.5.3,<2.2;python_version<"3.12"
-  - pandas>=2.1.1,<2.2;python_version>="3.12"
-
+  - pandas>=1.5.3,<2.2.0;python_version<"3.12"
+  - pandas>=2.1.1,<2.2.0;python_version>="3.12"
   # A transient dependency of google-cloud-bigquery-datatransfer, but we
   # further constrain it since older versions are buggy.
   - proto-plus>=1.19.6

--- a/airflow/providers/openai/provider.yaml
+++ b/airflow/providers/openai/provider.yaml
@@ -43,7 +43,7 @@ integrations:
 
 dependencies:
   - apache-airflow>=2.7.0
-  - openai[datalib]>=1.23
+  - openai[datalib]>=1.32.0
 
 hooks:
   - integration-name: OpenAI

--- a/contributing-docs/testing/unit_tests.rst
+++ b/contributing-docs/testing/unit_tests.rst
@@ -1272,7 +1272,7 @@ running the tests from there:
 
 .. code-block::bash
 
-    breeze shell --force-lowest-dependencies
+
 
 The way it works - when you run the breeze with ``--force-lowest-dependencies`` flag, breeze will use
 attempt (with the help of ``uv``) to downgrade the dependencies to the lowest version that is compatible

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -635,8 +635,8 @@
       "json-merge-patch>=0.2",
       "looker-sdk>=22.4.0",
       "pandas-gbq>=0.7.0",
-      "pandas>=1.5.3,<2.2;python_version<\"3.12\"",
-      "pandas>=2.1.1,<2.2;python_version>=\"3.12\"",
+      "pandas>=1.5.3,<2.2.0;python_version<\"3.12\"",
+      "pandas>=2.1.1,<2.2.0;python_version>=\"3.12\"",
       "proto-plus>=1.19.6",
       "python-slugify>=7.0.0",
       "sqlalchemy-bigquery>=1.2.1",
@@ -890,7 +890,7 @@
   "openai": {
     "deps": [
       "apache-airflow>=2.7.0",
-      "openai[datalib]>=1.23"
+      "openai[datalib]>=1.32.0"
     ],
     "devel-deps": [],
     "plugins": [],

--- a/tests/providers/openai/hooks/test_openai.py
+++ b/tests/providers/openai/hooks/test_openai.py
@@ -159,6 +159,7 @@ def mock_run():
         object="thread.run",
         created_at=1698107661,
         assistant_id=ASSISTANT_ID,
+        parallel_tool_calls=False,
         thread_id=THREAD_ID,
         status="completed",
         started_at=1699073476,


### PR DESCRIPTION
The new openai release adds new required parameter `parallel_tool_calls` and our mock did not have it. Bumping version and adding the parameter should solve the problem.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
