### PR TITLE
Revert "Update backfill tests to use executor loader (#40285)"

### DIFF
--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -37,9 +37,8 @@ from airflow.exceptions import (
     NoAvailablePoolSlot,
     TaskConcurrencyLimitReached,
 )
-from airflow.executors.debug_executor import DebugExecutor
+from airflow.executors.executor_constants import MOCK_EXECUTOR
 from airflow.executors.executor_loader import ExecutorLoader
-from airflow.executors.sequential_executor import SequentialExecutor
 from airflow.jobs.backfill_job_runner import BackfillJobRunner
 from airflow.jobs.job import Job, run_job
 from airflow.listeners.listener import get_listener_manager
@@ -80,38 +79,11 @@ def dag_bag():
     return DagBag(include_examples=True)
 
 
+# Patch the MockExecutor into the dict of known executors in the Loader
+@patch.dict(
+    ExecutorLoader.executors, {MOCK_EXECUTOR: f"{MockExecutor.__module__}.{MockExecutor.__qualname__}"}
+)
 class TestBackfillJob:
-    def _mock_executor(self, executor=None):
-        if not executor:
-            default_executor = MockExecutor()
-        else:
-            default_executor = executor()
-
-        default_executor.name = mock.MagicMock(
-            alias="default_exec",
-            module_path=f"{default_executor.__module__}.{default_executor.__class__.__qualname__}",
-        )
-        with mock.patch("airflow.jobs.job.Job.executors", new_callable=mock.PropertyMock) as executors_mock:
-            with mock.patch("airflow.jobs.job.Job.executor", new_callable=mock.PropertyMock) as executor_mock:
-                with mock.patch(
-                    "airflow.executors.executor_loader.ExecutorLoader.load_executor"
-                ) as loader_mock:
-                    executor_mock.return_value = default_executor
-                    executors_mock.return_value = [default_executor]
-                    # The executor is mocked, so cannot be loaded/imported. Mock load_executor and return the
-                    # correct object for the given input executor name.
-                    loader_mock.side_effect = lambda *x: {
-                        ("default_exec",): default_executor,
-                        ("default.exec.module.path",): default_executor,
-                        (None,): default_executor,
-                    }[x]
-
-                    yield default_executor
-
-    @pytest.fixture
-    def mock_executor(self):
-        yield from self._mock_executor()
-
     @staticmethod
     def clean_db():
         clear_db_dags()
@@ -153,7 +125,7 @@ class TestBackfillJob:
         dag = self._get_dummy_dag(dag_maker)
         dag_run = dag_maker.create_dagrun(state=None)
 
-        job = Job()
+        job = Job(executor=MockExecutor())
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -167,14 +139,14 @@ class TestBackfillJob:
 
         assert State.FAILED == dag_run.state
 
-    def test_dag_run_with_finished_tasks_set_to_success(self, dag_maker, mock_executor):
+    def test_dag_run_with_finished_tasks_set_to_success(self, dag_maker):
         dag = self._get_dummy_dag(dag_maker)
         dag_run = dag_maker.create_dagrun(state=None)
 
         for ti in dag_run.get_task_instances():
             ti.set_state(State.SUCCESS)
 
-        job = Job()
+        job = Job(executor=MockExecutor())
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -197,7 +169,7 @@ class TestBackfillJob:
         target_dag_run = session.query(DagRun).filter(DagRun.dag_id == target_dag.dag_id).one_or_none()
         assert target_dag_run is None
 
-        job = Job()
+        job = Job(executor=MockExecutor())
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -205,7 +177,6 @@ class TestBackfillJob:
             end_date=DEFAULT_DATE,
             ignore_first_depends_on_past=True,
         )
-
         run_job(job=job, execute_callable=job_runner._execute)
 
         dag_run = session.query(DagRun).filter(DagRun.dag_id == dag.dag_id).one_or_none()
@@ -216,13 +187,13 @@ class TestBackfillJob:
         assert task_instances_list
 
     @pytest.mark.backend("postgres", "mysql")
-    def test_backfill_multi_dates(self, mock_executor):
+    def test_backfill_multi_dates(self):
         dag = self.dagbag.get_dag("miscellaneous_test_dag")
 
         end_date = DEFAULT_DATE + datetime.timedelta(days=1)
 
-        job = Job()
-        executor = job.executor
+        executor = MockExecutor(parallelism=16)
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -318,7 +289,7 @@ class TestBackfillJob:
             ["latest_only", ("latest_only", "task1")],
         ],
     )
