### PR TITLE
S3 to wasb

### DIFF
--- a/airflow/providers/microsoft/azure/provider.yaml
+++ b/airflow/providers/microsoft/azure/provider.yaml
@@ -294,6 +294,10 @@ transfers:
     target-integration-name: Microsoft Azure Blob Storage
     how-to-guide: /docs/apache-airflow-providers-microsoft-azure/transfer/sftp_to_wasb.rst
     python-module: airflow.providers.microsoft.azure.transfers.sftp_to_wasb
+  - source-integration-name: Amazon AWS S3
+    target-integration-name: Microsoft Azure Blob Storage
+    how-to-guide: /docs/apache-airflow-providers-microsoft-azure/transfer/s3_to_wasb.rst
+    python-module: airflow.providers.microsoft.azure.transfers.s3_to_wasb
   - source-integration-name: Microsoft Azure Blob Storage
     target-integration-name: Google Cloud Storage (GCS)
     how-to-guide: /docs/apache-airflow-providers-microsoft-azure/transfer/azure_blob_to_gcs.rst

--- a/airflow/providers/microsoft/azure/provider.yaml
+++ b/airflow/providers/microsoft/azure/provider.yaml
@@ -294,7 +294,7 @@ transfers:
     target-integration-name: Microsoft Azure Blob Storage
     how-to-guide: /docs/apache-airflow-providers-microsoft-azure/transfer/sftp_to_wasb.rst
     python-module: airflow.providers.microsoft.azure.transfers.sftp_to_wasb
-  - source-integration-name: Amazon AWS S3
+  - source-integration-name: Amazon Simple Storage Service (S3)
     target-integration-name: Microsoft Azure Blob Storage
     how-to-guide: /docs/apache-airflow-providers-microsoft-azure/transfer/s3_to_wasb.rst
     python-module: airflow.providers.microsoft.azure.transfers.s3_to_wasb

--- a/airflow/providers/microsoft/azure/transfers/s3_to_wasb.py
+++ b/airflow/providers/microsoft/azure/transfers/s3_to_wasb.py
@@ -117,7 +117,7 @@ class S3ToAzureBlobStorageOperator(BaseOperator):
 
             # Assuming that files_to_move is a list (which it always should be), this will get "hit" after the
             # last file is moved from S3 -> Azure Blob
-            self.log.info("All done, uploaded % to Azure Blob.", len(files_to_move))
+            self.log.info("All done, uploaded %s to Azure Blob.", len(files_to_move))
 
         else:
             # If there are no files to move, a message will be logged. May want to consider alternative

--- a/airflow/providers/microsoft/azure/transfers/s3_to_wasb.py
+++ b/airflow/providers/microsoft/azure/transfers/s3_to_wasb.py
@@ -34,7 +34,9 @@ class S3ToAzureBlobStorageOperator(BaseOperator):
     exists to move data from Microsoft Azure Blob Storage to an AWS S3 Bucket, and lives in the
     airflow/providers/amazon/aws/transfers/azure_blob_to_s3.py file
 
-    TODO: Complete doc-string
+    Either an explicit S3 key can be provided, or a prefix containing the files that are to be transferred to
+    Azure blob storage. The same holds for a Blob name; an explicit name can be passed, or a Blob prefix can
+    be provided for the file to be stored to
     """
 
     template_fields: Sequence[str] = (
@@ -169,3 +171,15 @@ class S3ToAzureBlobStorageOperator(BaseOperator):
 
         # Return a list of the files that were moved
         return files_to_move
+
+    def move_file(self) -> None:
+        """
+        move_files
+
+        Description:
+            This "helper" method will take a file name, and move it from S3 to Azure Blob storage
+
+        Params: None
+        Returns None
+        """
+        pass

--- a/airflow/providers/microsoft/azure/transfers/s3_to_wasb.py
+++ b/airflow/providers/microsoft/azure/transfers/s3_to_wasb.py
@@ -195,15 +195,16 @@ class S3ToAzureBlobStorageOperator(BaseOperator):
             file_name (str)
         Returns: None
         """
-        with tempfile.NamedTemporaryFile() as temp_file:
+        with tempfile.NamedTemporaryFile("w") as temp_file:
             # If using an s3_key, this creates a scenario where the only file in the files_to_move
             # list is going to be the name pulled from the s3_key. It's not verbose, but provides
             # standard implementation across the operator
+            self.log.info(f"File name: {file_name}")
             source_s3_key: str = self.s3_key if self.s3_key else self.s3_prefix + "/" + file_name
-            self.s3_hook.download_file(
-                local_path=temp_file.name,  # Make sure to look at this
-                bucket_name=self.s3_bucket,
-                key=source_s3_key
+            self.s3_hook.get_conn().download_file(
+                self.s3_bucket,
+                source_s3_key,
+                temp_file.name
             )
 
             # Load the file to Azure Blob using either the key that has been passed in, or the key

--- a/airflow/providers/microsoft/azure/transfers/s3_to_wasb.py
+++ b/airflow/providers/microsoft/azure/transfers/s3_to_wasb.py
@@ -65,7 +65,7 @@ class S3ToAzureBlobStorageOperator(BaseOperator):
         s3_verify: bool = False,
         s3_extra_args: dict | None = None,
         wasb_extra_args: dict | None = None,
-        **kwargs
+        **kwargs,
     ):
         # Call to constructor of the inherited BaseOperator class
         super().__init__(**kwargs)
@@ -74,16 +74,16 @@ class S3ToAzureBlobStorageOperator(BaseOperator):
         self.wasb_conn_id = wasb_conn_id
         self.s3_bucket = s3_bucket
         self.container_name = container_name
-        self.s3_prefix = s3_prefix if s3_prefix.endswith("/") else s3_prefix + "/"
+        self.s3_prefix = s3_prefix
         self.s3_key = s3_key
-        self.blob_prefix = blob_prefix if blob_prefix.endswith("/") else blob_prefix + "/"
+        self.blob_prefix = blob_prefix
         self.blob_name = blob_name
         self.delimiter = delimiter
         self.create_container = create_container
         self.replace = replace
         self.s3_verify = s3_verify
-        self.s3_extra_args = s3_extra_args
-        self.wasb_extra_args = wasb_extra_args
+        self.s3_extra_args = s3_extra_args or {}
+        self.wasb_extra_args = wasb_extra_args or {}
 
     def execute(self, context: Context) -> List[str]:
         """
@@ -98,7 +98,8 @@ class S3ToAzureBlobStorageOperator(BaseOperator):
         Returns:
             None
         """
-        # First, create a WasbHook and an S3Hook using the conn's that were provided
+        # First, create a WasbHook and an S3Hook using the conn's that were provided. These hooks will be
+        # passed to the methods we use to "help" with execution
         wasb_hook: WasbHook = WasbHook(wasb_conn_id=self.wasb_conn_id, **self.wasb_extra_args)
         s3_hook: S3Hook = S3Hook(
             aws_conn_id=self.aws_conn_id,
@@ -111,75 +112,107 @@ class S3ToAzureBlobStorageOperator(BaseOperator):
             f"Getting file: {self.s3_key}" if self.s3_key else f"Getting files from: {self.s3_prefix}"
         )
 
