### PR TITLE
Fix editable setup for having old airflow and `main` providers

### DIFF
--- a/contributing-docs/testing/unit_tests.rst
+++ b/contributing-docs/testing/unit_tests.rst
@@ -1104,13 +1104,13 @@ directly to the container.
 2. Enter breeze environment by selecting the appropriate airflow version and choosing
    ``providers-and-tests`` option for ``--mount-sources`` flag.
 
-.. code-block::bash
+.. code-block:: bash
 
   breeze shell --use-airflow-version 2.9.1 --mount-sources providers-and-tests
 
 3. You can then run tests as usual:
 
-.. code-block::bash
+.. code-block:: bash
 
    pytest tests/providers/<provider>/test.py
 

--- a/scripts/in_container/install_airflow_and_providers.py
+++ b/scripts/in_container/install_airflow_and_providers.py
@@ -19,9 +19,11 @@
 
 from __future__ import annotations
 
+import os
 import re
 import sys
 from pathlib import Path
+from shutil import rmtree
 from typing import NamedTuple
 
 from in_container_utils import click, console, run_command
@@ -540,6 +542,15 @@ def install_airflow_and_providers(
             shell=True,
             check=False,
         )
+        import importlib.util
+
+        spec = importlib.util.find_spec("airflow")
+        if spec is None or spec.origin is None:
+            console.print("[red]Airflow not found - cannot mount sources")
+            sys.exit(1)
+        airflow_path = Path(spec.origin).parent
+        rmtree(airflow_path / "providers", ignore_errors=True)
+        os.symlink("/opt/airflow/airflow/providers", (airflow_path / "providers").as_posix())
     console.print("\n[green]Done!")
 
 


### PR DESCRIPTION
In order to locally develop and execute new providers with old sources you need to run breeze with `--use-airflow-version` and with the `--mount-sources` flag set to `providers-and-tests`. While for CI it worked with packages from dist, when you run it from sources, the providers mounted to inside container were not linked to where airflow has been installed. While this worked for tests, you could not really start airflow because the providers were not available. Also - even after removing the providers, the providers and providers/common folder remained inside installed airflow path.

This PR fixes both problems:

* in case there are any left-over "providers" directory in airflow installation location, it is removed

* the mounted sources of providers are symbolically linked to that airflow installation folder, making the provider folders available for import for airflow.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
