### PR TITLE
fix bigquery_to_gcs documentation

### DIFF
--- a/docs/apache-airflow-providers-google/operators/transfer/bigquery_to_gcs.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/bigquery_to_gcs.rst
@@ -37,7 +37,7 @@ Prerequisite Tasks
 Operator
 ^^^^^^^^
 
-File transfer from GCS to BigQuery is performed with the
+Table export from BigQuery to GCS is performed with the
 :class:`~airflow.providers.google.cloud.transfers.bigquery_to_gcs.BigQueryToGCSOperator` operator.
 
 Use :ref:`Jinja templating <concepts:jinja-templating>` with
@@ -48,10 +48,10 @@ You may define multiple destination URIs, as well as other settings such as ``co
 ``export_format``. For more information, please refer to the links above.
 
 
-Importing files
----------------
+Exporting tables
+----------------
 
-The following Operator imports one or more files from GCS into a BigQuery table.
+The following Operator exports BigQuery table into a GCS.
 
 .. exampleinclude:: /../../tests/system/providers/google/cloud/bigquery/example_bigquery_to_gcs.py
     :language: python


### PR DESCRIPTION
Currently the documentation states Importing files and also suggest that the file would be imported from GCS to BigQuery instead of what the operator actually does which is exporting single BigQuery table to GCS

Fixes: #40217 

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
