### PR TITLE
Implement XComArg concat()

### DIFF
--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -620,15 +620,20 @@ class _ConcatResult(Sequence):
         self.values = values
 
     def __getitem__(self, index: Any) -> Any:
-        i = index
+        if index >= 0:
+            i = index
+        else:
+            i = len(self) + index
         for value in self.values:
-            if i >= (curlen := len(value)):
+            if i < 0:
+                break
+            elif i >= (curlen := len(value)):
                 i -= curlen
             elif isinstance(value, Sequence):
                 return value[i]
             else:
                 return next(itertools.islice(iter(value), i, None))
-        raise IndexError(index)
+        raise IndexError("list index out of range")
 
     def __len__(self) -> int:
         return sum(len(v) for v in self.values)

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -670,7 +670,7 @@ class ConcatXComArg(XComArg):
             yield from arg.iter_references()
 
     def concat(self, *others: XComArg) -> ConcatXComArg:
-        # Flattern foo.concat(x).concat(y) into one call.
+        # Flatten foo.concat(x).concat(y) into one call.
         return ConcatXComArg([*self.args, *others])
 
     def get_task_map_length(self, run_id: str, *, session: Session) -> int | None:

--- a/docs/apache-airflow/authoring-and-scheduling/dynamic-task-mapping.rst
+++ b/docs/apache-airflow/authoring-and-scheduling/dynamic-task-mapping.rst
@@ -521,14 +521,14 @@ Since it is common to want to transform the output data format for task mapping,
 
 There are a couple of things to note:
 
-#. The callable argument of ``map()`` (``create_copy_kwargs`` in the example) **must not** be a task, but a plain Python function. The transformation is as a part of the "pre-processing" of the downstream task (i.e. ``copy_files``), not a standalone task in the DAG.
-#. The callable always take exactly one positional argument. This function is called for each item in the iterable used for task-mapping, similar to how Python's built-in ``map()`` works.
+#. The callable argument of :func:`map()` (``create_copy_kwargs`` in the example) **must not** be a task, but a plain Python function. The transformation is as a part of the "pre-processing" of the downstream task (i.e. ``copy_files``), not a standalone task in the DAG.
+#. The callable always take exactly one positional argument. This function is called for each item in the iterable used for task-mapping, similar to how Python's built-in :func:`map()` works.
 #. Since the callable is executed as a part of the downstream task, you can use any existing techniques to write the task function. To mark a component as skipped, for example, you should raise ``AirflowSkipException``. Note that returning ``None`` **does not** work here.
 
 Combining upstream data (aka "zipping")
 =======================================
 
