### PR TITLE
Improve Task TryHistory UI

### DIFF
--- a/airflow/www/static/js/dag/details/gantt/InstanceBar.tsx
+++ b/airflow/www/static/js/dag/details/gantt/InstanceBar.tsx
@@ -99,10 +99,10 @@ const InstanceBar = ({
       openDelay={hoverDelay}
     >
       <Flex
-        width={`${width + queuedWidth}px`}
         position="absolute"
         top="4px"
         left={`${offsetMargin}px`}
+        transition="left 0.5s"
         cursor="pointer"
         pointerEvents="auto"
         onClick={() => {
@@ -117,6 +117,7 @@ const InstanceBar = ({
             state="queued"
             width={`${queuedWidth}px`}
             borderRightRadius={0}
+            transition="width 0.5s"
             // The normal queued color is too dark when next to the actual task's state
             opacity={0.6}
           />
@@ -128,6 +129,7 @@ const InstanceBar = ({
               : instance.state
           }
           width={`${width}px`}
+          transition="width 0.5s"
           borderLeftRadius={
             instance.state !== "queued" && hasValidQueuedDttm ? 0 : undefined
           }

--- a/airflow/www/static/js/dag/details/gantt/Row.tsx
+++ b/airflow/www/static/js/dag/details/gantt/Row.tsx
@@ -72,29 +72,27 @@ const Row = ({
       >
         {!!instance && (
           <InstanceBar
-            instance={{ ...instance, queuedWhen: instance.queuedDttm }}
+            instance={{
+              ...instance,
+              queuedWhen: instance.queuedDttm,
+              dagRunId: instance.runId,
+            }}
             task={task}
             ganttWidth={ganttWidth}
             ganttStartDate={ganttStartDate}
             ganttEndDate={ganttEndDate}
           />
         )}
-        {(tiHistory || [])
-          .filter(
-            (ti) =>
-              ti.startDate !== instance?.startDate && // @ts-ignore
-              moment(ti.startDate).isAfter(ganttStartDate)
-          )
-          .map((ti) => (
-            <InstanceBar
-              key={`${taskId}-${ti.tryNumber}`}
-              instance={ti}
-              task={task}
-              ganttWidth={ganttWidth}
-              ganttStartDate={ganttStartDate}
-              ganttEndDate={ganttEndDate}
-            />
-          ))}
+        {(tiHistory || []).map((ti) => (
+          <InstanceBar
+            key={`${taskId}-${ti.tryNumber}`}
+            instance={ti}
+            task={task}
+            ganttWidth={ganttWidth}
+            ganttStartDate={ganttStartDate}
+            ganttEndDate={ganttEndDate}
+          />
+        ))}
       </Box>
       {isOpen &&
         !!task.children &&

--- a/airflow/www/static/js/dag/details/gantt/index.tsx
+++ b/airflow/www/static/js/dag/details/gantt/index.tsx
@@ -107,7 +107,8 @@ const Gantt = ({ openGroupIds, gridScrollRef, ganttScrollRef }: Props) => {
   const dagRun = dagRuns.find((dr) => dr.runId === runId);
 
   let startDate = dagRun?.queuedAt || dagRun?.startDate;
-  let endDate = dagRun?.endDate;
+  // @ts-ignore
+  let endDate = dagRun?.endDate ?? moment().add(1, "s").toString();
 
   // Check if any task instance dates are outside the bounds of the dag run dates and update our min start and max end
   groups.children?.forEach((task) => {

--- a/airflow/www/static/js/dag/details/taskInstance/Details.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Details.tsx
@@ -125,11 +125,9 @@ const Details = ({ gridInstance, taskInstance, group }: Props) => {
 
   return (
     <Box mt={3} flexGrow={1}>
-      {isTaskInstance && (
+      {isTaskInstance && !!taskInstance && (
         <TrySelector
-          taskId={taskId}
-          runId={runId}
-          mapIndex={mapIndex}
+          taskInstance={taskInstance}
           selectedTryNumber={selectedTryNumber || finalTryNumber}
           onSelectTryNumber={setSelectedTryNumber}
         />

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
@@ -28,6 +28,7 @@ import { useTimezone } from "src/context/timezone";
 import type { Dag, DagRun, TaskInstance } from "src/types";
 import MultiSelect from "src/components/MultiSelect";
 import URLSearchParamsWrapper from "src/utils/URLSearchParamWrapper";
+import { useTaskInstance } from "src/api";
 
 import LogLink from "./LogLink";
 import { LogLevel, logLevelColorMapping, parseLogs } from "./utils";
@@ -87,6 +88,13 @@ const Logs = ({
   >([]);
   const [unfoldedLogGroups, setUnfoldedLogGroup] = useState<Array<string>>([]);
   const { timezone } = useTimezone();
+
+  const { data: taskInstance } = useTaskInstance({
+    dagId,
+    dagRunId,
+    taskId: taskId || "",
+    mapIndex,
+  });
 
   const { data, isLoading } = useTaskLog({
     dagId,
@@ -162,13 +170,13 @@ const Logs = ({
         </Box>
       )}
       <Box>
-        <TrySelector
-          taskId={taskId}
-          runId={dagRunId}
-          mapIndex={mapIndex}
-          selectedTryNumber={selectedTryNumber}
-          onSelectTryNumber={setSelectedTryNumber}
-        />
+        {!!taskInstance && (
+          <TrySelector
+            taskInstance={taskInstance}
+            selectedTryNumber={selectedTryNumber}
+            onSelectTryNumber={setSelectedTryNumber}
+          />
+        )}
         <Flex my={1} justifyContent="space-between" flexWrap="wrap">
           <Flex alignItems="center" flexGrow={1} mr={10}>
             <Box width="100%" mr={2}>


### PR DESCRIPTION
- Fix clicking on a gantt chart bar to select that task instance
- Render the Try Buttons based on TI tryNumber first and then load information from task history. Therefore selecting a try is still possible even if the TI history endpoint is slow or not loading
- If there is no gantt end date, set it to 1 second in the future to improve auto-refresh ux
- Add animations to gantt row positions and width

![Jun-20-2024 15-19-48](https://github.com/apache/airflow/assets/4600967/d38383f7-0c35-4209-826d-f86f37e33878)


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
