### PR TITLE
Properly pass codecov-token to composite action

### DIFF
--- a/.github/actions/post_tests_success/action.yml
+++ b/.github/actions/post_tests_success/action.yml
@@ -18,6 +18,11 @@
 ---
 name: 'Post tests on success'
 description: 'Run post tests actions on success'
+inputs:
+  codecov-token:
+    description: 'Codecov token'
+    required: true
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -37,7 +42,7 @@ runs:
     - name: "Upload all coverage reports to codecov"
       uses: codecov/codecov-action@v4
       env:
-        CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
+        CODECOV_TOKEN: ${{ inputs.codecov-token }}
       if: env.ENABLE_COVERAGE == 'true' && env.TEST_TYPES != 'Helm'
       with:
         name: coverage-${{env.JOB_ID}}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -94,6 +94,8 @@ jobs:
         run: ./scripts/ci/testing/run_integration_tests_with_retry.sh ${{ matrix.integration }}
       - name: "Post Tests success: Integration Tests ${{ matrix.integration }}"
         uses: ./.github/actions/post_tests_success
+        with:
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
       - name: "Post Tests failure: Integration Tests ${{ matrix.integration }}"
         uses: ./.github/actions/post_tests_failure
         if: failure()

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -195,6 +195,8 @@ jobs:
           fi
       - name: "Post Tests success"
         uses: ./.github/actions/post_tests_success
+        with:
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
         if: success()
       - name: "Post Tests failure"
         uses: ./.github/actions/post_tests_failure


### PR DESCRIPTION
Turns out that in order to pass secret to a composite action you need to pass it as input.

Further follow up on #40136 and #40128

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
