### PR TITLE
Add try number to StatusBox

### DIFF
--- a/airflow/www/static/js/dag/StatusBox.tsx
+++ b/airflow/www/static/js/dag/StatusBox.tsx
@@ -53,12 +53,12 @@ export const StatusWithNotes = ({
       borderRadius="2px"
       borderWidth={state ? 0 : 1}
       color="white"
-      fontSize={boxSizePx}
+      fontSize={boxSizePx-4}
       textAlign="center"
       verticalAlign="middle"
       {...rest}
     >
-      {!!tryNumber && tryNumber > 1 && tryNumber}
+      {tryNumber > 1 ? tryNumber : null}
     </Box>
   );
 };

--- a/airflow/www/static/js/dag/StatusBox.tsx
+++ b/airflow/www/static/js/dag/StatusBox.tsx
@@ -35,11 +35,13 @@ export const boxSizePx = `${boxSize}px`;
 interface StatusWithNotesProps extends BoxProps {
   state: TaskState;
   containsNotes?: boolean;
+  tryNumber?: number;
 }
 
 export const StatusWithNotes = ({
   state,
   containsNotes,
+  tryNumber,
   ...rest
 }: StatusWithNotesProps) => {
   const color = state && stateColors[state] ? stateColors[state] : "white";
@@ -50,8 +52,14 @@ export const StatusWithNotes = ({
       background={getStatusBackgroundColor(color, !!containsNotes)}
       borderRadius="2px"
       borderWidth={state ? 0 : 1}
+      color="white"
+      fontSize={boxSizePx}
+      textAlign="center"
+      verticalAlign="middle"
       {...rest}
-    />
+    >
+      {!!tryNumber && tryNumber > 1 && tryNumber}
+    </Box>
   );
 };
 
@@ -137,6 +145,7 @@ const StatusBox = ({
         <StatusWithNotes
           state={instance.state}
           containsNotes={containsNotes}
+          tryNumber={instance.tryNumber}
           onClick={onClick}
           cursor="pointer"
           data-testid="task-instance"


### PR DESCRIPTION
Tiny UI improvement: 
If there are multiple tries of a task, show the count over the task instance status box in the DAG grid view.

This improves visibility into dag history in the grid view. 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
