### PR TITLE
Be able to remove ACL in S3 hook's copy_object

### DIFF
--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -1288,8 +1288,7 @@ class S3Hook(AwsBaseHook):
             It should be omitted when `dest_bucket_key` is provided as a full s3:// url.
         :param source_version_id: Version ID of the source object (OPTIONAL)
         :param acl_policy: The string to specify the canned ACL policy for the
-            object to be copied which is private by default. It is possible to remove
-            ACL by submitting "no-acl" explicitly
+            object to be copied which is private by default.
         """
         acl_policy = acl_policy or "private"
         if acl_policy != NO_ACL:

--- a/tests/providers/amazon/aws/hooks/test_s3.py
+++ b/tests/providers/amazon/aws/hooks/test_s3.py
@@ -1010,6 +1010,22 @@ class TestAwsS3Hook:
                 Key="my_key3",
                 CopySource={"Bucket": "airflow-test-s3-bucket", "Key": "my_key", "VersionId": None},
             )
+            patched_get_conn.reset_mock()
+
+            mock_hook.copy_object(
+                "my_key",
+                "my_key3",
+                s3_bucket,
+                s3_bucket,
+            )
+
+            # Check the default is "private"
+            patched_get_conn.return_value.copy_object.assert_called_once_with(
+                Bucket="airflow-test-s3-bucket",
+                Key="my_key3",
+                CopySource={"Bucket": "airflow-test-s3-bucket", "Key": "my_key", "VersionId": None},
+                ACL="private",
+            )
 
     @mock_aws
     def test_delete_bucket_if_bucket_exist(self, s3_bucket):

--- a/tests/providers/amazon/aws/hooks/test_s3.py
+++ b/tests/providers/amazon/aws/hooks/test_s3.py
@@ -35,6 +35,7 @@ from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.providers.amazon.aws.exceptions import S3HookUriParseFailure
 from airflow.providers.amazon.aws.hooks.s3 import (
+    NO_ACL,
     S3Hook,
     provide_bucket_name,
     unify_bucket_name_and_key,
@@ -989,6 +990,26 @@ class TestAwsS3Hook:
         )
         assert response["Grants"][0]["Permission"] == "FULL_CONTROL"
         assert len(response["Grants"]) == 1
+
+    @mock_aws
+    def test_copy_object_no_acl(
+        self,
+        s3_bucket,
+    ):
+        mock_hook = S3Hook()
+
+        with mock.patch.object(
+            S3Hook,
+            "get_conn",
+        ) as patched_get_conn:
+            mock_hook.copy_object("my_key", "my_key3", s3_bucket, s3_bucket, acl_policy=NO_ACL)
+
+            # Check we're not passing ACLs
+            patched_get_conn.return_value.copy_object.assert_called_once_with(
+                Bucket="airflow-test-s3-bucket",
+                Key="my_key3",
+                CopySource={"Bucket": "airflow-test-s3-bucket", "Key": "my_key", "VersionId": None},
+            )
 
     @mock_aws
     def test_delete_bucket_if_bucket_exist(self, s3_bucket):


### PR DESCRIPTION

---

In `providers.amazon.aws.hooks.s3.S3Hook`, it is currently not possible to run the `copy_object` method without an ACL policy.

As mentioned in the doc, the copy_object method will default to the canned ACL "private". Despite the capability to not write ACL in load/upload methods, It is not possible to copy without an ACL when implemented as such.

This change adds the capability to not write ACL on the destination object.
Since many users may rely on the default value being private, I suggest we used an explicit value that would remove the ACL.
The explicit value suggested: "no-acl". This value is not a [Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl) so we are not conflicting with any provider value. 
