### PR TITLE
Add dependency to httpx >= 0.25.0 everywhere

### DIFF
--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -154,7 +154,7 @@ dependencies:
   - google-cloud-run>=0.10.0
   - google-cloud-batch>=0.13.0
   - grpcio-gcp>=0.2.2
-  - httpx>=0.18.0
+  - httpx>=0.25.0
   - json-merge-patch>=0.2
   - looker-sdk>=22.4.0
   - pandas-gbq>=0.7.0

--- a/airflow/providers/weaviate/provider.yaml
+++ b/airflow/providers/weaviate/provider.yaml
@@ -48,6 +48,7 @@ integrations:
 
 dependencies:
   - apache-airflow>=2.7.0
+  - httpx>=0.25.0
   - weaviate-client>=3.24.2
   # In pandas 2.2 minimal version of the sqlalchemy is 2.0
   # https://pandas.pydata.org/docs/whatsnew/v2.2.0.html#increased-minimum-versions-for-dependencies

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -631,7 +631,7 @@
       "google-cloud-vision>=3.4.0",
       "google-cloud-workflows>=1.10.0",
       "grpcio-gcp>=0.2.2",
-      "httpx>=0.18.0",
+      "httpx>=0.25.0",
       "json-merge-patch>=0.2",
       "looker-sdk>=22.4.0",
       "pandas-gbq>=0.7.0",
@@ -1304,6 +1304,7 @@
   "weaviate": {
     "deps": [
       "apache-airflow>=2.7.0",
+      "httpx>=0.25.0",
       "pandas>=1.5.3,<2.2;python_version<\"3.12\"",
       "pandas>=2.1.1,<2.2;python_version>=\"3.12\"",
       "weaviate-client>=3.24.2"

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -443,7 +443,7 @@ DEPENDENCIES = [
     'google-re2>=1.0;python_version<"3.12"',
     'google-re2>=1.1;python_version>="3.12"',
     "gunicorn>=20.1.0",
-    "httpx>=0.18.0",
+    "httpx>=0.25.0",
     'importlib_metadata>=6.5;python_version<"3.12"',
     # Importib_resources 6.2.0-6.3.1 break pytest_rewrite
     # see https://github.com/python/importlib_resources/issues/299


### PR DESCRIPTION
Our "lowest-dependency" tests detectaed that weaviate client depends implicitly on httpx >= 0.19.0 (imports USE_CLIENT_DEFAULTS from httpx and it's missing < 0.19.0). Howeer this error is raised during importing of examples for weaviate in "Always" tests, and closer look at weaviate shows that it actually has >=0.25.0 and it makes sense for all our providers to bump httpx to 0.25.0 as minimum as well as add it to weaviate explicitly..

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
