### PR TITLE
Add on kill to ssh

### DIFF
--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -284,6 +284,7 @@ class SSHHook(BaseHook):
         cmd = self.host_proxy_cmd
         return paramiko.ProxyCommand(cmd) if cmd else None
 
+    @cached_property
     def get_conn(self) -> paramiko.SSHClient:
         """Establish an SSH connection to the remote host."""
         self.log.debug("Creating SSH client for conn_id: %s", self.ssh_conn_id)

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -301,7 +301,9 @@ class SSHHook(BaseHook):
                 client.load_system_host_keys()
 
             if self.no_host_key_check:
-                self.log.warning("No Host Key Verification. This won't protect against Man-In-The-Middle attacks")
+                self.log.warning(
+                    "No Host Key Verification. This won't protect against Man-In-The-Middle attacks"
+                )
                 client.set_missing_host_key_policy(paramiko.AutoAddPolicy())  # nosec B507
                 # to avoid BadHostKeyException, skip loading and saving host keys
                 known_hosts = os.path.expanduser("~/.ssh/known_hosts")

--- a/airflow/providers/ssh/operators/ssh.py
+++ b/airflow/providers/ssh/operators/ssh.py
@@ -193,7 +193,6 @@ class SSHOperator(BaseOperator):
         if not enable_pickling:
             result = b64encode(result).decode("utf-8")
 
-        self.on_kill()
         return result
 
     def tunnel(self) -> None:

--- a/airflow/providers/ssh/operators/ssh.py
+++ b/airflow/providers/ssh/operators/ssh.py
@@ -203,6 +203,9 @@ class SSHOperator(BaseOperator):
 
     def on_kill(self) -> None:
         """Close the ssh client session."""
-        ssh_client = self.hook.get_conn()
-        ssh_client.close()
-        self.log.info("SSH client closed.")
+        ssh_client = self.hook.client
+        if ssh_client:
+            ssh_client.close()
+            self.log.info("SSH client closed.")
+        else:
+            self.log.info("No SSH client to close.")

--- a/airflow/providers/ssh/operators/ssh.py
+++ b/airflow/providers/ssh/operators/ssh.py
@@ -192,6 +192,8 @@ class SSHOperator(BaseOperator):
         enable_pickling = conf.getboolean("core", "enable_xcom_pickling")
         if not enable_pickling:
             result = b64encode(result).decode("utf-8")
+
+        self.on_kill()
         return result
 
     def tunnel(self) -> None:

--- a/airflow/providers/ssh/operators/ssh.py
+++ b/airflow/providers/ssh/operators/ssh.py
@@ -198,3 +198,9 @@ class SSHOperator(BaseOperator):
         """Get ssh tunnel."""
         ssh_client = self.hook.get_conn()  # type: ignore[union-attr]
         ssh_client.get_transport()
+
+    def on_kill(self) -> None:
+        """Close the ssh client session."""
+        ssh_client = self.hook.get_conn()
+        ssh_client.close()
+        self.log.info("SSH client closed.")

--- a/tests/providers/amazon/aws/transfers/test_s3_to_sftp.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_sftp.py
@@ -124,6 +124,7 @@ class TestS3ToSFTPOperator:
         assert not s3_hook.check_for_bucket(self.s3_bucket)
 
     def delete_remote_resource(self):
+        # Initiate SHH hook
         hook = SSHHook(ssh_conn_id="ssh_default")
         hook.no_host_key_check = True
         # check the remote file content

--- a/tests/providers/amazon/aws/transfers/test_s3_to_sftp.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_sftp.py
@@ -124,10 +124,12 @@ class TestS3ToSFTPOperator:
         assert not s3_hook.check_for_bucket(self.s3_bucket)
 
     def delete_remote_resource(self):
