### PR TITLE
Recognize quotes when parsing urls in logs

### DIFF
--- a/airflow/www/static/js/dag/details/taskInstance/Logs/utils.test.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/utils.test.tsx
@@ -137,7 +137,7 @@ describe("Test Logs Utils.", () => {
   });
 
   test("parseLogs function with quoted urls", () => {
-    const { parsedLogs, fileSources } = parseLogs(
+    const { parsedLogs } = parseLogs(
       mockTaskLog,
       null,
       [LogLevel.INFO, LogLevel.WARNING],
@@ -146,7 +146,11 @@ describe("Test Logs Utils.", () => {
     );
 
     const lines = parsedLogs!.split("\n");
-    expect(lines[lines.length-1]).toContain("<a href=\"https://apple.com\" target=\"_blank\" style=\"color: blue; text-decoration: underline;\">https://apple.com</a>")
-    expect(lines[lines.length-1]).toContain("<a href=\"https://google.com\" target=\"_blank\" style=\"color: blue; text-decoration: underline;\">https://google.com</a>")
-  })
+    expect(lines[lines.length - 1]).toContain(
+      '<a href="https://apple.com" target="_blank" style="color: blue; text-decoration: underline;">https://apple.com</a>'
+    );
+    expect(lines[lines.length - 1]).toContain(
+      '<a href="https://google.com" target="_blank" style="color: blue; text-decoration: underline;">https://google.com</a>'
+    );
+  });
 });

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/utils.test.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/utils.test.tsx
@@ -38,6 +38,7 @@ const mockTaskLog = `
 [2022-06-04 00:00:01,921] {dagbag.py:507} INFO - Filling up the DagBag from /files/dags/test_ui_grid.py
 [2022-06-04 00:00:01,964] {task_command.py:377} INFO - Running <TaskInstance: test_ui_grid.section_1.get_entry_group scheduled__2022-06-03T00:00:00+00:00 [running]> on host 5d28cfda3219
 [2022-06-04 00:00:02,010] {taskinstance.py:1548} WARNING - Exporting env vars: AIRFLOW_CTX_DAG_OWNER=*** AIRFLOW_CTX_DAG_ID=test_ui_grid
+[2024-07-01 00:00:02,010] {taskinstance.py:1548} INFO - Url parsing test => "https://apple.com", "https://google.com" 
 `;
 
 describe("Test Logs Utils.", () => {
@@ -64,7 +65,7 @@ describe("Test Logs Utils.", () => {
   test.each([
     {
       logLevelFilters: [LogLevel.INFO],
-      expectedNumberOfLines: 11,
+      expectedNumberOfLines: 12,
       expectedNumberOfFileSources: 4,
     },
     {
@@ -111,7 +112,7 @@ describe("Test Logs Utils.", () => {
       "taskinstance.py",
     ]);
     const lines = parsedLogs!.split("\n");
-    expect(lines).toHaveLength(7);
+    expect(lines).toHaveLength(8);
     lines.forEach((line) => expect(line).toContain("taskinstance.py"));
   });
 
@@ -131,7 +132,21 @@ describe("Test Logs Utils.", () => {
       "taskinstance.py",
     ]);
     const lines = parsedLogs!.split("\n");
-    expect(lines).toHaveLength(7);
+    expect(lines).toHaveLength(8);
     lines.forEach((line) => expect(line).toMatch(/INFO|WARNING/));
   });
+
+  test("parseLogs function with quoted urls", () => {
+    const { parsedLogs, fileSources } = parseLogs(
+      mockTaskLog,
+      null,
+      [LogLevel.INFO, LogLevel.WARNING],
+      ["taskinstance.py"],
+      []
+    );
+
+    const lines = parsedLogs!.split("\n");
+    expect(lines[lines.length-1]).toContain("<a href=\"https://apple.com\" target=\"_blank\" style=\"color: blue; text-decoration: underline;\">https://apple.com</a>")
+    expect(lines[lines.length-1]).toContain("<a href=\"https://google.com\" target=\"_blank\" style=\"color: blue; text-decoration: underline;\">https://google.com</a>")
+  })
 });

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/utils.test.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/utils.test.tsx
@@ -38,7 +38,7 @@ const mockTaskLog = `
 [2022-06-04 00:00:01,921] {dagbag.py:507} INFO - Filling up the DagBag from /files/dags/test_ui_grid.py
 [2022-06-04 00:00:01,964] {task_command.py:377} INFO - Running <TaskInstance: test_ui_grid.section_1.get_entry_group scheduled__2022-06-03T00:00:00+00:00 [running]> on host 5d28cfda3219
 [2022-06-04 00:00:02,010] {taskinstance.py:1548} WARNING - Exporting env vars: AIRFLOW_CTX_DAG_OWNER=*** AIRFLOW_CTX_DAG_ID=test_ui_grid
-[2024-07-01 00:00:02,010] {taskinstance.py:1548} INFO - Url parsing test => "https://apple.com", "https://google.com" 
+[2024-07-01 00:00:02,010] {taskinstance.py:1548} INFO - Url parsing test => "https://apple.com", "https://google.com"
 `;
 
 describe("Test Logs Utils.", () => {

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
@@ -74,7 +74,7 @@ export const parseLogs = (
   const ansiUp = new AnsiUp();
   ansiUp.url_allowlist = {};
 
-  const urlRegex = /((https?:\/\/|http:\/\/)[^\s]+)/g;
+  const urlRegex = /((https?:\/\/|http:\/\/)(?:(?!&#x27;|&quot;)[^\s])+)/g;
   // Detect log groups which can be collapsed
   // Either in Github like format '::group::<group name>' to '::endgroup::'
   // see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

Currently, the log UI doesn't recognize single or double quotes when a url is parsed as a hyperlink, so when you click on it, you're taken to the wrong url, which is quite an inconvenient experience. I've created a PR to fix this.

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
