### PR TITLE
Kafka Operators - Add context to ConsumeFromTopicOperator's apply_function

### DIFF
--- a/airflow/providers/apache/kafka/operators/consume.py
+++ b/airflow/providers/apache/kafka/operators/consume.py
@@ -169,10 +169,10 @@ class ConsumeFromTopicOperator(BaseOperator):
 
             if self.apply_function:
                 for m in msgs:
-                    apply_callable(m)
+                    apply_callable(m, context=context)
 
             if self.apply_function_batch:
-                apply_callable(msgs)
+                apply_callable(msgs, context=context)
 
             if self.commit_cadence == "end_of_batch":
                 self.log.info("committing offset at %s", self.commit_cadence)

--- a/tests/integration/providers/apache/kafka/operators/test_consume.py
+++ b/tests/integration/providers/apache/kafka/operators/test_consume.py
@@ -43,7 +43,7 @@ def _batch_tester(messages, context, test_string=None):
         assert x.value().decode(encoding="utf-8") == test_string
 
 
-def _basic_message_tester(message,context, test=None) -> Any:
+def _basic_message_tester(message, context, test=None) -> Any:
     """a function that tests the message received"""
 
     assert test

--- a/tests/integration/providers/apache/kafka/operators/test_consume.py
+++ b/tests/integration/providers/apache/kafka/operators/test_consume.py
@@ -34,7 +34,7 @@ from airflow.utils import db
 log = logging.getLogger(__name__)
 
 
-def _batch_tester(messages, test_string=None):
+def _batch_tester(messages, context, test_string=None):
     assert test_string
     assert len(messages) == 10
 
@@ -43,7 +43,7 @@ def _batch_tester(messages, test_string=None):
         assert x.value().decode(encoding="utf-8") == test_string
 
 
-def _basic_message_tester(message, test=None) -> Any:
+def _basic_message_tester(message,context, test=None) -> Any:
     """a function that tests the message received"""
 
     assert test

--- a/tests/providers/apache/kafka/operators/test_consume.py
+++ b/tests/providers/apache/kafka/operators/test_consume.py
@@ -35,7 +35,7 @@ pytestmark = pytest.mark.db_test
 log = logging.getLogger(__name__)
 
 
-def _no_op(*args, **kwargs) -> Any:
+def _no_op(context, *args, **kwargs) -> Any:
     """no_op A function that returns its arguments
 
     :return: whatever was passed in


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
- Support passing AF context to `apply_function` when using `ConsumeFromTopicOperator`