### PR TITLE
Fix create a local virtualenv example

### DIFF
--- a/contributing-docs/16_contribution_workflow.rst
+++ b/contributing-docs/16_contribution_workflow.rst
@@ -112,7 +112,7 @@ to make them immediately visible in the environment.
 
 .. code-block:: bash
 
-   mkvirtualenv myenv --python=python3.9
+   python3 -m venv venv && source venv/bin/activate
 
 5. Initialize the created environment:
 


### PR DESCRIPTION
Fixing the docs to make it work.
This is the suggested method from `./scripts/tools/initialize_virtualenv.py` which works

