### PR TITLE
add next_kwargs to StartTriggerArgs

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1606,15 +1606,15 @@ def _defer_task(
 
     if exception is not None:
         trigger_row = Trigger.from_object(exception.trigger)
-        trigger_kwargs = exception.kwargs
         next_method = exception.method_name
+        next_kwargs = exception.kwargs
         timeout = exception.timeout
     elif ti.task is not None and ti.task.start_trigger_args is not None:
         trigger_row = Trigger(
             classpath=ti.task.start_trigger_args.trigger_cls,
             kwargs=ti.task.start_trigger_args.trigger_kwargs or {},
         )
-        trigger_kwargs = ti.task.start_trigger_args.trigger_kwargs
+        next_kwargs = ti.task.start_trigger_args.next_kwargs
         next_method = ti.task.start_trigger_args.next_method
         timeout = ti.task.start_trigger_args.timeout
     else:
@@ -1635,7 +1635,7 @@ def _defer_task(
     ti.state = TaskInstanceState.DEFERRED
     ti.trigger_id = trigger_row.id
     ti.next_method = next_method
-    ti.next_kwargs = trigger_kwargs or {}
+    ti.next_kwargs = next_kwargs or {}
 
     # Calculate timeout too if it was passed
     if timeout is not None:

--- a/airflow/triggers/base.py
+++ b/airflow/triggers/base.py
@@ -31,6 +31,7 @@ class StartTriggerArgs:
     trigger_cls: str
     next_method: str
     trigger_kwargs: dict[str, Any] | None = None
+    next_kwargs: dict[str, Any] | None = None
     timeout: timedelta | None = None
 
     def serialize(self):
@@ -38,6 +39,7 @@ class StartTriggerArgs:
             "trigger_cls": self.trigger_cls,
             "trigger_kwargs": self.trigger_kwargs,
             "next_method": self.next_method,
+            "next_kwargs": self.next_kwargs,
             "timeout": self.timeout,
         }
 

--- a/docs/apache-airflow/authoring-and-scheduling/deferring.rst
+++ b/docs/apache-airflow/authoring-and-scheduling/deferring.rst
@@ -148,8 +148,9 @@ Triggering Deferral from Start
 If you want to defer your task directly to the triggerer without going into the worker, you can set class level attribute ``start_with_trigger`` to ``True`` and add a class level attribute ``start_trigger_args`` with an ``StartTriggerArgs`` object with the following 4 attributes to your deferrable operator:
 
 * ``trigger_cls``: An importable path to your trigger class.
-* ``trigger_kwargs``: Additional keyword arguments to pass to the method when it is called.
+* ``trigger_kwargs``: Keyword arguments to pass to the ``trigger_cls`` when it's initialized.
 * ``next_method``: The method name on your operator that you want Airflow to call when it resumes.
+* ``next_kwargs``: Additional keyword arguments to pass to the ``next_method`` when it is called.
 * ``timeout``: (Optional) A timedelta that specifies a timeout after which this deferral will fail, and fail the task instance. Defaults to ``None``, which means no timeout.
 
 
@@ -170,6 +171,7 @@ This is particularly useful when deferring is the only thing the ``execute`` met
             trigger_cls="airflow.triggers.temporal.TimeDeltaTrigger",
             trigger_kwargs={"moment": timedelta(hours=1)},
             next_method="execute_complete",
+            next_kwargs=None,
             timeout=None,
         )
         start_from_trigger = True
@@ -198,6 +200,7 @@ This is particularly useful when deferring is the only thing the ``execute`` met
             trigger_cls="airflow.triggers.temporal.TimeDeltaTrigger",
             trigger_kwargs={},
             next_method="execute_complete",
+            next_kwargs=None,
             timeout=None,
         )
 

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -2199,6 +2199,7 @@ class TestStringifiedDAGs:
                 trigger_cls="airflow.triggers.testing.SuccessTrigger",
                 trigger_kwargs=None,
                 next_method="execute_complete",
+                next_kwargs=None,
                 timeout=None,
             )
             start_from_trigger = False
@@ -2216,6 +2217,7 @@ class TestStringifiedDAGs:
                 trigger_cls="airflow.triggers.testing.SuccessTrigger",
                 trigger_kwargs={},
                 next_method="execute_complete",
+                next_kwargs=None,
                 timeout=None,
             )
             start_from_trigger = True
@@ -2239,6 +2241,7 @@ class TestStringifiedDAGs:
                 "trigger_cls": "airflow.triggers.testing.SuccessTrigger",
                 "trigger_kwargs": {},
                 "next_method": "execute_complete",
+                "next_kwargs": None,
                 "timeout": None,
             }
             assert task["__var"]["start_from_trigger"] is True


### PR DESCRIPTION
## Why
In https://github.com/apache/airflow/pull/39585/files#diff-62f7d8a52fefdb8e05d4f040c6d3459b4a56fe46976c24f68843dbaeb5a98487R1615, I accidentally assign the `trigger_kwargs` (for the trigger class initialization) to the `next_kwargs` (for the `next_method`) which will cause error.

## What
This PR introduce a new arg `next_kwargs` to `StartTriggerArgs` as this is missed in the previous PR

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
