### PR TITLE
Support hybrid executors in backfill jobs

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -458,3 +458,7 @@ class DeserializingResultError(ValueError):
             "Error deserializing result. Note that result deserialization "
             "is not supported across major Python versions. Cause: " + str(self.__cause__)
         )
+
+
+class UnknownExecutorException(ValueError):
+    """Raised when an attempt is made to load an executor which is not configured."""

--- a/airflow/jobs/backfill_job_runner.py
+++ b/airflow/jobs/backfill_job_runner.py
@@ -35,6 +35,7 @@ from airflow.exceptions import (
     NoAvailablePoolSlot,
     PoolNotFound,
     TaskConcurrencyLimitReached,
+    UnknownExecutorException,
 )
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.jobs.base_job_runner import BaseJobRunner
@@ -262,6 +263,7 @@ class BackfillJobRunner(BaseJobRunner, LoggingMixin):
     def _manage_executor_state(
         self,
         running: Mapping[TaskInstanceKey, TaskInstance],
+        executor: BaseExecutor,
         session: Session,
     ) -> Iterator[tuple[AbstractOperator, str, Sequence[TaskInstance], int]]:
         """
@@ -272,7 +274,6 @@ class BackfillJobRunner(BaseJobRunner, LoggingMixin):
         :param running: dict of key, task to verify
         :return: An iterable of expanded TaskInstance per MappedTask
         """