-        # First, try to use the S3 key that is passed in. Otherwise, pull all files from the S3 bucket/path
-        # prefix and remove the prefix
-        if self.s3_key:
-            # Only pull the file name from the s3_key
-            files_to_move: List[str] = [self.s3_key.split("/")[-1]]
-        else:
-            # Pull the keys from the s3_bucket using the provided prefix. Remove the prefix from the file
-            # name, and add to the list of files to move
-            s3_keys: List[str] = s3_hook.list_keys(
-                bucket_name=self.s3_bucket,
-                prefix=self.s3_prefix,
-                delimiter=self.delimiter  # Optional filter by the "extension" of the file
-            )
-            files_to_move = [s3_key.replace(f"{self.s3_prefix}/", "", 1) for s3_key in s3_keys]
+        # Pull a list of files to move from S3 to Azure Blob storage
+        files_to_move: List[str] = self.get_files_to_move(s3_hook, wasb_hook)
 
-        if not self.replace:
-            # Only grab the files from S3 that are not in Azure Blob already. This will prevent any files that
-            # exist in both S3 and Azure Blob from being overwritten. If a blob_name is provided, create a
-            # list with only this value
-            azure_blob_files: List[str] = [self.blob_name] if self.blob_name else \
-                wasb_hook.get_blobs_list_recursive(
-                container_name=self.container_name,
-                prefix=self.blob_prefix,
-                endswith=self.delimiter  # Optional filter by the "extension" of the file
-            )
-            existing_files = azure_blob_files if azure_blob_files else []  # TODO: Clean blob names
-            files_to_move = list(set(files_to_move) - set(existing_files))
-
+        # Check to see if there are indeed files to move. If so, move each of these files. Otherwise, output
+        # a logging message that denotes there are no files to move
         if files_to_move:
-            for file in files_to_move:
-                with tempfile.NamedTemporaryFile() as temp_file:
-                    # If using an s3_key, this creates a scenario where the only file in the files_to_move
-                    # list is going to be the name pulled from the s3_key. It's not verbose, but provides
-                    # standard implementation across the operator
-                    source_s3_key: str = self.s3_key if self.s3_key else self.s3_prefix + file
-                    s3_hook.download_file(
-                        local_path=temp_file.name,  # Make sure to look at this
-                        bucket_name=self.s3_bucket,
-                        key=source_s3_key
-                    )
+            for file_name in files_to_move:
+                self.move_file(file_name, s3_hook, wasb_hook)
 
-                    # Load the file to Azure Blob using either the key that has been passed in, or the key
-                    # from the list of files present in the s3_prefix, plus the blob_prefix
-                    destination_azure_blob_name: str = self.blob_name if self.blob_name \
-                        else self.blob_prefix + file
-                    wasb_hook.load_file(
-                        file_path=temp_file.name,
-                        container_name=self.container_name,
-                        blob_name=destination_azure_blob_name,
-                        create_container=self.create_container,
-                        **self.wasb_extra_args
-                    )
-
+            # Assuming that files_to_move is a list (which it always should be), this will get "hit" after the
+            # last file is moved from S3 -> Azure Blob
             self.log.info(f"All done, uploaded {len(files_to_move)} to Azure Blob.")
 
         else:
+            # If there are no files to move, a message will be printed. May want to consider alternative
+            # functionality (should an exception instead be raised?)
             self.log.info("There are no files to move!")
 
         # Return a list of the files that were moved
         return files_to_move
 
-    def move_file(self) -> None:
+    def get_files_to_move(self, s3_hook: S3Hook, wasb_hook: WasbHook) -> List[str]:
         """
-        move_files
+        get_files_to_move
 
         Description:
-            This "helper" method will take a file name, and move it from S3 to Azure Blob storage
+            This "helper" method will determine the list of files that need to be moved, and return the name
+            of each of these files
 
-        Params: None
-        Returns None
+        Params:
+            s3_hook (S3Hook)
+            wasb_hook (WasbHook)
+
+        Returns:
+            files_to_move (List[str])
         """
-        pass
+        if self.s3_key:
+            # Only pull the file name from the s3_key, drop the rest of the key
+            files_to_move: List[str] = [self.s3_key.split("/")[-1]]
+        else:
+            # Pull the keys from the s3_bucket using the provided prefix. Remove the prefix from the file
+            # name, and add to the list of files to move
+            s3_keys: List[str] = s3_hook.list_keys(bucket_name=self.s3_bucket, prefix=self.s3_prefix)
+            files_to_move = [s3_key.replace(f"{self.s3_prefix}/", "", 1) for s3_key in s3_keys]
+
+        if not self.replace:
+            # Only grab the files from S3 that are not in Azure Blob already. This will prevent any files that
+            # exist in both S3 and Azure Blob from being overwritten. If a blob_name is provided, check to
+            # see if that blob exists
+            if self.blob_name:
+                azure_blob_files = [self.blob_name.split("/")[-1]] if \
+                    wasb_hook.check_for_blob(self.container_name, self.blob_name) else \
+                    []
+            else:
+                azure_blob_files: List[str] = wasb_hook.get_blobs_list_recursive(
+                    container_name=self.container_name,
+                    prefix=self.blob_prefix,
+                    endswith=self.delimiter  # Optional filter by the "extension" of the file
+                )
+            # This conditional block only does one thing - it alters the elements in the files_to_move list.
+            # This list is being trimmed to remove the existing files in the Azure Blob (as mentioned above)
+            existing_files = azure_blob_files if azure_blob_files else []
+            files_to_move = list(set(files_to_move) - set(existing_files))
+
+        return files_to_move
+
+    def move_file(self, file_name: str, s3_hook: S3Hook, wasb_hook: WasbHook) -> None:
+        """
+        move_file
+
+        Description:
+            Move file from S3 to Azure Blob storage
+
+        Params:
+            file_name (str)
+            s3_hook (str)
+            wasb_hook ()
+
+        Returns: None
+        """
+        with tempfile.NamedTemporaryFile() as temp_file:
+            # If using an s3_key, this creates a scenario where the only file in the files_to_move
+            # list is going to be the name pulled from the s3_key. It's not verbose, but provides
+            # standard implementation across the operator
+            source_s3_key: str = self.s3_key if self.s3_key else self.s3_prefix + "/" + file_name
+            s3_hook.download_file(
+                local_path=temp_file.name,  # Make sure to look at this
+                bucket_name=self.s3_bucket,
+                key=source_s3_key
+            )
+
+            # Load the file to Azure Blob using either the key that has been passed in, or the key
+            # from the list of files present in the s3_prefix, plus the blob_prefix. There may be
+            # desire to only pass in an S3 key, in which case, the blob_name should be derived from
+            # the S3 key
+            destination_azure_blob_name: str = self.blob_name if self.blob_name \
+                else self.blob_prefix + "/" + file_name
+            wasb_hook.load_file(
+                file_path=temp_file.name,
+                container_name=self.container_name,
+                blob_name=destination_azure_blob_name,
+                create_container=self.create_container,
+                **self.wasb_extra_args
+            )

--- a/airflow/providers/microsoft/azure/transfers/s3_to_wasb.py
+++ b/airflow/providers/microsoft/azure/transfers/s3_to_wasb.py
@@ -17,9 +17,9 @@
 # under the License.
 from __future__ import annotations
 
-from functools import cached_property
 import tempfile
