### PR TITLE
Change the pre-commit installing command to use pipx instead of pyenv

### DIFF
--- a/contributing-docs/03_contributors_quick_start.rst
+++ b/contributing-docs/03_contributors_quick_start.rst
@@ -466,15 +466,9 @@ on macOS, install via
 
 2. Installing required Python packages
 
-.. note::
-  If pyenv and pyenv-virtualenv are not installed, install them first.
-  `Install pyenv <https://github.com/pyenv/pyenv?tab=readme-ov-file#installation>`_
-  `Install pyenv-virtualenv <https://github.com/pyenv/pyenv-virtualenv?tab=readme-ov-file#installation>`_
-
 .. code-block:: bash
 
-  pyenv activate airflow-env
-  pip install pre-commit
+  pipx install pre-commit
 
 3. Go to your project directory
 

--- a/contributing-docs/03_contributors_quick_start.rst
+++ b/contributing-docs/03_contributors_quick_start.rst
@@ -466,6 +466,11 @@ on macOS, install via
 
 2. Installing required Python packages
 
+.. note::
+  If pyenv and pyenv-virtualenv are not installed, install them first.
+  `Install pyenv <https://github.com/pyenv/pyenv?tab=readme-ov-file#installation>`_
+  `Install pyenv-virtualenv <https://github.com/pyenv/pyenv-virtualenv?tab=readme-ov-file#installation>`_
+
 .. code-block:: bash
 
   pyenv activate airflow-env


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
--> The command that is used for installing pre-commit requires pyenv and pyenv-virtualenv to be installed. Therefore, added a note that one must install pyenv and pyenv-virtualenv first. This can reduce ambiguity whether the command pyenv should work without supplementary install or not


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
