### PR TITLE
Allow executors to be specified with only the class name of the Executor

### DIFF
--- a/airflow/executors/executor_loader.py
+++ b/airflow/executors/executor_loader.py
@@ -216,7 +216,8 @@ class ExecutorLoader:
         This supports the following formats:
         * by executor name for core executor
         * by ``{plugin_name}.{class_name}`` for executor from plugins
-        * by import path.
+        * by import path
+        * by class name of the Executor
         * by ExecutorName object specification
 
         :return: an instance of executor class via executor_name

--- a/airflow/executors/executor_loader.py
+++ b/airflow/executors/executor_loader.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
 # executor may have both so we need two lookup dicts.
 _alias_to_executors: dict[str, ExecutorName] = {}
 _module_to_executors: dict[str, ExecutorName] = {}
+_classname_to_executors: dict[str, ExecutorName] = {}
 # Used to cache the computed ExecutorNames so that we don't need to read/parse config more than once
 _executor_names: list[ExecutorName] = []
 # Used to cache executors so that we don't construct executor objects unnecessarily
@@ -149,6 +150,7 @@ class ExecutorLoader:
                 _alias_to_executors[executor_name.alias] = executor_name
             # All executors will have a module path
             _module_to_executors[executor_name.module_path] = executor_name
+            _classname_to_executors[executor_name.module_path.split(".")[-1]] = executor_name
             # Cache the executor names, so the logic of this method only runs once
             _executor_names.append(executor_name)
 
@@ -200,6 +202,8 @@ class ExecutorLoader:
         if executor_name := _alias_to_executors.get(executor_name_str):
             return executor_name
         elif executor_name := _module_to_executors.get(executor_name_str):
+            return executor_name
+        elif executor_name := _classname_to_executors.get(executor_name_str):
             return executor_name
         else:
             raise AirflowException(f"Unknown executor being loaded: {executor_name_str}")

--- a/tests/executors/test_executor_loader.py
+++ b/tests/executors/test_executor_loader.py
@@ -28,7 +28,7 @@ from airflow.exceptions import AirflowConfigException
 from airflow.executors import executor_loader
 from airflow.executors.executor_loader import ConnectorSource, ExecutorLoader, ExecutorName
 from airflow.executors.local_executor import LocalExecutor
-from airflow.providers.amazon.aws.executors.batch.batch_executor import AwsBatchExecutor
+from airflow.providers.amazon.aws.executors.ecs.ecs_executor import AwsEcsExecutor
 from airflow.providers.celery.executors.celery_executor import CeleryExecutor
 from tests.test_utils.config import conf_vars
 
@@ -336,28 +336,26 @@ class TestExecutorLoader:
                     ExecutorLoader.load_executor(executor_loader._executor_names[0]), LocalExecutor
                 )
 
-    def test_load_custom_executor_with_classname(self):
+    @mock.patch("airflow.providers.amazon.aws.executors.ecs.ecs_executor.AwsEcsExecutor", autospec=True)
+    def test_load_custom_executor_with_classname(self, mock_executor):
         with patch.object(ExecutorLoader, "block_use_of_hybrid_exec"):
             with conf_vars(
                 {
                     (
                         "core",
                         "executor",
-                    ): "my_alias:airflow.providers.amazon.aws.executors.batch.batch_executor.AwsBatchExecutor",
-                    ("aws_batch_executor", "job_queue"): "test-queue",
-                    ("aws_batch_executor", "job_name"): "test-name",
-                    ("aws_batch_executor", "job_definition"): "test-definition",
+                    ): "my_alias:airflow.providers.amazon.aws.executors.ecs.ecs_executor.AwsEcsExecutor"
                 }
             ):
                 ExecutorLoader.init_executors()
-                assert isinstance(ExecutorLoader.load_executor("my_alias"), AwsBatchExecutor)
-                assert isinstance(ExecutorLoader.load_executor("AwsBatchExecutor"), AwsBatchExecutor)
+                assert isinstance(ExecutorLoader.load_executor("my_alias"), AwsEcsExecutor)
+                assert isinstance(ExecutorLoader.load_executor("AwsEcsExecutor"), AwsEcsExecutor)
                 assert isinstance(
                     ExecutorLoader.load_executor(
-                        "airflow.providers.amazon.aws.executors.batch.batch_executor.AwsBatchExecutor"
+                        "airflow.providers.amazon.aws.executors.ecs.ecs_executor.AwsEcsExecutor"
                     ),
-                    AwsBatchExecutor,
+                    AwsEcsExecutor,
                 )
                 assert isinstance(
-                    ExecutorLoader.load_executor(executor_loader._executor_names[0]), AwsBatchExecutor
+                    ExecutorLoader.load_executor(executor_loader._executor_names[0]), AwsEcsExecutor
                 )


### PR DESCRIPTION
Currently, specifying executors is done by an alias, or the full module path of the Executor. This change allows users to also use the class name of the executor to specify which executor to run the task on.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
