### PR TITLE
fix BigQueryInsertJobOperator's return value and openlineage extraction in deferrable mode

### DIFF
--- a/airflow/providers/google/cloud/openlineage/mixins.py
+++ b/airflow/providers/google/cloud/openlineage/mixins.py
@@ -67,7 +67,17 @@ class _BigQueryOpenLineageMixin:
         from airflow.providers.openlineage.sqlparser import SQLParser
 
         if not self.job_id:
+            if hasattr(self, "log"):
+                self.log.warning("No BigQuery job_id was found by OpenLineage.")
             return OperatorLineage()
+
+        if not self.hook:
+            from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
+
+            self.hook = BigQueryHook(
+                gcp_conn_id=self.gcp_conn_id,
+                impersonation_chain=self.impersonation_chain,
+            )
 
         run_facets: dict[str, BaseFacet] = {
             "externalQuery": ExternalQueryRunFacet(externalQueryId=self.job_id, source="bigquery")

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -3038,6 +3038,8 @@ class BigQueryInsertJobOperator(GoogleCloudBaseOperator, _BigQueryOpenLineageMix
             self.task_id,
             event["message"],
         )
+        # Save job_id as an attribute to be later used by listeners
+        self.job_id = event.get("job_id")
         return self.job_id
 
     def on_kill(self) -> None:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
This PR fixes two things:
1. Return value of `BigQueryInsertJobOperator's` `execute_complete()` (so execution in deferrable mode) will now be an actual BQ job id instead of None. As described in [this](https://airflow.apache.org/docs/apache-airflow/stable/authoring-and-scheduling/deferring.html#triggering-deferral) docs, when deferring: `No state will persist, such as local variables or attributes set on self.`, so assigning value to self.job_id within `execute()` had no effect and was not actually used in `execute_complete()`.

2. We are re-assigning the job_id in `execute_complete()` as an instance attribute, so that we can later use it within OpenLineage method even when in deferrable mode. We are also re-creating any attributes (hook) that may be missing as a result of the state keeping logic mentioned above.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
