### PR TITLE
Remove double warning in CLI  when config value is deprecated

### DIFF
--- a/airflow/cli/commands/config_command.py
+++ b/airflow/cli/commands/config_command.py
@@ -24,6 +24,7 @@ import pygments
 from pygments.lexers.configs import IniLexer
 
 from airflow.configuration import conf
+from airflow.exceptions import AirflowConfigException
 from airflow.utils.cli import should_use_colors
 from airflow.utils.code_utils import get_terminal_formatter
 from airflow.utils.providers_configuration_loader import providers_configuration_loaded
@@ -58,8 +59,8 @@ def get_value(args):
     # providers are initialized. Theoretically Providers might add new sections and options
     # but also override defaults for existing options, so without loading all providers we
     # cannot be sure what is the final value of the option.
-    if not conf.has_option(args.section, args.option):
-        raise SystemExit(f"The option [{args.section}/{args.option}] is not found in config.")
-
-    value = conf.get(args.section, args.option)
-    print(value)
+    try:
+        value = conf.get(args.section, args.option)
+        print(value)
+    except AirflowConfigException:
+        pass

--- a/tests/cli/commands/test_config_command.py
+++ b/tests/cli/commands/test_config_command.py
@@ -20,8 +20,6 @@ import contextlib
 from io import StringIO
 from unittest import mock
 
-import pytest
-
 from airflow.cli import cli_parser
 from airflow.cli.commands import config_command
 from tests.test_utils.config import conf_vars
@@ -222,13 +220,8 @@ class TestCliConfigGetValue:
 
         config_command.get_value(self.parser.parse_args(["config", "get-value", "some_section", "value"]))
 
-    @mock.patch("airflow.cli.commands.config_command.conf")
-    def test_should_raise_exception_when_option_is_missing(self, mock_conf):
-        mock_conf.has_section.return_value = True
-        mock_conf.has_option.return_value = False
-
-        with pytest.raises(SystemExit) as ctx:
-            config_command.get_value(
-                self.parser.parse_args(["config", "get-value", "missing-section", "dags_folder"])
-            )
-        assert "The option [missing-section/dags_folder] is not found in config." == str(ctx.value)
+    def test_should_raise_exception_when_option_is_missing(self, caplog):
+        config_command.get_value(
+            self.parser.parse_args(["config", "get-value", "missing-section", "dags_folder"])
+        )
+        assert "section/key [missing-section/dags_folder] not found in config" in caplog.text

--- a/tests/cli/commands/test_plugins_command.py
+++ b/tests/cli/commands/test_plugins_command.py
@@ -21,6 +21,8 @@ import textwrap
 from contextlib import redirect_stdout
 from io import StringIO
 
+import pytest
+
 from airflow.cli import cli_parser
 from airflow.cli.commands import plugins_command
 from airflow.hooks.base import BaseHook
@@ -28,6 +30,8 @@ from airflow.listeners.listener import get_listener_manager
 from airflow.plugins_manager import AirflowPlugin
 from tests.plugins.test_plugin import AirflowTestPlugin as ComplexAirflowPlugin
 from tests.test_utils.mock_plugins import mock_plugin_manager
+
+pytestmark = pytest.mark.db_test
 
 
 class PluginHook(BaseHook):

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -45,6 +45,8 @@ from airflow.providers.amazon.aws.executors.ecs.ecs_executor import AwsEcsExecut
 from airflow.providers.celery.executors.celery_executor import CeleryExecutor
 from tests.test_utils.config import conf_vars
 
+pytestmark = pytest.mark.db_test
+
 # Can not be `--snake_case` or contain uppercase letter
 ILLEGAL_LONG_OPTION_PATTERN = re.compile("^--[a-z]+_[a-z]+|^--.*[A-Z].*")
 # Only can be `-[a-z]` or `-[A-Z]`


### PR DESCRIPTION
There's a double warning when getting a value for a deprecated configuration. This happens because we first check if the config exists, which issues a warning and then getting the config also issues the same warning. Now that we don't error for non-existing configs, we should not check existence before getting a config value

