### PR TITLE
Validate expected types for args for DAG, BaseOperator and TaskGroup

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -95,7 +95,7 @@ from airflow.utils import timezone
 from airflow.utils.context import Context, context_get_outlet_events
 from airflow.utils.decorators import fixup_decorator_warning_stack
 from airflow.utils.edgemodifier import EdgeModifier
-from airflow.utils.helpers import validate_key
+from airflow.utils.helpers import validate_instance_args, validate_key
 from airflow.utils.operator_helpers import ExecutionCallableRunner
 from airflow.utils.operator_resources import Resources
 from airflow.utils.session import NEW_SESSION, provide_session
@@ -160,8 +160,6 @@ def _get_parent_defaults(dag: DAG | None, task_group: TaskGroup | None) -> tuple
     dag_args = copy.copy(dag.default_args)
     dag_params = copy.deepcopy(dag.params)
     if task_group:
-        if task_group.default_args and not isinstance(task_group.default_args, collections.abc.Mapping):
-            raise TypeError("default_args must be a mapping")
         dag_args.update(task_group.default_args)
     return dag_args, dag_params
 
@@ -178,8 +176,6 @@ def get_merged_defaults(
             raise TypeError("params must be a mapping")
         params.update(task_params)
     if task_default_args:
-        if not isinstance(task_default_args, collections.abc.Mapping):
-            raise TypeError("default_args must be a mapping")
         args.update(task_default_args)
         with contextlib.suppress(KeyError):
             params.update(task_default_args["params"] or {})
@@ -794,6 +790,40 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         "executor",
     }
 
+    _expected_args_types = {
+        "task_id": str,
+        "email": (str, Iterable),
+        "email_on_retry": bool,
+        "email_on_failure": bool,
+        "retries": int,
+        "retry_exponential_backoff": bool,
+        "depends_on_past": bool,
+        "ignore_first_depends_on_past": bool,
+        "wait_for_past_depends_before_skipping": bool,
+        "wait_for_downstream": bool,
+        "priority_weight": int,
+        "queue": str,
+        "pool": str,
+        "pool_slots": int,
+        "trigger_rule": str,
+        "run_as_user": str,
+        "task_concurrency": int,
+        "map_index_template": str,
+        "max_active_tis_per_dag": int,
+        "max_active_tis_per_dagrun": int,
+        "executor": str,
+        "do_xcom_push": bool,
+        "multiple_outputs": bool,
+        "doc": str,
+        "doc_md": str,
+        "doc_json": str,
+        "doc_yaml": str,
+        "doc_rst": str,
+        "task_display_name": str,
+        "logger_name": str,
+        "allow_nested_operators": bool,
+    }
+
     # Defines if the operator supports lineage without manual definitions
     supports_lineage = False
 
@@ -1077,6 +1107,8 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         self._is_teardown = False
         if SetupTeardownContext.active:
             SetupTeardownContext.update_context_map(self)
+
+        validate_instance_args(self, self._expected_args_types)
 
     def __eq__(self, other):
         if type(self) is type(other):

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -160,6 +160,8 @@ def _get_parent_defaults(dag: DAG | None, task_group: TaskGroup | None) -> tuple
     dag_args = copy.copy(dag.default_args)
     dag_params = copy.deepcopy(dag.params)
     if task_group:
+        if task_group.default_args and not isinstance(task_group.default_args, collections.abc.Mapping):
+            raise TypeError("default_args must be a mapping")
         dag_args.update(task_group.default_args)
     return dag_args, dag_params
 