-    def test_backfill_examples(self, dag_id, expected_execution_order, mock_executor):
+    def test_backfill_examples(self, dag_id, expected_execution_order):
         """
         Test backfilling example dags
 
@@ -329,8 +300,8 @@ class TestBackfillJob:
         dag = self.dagbag.get_dag(dag_id)
 
         logger.info("*** Running example DAG: %s", dag.dag_id)
-        job = Job()
-        executor = job.executor
+        executor = MockExecutor()
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -345,12 +316,14 @@ class TestBackfillJob:
             for task_id in expected_execution_order
         ] == executor.sorted_tasks
 
-    def test_backfill_conf(self, dag_maker, mock_executor):
+    def test_backfill_conf(self, dag_maker):
         dag = self._get_dummy_dag(dag_maker, dag_id="test_backfill_conf")
         dag_maker.create_dagrun(state=None)
 
+        executor = MockExecutor()
+
         conf_ = json.loads("""{"key": "value"}""")
-        job = Job()
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -368,7 +341,7 @@ class TestBackfillJob:
         assert conf_ == dr[0].conf
 
     @patch("airflow.jobs.backfill_job_runner.BackfillJobRunner.log")
-    def test_backfill_respect_max_active_tis_per_dag_limit(self, mock_log, dag_maker, mock_executor):
+    def test_backfill_respect_max_active_tis_per_dag_limit(self, mock_log, dag_maker):
         max_active_tis_per_dag = 2
         dag = self._get_dummy_dag(
             dag_maker,
@@ -377,8 +350,9 @@ class TestBackfillJob:
         )
         dag_maker.create_dagrun(state=None)
 
-        job = Job()
-        executor = job.executor
+        executor = MockExecutor()
+
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -424,7 +398,7 @@ class TestBackfillJob:
     @pytest.mark.parametrize("with_max_active_tis_per_dag", [False, True])
     @patch("airflow.jobs.backfill_job_runner.BackfillJobRunner.log")
     def test_backfill_respect_max_active_tis_per_dagrun_limit(
-        self, mock_log, dag_maker, with_max_active_tis_per_dag, mock_executor
+        self, mock_log, dag_maker, with_max_active_tis_per_dag
     ):
         max_active_tis_per_dag = 3
         max_active_tis_per_dagrun = 2
@@ -437,8 +411,9 @@ class TestBackfillJob:
 
         dag_maker.create_dagrun(state=None)
 
-        job = Job()
-        executor = job.executor
+        executor = MockExecutor()
+
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -503,13 +478,14 @@ class TestBackfillJob:
         assert times_task_concurrency_limit_reached_in_debug > 0
 
     @patch("airflow.jobs.backfill_job_runner.BackfillJobRunner.log")
-    def test_backfill_respect_dag_concurrency_limit(self, mock_log, dag_maker, mock_executor):
+    def test_backfill_respect_dag_concurrency_limit(self, mock_log, dag_maker):
         dag = self._get_dummy_dag(dag_maker, dag_id="test_backfill_respect_concurrency_limit")
         dag_maker.create_dagrun(state=None)
         dag.max_active_tasks = 2
 
-        job = Job()
-        executor = job.executor
+        executor = MockExecutor()
+
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -553,15 +529,16 @@ class TestBackfillJob:
         assert times_dag_concurrency_limit_reached_in_debug > 0
 
     @patch("airflow.jobs.backfill_job_runner.BackfillJobRunner.log")
-    def test_backfill_respect_default_pool_limit(self, mock_log, dag_maker, mock_executor):
+    def test_backfill_respect_default_pool_limit(self, mock_log, dag_maker):
         default_pool_slots = 2
         set_default_pool_slots(default_pool_slots)
 
         dag = self._get_dummy_dag(dag_maker, dag_id="test_backfill_with_no_pool_limit")
         dag_maker.create_dagrun(state=None)
 
-        job = Job()
-        executor = job.executor
+        executor = MockExecutor()
+
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -608,7 +585,7 @@ class TestBackfillJob:
         assert 0 == times_task_concurrency_limit_reached_in_debug
         assert times_pool_limit_reached_in_debug > 0
 
-    def test_backfill_pool_not_found(self, dag_maker, mock_executor):
+    def test_backfill_pool_not_found(self, dag_maker):
         dag = self._get_dummy_dag(
             dag_maker,
             dag_id="test_backfill_pool_not_found",
@@ -616,7 +593,9 @@ class TestBackfillJob:
         )
         dag_maker.create_dagrun(state=None)
 
-        job = Job()
+        executor = MockExecutor()
+
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -630,7 +609,7 @@ class TestBackfillJob:
             return
 
     @patch("airflow.jobs.backfill_job_runner.BackfillJobRunner.log")
-    def test_backfill_respect_pool_limit(self, mock_log, dag_maker, mock_executor):
+    def test_backfill_respect_pool_limit(self, mock_log, dag_maker):
         session = settings.Session()
 
         slots = 2
@@ -649,8 +628,9 @@ class TestBackfillJob:
         )
         dag_maker.create_dagrun(state=None)
 
-        job = Job()
-        executor = job.executor
+        executor = MockExecutor()
+
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -693,13 +673,15 @@ class TestBackfillJob:
         assert 0 == times_dag_concurrency_limit_reached_in_debug
         assert times_pool_limit_reached_in_debug > 0
 
-    def test_backfill_run_rescheduled(self, dag_maker, mock_executor):
+    def test_backfill_run_rescheduled(self, dag_maker):
         dag = self._get_dummy_dag(
             dag_maker, dag_id="test_backfill_run_rescheduled", task_id="test_backfill_run_rescheduled_task-1"
         )
         dag_maker.create_dagrun(state=None, run_id=DEFAULT_DAG_RUN_ID)
 
-        job = Job()
+        executor = MockExecutor()
+
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -712,21 +694,20 @@ class TestBackfillJob:
         ti.refresh_from_db()
         ti.set_state(State.UP_FOR_RESCHEDULE)
 
-        for _ in self._mock_executor():
-            job = Job()
-            job_runner = BackfillJobRunner(
-                job=job,
-                dag=dag,
-                start_date=DEFAULT_DATE,
-                end_date=DEFAULT_DATE + datetime.timedelta(days=2),
-                rerun_failed_tasks=True,
-            )
-            run_job(job=job, execute_callable=job_runner._execute)
-            ti = TI(task=dag.get_task("test_backfill_run_rescheduled_task-1"), run_id=DEFAULT_DAG_RUN_ID)
-            ti.refresh_from_db()
-            assert ti.state == State.SUCCESS
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=2),
+            rerun_failed_tasks=True,
+        )
+        run_job(job=job, execute_callable=job_runner._execute)
+        ti = TI(task=dag.get_task("test_backfill_run_rescheduled_task-1"), run_id=DEFAULT_DAG_RUN_ID)
+        ti.refresh_from_db()
+        assert ti.state == State.SUCCESS
 
-    def test_backfill_override_conf(self, dag_maker, mock_executor):
+    def test_backfill_override_conf(self, dag_maker):
         dag = self._get_dummy_dag(
             dag_maker, dag_id="test_backfill_override_conf", task_id="test_backfill_override_conf-1"
         )
@@ -735,7 +716,9 @@ class TestBackfillJob:
             start_date=DEFAULT_DATE,
         )
 
-        job = Job()
+        executor = MockExecutor()
+
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -753,7 +736,7 @@ class TestBackfillJob:
             dr = wrapped_task_instances_for_dag_run.call_args_list[0][0][1]
             assert dr.conf == {"a": 1}
 
-    def test_backfill_skip_active_scheduled_dagrun(self, dag_maker, caplog, mock_executor):
+    def test_backfill_skip_active_scheduled_dagrun(self, dag_maker, caplog):
         dag = self._get_dummy_dag(
             dag_maker,
             dag_id="test_backfill_skip_active_scheduled_dagrun",
@@ -761,7 +744,9 @@ class TestBackfillJob:
         )
         dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED, state=State.RUNNING, run_id=DEFAULT_DAG_RUN_ID)
 
-        job = Job()
+        executor = MockExecutor()
+
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -778,13 +763,15 @@ class TestBackfillJob:
         # since DAG backfill is skipped, task state should be none
         assert ti.state == State.NONE
 
-    def test_backfill_rerun_failed_tasks(self, dag_maker, mock_executor):
+    def test_backfill_rerun_failed_tasks(self, dag_maker):
         dag = self._get_dummy_dag(
             dag_maker, dag_id="test_backfill_rerun_failed", task_id="test_backfill_rerun_failed_task-1"
         )
         dag_maker.create_dagrun(state=None, run_id=DEFAULT_DAG_RUN_ID)
 
-        job = Job()
+        executor = MockExecutor()
+
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -797,7 +784,7 @@ class TestBackfillJob:
         ti.refresh_from_db()
         ti.set_state(State.FAILED)
 
-        job = Job()
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -810,14 +797,16 @@ class TestBackfillJob:
         ti.refresh_from_db()
         assert ti.state == State.SUCCESS
 
-    def test_backfill_rerun_upstream_failed_tasks(self, dag_maker, mock_executor):
+    def test_backfill_rerun_upstream_failed_tasks(self, dag_maker):
         with dag_maker(dag_id="test_backfill_rerun_upstream_failed", schedule="@daily") as dag:
             op1 = EmptyOperator(task_id="test_backfill_rerun_upstream_failed_task-1")
             op2 = EmptyOperator(task_id="test_backfill_rerun_upstream_failed_task-2")
             op1.set_upstream(op2)
         dag_maker.create_dagrun(state=None, run_id=DEFAULT_DAG_RUN_ID)
 
-        job = Job()
+        executor = MockExecutor()
+
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -830,7 +819,7 @@ class TestBackfillJob:
         ti.refresh_from_db()
         ti.set_state(State.UPSTREAM_FAILED)
 
-        job = Job()
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -843,13 +832,15 @@ class TestBackfillJob:
         ti.refresh_from_db()
         assert ti.state == State.SUCCESS
 
-    def test_backfill_rerun_failed_tasks_without_flag(self, dag_maker, mock_executor):
+    def test_backfill_rerun_failed_tasks_without_flag(self, dag_maker):
         dag = self._get_dummy_dag(
             dag_maker, dag_id="test_backfill_rerun_failed", task_id="test_backfill_rerun_failed_task-1"
         )
         dag_maker.create_dagrun(state=None, run_id=DEFAULT_DAG_RUN_ID)
 
-        job = Job()
+        executor = MockExecutor()
+
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -862,7 +853,7 @@ class TestBackfillJob:
         ti.refresh_from_db()
         ti.set_state(State.FAILED)
 
-        job = Job()
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -874,7 +865,7 @@ class TestBackfillJob:
         with pytest.raises(AirflowException):
             run_job(job=job, execute_callable=job_runner._execute)
 
-    def test_backfill_retry_intermittent_failed_task(self, dag_maker, mock_executor):
+    def test_backfill_retry_intermittent_failed_task(self, dag_maker):
         with dag_maker(
             dag_id="test_intermittent_failure_job",
             schedule="@daily",
@@ -886,14 +877,14 @@ class TestBackfillJob:
             task1 = EmptyOperator(task_id="task1")
         dag_maker.create_dagrun(state=None)
 
-        executor = mock_executor
+        executor = MockExecutor(parallelism=16)
         executor.mock_task_results[TaskInstanceKey(dag.dag_id, task1.task_id, DEFAULT_DATE, try_number=1)] = (
             State.UP_FOR_RETRY
         )
         executor.mock_task_results[TaskInstanceKey(dag.dag_id, task1.task_id, DEFAULT_DATE, try_number=2)] = (
             State.UP_FOR_RETRY
         )
-        job = Job()
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -902,7 +893,7 @@ class TestBackfillJob:
         )
         run_job(job=job, execute_callable=job_runner._execute)
 
-    def test_backfill_retry_always_failed_task(self, dag_maker, mock_executor):
+    def test_backfill_retry_always_failed_task(self, dag_maker):
         with dag_maker(
             dag_id="test_always_failure_job",
             schedule="@daily",
@@ -914,12 +905,12 @@ class TestBackfillJob:
             task1 = EmptyOperator(task_id="task1")
         dr = dag_maker.create_dagrun(state=None)
 
-        executor = mock_executor
+        executor = MockExecutor(parallelism=16)
         executor.mock_task_results[TaskInstanceKey(dag.dag_id, task1.task_id, dr.run_id, try_number=0)] = (
             State.UP_FOR_RETRY
         )
         executor.mock_task_fail(dag.dag_id, task1.task_id, dr.run_id, try_number=1)
-        job = Job()
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -929,7 +920,7 @@ class TestBackfillJob:
         with pytest.raises(BackfillUnfinished):
             run_job(job=job, execute_callable=job_runner._execute)
 
-    def test_backfill_ordered_concurrent_execute(self, dag_maker, mock_executor):
+    def test_backfill_ordered_concurrent_execute(self, dag_maker):
         with dag_maker(
             dag_id="test_backfill_ordered_concurrent_execute",
             schedule="@daily",
@@ -947,8 +938,8 @@ class TestBackfillJob:
         runid0 = f"backfill__{DEFAULT_DATE.isoformat()}"
         dag_maker.create_dagrun(run_id=runid0)
 
-        executor = mock_executor
-        job = Job()
+        executor = MockExecutor(parallelism=16)
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -1006,7 +997,8 @@ class TestBackfillJob:
         dag = self.dagbag.get_dag("test_backfill_pooled_task_dag")
         dag.clear()
 
-        job = Job()
+        executor = MockExecutor(do_update=True)
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(job=job, dag=dag, start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 
         # run with timeout because this creates an infinite loop if not
@@ -1023,13 +1015,13 @@ class TestBackfillJob:
 
     @pytest.mark.parametrize("ignore_depends_on_past", [True, False])
     def test_backfill_depends_on_past_works_independently_on_ignore_depends_on_past(
-        self, ignore_depends_on_past, mock_executor
+        self, ignore_depends_on_past
     ):
         dag = self.dagbag.get_dag("test_depends_on_past")
         dag.clear()
         run_date = DEFAULT_DATE + datetime.timedelta(days=5)
 
-        job = Job()
+        job = Job(executor=MockExecutor())
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -1045,7 +1037,7 @@ class TestBackfillJob:
         ti.refresh_from_db()
         assert ti.state == State.SUCCESS
 
-    def test_backfill_depends_on_past_backwards(self, mock_executor):
+    def test_backfill_depends_on_past_backwards(self):
         """
         Test that CLI respects -B argument and raises on interaction with depends_on_past
         """
@@ -1059,7 +1051,8 @@ class TestBackfillJob:
         dag = self.dagbag.get_dag(dag_id)
         dag.clear()
 
-        job = Job()
+        executor = MockExecutor()
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(job=job, dag=dag, ignore_first_depends_on_past=True, **kwargs)
         run_job(job=job, execute_callable=job_runner._execute)
 
@@ -1071,13 +1064,11 @@ class TestBackfillJob:
 
         # raises backwards
         expected_msg = "You cannot backfill backwards because one or more tasks depend_on_past: test_dop_task"
-
-        for _ in self._mock_executor():
-            # Mock again to get a new executor
-            job = Job()
-            job_runner = BackfillJobRunner(job=job, dag=dag, run_backwards=True, **kwargs)
-            with pytest.raises(AirflowException, match=expected_msg):
-                run_job(job=job, execute_callable=job_runner._execute)
+        executor = MockExecutor()
+        job = Job(executor=executor)
+        job_runner = BackfillJobRunner(job=job, dag=dag, run_backwards=True, **kwargs)
+        with pytest.raises(AirflowException, match=expected_msg):
+            run_job(job=job, execute_callable=job_runner._execute)
 
     def test_cli_receives_delay_arg(self):
         """
