### PR TITLE
Add slightly more detailed guidance about upgrading to the docs

### DIFF
--- a/docs/apache-airflow/installation/upgrading.rst
+++ b/docs/apache-airflow/installation/upgrading.rst
@@ -57,11 +57,15 @@ when you choose to upgrade airflow via their UI.
 How to upgrade
 ==============
 
-Reinstall Apache Airflow™, specifying the desired new version. For example, in the case of a bootstrapped
-local instance, you can upgrade easily by setting the ``AIRFLOW_VERSION`` environment variable
-to the intended version prior to rerunning the installation command. Upgrade incrementally by patch version:
-e.g., if upgrading from version 2.8.2 to 2.8.4, upgrade first to 2.8.3. For detailed installation guidance,
-see :doc:`/start` and :doc:`/installation/index`.
+Reinstall Apache Airflow™, specifying the desired new version.
+
+To upgrade a bootstrapped local instance, you can set the ``AIRFLOW_VERSION`` environment variable to the
+intended version prior to rerunning the installation command. Upgrade incrementally by patch version: e.g.,
+if upgrading from version 2.8.2 to 2.8.4, upgrade first to 2.8.3. For detailed installation guidance, see
+:doc:`/start`.
+
+To upgrade a PyPI package, rerun the ``pip install`` command in your environment using the desired version
+as a constraint. For more detailed guidance, see :doc:`/installation/installing-from-pypi`.
 
 In order to manually migrate the database you should run the ``airflow db migrate`` command in your
 environment. It can be run either in your virtual environment or in the containers that give

--- a/docs/apache-airflow/installation/upgrading.rst
+++ b/docs/apache-airflow/installation/upgrading.rst
@@ -59,8 +59,9 @@ How to upgrade
 
 Reinstall Apache Airflow™, specifying the desired new version. For example, in the case of a bootstrapped
 local instance, you can upgrade easily by setting the ``AIRFLOW_VERSION`` environment variable
-to the intended version prior to rerunning the installation command. For more details, see :doc:`/start`
-and :doc:`/installation/index`.
+to the intended version prior to rerunning the installation command. Upgrade incrementally by patch version:
+e.g., if upgrading from version 2.8.2 to 2.8.4, upgrade first to 2.8.3. For detailed installation guidance,
+see :doc:`/start` and :doc:`/installation/index`.
 
 In order to manually migrate the database you should run the ``airflow db migrate`` command in your
 environment. It can be run either in your virtual environment or in the containers that give

--- a/docs/apache-airflow/installation/upgrading.rst
+++ b/docs/apache-airflow/installation/upgrading.rst
@@ -61,7 +61,7 @@ Reinstall Apache Airflow™, specifying the desired new version.
 
 To upgrade a bootstrapped local instance, you can set the ``AIRFLOW_VERSION`` environment variable to the
 intended version prior to rerunning the installation command. Upgrade incrementally by patch version: e.g.,
-if upgrading from version 2.8.2 to 2.8.4, upgrade first to 2.8.3. For detailed installation guidance, see
+if upgrading from version 2.8.2 to 2.8.4, upgrade first to 2.8.3. For more detailed guidance, see
 :doc:`/start`.
 
 To upgrade a PyPI package, rerun the ``pip install`` command in your environment using the desired version

--- a/docs/apache-airflow/installation/upgrading.rst
+++ b/docs/apache-airflow/installation/upgrading.rst
@@ -57,6 +57,10 @@ when you choose to upgrade airflow via their UI.
 How to upgrade
 ==============
 
+Reinstall Apache Airflow™, specifying the desired new version. For example, in the case of a bootstrapped
+local instance, this can be accomplished easily with the ``AIRFLOW_VERSION`` environment variable. For more
+details, see :doc:`/installation/index`.
+
 In order to manually migrate the database you should run the ``airflow db migrate`` command in your
 environment. It can be run either in your virtual environment or in the containers that give
 you access to Airflow ``CLI`` :doc:`/howto/usage-cli` and the database.

--- a/docs/apache-airflow/installation/upgrading.rst
+++ b/docs/apache-airflow/installation/upgrading.rst
@@ -58,7 +58,7 @@ How to upgrade
 ==============
 
 Reinstall Apache Airflow™, specifying the desired new version. For example, in the case of a bootstrapped
-local instance, you can upgrade easily by setting the ``AIRFLOW_VERSION`` environment variable 
+local instance, you can upgrade easily by setting the ``AIRFLOW_VERSION`` environment variable
 to the intended version prior to rerunning the installation command. For more details, see :doc:`/start`
 and :doc:`/installation/index`.
 

--- a/docs/apache-airflow/installation/upgrading.rst
+++ b/docs/apache-airflow/installation/upgrading.rst
@@ -58,8 +58,9 @@ How to upgrade
 ==============
 
 Reinstall Apache Airflow™, specifying the desired new version. For example, in the case of a bootstrapped
-local instance, this can be accomplished easily with the ``AIRFLOW_VERSION`` environment variable. For more
-details, see :doc:`/installation/index`.
+local instance, you can upgrade easily by setting the ``AIRFLOW_VERSION`` environment variable 
+to the intended version prior to rerunning the installation command. For more details, see :doc:`/start`
+and :doc:`/installation/index`.
 
 In order to manually migrate the database you should run the ``airflow db migrate`` command in your
 environment. It can be run either in your virtual environment or in the containers that give


### PR DESCRIPTION
The docs lack specific guidance on upgrading Airflow. Although the path might be obvious to advanced users, more details would be useful to many -- if the views [here](https://stackoverflow.com/questions/72283506/how-to-upgrade-airflow) are any indication.

This adds guidance on upgrading to `installation/upgrading`.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
