### PR TITLE
Clean up dark mode

### DIFF
--- a/airflow/www/static/css/bootstrap-theme.css
+++ b/airflow/www/static/css/bootstrap-theme.css
@@ -39,14 +39,17 @@ html {
 html[data-color-scheme="dark"] {
   filter: invert(100%) hue-rotate(180deg);
 }
+
+/* Default icons to not display until the data-color-scheme has been set */
+#dark_icon,
+#light_icon {
+  display: none;
+}
 html[data-color-scheme="dark"] #dark_icon {
   display: block;
 }
 html[data-color-scheme="dark"] #light_icon {
   display: none;
-}
-html[data-color-scheme="light"] {
-  /* not do */
 }
 html[data-color-scheme="light"] #dark_icon {
   display: none;

--- a/airflow/www/static/js/toggle_theme.js
+++ b/airflow/www/static/js/toggle_theme.js
@@ -31,7 +31,7 @@ const updateTheme = (isDark) => {
 };
 const initTheme = () => {
   const isDark = getJsonFromStorage(STORAGE_THEME_KEY);
-  if (isDark !== null) updateTheme(isDark);
+  updateTheme(isDark);
 };
 const toggleTheme = () => {
   const isDark = getJsonFromStorage(STORAGE_THEME_KEY);

--- a/airflow/www/templates/appbuilder/navbar.html
+++ b/airflow/www/templates/appbuilder/navbar.html
@@ -51,7 +51,7 @@
       </ul>
       <ul class="nav navbar-nav navbar-right">
         <li class="active">
-          <div title="Experimental Dark Mode" aria-label="Experimental Dark Mode" style="padding: 20px; cursor: pointer" id="themeToggleButton">
+          <div title="Toggle Dark Mode (experimental)" aria-label="Toggle Dark Mode (experimental)" style="padding: 20px; cursor: pointer" id="themeToggleButton">
             <div id="dark_icon">
               <i class="fa-regular fa-moon fa-lg" id="themeToggleButton"></i>
             </div>


### PR DESCRIPTION
When localStorage wasn't set. Both dark and light icons could appear at the same time. Instead, they default to display none, until we run `initTheme()`

also, some code cleanup and copy changes

Before:
<img width="1038" alt="Screenshot 2024-06-27 at 2 48 20 PM" src="https://github.com/apache/airflow/assets/4600967/8b90d5c5-6b9a-4a70-9ae9-91f02247b208">

After:
<img width="1048" alt="Screenshot 2024-06-27 at 2 56 07 PM" src="https://github.com/apache/airflow/assets/4600967/f448c8ac-f9f2-4a47-8ed7-57d7c2ed5af2">



---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