+        hook = SSHHook(ssh_conn_id="ssh_default")
+        hook.no_host_key_check = True
         # check the remote file content
         remove_file_task = SSHOperator(
             task_id="test_rm_file",
-            ssh_hook=self.hook,
+            ssh_hook=hook,
             command=f"rm {self.sftp_path}",
             do_xcom_push=True,
             dag=self.dag,

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -1070,7 +1070,8 @@ class TestSSHHook:
         with mock.patch("os.path.isfile", return_value=False):
             # Reset ssh hook to initial state
             hook = SSHHook(
-                ssh_conn_id=self.CONN_SSH_WITH_NO_HOST_KEY_CHECK_TRUE_AND_ALLOW_HOST_KEY_CHANGES_FALSE)
+                ssh_conn_id=self.CONN_SSH_WITH_NO_HOST_KEY_CHECK_TRUE_AND_ALLOW_HOST_KEY_CHANGES_FALSE
+            )
             with hook.get_conn():
                 print("TESTS", ssh_mock.return_value)
                 assert ssh_mock.return_value.set_missing_host_key_policy.called is True

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -1068,7 +1068,11 @@ class TestSSHHook:
 
         ssh_mock.reset_mock()
         with mock.patch("os.path.isfile", return_value=False):
+            # Reset ssh hook to initial state
+            hook = SSHHook(
+                ssh_conn_id=self.CONN_SSH_WITH_NO_HOST_KEY_CHECK_TRUE_AND_ALLOW_HOST_KEY_CHANGES_FALSE)
             with hook.get_conn():
+                print("TESTS", ssh_mock.return_value)
                 assert ssh_mock.return_value.set_missing_host_key_policy.called is True
                 assert isinstance(
                     ssh_mock.return_value.set_missing_host_key_policy.call_args.args[0],

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -1073,7 +1073,6 @@ class TestSSHHook:
                 ssh_conn_id=self.CONN_SSH_WITH_NO_HOST_KEY_CHECK_TRUE_AND_ALLOW_HOST_KEY_CHANGES_FALSE
             )
             with hook.get_conn():
-                print("TESTS", ssh_mock.return_value)
                 assert ssh_mock.return_value.set_missing_host_key_policy.called is True
                 assert isinstance(
                     ssh_mock.return_value.set_missing_host_key_policy.call_args.args[0],

--- a/tests/providers/ssh/operators/test_ssh.py
+++ b/tests/providers/ssh/operators/test_ssh.py
@@ -199,7 +199,7 @@ class TestSSHOperator:
             command="ls",
         )
 
-        with mock.patch.object(task, "on_kill") as on_kill:
+        with mock.patch.object(task, "on_kill"):
             task.execute()
             task.on_kill.assert_called_once()
 

--- a/tests/providers/ssh/operators/test_ssh.py
+++ b/tests/providers/ssh/operators/test_ssh.py
@@ -266,3 +266,15 @@ class TestSSHOperator:
         with pytest.raises(AirflowException, match=f"SSH operator error: exit status = {ssh_exit_code}"):
             ti.run()
         assert ti.xcom_pull(task_ids=task.task_id, key="ssh_exit") == ssh_exit_code
+
+    def test_on_kill(self):
+        # Test that on_kill closes the connection
+        task = SSHOperator(
+            task_id="test",
+            ssh_hook=self.hook,
+            command="echo test",
+        )
+
+        task.on_kill()
+        self.hook.get_conn.assert_called_once()
+        self.hook.get_conn.return_value.close.assert_called_once()

--- a/tests/providers/ssh/operators/test_ssh.py
+++ b/tests/providers/ssh/operators/test_ssh.py
@@ -286,7 +286,7 @@ class TestSSHOperator:
         dr = dag_maker.create_dagrun(run_id="test_timeout")
         ti = TaskInstance(task=task, run_id=dr.run_id)
 
-        with mock.patch.object(SSHOperator, 'on_kill') as mock_on_kill:
+        with mock.patch.object(SSHOperator, "on_kill") as mock_on_kill:
             with pytest.raises(AirflowTaskTimeout):
                 ti.run()
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
This is my first contribution here, so still learning the codebase. The `SSHOperator` does not have on_kill method that can be used to close a connection when needed.  This PR adds a `on_kill` method to the `SSHOperator` class.

Not sure how extensive the changes should be. The new method should most likely be used in different parts of the codebase that the ssh hook is used.

closes: #40343 


<!-- Please keep an empty line above the dashes. -->
---