### PR TITLE
Make Databricks operators' json parameter compatible with XComs, Jinja expression values

### DIFF
--- a/airflow/providers/databricks/utils/databricks.py
+++ b/airflow/providers/databricks/utils/databricks.py
@@ -21,7 +21,7 @@ from airflow.exceptions import AirflowException
 from airflow.providers.databricks.hooks.databricks import RunState
 
 
-def normalise_json_content(content, json_path: str = "json") -> str | bool | list | dict:
+def _normalise_json_content(content, json_path: str = "json") -> str | bool | list | dict:
     """
     Normalize content or all values of content if it is a dict to a string.
 
@@ -33,7 +33,7 @@ def normalise_json_content(content, json_path: str = "json") -> str | bool | lis
     The only one exception is when we have boolean values, they can not be converted
     to string type because databricks does not understand 'True' or 'False' values.
     """
-    normalise = normalise_json_content
+    normalise = _normalise_json_content
     if isinstance(content, (str, bool)):
         return content
     elif isinstance(content, (int, float)):

--- a/tests/providers/databricks/operators/test_databricks.py
+++ b/tests/providers/databricks/operators/test_databricks.py
@@ -1246,7 +1246,7 @@ class TestDatabricksRunNowOperator:
     @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
     def test_validate_json_with_templated_json(self, db_mock_class, dag_maker):
         json = "{{ ti.xcom_pull(task_ids='push_json') }}"
-        with dag_maker("test_chime_notifier", render_template_as_native_obj=True) as dag:
+        with dag_maker("test_templated", render_template_as_native_obj=True) as dag:
             push_json = PythonOperator(
                 task_id="push_json",
                 python_callable=lambda: {

--- a/tests/providers/databricks/operators/test_databricks.py
+++ b/tests/providers/databricks/operators/test_databricks.py
@@ -1499,7 +1499,7 @@ class TestDatabricksRunNowOperator:
                     "job_id": JOB_ID,
                 },
             )
-            op = DatabricksRunNowOperator(dag=dag, task_id=TASK_ID, job_id=JOB_ID, json=json)
+            op = DatabricksRunNowOperator(task_id=TASK_ID, job_id=JOB_ID, json=json)
             push_json >> op
 
         db_mock = db_mock_class.return_value
@@ -1546,7 +1546,7 @@ class TestDatabricksRunNowOperator:
 
             json = push_json()
 
-            op = DatabricksRunNowOperator(dag=dag, task_id=TASK_ID, job_id=JOB_ID, json=json)
+            op = DatabricksRunNowOperator(task_id=TASK_ID, job_id=JOB_ID, json=json)
 
         db_mock = db_mock_class.return_value
         db_mock.run_now.return_value = RUN_ID

--- a/tests/providers/databricks/operators/test_databricks.py
+++ b/tests/providers/databricks/operators/test_databricks.py
@@ -979,7 +979,7 @@ class TestDatabricksSubmitRunOperator:
     @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
     def test_validate_json_with_templated_json(self, db_mock_class, dag_maker):
         json = "{{ ti.xcom_pull(task_ids='push_json') }}"
