### PR TITLE
Reduce memory footprint of s3 key trigger

### DIFF
--- a/airflow/providers/amazon/CHANGELOG.rst
+++ b/airflow/providers/amazon/CHANGELOG.rst
@@ -26,6 +26,22 @@
 Changelog
 ---------
 
+main
+....
+
+Bug Fixes
+~~~~~~~~~
+
+* Reduce memory footprint of s3 key trigger (#40473)
+  - Decorator ``provide_bucket_name_async`` removed
+    * We do not need a separate decorator for async.  The old one is removed and users can use ``provide_bucket_name``
+      for coroutine functions, async iterators, and normal synchronous functions.
+  - Hook method ``get_file_metadata_async`` is now an async iterator
+    * Previously, the metadata objects were accumulated in a list.  Now the objects are yielded as we page
+      through the results.  To get a list you may use ``async for`` in a list comprehension.
+  - S3KeyTrigger avoids loading all positive matches into memory in some circumstances
+
+
 8.25.0
 ......
 

--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -526,7 +526,7 @@ class S3Hook(AwsBaseHook):
                 if re.match(pattern=key, string=k["Key"]):
                     return True
             return False
-        if await self.get_head_object_async(client, key, bucket_name):
+        return bool(await self.get_head_object_async(client, key, bucket_name))
             return True
         else:
             return False

--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -64,7 +64,6 @@ logger = logging.getLogger(__name__)
 
 def provide_bucket_name(func: Callable) -> Callable:
     """Provide a bucket name taken from the connection if no bucket name has been passed to the function."""
-    """Provide a bucket name taken from the connection if no bucket name has been passed to the function."""
     if hasattr(func, "_unify_bucket_name_and_key_wrapped"):
         logger.warning("`unify_bucket_name_and_key` should wrap `provide_bucket_name`.")
 

--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -526,7 +526,7 @@ class S3Hook(AwsBaseHook):
                 if re.match(pattern=key, string=k["Key"]):
                     return True
             return False
-        return bool(await self.get_head_object_async(client, key, bucket_name))
+        if await self.get_head_object_async(client, key, bucket_name):
             return True
         else:
             return False

--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -68,6 +68,10 @@ def provide_bucket_name(func: Callable) -> Callable:
         logger.warning("`unify_bucket_name_and_key` should wrap `provide_bucket_name`.")
 
     function_signature = signature(func)
+    if "bucket_name" not in function_signature.parameters:
+        raise RuntimeError(
+            "Decorator provide_bucket_name should only wrap a function with param 'bucket_name'."
+        )
 
     # todo: raise immediately if func has no bucket_name arg
     async def maybe_add_bucket_name(*args, **kwargs):

--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -526,10 +526,7 @@ class S3Hook(AwsBaseHook):
                 if re.match(pattern=key, string=k["Key"]):
                     return True
             return False
-        if await self.get_head_object_async(client, key, bucket_name):
-            return True
-        else:
-            return False
+        return bool(await self.get_head_object_async(client, key, bucket_name))
 
     async def check_key_async(
         self,

--- a/tests/providers/amazon/aws/hooks/test_s3.py
+++ b/tests/providers/amazon/aws/hooks/test_s3.py
@@ -23,7 +23,7 @@ import os
 import re
 from datetime import datetime as std_datetime, timezone
 from unittest import mock, mock as async_mock
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 from urllib.parse import parse_qs
 
 import boto3
@@ -428,8 +428,9 @@ class TestAwsS3Hook:
 
         s3_hook_async = S3Hook(client_type="S3")
         mock_client.get_paginator = mock.Mock(return_value=mock_paginator)
-        task = await s3_hook_async.get_file_metadata_async(mock_client, "test_bucket", "test*")
-        assert task == [
+        keys = [x async for x in s3_hook_async.get_file_metadata_async(mock_client, "test_bucket", "test*")]
+
+        assert keys == [
             {"Key": "test_key", "ETag": "etag1", "LastModified": datetime(2020, 8, 14, 17, 19, 34)},
             {"Key": "test_key2", "ETag": "etag2", "LastModified": datetime(2020, 8, 14, 17, 19, 34)},
         ]
@@ -632,64 +633,90 @@ class TestAwsS3Hook:
 
     @pytest.mark.asyncio
     @async_mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_s3_bucket_key")
-    @async_mock.patch("airflow.providers.amazon.aws.triggers.s3.S3Hook.get_head_object_async")
     @async_mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.async_conn")
-    async def test__check_key_async_without_wildcard_match(
-        self, mock_client, mock_head_object, mock_get_bucket_key
-    ):
+    async def test__check_key_async_without_wildcard_match(self, mock_get_conn, mock_get_bucket_key):
         """Test _check_key_async function without using wildcard_match"""
         mock_get_bucket_key.return_value = "test_bucket", "test.txt"
-        mock_head_object.return_value = {"ContentLength": 0}
+        mock_client = mock_get_conn.return_value
+        mock_client.head_object = AsyncMock(return_value={"ContentLength": 0})
         s3_hook_async = S3Hook(client_type="S3", resource_type="S3")
         response = await s3_hook_async._check_key_async(
-            mock_client.return_value, "test_bucket", False, "s3://test_bucket/file/test.txt"
+            mock_client, "test_bucket", False, "s3://test_bucket/file/test.txt"
         )
         assert response is True
 
     @pytest.mark.asyncio
     @async_mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_s3_bucket_key")
-    @async_mock.patch("airflow.providers.amazon.aws.triggers.s3.S3Hook.get_head_object_async")
     @async_mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.async_conn")
     async def test_s3__check_key_async_without_wildcard_match_and_get_none(
-        self, mock_client, mock_head_object, mock_get_bucket_key
+        self, mock_get_conn, mock_get_bucket_key
     ):
         """Test _check_key_async function when get head object returns none"""
         mock_get_bucket_key.return_value = "test_bucket", "test.txt"
-        mock_head_object.return_value = None
         s3_hook_async = S3Hook(client_type="S3", resource_type="S3")
+        mock_client = mock_get_conn.return_value
+        mock_client.head_object = AsyncMock(return_value=None)
         response = await s3_hook_async._check_key_async(
-            mock_client.return_value, "test_bucket", False, "s3://test_bucket/file/test.txt"
+            mock_client, "test_bucket", False, "s3://test_bucket/file/test.txt"
         )
         assert response is False
 
+    # @async_mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_s3_bucket_key")
     @pytest.mark.asyncio
-    @async_mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_s3_bucket_key")
-    @async_mock.patch("airflow.providers.amazon.aws.triggers.s3.S3Hook.get_file_metadata_async")
     @async_mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.async_conn")
-    async def test_s3__check_key_async_with_wildcard_match(
-        self, mock_client, mock_get_file_metadata, mock_get_bucket_key
-    ):
+    @pytest.mark.parametrize(
+        "contents, result",
+        [
+            (
+                [
+                    {
+                        "Key": "test/example_s3_test_file.txt",
+                        "ETag": "etag1",
+                        "LastModified": datetime(2020, 8, 14, 17, 19, 34),
+                        "Size": 0,
+                    },
+                    {
+                        "Key": "test_key2",
+                        "ETag": "etag2",
+                        "LastModified": datetime(2020, 8, 14, 17, 19, 34),
+                        "Size": 0,
+                    },
+                ],
+                True,
+            ),
+            (
+                [
+                    {
+                        "Key": "test/example_aeoua.txt",
+                        "ETag": "etag1",
+                        "LastModified": datetime(2020, 8, 14, 17, 19, 34),
+                        "Size": 0,
+                    },
+                    {
+                        "Key": "test_key2",
+                        "ETag": "etag2",
+                        "LastModified": datetime(2020, 8, 14, 17, 19, 34),
+                        "Size": 0,
+                    },
+                ],
+                False,
+            ),
+        ],
+    )
+    async def test_s3__check_key_async_with_wildcard_match(self, mock_get_conn, contents, result):
         """Test _check_key_async function"""
-        mock_get_bucket_key.return_value = "test_bucket", "test"
-        mock_get_file_metadata.return_value = [
-            {
-                "Key": "test_key",
-                "ETag": "etag1",
-                "LastModified": datetime(2020, 8, 14, 17, 19, 34),
-                "Size": 0,
-            },
-            {
-                "Key": "test_key2",
-                "ETag": "etag2",
-                "LastModified": datetime(2020, 8, 14, 17, 19, 34),
-                "Size": 0,
-            },
-        ]
+        client = mock_get_conn.return_value
+        paginator = client.get_paginator.return_value
+        r = paginator.paginate.return_value
+        r.__aiter__.return_value = [{"Contents": contents}]
         s3_hook_async = S3Hook(client_type="S3", resource_type="S3")
         response = await s3_hook_async._check_key_async(
-            mock_client.return_value, "test_bucket", True, "test/example_s3_test_file.txt"
+            client=client,
+            bucket_val="test_bucket",
+            wildcard_match=True,
+            key="test/example_s3_test_file.txt",
         )
-        assert response is False
+        assert response is result
 
     @pytest.mark.parametrize(
         "key, pattern, expected",
@@ -701,24 +728,31 @@ class TestAwsS3Hook:
     )
     @pytest.mark.asyncio
     @async_mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_s3_bucket_key")
-    @async_mock.patch("airflow.providers.amazon.aws.triggers.s3.S3Hook.get_file_metadata_async")
     @async_mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.async_conn")
     async def test__check_key_async_with_use_regex(
-        self, mock_client, mock_get_file_metadata, mock_get_bucket_key, key, pattern, expected
+        self, mock_get_conn, mock_get_bucket_key, key, pattern, expected
     ):
         """Match AWS S3 key with regex expression"""
         mock_get_bucket_key.return_value = "test_bucket", pattern
-        mock_get_file_metadata.return_value = [
+        client = mock_get_conn.return_value
+        paginator = client.get_paginator.return_value
+        r = paginator.paginate.return_value
+        r.__aiter__.return_value = [
             {
-                "Key": key,
-                "ETag": "etag1",
-                "LastModified": datetime(2020, 8, 14, 17, 19, 34),
-                "Size": 0,
-            },
+                "Contents": [
+                    {
+                        "Key": key,
+                        "ETag": "etag1",
+                        "LastModified": datetime(2020, 8, 14, 17, 19, 34),
+                        "Size": 0,
+                    },
+                ]
+            }
         ]
+
         s3_hook_async = S3Hook(client_type="S3", resource_type="S3")
         response = await s3_hook_async._check_key_async(
-            client=mock_client.return_value,
+            client=client,
             bucket_val="test_bucket",
             wildcard_match=False,
             key=pattern,


### PR DESCRIPTION
Also had to make the provide_bucket_name decorator support async generators, and in the process i realized we didn't need a separate "async" version of the decorator.