### PR TITLE
Move Post Execution Log Grouping behind Exception Print

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -334,6 +334,9 @@ def _run_raw_task(
             ti.handle_failure(e, test_mode, context, session=session)
             raise
         finally:
+            # Print a marker post execution for internals of post task processing
+            log.info("::group::Post task execution logs")
+
             Stats.incr(
                 f"ti.finish.{ti.dag_id}.{ti.task_id}.{ti.state}",
                 tags=ti.stats_tags,
@@ -730,9 +733,6 @@ def _execute_task(task_instance: TaskInstance | TaskInstancePydantic, context: C
             if e.code is not None and e.code != 0:
                 raise
             return None
-        finally:
-            # Print a marker post execution for internals of post task processing
-            log.info("::group::Post task execution logs")
 
     # If a timeout is specified for the task, make it fail
     # if it goes beyond


### PR DESCRIPTION
In PR #38021 we added log grouping into log printing. We all love this feature but I got some negative feedback for cases where people look for a failed task: If you are not an Airflow expert and you look for the exception/eror in the logs, in many cases the exception is not printed. If the task execution fails in an exception the exception trace will be in the "Post task execution logs" group that you need to un-fold.

This PR moves the "Post task execution logs" behind the exception print. Side effect is (due to placement) that error handling code might be called before (on success/skip handler will be called after/inside the group though).

Before - no exception in failed task:
![image](https://github.com/apache/airflow/assets/95105677/038860cc-4154-41aa-8df5-6d609bf537b8)

...and you needed to un-fold to see it - note that on_failure_callback is also executed before post block:
![image](https://github.com/apache/airflow/assets/95105677/9dbe0b69-b281-466b-b369-7da300c9ef41)

After - exception is moved in front of log group:
![image](https://github.com/apache/airflow/assets/95105677/d0a76dd6-eadf-48ef-8181-2b9c2860685d)

Plus tasks without exception have no change in beautiful text:
![image](https://github.com/apache/airflow/assets/95105677/e7adeaaa-f455-4443-ad30-7327da1b5025)
