### PR TITLE
Display the actual error message in UI alert component

### DIFF
--- a/airflow/www/static/js/components/ErrorAlert.tsx
+++ b/airflow/www/static/js/components/ErrorAlert.tsx
@@ -17,22 +17,20 @@
  * under the License.
  */
 
-import { useToast } from "@chakra-ui/react";
-import type { ReactNode } from "react";
+import React from "react";
+import { Alert, AlertIcon } from "@chakra-ui/react";
+import handleError from "src/utils/handleError";
 
-import handleError from "./handleError";
-
-const useErrorToast = () => {
-  const toast = useToast();
-  // Add an error prop and handle it as a description
-  return ({ error, title, ...rest }: { error: Error; title?: ReactNode }) => {
-    toast({
-      ...rest,
-      status: "error",
-      title: title || "Error",
-      description: handleError(error).slice(0, 500),
-    });
-  };
+type Props = {
+  error?: unknown;
 };
 
-export default useErrorToast;
+const ErrorAlert = ({ error }: Props) =>
+  error ? (
+    <Alert status="error" marginBottom="10px">
+      <AlertIcon />
+      {handleError(error)}
+    </Alert>
+  ) : null;
+
+export default ErrorAlert;

--- a/airflow/www/static/js/dag/details/dagCode/index.tsx
+++ b/airflow/www/static/js/dag/details/dagCode/index.tsx
@@ -18,11 +18,13 @@
  */
 
 import React, { useRef } from "react";
-import { Box, Heading, Spinner, Alert, AlertIcon } from "@chakra-ui/react";
+import { Box, Heading, Spinner } from "@chakra-ui/react";
+
 import { useOffsetTop } from "src/utils";
 import Time from "src/components/Time";
-
 import { useDag, useDagCode } from "src/api";
+import ErrorAlert from "src/components/ErrorAlert";
+
 import CodeBlock from "./CodeBlock";
 
 const DagCode = () => {
@@ -45,12 +47,7 @@ const DagCode = () => {
           Parsed at: <Time dateTime={dagData.lastParsedTime} />
         </Heading>
       )}
-      {!!error && (
-        <Alert status="error" marginBottom="10px">
-          <AlertIcon />
-          An error occurred while fetching the dag source code.
-        </Alert>
-      )}
+      <ErrorAlert error={error} />
       {isLoading && (
         <Spinner size="xl" color="blue.500" thickness="4px" speed="0.65s" />
       )}

--- a/airflow/www/static/js/dag/details/taskInstance/TaskDocumentation.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/TaskDocumentation.tsx
@@ -24,8 +24,6 @@ import {
   AccordionButton,
   AccordionPanel,
   AccordionIcon,
-  Alert,
-  AlertIcon,
   Box,
   Spinner,
   Text,
@@ -33,6 +31,7 @@ import {
 
 import { useTaskDetail } from "src/api";
 import ReactMarkdown from "src/components/ReactMarkdown";
+import ErrorAlert from "src/components/ErrorAlert";
 
 interface Props {
   taskId: string;
@@ -48,12 +47,7 @@ const TaskDocumentation = ({ taskId }: Props) => {
   }
 
   if (error) {
-    return (
-      <Alert status="error" marginBottom="10px">
-        <AlertIcon />
-        An error occurred while fetching task documentation.
-      </Alert>
-    );
+    return <ErrorAlert error={error} />;
   }
 
   if (data && data.docMd) {

--- a/airflow/www/static/js/dag/details/taskInstance/TaskFailedDependency.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/TaskFailedDependency.tsx
@@ -18,20 +18,10 @@
  */
 
 import React from "react";
-import {
-  Alert,
-  AlertIcon,
-  Box,
-  Spinner,
-  Text,
-  Table,
-  Tbody,
-  Tr,
-  Th,
-  Td,
-} from "@chakra-ui/react";
+import { Box, Spinner, Text, Table, Tbody, Tr, Th, Td } from "@chakra-ui/react";
 
 import { useTaskFailedDependency } from "src/api";
+import ErrorAlert from "src/components/ErrorAlert";
 
 interface Props {
   dagId: string;
@@ -60,13 +50,7 @@ const TaskFailedDependency = ({ dagId, runId, taskId, mapIndex }: Props) => {
       <br />
 
       {isLoading && <Spinner size="md" thickness="4px" speed="0.65s" />}
-      {!!error && (
-        <Alert status="error" marginBottom="10px">
-          <AlertIcon />
-          An error occurred while fetching task dependencies.
-        </Alert>
-      )}
-
+      <ErrorAlert error={error} />
       {dependencies && (
         <Box mt={3}>
           <Text>Dependencies Blocking Task From Getting Scheduled</Text>

--- a/airflow/www/static/js/dag/details/taskInstance/Xcom/XcomEntry.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Xcom/XcomEntry.tsx
@@ -19,7 +19,9 @@
 
 import { Alert, AlertIcon, Spinner, Td, Text, Tr } from "@chakra-ui/react";
 import React from "react";
+
 import { useTaskXcomEntry } from "src/api";
+import ErrorAlert from "src/components/ErrorAlert";
 import type { Dag, DagRun, TaskInstance } from "src/types";
 
 interface Props {
@@ -56,12 +58,7 @@ const XcomEntry = ({
   if (isLoading) {
     content = <Spinner />;
   } else if (error) {
-    content = (
-      <Alert status="error">
-        <AlertIcon />
-        Error loading XCom entry
-      </Alert>
-    );
+    content = <ErrorAlert error={error} />;
   } else if (!xcom) {
     content = (
       <Alert status="info">

--- a/airflow/www/static/js/dag/details/taskInstance/Xcom/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Xcom/index.tsx
@@ -18,7 +18,6 @@
  */
 
 import React, { useRef } from "react";
-import type { Dag, DagRun, TaskInstance } from "src/types";
 import {
   Table,
   Text,
@@ -27,12 +26,14 @@ import {
   Tr,
   Td,
   Spinner,
-  Alert,
-  AlertIcon,
   Box,
 } from "@chakra-ui/react";
+
+import type { Dag, DagRun, TaskInstance } from "src/types";
 import { useTaskXcomCollection } from "src/api";
 import { useOffsetTop } from "src/utils";
+import ErrorAlert from "src/components/ErrorAlert";
+
 import XcomEntry from "./XcomEntry";
 
 interface Props {
@@ -73,12 +74,7 @@ const XcomCollection = ({
       overflowY="auto"
     >
       {isLoading && <Spinner size="xl" thickness="4px" speed="0.65s" />}
-      {!!error && (
-        <Alert status="error" marginBottom="10px">
-          <AlertIcon />
-          An error occurred while fetching task XCom.
-        </Alert>
-      )}
+      <ErrorAlert error={error} />
       {xcomCollection &&
         (xcomCollection.totalEntries === 0 ? (
           <Text>No XCom</Text>

--- a/airflow/www/static/js/utils/handleError.test.ts
+++ b/airflow/www/static/js/utils/handleError.test.ts
@@ -20,9 +20,9 @@
 /* global describe, test, expect */
 
 import type { AxiosError, AxiosResponse } from "axios";
-import { getErrorDescription } from "./useErrorToast";
+import handleError from "./handleError";
 
-describe("Test getErrorDescription()", () => {
+describe("Test handleError()", () => {
   test("Returns expected results", () => {
     let description;
 
@@ -40,29 +40,29 @@ describe("Test getErrorDescription()", () => {
     axiosError.isAxiosError = true;
 
     // if response.data is defined
-    description = getErrorDescription(axiosError);
+    description = handleError(axiosError);
     expect(description).toBe("Not available for this Executor");
 
     axiosError.response.data = "";
 
     // if it is not, use the error message
-    description = getErrorDescription(axiosError);
+    description = handleError(axiosError);
     expect(description).toBe("Error message");
 
     // if error object, return the message
-    description = getErrorDescription(new Error("no no"));
+    description = handleError(new Error("no no"));
     expect(description).toBe("no no");
 
     // if string, return the string
-    description = getErrorDescription("error!");
+    description = handleError("error!");
     expect(description).toBe("error!");
 
     // if it's undefined, use a fallback
-    description = getErrorDescription(null, "fallback");
+    description = handleError(null, "fallback");
     expect(description).toBe("fallback");
 
     // use default if nothing is defined
-    description = getErrorDescription();
+    description = handleError();
     expect(description).toBe("Something went wrong.");
   });
 });

--- a/airflow/www/static/js/utils/handleError.ts
+++ b/airflow/www/static/js/utils/handleError.ts
@@ -17,22 +17,20 @@
  * under the License.
  */
 
-import { useToast } from "@chakra-ui/react";
-import type { ReactNode } from "react";
+import axios from "axios";
 
-import handleError from "./handleError";
-
-const useErrorToast = () => {
-  const toast = useToast();
-  // Add an error prop and handle it as a description
-  return ({ error, title, ...rest }: { error: Error; title?: ReactNode }) => {
-    toast({
-      ...rest,
-      status: "error",
-      title: title || "Error",
-      description: handleError(error).slice(0, 500),
-    });
-  };
+const handleError = (error?: any, fallbackMessage?: string) => {
+  if (typeof error === "string") return error;
+  if (error?.response?.errors) {
+    return error.response.errors.map((e: any) => e.message).join("\n");
+  }
+  if (axios.isAxiosError(error)) {
+    return (
+      error.response?.data?.detail || error.response?.data || error.message
+    );
+  }
+  if (error?.message) return error.message;
+  return fallbackMessage || "Something went wrong.";
 };
 
-export default useErrorToast;
+export default handleError;


### PR DESCRIPTION
In a few parts of the UI we just displayed text  "An error occurred." Instead, we should try to display the actual error message. Since we do this in enough places, it should also be a shared Alert component when we don't want to use the error toast.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