-from typing import TYPE_CHECKING, Sequence, List
+from functools import cached_property
+from typing import TYPE_CHECKING, Sequence
 
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
@@ -31,8 +31,9 @@ if TYPE_CHECKING:
 
 class S3ToAzureBlobStorageOperator(BaseOperator):
     """
-    Operator to move data from and AWS S3 Bucket to Microsoft Azure Blob Storage. A similar class
-    exists to move data from Microsoft Azure Blob Storage to an AWS S3 Bucket, and lives in the
+    Operator to move data from and AWS S3 Bucket to Microsoft Azure Blob Storage.
+
+    A similar class exists to move data from Microsoft Azure Blob Storage to an AWS S3 Bucket, and lives in the
     airflow/providers/amazon/aws/transfers/azure_blob_to_s3.py file
 
     Either an explicit S3 key can be provided, or a prefix containing the files that are to be transferred to
@@ -46,7 +47,7 @@ class S3ToAzureBlobStorageOperator(BaseOperator):
         "s3_prefix",
         "s3_key",
         "blob_prefix",
-        "blob_name"
+        "blob_name",
     )
 
     def __init__(
@@ -60,7 +61,6 @@ class S3ToAzureBlobStorageOperator(BaseOperator):
         s3_key: str | None = None,  # Only use this to pull a single file
         blob_prefix: str | None = None,
         blob_name: str | None = None,
-        delimiter: str | None = None,
         create_container: bool = False,
         replace: bool = False,
         s3_verify: bool = False,
@@ -79,7 +79,6 @@ class S3ToAzureBlobStorageOperator(BaseOperator):
         self.s3_key = s3_key
         self.blob_prefix = blob_prefix
         self.blob_name = blob_name
-        self.delimiter = delimiter
         self.create_container = create_container
         self.replace = replace
         self.s3_verify = s3_verify
@@ -92,37 +91,23 @@ class S3ToAzureBlobStorageOperator(BaseOperator):
     @cached_property
     def s3_hook(self) -> S3Hook:
         """Create and return an S3Hook."""
-        return S3Hook(
-            aws_conn_id=self.aws_conn_id,
-            verify=self.s3_verify,
-            **self.s3_extra_args
-        )
+        return S3Hook(aws_conn_id=self.aws_conn_id, verify=self.s3_verify, **self.s3_extra_args)
 
     @cached_property
     def wasb_hook(self) -> WasbHook:
         """Create and return a WasbHook."""
         return WasbHook(wasb_conn_id=self.wasb_conn_id, **self.wasb_extra_args)
 
-    def execute(self, context: Context) -> List[str]:
-        """
-        execute
-
-        Description:
-            execute() method is called when the Operator is triggered in a DAG
-
-        Params:
-            context (Content)
-
-        Returns:
-            None
-        """
+    def execute(self, context: Context) -> list[str]:
+        """Method called when task is executed in a DAG."""
         self.log.info(
-            f"Getting list of files in the Bucket: {self.s3_bucket}"
-            f"Getting file: {self.s3_key}" if self.s3_key else f"Getting files from: {self.s3_prefix}"
+            f"Getting list of files in the Bucket: {self.s3_bucket}Getting file: {self.s3_key}"
+            if self.s3_key
+            else f"Getting files from: {self.s3_prefix}"
         )
 
         # Pull a list of files to move from S3 to Azure Blob storage
-        files_to_move: List[str] = self.get_files_to_move()
+        files_to_move: list[str] = self.get_files_to_move()
 
         # Check to see if there are indeed files to move. If so, move each of these files. Otherwise, output
         # a logging message that denotes there are no files to move
@@ -132,7 +117,7 @@ class S3ToAzureBlobStorageOperator(BaseOperator):
 
             # Assuming that files_to_move is a list (which it always should be), this will get "hit" after the
             # last file is moved from S3 -> Azure Blob
-            self.log.info(f"All done, uploaded {len(files_to_move)} to Azure Blob.")
+            self.log.info("All done, uploaded % to Azure Blob.", len(files_to_move))
 
         else:
             # If there are no files to move, a message will be logged. May want to consider alternative
@@ -142,41 +127,36 @@ class S3ToAzureBlobStorageOperator(BaseOperator):
         # Return a list of the files that were moved
         return files_to_move
 
-    def get_files_to_move(self) -> List[str]:
-        """
-        get_files_to_move
-
-        Description:
-            This "helper" method will determine the list of files that need to be moved, and return the name
-            of each of these files
-
-        Params: None
-        Returns:
-            files_to_move (List[str])
-        """
+    def get_files_to_move(self) -> list[str]:
+        """Determine the list of files that need to be moved, and return the name."""
         if self.s3_key:
             # Only pull the file name from the s3_key, drop the rest of the key
-            files_to_move: List[str] = [self.s3_key.split("/")[-1]]
+            files_to_move: list[str] = [self.s3_key.split("/")[-1]]
         else:
             # Pull the keys from the s3_bucket using the provided prefix. Remove the prefix from the file
             # name, and add to the list of files to move
-            s3_keys: List[str] = self.s3_hook.list_keys(bucket_name=self.s3_bucket, prefix=self.s3_prefix)
+            s3_keys: list[str] = self.s3_hook.list_keys(bucket_name=self.s3_bucket, prefix=self.s3_prefix)
             files_to_move = [s3_key.replace(f"{self.s3_prefix}/", "", 1) for s3_key in s3_keys]
 
         if not self.replace:
             # Only grab the files from S3 that are not in Azure Blob already. This will prevent any files that
             # exist in both S3 and Azure Blob from being overwritten. If a blob_name is provided, check to
             # see if that blob exists
+            azure_blob_files: list[str] = []
+
             if self.blob_name:
-                azure_blob_files = [self.blob_name.split("/")[-1]] if \
-                    self.wasb_hook.check_for_blob(self.container_name, self.blob_name) else \
-                    []
-            else:
-                azure_blob_files: List[str] = self.wasb_hook.get_blobs_list_recursive(
-                    container_name=self.container_name,
-                    prefix=self.blob_prefix,
-                    endswith=self.delimiter  # Optional filter by the "extension" of the file
+                # If the singular blob (stored at self.blob_name) exists, add it to azure_blob_files so it
+                # can be removed from the list of files to move
+                if self.wasb_hook.check_for_blob(self.container_name, self.blob_name):
+                    azure_blob_files.append(self.blob_name.split("/")[-1])
+
+            elif self.blob_prefix:
+                azure_blob_files += self.wasb_hook.get_blobs_list_recursive(
+                    container_name=self.container_name, prefix=self.blob_prefix
                 )
+            else:
+                raise Exception("One of blob_name or blob_prefix must be provided.")
+
             # This conditional block only does one thing - it alters the elements in the files_to_move list.
             # This list is being trimmed to remove the existing files in the Azure Blob (as mentioned above)
             existing_files = azure_blob_files if azure_blob_files else []
@@ -185,38 +165,37 @@ class S3ToAzureBlobStorageOperator(BaseOperator):
         return files_to_move
 
     def move_file(self, file_name: str) -> None:
-        """
-        move_file
-
-        Description:
-            Move file from S3 to Azure Blob storage
-
-        Params:
-            file_name (str)
-        Returns: None
-        """
+        """Move file from S3 to Azure Blob storage."""
         with tempfile.NamedTemporaryFile("w") as temp_file:
             # If using an s3_key, this creates a scenario where the only file in the files_to_move
             # list is going to be the name pulled from the s3_key. It's not verbose, but provides
             # standard implementation across the operator
-            self.log.info(f"File name: {file_name}")
-            source_s3_key: str = self.s3_key if self.s3_key else self.s3_prefix + "/" + file_name
-            self.s3_hook.get_conn().download_file(
-                self.s3_bucket,
-                source_s3_key,
-                temp_file.name
-            )
+            source_s3_key: str = self._create_key(self.s3_key, self.s3_prefix, file_name)
+
+            # Create retrieve the S3 client itself, rather than directly using the hook. Download the file to
+            # the temp_file.name
+            s3_client = self.s3_hook.get_conn()
+            s3_client.download_file(self.s3_bucket, source_s3_key, temp_file.name)
 
             # Load the file to Azure Blob using either the key that has been passed in, or the key
             # from the list of files present in the s3_prefix, plus the blob_prefix. There may be
             # desire to only pass in an S3 key, in which case, the blob_name should be derived from
             # the S3 key
-            destination_azure_blob_name: str = self.blob_name if self.blob_name \
-                else self.blob_prefix + "/" + file_name
+            destination_azure_blob_name: str = self._create_key(self.blob_name, self.blob_prefix, file_name)
             self.wasb_hook.load_file(
                 file_path=temp_file.name,
                 container_name=self.container_name,
                 blob_name=destination_azure_blob_name,
                 create_container=self.create_container,
-                **self.wasb_extra_args
+                **self.wasb_extra_args,
             )
+
+    @staticmethod
+    def _create_key(full_path: str | None, prefix: str | None, file_name: str | None):
+        """Return a file key using its components."""
+        if full_path:
+            return full_path
+        elif prefix and file_name:
+            return f"{prefix}/{file_name}"
+        else:
+            raise Exception("Either full_path of prefix and file_name must not be None")

--- a/airflow/providers/microsoft/azure/transfers/s3_to_wasb.py
+++ b/airflow/providers/microsoft/azure/transfers/s3_to_wasb.py
@@ -1,0 +1,100 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import TYPE_CHECKING, Sequence
+
+from airflow.models import BaseOperator
+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
+
+
+class S3ToAzureBlobStorageOperator(BaseOperator):
+    """
+    Operator to move data from and AWS S3 Bucket to Microsoft Azure Blob Storage. A similar class
+    exists to move data from Microsoft Azure Blob Storage to an AWS S3 Bucket, and lives in the
+    airflow/providers/amazon/aws/transfers/azure_blob_to_s3.py file
+
+    TODO: Complete doc-string
+    """
+
+    template_fields: Sequence[str] = (
+        "s3_key",
+        "blob_name"
+    )
+
+    def __init__(
+        self,
+        *,
+        aws_conn_id: str = "aws_default",
+        s3_bucket: str,
+        s3_key: str,  # Maybe, s3_key_prefix
+        wasb_conn_id: str = "wasb_default",
+        blob_name: str,  # TODO: Think about making this optional
+        container_name: str,
+        create_container: str,
+        replace: bool = True,
+        s3_extra_args: dict | None = None,
+        wasb_extra_args: dict | None = None,
+        **kwargs
+    ):
+        # Call to super
+        super().__init__(**kwargs)
+
+        self.aws_conn_id = aws_conn_id
+        self.s3_bucket = s3_bucket
+        self.s3_key = s3_key
+        self.wasb_conn_id = wasb_conn_id
+        self.blob_name = blob_name
+        self.container_name = container_name
+        self.create_container = create_container
+        self.replace = replace
+        self.s3_extra_args = s3_extra_args
+        self.wasb_extra_args = wasb_extra_args
+
+        # Placeholder for now, remove this before pushing
+        self.dest_verify = None
+        self.dest_s3_extra_args = None
+
+    def execute(self, context: Context) -> None:
+        """
+        execute
+
+        Description:
+            execute() method is called when the Operator is triggered in a DAG
+
+        Params:
+            context (Content)
+
+        Returns:
+            None
+        """
+        # First, create a WasbHook and an S3Hook using the conn's that were provided
+        wasb_hook = WasbHook(wasb_conn_id=self.wasb_conn_id, **self.wasb_extra_args)
+        s3_hook = S3Hook(
+            aws_conn_id=self.aws_conn_id,
+            verify=self.dest_verify,  # TODO: How to handle this? Do we need to verify if it is a source?
+            extra_args=self.dest_s3_extra_args,  # TODO: Should we use a different parameter for this?
+            **self.s3_extra_args,
+        )
+        pass

--- a/airflow/providers/microsoft/azure/transfers/s3_to_wasb.py
+++ b/airflow/providers/microsoft/azure/transfers/s3_to_wasb.py
@@ -17,9 +17,8 @@
 # under the License.
 from __future__ import annotations
 
-import os
 import tempfile
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING, Sequence, List
 
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
@@ -39,7 +38,11 @@ class S3ToAzureBlobStorageOperator(BaseOperator):
     """
 
     template_fields: Sequence[str] = (
+        "s3_bucket",
+        "container_name",
+        "s3_prefix",
         "s3_key",
+        "blob_prefix",
         "blob_name"
     )
 
