### PR TITLE
Add return type of kerberos.py and Create test of test_perform_krb181_workaround

### DIFF
--- a/airflow/security/kerberos.py
+++ b/airflow/security/kerberos.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import Any
 
 # Licensed to Cloudera, Inc. under one
 # or more contributor license agreements.  See the NOTICE file
@@ -65,13 +66,13 @@ def get_kerberos_principle(principal: str | None) -> str:
     return principal or conf.get_mandatory_value("kerberos", "principal").replace("_HOST", get_hostname())
 
 
-def renew_from_kt(principal: str | None, keytab: str, exit_on_fail: bool = True) -> int | None:
+def renew_from_kt(principal: str | None, keytab: str, exit_on_fail: bool = True) -> int | Any:
     """
     Renew kerberos token from keytab.
 
     :param principal: principal
     :param keytab: keytab file
-    :return: int | None
+    :return: int | Any
     """
     # The config is specified in seconds. But we ask for that same amount in
     # minutes to give ourselves a large renewal buffer.

--- a/airflow/security/kerberos.py
+++ b/airflow/security/kerberos.py
@@ -139,12 +139,12 @@ def renew_from_kt(principal: str | None, keytab: str, exit_on_fail: bool = True)
     return 0
 
 
-def perform_krb181_workaround(principal: str):
+def perform_krb181_workaround(principal: str) -> int:
     """
     Workaround for Kerberos 1.8.1.
 
     :param principal: principal name
-    :return: None
+    :return: int
     """
     cmdv: list[str] = [
         conf.get_mandatory_value("kerberos", "kinit_path"),

--- a/airflow/security/kerberos.py
+++ b/airflow/security/kerberos.py
@@ -65,13 +65,13 @@ def get_kerberos_principle(principal: str | None) -> str:
     return principal or conf.get_mandatory_value("kerberos", "principal").replace("_HOST", get_hostname())
 
 
-def renew_from_kt(principal: str | None, keytab: str, exit_on_fail: bool = True):
+def renew_from_kt(principal: str | None, keytab: str, exit_on_fail: bool = True) -> int | None:
     """
     Renew kerberos token from keytab.
 
     :param principal: principal
     :param keytab: keytab file
-    :return: None
+    :return: int | None
     """
     # The config is specified in seconds. But we ask for that same amount in
     # minutes to give ourselves a large renewal buffer.


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
# What I did
1. Type annotation correction:
    - In the Airflow codebase, a return type was incorrectly annotated as None when it actually returns an int.
    - While Python allows for flexible typing, accurate type annotations improve code clarity and catch potential errors early.
1. Test coverage improvement:
    - Some existing function tests were not comprehensive.
    - Added more thorough unit tests to cover all conditional branches of the affected function(s).


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
