### PR TITLE
Move import to make PythonOperator working on Windows

### DIFF
--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import fcntl
 import importlib
 import inspect
 import json
@@ -790,6 +789,8 @@ class PythonVirtualenvOperator(_BasePythonVirtualenvOperator):
         venv_path.parent.mkdir(parents=True, exist_ok=True)
         with open(f"{venv_path}.lock", "w") as f:
             # Ensure that cache is not build by parallel workers
+            import fcntl
+
             fcntl.flock(f, fcntl.LOCK_EX)
 
             hash_marker = venv_path / "install_complete_marker.json"


### PR DESCRIPTION
As I was testing the PoC for AIP-69 (#40224) for Windows compatability I saw some error beings raised because of problematic import of fnctl in Windows.
This is used (and was introduced by me) to lock exclusive access for virtualenv install. But other code is not affected. Therefore moved the import to the location where needed and... whoops. PoC with Windows was (almost) working.

This PR therefore does not enable Windows support but fixes one of the problems.

related: #10388