@@ -176,6 +178,8 @@ def get_merged_defaults(
             raise TypeError("params must be a mapping")
         params.update(task_params)
     if task_default_args:
+        if not isinstance(task_default_args, collections.abc.Mapping):
+            raise TypeError("default_args must be a mapping")
         args.update(task_default_args)
         with contextlib.suppress(KeyError):
             params.update(task_default_args["params"] or {})

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -521,6 +521,47 @@ class BaseOperatorMeta(abc.ABCMeta):
         return new_cls
 
 
+# TODO: The following mapping is used to validate that the arguments passed to the BaseOperator are of the
+#  correct type. This is a temporary solution until we find a more sophisticated method for argument
+#  validation. One potential method is to use `get_type_hints` from the typing module. However, this is not
+#  fully compatible with future annotations for Python versions below 3.10. Once we require a minimum Python
+#  version that supports `get_type_hints` effectively or find a better approach, we can replace this
+#  manual type-checking method.
+BASEOPERATOR_ARGS_EXPECTED_TYPES = {
+    "task_id": str,
+    "email": (str, Iterable),
+    "email_on_retry": bool,
+    "email_on_failure": bool,
+    "retries": int,
+    "retry_exponential_backoff": bool,
+    "depends_on_past": bool,
+    "ignore_first_depends_on_past": bool,
+    "wait_for_past_depends_before_skipping": bool,
+    "wait_for_downstream": bool,
+    "priority_weight": int,
+    "queue": str,
+    "pool": str,
+    "pool_slots": int,
+    "trigger_rule": str,
+    "run_as_user": str,
+    "task_concurrency": int,
+    "map_index_template": str,
+    "max_active_tis_per_dag": int,
+    "max_active_tis_per_dagrun": int,
+    "executor": str,
+    "do_xcom_push": bool,
+    "multiple_outputs": bool,
+    "doc": str,
+    "doc_md": str,
+    "doc_json": str,
+    "doc_yaml": str,
+    "doc_rst": str,
+    "task_display_name": str,
+    "logger_name": str,
+    "allow_nested_operators": bool,
+}
+
+
 @total_ordering
 class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
     r"""
@@ -792,40 +833,6 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         "multiple_outputs",
         "allow_nested_operators",
         "executor",
-    }
-
-    _expected_args_types = {
-        "task_id": str,
-        "email": (str, Iterable),
-        "email_on_retry": bool,
-        "email_on_failure": bool,
-        "retries": int,
-        "retry_exponential_backoff": bool,
-        "depends_on_past": bool,
-        "ignore_first_depends_on_past": bool,
-        "wait_for_past_depends_before_skipping": bool,
-        "wait_for_downstream": bool,
-        "priority_weight": int,
-        "queue": str,
-        "pool": str,
-        "pool_slots": int,
-        "trigger_rule": str,
-        "run_as_user": str,
-        "task_concurrency": int,
-        "map_index_template": str,
-        "max_active_tis_per_dag": int,
-        "max_active_tis_per_dagrun": int,
-        "executor": str,
-        "do_xcom_push": bool,
-        "multiple_outputs": bool,
-        "doc": str,
-        "doc_md": str,
-        "doc_json": str,
-        "doc_yaml": str,
-        "doc_rst": str,
-        "task_display_name": str,
-        "logger_name": str,
-        "allow_nested_operators": bool,
     }
 
     # Defines if the operator supports lineage without manual definitions
@@ -1112,7 +1119,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         if SetupTeardownContext.active:
             SetupTeardownContext.update_context_map(self)
 
-        validate_instance_args(self, self._expected_args_types)
+        validate_instance_args(self, BASEOPERATOR_ARGS_EXPECTED_TYPES)
 
     def __eq__(self, other):
         if type(self) is type(other):

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -128,7 +128,7 @@ from airflow.utils import timezone
 from airflow.utils.dag_cycle_tester import check_cycle
 from airflow.utils.dates import cron_presets, date_range as utils_date_range
 from airflow.utils.decorators import fixup_decorator_warning_stack
-from airflow.utils.helpers import at_most_one, exactly_one, validate_key
+from airflow.utils.helpers import at_most_one, exactly_one, validate_instance_args, validate_key
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.sqlalchemy import (
@@ -468,6 +468,25 @@ class DAG(LoggingMixin):
         "last_loaded",
     }
 
+    _expected_args_types = {
+        "dag_id": str,
+        "description": str,
+        "max_active_tasks": int,
+        "max_active_runs": int,
+        "max_consecutive_failed_dag_runs": int,
+        "dagrun_timeout": timedelta,
+        "default_view": str,
+        "orientation": str,
+        "catchup": bool,
+        "doc_md": str,
+        "is_paused_upon_creation": bool,
+        "render_template_as_native_obj": bool,
+        "tags": list,
+        "auto_register": bool,
+        "fail_stop": bool,
+        "dag_display_name": str,
+    }
+
     __serialized_fields: frozenset[str] | None = None
 
     fileloc: str
@@ -743,6 +762,8 @@ class DAG(LoggingMixin):
         # it's only use is for determining the relative
         # fileloc based only on the serialize dag
         self._processor_dags_folder = None
+
+        validate_instance_args(self, self._expected_args_types)
 
     def get_doc_md(self, doc_md: str | None) -> str | None:
         if doc_md is None:

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -341,6 +341,32 @@ def _create_orm_dagrun(
     return run
 
 
+# TODO: The following mapping is used to validate that the arguments passed to the DAG are of the correct
+#  type. This is a temporary solution until we find a more sophisticated method for argument validation.
+#  One potential method is to use `get_type_hints` from the typing module. However, this is not fully
+#  compatible with future annotations for Python versions below 3.10. Once we require a minimum Python
+#  version that supports `get_type_hints` effectively or find a better approach, we can replace this
+#  manual type-checking method.
+DAG_ARGS_EXPECTED_TYPES = {
+    "dag_id": str,
+    "description": str,
+    "max_active_tasks": int,
+    "max_active_runs": int,
+    "max_consecutive_failed_dag_runs": int,
+    "dagrun_timeout": timedelta,
+    "default_view": str,
+    "orientation": str,
+    "catchup": bool,
+    "doc_md": str,
+    "is_paused_upon_creation": bool,
+    "render_template_as_native_obj": bool,
+    "tags": list,
+    "auto_register": bool,
+    "fail_stop": bool,
+    "dag_display_name": str,
+}
+
+
 @functools.total_ordering
 class DAG(LoggingMixin):
     """
@@ -466,25 +492,6 @@ class DAG(LoggingMixin):
         "fileloc",
         "template_searchpath",
         "last_loaded",
-    }
-
-    _expected_args_types = {
-        "dag_id": str,
-        "description": str,
-        "max_active_tasks": int,
-        "max_active_runs": int,
-        "max_consecutive_failed_dag_runs": int,
-        "dagrun_timeout": timedelta,
-        "default_view": str,
-        "orientation": str,
-        "catchup": bool,
-        "doc_md": str,
-        "is_paused_upon_creation": bool,
-        "render_template_as_native_obj": bool,
-        "tags": list,
-        "auto_register": bool,
-        "fail_stop": bool,
-        "dag_display_name": str,
     }
 
     __serialized_fields: frozenset[str] | None = None
