### PR TITLE
revamp was it killed externally question

### DIFF
--- a/airflow/jobs/backfill_job_runner.py
+++ b/airflow/jobs/backfill_job_runner.py
@@ -315,6 +315,9 @@ class BackfillJobRunner(BaseJobRunner, LoggingMixin):
                 msg = (
                     f"The executor reported that the task instance {ti} finished with state {state}, "
                     f"but the task instance's state attribute is {ti.state}."
+                    "This indicates that the task was marked failed by something other than the scheduler. "
+                    "The task might have been marked failed by a user, by the task_queued_timeout configuration, "
+                    "or it might have been killed by something else."
                 )
                 if info is not None:
                     msg += f" Extra info: {info}"

--- a/airflow/jobs/backfill_job_runner.py
+++ b/airflow/jobs/backfill_job_runner.py
@@ -314,7 +314,7 @@ class BackfillJobRunner(BaseJobRunner, LoggingMixin):
             ):
                 msg = (
                     f"The executor reported that the task instance {ti} finished with state {state}, "
-                    f"but the task instance's state attribute is {ti.state}."
+                    f"but the task instance's state attribute is {ti.state}. "
                     "This indicates that the task was marked failed by something other than the scheduler. "
                     "The task might have been marked failed by a user, by the task_queued_timeout configuration, "
                     "or it might have been killed by something else."

--- a/airflow/jobs/backfill_job_runner.py
+++ b/airflow/jobs/backfill_job_runner.py
@@ -313,9 +313,11 @@ class BackfillJobRunner(BaseJobRunner, LoggingMixin):
                 and ti.state in self.STATES_COUNT_AS_RUNNING
             ):
                 msg = (
-                    f"Executor reports task instance {ti} finished ({state}) although the task says its "
-                    f"{ti.state}. Was the task killed externally? Info: {info}"
+                    f"The executor reported that the task instance {ti} finished with state {state}, "
+                    f"but the task instance's state attribute is {ti.state}."
                 )
+                if info is not None:
+                    msg += f" Extra info: {info}"
                 self.log.error(msg)
                 ti.handle_failure(error=msg)
                 continue

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -773,7 +773,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     "scheduler.tasks.killed_externally",
                     tags={"dag_id": ti.dag_id, "task_id": ti.task_id},
                 )
-                msg = f"The executor reported that the task instance {ti} finished with state {state}, but the task instance's state attribute is {ti.state}."
+                msg = f"The executor reported that the task instance {ti} finished with state {state}, but the task instance's state attribute is {ti.state}. This indicates that the task was marked failed by something other than the scheduler. The task might have been marked failed by a user, by the task_queued_timeout configuration, or it might have been killed by something else."
                 if info is not None:
                     msg += f" Extra info: {info}"
                 self._task_context_logger.error(msg, ti, state, ti.state, info, ti=ti)

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -773,10 +773,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     "scheduler.tasks.killed_externally",
                     tags={"dag_id": ti.dag_id, "task_id": ti.task_id},
                 )
-                msg = (
-                    f"The executor reported that the task instance {ti} finished with state {state}, "
-                    f"but the task instance's state attribute is {ti.state}."
-                )
+                msg = f"The executor reported that the task instance {ti} finished with state {state}, but the task instance's state attribute is {ti.state}."
                 if info is not None:
                     msg += f" Extra info: {info}"
                 self._task_context_logger.error(msg, ti, state, ti.state, info, ti=ti)
@@ -794,12 +791,12 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     request = TaskCallbackRequest(
                         full_filepath=ti.dag_model.fileloc,
                         simple_task_instance=SimpleTaskInstance.from_ti(ti),
-                        msg=msg % (ti, state, ti.state, info),
+                        msg=msg,
                         processor_subdir=ti.dag_model.processor_subdir,
                     )
                     self.job.executor.send_callback(request)
                 else:
-                    ti.handle_failure(error=msg % (ti, state, ti.state, info), session=session)
+                    ti.handle_failure(error=msg, session=session)
 
         return len(event_buffer)
 

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -774,9 +774,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     tags={"dag_id": ti.dag_id, "task_id": ti.task_id},
                 )
                 msg = (
-                    "Executor reports task instance %s finished (%s) although the "
-                    "task says it's %s. (Info: %s) Was the task killed externally?"
+                    f"The executor reported that the task instance {ti} finished with state {state}, "
+                    f"but the task instance's state attribute is {ti.state}."
                 )
+                if info is not None:
+                    msg += f" Extra info: {info}"
                 self._task_context_logger.error(msg, ti, state, ti.state, info, ti=ti)
 
                 # Get task from the Serialized DAG

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -400,10 +400,9 @@ class TestSchedulerJob:
             full_filepath=dag.fileloc,
             simple_task_instance=mock.ANY,
             processor_subdir=None,
-            msg="Executor reports task instance "
+            msg="The executor reported that the task instance "
             "<TaskInstance: test_process_executor_events_with_callback.dummy_task test [queued]> "
-            "finished (failed) although the task says it's queued. (Info: None) "
-            "Was the task killed externally?",
+            "finished with state failedbut the task instance's state attribute is queued."
         )
         scheduler_job.executor.callback_sink.send.assert_called_once_with(task_callback)
         scheduler_job.executor.callback_sink.reset_mock()

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -402,7 +402,7 @@ class TestSchedulerJob:
             processor_subdir=None,
             msg="The executor reported that the task instance "
             "<TaskInstance: test_process_executor_events_with_callback.dummy_task test [queued]> "
-            "finished with state failedbut the task instance's state attribute is queued."
+            "finished with state failed, but the task instance's state attribute is queued.",
         )
         scheduler_job.executor.callback_sink.send.assert_called_once_with(task_callback)
         scheduler_job.executor.callback_sink.reset_mock()

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -402,7 +402,10 @@ class TestSchedulerJob:
             processor_subdir=None,
             msg="The executor reported that the task instance "
             "<TaskInstance: test_process_executor_events_with_callback.dummy_task test [queued]> "
-            "finished with state failed, but the task instance's state attribute is queued.",
+            "finished with state failed, but the task instance's state attribute is queued."
+            "This indicates that the task was marked failed by something other than the scheduler. "
+            "The task might have been marked failed by a user, by the task_queued_timeout configuration, "
+            "or it might have been killed by something else.",
         )
         scheduler_job.executor.callback_sink.send.assert_called_once_with(task_callback)
         scheduler_job.executor.callback_sink.reset_mock()

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -402,7 +402,7 @@ class TestSchedulerJob:
             processor_subdir=None,
             msg="The executor reported that the task instance "
             "<TaskInstance: test_process_executor_events_with_callback.dummy_task test [queued]> "
-            "finished with state failed, but the task instance's state attribute is queued."
+            "finished with state failed, but the task instance's state attribute is queued. "
             "This indicates that the task was marked failed by something other than the scheduler. "
             "The task might have been marked failed by a user, by the task_queued_timeout configuration, "
             "or it might have been killed by something else.",


### PR DESCRIPTION
The "Was it killed externally?" message isn't particularly helpful. I think the log message should provide all the available context and nothing more.