### PR TITLE
Fix typing in telegram provider

### DIFF
--- a/airflow/providers/telegram/hooks/telegram.py
+++ b/airflow/providers/telegram/hooks/telegram.py
@@ -142,17 +142,18 @@ class TelegramHook(BaseHook):
 
         :param api_params: params for telegram_instance.send_message. It can also be used to override chat_id
         """
-        kwargs = {
-            "chat_id": self.chat_id,
+        kwargs: dict[str, int | str | bool] = {
             "parse_mode": telegram.constants.ParseMode.HTML,
             "disable_web_page_preview": True,
         }
+        if self.chat_id is not None:
+            kwargs["chat_id"] = self.chat_id
         kwargs.update(api_params)
 
         if "text" not in kwargs or kwargs["text"] is None:
             raise AirflowException("'text' must be provided for telegram message")
 
-        if kwargs["chat_id"] is None:
+        if kwargs.get("chat_id") is None:
             raise AirflowException("'chat_id' must be provided for telegram message")
 
         response = asyncio.run(self.connection.send_message(**kwargs))

--- a/tests/providers/telegram/hooks/test_telegram.py
+++ b/tests/providers/telegram/hooks/test_telegram.py
@@ -93,21 +93,21 @@ class TestTelegramHook:
         hook = TelegramHook(telegram_conn_id="telegram_default")
         error_message = "'text' must be provided for telegram message"
         with pytest.raises(airflow.exceptions.AirflowException, match=error_message):
-            hook.send_message({"chat_id": -420913222})
+            hook.send_message({"chat_id": "-420913222"})
 
     @mock.patch("airflow.providers.telegram.hooks.telegram.TelegramHook.get_conn")
     def test_should_send_message_if_all_parameters_are_correctly_provided(self, mock_get_conn):
         mock_get_conn.return_value = AsyncMock(password="some_token")
 
         hook = TelegramHook(telegram_conn_id="telegram_default")
-        hook.send_message({"chat_id": -420913222, "text": "test telegram message"})
+        hook.send_message({"chat_id": "-420913222", "text": "test telegram message"})
 
         mock_get_conn.return_value.send_message.return_value = "OK."
 
         mock_get_conn.assert_called_once()
         mock_get_conn.return_value.send_message.assert_called_once_with(
             **{
-                "chat_id": -420913222,
+                "chat_id": "-420913222",
                 "parse_mode": "HTML",
                 "disable_web_page_preview": True,
                 "text": "test telegram message",
@@ -118,7 +118,7 @@ class TestTelegramHook:
     def test_should_send_message_if_chat_id_is_provided_through_constructor(self, mock_get_conn):
         mock_get_conn.return_value = AsyncMock(password="some_token")
 
-        hook = TelegramHook(telegram_conn_id="telegram_default", chat_id=-420913222)
+        hook = TelegramHook(telegram_conn_id="telegram_default", chat_id="-420913222")
         hook.send_message({"text": "test telegram message"})
 
         mock_get_conn.return_value.send_message.return_value = "OK."
@@ -126,7 +126,7 @@ class TestTelegramHook:
         mock_get_conn.assert_called_once()
         mock_get_conn.return_value.send_message.assert_called_once_with(
             **{
-                "chat_id": -420913222,
+                "chat_id": "-420913222",
                 "parse_mode": "HTML",
                 "disable_web_page_preview": True,
                 "text": "test telegram message",
@@ -182,7 +182,7 @@ class TestTelegramHook:
     def test_should_send_message_if_token_is_provided(self, mock_get_conn):
         mock_get_conn.return_value = AsyncMock(password="some_token")
 
-        hook = TelegramHook(token=TELEGRAM_TOKEN, chat_id=-420913222)
+        hook = TelegramHook(token=TELEGRAM_TOKEN, chat_id="-420913222")
         hook.send_message({"text": "test telegram message"})
 
         mock_get_conn.return_value.send_message.return_value = "OK."
@@ -190,7 +190,7 @@ class TestTelegramHook:
         mock_get_conn.assert_called_once()
         mock_get_conn.return_value.send_message.assert_called_once_with(
             **{
-                "chat_id": -420913222,
+                "chat_id": "-420913222",
                 "parse_mode": "HTML",
                 "disable_web_page_preview": True,
                 "text": "test telegram message",


### PR DESCRIPTION
The python-telegram-bot new version has typing added and we should
pass the right dict type to it.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
