### PR TITLE
Support upper bound in provider dependencies

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/packages.py
+++ b/dev/breeze/src/airflow_breeze/utils/packages.py
@@ -418,6 +418,9 @@ def apply_version_suffix(install_clause: str, version_suffix: str) -> str:
         # `apache-airflow>=2.9.0.dev0` and not `apache-airflow>=2.9.0` because both packages are
         # released together and >= 2.9.0 is not correct reference for 2.9.0.dev0 version of Airflow.
         prefix, version = install_clause.split(">=")
+        # If version has a upper limit (e.g. ">=2.10.0,<3.0"), we need to cut this off not to fail
+        if "," in version:
+            version = version.split(",")[0]
         from packaging.version import Version
 
         base_version = Version(version).base_version
@@ -525,6 +528,9 @@ def get_min_airflow_version(provider_id: str) -> str:
     for dependency in provider_details.dependencies:
         if dependency.startswith("apache-airflow>="):
             current_min_airflow_version = dependency.split(">=")[1]
+            # If version has a upper limit (e.g. ">=2.10.0,<3.0"), we need to cut this off not to fail
+            if "," in current_min_airflow_version:
+                current_min_airflow_version = current_min_airflow_version.split(",")[0]
             if PackagingVersion(current_min_airflow_version) > PackagingVersion(MIN_AIRFLOW_VERSION):
                 min_airflow_version = current_min_airflow_version
     return min_airflow_version


### PR DESCRIPTION
Following the discussions in https://apache-airflow.slack.com/archives/C06K9Q5G2UA/p1719428745370839 this PR provides a fix for breeze and version handling logic if an upper limit version is defined.

Foud in AIP-69 PoC PR in https://github.com/apache/airflow/actions/runs/9668809749/job/26674145127?pr=40224 as the new provider remote attempted to define the dependency to airflow as `apache-airflow>=2.10.0,<3.0` as it will require Airflow 2.10 and it is assumed due to planned breaking changes it will not work with Airflow 3.0 anymore.

Note: Thought about a pytest but existing pytest depends on providers and did not want to make an artificial provider upper limit. Would offer to make a test in PR #40224

related: #40224
