### PR TITLE
Fix TriggeredDagRunOperator triggered link

### DIFF
--- a/airflow/operators/trigger_dagrun.py
+++ b/airflow/operators/trigger_dagrun.py
@@ -69,10 +69,13 @@ class TriggerDagRunLink(BaseOperatorLink):
     name = "Triggered DAG"
 
     def get_link(self, operator: BaseOperator, *, ti_key: TaskInstanceKey) -> str:
-        # Fetch the correct execution date for the triggerED dag which is
+        # Fetch the correct dag_run_id for the triggerED dag which is
         # stored in xcom during execution of the triggerING task.
-        when = XCom.get_value(ti_key=ti_key, key=XCOM_LOGICAL_DATE_ISO)
-        query = {"dag_id": cast(TriggerDagRunOperator, operator).trigger_dag_id, "base_date": when}
+        triggered_dag_run_id = XCom.get_value(ti_key=ti_key, key=XCOM_RUN_ID)
+        query = {
+            "dag_id": cast(TriggerDagRunOperator, operator).trigger_dag_id,
+            "dag_run_id": triggered_dag_run_id,
+        }
         return build_airflow_url_with_query(query)
 
 
@@ -218,7 +221,7 @@ class TriggerDagRunOperator(BaseOperator):
                 raise e
         if dag_run is None:
             raise RuntimeError("The dag_run should be set here!")
-        # Store the execution date from the dag run (either created or found above) to
+        # Store the run id from the dag run (either created or found above) to
         # be used when creating the extra link on the webserver.
         ti = context["task_instance"]
         ti.xcom_push(key=XCOM_LOGICAL_DATE_ISO, value=dag_run.logical_date.isoformat())

--- a/airflow/operators/trigger_dagrun.py
+++ b/airflow/operators/trigger_dagrun.py
@@ -223,6 +223,7 @@ class TriggerDagRunOperator(BaseOperator):
             raise RuntimeError("The dag_run should be set here!")
         # Store the run id from the dag run (either created or found above) to
         # be used when creating the extra link on the webserver.
+        # TODO: Logical date as xcom stored only for backwards compatibility. Remove in Airflow 3.0
         ti = context["task_instance"]
         ti.xcom_push(key=XCOM_LOGICAL_DATE_ISO, value=dag_run.logical_date.isoformat())
         ti.xcom_push(key=XCOM_RUN_ID, value=dag_run.run_id)

--- a/tests/operators/test_trigger_dagrun.py
+++ b/tests/operators/test_trigger_dagrun.py
@@ -92,7 +92,7 @@ class TestDagRunOperator:
         """
         Asserts whether the correct extra links url will be created.
 
-        Specifically it tests whether the correct dag id and date are passed to
+        Specifically it tests whether the correct dag id and run id are passed to
         the method which constructs the final url.
         Note: We can't run that method to generate the url itself because the Flask app context
         isn't available within the test logic, so it is mocked here.
@@ -111,7 +111,7 @@ class TestDagRunOperator:
         args, _ = mock_build_url.call_args
         expected_args = {
             "dag_id": triggered_dag_run.dag_id,
-            "base_date": triggered_dag_run.logical_date.isoformat(),
+            "dag_run_id": triggered_dag_run.run_id,
         }
         assert expected_args in args
 


### PR DESCRIPTION
Link to the specific dag run id that was triggered, as opposed to the logical date, such that the instance that was triggered on the DAG grid UI.

This was alluded to in #19264, but you want the DAG run that was triggered select in the DAG grid UI.

Current link and DAG grid UI view:
<img width="1504" alt="Screenshot 2024-06-19 at 19 18 08" src="https://github.com/apache/airflow/assets/880064/a26cef97-079f-48a5-a9ce-a816c312535c">


This PR's changed link and DAG grid UI view:
<img width="1493" alt="Screenshot 2024-06-19 at 19 38 17" src="https://github.com/apache/airflow/assets/880064/cdd4c4b0-6a54-4d76-abc0-0d4f78d575cf">

Simple DAGs to demonstrate:
```
from airflow.decorators import dag, task
from airflow.operators.trigger_dagrun import TriggerDagRunOperator


@dag()
def triggering_dag():
    t = TriggerDagRunOperator(
        trigger_dag_id="triggered_dag",
        task_id="triggering_task",
    )

    t

@dag()
def triggered_dag():
    @task()
    def empty_task() -> int:
        return 0

    empty_task()

triggering_dag()
triggered_dag()
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

related: #19264

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
