### PR TITLE
Validating provider description for urls in provider list view

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -36,7 +36,7 @@ from functools import cached_property
 from json import JSONDecodeError
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Collection, Iterator, Mapping, MutableMapping, Sequence
-from urllib.parse import unquote, urlencode, urljoin, urlsplit
+from urllib.parse import unquote, urlencode, urljoin, urlparse, urlsplit
 
 import configupdater
 import flask.json
@@ -4514,6 +4514,13 @@ class ProviderView(AirflowBaseView):
         def _build_link(match_obj):
             text = match_obj.group(1)
             url = match_obj.group(2)
+
+            # parsing the url to check if ita a valid url
+            parsed_url = urlparse(url)
+            if not (parsed_url.scheme == "http" or parsed_url.scheme == "https"):
+                # returning the original raw text
+                return escape(match_obj.group(0))
+
             return Markup(f'<a href="{url}">{text}</a>')
 
         cd = escape(description)

--- a/tests/www/views/test_views.py
+++ b/tests/www/views/test_views.py
@@ -23,6 +23,7 @@ from unittest import mock
 from unittest.mock import patch
 
 import pytest
+from markupsafe import Markup
 
 from airflow import __version__ as airflow_version
 from airflow.configuration import (
@@ -33,6 +34,7 @@ from airflow.configuration import (
 from airflow.plugins_manager import AirflowPlugin, EntryPointSource
 from airflow.utils.task_group import TaskGroup
 from airflow.www.views import (
+    ProviderView,
     build_scarf_url,
     get_key_paths,
     get_safe_url,
@@ -140,6 +142,37 @@ def test_should_list_providers_on_page_with_details(admin_client):
     check_content_in_response(beam_text, resp)
     check_content_in_response(beam_description, resp)
     check_content_in_response("Providers", resp)
+
+
+@pytest.mark.parametrize(
+    "provider_description, expected",
+    [
+        ("`Airbyte <https://airbyte.com/>`__", Markup('<a href="https://airbyte.com/">Airbyte</a>')),
+        (
+            "Amazon integration (including `Amazon Web Services (AWS) <https://aws.amazon.com/>`__).",
+            Markup(
+                'Amazon integration (including <a href="https://aws.amazon.com/">Amazon Web Services ('
+                "AWS)</a>)."
+            ),
+        ),
+        (
+            "`Java Database Connectivity (JDBC) <https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc"
+            "/>`__",
+            Markup(
+                '<a href="https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/">Java '
+                "Database Connectivity (JDBC)</a>"
+            ),
+        ),
+        (
+            "`click me <javascript:prompt(document.domain)>`__",
+            Markup("`click me &lt;javascript:prompt(document.domain)&gt;`__"),
+        ),
+    ],
+)
+def test__clean_description(admin_client, provider_description, expected):
+    p = ProviderView()
+    actual = p._clean_description(provider_description)
+    assert actual == expected
 
 
 def test_endpoint_should_not_be_unauthenticated(app):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Validating URLs in Provider Descriptions for Provider List View


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
