### PR TITLE
Support multiline input for Params of type string in trigger UI form

### DIFF
--- a/airflow/example_dags/example_params_ui_tutorial.py
+++ b/airflow/example_dags/example_params_ui_tutorial.py
@@ -165,6 +165,12 @@ with DAG(
             title="Time Picker",
             description="Please select a time, use the button on the left for a pop-up tool.",
         ),
+        "multiline_text": Param(
+            "A multiline text Param\nthat will keep the newline\ncharacters in its value.",
+            description="This field allows for multiline text input. The returned value will be a single with newline (\\n) characters kept intact.",
+            type=["string", "null"],
+            format="multiline",
+        ),
         # Fields can be required or not. If the defined fields are typed they are getting required by default
         # (else they would not pass JSON schema validation) - to make typed fields optional you must
         # permit the optional "null" type.

--- a/airflow/www/templates/airflow/trigger.html
+++ b/airflow/www/templates/airflow/trigger.html
@@ -127,13 +127,12 @@
         {%- if form_details.schema.minimum %} min="{{ form_details.schema.minimum }}"{% endif %}
         {%- if form_details.schema.maximum %} max="{{ form_details.schema.maximum }}"{% endif %}
         {%- if form_details.schema.type and not "null" in form_details.schema.type %} required=""{% endif %} />
-    {% elif form_details.schema and "string" in form_details.schema.type and "examples" in form_details.schema and "\n" in (form_details.schema.examples | join) %}
+    {% elif form_details.schema and "string" in form_details.schema.type and "format" in form_details.schema and form_details.schema.format == "multiline" %}
       <textarea class="form-control" name="element_{{ form_key }}" id="element_{{ form_key }}" rows="6"
         {%- if not "null" in form_details.schema.type %} required=""{% endif -%}
         {%- if form_details.schema and form_details.schema.minLength %} minlength="{{ form_details.schema.minLength }}"{% endif %}
-        {%- if form_details.schema and form_details.schema.maxLength %} maxlength="{{ form_details.schema.maxLength }}"{% endif %}>
-          {% if form_details.value %}{{ form_details.value }}{% endif %}
-      </textarea>
+        {%- if form_details.schema and form_details.schema.maxLength %} maxlength="{{ form_details.schema.maxLength }}"{% endif %}
+      >{% if form_details.value %}{{- form_details.value -}}{% endif %}</textarea>
     {% else %}
       <input class="form-control" name="element_{{ form_key }}" id="element_{{ form_key }}"
         type="{% if "examples" in form_details.schema and form_details.schema.examples %}search{% else %}text{% endif %}"

--- a/airflow/www/templates/airflow/trigger.html
+++ b/airflow/www/templates/airflow/trigger.html
@@ -127,6 +127,13 @@
         {%- if form_details.schema.minimum %} min="{{ form_details.schema.minimum }}"{% endif %}
         {%- if form_details.schema.maximum %} max="{{ form_details.schema.maximum }}"{% endif %}
         {%- if form_details.schema.type and not "null" in form_details.schema.type %} required=""{% endif %} />
+    {% elif form_details.schema and "string" in form_details.schema.type and "examples" in form_details.schema and "\n" in (form_details.schema.examples | join) %}
+      <textarea class="form-control" name="element_{{ form_key }}" id="element_{{ form_key }}" rows="6"
+        {%- if not "null" in form_details.schema.type %} required=""{% endif -%}
+        {%- if form_details.schema and form_details.schema.minLength %} minlength="{{ form_details.schema.minLength }}"{% endif %}
+        {%- if form_details.schema and form_details.schema.maxLength %} maxlength="{{ form_details.schema.maxLength }}"{% endif %}>
+          {% if form_details.value %}{{ form_details.value }}{% endif %}
+      </textarea>
     {% else %}
       <input class="form-control" name="element_{{ form_key }}" id="element_{{ form_key }}"
         type="{% if "examples" in form_details.schema and form_details.schema.examples %}search{% else %}text{% endif %}"

--- a/docs/apache-airflow/core-concepts/params.rst
+++ b/docs/apache-airflow/core-concepts/params.rst
@@ -232,7 +232,7 @@ The following features are supported in the Trigger UI Form:
           - Example
 
         * - ``string``
-          - Generates a single-line text box to edit text.
+          - Generates a single-line text box or a text area to edit text.
           - * ``minLength``: Minimum text length
             * ``maxLength``: Maximum text length
             * | ``format="date"``: Generate a date-picker
@@ -240,6 +240,7 @@ The following features are supported in the Trigger UI Form:
             * | ``format="date-time"``: Generate a date and
               | time-picker with calendar pop-up
             * ``format="time"``: Generate a time-picker
+            * ``format="multiline"``: Generate a multi-line textarea
             * | ``enum=["a", "b", "c"]``: Generates a
               | drop-down select list for scalar values.
               | As of JSON validation, a value must be


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
This patch adds the possibility to have a multiline input (textarea) for Params of type "string" in the trigger UI form. The choice between rendering a text input (single line) or a textarea (multiline) is based on the presence of a new line character in any of the examples of the Param.
For instance, the following code generates a multiline input:
```python
Param(
    description="a parameter that is rendered better with a textarea",
    type=["string", "null"],
    examples=["first line of text before\na new line"],
)
```

I know Params of type "array" are rendered as textareas but forcing our end-users to format their multiline text into an array of strings would not be very friendly :). So it seems more practical to leave the Param as a "string" type and work on the rendering options instead.

The patch is merely a PoC to showcase what the feature would look like and by no means a definitive solution. I think that relying on the `examples` attribute is more a hack than a solution, but adding a new explicit attribute to the Param object is beyond my understanding of Airflow. So feel free to rewrite it completely if you think the feature is worth it.