@@ -763,7 +770,7 @@ class DAG(LoggingMixin):
         # fileloc based only on the serialize dag
         self._processor_dags_folder = None
 
-        validate_instance_args(self, self._expected_args_types)
+        validate_instance_args(self, DAG_ARGS_EXPECTED_TYPES)
 
     def get_doc_md(self, doc_md: str | None) -> str | None:
         if doc_md is None:

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -60,6 +60,17 @@ def validate_key(k: str, max_length: int = 250):
         )
 
 
+def validate_instance_args(instance: object, expected_arg_types: dict[str, Any]) -> None:
+    """Validate that the instance has the expected types for the arguments."""
+    for arg_name, expected_arg_type in expected_arg_types.items():
+        instance_arg_value = getattr(instance, arg_name, None)
+        if instance_arg_value is not None and not isinstance(instance_arg_value, expected_arg_type):
+            raise TypeError(
+                f"'{arg_name}' has an invalid type {type(instance_arg_value)} with value "
+                f"{instance_arg_value}, expected type is {expected_arg_type}"
+            )
+
+
 def validate_group_key(k: str, max_length: int = 200):
     """Validate value used as a group key."""
     if not isinstance(k, str):

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -36,7 +36,7 @@ from airflow.exceptions import (
 )
 from airflow.models.taskmixin import DAGNode
 from airflow.serialization.enums import DagAttributeTypes
