### PR TITLE
doc: metrics allow_list complet example

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1049,7 +1049,8 @@ metrics:
         If ``[metrics] metrics_use_pattern_match`` is ``true``, provide regex patterns to match.
       version_added: 2.6.0
       type: string
-      example: "\"scheduler,executor,dagrun\" or \"^scheduler,^executor,heartbeat|timeout\""
+      example: "\"scheduler,executor,dagrun,pool,triggerer,celery\"
+      or \"^scheduler,^executor,heartbeat|timeout\""
       default: ""
     metrics_block_list:
       description: |
@@ -1062,7 +1063,8 @@ metrics:
         If ``[metrics] metrics_use_pattern_match`` is ``true``, provide regex patterns to match.
       version_added: 2.6.0
       type: string
-      example: "\"scheduler,executor,dagrun\" or \"^scheduler,^executor,heartbeat|timeout\""
+      example: "\"scheduler,executor,dagrun,pool,triggerer,celery\"
+      or \"^scheduler,^executor,heartbeat|timeout\""
       default: ""
     statsd_on:
       description: |

--- a/docs/apache-airflow/administration-and-deployment/logging-monitoring/metrics.rst
+++ b/docs/apache-airflow/administration-and-deployment/logging-monitoring/metrics.rst
@@ -101,12 +101,12 @@ of prefixes to send or block only the metrics that start with the elements of th
 .. code-block:: ini
 
     [metrics]
-    metrics_allow_list = scheduler,executor,dagrun
+    metrics_allow_list = scheduler,executor,dagrun,pool,triggerer,celery
 
 .. code-block:: ini
 
     [metrics]
-    metrics_block_list = scheduler,executor,dagrun
+    metrics_block_list = scheduler,executor,dagrun,pool,triggerer,celery
 
 
 Rename Metrics


### PR DESCRIPTION
would be great to show the full list of available metrics in the doc