### PR TITLE
openlineage: provide stack trace under proper key in error facet

### DIFF
--- a/airflow/providers/openlineage/plugins/adapter.py
+++ b/airflow/providers/openlineage/plugins/adapter.py
@@ -295,11 +295,17 @@ class OpenLineageAdapter(LoggingMixin):
         """
         error_facet = {}
         if error:
-            if isinstance(error, BaseException):
+            stack_trace = None
+            if isinstance(error, BaseException) and error.__traceback__:
                 import traceback
 
-                error = "\\n".join(traceback.format_exception(type(error), error, error.__traceback__))
-            error_facet = {"errorMessage": ErrorMessageRunFacet(message=error, programmingLanguage="python")}
+                stack_trace = "\\n".join(traceback.format_exception(type(error), error, error.__traceback__))
+
+            error_facet = {
+                "errorMessage": ErrorMessageRunFacet(
+                    message=str(error), programmingLanguage="python", stackTrace=stack_trace
+                )
+            }
 
         event = RunEvent(
             eventType=RunState.FAIL,

--- a/tests/providers/openlineage/plugins/test_adapter.py
+++ b/tests/providers/openlineage/plugins/test_adapter.py
@@ -457,6 +457,7 @@ def test_emit_failed_event_with_additional_information(mock_stats_incr, mock_sta
             run_facets={"externalQuery": ExternalQueryRunFacet(externalQueryId="123", source="source")},
             job_facets={"sql": SqlJobFacet(query="SELECT 1;")},
         ),
+        error=ValueError("Error message"),
     )
 
     assert (
@@ -476,6 +477,9 @@ def test_emit_failed_event_with_additional_information(mock_stats_incr, mock_sta
                             job={"namespace": namespace(), "name": "parent_job_name"},
                         ),
                         "externalQuery": ExternalQueryRunFacet(externalQueryId="123", source="source"),
+                        "errorMessage": ErrorMessageRunFacet(
+                            message="Error message", programmingLanguage="python", stackTrace=None
+                        ),
                     },
                 ),
                 job=Job(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

I misplaced the stacktrace when implementing it in #39813, it should be available under `stackTrace` and not `message`.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
