### PR TITLE
Add multiple task instance selection in Grid View (#33448)

### DIFF
--- a/airflow/www/static/js/dag/StatusBox.tsx
+++ b/airflow/www/static/js/dag/StatusBox.tsx
@@ -78,6 +78,9 @@ interface Props {
   group: Task;
   instance: TaskInstance;
   onSelect: (selection: SelectionProps) => void;
+  onAddSelectedTask: (selection: SelectionProps) => void;
+  onAddSelectedTaskBlock: ({ runId, taskId, mapIndex }: SelectionProps) => void;
+  clearSelectionTasks: () => void;
   isActive: boolean;
   containsNotes?: boolean;
 }
@@ -86,6 +89,9 @@ const StatusBox = ({
   group,
   instance,
   onSelect,
+  onAddSelectedTask,
+  onAddSelectedTaskBlock,
+  clearSelectionTasks,
   isActive,
   containsNotes = false,
 }: Props) => {
@@ -120,9 +126,17 @@ const StatusBox = ({
     }
   };
 
-  const onClick = () => {
+  const onClick = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     onMouseLeave();
-    onSelect({ taskId, runId });
+    if (event.ctrlKey) {
+      onAddSelectedTask({ taskId, runId });
+    } else if (event.shiftKey) {
+      onAddSelectedTaskBlock({ taskId, runId });
+    } else {
+      clearSelectionTasks();
+      onAddSelectedTask({ taskId, runId });
+      onSelect({ taskId, runId });
+    }
   };
 
   return (
@@ -137,7 +151,7 @@ const StatusBox = ({
         <StatusWithNotes
           state={instance.state}
           containsNotes={containsNotes}
-          onClick={onClick}
+          onClick={(e) => onClick(e)}
           cursor="pointer"
           data-testid="task-instance"
           zIndex={1}
@@ -156,6 +170,8 @@ const StatusBox = ({
 const compareProps = (prevProps: Props, nextProps: Props) =>
   isEqual(prevProps.group, nextProps.group) &&
   isEqual(prevProps.instance, nextProps.instance) &&
-  isEqual(prevProps.isActive, nextProps.isActive);
+  isEqual(prevProps.isActive, nextProps.isActive) &&
+  isEqual(prevProps.onAddSelectedTask, nextProps.onAddSelectedTask) &&
+  isEqual(prevProps.onAddSelectedTaskBlock, nextProps.onAddSelectedTaskBlock);
 
 export default React.memo(StatusBox, compareProps);

--- a/airflow/www/static/js/dag/grid/dagRuns/index.test.tsx
+++ b/airflow/www/static/js/dag/grid/dagRuns/index.test.tsx
@@ -95,12 +95,9 @@ describe("Test DagRuns", () => {
           data,
         } as any)
     );
-    const { queryAllByTestId, getByText, queryByText } = render(
-      <DagRuns selectedTaskInstances={[]} />,
-      {
-        wrapper: TableWrapper,
-      }
-    );
+    const { queryAllByTestId, getByText, queryByText } = render(<DagRuns />, {
+      wrapper: TableWrapper,
+    });
 
     expect(queryAllByTestId("run")).toHaveLength(2);
     expect(queryAllByTestId("manual-run")).toHaveLength(1);
@@ -125,7 +122,7 @@ describe("Test DagRuns", () => {
           data,
         } as any)
     );
-    const { getByText } = render(<DagRuns selectedTaskInstances={[]} />, {
+    const { getByText } = render(<DagRuns />, {
       wrapper: TableWrapper,
     });
     expect(
@@ -146,7 +143,7 @@ describe("Test DagRuns", () => {
           data,
         } as any)
     );
-    const { queryAllByText } = render(<DagRuns selectedTaskInstances={[]} />, {
+    const { queryAllByText } = render(<DagRuns />, {
       wrapper: TableWrapper,
     });
     expect(
@@ -167,7 +164,7 @@ describe("Test DagRuns", () => {
           data,
         } as any)
     );
-    const { queryAllByText } = render(<DagRuns selectedTaskInstances={[]} />, {
+    const { queryAllByText } = render(<DagRuns />, {
       wrapper: TableWrapper,
     });
     expect(
@@ -185,7 +182,7 @@ describe("Test DagRuns", () => {
         } as any)
     );
 
-    const { queryByTestId } = render(<DagRuns selectedTaskInstances={[]} />, {
+    const { queryByTestId } = render(<DagRuns />, {
       wrapper: TableWrapper,
     });
     expect(queryByTestId("run")).toBeNull();

--- a/airflow/www/static/js/dag/grid/dagRuns/index.test.tsx
+++ b/airflow/www/static/js/dag/grid/dagRuns/index.test.tsx
@@ -95,9 +95,12 @@ describe("Test DagRuns", () => {
           data,
         } as any)
     );
-    const { queryAllByTestId, getByText, queryByText } = render(<DagRuns />, {
-      wrapper: TableWrapper,
-    });
+    const { queryAllByTestId, getByText, queryByText } = render(
+      <DagRuns selectedTaskInstances={[]} />,
+      {
+        wrapper: TableWrapper,
+      }
+    );
 
     expect(queryAllByTestId("run")).toHaveLength(2);
     expect(queryAllByTestId("manual-run")).toHaveLength(1);
@@ -122,7 +125,9 @@ describe("Test DagRuns", () => {
           data,
         } as any)
     );
-    const { getByText } = render(<DagRuns />, { wrapper: TableWrapper });
+    const { getByText } = render(<DagRuns selectedTaskInstances={[]} />, {
+      wrapper: TableWrapper,
+    });
     expect(
       // @ts-ignore
       getByText(moment.utc(datestring).format("MMM DD, HH:mm"))
@@ -141,7 +146,9 @@ describe("Test DagRuns", () => {
           data,
         } as any)
     );
-    const { queryAllByText } = render(<DagRuns />, { wrapper: TableWrapper });
+    const { queryAllByText } = render(<DagRuns selectedTaskInstances={[]} />, {
+      wrapper: TableWrapper,
+    });
     expect(
       // @ts-ignore
       queryAllByText(moment.utc(datestring).format("MMM DD, HH:mm"))
@@ -160,7 +167,9 @@ describe("Test DagRuns", () => {
           data,
         } as any)
     );
-    const { queryAllByText } = render(<DagRuns />, { wrapper: TableWrapper });
+    const { queryAllByText } = render(<DagRuns selectedTaskInstances={[]} />, {
+      wrapper: TableWrapper,
+    });
     expect(
       // @ts-ignore
       queryAllByText(moment.utc(datestring).format("MMM DD, HH:mm"))
@@ -176,7 +185,9 @@ describe("Test DagRuns", () => {
         } as any)
     );
 
-    const { queryByTestId } = render(<DagRuns />, { wrapper: TableWrapper });
+    const { queryByTestId } = render(<DagRuns selectedTaskInstances={[]} />, {
+      wrapper: TableWrapper,
+    });
     expect(queryByTestId("run")).toBeNull();
 
     spy.mockRestore();

--- a/airflow/www/static/js/dag/grid/dagRuns/index.tsx
+++ b/airflow/www/static/js/dag/grid/dagRuns/index.tsx
@@ -82,7 +82,7 @@ interface Props {
   openGroupIds?: string[];
   onToggleGroups?: (groupIds: string[]) => void;
   isGridCollapsed?: boolean;
-  selectedTaskInstances: SelectionProps[];
+  selectedTaskInstances?: SelectionProps[];
 }
 
 const DagRuns = ({
@@ -174,6 +174,7 @@ const DagRuns = ({
               max={max}
               isSelected={
                 !isGridCollapsed &&
+                !!selectedTaskInstances &&
                 selectedTaskInstances.some((ti) => ti && ti.runId === run.runId)
               }
               onSelect={onSelect}

--- a/airflow/www/static/js/dag/grid/dagRuns/index.tsx
+++ b/airflow/www/static/js/dag/grid/dagRuns/index.tsx
@@ -31,7 +31,7 @@ import {
 
 import { useGridData } from "src/api";
 import { getDuration, formatDuration } from "src/datetime_utils";
-import useSelection from "src/dag/useSelection";
+import useSelection, { SelectionProps } from "src/dag/useSelection";
 import type { DagRun, Task } from "src/types";
 
 import DagRunBar from "./Bar";
@@ -82,6 +82,7 @@ interface Props {
   openGroupIds?: string[];
   onToggleGroups?: (groupIds: string[]) => void;
   isGridCollapsed?: boolean;
+  selectedTaskInstances: SelectionProps[];
 }
 
 const DagRuns = ({
@@ -89,6 +90,7 @@ const DagRuns = ({
   openGroupIds,
   onToggleGroups,
   isGridCollapsed,
+  selectedTaskInstances,
 }: Props) => {
   const {
     data: { dagRuns },
@@ -170,7 +172,10 @@ const DagRuns = ({
               index={index}
               totalRuns={runs.length}
               max={max}
-              isSelected={run.runId === selected.runId && !isGridCollapsed}
+              isSelected={
+                !isGridCollapsed &&
+                selectedTaskInstances.some((ti) => ti && ti.runId === run.runId)
+              }
               onSelect={onSelect}
             />
           ))}

--- a/airflow/www/static/js/dag/grid/index.tsx
+++ b/airflow/www/static/js/dag/grid/index.tsx
@@ -33,8 +33,8 @@ import useSelection from "../useSelection";
 
 interface Props {
   hoveredTaskState?: string | null;
-  openGroupIds: string[];
-  onToggleGroups: (groupIds: string[]) => void;
+  openGroupIds?: string[];
+  onToggleGroups?: (groupIds: string[]) => void;
   isGridCollapsed?: boolean;
   gridScrollRef?: React.RefObject<HTMLDivElement>;
   ganttScrollRef?: React.RefObject<HTMLDivElement>;

--- a/airflow/www/static/js/dag/grid/index.tsx
+++ b/airflow/www/static/js/dag/grid/index.tsx
@@ -25,6 +25,8 @@ import { Table, Tbody, Box, Thead } from "@chakra-ui/react";
 import { useGridData } from "src/api";
 import { useOffsetTop } from "src/utils";
 
+import useMultipleSelection from "../useMultipleSelection";
+
 import renderTaskRows from "./renderTaskRows";
 import DagRuns from "./dagRuns";
 import useSelection from "../useSelection";
@@ -62,6 +64,13 @@ const Grid = ({
       }
       return true;
     });
+
+  const {
+    selectedTaskInstances,
+    onAddSelectedTask,
+    clearSelectionTasks,
+    onAddSelectedTaskBlock,
+  } = useMultipleSelection(groups, dagRunIds, openGroupIds);
 
   const onGanttScroll = (e: Event) => {
     const { scrollTop } = e.currentTarget as HTMLDivElement;
@@ -130,6 +139,7 @@ const Grid = ({
             openGroupIds={openGroupIds}
             onToggleGroups={onToggleGroups}
             isGridCollapsed={isGridCollapsed}
+            selectedTaskInstances={selectedTaskInstances}
           />
         </Thead>
         <Tbody ref={tableRef}>
@@ -140,6 +150,10 @@ const Grid = ({
             onToggleGroups,
             hoveredTaskState,
             isGridCollapsed,
+            selectedTaskInstances,
+            onAddSelectedTask,
+            clearSelectionTasks,
+            onAddSelectedTaskBlock,
           })}
         </Tbody>
       </Table>

--- a/airflow/www/static/js/dag/grid/renderTaskRows.test.tsx
+++ b/airflow/www/static/js/dag/grid/renderTaskRows.test.tsx
@@ -27,6 +27,11 @@ import type { Task } from "src/types";
 
 import renderTaskRows from "./renderTaskRows";
 
+const selectedTaskInstances = [{}];
+const onAddSelectedTask = jest.fn();
+const onAddSelectedTaskBlock = jest.fn();
+const clearSelectionTasks = jest.fn();
+
 describe("Test renderTaskRows", () => {
   test("Renders name and task instance", () => {
     const task: Task = {
@@ -70,7 +75,16 @@ describe("Test renderTaskRows", () => {
     };
 
     const { queryByTestId, getByText } = render(
-      <>{renderTaskRows({ task, dagRunIds: ["run1"] })}</>,
+      <>
+        {renderTaskRows({
+          task,
+          dagRunIds: ["run1"],
+          selectedTaskInstances,
+          onAddSelectedTask,
+          onAddSelectedTaskBlock,
+          clearSelectionTasks,
+        })}
+      </>,
       { wrapper: TableWrapper }
     );
 
@@ -95,7 +109,16 @@ describe("Test renderTaskRows", () => {
     };
 
     const { queryByTestId, getByText } = render(
-      <>{renderTaskRows({ task, dagRunIds: [] })}</>,
+      <>
+        {renderTaskRows({
+          task,
+          dagRunIds: [],
+          selectedTaskInstances,
+          onAddSelectedTask,
+          onAddSelectedTaskBlock,
+          clearSelectionTasks,
+        })}
+      </>,
       { wrapper: TableWrapper }
     );
 
@@ -127,7 +150,16 @@ describe("Test renderTaskRows", () => {
     };
 
     const { queryByTestId, getByText } = render(
-      <>{renderTaskRows({ task, dagRunIds: ["run1"] })}</>,
+      <>
+        {renderTaskRows({
+          task,
+          dagRunIds: ["run1"],
+          selectedTaskInstances,
+          onAddSelectedTask,
+          onAddSelectedTaskBlock,
+          clearSelectionTasks,
+        })}
+      </>,
       { wrapper: TableWrapper }
     );
 

--- a/airflow/www/static/js/dag/useMultipleSelection.test.tsx
+++ b/airflow/www/static/js/dag/useMultipleSelection.test.tsx
@@ -1,0 +1,208 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* global describe, test, expect */
+
+import React, { PropsWithChildren } from "react";
+import { act, renderHook } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { GridData } from "../api/useGridData";
+
+import useMultipleSelection from "./useMultipleSelection";
+
+const Wrapper = ({ children }: PropsWithChildren) => (
+  <MemoryRouter>{children}</MemoryRouter>
+);
+
+const mockGridData = {
+  groups: {
+    id: null,
+    label: null,
+    children: [
+      {
+        id: "group_1",
+        label: "group_1",
+        instances: [
+          {
+            endDate: "2021-10-26T15:42:03.391939+00:00",
+            runId: "run1",
+            startDate: "2021-10-26T15:42:03.391917+00:00",
+            state: "success",
+            taskId: "group_1",
+            tryNumber: 1,
+            note: "abc",
+          },
+        ],
+        children: [
+          {
+            id: "group_1.task_1",
+            operator: "DummyOperator",
+            label: "task_1",
+            instances: [
+              {
+                endDate: "2021-10-26T15:42:03.391939+00:00",
+                runId: "run1",
+                startDate: "2021-10-26T15:42:03.391917+00:00",
+                state: "success",
+                taskId: "group_1.task_1",
+                tryNumber: 1,
+                note: "abc",
+              },
+            ],
+            children: [
+              {
+                id: "group_1.task_1.sub_task_1",
+                label: "sub_task_1",
+                extraLinks: [],
+                operator: "DummyOperator",
+                instances: [
+                  {
+                    endDate: "2021-10-26T15:42:03.391939+00:00",
+                    runId: "run1",
+                    startDate: "2021-10-26T15:42:03.391917+00:00",
+                    state: "success",
+                    taskId: "group_1.task_1.sub_task_1",
+                    tryNumber: 1,
+                    note: "abc",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: "group_2",
+        label: "group_2",
+        instances: [
+          {
+            endDate: "2021-10-26T15:42:03.391939+00:00",
+            runId: "run1",
+            startDate: "2021-10-26T15:42:03.391917+00:00",
+            state: "success",
+            taskId: "group_1",
+            tryNumber: 1,
+          },
+        ],
+        children: [
+          {
+            id: "group_2.task_1",
+            operator: "DummyOperator",
+            label: "task_1",
+            instances: [
+              {
+                endDate: "2021-10-26T15:42:03.391939+00:00",
+                runId: "run1",
+                startDate: "2021-10-26T15:42:03.391917+00:00",
+                state: "success",
+                taskId: "group_1.task_1",
+                tryNumber: 1,
+              },
+            ],
+            children: [
+              {
+                id: "group_2.task_1.sub_task_1",
+                label: "sub_task_1",
+                extraLinks: [],
+                operator: "DummyOperator",
+                instances: [
+                  {
+                    endDate: "2021-10-26T15:42:03.391939+00:00",
+                    runId: "run1",
+                    startDate: "2021-10-26T15:42:03.391917+00:00",
+                    state: "success",
+                    taskId: "group_2.task_1.sub_task_1",
+                    tryNumber: 1,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    instances: [],
+  },
+  dagRuns: [
+    {
+      runId: "run1",
+      dataIntervalStart: "2021-11-08T21:14:19.704433+00:00",
+      dataIntervalEnd: "2021-11-08T21:17:13.206426+00:00",
+      queuedAt: "2021-11-08T21:14:19.604433+00:00",
+      startDate: "2021-11-08T21:14:19.704433+00:00",
+      endDate: "2021-11-08T21:17:13.206426+00:00",
+      state: "failed",
+      runType: "scheduled",
+      executionDate: "2021-11-08T21:14:19.704433+00:00",
+      lastSchedulingDecision: "2021-11-08T21:14:19.704433+00:00",
+      note: "myCoolDagRun",
+      externalTrigger: false,
+      conf: null,
+      confIsJson: false,
+    },
+  ],
+  ordering: ["dataIntervalStart"],
+} as GridData;
+
+const task1 = { taskId: "group_1.task_1.sub_task_1", runId: "run1" };
+const task2 = { taskId: "group_2.task_1.sub_task_1", runId: "run1" };
+
+const dagRunIds = mockGridData.dagRuns.map((dr) => dr.runId);
+
+describe("Test useMultipleSelection hook", () => {
+  test("Initial values", async () => {
+    const { result } = renderHook(
+      () => useMultipleSelection(mockGridData.groups, dagRunIds, dagRunIds),
+      { wrapper: Wrapper }
+    );
+
+    expect(result.current.selectedTaskInstances).toEqual([]);
+  });
+
+  test("Adding single task", async () => {
+    const { result } = renderHook(
+      () => useMultipleSelection(mockGridData.groups, dagRunIds, dagRunIds),
+      { wrapper: Wrapper }
+    );
+
+    await act(async () => {
+      result.current.onAddSelectedTask(task1);
+    });
+
+    expect(result.current.selectedTaskInstances[0].taskId).toBe(task1.taskId);
+    expect(result.current.selectedTaskInstances[0].runId).toBe(task1.runId);
+  });
+
+  test("Adding block of tasks", async () => {
+    const { result } = renderHook(
+      () => useMultipleSelection(mockGridData.groups, dagRunIds, dagRunIds),
+      { wrapper: Wrapper }
+    );
+
+    await act(async () => {
+      result.current.onAddSelectedTask(task1);
+    });
+
+    await act(async () => {
+      result.current.onAddSelectedTaskBlock(task2);
+    });
+
+    expect(result.current.selectedTaskInstances.length).toBe(3);
+  });
+});

--- a/airflow/www/static/js/dag/useMultipleSelection.test.tsx
+++ b/airflow/www/static/js/dag/useMultipleSelection.test.tsx
@@ -29,139 +29,137 @@ import useMultipleSelection from "./useMultipleSelection";
 const Wrapper = ({ children }: PropsWithChildren) => (
   <MemoryRouter>{children}</MemoryRouter>
 );
-
-const mockGridData = {
+const mockGridData: GridData = {
   groups: {
-    id: null,
-    label: null,
     children: [
       {
-        id: "group_1",
-        label: "group_1",
+        id: "task_a",
         instances: [
           {
-            endDate: "2021-10-26T15:42:03.391939+00:00",
-            runId: "run1",
-            startDate: "2021-10-26T15:42:03.391917+00:00",
+            endDate: "2024-06-08T22:55:20.749988+00:00",
+            note: null,
+            queuedDttm: "2024-06-08T22:55:20.016931+00:00",
+            runId: "run2",
+            startDate: "2024-06-08T22:55:20.476427+00:00",
             state: "success",
-            taskId: "group_1",
+            taskId: "task_a",
             tryNumber: 1,
-            note: "abc",
           },
-        ],
-        children: [
           {
-            id: "group_1.task_1",
-            operator: "DummyOperator",
-            label: "task_1",
-            instances: [
-              {
-                endDate: "2021-10-26T15:42:03.391939+00:00",
-                runId: "run1",
-                startDate: "2021-10-26T15:42:03.391917+00:00",
-                state: "success",
-                taskId: "group_1.task_1",
-                tryNumber: 1,
-                note: "abc",
-              },
-            ],
-            children: [
-              {
-                id: "group_1.task_1.sub_task_1",
-                label: "sub_task_1",
-                extraLinks: [],
-                operator: "DummyOperator",
-                instances: [
-                  {
-                    endDate: "2021-10-26T15:42:03.391939+00:00",
-                    runId: "run1",
-                    startDate: "2021-10-26T15:42:03.391917+00:00",
-                    state: "success",
-                    taskId: "group_1.task_1.sub_task_1",
-                    tryNumber: 1,
-                    note: "abc",
-                  },
-                ],
-              },
-            ],
+            endDate: "2024-06-08T22:55:20.749826+00:00",
+            note: null,
+            queuedDttm: "2024-06-08T22:55:20.016931+00:00",
+            runId: "run1",
+            startDate: "2024-06-08T22:55:20.481613+00:00",
+            state: "success",
+            taskId: "task_a",
+            tryNumber: 1,
           },
         ],
+        isMapped: false,
+        label: "task_a",
+        operator: "PythonOperator",
       },
       {
-        id: "group_2",
-        label: "group_2",
+        id: "task_b",
         instances: [
           {
-            endDate: "2021-10-26T15:42:03.391939+00:00",
-            runId: "run1",
-            startDate: "2021-10-26T15:42:03.391917+00:00",
+            endDate: "2024-06-08T22:55:21.259311+00:00",
+            note: null,
+            queuedDttm: "2024-06-08T22:55:20.785072+00:00",
+            runId: "run2",
+            startDate: "2024-06-08T22:55:21.025994+00:00",
             state: "success",
-            taskId: "group_1",
+            taskId: "task_b",
+            tryNumber: 1,
+          },
+          {
+            endDate: "2024-06-08T22:55:21.325288+00:00",
+            note: null,
+            queuedDttm: "2024-06-08T22:55:20.868299+00:00",
+            runId: "run1",
+            startDate: "2024-06-08T22:55:21.091137+00:00",
+            state: "success",
+            taskId: "task_b",
             tryNumber: 1,
           },
         ],
-        children: [
+        isMapped: false,
+        label: "task_b",
+        operator: "PythonOperator",
+      },
+      {
+        id: "task_c",
+        instances: [
           {
-            id: "group_2.task_1",
-            operator: "DummyOperator",
-            label: "task_1",
-            instances: [
-              {
-                endDate: "2021-10-26T15:42:03.391939+00:00",
-                runId: "run1",
-                startDate: "2021-10-26T15:42:03.391917+00:00",
-                state: "success",
-                taskId: "group_1.task_1",
-                tryNumber: 1,
-              },
-            ],
-            children: [
-              {
-                id: "group_2.task_1.sub_task_1",
-                label: "sub_task_1",
-                extraLinks: [],
-                operator: "DummyOperator",
-                instances: [
-                  {
-                    endDate: "2021-10-26T15:42:03.391939+00:00",
-                    runId: "run1",
-                    startDate: "2021-10-26T15:42:03.391917+00:00",
-                    state: "success",
-                    taskId: "group_2.task_1.sub_task_1",
-                    tryNumber: 1,
-                  },
-                ],
-              },
-            ],
+            endDate: "2024-06-08T22:55:22.490842+00:00",
+            note: null,
+            queuedDttm: "2024-06-08T22:55:22.007508+00:00",
+            runId: "run2",
+            startDate: "2024-06-08T22:55:22.256614+00:00",
+            state: "success",
+            taskId: "task_c",
+            tryNumber: 1,
+          },
+          {
+            endDate: "2024-06-08T22:55:22.490833+00:00",
+            note: null,
+            queuedDttm: "2024-06-08T22:55:22.007508+00:00",
+            runId: "run1",
+            startDate: "2024-06-08T22:55:22.257144+00:00",
+            state: "success",
+            taskId: "task_c",
+            tryNumber: 1,
           },
         ],
+        isMapped: false,
+        label: "task_c",
+        operator: "PythonOperator",
       },
     ],
+    id: null,
     instances: [],
+    label: null,
   },
   dagRuns: [
     {
-      runId: "run1",
-      dataIntervalStart: "2021-11-08T21:14:19.704433+00:00",
-      dataIntervalEnd: "2021-11-08T21:17:13.206426+00:00",
-      queuedAt: "2021-11-08T21:14:19.604433+00:00",
-      startDate: "2021-11-08T21:14:19.704433+00:00",
-      endDate: "2021-11-08T21:17:13.206426+00:00",
-      state: "failed",
-      runType: "scheduled",
-      executionDate: "2021-11-08T21:14:19.704433+00:00",
-      lastSchedulingDecision: "2021-11-08T21:14:19.704433+00:00",
-      note: "myCoolDagRun",
-      externalTrigger: false,
       conf: null,
       confIsJson: false,
+      dataIntervalEnd: "2024-06-08T00:00:00+00:00",
+      dataIntervalStart: "2024-06-07T00:00:00+00:00",
+      endDate: "2024-06-08T22:55:23.156380+00:00",
+      executionDate: "2024-06-07T00:00:00+00:00",
+      externalTrigger: false,
+      lastSchedulingDecision: "2024-06-08T22:55:23.151503+00:00",
+      note: null,
+      queuedAt: "2024-06-08T22:55:19.887507+00:00",
+      runId: "run1",
+      runType: "scheduled",
+      startDate: "2024-06-08T22:55:19.928411+00:00",
+      state: "success",
+    },
+    {
+      conf: null,
+      confIsJson: false,
+      dataIntervalEnd: "2024-06-08T00:00:00+00:00",
+      dataIntervalStart: "2024-06-07T00:00:00+00:00",
+      endDate: "2024-06-08T22:55:23.134110+00:00",
+      executionDate: "2024-06-08T22:55:19.315019+00:00",
+      externalTrigger: true,
+      lastSchedulingDecision: "2024-06-08T22:55:23.128811+00:00",
+      note: null,
+      queuedAt: "2024-06-08T22:55:19.368711+00:00",
+      runId: "run2",
+      runType: "manual",
+      startDate: "2024-06-08T22:55:19.928888+00:00",
+      state: "success",
     },
   ],
   ordering: ["dataIntervalStart"],
 } as GridData;
 
-const task1 = { taskId: "group_1.task_1.sub_task_1", runId: "run1" };
-const task2 = { taskId: "group_2.task_1.sub_task_1", runId: "run1" };
+const task1 = { taskId: "task_a", runId: "run1" };
+const task2 = { taskId: "task_c", runId: "run2" };
 
 const dagRunIds = mockGridData.dagRuns.map((dr) => dr.runId);
 
@@ -183,10 +181,14 @@ describe("Test useMultipleSelection hook", () => {
 
     await act(async () => {
       result.current.onAddSelectedTask(task1);
+      result.current.onAddSelectedTask(task2);
     });
 
+    expect(result.current.selectedTaskInstances.length).toBe(2);
     expect(result.current.selectedTaskInstances[0].taskId).toBe(task1.taskId);
     expect(result.current.selectedTaskInstances[0].runId).toBe(task1.runId);
+    expect(result.current.selectedTaskInstances[1].taskId).toBe(task2.taskId);
+    expect(result.current.selectedTaskInstances[1].runId).toBe(task2.runId);
   });
 
   test("Adding block of tasks", async () => {
@@ -196,13 +198,13 @@ describe("Test useMultipleSelection hook", () => {
     );
 
     await act(async () => {
-      result.current.onAddSelectedTask(task1);
+      result.current.onAddSelectedTaskBlock(task1);
     });
 
     await act(async () => {
       result.current.onAddSelectedTaskBlock(task2);
     });
 
-    expect(result.current.selectedTaskInstances.length).toBe(3);
+    expect(result.current.selectedTaskInstances.length).toBe(6);
   });
 });

--- a/airflow/www/static/js/dag/useMultipleSelection.ts
+++ b/airflow/www/static/js/dag/useMultipleSelection.ts
@@ -1,0 +1,155 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useState, useCallback } from "react";
+import type { Task } from "../types";
+
+interface SelectionProps {
+  runId?: string | null;
+  taskId?: string | null;
+  mapIndex?: number;
+}
+
+const useMultipleSelection = (
+  groups: Task,
+  dagRunIds: string[],
+  openGroupIds: string[]
+) => {
+  const [selectedTaskInstances, setSelectedTaskInstances] = useState<
+    SelectionProps[]
+  >([]);
+
+  const clearSelectionTasks = useCallback(() => {
+    setSelectedTaskInstances([]);
+  }, []);
+
+  const onAddSelectedTask = useCallback(
+    ({ runId, taskId, mapIndex }: SelectionProps) => {
+      setSelectedTaskInstances((tis) => {
+        const isRepeatedTask = tis.some(
+          (ti) => ti.taskId === taskId && ti.runId === runId
+        );
+        if (!isRepeatedTask) {
+          return [...tis, { runId, taskId, mapIndex }];
+        }
+        return tis;
+      });
+    },
+    []
+  );
+
+  const selectedRunIds = useCallback(
+    (topRunId?: string | null, botRunId?: string | null) => {
+      if (topRunId === botRunId) return [topRunId];
+
+      const selectedRunIdsArr: string[] = [];
+      let isInRunBlock = false;
+
+      dagRunIds.forEach((runId: string) => {
+        const isBlockLimit = topRunId === runId || botRunId === runId;
+        if (!isInRunBlock && isBlockLimit) {
+          isInRunBlock = true;
+        } else if (isInRunBlock && isBlockLimit) {
+          isInRunBlock = false;
+          selectedRunIdsArr.push(runId);
+        }
+        if (isInRunBlock) {
+          selectedRunIdsArr.push(runId);
+        }
+      });
+
+      return selectedRunIdsArr;
+    },
+    [dagRunIds]
+  );
+
+  const addTaskBlock = useCallback(
+    (
+      tasks: Task[],
+      topTask: SelectionProps,
+      bottomTask: SelectionProps,
+      selectedRunIdsArr: (string | null | undefined)[],
+      isInTaskBlock = false
+    ) => {
+      tasks.forEach((task) => {
+        const isOpen = openGroupIds.some((g) => g === task.id);
+        const isBlockLimit =
+          task.id === topTask.taskId || task.id === bottomTask.taskId;
+        if (isBlockLimit) isInTaskBlock = !isInTaskBlock;
+        if (isInTaskBlock || isBlockLimit) {
+          task.instances.forEach((ti) => {
+            const isInRunBlock = selectedRunIdsArr.some(
+              (runId) => runId === ti.runId
+            );
+            if (isInRunBlock) {
+              onAddSelectedTask({ runId: ti.runId, taskId: task.id });
+            }
+          });
+          if (topTask.taskId === bottomTask.taskId) {
+            isInTaskBlock = false;
+          }
+        }
+        if (isOpen) {
+          isInTaskBlock = addTaskBlock(
+            task?.children || [],
+            topTask,
+            bottomTask,
+            selectedRunIdsArr,
+            isInTaskBlock
+          );
+        }
+      });
+      return isInTaskBlock;
+    },
+    [openGroupIds, onAddSelectedTask]
+  );
+
+  const onAddSelectedTaskBlock = useCallback(
+    ({ runId, taskId, mapIndex }: SelectionProps) => {
+      if (selectedTaskInstances.length === 0) {
+        onAddSelectedTask({ runId, taskId, mapIndex });
+      } else {
+        const lastTask =
+          selectedTaskInstances[selectedTaskInstances.length - 1];
+        const selectedRunIdsArr = selectedRunIds(lastTask.runId, runId);
+        addTaskBlock(
+          groups?.children || [],
+          lastTask,
+          { runId, taskId, mapIndex },
+          selectedRunIdsArr
+        );
+      }
+    },
+    [
+      selectedTaskInstances,
+      onAddSelectedTask,
+      selectedRunIds,
+      addTaskBlock,
+      groups,
+    ]
+  );
+
+  return {
+    selectedTaskInstances,
+    onAddSelectedTask,
+    clearSelectionTasks,
+    onAddSelectedTaskBlock,
+  };
+};
+
+export default useMultipleSelection;


### PR DESCRIPTION
(Implemented SHIFT and CTRL selection)
Pressing CTRL adds one extra task to selection,
while SHIFT adds a square of tasks
Co-authored-by: João Rocha <joaonolascorocha@tecnico.ulisboa.pt>

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

related: #33448

We added a new custom hook useMultipleSelection that stores an array with all selected tasks. Since this is a pretty big feature, we only completed the selection itself and not the state change. We are leaving up to you if we should just hide the functionality of this code to be a base for another PR that implements the state change feature, or continue updating this PR. We would need some opinions on how this functionality should behave when interacting with marking state as. Since changing a state of a task can affect the state of another task, how should the states of multiple tasks be handled.

Also for now we've made selected tasks stand out by applying a darker blue background. This helped differentiate between selected tasks, since when multiple tasks within the same rows and columns are chosen it was unclear which tasks were selected.

Video before/after changes: [https://www.youtube.com/watch?v=G18f3BUei4U](url)

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
