### PR TITLE
Databricks: stop including user names in `list_jobs`

### DIFF
--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -256,6 +256,7 @@ class DatabricksHook(BaseDatabricksHook):
         expand_tasks: bool = False,
         job_name: str | None = None,
         page_token: str | None = None,
+        include_user_names: bool = False,
     ) -> list[dict[str, Any]]:
         """
         List the jobs in the Databricks Job Service.
@@ -275,6 +276,7 @@ class DatabricksHook(BaseDatabricksHook):
             payload: dict[str, Any] = {
                 "limit": limit,
                 "expand_tasks": expand_tasks,
+                "include_user_names": include_user_names,
             }
             payload["page_token"] = page_token
             if job_name:

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -912,7 +912,7 @@ class TestDatabricksHook:
         mock_requests.get.assert_called_once_with(
             list_jobs_endpoint(HOST),
             json=None,
-            params={"limit": 25, "page_token": "", "expand_tasks": False},
+            params={"limit": 25, "page_token": "", "expand_tasks": False, "include_user_names": False},
             auth=HTTPBasicAuth(LOGIN, PASSWORD),
             headers=self.hook.user_agent_header,
             timeout=self.hook.timeout_seconds,

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -936,7 +936,12 @@ class TestDatabricksHook:
 
         first_call_args = mock_requests.method_calls[0]
         assert first_call_args[1][0] == list_jobs_endpoint(HOST)
-        assert first_call_args[2]["params"] == {"limit": 25, "page_token": "", "expand_tasks": False}
+        assert first_call_args[2]["params"] == {
+            "limit": 25,
+            "page_token": "",
+            "expand_tasks": False,
+            "include_user_names": False
+        }
 
         second_call_args = mock_requests.method_calls[1]
         assert second_call_args[1][0] == list_jobs_endpoint(HOST)
@@ -944,6 +949,7 @@ class TestDatabricksHook:
             "limit": 25,
             "page_token": "PAGETOKEN",
             "expand_tasks": False,
+            "include_user_names": False
         }
 
         assert len(jobs) == 2
@@ -959,7 +965,13 @@ class TestDatabricksHook:
         mock_requests.get.assert_called_once_with(
             list_jobs_endpoint(HOST),
             json=None,
-            params={"limit": 25, "page_token": "", "expand_tasks": False, "name": JOB_NAME},
+            params={
+                "limit": 25,
+                "page_token": "",
+                "expand_tasks": False,
+                "include_user_names": False,
+                "name": JOB_NAME
+            },
             auth=HTTPBasicAuth(LOGIN, PASSWORD),
             headers=self.hook.user_agent_header,
             timeout=self.hook.timeout_seconds,
@@ -978,7 +990,13 @@ class TestDatabricksHook:
         mock_requests.get.assert_called_once_with(
             list_jobs_endpoint(HOST),
             json=None,
-            params={"limit": 25, "page_token": "", "expand_tasks": False, "name": job_name},
+            params={
+                "limit": 25,
+                "page_token": "",
+                "expand_tasks": False,
+                "include_user_names": False,
+                "name": job_name
+            },
             auth=HTTPBasicAuth(LOGIN, PASSWORD),
             headers=self.hook.user_agent_header,
             timeout=self.hook.timeout_seconds,
@@ -1001,7 +1019,13 @@ class TestDatabricksHook:
         mock_requests.get.assert_called_once_with(
             list_jobs_endpoint(HOST),
             json=None,
-            params={"limit": 25, "page_token": "", "expand_tasks": False, "name": JOB_NAME},
+            params={
+                "limit": 25,
+                "page_token": "",
+                "expand_tasks": False,
+                "include_user_names": False,
+                "name": JOB_NAME
+            },
             auth=HTTPBasicAuth(LOGIN, PASSWORD),
             headers=self.hook.user_agent_header,
             timeout=self.hook.timeout_seconds,

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -940,7 +940,7 @@ class TestDatabricksHook:
             "limit": 25,
             "page_token": "",
             "expand_tasks": False,
-            "include_user_names": False
+            "include_user_names": False,
         }
 
         second_call_args = mock_requests.method_calls[1]
@@ -949,7 +949,7 @@ class TestDatabricksHook:
             "limit": 25,
             "page_token": "PAGETOKEN",
             "expand_tasks": False,
-            "include_user_names": False
+            "include_user_names": False,
         }
 
         assert len(jobs) == 2
@@ -970,7 +970,7 @@ class TestDatabricksHook:
                 "page_token": "",
                 "expand_tasks": False,
                 "include_user_names": False,
-                "name": JOB_NAME
+                "name": JOB_NAME,
             },
             auth=HTTPBasicAuth(LOGIN, PASSWORD),
             headers=self.hook.user_agent_header,
@@ -995,7 +995,7 @@ class TestDatabricksHook:
                 "page_token": "",
                 "expand_tasks": False,
                 "include_user_names": False,
-                "name": job_name
+                "name": job_name,
             },
             auth=HTTPBasicAuth(LOGIN, PASSWORD),
             headers=self.hook.user_agent_header,
@@ -1024,7 +1024,7 @@ class TestDatabricksHook:
                 "page_token": "",
                 "expand_tasks": False,
                 "include_user_names": False,
-                "name": JOB_NAME
+                "name": JOB_NAME,
             },
             auth=HTTPBasicAuth(LOGIN, PASSWORD),
             headers=self.hook.user_agent_header,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

When querying `list_jobs`, by default the owning user's name is resolved. This field is not used on the Airflow side, and the lookup is (relatively) expensive.

With this new argument, the lookup is skipped. This will make requests faster and more reliable.

<!-- Please keep an empty line above the dashes. -->
---

