### PR TITLE
fix for GroupingError due to an incorrect SQL query when detecting orphaned datasets

### DIFF
--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1814,7 +1814,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         An orphaned dataset is no longer referenced in any DAG schedule parameters or task outlets.
         """
         orphaned_dataset_query = session.scalars(
-            select(DatasetModel)
+            select(DatasetModel.id)
             .join(
                 DagScheduleDatasetReference,
                 isouter=True,


### PR DESCRIPTION
Fixes: #40349 
[Issue 40349](https://github.com/apache/airflow/issues/40349) - Simple fix for Airflow scheduler crashes with a psycopg2.errors.GroupingError due to an incorrect SQL query when detecting orphaned datasets
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