@@ -47,36 +50,40 @@ class S3ToAzureBlobStorageOperator(BaseOperator):
         self,
         *,
         aws_conn_id: str = "aws_default",
-        s3_bucket: str,
-        s3_key: str,  # Maybe, s3_key_prefix
         wasb_conn_id: str = "wasb_default",
-        blob_name: str,  # TODO: Think about making this optional
+        s3_bucket: str,
         container_name: str,
-        create_container: str,
-        replace: bool = True,
+        s3_prefix: str | None = None,  # Only use this to pull an entire directory of files
+        s3_key: str | None = None,  # Only use this to pull a single file
+        blob_prefix: str | None = None,
+        blob_name: str | None = None,
+        delimiter: str | None = None,
+        create_container: bool = False,
+        replace: bool = False,
+        s3_verify: bool = False,
         s3_extra_args: dict | None = None,
         wasb_extra_args: dict | None = None,
         **kwargs
     ):
-        # Call to super
+        # Call to constructor of the inherited BaseOperator class
         super().__init__(**kwargs)
 
         self.aws_conn_id = aws_conn_id
-        self.s3_bucket = s3_bucket
-        self.s3_key = s3_key
         self.wasb_conn_id = wasb_conn_id
-        self.blob_name = blob_name
+        self.s3_bucket = s3_bucket
         self.container_name = container_name
+        self.s3_prefix = s3_prefix if s3_prefix.endswith("/") else s3_prefix + "/"
+        self.s3_key = s3_key
+        self.blob_prefix = blob_prefix if blob_prefix.endswith("/") else blob_prefix + "/"
+        self.blob_name = blob_name
+        self.delimiter = delimiter
         self.create_container = create_container
         self.replace = replace
+        self.s3_verify = s3_verify
         self.s3_extra_args = s3_extra_args
         self.wasb_extra_args = wasb_extra_args
 
-        # Placeholder for now, remove this before pushing
-        self.dest_verify = None
-        self.dest_s3_extra_args = None
-
-    def execute(self, context: Context) -> None:
+    def execute(self, context: Context) -> List[str]:
         """
         execute
 
@@ -90,11 +97,75 @@ class S3ToAzureBlobStorageOperator(BaseOperator):
             None
         """
         # First, create a WasbHook and an S3Hook using the conn's that were provided
