### PR TITLE
Bump minimum version of google auth

### DIFF
--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -111,7 +111,7 @@ dependencies:
   # - https://github.com/apache/airflow/issues/39394
   - google-api-core>=2.11.0,!=2.16.0,!=2.18.0
   - google-api-python-client>=2.0.2
-  - google-auth>=1.0.0
+  - google-auth>=2.29.0
   - google-auth-httplib2>=0.0.1
   - google-cloud-aiplatform>=1.42.1
   - google-cloud-automl>=2.12.0

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -592,7 +592,7 @@
       "google-api-core>=2.11.0,!=2.16.0,!=2.18.0",
       "google-api-python-client>=2.0.2",
       "google-auth-httplib2>=0.0.1",
-      "google-auth>=1.0.0",
+      "google-auth>=2.29.0",
       "google-cloud-aiplatform>=1.42.1",
       "google-cloud-automl>=2.12.0",
       "google-cloud-batch>=0.13.0",


### PR DESCRIPTION
The #39873 added an implicit dependency to google auth > 2.29.0 because it uses SubjectTokenSupplier added in that version.

Our "Lowest-direct" tests caught it (yay!) so we should add the min requirement to the dependency.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
