### PR TITLE
fix(statsd): handle unsupport operand int + str when value of tag is not str

### DIFF
--- a/airflow/metrics/statsd_logger.py
+++ b/airflow/metrics/statsd_logger.py
@@ -55,7 +55,7 @@ def prepare_stat_with_tags(fn: T) -> T:
             if stat is not None and tags is not None:
                 for k, v in tags.items():
                     if self.metric_tags_validator.test(k):
-                        if all(c not in [",", "="] for c in v + k):
+                        if all(c not in [",", "="] for c in f"{v}{k}"):
                             stat += f",{k}={v}"
                         else:
                             log.error("Dropping invalid tag: %s=%s.", k, v)

--- a/tests/core/test_stats.py
+++ b/tests/core/test_stats.py
@@ -502,9 +502,9 @@ class TestStatsWithInfluxDBEnabled:
     def test_increment_counter_with_tags(self):
         self.stats.incr(
             "test_stats_run.delay",
-            tags={"key0": "val0", "key1": "val1", "key2": "val2"},
+            tags={"key0": 0, "key1": "val1", "key2": "val2"},
         )
-        self.statsd_client.incr.assert_called_once_with("test_stats_run.delay,key0=val0,key1=val1", 1, 1)
+        self.statsd_client.incr.assert_called_once_with("test_stats_run.delay,key0=0,key1=val1", 1, 1)
 
     def test_does_not_increment_counter_drops_invalid_tags(self):
         self.stats.incr(


### PR DESCRIPTION
Default case is expose metrics with job_id in tag at https://github.com/apache/airflow/blob/main/airflow/jobs/local_task_job_runner.py#L332