-        wasb_hook = WasbHook(wasb_conn_id=self.wasb_conn_id, **self.wasb_extra_args)
-        s3_hook = S3Hook(
+        wasb_hook: WasbHook = WasbHook(wasb_conn_id=self.wasb_conn_id, **self.wasb_extra_args)
+        s3_hook: S3Hook = S3Hook(
             aws_conn_id=self.aws_conn_id,
-            verify=self.dest_verify,  # TODO: How to handle this? Do we need to verify if it is a source?
-            extra_args=self.dest_s3_extra_args,  # TODO: Should we use a different parameter for this?
+            verify=self.s3_verify,
             **self.s3_extra_args,
         )
-        pass
+
+        self.log.info(
+            f"Getting list of files in the Bucket: {self.s3_bucket}"
+            f"Getting file: {self.s3_key}" if self.s3_key else f"Getting files from: {self.s3_prefix}"
+        )
+
+        # First, try to use the S3 key that is passed in. Otherwise, pull all files from the S3 bucket/path
+        # prefix and remove the prefix
+        if self.s3_key:
+            # Only pull the file name from the s3_key
+            files_to_move: List[str] = [self.s3_key.split("/")[-1]]
+        else:
+            # Pull the keys from the s3_bucket using the provided prefix. Remove the prefix from the file
+            # name, and add to the list of files to move
+            s3_keys: List[str] = s3_hook.list_keys(
+                bucket_name=self.s3_bucket,
+                prefix=self.s3_prefix,
+                delimiter=self.delimiter  # Optional filter by the "extension" of the file
+            )
+            files_to_move = [s3_key.replace(f"{self.s3_prefix}/", "", 1) for s3_key in s3_keys]
+
+        if not self.replace:
+            # Only grab the files from S3 that are not in Azure Blob already. This will prevent any files that
+            # exist in both S3 and Azure Blob from being overwritten. If a blob_name is provided, create a
+            # list with only this value
+            azure_blob_files: List[str] = [self.blob_name] if self.blob_name else \
+                wasb_hook.get_blobs_list_recursive(
+                container_name=self.container_name,
+                prefix=self.blob_prefix,
+                endswith=self.delimiter  # Optional filter by the "extension" of the file
+            )
+            existing_files = azure_blob_files if azure_blob_files else []  # TODO: Clean blob names
+            files_to_move = list(set(files_to_move) - set(existing_files))
+
+        if files_to_move:
+            for file in files_to_move:
+                with tempfile.NamedTemporaryFile() as temp_file:
+                    # If using an s3_key, this creates a scenario where the only file in the files_to_move
+                    # list is going to be the name pulled from the s3_key. It's not verbose, but provides
+                    # standard implementation across the operator
+                    source_s3_key: str = self.s3_key if self.s3_key else self.s3_prefix + file
+                    s3_hook.download_file(
+                        local_path=temp_file.name,  # Make sure to look at this
+                        bucket_name=self.s3_bucket,
+                        key=source_s3_key
+                    )
+
+                    # Load the file to Azure Blob using either the key that has been passed in, or the key
+                    # from the list of files present in the s3_prefix, plus the blob_prefix
+                    destination_azure_blob_name: str = self.blob_name if self.blob_name \
+                        else self.blob_prefix + file
+                    wasb_hook.load_file(
+                        file_path=temp_file.name,
+                        container_name=self.container_name,
+                        blob_name=destination_azure_blob_name,
+                        create_container=self.create_container,
+                        **self.wasb_extra_args
+                    )
+
+            self.log.info(f"All done, uploaded {len(files_to_move)} to Azure Blob.")
+
+        else:
+            self.log.info("There are no files to move!")
+
+        # Return a list of the files that were moved
+        return files_to_move

--- a/airflow/providers/microsoft/azure/transfers/s3_to_wasb.py
+++ b/airflow/providers/microsoft/azure/transfers/s3_to_wasb.py
@@ -86,6 +86,9 @@ class S3ToAzureBlobStorageOperator(BaseOperator):
         self.s3_extra_args = s3_extra_args or {}
         self.wasb_extra_args = wasb_extra_args or {}
 
+    # These cached properties come in handy when working with hooks. Rather than closing and opening new
+    # hooks, the same hook can be used across multiple methods (without having to use the constructor to
+    # create the hook)
     @cached_property
     def s3_hook(self) -> S3Hook:
         """Create and return an S3Hook."""

--- a/docs/apache-airflow-providers-microsoft-azure/transfer/s3_to_wasb.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/transfer/s3_to_wasb.rst
@@ -1,0 +1,62 @@
+
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+=================================================
+Amazon S3 to Azure Blob Storage Transfer Operator
+=================================================
+
+The Blob service stores text and binary data as objects in the cloud.
+The Blob service offers the following three resources: the storage account, containers, and blobs.
+Within your storage account, containers provide a way to organize sets of blobs.
+For more information about the service visit `Azure Blob Storage API documentation <https://docs.microsoft.com/en-us/rest/api/storageservices/blob-service-rest-api>`_.
+This page shows how to upload data from local filesystem to Azure Blob Storage.
+
+Use the ``S3ToWasbOperator`` transfer to copy the data from Amazon Simple Storage Service (S3) to Azure Blob Storage.
+
+Prerequisite Tasks
+------------------
+
+.. include:: ../operators/_partials/prerequisite_tasks.rst
+
+Operators
+---------
+
+.. _howto/operator:S3ToWasbOperator:
+
+
+Transfer Data from Amazon S3 to Blob Storage
+============================================
+
+To copy data from an Amazon AWS S3 Bucket to an Azure Blob Storage container, you can use
+:class:`~airflow.providers.microsoft.azure.transfers.s3_to_wasb.S3ToWasbOperator`
+
+Example usage:
+
+.. exampleinclude:: ../../../tests/system/providers/microsoft/azure/example_s3_to_wasb.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_s3_to_wasb]
+    :end-before: [END howto_s3_to_wasb]
+
+Reference
+---------
+
+For further information, please refer to the following links:
+
+* `AWS boto3 library documentation for Amazon S3 <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html>`__
+* `Azure Blob Storage client library <https://learn.microsoft.com/en-us/python/api/overview/azure/storage-blob-readme?view=azure-python>`__

--- a/docs/apache-airflow-providers-microsoft-azure/transfer/s3_to_wasb.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/transfer/s3_to_wasb.rst
@@ -50,8 +50,8 @@ Example usage:
 .. exampleinclude:: /../../tests/system/providers/microsoft/azure/example_s3_to_wasb.py
     :language: python
     :dedent: 4
-    :start-after: [START howto_s3_to_wasb]
-    :end-before: [END howto_s3_to_wasb]
+    :start-after: [START howto_transfer_s3_to_wasb]
+    :end-before: [END howto_transfer_s3_to_wasb]
 
 Reference
 ---------

--- a/docs/apache-airflow-providers-microsoft-azure/transfer/s3_to_wasb.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/transfer/s3_to_wasb.rst
@@ -42,7 +42,7 @@ Operators
 Transfer Data from Amazon S3 to Blob Storage
 ============================================
 
-To copy data from an Amazon AWS S3 Bucket to an Azure Blob Storage container, you can use
+To copy data from an Amazon AWS S3 Bucket to an Azure Blob Storage container, the following operator can be used:
 :class:`~airflow.providers.microsoft.azure.transfers.s3_to_wasb.S3ToWasbOperator`
 
 Example usage:

