### PR TITLE
handle gitsync v4 env var change

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -224,7 +224,7 @@ If release name contains chart name it will be used as a full name.
       value: "false"
     {{- end }}
     {{ else if .Values.dags.gitSync.credentialsSecret }}
-    {{- if int (regexFind "[0-9]+" .Values.images.gitSync.tag) < 4 }}
+    {{- if semverCompare "<v4.0.0" .Values.images.gitSync.tag }}
     - name: GIT_SYNC_USERNAME
       valueFrom:
         secretKeyRef:

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -224,21 +224,23 @@ If release name contains chart name it will be used as a full name.
       value: "false"
     {{- end }}
     {{ else if .Values.dags.gitSync.credentialsSecret }}
+    {{ if int (regexFind "[0-9]+" .Values.images.gitSync.tag) < 4 }}
     - name: GIT_SYNC_USERNAME
       valueFrom:
         secretKeyRef:
           name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
           key: GIT_SYNC_USERNAME
-    - name: GITSYNC_USERNAME
-      valueFrom:
-        secretKeyRef:
-          name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
-          key: GITSYNC_USERNAME
     - name: GIT_SYNC_PASSWORD
       valueFrom:
         secretKeyRef:
           name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
           key: GIT_SYNC_PASSWORD
+    {{- end }}
+    - name: GITSYNC_USERNAME
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
+          key: GITSYNC_USERNAME
     - name: GITSYNC_PASSWORD
       valueFrom:
         secretKeyRef:

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -224,7 +224,7 @@ If release name contains chart name it will be used as a full name.
       value: "false"
     {{- end }}
     {{ else if .Values.dags.gitSync.credentialsSecret }}
-    {{ if int (regexFind "[0-9]+" .Values.images.gitSync.tag) < 4 }}
+    {{- if int (regexFind "[0-9]+" .Values.images.gitSync.tag) < 4 }}
     - name: GIT_SYNC_USERNAME
       valueFrom:
         secretKeyRef:
@@ -235,7 +235,7 @@ If release name contains chart name it will be used as a full name.
         secretKeyRef:
           name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
           key: GIT_SYNC_PASSWORD
-    {{- end }}
+    {{- else }}
     - name: GITSYNC_USERNAME
       valueFrom:
         secretKeyRef:
@@ -246,6 +246,7 @@ If release name contains chart name it will be used as a full name.
         secretKeyRef:
           name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
           key: GITSYNC_PASSWORD
+    {{- end }}
     {{- end }}
     - name: GIT_SYNC_REV
       value: {{ .Values.dags.gitSync.rev | quote }}


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


When using gitsync v4, deployed via argoCD to AKS, my `git-sync-init` containers fail with this message:
```
CreateContainerConfigError: couldn't find key GIT_SYNC_USERNAME in Secret data-airflow/airflow-secrets
```

As of gitsync v4, the expected format is `GITSYNC_` (see [release notes](https://github.com/kubernetes/git-sync/releases/tag/v4.0.0)).