### PR TITLE
Lazy match escaped quotes in `RedshiftToS3Operator`

### DIFF
--- a/airflow/providers/amazon/aws/transfers/redshift_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/redshift_to_s3.py
@@ -128,7 +128,7 @@ class RedshiftToS3Operator(BaseOperator):
         self, credentials_block: str, select_query: str, s3_key: str, unload_options: str
     ) -> str:
         # Un-escape already escaped queries
-        select_query = re.sub(r"''(.+)''", r"'\1'", select_query)
+        select_query = re.sub(r"''(.+?)''", r"'\1'", select_query)
         return f"""
                     UNLOAD ($${select_query}$$)
                     TO 's3://{self.s3_bucket}/{s3_key}'

--- a/tests/providers/amazon/aws/transfers/test_redshift_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_redshift_to_s3.py
@@ -245,6 +245,12 @@ class TestRedshiftToS3Transfer:
                 "SELECT 'Single Quotes Break this Operator'",
             ],
             [False, "key", "SELECT ''", "SELECT ''"],
+            [
+                False,
+                "key",
+                "SELECT ''Single Quotes '' || ''Break this Operator''",
+                "SELECT 'Single Quotes ' || 'Break this Operator'",
+            ],
         ],
     )
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")


### PR DESCRIPTION
In https://github.com/apache/airflow/pull/35986, `RedshiftToS3Operator` began wrapping `select_query` in `$$` to handle single quotes. Escaped single quotes (`''`) are un-escaped using regex replacement for backwards compatibilty. The regex is greedy, however, and lines containing multiple strings inside of escaped single quotes only have the outermost quotes un-escaped.

A query such as:
```sql
SELECT * FROM table WHERE name IN (''foo'', ''bar'')
```
is modified to:
```sql
SELECT * FROM table WHERE name IN ('foo'', ''bar')
```
In this example, the operator succeeds but the results are unexpected.

This PR changes the regex pattern to match as few characters as possible, and adds test coverage for this case.
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