--- a/docs/apache-airflow-providers-microsoft-azure/transfer/s3_to_wasb.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/transfer/s3_to_wasb.rst
@@ -47,7 +47,7 @@ To copy data from an Amazon AWS S3 Bucket to an Azure Blob Storage container, yo
 
 Example usage:
 
-.. exampleinclude:: ../../../tests/system/providers/microsoft/azure/example_s3_to_wasb.py
+.. exampleinclude:: /../../tests/system/providers/microsoft/azure/example_s3_to_wasb.py
     :language: python
     :dedent: 4
     :start-after: [START howto_s3_to_wasb]

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -795,6 +795,7 @@
     ],
     "plugins": [],
     "cross-providers-deps": [
+      "amazon",
       "google",
       "oracle",
       "sftp"

--- a/tests/providers/microsoft/azure/transfers/test_s3_to_wasb.py
+++ b/tests/providers/microsoft/azure/transfers/test_s3_to_wasb.py
@@ -64,7 +64,7 @@ class TestS3ToAzureBlobStorageOperator:
             container_name=CONTAINER_NAME,
             blob_prefix=PREFIX,
             replace=True,
-            delimiter=DELIMITER
+            delimiter=DELIMITER,
         )
 
         # ... is None is used to validate if a value is None, while not ... is used to evaluate if a value
@@ -236,7 +236,7 @@ class TestS3ToAzureBlobStorageOperator:
             s3_key="TEST/TEST1.csv",
             container_name=CONTAINER_NAME,
             blob_name="TEST/TEST1.csv",
-            replace=True
+            replace=True,
         )
         # Placing an empty "context" object here (using None)
         uploaded_files = operator.get_files_to_move()

--- a/tests/providers/microsoft/azure/transfers/test_s3_to_wasb.py
+++ b/tests/providers/microsoft/azure/transfers/test_s3_to_wasb.py
@@ -23,45 +23,181 @@ from unittest import mock
 
 from moto import mock_aws
 
-from airflow.providers.amazon.aws.hooks.s3 import S3Hook
-from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
 from airflow.providers.microsoft.azure.transfers.s3_to_wasb import S3ToAzureBlobStorageOperator
 
-from tests.test_utils.azure_system_helpers import WASB_CONNECTION_ID
-
 TASK_ID = "test-s3-to-azure-blob-operator"
+AWS_CONN_ID = "test-conn-id"
+S3_BUCKET = "s3://test-bucket/"
 CONTAINER_NAME = "test-container"
 DELIMITER = ".csv"
 PREFIX = "TEST"
-S3_BUCKET = "s3://test-bucket/"
+TEMPFILE_NAME = "test-tempfile"
 MOCK_FILES = ["TEST1.csv", "TEST2.csv", "TEST3.csv"]
-S3_ACL_POLICY = "private-read"
+
+# Here are some of the tests that need to be run (for the execute() function)
+# 1. Prefix with no existing files, without replace [DONE]
+# 2. Prefix with existing files, without replace [DONE]
+# 3. Prefix with existing files, with replace [DONE]
+# 4. Two keys without existing files, without replace [DONE]
+# 5. Two keys with existing files, without replace
+# 6. Two keys with existing files, with replace
+# 7. S3 key with Azure prefix, without existing files, without replace
+# 8. S3 key with Azure prefix, with existing files, without replace
+# 9. S3 key with Azure prefix, with existing files, with replace
+
+# Other tests that need to be run
+# - Test __init__
+# - Test get_files_to_move
 
 
 @mock_aws
 class TestS3ToAzureBlobStorageOperator:
+    def test__init__(self):
+        # Create a mock operator with a single set of parameters that are used to test the __init__()
+        # constructor. Not every parameter needs to be provided, as this code will also be used to test the
+        # default parameters that are configured
+        operator = S3ToAzureBlobStorageOperator(
+            task_id=TASK_ID,
+            aws_conn_id="test-conn-id",
+            s3_bucket=S3_BUCKET,
+            s3_prefix=PREFIX,
+            container_name=CONTAINER_NAME,
+            blob_prefix=PREFIX,
+            replace=True,
+            delimiter=DELIMITER
+        )
 
-    @mock.patch("airflow.providers.amazon.aws.transfers.azure_blob_to_s3.S3Hook")
-    @mock.patch("airflow.providers.amazon.microsoft.azure.transfers.s3_to_wasb.WasbHook")
-    def test_operators_prefix(self, s3_mock_hook, wasb_mock_hook):
-        # Set the list files that the S3Hook should return
+        # ... is None is used to validate if a value is None, while not ... is used to evaluate if a value
+        # is False
+        assert operator.task_id == TASK_ID
+        assert operator.aws_conn_id == AWS_CONN_ID
+        assert operator.wasb_conn_id == "wasb_default"
+        assert operator.s3_bucket == S3_BUCKET
+        assert operator.container_name == CONTAINER_NAME
+        assert operator.s3_prefix == PREFIX
+        assert operator.s3_key is None
+        assert operator.blob_prefix == PREFIX
+        assert operator.blob_name is None
+        assert operator.delimiter == DELIMITER
+        assert not operator.create_container  # Should be false (match default value in constructor)
+        assert operator.replace
+        assert not operator.s3_verify  # Should be false (match default value in constructor)
+        assert operator.s3_extra_args == {}
+        assert operator.wasb_extra_args == {}
+
+    # There are a number of very similar tests that use the same mocking, and for the most part, the same
+    # logic
+    @mock.patch("airflow.providers.microsoft.azure.transfers.s3_to_wasb.S3Hook")
+    @mock.patch("airflow.providers.microsoft.azure.transfers.s3_to_wasb.WasbHook")
+    @mock.patch("tempfile.NamedTemporaryFile")
+    def test_execute_prefix_without_replace_empty_destination(
+        self, tempfile_mock, wasb_mock_hook, s3_mock_hook
+    ):
+        # TODO: Ideally, I'd like to rewrite this to use the get_files_to_move() method, rather than execute
+        # Set the list files that the S3Hook should return, as well as the list of files that are returned
+        # when the get_blobs_list_recursive method is called using the WasbHook. In this scenario, the
+        # destination is empty, meaning that the full list should be returned
         s3_mock_hook.return_value.list_keys.return_value = MOCK_FILES
         wasb_mock_hook.return_value.get_blobs_list_recursive.return_value = []
 
+        s3_mock_hook.return_value.download_file.return_value = RawIOBase(b"test file contents")
+        tempfile_mock.return_value.__enter__.return_value.name = TEMPFILE_NAME
+
+        # For testing, we're using a few default values. The most notable are the s3_conn_id and the
+        # wasb_conn_id
         operator = S3ToAzureBlobStorageOperator(
             task_id=TASK_ID,
             s3_bucket=S3_BUCKET,
-            s3_prefix="TEST",
+            s3_prefix=PREFIX,
             container_name=CONTAINER_NAME,
-            blob_prefix="TEST"
+            blob_prefix=PREFIX,
         )
-        # Need to create a container here
+        # When the execute() method is called in the operator, it first creates two hooks (S3Hook and
+        # WasbHook). The return values from any calls that use these hooks are mocked above, allowing the
+        # tests to run in a test setting
         uploaded_files = operator.execute(None)
 
         assert sorted(uploaded_files) == sorted(MOCK_FILES)
 