-        executor = self.job.executor
         # list of tuples (dag_id, task_id, execution_date, map_index) of running tasks in executor
         buffered_events = list(executor.get_event_buffer().items())
         running_tis_ids = [
@@ -468,7 +469,6 @@ class BackfillJobRunner(BaseJobRunner, LoggingMixin):
     def _process_backfill_task_instances(
         self,
         ti_status: _DagRunTaskStatus,
-        executor: BaseExecutor,
         pickle_id: int | None,
         start_date: datetime.datetime | None = None,
         *,
@@ -557,6 +557,7 @@ class BackfillJobRunner(BaseJobRunner, LoggingMixin):
                     flag_upstream_failed=True,
                 )
 
+                executor = ExecutorLoader.load_executor(str(ti.executor) if ti.executor else None)
                 # Is the task runnable? -- then run it
                 # the dependency checker can change states of tis
                 if ti.are_dependencies_met(
@@ -723,7 +724,8 @@ class BackfillJobRunner(BaseJobRunner, LoggingMixin):
                 only_if_necessary=True,
             )
             # execute the tasks in the queue
-            executor.heartbeat()
+            for executor in self.job.executors:
+                executor.heartbeat()
 
             # If the set of tasks that aren't ready ever equals the set of
             # tasks to run and there are no running tasks then the backfill
@@ -733,25 +735,26 @@ class BackfillJobRunner(BaseJobRunner, LoggingMixin):
                 ti_status.deadlocked.update(ti_status.to_run.values())
                 ti_status.to_run.clear()
 
-            # check executor state -- and expand any mapped TIs
-            for node, run_id, new_mapped_tis, max_map_index in self._manage_executor_state(
-                ti_status.running, session
-            ):
+            for executor in self.job.executors:
+                # check executor state -- and expand any mapped TIs
+                for node, run_id, new_mapped_tis, max_map_index in self._manage_executor_state(
+                    ti_status.running, executor, session
+                ):
 
-                def to_keep(key: TaskInstanceKey) -> bool:
-                    if key.dag_id != node.dag_id or key.task_id != node.task_id or key.run_id != run_id:
-                        # For another Dag/Task/Run -- don't remove
-                        return True
-                    return 0 <= key.map_index <= max_map_index
+                    def to_keep(key: TaskInstanceKey) -> bool:
+                        if key.dag_id != node.dag_id or key.task_id != node.task_id or key.run_id != run_id:
+                            # For another Dag/Task/Run -- don't remove
+                            return True
+                        return 0 <= key.map_index <= max_map_index
 
-                # remove the old unmapped TIs for node -- they have been replaced with the mapped TIs
-                ti_status.to_run = {key: ti for (key, ti) in ti_status.to_run.items() if to_keep(key)}
+                    # remove the old unmapped TIs for node -- they have been replaced with the mapped TIs
+                    ti_status.to_run = {key: ti for (key, ti) in ti_status.to_run.items() if to_keep(key)}
 
-                ti_status.to_run.update({ti.key: ti for ti in new_mapped_tis})
+                    ti_status.to_run.update({ti.key: ti for ti in new_mapped_tis})
 
-                for new_ti in new_mapped_tis:
-                    new_ti.try_number += 1
-                    new_ti.set_state(TaskInstanceState.SCHEDULED, session=session)
+                    for new_ti in new_mapped_tis:
+                        new_ti.try_number += 1
+                        new_ti.set_state(TaskInstanceState.SCHEDULED, session=session)
 
             # Set state to failed for running TIs that are set up for retry if disable-retry flag is set
             for ti in ti_status.running.values():
@@ -844,7 +847,6 @@ class BackfillJobRunner(BaseJobRunner, LoggingMixin):
         self,
         dagrun_infos: Iterable[DagRunInfo],
         ti_status: _DagRunTaskStatus,
-        executor: BaseExecutor,
         pickle_id: int | None,
         start_date: datetime.datetime | None,
         session: Session = NEW_SESSION,
@@ -856,7 +858,6 @@ class BackfillJobRunner(BaseJobRunner, LoggingMixin):
 
         :param dagrun_infos: Schedule information for dag runs
         :param ti_status: internal BackfillJobRunner status structure to tis track progress
-        :param executor: the executor to use, it must be previously started
         :param pickle_id: numeric id of the pickled dag, None if not pickled
         :param start_date: backfill start date
         :param session: the current session object
@@ -869,9 +870,25 @@ class BackfillJobRunner(BaseJobRunner, LoggingMixin):
                     ti_status.active_runs.add(dag_run)
                     ti_status.to_run.update(tis_map or {})
 
+        tis_missing_executor = []
+        for ti in ti_status.to_run.values():
+            if ti.executor:
+                try:
+                    ExecutorLoader.lookup_executor_name_by_str(ti.executor)
+                except UnknownExecutorException:
+                    tis_missing_executor.append(ti)
+
+        if tis_missing_executor:
+            raise UnknownExecutorException(
+                "The following task instances are configured to use an executor that is not present. "
+                "Review the core.executors Airflow configuration to add it or clear the task instance to "
+                "clear the executor configuration for this task.\n"
+                + "\n".join(
+                    [f"  {ti.task_id}: {ti.run_id} (executor: {ti.executor})" for ti in tis_missing_executor]
+                )
+            )
         processed_dag_run_dates = self._process_backfill_task_instances(
             ti_status=ti_status,
-            executor=executor,
             pickle_id=pickle_id,
             start_date=start_date,
             session=session,
@@ -958,17 +975,19 @@ class BackfillJobRunner(BaseJobRunner, LoggingMixin):
             return
         pickle_id = None
 
-        executor_class, _ = ExecutorLoader.import_default_executor_cls()
+        _support_pickling = []
 
-        if not self.donot_pickle and executor_class.supports_pickling:
+        for executor in self.job.executors:
+            _support_pickling.append(executor.supports_pickling)
+
+            executor.job_id = self.job.id
+            executor.start()
+
+        if not self.donot_pickle and all(_support_pickling):
             pickle = DagPickle(self.dag)
             session.add(pickle)
             session.commit()
             pickle_id = pickle.id
-
-        executor = self.job.executor
-        executor.job_id = self.job.id
-        executor.start()
 
         ti_status.total_runs = len(dagrun_infos)  # total dag runs in backfill
 
@@ -983,7 +1002,6 @@ class BackfillJobRunner(BaseJobRunner, LoggingMixin):
                 self._execute_dagruns(
                     dagrun_infos=dagrun_infos_to_process,
                     ti_status=ti_status,
-                    executor=executor,
                     pickle_id=pickle_id,
                     start_date=start_date,
                     session=session,
@@ -1016,7 +1034,8 @@ class BackfillJobRunner(BaseJobRunner, LoggingMixin):
             raise
         finally:
             session.commit()
-            executor.end()
+            for executor in self.job.executors:
+                executor.end()
 
         self.log.info("Backfill done for DAG %s. Exiting.", self.dag)
 
@@ -1038,9 +1057,12 @@ class BackfillJobRunner(BaseJobRunner, LoggingMixin):
         :param filter_by_dag_run: the dag_run we want to process, None if all
         :return: the number of TIs reset
         """
-        queued_tis = self.job.executor.queued_tasks
-        # also consider running as the state might not have changed in the db yet
-        running_tis = self.job.executor.running
+        queued_tis = []
+        running_tis = []
+        for executor in self.job.executors:
+            queued_tis.append(executor.queued_tasks)
+            # also consider running as the state might not have changed in the db yet
+            running_tis.append(executor.running)
 
         # Can't use an update here since it doesn't support joins.
         resettable_states = [TaskInstanceState.SCHEDULED, TaskInstanceState.QUEUED]

--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -22,8 +22,9 @@ import json
 import logging
 import threading
 from collections import defaultdict
+from importlib import reload
 from unittest import mock
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -36,6 +37,7 @@ from airflow.exceptions import (
     DagConcurrencyLimitReached,
     NoAvailablePoolSlot,
     TaskConcurrencyLimitReached,
+    UnknownExecutorException,
 )
 from airflow.executors.debug_executor import DebugExecutor
 from airflow.executors.executor_loader import ExecutorLoader
@@ -57,6 +59,7 @@ from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.types import DagRunType
 from tests.listeners import dag_listener
 from tests.models import TEST_DAGS_FOLDER
+from tests.test_utils.config import conf_vars
 from tests.test_utils.db import (
     clear_db_dags,
     clear_db_pools,
@@ -80,38 +83,96 @@ def dag_bag():
     return DagBag(include_examples=True)
 
 
+class SecondaryMockExecutor(MockExecutor):
+    """Copy of MockExecutor class with a new name for testing with hybrid executors (which currently
+    disallows using the same executor concurrently)"""
+
+
+def _mock_executor(executor=None):
+    if not executor:
+        default_executor = MockExecutor()
+    else:
+        if isinstance(executor, type):
+            default_executor = executor()
+        else:
+            default_executor = executor
+
+    default_executor.name = mock.MagicMock(
+        alias="default_exec",
+        module_path=f"{default_executor.__module__}.{default_executor.__class__.__qualname__}",
+    )
+    with mock.patch("airflow.jobs.job.Job.executors", new_callable=mock.PropertyMock) as executors_mock:
+        with mock.patch("airflow.jobs.job.Job.executor", new_callable=mock.PropertyMock) as executor_mock:
+            with mock.patch("airflow.executors.executor_loader.ExecutorLoader.load_executor") as loader_mock:
+                executor_mock.return_value = default_executor
+                executors_mock.return_value = [default_executor]
+                # The executor is mocked, so cannot be loaded/imported. Mock load_executor and return the
+                # correct object for the given input executor name.
+                loader_mock.side_effect = lambda *x: {
+                    ("default_exec",): default_executor,
+                    ("default.exec.module.path",): default_executor,
+                    (None,): default_executor,
+                }[x]
+
+                # Reload the job runner so that it gets a fresh instances of the mocked executor loader
+                from airflow.jobs import backfill_job_runner
+
+                reload(backfill_job_runner)
+
+                yield default_executor
+
+
 @pytest.mark.execution_timeout(120)
 class TestBackfillJob:
-    def _mock_executor(self, executor=None):
-        if not executor:
-            default_executor = MockExecutor()
-        else:
-            default_executor = executor()
-
-        default_executor.name = mock.MagicMock(
-            alias="default_exec",
-            module_path=f"{default_executor.__module__}.{default_executor.__class__.__qualname__}",
-        )
-        with mock.patch("airflow.jobs.job.Job.executors", new_callable=mock.PropertyMock) as executors_mock:
-            with mock.patch("airflow.jobs.job.Job.executor", new_callable=mock.PropertyMock) as executor_mock:
-                with mock.patch(
-                    "airflow.executors.executor_loader.ExecutorLoader.load_executor"
-                ) as loader_mock:
-                    executor_mock.return_value = default_executor
-                    executors_mock.return_value = [default_executor]
-                    # The executor is mocked, so cannot be loaded/imported. Mock load_executor and return the
-                    # correct object for the given input executor name.
-                    loader_mock.side_effect = lambda *x: {
-                        ("default_exec",): default_executor,
-                        ("default.exec.module.path",): default_executor,
-                        (None,): default_executor,
-                    }[x]
-
-                    yield default_executor
-
     @pytest.fixture
     def mock_executor(self):
-        yield from self._mock_executor()
+        yield from _mock_executor()
+
+    def _mock_executors(self):
+        default_executor = MockExecutor()
+        _default_executor = Mock(wraps=default_executor)
+        default_alias = "default_exec"
+        default_module_path = f"{default_executor.__module__}.{default_executor.__class__.__qualname__}"
+        _default_executor.name = mock.MagicMock(alias=default_alias, module_path=default_module_path)
+
+        secondary_executor = SecondaryMockExecutor()
+        _secondary_executor = Mock(wraps=secondary_executor)
+        secondary_alias = "secondary_exec"
+        secondary_module_path = f"{secondary_executor.__module__}.{secondary_executor.__class__.__qualname__}"
+        _secondary_executor.name = mock.MagicMock(alias=secondary_alias, module_path=secondary_module_path)
+
+        with mock.patch(
+            "airflow.jobs.job.Job.executors", new_callable=mock.PropertyMock
+        ) as executors_mock, mock.patch(
+            "airflow.jobs.job.Job.executor", new_callable=mock.PropertyMock
+        ) as executor_mock, mock.patch(
+            "airflow.executors.executor_loader.ExecutorLoader.load_executor"
+        ) as loader_mock, conf_vars(
+            {
+                (
+                    "core",
+                    "executor",
+                ): f"{default_alias}:{default_module_path},{secondary_alias}:{secondary_module_path}"
+            }
+        ):
+            # The executor is mocked, so cannot be loaded/imported. Mock load_executor and return the
+            # correct object for the given input executor name.
+            loader_mock.side_effect = lambda *x: {
+                (_secondary_executor.name.alias,): _secondary_executor,
+                (_secondary_executor.name.module_path,): _secondary_executor,
+                (default_alias,): _default_executor,
+                (default_module_path,): _default_executor,
+                (None,): _default_executor,
+            }[x]
+
+            executor_mock.return_value = _default_executor
+            executors_mock.return_value = [_default_executor, _secondary_executor]
+
+            yield (_default_executor, _secondary_executor)
+
+    @pytest.fixture
+    def mock_executors(self):
+        yield from self._mock_executors()
 
     @staticmethod
     def clean_db():
@@ -368,8 +429,7 @@ class TestBackfillJob:
 
         assert conf_ == dr[0].conf
 
-    @patch("airflow.jobs.backfill_job_runner.BackfillJobRunner.log")
-    def test_backfill_respect_max_active_tis_per_dag_limit(self, mock_log, dag_maker, mock_executor):
+    def test_backfill_respect_max_active_tis_per_dag_limit(self, dag_maker, mock_executor):
         max_active_tis_per_dag = 2
         dag = self._get_dummy_dag(
             dag_maker,
@@ -386,6 +446,9 @@ class TestBackfillJob:
             start_date=DEFAULT_DATE,
             end_date=DEFAULT_DATE + datetime.timedelta(days=7),
         )
+
+        mock_log = Mock()
+        job_runner._log = mock_log
 
         run_job(job=job, execute_callable=job_runner._execute)
 
@@ -423,9 +486,8 @@ class TestBackfillJob:
         assert times_task_concurrency_limit_reached_in_debug > 0
 
     @pytest.mark.parametrize("with_max_active_tis_per_dag", [False, True])
-    @patch("airflow.jobs.backfill_job_runner.BackfillJobRunner.log")
     def test_backfill_respect_max_active_tis_per_dagrun_limit(
-        self, mock_log, dag_maker, with_max_active_tis_per_dag, mock_executor
+        self, dag_maker, with_max_active_tis_per_dag, mock_executor
     ):
         max_active_tis_per_dag = 3
         max_active_tis_per_dagrun = 2
@@ -446,6 +508,9 @@ class TestBackfillJob:
             start_date=DEFAULT_DATE,
             end_date=DEFAULT_DATE + datetime.timedelta(days=7),
         )
+
+        mock_log = Mock()
+        job_runner._log = mock_log
 
         run_job(job=job, execute_callable=job_runner._execute)
 
@@ -503,8 +568,7 @@ class TestBackfillJob:
         assert 0 == times_dag_concurrency_limit_reached_in_debug
         assert times_task_concurrency_limit_reached_in_debug > 0
 
-    @patch("airflow.jobs.backfill_job_runner.BackfillJobRunner.log")
-    def test_backfill_respect_dag_concurrency_limit(self, mock_log, dag_maker, mock_executor):
+    def test_backfill_respect_dag_concurrency_limit(self, dag_maker, mock_executor):
         dag = self._get_dummy_dag(dag_maker, dag_id="test_backfill_respect_concurrency_limit")
         dag_maker.create_dagrun(state=None)
         dag.max_active_tasks = 2
@@ -517,6 +581,10 @@ class TestBackfillJob:
             start_date=DEFAULT_DATE,
             end_date=DEFAULT_DATE + datetime.timedelta(days=7),
         )
+
+        mock_log = Mock()
+        job_runner._log = mock_log
+
         run_job(job=job, execute_callable=job_runner._execute)
 
         assert len(executor.history) > 0
@@ -553,8 +621,7 @@ class TestBackfillJob:
         assert 0 == times_task_concurrency_limit_reached_in_debug
         assert times_dag_concurrency_limit_reached_in_debug > 0
 
-    @patch("airflow.jobs.backfill_job_runner.BackfillJobRunner.log")
-    def test_backfill_respect_default_pool_limit(self, mock_log, dag_maker, mock_executor):
+    def test_backfill_respect_default_pool_limit(self, dag_maker, mock_executor):
         default_pool_slots = 2
         set_default_pool_slots(default_pool_slots)
 
@@ -569,6 +636,9 @@ class TestBackfillJob:
             start_date=DEFAULT_DATE,
             end_date=DEFAULT_DATE + datetime.timedelta(days=7),
         )
+
+        mock_log = Mock()
+        job_runner._log = mock_log
 
         run_job(job=job, execute_callable=job_runner._execute)
 
@@ -630,8 +700,7 @@ class TestBackfillJob:
         except AirflowException:
             return
 
-    @patch("airflow.jobs.backfill_job_runner.BackfillJobRunner.log")
-    def test_backfill_respect_pool_limit(self, mock_log, dag_maker, mock_executor):
+    def test_backfill_respect_pool_limit(self, dag_maker, mock_executor):
         session = settings.Session()
 
         slots = 2
@@ -658,6 +727,9 @@ class TestBackfillJob:
             start_date=DEFAULT_DATE,
             end_date=DEFAULT_DATE + datetime.timedelta(days=7),
         )
+
+        mock_log = Mock()
+        job_runner._log = mock_log
 
         run_job(job=job, execute_callable=job_runner._execute)
 
@@ -713,7 +785,7 @@ class TestBackfillJob:
         ti.refresh_from_db()
         ti.set_state(State.UP_FOR_RESCHEDULE)
 
-        for _ in self._mock_executor():
+        for _ in _mock_executor():
             job = Job()
             job_runner = BackfillJobRunner(
                 job=job,
@@ -1073,7 +1145,7 @@ class TestBackfillJob:
         # raises backwards
         expected_msg = "You cannot backfill backwards because one or more tasks depend_on_past: test_dop_task"
 
-        for _ in self._mock_executor():
+        for _ in _mock_executor():
             # Mock again to get a new executor
             job = Job()
             job_runner = BackfillJobRunner(job=job, dag=dag, run_backwards=True, **kwargs)
@@ -1831,6 +1903,73 @@ class TestBackfillJob:
         dr: DagRun = dag.get_last_dagrun()
         assert dr.creating_job_id == job.id
 
+    def test_executor_lifecycle(self, dag_maker, mock_executors):
+        """Ensure that all executors go through the full lifecycle of start, heartbeat, end, etc"""
+        dag_id = "test_executor_lifecycle"
+        with dag_maker(dag_id=dag_id, start_date=DEFAULT_DATE, schedule="@daily") as dag:
+            EmptyOperator(task_id="dummy_task", dag=dag)
+
+        job = Job()
+        job_runner = BackfillJobRunner(
+            job=job, dag=dag, start_date=timezone.utcnow() - datetime.timedelta(days=1)
+        )
+        run_job(job=job, execute_callable=job_runner._execute)
+
+        for executor_mock in mock_executors:
+            assert executor_mock.job_id == job.id
+            executor_mock.start.assert_called_once()
+            executor_mock.heartbeat.assert_called_once()
+            executor_mock.end.assert_called_once()
+
+    def test_non_existing_executor(self, dag_maker, mock_executors):
+        dag_id = "test_non_existing_executor"
+        with dag_maker(dag_id=dag_id, start_date=DEFAULT_DATE, schedule="@daily") as dag:
+            EmptyOperator(task_id="dummy_task", dag=dag, executor="foobar")
+
+        job = Job()
+        job_runner = BackfillJobRunner(
+            job=job, dag=dag, start_date=timezone.utcnow() - datetime.timedelta(days=1)
+        )
+        # Executor "foobar" does not exist, so the Backfill job should fail to run those tasks and
+        # throw an UnknownExecutorException
+        with pytest.raises(UnknownExecutorException):
+            run_job(job=job, execute_callable=job_runner._execute)
+
+    def test_hybrid_executors(self, dag_maker, mock_executors, session):
+        dag_id = "test_hybrid_executors"
+        with dag_maker(dag_id=dag_id, start_date=DEFAULT_DATE, schedule="@daily") as dag:
+            EmptyOperator(task_id="default_exec", dag=dag)
+            EmptyOperator(task_id="default_exec_explicit", dag=dag, executor=mock_executors[0].name.alias)
+            EmptyOperator(task_id="secondary_exec", dag=dag, executor=mock_executors[1].name.alias)
+
+        job = Job()
+        job_runner = BackfillJobRunner(
+            job=job, dag=dag, start_date=timezone.utcnow() - datetime.timedelta(days=1)
+        )
+
+        with mock.patch("airflow.executors.executor_loader.ExecutorLoader.lookup_executor_name_by_str"):
+            run_job(job=job, execute_callable=job_runner._execute)
+
+        dr = DagRun.find(dag_id=dag.dag_id, session=session)[0]
+
+        call_list = mock_executors[0].queue_task_instance.call_args_list
+        assert len(call_list) == 2
+        assert call_list[0].args[0].task_id == "default_exec"
+        assert call_list[1].args[0].task_id == "default_exec_explicit"
+
+        call_list = mock_executors[1].queue_task_instance.call_args_list
+        assert len(call_list) == 1
+        assert call_list[0].args[0].task_id == "secondary_exec"
+
+        assert dr
+        assert dr.state == DagRunState.SUCCESS
+
+        # Check that every task has a start and end date
+        for ti in dr.task_instances:
+            assert ti.state == TaskInstanceState.SUCCESS
+            assert ti.start_date is not None
+            assert ti.end_date is not None
+
     def test_backfill_has_job_id_int(self, mock_executor):
         """Make sure that backfill jobs are assigned job_ids and that the job_id is an int."""
         dag = self.dagbag.get_dag("test_start_date_scheduling")
@@ -1859,7 +1998,7 @@ class TestBackfillJob:
 
         """
         # This test needs a real executor to run, so that the `make_list` task can write out the TaskMap
-        for _ in self._mock_executor(executor):
+        for _ in _mock_executor(executor):
             self.dagbag.process_file(str(TEST_DAGS_FOLDER / f"{dag_id}.py"))
             dag = self.dagbag.get_dag(dag_id)
 
@@ -1953,7 +2092,6 @@ class TestBackfillJob:
         with patch.object(executor, "change_state", side_effect=on_change_state):
             job_runner._process_backfill_task_instances(
                 ti_status=ti_status,
-                executor=executor,
                 start_date=dr.execution_date,
                 pickle_id=None,
                 session=session,

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -65,6 +65,7 @@ from airflow.utils.file import list_py_file_paths
 from airflow.utils.session import create_session, provide_session
 from airflow.utils.state import DagRunState, JobState, State, TaskInstanceState
 from airflow.utils.types import DagRunType
+from tests.jobs.test_backfill_job import _mock_executor
 from tests.listeners import dag_listener
 from tests.listeners.test_listeners import get_listener_manager
 from tests.models import TEST_DAGS_FOLDER
@@ -2520,7 +2521,8 @@ class TestSchedulerJob:
             assert not isinstance(dag, SerializedDAG)
             # TODO: Can this be replaced with `self.run_scheduler_until_dagrun_terminal. `dag.run` isn't
             # great to use here as it uses BackfillJobRunner!
-            dag.run(start_date=ex_date, end_date=ex_date, executor=self.null_exec, **run_kwargs)
+            for _ in _mock_executor(self.null_exec):
+                dag.run(start_date=ex_date, end_date=ex_date, **run_kwargs)
         except AirflowException:
             pass
 
@@ -2592,8 +2594,9 @@ class TestSchedulerJob:
         )
         self.null_exec.mock_task_fail(dag_id, "test_dagrun_fail", dr.run_id)
 
-        with pytest.raises(AirflowException):
-            dag.run(start_date=dr.execution_date, end_date=dr.execution_date, executor=self.null_exec)
+        for _ in _mock_executor(self.null_exec):
+            with pytest.raises(AirflowException):
+                dag.run(start_date=dr.execution_date, end_date=dr.execution_date)
 
         # Mark the successful task as never having run since we want to see if the
         # dagrun will be in a running state despite having an unfinished task.
@@ -2700,11 +2703,12 @@ class TestSchedulerJob:
                 # That behavior still exists, but now it will only do so if after the
                 # start date
                 bf_exec = MockExecutor()
-                backfill_job = Job(executor=bf_exec)
-                job_runner = BackfillJobRunner(
-                    job=backfill_job, dag=dag, start_date=DEFAULT_DATE, end_date=DEFAULT_DATE
-                )
-                run_job(job=backfill_job, execute_callable=job_runner._execute)
+                for _ in _mock_executor(bf_exec):
+                    backfill_job = Job()
+                    job_runner = BackfillJobRunner(
+                        job=backfill_job, dag=dag, start_date=DEFAULT_DATE, end_date=DEFAULT_DATE
+                    )
+                    run_job(job=backfill_job, execute_callable=job_runner._execute)
 
                 # one task ran
                 assert len(session.query(TaskInstance).filter(TaskInstance.dag_id == dag_id).all()) == 1


### PR DESCRIPTION
The backfill job does its own scheduling and so needs changes to support hybrid executors outside of the Airflow Scheduler.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