@@ -1115,7 +1106,7 @@ class TestBackfillJob:
             op4 >> op3
         return dag
 
-    def test_backfill_max_limit_check_within_limit(self, dag_maker, mock_executor):
+    def test_backfill_max_limit_check_within_limit(self, dag_maker):
         dag = self._get_dag_test_max_active_limits(
             dag_maker, dag_id="test_backfill_max_limit_check_within_limit", max_active_runs=16
         )
@@ -1123,7 +1114,8 @@ class TestBackfillJob:
         start_date = DEFAULT_DATE - datetime.timedelta(hours=1)
         end_date = DEFAULT_DATE
 
-        job = Job()
+        executor = MockExecutor()
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -1137,7 +1129,7 @@ class TestBackfillJob:
         assert 2 == len(dagruns)
         assert all(run.state == State.SUCCESS for run in dagruns)
 
-    def test_backfill_notifies_dagrun_listener(self, dag_maker, mock_executor):
+    def test_backfill_notifies_dagrun_listener(self, dag_maker):
         dag = self._get_dummy_dag(dag_maker)
         dag_run = dag_maker.create_dagrun(state=None)
         dag_listener.clear()
@@ -1146,7 +1138,8 @@ class TestBackfillJob:
         start_date = DEFAULT_DATE - datetime.timedelta(hours=1)
         end_date = DEFAULT_DATE
 