-from airflow.utils.helpers import validate_group_key
+from airflow.utils.helpers import validate_group_key, validate_instance_args
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -81,6 +81,15 @@ class TaskGroup(DAGNode):
     """
 
     used_group_ids: set[str | None]
+
+    _expected_args_types = {
+        "group_id": str,
+        "prefix_group_id": bool,
+        "tooltip": str,
+        "ui_color": str,
+        "ui_fgcolor": str,
+        "add_suffix_on_collision": bool,
+    }
 
     def __init__(
         self,
@@ -159,6 +168,8 @@ class TaskGroup(DAGNode):
         self.downstream_group_ids: set[str | None] = set()
         self.upstream_task_ids = set()
         self.downstream_task_ids = set()
+
+        validate_instance_args(self, self._expected_args_types)
 
     def _check_for_group_id_collisions(self, add_suffix_on_collision: bool):
         if self._group_id is None:

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -49,6 +49,21 @@ if TYPE_CHECKING:
     from airflow.models.taskmixin import DependencyMixin
     from airflow.utils.edgemodifier import EdgeModifier
 
+# TODO: The following mapping is used to validate that the arguments passed to the TaskGroup are of the
+#  correct type. This is a temporary solution until we find a more sophisticated method for argument
+#  validation. One potential method is to use get_type_hints from the typing module. However, this is not
+#  fully compatible with future annotations for Python versions below 3.10. Once we require a minimum Python
+#  version that supports `get_type_hints` effectively or find a better approach, we can replace this
+#  manual type-checking method.
+TASKGROUP_ARGS_EXPECTED_TYPES = {
+    "group_id": str,
+    "prefix_group_id": bool,
+    "tooltip": str,
+    "ui_color": str,
+    "ui_fgcolor": str,
+    "add_suffix_on_collision": bool,
+}
+
 
 class TaskGroup(DAGNode):
     """
