### PR TITLE
Default client in KafkaBaseHook

### DIFF
--- a/airflow/providers/apache/kafka/hooks/base.py
+++ b/airflow/providers/apache/kafka/hooks/base.py
@@ -52,8 +52,8 @@ class KafkaBaseHook(BaseHook):
             },
         }
 
-    def _get_client(self, config):
-        raise NotImplementedError
+    def _get_client(self, config) -> Any:
+        return AdminClient(config)
 
     @cached_property
     def get_conn(self) -> Any:

--- a/airflow/providers/apache/kafka/hooks/client.py
+++ b/airflow/providers/apache/kafka/hooks/client.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from typing import Any, Sequence
 
 from confluent_kafka import KafkaException
-from confluent_kafka.admin import AdminClient, NewTopic
+from confluent_kafka.admin import NewTopic
 
 from airflow.providers.apache.kafka.hooks.base import KafkaBaseHook
 

--- a/airflow/providers/apache/kafka/hooks/client.py
+++ b/airflow/providers/apache/kafka/hooks/client.py
@@ -34,9 +34,6 @@ class KafkaAdminClientHook(KafkaBaseHook):
     def __init__(self, kafka_config_id=KafkaBaseHook.default_conn_name) -> None:
         super().__init__(kafka_config_id=kafka_config_id)
 
-    def _get_client(self, config) -> AdminClient:
-        return AdminClient(config)
-
     def create_topic(
         self,
         topics: Sequence[Sequence[Any]],

--- a/tests/providers/apache/kafka/hooks/test_client.py
+++ b/tests/providers/apache/kafka/hooks/test_client.py
@@ -58,7 +58,7 @@ class TestKafkaAdminClientHook:
         assert isinstance(self.hook.get_conn, AdminClient)
 
     @patch(
-        "airflow.providers.apache.kafka.hooks.client.AdminClient",
+        "airflow.providers.apache.kafka.hooks.base.AdminClient",
     )
     def test_create_topic(self, admin_client):
         mock_f = MagicMock()
@@ -68,7 +68,7 @@ class TestKafkaAdminClientHook:
         mock_f.result.assert_called_once()
 
     @patch(
-        "airflow.providers.apache.kafka.hooks.client.AdminClient",
+        "airflow.providers.apache.kafka.hooks.base.AdminClient",
     )
     def test_create_topic_error(self, admin_client):
         mock_f = MagicMock()
@@ -82,7 +82,7 @@ class TestKafkaAdminClientHook:
             self.hook.create_topic(topics=[("topic_name", 0, 1)])
 
     @patch(
-        "airflow.providers.apache.kafka.hooks.client.AdminClient",
+        "airflow.providers.apache.kafka.hooks.base.AdminClient",
     )
     def test_create_topic_warning(self, admin_client, caplog):
         mock_f = MagicMock()
@@ -99,7 +99,7 @@ class TestKafkaAdminClientHook:
             assert "The topic topic_name already exists" in caplog.text
 
     @patch(
-        "airflow.providers.apache.kafka.hooks.client.AdminClient",
+        "airflow.providers.apache.kafka.hooks.base.AdminClient",
     )
     def test_delete_topic(self, admin_client):
         mock_f = MagicMock()


### PR DESCRIPTION
Moving the definition of AdminClient as the default client for KafkaBaseHook
Closes: https://github.com/apache/airflow/issues/40204

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