-        job = Job()
+        executor = MockExecutor()
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -1167,7 +1160,7 @@ class TestBackfillJob:
         assert dag_listener.success[0].run_id == dag_run.run_id
         assert dag_listener.success[0].state == DagRunState.SUCCESS
 
-    def test_backfill_max_limit_check(self, dag_maker, mock_executor):
+    def test_backfill_max_limit_check(self, dag_maker):
         dag_id = "test_backfill_max_limit_check"
         run_id = "test_dag_run"
         start_date = DEFAULT_DATE - datetime.timedelta(hours=1)
@@ -1198,7 +1191,10 @@ class TestBackfillJob:
                     cond.release()
                     thread_session.close()
 
-                job = Job()
+                executor = MockExecutor()
+                job = Job(
+                    executor=executor,
+                )
                 job_runner = BackfillJobRunner(
                     job=job,
                     dag=dag,
@@ -1240,7 +1236,7 @@ class TestBackfillJob:
             finally:
                 dag_run_created_cond.release()
 
-    def test_backfill_max_limit_check_no_count_existing(self, dag_maker, mock_executor):
+    def test_backfill_max_limit_check_no_count_existing(self, dag_maker):
         start_date = DEFAULT_DATE
         end_date = DEFAULT_DATE
         # Existing dagrun that is within the backfill range
@@ -1249,7 +1245,8 @@ class TestBackfillJob:
         )
         dag_maker.create_dagrun(state=None)
 
