### PR TITLE
Add warning to deprecated api docs that access control isn't applied

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1293,8 +1293,8 @@ api:
   options:
     enable_experimental_api:
       description: |
-        Enables the deprecated experimental API. Please note that these APIs do not have access control.
-        The authenticated user has full access.
+        Enables the deprecated experimental API. Please note that these API endpoints do not have
+        access control. An authenticated user has full access.
 
         .. warning::
 

--- a/docs/apache-airflow/deprecated-rest-api-ref.rst
+++ b/docs/apache-airflow/deprecated-rest-api-ref.rst
@@ -23,6 +23,11 @@ Deprecated REST API
   This REST API is deprecated since version 2.0. Please consider using the :doc:`stable REST API <stable-rest-api-ref>`.
   For more information on migration, see `UPDATING.md <https://airflow.apache.org/docs/apache-airflow/stable/howto/upgrading-from-1-10/>`_
 
+.. warning::
+
+  Please note that these API endpoints do not have access control. An authenticated user has full access.
+
+
 Before Airflow 2.0 this REST API was known as the "experimental" API, but now that the :doc:`stable REST API <stable-rest-api-ref>` is available, it has been renamed.
 
 The endpoints for this API are available at ``/api/experimental/``.


### PR DESCRIPTION
![Screenshot 2024-06-07 at 1 36 14 PM](https://github.com/apache/airflow/assets/66968678/277127f8-b950-4179-87fc-79c1a82055ab)