@@ -81,15 +96,6 @@ class TaskGroup(DAGNode):
     """
 
     used_group_ids: set[str | None]
-
-    _expected_args_types = {
-        "group_id": str,
-        "prefix_group_id": bool,
-        "tooltip": str,
-        "ui_color": str,
-        "ui_fgcolor": str,
-        "add_suffix_on_collision": bool,
-    }
 
     def __init__(
         self,
@@ -169,7 +175,7 @@ class TaskGroup(DAGNode):
         self.upstream_task_ids = set()
         self.downstream_task_ids = set()
 
-        validate_instance_args(self, self._expected_args_types)
+        validate_instance_args(self, TASKGROUP_ARGS_EXPECTED_TYPES)
 
     def _check_for_group_id_collisions(self, add_suffix_on_collision: bool):
         if self._group_id is None:

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -32,6 +32,7 @@ from airflow.decorators import task as task_decorator
 from airflow.exceptions import AirflowException, FailStopDagInvalidTriggerRule, RemovedInAirflow3Warning
 from airflow.lineage.entities import File
 from airflow.models.baseoperator import (
+    BASEOPERATOR_ARGS_EXPECTED_TYPES,
     BaseOperator,
     BaseOperatorMeta,
     chain,
@@ -821,23 +822,11 @@ class TestBaseOperator:
         with pytest.raises(TypeError, match=error_msg):
             BaseOperator(task_id="test", max_active_tis_per_dag="not_an_int")
 
-    def test_baseoperator_defines_expected_arg_types(self):
+    @mock.patch("airflow.models.baseoperator.validate_instance_args")
+    def test_baseoperator_init_validates_arg_types(self, mock_validate_instance_args):
         operator = BaseOperator(task_id="test")
 
-        assert operator._expected_args_types is not None
-        assert isinstance(operator._expected_args_types, dict)
-
-        expected_args_types_subset = {
-            "task_id": str,
-            "email_on_retry": bool,
-            "email_on_failure": bool,
-            "retries": int,
-            "retry_exponential_backoff": bool,
-            "depends_on_past": bool,
-        }
-        assert set(operator._expected_args_types.items()).intersection(
-            set(expected_args_types_subset.items())
-        ) == set(expected_args_types_subset.items())
+        mock_validate_instance_args.assert_called_once_with(operator, BASEOPERATOR_ARGS_EXPECTED_TYPES)
 
 
 def test_init_subclass_args():

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -811,6 +811,34 @@ class TestBaseOperator:
         # leaking a lot of state)
         assert caplog.messages == ["test"]
 
+    def test_invalid_type_for_default_arg(self):
+        error_msg = "'max_active_tis_per_dag' has an invalid type <class 'str'> with value not_an_int, expected type is <class 'int'>"
+        with pytest.raises(TypeError, match=error_msg):
+            BaseOperator(task_id="test", default_args={"max_active_tis_per_dag": "not_an_int"})
+
+    def test_invalid_type_for_operator_arg(self):
+        error_msg = "'max_active_tis_per_dag' has an invalid type <class 'str'> with value not_an_int, expected type is <class 'int'>"
+        with pytest.raises(TypeError, match=error_msg):
+            BaseOperator(task_id="test", max_active_tis_per_dag="not_an_int")
+
+    def test_baseoperator_defines_expected_arg_types(self):
+        operator = BaseOperator(task_id="test")
+
+        assert operator._expected_args_types is not None
+        assert isinstance(operator._expected_args_types, dict)
+
+        expected_args_types_subset = {
+            "task_id": str,
+            "email_on_retry": bool,
+            "email_on_failure": bool,
+            "retries": int,
+            "retry_exponential_backoff": bool,
+            "depends_on_past": bool,
+        }
+        assert set(operator._expected_args_types.items()).intersection(
+            set(expected_args_types_subset.items())
+        ) == set(expected_args_types_subset.items())
+
 
 def test_init_subclass_args():
     class InitSubclassOp(BaseOperator):

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -3928,6 +3928,30 @@ def test_create_dagrun_disallow_manual_to_use_automated_run_id(run_id_type: DagR
     )
 
 
+def test_invalid_type_for_args():
+    with pytest.raises(TypeError):
+        DAG("invalid-default-args", max_consecutive_failed_dag_runs="not_an_int")
+
+
+def test_dag_defines_expected_args():
+    dag = DAG("dag_with_expected_args")
+
+    assert dag._expected_args_types is not None
+    assert isinstance(dag._expected_args_types, dict)
+
+    expected_args_types_subset = {
+        "dag_id": str,
+        "description": str,
+        "max_active_tasks": int,
+        "max_active_runs": int,
+        "max_consecutive_failed_dag_runs": int,
+    }
+
+    assert set(dag._expected_args_types.items()).intersection(set(expected_args_types_subset.items())) == set(
+        expected_args_types_subset.items()
+    )
+
+
 class TestTaskClearingSetupTeardownBehavior:
     """
     Task clearing behavior is mainly controlled by dag.partial_subset.

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -56,6 +56,7 @@ from airflow.exceptions import (
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.dag import (
     DAG,
+    DAG_ARGS_EXPECTED_TYPES,
     DagModel,
     DagOwnerAttributes,
     DagTag,
@@ -3933,23 +3934,11 @@ def test_invalid_type_for_args():
         DAG("invalid-default-args", max_consecutive_failed_dag_runs="not_an_int")
 
 
-def test_dag_defines_expected_args():
+@mock.patch("airflow.models.dag.validate_instance_args")
+def test_dag_init_validates_arg_types(mock_validate_instance_args):
     dag = DAG("dag_with_expected_args")
 
-    assert dag._expected_args_types is not None
-    assert isinstance(dag._expected_args_types, dict)
-
-    expected_args_types_subset = {
-        "dag_id": str,
-        "description": str,
-        "max_active_tasks": int,
-        "max_active_runs": int,
-        "max_consecutive_failed_dag_runs": int,
-    }
-
-    assert set(dag._expected_args_types.items()).intersection(set(expected_args_types_subset.items())) == set(
-        expected_args_types_subset.items()
-    )
+    mock_validate_instance_args.assert_called_once_with(dag, DAG_ARGS_EXPECTED_TYPES)
 
 
 class TestTaskClearingSetupTeardownBehavior:

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -33,6 +33,7 @@ from airflow.utils.helpers import (
     merge_dicts,
     prune_dict,
     validate_group_key,
+    validate_instance_args,
     validate_key,
 )
 from airflow.utils.types import NOTSET
@@ -355,3 +356,36 @@ class SchedulerJobRunner(MockJobRunner):
 
 class TriggererJobRunner(MockJobRunner):
     job_type = "TriggererJob"
+
+
+class ClassToValidateArgs:
+    def __init__(self, name, age, active):
+        self.name = name
+        self.age = age
+        self.active = active
+
+
+# Edge cases
+@pytest.mark.parametrize(
+    "instance, expected_arg_types",
+    [
+        (ClassToValidateArgs("Alice", 30, None), {"name": str, "age": int, "active": bool}),
+        (ClassToValidateArgs(None, 25, True), {"name": str, "age": int, "active": bool}),
+    ],
+)
+def test_validate_instance_args_raises_no_error(instance, expected_arg_types):
+    validate_instance_args(instance, expected_arg_types)
+
+
+# Error cases
+@pytest.mark.parametrize(
+    "instance, expected_arg_types",
+    [
+        (ClassToValidateArgs("Alice", "thirty", True), {"name": str, "age": int, "active": bool}),
+        (ClassToValidateArgs("Bob", 25, "yes"), {"name": str, "age": int, "active": bool}),
+        (ClassToValidateArgs(123, 25, True), {"name": str, "age": int, "active": bool}),
+    ],
+)
+def test_validate_instance_args_raises_error(instance, expected_arg_types):
+    with pytest.raises(TypeError):
+        validate_instance_args(instance, expected_arg_types)

--- a/tests/utils/test_task_group.py
+++ b/tests/utils/test_task_group.py
@@ -1630,3 +1630,31 @@ def test_task_group_arrow_with_setup_group_deeper_setup():
     assert set(w1.operator.downstream_task_ids) == {"group_2.teardown_1", "group_2.teardown_2"}
     assert set(t1.operator.downstream_task_ids) == set()
     assert set(t2.operator.downstream_task_ids) == set()
+
+
+def test_task_group_with_invalid_arg_type_raises_error():
+    error_msg = "'ui_color' has an invalid type <class 'int'> with value 123, expected type is <class 'str'>"
+    with DAG(dag_id="dag_with_tg_invalid_arg_type"):
+        with pytest.raises(TypeError, match=error_msg):
+            with TaskGroup("group_1", ui_color=123):
+                EmptyOperator(task_id="task1")
+
+
+def test_task_group_defines_expected_arg_types():
+    with DAG(dag_id="dag_with_tg_valid_arg_types"):
+        with TaskGroup("group_1", ui_color="red") as tg:
+            EmptyOperator(task_id="task1")
+
+    assert tg._expected_args_types is not None
+    assert isinstance(tg._expected_args_types, dict)
+
+    expected_args_types_subset = {
+        "group_id": str,
+        "prefix_group_id": bool,
+        "tooltip": str,
+        "ui_color": str,
+    }
+
+    assert set(tg._expected_args_types.items()).intersection(set(expected_args_types_subset.items())) == set(
+        expected_args_types_subset.items()
+    )


### PR DESCRIPTION
Validates that some commonly used arguments by DAG authors 
conform to the expected types. If the provided values do not 
match the expected types, a TypeError is raised, resulting in 
DAG import errors that appear in the Airflow UI.

Closes: #40187

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