-It is also common to want to combine multiple input sources into one task mapping iterable. This is generally known as "zipping" (like Python's built-in ``zip()`` function), and is also performed as pre-processing of the downstream task.
+It is also common to want to combine multiple input sources into one task mapping iterable. This is generally known as "zipping" (like Python's built-in :func:`zip()` function), and is also performed as pre-processing of the downstream task.
 
 This is especially useful for conditional logic in task mapping. For example, if you want to download files from S3, but rename those files, something like this would be possible:
 
@@ -552,7 +552,46 @@ This is especially useful for conditional logic in task mapping. For example, if
 
     download_filea_from_a_rename.expand(filenames_a_b=filenames_a_b)
 
-The ``zip`` function takes arbitrary positional arguments, and return an iterable of tuples of the positional arguments' count. By default, the zipped iterable's length is the same as the shortest of the zipped iterables, with superfluous items dropped. An optional keyword argument ``default`` can be passed to switch the behavior to match Python's ``itertools.zip_longest``—the zipped iterable will have the same length as the *longest* of the zipped iterables, with missing items filled with the value provided by ``default``.
+The ``zip`` function takes arbitrary positional arguments, and returns an iterable of tuples of the positional arguments' count. By default, the zipped iterable's length is the same as the shortest of the zipped iterables, with superfluous items dropped. An optional keyword argument ``default`` can be passed to switch the behavior to match Python's :func:`itertools.zip_longest`—the zipped iterable will have the same length as the *longest* of the zipped iterables, with missing items filled with the value provided by ``default``.
+
+Concatenating multiple upstreams
+================================
+
+Another common pattern to combine input sources is to run the same task against multiple iterables. It is of course totally valid to simply run the same code separately for each iterable, for example:
+
+.. code-block:: python
+
+    list_filenames_a = S3ListOperator(
+        task_id="list_files_in_a",
+        bucket="bucket",
+        prefix="incoming/provider_a/{{ data_interval_start|ds }}",
+    )
+    list_filenames_b = S3ListOperator(
+        task_id="list_files_in_b",
+        bucket="bucket",
+        prefix="incoming/provider_b/{{ data_interval_start|ds }}",
+    )
+
+
+    @task
+    def download_file(filename):
+        S3Hook().download_file(filename)
+        # process file...
+
+
+    download_file.override(task_id="download_file_a").expand(filename=list_filenames_a.output)
+    download_file.override(task_id="download_file_b").expand(filename=list_filenames_b.output)
+
+The DAG, however, would be both more scalable and easier to inspect if the tasks can be combined into one. This can done with ``concat``:
+
+.. code-block:: python
+
+    # Tasks list_filenames_a and list_filenames_b, and download_file stay unchanged.
+
+    list_filenames_concat = list_filenames_a.concat(list_filenames_b)
+    download_file.expand(filename=list_filenames_concat)
+
+This creates one single task to expand against both lists instead. The ``concat`` function takes arbitrary positional arguments, and returns one single iterable that concatenates all of them in order—similar to Python's :func:`itertools.chain`.
 
 What data types can be expanded?
 ================================

--- a/docs/apache-airflow/authoring-and-scheduling/dynamic-task-mapping.rst
+++ b/docs/apache-airflow/authoring-and-scheduling/dynamic-task-mapping.rst
@@ -552,7 +552,7 @@ This is especially useful for conditional logic in task mapping. For example, if
 
     download_filea_from_a_rename.expand(filenames_a_b=filenames_a_b)
 
-The ``zip`` function takes arbitrary positional arguments, and returns an iterable of tuples of the positional arguments' count. By default, the zipped iterable's length is the same as the shortest of the zipped iterables, with superfluous items dropped. An optional keyword argument ``default`` can be passed to switch the behavior to match Python's :func:`itertools.zip_longest`—the zipped iterable will have the same length as the *longest* of the zipped iterables, with missing items filled with the value provided by ``default``.
+Similar to the built-in :func:`zip`, you can zip an arbitrary number of iterables together to get an iterable of tuples of the positional arguments' count. By default, the zipped iterable's length is the same as the shortest of the zipped iterables, with superfluous items dropped. An optional keyword argument ``default`` can be passed to switch the behavior to match Python's :func:`itertools.zip_longest`—the zipped iterable will have the same length as the *longest* of the zipped iterables, with missing items filled with the value provided by ``default``.
 
 Concatenating multiple upstreams
 ================================
@@ -591,7 +591,7 @@ The DAG, however, would be both more scalable and easier to inspect if the tasks
     list_filenames_concat = list_filenames_a.concat(list_filenames_b)
     download_file.expand(filename=list_filenames_concat)
 
-This creates one single task to expand against both lists instead. The ``concat`` function takes arbitrary positional arguments, and returns one single iterable that concatenates all of them in order—similar to Python's :func:`itertools.chain`.
+This creates one single task to expand against both lists instead. You can ``concat`` an arbitrary number of iterables together (e.g. ``foo.concat(bar, rex)``); alternatively, since the return value is also an XCom reference, the ``concat`` calls can be chained (e.g. ``foo.concat(bar).concat(rex)``) to achieve the same result: one single iterable that concatenates all of them in order, similar to Python's :func:`itertools.chain`.
 
 What data types can be expanded?
 ================================

--- a/tests/models/test_xcom_arg_map.py
+++ b/tests/models/test_xcom_arg_map.py
@@ -333,8 +333,22 @@ def test_xcom_concat(dag_maker, session):
 
         @dag.task
         def pull_all(value):
-            nonlocal all_results
             assert isinstance(value, _ConcatResult)
+            assert value[0] == "a"
+            assert value[1] == "b"
+            assert value[2] == "c"
+            assert value[3] == 1
+            assert value[4] == 2
+            with pytest.raises(IndexError):
+                value[5]
+            assert value[-5] == "a"
+            assert value[-4] == "b"
+            assert value[-3] == "c"
+            assert value[-2] == 1
+            assert value[-1] == 2
+            with pytest.raises(IndexError):
+                value[-6]
+            nonlocal all_results
             all_results = list(value)
 
         pushed_values = push_letters().concat(push_numbers())

--- a/tests/models/test_xcom_arg_map.py
+++ b/tests/models/test_xcom_arg_map.py
@@ -311,8 +311,8 @@ def test_xcom_map_zip_nest(dag_maker, session):
     assert results == {"aa", "bbbb", "cccccc", "dddddddd"}
 
 
-def test_xcom_chain(dag_maker, session):
-    from airflow.models.xcom_arg import _ChainResult
+def test_xcom_concat(dag_maker, session):
+    from airflow.models.xcom_arg import _ConcatResult
 
     agg_results = set()
     all_results = None
@@ -334,10 +334,10 @@ def test_xcom_chain(dag_maker, session):
         @dag.task
         def pull_all(value):
             nonlocal all_results
-            assert isinstance(value, _ChainResult)
+            assert isinstance(value, _ConcatResult)
             all_results = list(value)
 
-        pushed_values = push_letters().chain(push_numbers())
+        pushed_values = push_letters().concat(push_numbers())
 
         pull_one.expand(value=pushed_values)
         pull_all(pushed_values)

--- a/tests/models/test_xcom_arg_map.py
+++ b/tests/models/test_xcom_arg_map.py
@@ -309,3 +309,58 @@ def test_xcom_map_zip_nest(dag_maker, session):
         ti.run(session=session)
 
     assert results == {"aa", "bbbb", "cccccc", "dddddddd"}
+
+
+def test_xcom_chain(dag_maker, session):
+    from airflow.models.xcom_arg import _ChainResult
+
+    agg_results = set()
+    all_results = None
+
+    with dag_maker(session=session) as dag:
+
+        @dag.task
+        def push_letters():
+            return ["a", "b", "c"]
+
+        @dag.task
+        def push_numbers():
+            return [1, 2]
+
+        @dag.task
+        def pull_one(value):
+            agg_results.add(value)
+
+        @dag.task
+        def pull_all(value):
+            nonlocal all_results
+            assert isinstance(value, _ChainResult)
+            all_results = list(value)
+
+        pushed_values = push_letters().chain(push_numbers())
+
+        pull_one.expand(value=pushed_values)
+        pull_all(pushed_values)
+
+    dr = dag_maker.create_dagrun(session=session)
+
+    # Run "push_letters" and "push_numbers".
+    decision = dr.task_instance_scheduling_decisions(session=session)
+    assert len(decision.schedulable_tis) == 2
+    assert all(ti.task_id.startswith("push_") for ti in decision.schedulable_tis)
+    for ti in decision.schedulable_tis:
+        ti.run(session=session)
+    session.commit()
+
+    # Run "pull_one" and "pull_all".
+    decision = dr.task_instance_scheduling_decisions(session=session)
+    assert len(decision.schedulable_tis) == 6
+    assert all(ti.task_id.startswith("pull_") for ti in decision.schedulable_tis)
+    for ti in decision.schedulable_tis:
+        ti.run(session=session)
+
+    assert agg_results == {"a", "b", "c", 1, 2}
+    assert all_results == ["a", "b", "c", 1, 2]
+
+    decision = dr.task_instance_scheduling_decisions(session=session)
+    assert not decision.schedulable_tis


### PR DESCRIPTION
This is useful when you want to do a thing against more than one list of things. You can sort of already do this with an extra task, but this is lazier and saves some resources both in the XCom storage and memory needed to run tasks.