### PR TITLE
Swap dag run link from legacy graph to grid with graph tab

### DIFF
--- a/airflow/www/static/js/dag/details/FilterTasks.tsx
+++ b/airflow/www/static/js/dag/details/FilterTasks.tsx
@@ -89,6 +89,7 @@ const FilterTasks = ({ taskId }: Props) => {
         title={label}
         aria-label={label}
         mt={2}
+        ml={2}
       >
         <Flex>
           {root

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -527,7 +527,12 @@ def dag_run_link(attr):
     dag_id = attr.get("dag_id")
     run_id = attr.get("run_id")
 
-    url = url_for("Airflow.graph", dag_id=dag_id, dag_run_id=run_id)
+    url = url_for(
+        "Airflow.grid",
+        dag_id=dag_id,
+        dag_run_id=run_id,
+        tab="graph",
+    )
     return Markup('<a href="{url}">{run_id}</a>').format(url=url, run_id=run_id)
 
 


### PR DESCRIPTION
Looks like there were issues using the old `Airflow.graph` links for dag runs vs `Airflow.grid` with tab="graph". I'll do another PR to replace all of the links to legacy pages and rely less on a bunch of redirects.

Fixes: https://github.com/apache/airflow/issues/39642



---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
