### PR TITLE
Adding version while releasing providers using prepare-provider-documentation

### DIFF
--- a/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
+++ b/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
@@ -683,7 +683,10 @@ def update_release_notes(
             if non_interactive:
                 answer = Answer.YES
             else:
-                answer = user_confirm(f"Provider {provider_package_id} marked for release. Proceed?")
+                provider_details = get_provider_details(provider_package_id)
+                current_release_version = provider_details.versions[0]
+                answer = user_confirm(f"Provider {provider_package_id} with "
+                                      f"version: {current_release_version} marked for release. Proceed?")
             if answer == Answer.NO:
                 get_console().print(
                     f"\n[warning]Skipping provider: {provider_package_id} on user request![/]\n"

--- a/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
+++ b/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
@@ -685,8 +685,10 @@ def update_release_notes(
             else:
                 provider_details = get_provider_details(provider_package_id)
                 current_release_version = provider_details.versions[0]
-                answer = user_confirm(f"Provider {provider_package_id} with "
-                                      f"version: {current_release_version} marked for release. Proceed?")
+                answer = user_confirm(
+                    f"Provider {provider_package_id} with "
+                    f"version: {current_release_version} marked for release. Proceed?"
+                )
             if answer == Answer.NO:
                 get_console().print(
                     f"\n[warning]Skipping provider: {provider_package_id} on user request![/]\n"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

While releasing providers, it is informative to have the version printed along with the interactive terminal under prepare-provider-documentation. Adding that change here.

It looks like this with the change now:
```
Provider amazon with version: 8.25.0 marked for release. Proceed?
Press y/N/q: y
Checking for backticks correctly generated in: /Users/adesai/Documents/OSS/airflow/docs/apache-airflow-providers-amazon/changelog.rst
Generated /Users/adesai/Documents/OSS/airflow/docs/apache-airflow-providers-amazon/changelog.rst for amazon is OK
Checking for backticks correctly generated in: /Users/adesai/Documents/OSS/airflow/docs/apache-airflow-providers-amazon/commits.rst
Generated /Users/adesai/Documents/OSS/airflow/docs/apache-airflow-providers-amazon/commits.rst for amazon is OK

Updates changelog for last release of package 'amazon'

New version of the 'amazon' package is ready to be released!

The provider amazon changelog for `8.25.0` has no new changes. Not updating the changelog.

Update index.rst for amazon



Summary of prepared documentation:

Success: 1

amazon


Successfully prepared documentation for packages!



Please review the updated files, classify the changelog entries and commit the changes
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