+    @mock.patch("airflow.providers.microsoft.azure.transfers.s3_to_wasb.S3Hook")
+    @mock.patch("airflow.providers.microsoft.azure.transfers.s3_to_wasb.WasbHook")
+    @mock.patch("tempfile.NamedTemporaryFile")
+    def test_execute_prefix_without_replace_populated_destination(
+        self, tempfile_mock, wasb_mock_hook, s3_mock_hook
+    ):
+        # Set the list files that the S3Hook should return
+        s3_mock_hook.return_value.list_keys.return_value = MOCK_FILES
+        wasb_mock_hook.return_value.get_blobs_list_recursive.return_value = MOCK_FILES[1:]
+
+        s3_mock_hook.return_value.download_file.return_value = RawIOBase(b"test file contents")
+        tempfile_mock.return_value.__enter__.return_value.name = TEMPFILE_NAME
+
+        operator = S3ToAzureBlobStorageOperator(
+            task_id=TASK_ID,
+            s3_bucket=S3_BUCKET,
+            s3_prefix=PREFIX,
+            container_name=CONTAINER_NAME,
+            blob_prefix=PREFIX,
+        )
+        # Placing an empty "context" object here (using None)
+        uploaded_files = operator.execute(None)
+
+        assert sorted(uploaded_files) == sorted([MOCK_FILES[0]])
+
+    @mock.patch("airflow.providers.microsoft.azure.transfers.s3_to_wasb.S3Hook")
+    @mock.patch("airflow.providers.microsoft.azure.transfers.s3_to_wasb.WasbHook")
+    @mock.patch("tempfile.NamedTemporaryFile")
+    def test_execute_prefix_with_replace_populated_destination(
+        self, tempfile_mock, wasb_mock_hook, s3_mock_hook
+    ):
+        # Set the list files that the S3Hook should return
+        s3_mock_hook.return_value.list_keys.return_value = MOCK_FILES
+        wasb_mock_hook.return_value.get_blobs_list_recursive.return_value = MOCK_FILES[1:]
+
+        s3_mock_hook.return_value.download_file.return_value = RawIOBase(b"test file contents")
+        tempfile_mock.return_value.__enter__.return_value.name = TEMPFILE_NAME
+
+        operator = S3ToAzureBlobStorageOperator(
+            task_id=TASK_ID,
+            s3_bucket=S3_BUCKET,
+            s3_prefix=PREFIX,
+            container_name=CONTAINER_NAME,
+            blob_prefix=PREFIX,
+            replace=True,
+        )
+        # Placing an empty "context" object here (using None)
+        uploaded_files = operator.execute(None)
+
+        # Since the replace parameter is being set to True, all the files that are present in the S3 bucket
+        # will be moved to the Azure Blob, even though there are existing files in the Azure Blob
+        assert sorted(uploaded_files) == sorted(MOCK_FILES)
+
+    @mock.patch("airflow.providers.microsoft.azure.transfers.s3_to_wasb.S3Hook")
+    @mock.patch("airflow.providers.microsoft.azure.transfers.s3_to_wasb.WasbHook")
+    @mock.patch("tempfile.NamedTemporaryFile")
+    def test_execute_key_without_replace_empty_destination(
+        self, tempfile_mock, wasb_mock_hook, s3_mock_hook
+    ):
+        # Different than above, able to remove the mocking of the list_keys method for the S3 hook (since a
+        # single key is being passed, rather than a prefix). Here, there is no file present in the container,
+        # so the file can be moved
+        wasb_mock_hook.return_value.check_for_blob.return_value = False
+
+        s3_mock_hook.return_value.download_file.return_value = RawIOBase(b"test file contents")
+        tempfile_mock.return_value.__enter__.return_value.name = TEMPFILE_NAME
+
+        operator = S3ToAzureBlobStorageOperator(
+            task_id=TASK_ID,
+            s3_bucket=S3_BUCKET,
+            s3_key="TEST/TEST1.csv",
+            container_name=CONTAINER_NAME,
+            blob_name="TEST/TEST1.csv",
+        )
+        # Placing an empty "context" object here (using None)
+        uploaded_files = operator.execute(None)
+
+        # Only the file name should be returned, rather than the entire blob name
+        assert sorted(uploaded_files) == sorted(["TEST1.csv"])
+
 
 # Test helpers
-def _create_container():
-    hook = WasbHook(WASB_CONNECTION_ID)
-    return hook

--- a/tests/providers/microsoft/azure/transfers/test_s3_to_wasb.py
+++ b/tests/providers/microsoft/azure/transfers/test_s3_to_wasb.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 
-from io import RawIOBase
+from io import BytesIO
 from unittest import mock
 
 import pytest
@@ -100,7 +100,7 @@ class TestS3ToAzureBlobStorageOperator:
         s3_mock_hook.return_value.list_keys.return_value = MOCK_FILES
         wasb_mock_hook.return_value.get_blobs_list_recursive.return_value = []
 