-        job = Job()
+        executor = MockExecutor()
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job, dag=dag, start_date=start_date, end_date=end_date, donot_pickle=True
         )
@@ -1263,7 +1260,7 @@ class TestBackfillJob:
         assert 1 == len(dagruns)
         assert State.SUCCESS == dagruns[0].state
 
-    def test_backfill_max_limit_check_complete_loop(self, dag_maker, mock_executor):
+    def test_backfill_max_limit_check_complete_loop(self, dag_maker):
         dag = self._get_dag_test_max_active_limits(
             dag_maker, dag_id="test_backfill_max_limit_check_complete_loop"
         )
@@ -1274,7 +1271,8 @@ class TestBackfillJob:
         # Given the max limit to be 1 in active dag runs, we need to run the
         # backfill job 3 times
         success_expected = 2
-        job = Job()
+        executor = MockExecutor()
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -1289,7 +1287,7 @@ class TestBackfillJob:
         assert success_expected == success_dagruns
         assert 0 == running_dagruns  # no dag_runs in running state are left
 
-    def test_sub_set_subdag(self, dag_maker, mock_executor):
+    def test_sub_set_subdag(self, dag_maker):
         with dag_maker(
             "test_sub_set_subdag",
             on_success_callback=lambda _: None,
@@ -1308,10 +1306,11 @@ class TestBackfillJob:
 
         dr = dag_maker.create_dagrun(state=None)
 
+        executor = MockExecutor()
         sub_dag = dag.partial_subset(
             task_ids_or_regex="leave*", include_downstream=False, include_upstream=False
         )
-        job = Job()
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(job=job, dag=sub_dag, start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
         run_job(job=job, execute_callable=job_runner._execute)
 
@@ -1321,7 +1320,7 @@ class TestBackfillJob:
             else:
                 assert State.NONE == ti.state
 
-    def test_backfill_fill_blanks(self, dag_maker, mock_executor):
+    def test_backfill_fill_blanks(self, dag_maker):
         with dag_maker(
             "test_backfill_fill_blanks",
         ) as dag:
@@ -1333,6 +1332,8 @@ class TestBackfillJob:
             op6 = EmptyOperator(task_id="op6")
 
         dr = dag_maker.create_dagrun(state=None)
+
+        executor = MockExecutor()
 
         session = settings.Session()
 
@@ -1354,7 +1355,7 @@ class TestBackfillJob:
         session.commit()
         session.close()
 
-        job = Job()
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(job=job, dag=dag, start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
         with pytest.raises(AirflowException, match="Some task instances failed"):
             run_job(job=job, execute_callable=job_runner._execute)
@@ -1374,7 +1375,7 @@ class TestBackfillJob:
             elif ti.task_id == op5.task_id:
                 assert ti.state == State.UPSTREAM_FAILED
 
-    def test_backfill_execute_subdag(self, mock_executor):
+    def test_backfill_execute_subdag(self):
         dag = self.dagbag.get_dag("example_subdag_operator")
         subdag_op_task = dag.get_task("section-1")
 
@@ -1382,8 +1383,8 @@ class TestBackfillJob:
         subdag.timetable = cron_timetable("@daily")
 
         start_date = timezone.utcnow()
-        executor = mock_executor
-        job = Job()
+        executor = MockExecutor()
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=subdag,
@@ -1420,13 +1421,14 @@ class TestBackfillJob:
         subdag.clear()
         dag.clear()
 
-    def test_subdag_clear_parentdag_downstream_clear(self, mock_executor):
+    def test_subdag_clear_parentdag_downstream_clear(self):
         dag = self.dagbag.get_dag("clear_subdag_test_dag")
         subdag_op_task = dag.get_task("daily_job")
 
         subdag = subdag_op_task.subdag
 
-        job = Job()
+        executor = MockExecutor()
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -1469,7 +1471,7 @@ class TestBackfillJob:
         subdag.clear()
         dag.clear()
 
-    def test_backfill_execute_subdag_with_removed_task(self, mock_executor):
+    def test_backfill_execute_subdag_with_removed_task(self):
         """
         Ensure that subdag operators execute properly in the case where
         an associated task of the subdag has been removed from the dag
@@ -1479,7 +1481,8 @@ class TestBackfillJob:
         subdag = dag.get_task("section-1").subdag
 
         session = settings.Session()
-        job = Job()
+        executor = MockExecutor()
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=subdag,
@@ -1690,11 +1693,13 @@ class TestBackfillJob:
             )
         ]
 
-    def test_backfill_run_backwards(self, mock_executor):
+    def test_backfill_run_backwards(self):
         dag = self.dagbag.get_dag("test_start_date_scheduling")
         dag.clear()
 
-        job = Job()
+        executor = MockExecutor(parallelism=16)
+
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -1817,12 +1822,12 @@ class TestBackfillJob:
         assert State.SCHEDULED == ti1.state
         assert State.NONE == ti2.state
 
-    def test_job_id_is_assigned_to_dag_run(self, dag_maker, mock_executor):
+    def test_job_id_is_assigned_to_dag_run(self, dag_maker):
         dag_id = "test_job_id_is_assigned_to_dag_run"
         with dag_maker(dag_id=dag_id, start_date=DEFAULT_DATE, schedule="@daily") as dag:
             EmptyOperator(task_id="dummy_task", dag=dag)
 
-        job = Job()
+        job = Job(executor=MockExecutor())
         job_runner = BackfillJobRunner(
             job=job, dag=dag, start_date=timezone.utcnow() - datetime.timedelta(days=1)
         )
@@ -1830,12 +1835,14 @@ class TestBackfillJob:
         dr: DagRun = dag.get_last_dagrun()
         assert dr.creating_job_id == job.id
 
-    def test_backfill_has_job_id_int(self, mock_executor):
+    def test_backfill_has_job_id_int(self):
         """Make sure that backfill jobs are assigned job_ids and that the job_id is an int."""
         dag = self.dagbag.get_dag("test_start_date_scheduling")
         dag.clear()
 
-        job = Job()
+        executor = MockExecutor(parallelism=16)
+
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -1844,12 +1851,12 @@ class TestBackfillJob:
             run_backwards=True,
         )
         run_job(job=job, execute_callable=job_runner._execute)
-        assert isinstance(job.executor.job_id, int)
+        assert isinstance(executor.job_id, int)
 
     @pytest.mark.long_running
-    @pytest.mark.parametrize("executor", [SequentialExecutor, DebugExecutor])
+    @pytest.mark.parametrize("executor_name", ["SequentialExecutor", "DebugExecutor"])
     @pytest.mark.parametrize("dag_id", ["test_mapped_classic", "test_mapped_taskflow", "test_sensor"])
-    def test_backfilling_dags(self, dag_id, executor, session):
+    def test_backfilling_dags(self, dag_id, executor_name, session):
         """
         End-to-end test for backfilling dags with various executors.
 
@@ -1858,33 +1865,34 @@ class TestBackfillJob:
 
         """
         # This test needs a real executor to run, so that the `make_list` task can write out the TaskMap
-        for _ in self._mock_executor(executor):
-            self.dagbag.process_file(str(TEST_DAGS_FOLDER / f"{dag_id}.py"))
-            dag = self.dagbag.get_dag(dag_id)
+        from airflow.executors.executor_loader import ExecutorLoader
 
-            when = timezone.datetime(2022, 1, 1)
+        self.dagbag.process_file(str(TEST_DAGS_FOLDER / f"{dag_id}.py"))
+        dag = self.dagbag.get_dag(dag_id)
 
-            job = Job()
-            job_runner = BackfillJobRunner(
-                job=job,
-                dag=dag,
-                start_date=when,
-                end_date=when,
-                donot_pickle=True,
-            )
-            run_job(job=job, execute_callable=job_runner._execute)
+        when = timezone.datetime(2022, 1, 1)
 
-            dr = DagRun.find(dag_id=dag.dag_id, execution_date=when, session=session)[0]
-            assert dr
-            assert dr.state == DagRunState.SUCCESS
+        job = Job(executor=ExecutorLoader.load_executor(executor_name))
+        job_runner = BackfillJobRunner(
+            job=job,
+            dag=dag,
+            start_date=when,
+            end_date=when,
+            donot_pickle=True,
+        )
+        run_job(job=job, execute_callable=job_runner._execute)
 
-            # Check that every task has a start and end date
-            for ti in dr.task_instances:
-                assert ti.state == TaskInstanceState.SUCCESS
-                assert ti.start_date is not None
-                assert ti.end_date is not None
+        dr = DagRun.find(dag_id=dag.dag_id, execution_date=when, session=session)[0]
+        assert dr
+        assert dr.state == DagRunState.SUCCESS
 
-    def test_mapped_dag_pre_existing_tis(self, dag_maker, session, mock_executor):
+        # Check that every task has a start and end date
+        for ti in dr.task_instances:
+            assert ti.state == TaskInstanceState.SUCCESS
+            assert ti.start_date is not None
+            assert ti.end_date is not None
+
+    def test_mapped_dag_pre_existing_tis(self, dag_maker, session):
         """If the DagRun already has some mapped TIs, ensure that we re-run them successfully"""
         from airflow.decorators import task
         from airflow.operators.python import PythonOperator
@@ -1917,13 +1925,13 @@ class TestBackfillJob:
             ti.dag_run = dr
         session.flush()
 
-        executor = mock_executor
+        executor = MockExecutor()
 
         ti_status = BackfillJobRunner._DagRunTaskStatus()
         ti_status.active_runs.add(dr)
         ti_status.to_run = {ti.key: ti for ti in dr.task_instances}
 
-        job = Job()
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -1952,7 +1960,7 @@ class TestBackfillJob:
         with patch.object(executor, "change_state", side_effect=on_change_state):
             job_runner._process_backfill_task_instances(
                 ti_status=ti_status,
-                executor=executor,
+                executor=job.executor,
                 start_date=dr.execution_date,
                 pickle_id=None,
                 session=session,
@@ -1976,7 +1984,7 @@ class TestBackfillJob:
             ),
         }
 
-    def test_mapped_dag_unexpandable(self, dag_maker, session, mock_executor):
+    def test_mapped_dag_unexpandable(self, dag_maker, session):
         with dag_maker(session=session) as dag:
 
             @dag.task
@@ -1993,8 +2001,9 @@ class TestBackfillJob:
 
             consumer.expand(a=get_things(), b=this_fails())
 
+        executor = MockExecutor()
         when = timezone.datetime(2022, 1, 1)
-        job = Job()
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(job=job, dag=dag, start_date=when, end_date=when, donot_pickle=True)
         run_job(job=job, execute_callable=job_runner._execute)
         (dr,) = DagRun.find(dag_id=dag.dag_id, execution_date=when, session=session)
@@ -2007,7 +2016,7 @@ class TestBackfillJob:
         tis[("this_fails", -1)].state == TaskInstanceState.FAILED
         tis[("consumer", -1)].state == TaskInstanceState.UPSTREAM_FAILED
 
-    def test_start_date_set_for_resetted_dagruns(self, dag_maker, session, caplog, mock_executor):
+    def test_start_date_set_for_resetted_dagruns(self, dag_maker, session, caplog):
         with dag_maker() as dag:
             EmptyOperator(task_id="task1")
 
@@ -2016,7 +2025,7 @@ class TestBackfillJob:
         session.merge(dr)
         session.flush()
         dag.clear()
-        job = Job()
+        job = Job(executor=MockExecutor())
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -2030,9 +2039,7 @@ class TestBackfillJob:
         assert dr.start_date
         assert f"Failed to record duration of {dr}" not in caplog.text
 
-    def test_task_instances_are_not_set_to_scheduled_when_dagrun_reset(
-        self, dag_maker, session, mock_executor
-    ):
+    def test_task_instances_are_not_set_to_scheduled_when_dagrun_reset(self, dag_maker, session):
         """Test that when dagrun is reset, task instances are not set to scheduled"""
 
         with dag_maker() as dag:
@@ -2048,7 +2055,7 @@ class TestBackfillJob:
 
         dag.clear()
 
-        job = Job()
+        job = Job(executor=MockExecutor())
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,
@@ -2069,7 +2076,7 @@ class TestBackfillJob:
             (False, 2, AirflowException),
         ),
     )
-    def test_backfill_disable_retry(self, dag_maker, disable_retry, try_number, exception, mock_executor):
+    def test_backfill_disable_retry(self, dag_maker, disable_retry, try_number, exception):
         with dag_maker(
             dag_id="test_disable_retry",
             schedule="@daily",
@@ -2081,8 +2088,7 @@ class TestBackfillJob:
             task1 = EmptyOperator(task_id="task1")
         dag_run = dag_maker.create_dagrun(state=None)
 
-        executor = mock_executor
-        executor.parallelism = 16
+        executor = MockExecutor(parallelism=16)
         executor.mock_task_results[
             TaskInstanceKey(dag.dag_id, task1.task_id, dag_run.run_id, try_number=1)
         ] = TaskInstanceState.UP_FOR_RETRY
@@ -2090,7 +2096,7 @@ class TestBackfillJob:
             TaskInstanceKey(dag.dag_id, task1.task_id, dag_run.run_id, try_number=2)
         ] = TaskInstanceState.FAILED
 
-        job = Job()
+        job = Job(executor=executor)
         job_runner = BackfillJobRunner(
             job=job,
             dag=dag,

--- a/tests/test_utils/mock_executor.py
+++ b/tests/test_utils/mock_executor.py
@@ -31,8 +31,6 @@ class MockExecutor(BaseExecutor):
     TestExecutor is used for unit testing purposes.
     """
 
-    supports_pickling = False
-
     def __init__(self, do_update=True, *args, **kwargs):
         self.do_update = do_update
         self._running = []


### PR DESCRIPTION
This reverts commit 3f3bb463aecdf5c1ce41d25b442df24639a115d7.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