-        with dag_maker("test_templated", render_template_as_native_obj=True) as dag:
+        with dag_maker("test_templated", render_template_as_native_obj=True):
             push_json = PythonOperator(
                 task_id="push_json",
                 python_callable=lambda: {
@@ -1016,7 +1016,7 @@ class TestDatabricksSubmitRunOperator:
 
     @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
     def test_validate_json_with_xcomarg_json(self, db_mock_class, dag_maker):
-        with dag_maker("test_xcomarg", render_template_as_native_obj=True) as dag:
+        with dag_maker("test_xcomarg", render_template_as_native_obj=True):
 
             @task
             def push_json() -> dict:
@@ -1489,7 +1489,7 @@ class TestDatabricksRunNowOperator:
     @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
     def test_validate_json_with_templated_json(self, db_mock_class, dag_maker):
         json = "{{ ti.xcom_pull(task_ids='push_json') }}"
-        with dag_maker("test_templated", render_template_as_native_obj=True) as dag:
+        with dag_maker("test_templated", render_template_as_native_obj=True):
             push_json = PythonOperator(
                 task_id="push_json",
                 python_callable=lambda: {
@@ -1533,7 +1533,7 @@ class TestDatabricksRunNowOperator:
 
     @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
     def test_validate_json_with_xcomarg_json(self, db_mock_class, dag_maker):
-        with dag_maker("test_xcomarg", render_template_as_native_obj=True) as dag:
+        with dag_maker("test_xcomarg", render_template_as_native_obj=True):
 
             @task
             def push_json() -> dict[str, str]:

--- a/tests/providers/databricks/operators/test_databricks.py
+++ b/tests/providers/databricks/operators/test_databricks.py
@@ -589,66 +589,76 @@ class TestDatabricksCreateJobsOperator:
 
 
 class TestDatabricksSubmitRunOperator:
-    def test_init_with_notebook_task_named_parameters(self):
+    def test_validate_json_with_notebook_task_named_parameters(self):
         """
-        Test the initializer with the named parameters.
+        Test the _setup_and_validate_json function with named parameters.
         """
         op = DatabricksSubmitRunOperator(
             task_id=TASK_ID, new_cluster=NEW_CLUSTER, notebook_task=NOTEBOOK_TASK
         )
+        op._setup_and_validate_json()
+
         expected = utils.normalise_json_content(
             {"new_cluster": NEW_CLUSTER, "notebook_task": NOTEBOOK_TASK, "run_name": TASK_ID}
         )
 
         assert expected == utils.normalise_json_content(op.json)
 
-    def test_init_with_spark_python_task_named_parameters(self):
+    def test_validate_json_with_spark_python_task_named_parameters(self):
         """
-        Test the initializer with the named parameters.
+        Test the _setup_and_validate_json function with the named parameters.
         """
         op = DatabricksSubmitRunOperator(
             task_id=TASK_ID, new_cluster=NEW_CLUSTER, spark_python_task=SPARK_PYTHON_TASK
         )
+        op._setup_and_validate_json()
+
         expected = utils.normalise_json_content(
             {"new_cluster": NEW_CLUSTER, "spark_python_task": SPARK_PYTHON_TASK, "run_name": TASK_ID}
         )
 
         assert expected == utils.normalise_json_content(op.json)
 
-    def test_init_with_pipeline_name_task_named_parameters(self):
+    def test_validate_json_with_pipeline_name_task_named_parameters(self):
         """
-        Test the initializer with the named parameters.
+        Test the _setup_and_validate_json function with the named parameters.
         """
         op = DatabricksSubmitRunOperator(task_id=TASK_ID, pipeline_task=PIPELINE_NAME_TASK)
+        op._setup_and_validate_json()
+
         expected = utils.normalise_json_content({"pipeline_task": PIPELINE_NAME_TASK, "run_name": TASK_ID})
 
         assert expected == utils.normalise_json_content(op.json)
 
-    def test_init_with_pipeline_id_task_named_parameters(self):
+    def test_validate_json_with_pipeline_id_task_named_parameters(self):
         """
-        Test the initializer with the named parameters.
+        Test the _setup_and_validate_json function with the named parameters.
         """
         op = DatabricksSubmitRunOperator(task_id=TASK_ID, pipeline_task=PIPELINE_ID_TASK)
+        op._setup_and_validate_json()
+
         expected = utils.normalise_json_content({"pipeline_task": PIPELINE_ID_TASK, "run_name": TASK_ID})
 
         assert expected == utils.normalise_json_content(op.json)
 
-    def test_init_with_spark_submit_task_named_parameters(self):
+    def test_validate_json_with_spark_submit_task_named_parameters(self):
         """
-        Test the initializer with the named parameters.
+        Test the _setup_and_validate_json function with the named parameters.
         """
         op = DatabricksSubmitRunOperator(
             task_id=TASK_ID, new_cluster=NEW_CLUSTER, spark_submit_task=SPARK_SUBMIT_TASK
         )
+        op._setup_and_validate_json()
+
         expected = utils.normalise_json_content(
             {"new_cluster": NEW_CLUSTER, "spark_submit_task": SPARK_SUBMIT_TASK, "run_name": TASK_ID}
         )
 
         assert expected == utils.normalise_json_content(op.json)
 
-    def test_init_with_dbt_task_named_parameters(self):
+    def test_validate_json_with_dbt_task_named_parameters(self):
         """
-        Test the initializer with the named parameters.
+        Test the _setup_and_validate_json function with the named parameters.
         """
         git_source = {
             "git_url": "https://github.com/dbt-labs/jaffle_shop",
@@ -658,15 +668,17 @@ class TestDatabricksSubmitRunOperator:
         op = DatabricksSubmitRunOperator(
             task_id=TASK_ID, new_cluster=NEW_CLUSTER, dbt_task=DBT_TASK, git_source=git_source
         )
+        op._setup_and_validate_json()
+
         expected = utils.normalise_json_content(
             {"new_cluster": NEW_CLUSTER, "dbt_task": DBT_TASK, "git_source": git_source, "run_name": TASK_ID}
         )
 
         assert expected == utils.normalise_json_content(op.json)
 
-    def test_init_with_dbt_task_mixed_parameters(self):
+    def test_validate_json_with_dbt_task_mixed_parameters(self):
         """
-        Test the initializer with mixed parameters.
+        Test the _setup_and_validate_json function with mixed parameters.
         """
         git_source = {
             "git_url": "https://github.com/dbt-labs/jaffle_shop",
@@ -677,73 +689,85 @@ class TestDatabricksSubmitRunOperator:
         op = DatabricksSubmitRunOperator(
             task_id=TASK_ID, new_cluster=NEW_CLUSTER, dbt_task=DBT_TASK, json=json
         )
+        op._setup_and_validate_json()
+
         expected = utils.normalise_json_content(
             {"new_cluster": NEW_CLUSTER, "dbt_task": DBT_TASK, "git_source": git_source, "run_name": TASK_ID}
         )
 
         assert expected == utils.normalise_json_content(op.json)
 
-    def test_init_with_dbt_task_without_git_source_raises_error(self):
+    def test_validate_json_with_dbt_task_without_git_source_raises_error(self):
         """
-        Test the initializer without the necessary git_source for dbt_task raises error.
+        Test the _setup_and_validate_json function without the necessary git_source for dbt_task raises error.
         """
         exception_message = "git_source is required for dbt_task"
         with pytest.raises(AirflowException, match=exception_message):
-            DatabricksSubmitRunOperator(task_id=TASK_ID, new_cluster=NEW_CLUSTER, dbt_task=DBT_TASK)
+            DatabricksSubmitRunOperator(
+                task_id=TASK_ID, new_cluster=NEW_CLUSTER, dbt_task=DBT_TASK
+            )._setup_and_validate_json()
 
-    def test_init_with_dbt_task_json_without_git_source_raises_error(self):
+    def test_validate_json_with_dbt_task_json_without_git_source_raises_error(self):
         """
-        Test the initializer without the necessary git_source for dbt_task raises error.
+        Test the _setup_and_validate_json function without the necessary git_source for dbt_task raises error.
         """
         json = {"dbt_task": DBT_TASK, "new_cluster": NEW_CLUSTER}
 
         exception_message = "git_source is required for dbt_task"
         with pytest.raises(AirflowException, match=exception_message):
-            DatabricksSubmitRunOperator(task_id=TASK_ID, json=json)
+            DatabricksSubmitRunOperator(task_id=TASK_ID, json=json)._setup_and_validate_json()
 
-    def test_init_with_json(self):
+    def test_validate_json_with_json(self):
         """
-        Test the initializer with json data.
+        Test the _setup_and_validate_json function with json data.
         """
         json = {"new_cluster": NEW_CLUSTER, "notebook_task": NOTEBOOK_TASK}
         op = DatabricksSubmitRunOperator(task_id=TASK_ID, json=json)
+        op._setup_and_validate_json()
+
         expected = utils.normalise_json_content(
             {"new_cluster": NEW_CLUSTER, "notebook_task": NOTEBOOK_TASK, "run_name": TASK_ID}
         )
         assert expected == utils.normalise_json_content(op.json)
 
-    def test_init_with_tasks(self):
+    def test_validate_json_with_tasks(self):
         tasks = [{"task_key": 1, "new_cluster": NEW_CLUSTER, "notebook_task": NOTEBOOK_TASK}]
         op = DatabricksSubmitRunOperator(task_id=TASK_ID, tasks=tasks)
+        op._setup_and_validate_json()
+
         expected = utils.normalise_json_content({"run_name": TASK_ID, "tasks": tasks})
         assert expected == utils.normalise_json_content(op.json)
 
-    def test_init_with_specified_run_name(self):
+    def test_validate_json_with_specified_run_name(self):
         """
-        Test the initializer with a specified run_name.
+        Test the _setup_and_validate_json function with a specified run_name.
         """
         json = {"new_cluster": NEW_CLUSTER, "notebook_task": NOTEBOOK_TASK, "run_name": RUN_NAME}
         op = DatabricksSubmitRunOperator(task_id=TASK_ID, json=json)
+        op._setup_and_validate_json()
+
         expected = utils.normalise_json_content(
             {"new_cluster": NEW_CLUSTER, "notebook_task": NOTEBOOK_TASK, "run_name": RUN_NAME}
         )
         assert expected == utils.normalise_json_content(op.json)
 
-    def test_pipeline_task(self):
+    def test_validate_json_with_pipeline_task(self):
         """
-        Test the initializer with a pipeline task.
+        Test the _setup_and_validate_json function with a pipeline task.
         """
         pipeline_task = {"pipeline_id": "test-dlt"}
         json = {"new_cluster": NEW_CLUSTER, "run_name": RUN_NAME, "pipeline_task": pipeline_task}
         op = DatabricksSubmitRunOperator(task_id=TASK_ID, json=json)
+        op._setup_and_validate_json()
+
         expected = utils.normalise_json_content(
             {"new_cluster": NEW_CLUSTER, "pipeline_task": pipeline_task, "run_name": RUN_NAME}
         )
         assert expected == utils.normalise_json_content(op.json)
 
-    def test_init_with_merging(self):
+    def test_validate_json_with_merging(self):
         """
-        Test the initializer when json and other named parameters are both
+        Test the _setup_and_validate_json function when json and other named parameters are both
         provided. The named parameters should override top level keys in the
         json dict.
         """
@@ -753,6 +777,8 @@ class TestDatabricksSubmitRunOperator:
             "notebook_task": NOTEBOOK_TASK,
         }
         op = DatabricksSubmitRunOperator(task_id=TASK_ID, json=json, new_cluster=override_new_cluster)
+        op._setup_and_validate_json()
+
         expected = utils.normalise_json_content(
             {
                 "new_cluster": override_new_cluster,
@@ -763,13 +789,15 @@ class TestDatabricksSubmitRunOperator:
         assert expected == utils.normalise_json_content(op.json)
 
     @pytest.mark.db_test
-    def test_init_with_templating(self):
+    def test_validate_json_with_templating(self):
         json = {
             "new_cluster": NEW_CLUSTER,
             "notebook_task": TEMPLATED_NOTEBOOK_TASK,
         }
         dag = DAG("test", start_date=datetime.now())
         op = DatabricksSubmitRunOperator(dag=dag, task_id=TASK_ID, json=json)
+        op._setup_and_validate_json()
+
         op.render_template_fields(context={"ds": DATE})
         expected = utils.normalise_json_content(
             {
@@ -780,7 +808,7 @@ class TestDatabricksSubmitRunOperator:
         )
         assert expected == utils.normalise_json_content(op.json)
 
-    def test_init_with_git_source(self):
+    def test_validate_json_with_git_source(self):
         json = {"new_cluster": NEW_CLUSTER, "notebook_task": NOTEBOOK_TASK, "run_name": RUN_NAME}
         git_source = {
             "git_url": "https://github.com/apache/airflow",
@@ -788,6 +816,8 @@ class TestDatabricksSubmitRunOperator:
             "git_branch": "main",
         }
         op = DatabricksSubmitRunOperator(task_id=TASK_ID, git_source=git_source, json=json)
+        op._setup_and_validate_json()
+
         expected = utils.normalise_json_content(
             {
                 "new_cluster": NEW_CLUSTER,
@@ -798,16 +828,91 @@ class TestDatabricksSubmitRunOperator:
         )
         assert expected == utils.normalise_json_content(op.json)
 
-    def test_init_with_bad_type(self):
+    def test_validate_json_with_bad_type(self):
         json = {"test": datetime.now()}
-        op = DatabricksSubmitRunOperator(task_id=TASK_ID, json=json)
         # Looks a bit weird since we have to escape regex reserved symbols.
         exception_message = (
             r"Type \<(type|class) \'datetime.datetime\'\> used "
             r"for parameter json\[test\] is not a number or a string"
         )
         with pytest.raises(AirflowException, match=exception_message):
-            utils.normalise_json_content(op.json)
+            DatabricksSubmitRunOperator(task_id=TASK_ID, json=json)._setup_and_validate_json()
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_validate_json_with_templated_json(self, db_mock_class, dag_maker):
+        json = "{{ ti.xcom_pull(task_ids='push_json') }}"
+        with dag_maker("test_templated", render_template_as_native_obj=True) as dag:
+            push_json = PythonOperator(
+                task_id="push_json",
+                python_callable=lambda: {
+                    "new_cluster": NEW_CLUSTER,
+                    "notebook_task": NOTEBOOK_TASK,
+                },
+            )
+            op = DatabricksSubmitRunOperator(task_id=TASK_ID, json=json)
+            push_json >> op
+
+        db_mock = db_mock_class.return_value
+        db_mock.submit_run.return_value = RUN_ID
+        db_mock.get_run = make_run_with_state_mock("TERMINATED", "SUCCESS")
+
+        dagrun = dag_maker.create_dagrun(execution_date=timezone.utcnow())
+        tis = {ti.task_id: ti for ti in dagrun.task_instances}
+        tis["push_json"].run()
+        tis[TASK_ID].run()
+
+        expected = utils.normalise_json_content(
+            {"new_cluster": NEW_CLUSTER, "notebook_task": NOTEBOOK_TASK, "run_name": TASK_ID}
+        )
+        db_mock_class.assert_called_once_with(
+            DEFAULT_CONN_ID,
+            retry_limit=op.databricks_retry_limit,
+            retry_delay=op.databricks_retry_delay,
+            retry_args=None,
+            caller="DatabricksSubmitRunOperator",
+        )
+
+        db_mock.submit_run.assert_called_once_with(expected)
+        db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
+        db_mock.get_run.assert_called_once_with(RUN_ID)
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_validate_json_with_xcomarg_json(self, db_mock_class, dag_maker):
+        with dag_maker("test_xcomarg", render_template_as_native_obj=True) as dag:
+
+            @task
+            def push_json() -> dict:
+                return {
+                    "new_cluster": NEW_CLUSTER,
+                    "notebook_task": NOTEBOOK_TASK,
+                }
+
+            json = push_json()
+
+            op = DatabricksSubmitRunOperator(task_id=TASK_ID, json=json)
+        db_mock = db_mock_class.return_value
+        db_mock.submit_run.return_value = RUN_ID
+        db_mock.get_run = make_run_with_state_mock("TERMINATED", "SUCCESS")
+
+        dagrun = dag_maker.create_dagrun(execution_date=timezone.utcnow())
+        tis = {ti.task_id: ti for ti in dagrun.task_instances}
+        tis["push_json"].run()
+        tis[TASK_ID].run()
+
+        expected = utils.normalise_json_content(
+            {"new_cluster": NEW_CLUSTER, "notebook_task": NOTEBOOK_TASK, "run_name": TASK_ID}
+        )
+        db_mock_class.assert_called_once_with(
+            DEFAULT_CONN_ID,
+            retry_limit=op.databricks_retry_limit,
+            retry_delay=op.databricks_retry_delay,
+            retry_args=None,
+            caller="DatabricksSubmitRunOperator",
+        )
+
+        db_mock.submit_run.assert_called_once_with(expected)
+        db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
+        db_mock.get_run.assert_called_once_with(RUN_ID)
 
     @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
     def test_exec_success(self, db_mock_class):

--- a/tests/providers/databricks/operators/test_databricks.py
+++ b/tests/providers/databricks/operators/test_databricks.py
@@ -271,7 +271,7 @@ class TestDatabricksCreateJobsOperator:
         )
         op._setup_and_validate_json()
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {
                 "name": JOB_NAME,
                 "tags": TAGS,
@@ -309,7 +309,7 @@ class TestDatabricksCreateJobsOperator:
         op = DatabricksCreateJobsOperator(task_id=TASK_ID, json=json)
         op._setup_and_validate_json()
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {
                 "name": JOB_NAME,
                 "tags": TAGS,
@@ -375,7 +375,7 @@ class TestDatabricksCreateJobsOperator:
         )
         op._setup_and_validate_json()
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {
                 "name": override_name,
                 "tags": override_tags,
@@ -401,7 +401,7 @@ class TestDatabricksCreateJobsOperator:
         op.render_template_fields(context={"ds": DATE})
         op._setup_and_validate_json()
 
-        expected = utils.normalise_json_content({"name": f"test-{DATE}"})
+        expected = utils._normalise_json_content({"name": f"test-{DATE}"})
         assert expected == op.json
 
     def test_validate_json_with_bad_type(self):
@@ -455,7 +455,7 @@ class TestDatabricksCreateJobsOperator:
         tis["push_json"].run()
         tis[TASK_ID].run()
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {
                 "name": JOB_NAME,
                 "description": JOB_DESCRIPTION,
@@ -518,7 +518,7 @@ class TestDatabricksCreateJobsOperator:
         tis["push_json"].run()
         tis[TASK_ID].run()
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {
                 "name": JOB_NAME,
                 "description": JOB_DESCRIPTION,
@@ -574,7 +574,7 @@ class TestDatabricksCreateJobsOperator:
 
         return_result = op.execute({})
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {
                 "name": JOB_NAME,
                 "description": JOB_DESCRIPTION,
@@ -628,7 +628,7 @@ class TestDatabricksCreateJobsOperator:
 
         return_result = op.execute({})
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {
                 "name": JOB_NAME,
                 "description": JOB_DESCRIPTION,
@@ -680,7 +680,7 @@ class TestDatabricksCreateJobsOperator:
 
         op.execute({})
 
-        expected = utils.normalise_json_content({"access_control_list": ACCESS_CONTROL_LIST})
+        expected = utils._normalise_json_content({"access_control_list": ACCESS_CONTROL_LIST})
 
         db_mock_class.assert_called_once_with(
             DEFAULT_CONN_ID,
@@ -736,11 +736,11 @@ class TestDatabricksSubmitRunOperator:
         )
         op._setup_and_validate_json()
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {"new_cluster": NEW_CLUSTER, "notebook_task": NOTEBOOK_TASK, "run_name": TASK_ID}
         )
 
-        assert expected == utils.normalise_json_content(op.json)
+        assert expected == utils._normalise_json_content(op.json)
 
     def test_validate_json_with_spark_python_task_named_parameters(self):
         """
@@ -751,11 +751,11 @@ class TestDatabricksSubmitRunOperator:
         )
         op._setup_and_validate_json()
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {"new_cluster": NEW_CLUSTER, "spark_python_task": SPARK_PYTHON_TASK, "run_name": TASK_ID}
         )
 
-        assert expected == utils.normalise_json_content(op.json)
+        assert expected == utils._normalise_json_content(op.json)
 
     def test_validate_json_with_pipeline_name_task_named_parameters(self):
         """
@@ -764,9 +764,9 @@ class TestDatabricksSubmitRunOperator:
         op = DatabricksSubmitRunOperator(task_id=TASK_ID, pipeline_task=PIPELINE_NAME_TASK)
         op._setup_and_validate_json()
 
-        expected = utils.normalise_json_content({"pipeline_task": PIPELINE_NAME_TASK, "run_name": TASK_ID})
+        expected = utils._normalise_json_content({"pipeline_task": PIPELINE_NAME_TASK, "run_name": TASK_ID})
 
-        assert expected == utils.normalise_json_content(op.json)
+        assert expected == utils._normalise_json_content(op.json)
 
     def test_validate_json_with_pipeline_id_task_named_parameters(self):
         """
@@ -775,9 +775,9 @@ class TestDatabricksSubmitRunOperator:
         op = DatabricksSubmitRunOperator(task_id=TASK_ID, pipeline_task=PIPELINE_ID_TASK)
         op._setup_and_validate_json()
 
-        expected = utils.normalise_json_content({"pipeline_task": PIPELINE_ID_TASK, "run_name": TASK_ID})
+        expected = utils._normalise_json_content({"pipeline_task": PIPELINE_ID_TASK, "run_name": TASK_ID})
 
-        assert expected == utils.normalise_json_content(op.json)
+        assert expected == utils._normalise_json_content(op.json)
 
     def test_validate_json_with_spark_submit_task_named_parameters(self):
         """
@@ -788,11 +788,11 @@ class TestDatabricksSubmitRunOperator:
         )
         op._setup_and_validate_json()
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {"new_cluster": NEW_CLUSTER, "spark_submit_task": SPARK_SUBMIT_TASK, "run_name": TASK_ID}
         )
 
-        assert expected == utils.normalise_json_content(op.json)
+        assert expected == utils._normalise_json_content(op.json)
 
     def test_validate_json_with_dbt_task_named_parameters(self):
         """
@@ -808,11 +808,11 @@ class TestDatabricksSubmitRunOperator:
         )
         op._setup_and_validate_json()
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {"new_cluster": NEW_CLUSTER, "dbt_task": DBT_TASK, "git_source": git_source, "run_name": TASK_ID}
         )
 
-        assert expected == utils.normalise_json_content(op.json)
+        assert expected == utils._normalise_json_content(op.json)
 
     def test_validate_json_with_dbt_task_mixed_parameters(self):
         """
@@ -829,11 +829,11 @@ class TestDatabricksSubmitRunOperator:
         )
         op._setup_and_validate_json()
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {"new_cluster": NEW_CLUSTER, "dbt_task": DBT_TASK, "git_source": git_source, "run_name": TASK_ID}
         )
 
-        assert expected == utils.normalise_json_content(op.json)
+        assert expected == utils._normalise_json_content(op.json)
 
     def test_validate_json_with_dbt_task_without_git_source_raises_error(self):
         """
@@ -863,18 +863,18 @@ class TestDatabricksSubmitRunOperator:
         op = DatabricksSubmitRunOperator(task_id=TASK_ID, json=json)
         op._setup_and_validate_json()
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {"new_cluster": NEW_CLUSTER, "notebook_task": NOTEBOOK_TASK, "run_name": TASK_ID}
         )
-        assert expected == utils.normalise_json_content(op.json)
+        assert expected == utils._normalise_json_content(op.json)
 
     def test_validate_json_with_tasks(self):
         tasks = [{"task_key": 1, "new_cluster": NEW_CLUSTER, "notebook_task": NOTEBOOK_TASK}]
         op = DatabricksSubmitRunOperator(task_id=TASK_ID, tasks=tasks)
         op._setup_and_validate_json()
 
-        expected = utils.normalise_json_content({"run_name": TASK_ID, "tasks": tasks})
-        assert expected == utils.normalise_json_content(op.json)
+        expected = utils._normalise_json_content({"run_name": TASK_ID, "tasks": tasks})
+        assert expected == utils._normalise_json_content(op.json)
 
     def test_validate_json_with_specified_run_name(self):
         """
@@ -884,10 +884,10 @@ class TestDatabricksSubmitRunOperator:
         op = DatabricksSubmitRunOperator(task_id=TASK_ID, json=json)
         op._setup_and_validate_json()
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {"new_cluster": NEW_CLUSTER, "notebook_task": NOTEBOOK_TASK, "run_name": RUN_NAME}
         )
-        assert expected == utils.normalise_json_content(op.json)
+        assert expected == utils._normalise_json_content(op.json)
 
     def test_validate_json_with_pipeline_task(self):
         """
@@ -898,10 +898,10 @@ class TestDatabricksSubmitRunOperator:
         op = DatabricksSubmitRunOperator(task_id=TASK_ID, json=json)
         op._setup_and_validate_json()
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {"new_cluster": NEW_CLUSTER, "pipeline_task": pipeline_task, "run_name": RUN_NAME}
         )
-        assert expected == utils.normalise_json_content(op.json)
+        assert expected == utils._normalise_json_content(op.json)
 
     def test_validate_json_with_merging(self):
         """
@@ -917,14 +917,14 @@ class TestDatabricksSubmitRunOperator:
         op = DatabricksSubmitRunOperator(task_id=TASK_ID, json=json, new_cluster=override_new_cluster)
         op._setup_and_validate_json()
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {
                 "new_cluster": override_new_cluster,
                 "notebook_task": NOTEBOOK_TASK,
                 "run_name": TASK_ID,
             }
         )
-        assert expected == utils.normalise_json_content(op.json)
+        assert expected == utils._normalise_json_content(op.json)
 
     @pytest.mark.db_test
     def test_validate_json_with_templating(self):
@@ -937,14 +937,14 @@ class TestDatabricksSubmitRunOperator:
         op._setup_and_validate_json()
 
         op.render_template_fields(context={"ds": DATE})
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {
                 "new_cluster": NEW_CLUSTER,
                 "notebook_task": RENDERED_TEMPLATED_NOTEBOOK_TASK,
                 "run_name": TASK_ID,
             }
         )
-        assert expected == utils.normalise_json_content(op.json)
+        assert expected == utils._normalise_json_content(op.json)
 
     def test_validate_json_with_git_source(self):
         json = {"new_cluster": NEW_CLUSTER, "notebook_task": NOTEBOOK_TASK, "run_name": RUN_NAME}
@@ -956,7 +956,7 @@ class TestDatabricksSubmitRunOperator:
         op = DatabricksSubmitRunOperator(task_id=TASK_ID, git_source=git_source, json=json)
         op._setup_and_validate_json()
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {
                 "new_cluster": NEW_CLUSTER,
                 "notebook_task": NOTEBOOK_TASK,
@@ -964,7 +964,7 @@ class TestDatabricksSubmitRunOperator:
                 "git_source": git_source,
             }
         )
-        assert expected == utils.normalise_json_content(op.json)
+        assert expected == utils._normalise_json_content(op.json)
 
     def test_validate_json_with_bad_type(self):
         json = {"test": datetime.now()}
@@ -1000,7 +1000,7 @@ class TestDatabricksSubmitRunOperator:
         tis["push_json"].run()
         tis[TASK_ID].run()
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {"new_cluster": NEW_CLUSTER, "notebook_task": NOTEBOOK_TASK, "run_name": TASK_ID}
         )
         db_mock_class.assert_called_once_with(
@@ -1039,7 +1039,7 @@ class TestDatabricksSubmitRunOperator:
         tis["push_json"].run()
         tis[TASK_ID].run()
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {"new_cluster": NEW_CLUSTER, "notebook_task": NOTEBOOK_TASK, "run_name": TASK_ID}
         )
         db_mock_class.assert_called_once_with(
@@ -1070,7 +1070,7 @@ class TestDatabricksSubmitRunOperator:
 
         op.execute(None)
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {"new_cluster": NEW_CLUSTER, "notebook_task": NOTEBOOK_TASK, "run_name": TASK_ID}
         )
         db_mock_class.assert_called_once_with(
@@ -1100,7 +1100,7 @@ class TestDatabricksSubmitRunOperator:
 
         op.execute(None)
 
-        expected = utils.normalise_json_content({"pipeline_task": PIPELINE_ID_TASK, "run_name": TASK_ID})
+        expected = utils._normalise_json_content({"pipeline_task": PIPELINE_ID_TASK, "run_name": TASK_ID})
         db_mock_class.assert_called_once_with(
             DEFAULT_CONN_ID,
             retry_limit=op.databricks_retry_limit,
@@ -1132,7 +1132,7 @@ class TestDatabricksSubmitRunOperator:
         with pytest.raises(AirflowException):
             op.execute(None)
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {
                 "new_cluster": NEW_CLUSTER,
                 "notebook_task": NOTEBOOK_TASK,
@@ -1180,7 +1180,7 @@ class TestDatabricksSubmitRunOperator:
 
         op.execute(None)
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {"new_cluster": NEW_CLUSTER, "notebook_task": NOTEBOOK_TASK, "run_name": TASK_ID}
         )
         db_mock_class.assert_called_once_with(
@@ -1209,7 +1209,7 @@ class TestDatabricksSubmitRunOperator:
 
         op.execute(None)
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {"new_cluster": NEW_CLUSTER, "notebook_task": NOTEBOOK_TASK, "run_name": TASK_ID}
         )
         db_mock_class.assert_called_once_with(
@@ -1243,7 +1243,7 @@ class TestDatabricksSubmitRunOperator:
         assert isinstance(exc.value.trigger, DatabricksExecutionTrigger)
         assert exc.value.method_name == "execute_complete"
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {"new_cluster": NEW_CLUSTER, "notebook_task": NOTEBOOK_TASK, "run_name": TASK_ID}
         )
         db_mock_class.assert_called_once_with(
@@ -1325,7 +1325,7 @@ class TestDatabricksSubmitRunOperator:
         db_mock.get_run = make_run_with_state_mock("TERMINATED", "FAILED")
         op.execute(None)
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {"new_cluster": NEW_CLUSTER, "notebook_task": NOTEBOOK_TASK, "run_name": TASK_ID}
         )
         db_mock_class.assert_called_once_with(
@@ -1355,7 +1355,7 @@ class TestDatabricksSubmitRunOperator:
         db_mock.get_run = make_run_with_state_mock("TERMINATED", "SUCCESS")
         op.execute(None)
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {"new_cluster": NEW_CLUSTER, "notebook_task": NOTEBOOK_TASK, "run_name": TASK_ID}
         )
         db_mock_class.assert_called_once_with(
@@ -1380,7 +1380,7 @@ class TestDatabricksRunNowOperator:
         op = DatabricksRunNowOperator(job_id=JOB_ID, task_id=TASK_ID)
         op._setup_and_validate_json()
 
-        expected = utils.normalise_json_content({"job_id": 42})
+        expected = utils._normalise_json_content({"job_id": 42})
 
         assert expected == op.json
 
@@ -1399,7 +1399,7 @@ class TestDatabricksRunNowOperator:
         op = DatabricksRunNowOperator(task_id=TASK_ID, json=json)
         op._setup_and_validate_json()
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {
                 "notebook_params": NOTEBOOK_PARAMS,
                 "jar_params": JAR_PARAMS,
@@ -1433,7 +1433,7 @@ class TestDatabricksRunNowOperator:
         )
         op._setup_and_validate_json()
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {
                 "notebook_params": override_notebook_params,
                 "jar_params": override_jar_params,
@@ -1453,7 +1453,7 @@ class TestDatabricksRunNowOperator:
         op = DatabricksRunNowOperator(dag=dag, task_id=TASK_ID, job_id=JOB_ID, json=json)
         op.render_template_fields(context={"ds": DATE})
         op._setup_and_validate_json()
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {
                 "notebook_params": NOTEBOOK_PARAMS,
                 "jar_params": RENDERED_TEMPLATED_JAR_PARAMS,
@@ -1514,7 +1514,7 @@ class TestDatabricksRunNowOperator:
         tis["push_json"].run()
         tis[TASK_ID].run()
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {
                 "notebook_params": NOTEBOOK_PARAMS,
                 "notebook_task": NOTEBOOK_TASK,
@@ -1561,7 +1561,7 @@ class TestDatabricksRunNowOperator:
         tis["push_json"].run()
         tis[TASK_ID].run()
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {
                 "notebook_params": NOTEBOOK_PARAMS,
                 "notebook_task": NOTEBOOK_TASK,
@@ -1594,7 +1594,7 @@ class TestDatabricksRunNowOperator:
 
         op.execute(None)
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {
                 "notebook_params": NOTEBOOK_PARAMS,
                 "notebook_task": NOTEBOOK_TASK,
@@ -1629,7 +1629,7 @@ class TestDatabricksRunNowOperator:
         with pytest.raises(AirflowException):
             op.execute(None)
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {
                 "notebook_params": NOTEBOOK_PARAMS,
                 "notebook_task": NOTEBOOK_TASK,
@@ -1685,7 +1685,7 @@ class TestDatabricksRunNowOperator:
         with pytest.raises(AirflowException, match="Exception: Something went wrong"):
             op.execute(None)
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {
                 "notebook_params": NOTEBOOK_PARAMS,
                 "notebook_task": NOTEBOOK_TASK,
@@ -1753,7 +1753,7 @@ class TestDatabricksRunNowOperator:
         ):
             op.execute(None)
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {
                 "notebook_params": NOTEBOOK_PARAMS,
                 "notebook_task": NOTEBOOK_TASK,
@@ -1797,7 +1797,7 @@ class TestDatabricksRunNowOperator:
 
         op.execute(None)
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {
                 "notebook_params": NOTEBOOK_PARAMS,
                 "notebook_task": NOTEBOOK_TASK,
@@ -1828,7 +1828,7 @@ class TestDatabricksRunNowOperator:
 
         op.execute(None)
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {
                 "notebook_params": NOTEBOOK_PARAMS,
                 "notebook_task": NOTEBOOK_TASK,
@@ -1859,7 +1859,7 @@ class TestDatabricksRunNowOperator:
 
         op.execute(None)
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {
                 "notebook_params": NOTEBOOK_PARAMS,
                 "notebook_task": NOTEBOOK_TASK,
@@ -1907,7 +1907,7 @@ class TestDatabricksRunNowOperator:
 
         op.execute(None)
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {
                 "notebook_params": NOTEBOOK_PARAMS,
                 "notebook_task": NOTEBOOK_TASK,
@@ -1941,7 +1941,7 @@ class TestDatabricksRunNowOperator:
 
         op.execute(None)
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {
                 "notebook_params": NOTEBOOK_PARAMS,
                 "notebook_task": NOTEBOOK_TASK,
@@ -1978,7 +1978,7 @@ class TestDatabricksRunNowOperator:
         assert isinstance(exc.value.trigger, DatabricksExecutionTrigger)
         assert exc.value.method_name == "execute_complete"
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {
                 "notebook_params": NOTEBOOK_PARAMS,
                 "notebook_task": NOTEBOOK_TASK,
@@ -2088,7 +2088,7 @@ class TestDatabricksRunNowOperator:
         db_mock.get_run = make_run_with_state_mock("TERMINATED", "FAILED")
 
         op.execute(None)
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {
                 "notebook_params": NOTEBOOK_PARAMS,
                 "notebook_task": NOTEBOOK_TASK,
@@ -2122,7 +2122,7 @@ class TestDatabricksRunNowOperator:
 
         op.execute(None)
 
-        expected = utils.normalise_json_content(
+        expected = utils._normalise_json_content(
             {
                 "notebook_params": NOTEBOOK_PARAMS,
                 "notebook_task": NOTEBOOK_TASK,

--- a/tests/providers/databricks/operators/test_databricks.py
+++ b/tests/providers/databricks/operators/test_databricks.py
@@ -992,6 +992,7 @@ class TestDatabricksSubmitRunOperator:
 
         db_mock = db_mock_class.return_value
         db_mock.submit_run.return_value = RUN_ID
+        db_mock.get_run_page_url.return_value = RUN_PAGE_URL
         db_mock.get_run = make_run_with_state_mock("TERMINATED", "SUCCESS")
 
         dagrun = dag_maker.create_dagrun(execution_date=timezone.utcnow())
@@ -1030,6 +1031,7 @@ class TestDatabricksSubmitRunOperator:
             op = DatabricksSubmitRunOperator(task_id=TASK_ID, json=json)
         db_mock = db_mock_class.return_value
         db_mock.submit_run.return_value = RUN_ID
+        db_mock.get_run_page_url.return_value = RUN_PAGE_URL
         db_mock.get_run = make_run_with_state_mock("TERMINATED", "SUCCESS")
 
         dagrun = dag_maker.create_dagrun(execution_date=timezone.utcnow())
@@ -1504,6 +1506,7 @@ class TestDatabricksRunNowOperator:
 
         db_mock = db_mock_class.return_value
         db_mock.run_now.return_value = RUN_ID
+        db_mock.get_run_page_url.return_value = RUN_PAGE_URL
         db_mock.get_run = make_run_with_state_mock("TERMINATED", "SUCCESS")
 
         dagrun = dag_maker.create_dagrun(execution_date=timezone.utcnow())
@@ -1550,6 +1553,7 @@ class TestDatabricksRunNowOperator:
 
         db_mock = db_mock_class.return_value
         db_mock.run_now.return_value = RUN_ID
+        db_mock.get_run_page_url.return_value = RUN_PAGE_URL
         db_mock.get_run = make_run_with_state_mock("TERMINATED", "SUCCESS")
 
         dagrun = dag_maker.create_dagrun(execution_date=timezone.utcnow())

--- a/tests/providers/databricks/operators/test_databricks.py
+++ b/tests/providers/databricks/operators/test_databricks.py
@@ -1536,7 +1536,7 @@ class TestDatabricksRunNowOperator:
         with dag_maker("test_xcomarg", render_template_as_native_obj=True):
 
             @task
-            def push_json() -> dict[str, str]:
+            def push_json() -> dict:
                 return {
                     "notebook_params": NOTEBOOK_PARAMS,
                     "notebook_task": NOTEBOOK_TASK,

--- a/tests/providers/databricks/utils/test_databricks.py
+++ b/tests/providers/databricks/utils/test_databricks.py
@@ -21,7 +21,7 @@ import pytest
 
 from airflow.exceptions import AirflowException
 from airflow.providers.databricks.hooks.databricks import RunState
-from airflow.providers.databricks.utils.databricks import normalise_json_content, validate_trigger_event
+from airflow.providers.databricks.utils.databricks import _normalise_json_content, validate_trigger_event
 
 RUN_ID = 1
 RUN_PAGE_URL = "run-page-url"
@@ -46,7 +46,7 @@ class TestDatabricksOperatorSharedFunctions:
             "test_list": ["1", "1.0", "a", "b"],
             "test_tuple": ["1", "1.0", "a", "b"],
         }
-        assert normalise_json_content(test_json) == expected
+        assert _normalise_json_content(test_json) == expected
 
     def test_validate_trigger_event_success(self):
         event = {


### PR DESCRIPTION
This PR moves the assignment operations on the `json` templated field to the `execute` function in the following operators:

- DatabricksCreateJobsOperator
- DatabricksSubmitRunOperator
- DatabricksRunNowOperator

closes: #35433

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