-        s3_mock_hook.return_value.download_file.return_value = RawIOBase(b"test file contents")
+        s3_mock_hook.return_value.download_file.return_value = BytesIO().write(b"test file contents")
         tempfile_mock.return_value.__enter__.return_value.name = TEMPFILE_NAME
 
         operator = S3ToAzureBlobStorageOperator(
@@ -238,7 +238,7 @@ class TestS3ToAzureBlobStorageOperator:
         # Only a single S3 key is provided, and there are no blobs in the container. This means that this file
         # should be moved, and the move_file method will be executed
         wasb_mock_hook.return_value.get_blobs_list_recursive.return_value = []
-        s3_mock_hook.return_value.download_file.return_value = RawIOBase(b"test file contents")
+        s3_mock_hook.return_value.download_file.return_value = BytesIO().write(b"test file contents")
 
         operator = S3ToAzureBlobStorageOperator(
             task_id=TASK_ID,

--- a/tests/providers/microsoft/azure/transfers/test_s3_to_wasb.py
+++ b/tests/providers/microsoft/azure/transfers/test_s3_to_wasb.py
@@ -1,0 +1,67 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from io import RawIOBase
+from unittest import mock
+
+from moto import mock_aws
+
+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
+from airflow.providers.microsoft.azure.transfers.s3_to_wasb import S3ToAzureBlobStorageOperator
+
+from tests.test_utils.azure_system_helpers import WASB_CONNECTION_ID
+
+TASK_ID = "test-s3-to-azure-blob-operator"
+CONTAINER_NAME = "test-container"
+DELIMITER = ".csv"
+PREFIX = "TEST"
+S3_BUCKET = "s3://test-bucket/"
+MOCK_FILES = ["TEST1.csv", "TEST2.csv", "TEST3.csv"]
+S3_ACL_POLICY = "private-read"
+
+
+@mock_aws
+class TestS3ToAzureBlobStorageOperator:
+
+    @mock.patch("airflow.providers.amazon.aws.transfers.azure_blob_to_s3.S3Hook")
+    @mock.patch("airflow.providers.amazon.microsoft.azure.transfers.s3_to_wasb.WasbHook")
+    def test_operators_prefix(self, s3_mock_hook, wasb_mock_hook):
+        # Set the list files that the S3Hook should return
+        s3_mock_hook.return_value.list_keys.return_value = MOCK_FILES
+        wasb_mock_hook.return_value.get_blobs_list_recursive.return_value = []
+
+        operator = S3ToAzureBlobStorageOperator(
+            task_id=TASK_ID,
+            s3_bucket=S3_BUCKET,
+            s3_prefix="TEST",
+            container_name=CONTAINER_NAME,
+            blob_prefix="TEST"
+        )
+        # Need to create a container here
+        uploaded_files = operator.execute(None)
+
+        assert sorted(uploaded_files) == sorted(MOCK_FILES)
+
+
+# Test helpers
+def _create_container():
+    hook = WasbHook(WASB_CONNECTION_ID)
+    return hook

--- a/tests/system/providers/microsoft/azure/example_s3_to_wasb.py
+++ b/tests/system/providers/microsoft/azure/example_s3_to_wasb.py
@@ -1,0 +1,114 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from datetime import datetime
+
+from airflow import DAG
+from airflow.decorators import task
+from airflow.models.baseoperator import chain
+
+from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
+from airflow.providers.amazon.aws.operators.s3 import (
+    S3CreateObjectOperator,
+    S3CreateBucketOperator,
+    S3DeleteBucketOperator
+)
+from airflow.providers.microsoft.azure.transfers.s3_to_wasb import S3ToAzureBlobStorageOperator
+
+from tests.system.providers.amazon.aws.utils import SystemTestContextBuilder
+
+sys_test_context_task = SystemTestContextBuilder().build()
+
+# Set constants
+DAG_ID: str = "example_s3_to_wasb"
+S3_KEY: str = "test/TEST1.csv"
+BLOB_PREFIX: str = "test"
+
+
+# Create tasks using the TaskFlow API to create and remove a container
+@task
+def create_wasb_container(container_name):
+    return WasbHook().create_container(container_name)
+
+
+@task
+def remove_wasb_container(container_name):
+    return WasbHook().delete_container(container_name)
+
+
+with DAG(
+    dag_id=DAG_ID,
+    start_date=datetime(2024, 1, 1),
+    schedule=None,
+    catchup=False
+) as dag:
+    # Pull the task context, as well as the ENV_ID
+    test_context = sys_test_context_task()
+    env_id = test_context["ENV_ID"]
+
+    # Create the bucket name and container name using the ENV_ID
+    s3_bucket_name: str = f"{env_id}-s3-bucket"
+    wasb_container_name: str = f"{env_id}-wasb-container"
+
+    # Create an S3 bucket
+    create_s3_bucket = S3CreateBucketOperator(task_id="create-s3-bucket", bucket_name=s3_bucket_name)
+
+    # Add a file to S3
+    create_s3_object = S3CreateObjectOperator(
+        task_id="create-s3-object",
+        s3_bucket=s3_bucket_name,
+        s3_key=S3_KEY,
+        data=b"Testing...",
+        replace=True,
+        encrypt=False
+    )
+
+    # Move a file from S3 to WASB
+    s3_to_wasb = S3ToAzureBlobStorageOperator(
+        task_id="s3-to-wasb",
+        s3_bucket=s3_bucket_name,
+        container_name=wasb_container_name,
+        s3_key=S3_KEY,
+        blob_prefix=BLOB_PREFIX,  # Using a prefix for this
+        replace=True
+    )
+
+    # Remove an S3 bucket
+    remove_s3_bucket = S3DeleteBucketOperator(task_id="remove-s3-bucket", bucket_name=s3_bucket_name)
+
+    # Set dependencies
+    chain(
+        create_s3_bucket,
+        create_wasb_container(wasb_container_name),
+        create_s3_object,
+        s3_to_wasb,
+        remove_wasb_container(wasb_container_name),
+        remove_s3_bucket
+    )
+
+    from tests.system.utils.watcher import watcher
+
+    # This test needs watcher in order to properly mark success/failure when "tearDown" task with trigger
+    # rule is part of the DAG
+    list(dag.tasks) >> watcher()
+
+from tests.system.utils import get_test_run  # noqa: E402
+
+# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+test_run = get_test_run(dag)

--- a/tests/system/providers/microsoft/azure/example_s3_to_wasb.py
+++ b/tests/system/providers/microsoft/azure/example_s3_to_wasb.py
@@ -65,7 +65,7 @@ with DAG(dag_id=DAG_ID, start_date=datetime(2024, 1, 1), schedule="@once", catch
         encrypt=False,
     )
 
-    # [START howto_s3_to_howto_s3_to_wasbwasb]
+    # [START howto_s3_to_wasb]
     s3_to_wasb = S3ToAzureBlobStorageOperator(
         task_id="s3_to_wasb",
         s3_bucket=s3_bucket_name,

--- a/tests/system/providers/microsoft/azure/example_s3_to_wasb.py
+++ b/tests/system/providers/microsoft/azure/example_s3_to_wasb.py
@@ -65,7 +65,7 @@ with DAG(dag_id=DAG_ID, start_date=datetime(2024, 1, 1), schedule="@once", catch
         encrypt=False,
     )
 
-    # [START howto_s3_to_wasb]
+    # [START howto_transfer_s3_to_wasb]
     s3_to_wasb = S3ToAzureBlobStorageOperator(
         task_id="s3_to_wasb",
         s3_bucket=s3_bucket_name,
@@ -75,7 +75,7 @@ with DAG(dag_id=DAG_ID, start_date=datetime(2024, 1, 1), schedule="@once", catch
         trigger_rule=TriggerRule.ALL_DONE,
         replace=True,
     )
-    # [END howto_s3_to_wasb]
+    # [END howto_transfer_s3_to_wasb]
 
     # Part of tear down, remove all the objects at the S3_PREFIX
     remove_s3_object = S3DeleteObjectsOperator(

--- a/tests/system/providers/microsoft/azure/example_s3_to_wasb.py
+++ b/tests/system/providers/microsoft/azure/example_s3_to_wasb.py
@@ -111,11 +111,4 @@ with DAG(dag_id=DAG_ID, start_date=datetime(2024, 1, 1), schedule="@once", catch
 from tests.system.utils import get_test_run  # noqa: E402
 
 # Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
-# To execute, run pytest --system microsoft tests/system/providers/microsoft/azure/example_s3_to_wasb.py
-test_run = get_test_run(dag)
-
-
-from tests.system.utils import get_test_run  # noqa: E402
-
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
 test_run = get_test_run(dag)

--- a/tests/system/providers/microsoft/azure/example_s3_to_wasb.py
+++ b/tests/system/providers/microsoft/azure/example_s3_to_wasb.py
@@ -65,7 +65,7 @@ with DAG(dag_id=DAG_ID, start_date=datetime(2024, 1, 1), schedule="@once", catch
         encrypt=False,
     )
 
-    # [START how_to_s3_to_wasb]
+    # [START howto_s3_to_howto_s3_to_wasbwasb]
     s3_to_wasb = S3ToAzureBlobStorageOperator(
         task_id="s3_to_wasb",
         s3_bucket=s3_bucket_name,
@@ -75,7 +75,7 @@ with DAG(dag_id=DAG_ID, start_date=datetime(2024, 1, 1), schedule="@once", catch
         trigger_rule=TriggerRule.ALL_DONE,
         replace=True,
     )
-    # [END how_to_s3_to_wasb]
+    # [END howto_s3_to_wasb]
 
     # Part of tear down, remove all the objects at the S3_PREFIX
     remove_s3_object = S3DeleteObjectsOperator(


### PR DESCRIPTION
This pull request looks to add an operator to the Microsoft provider to move data from S3 to Azure Blob Storage (WASB). The operator has full test-coverage, include an example DAG in `tests/system/providers/microsoft/azure/example_s3_to_wasb.py`.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
