### PR TITLE
Sanitize doc_md for jinja templating while initialising DAG

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -366,6 +366,8 @@ DAG_ARGS_EXPECTED_TYPES = {
     "dag_display_name": str,
 }
 
+SANITIZED_DOC_MD_TEXT = "[[ Riksy Jinja template detected & removed ]]"
+
 
 @functools.total_ordering
 class DAG(LoggingMixin):
@@ -768,10 +770,18 @@ class DAG(LoggingMixin):
 
         validate_instance_args(self, DAG_ARGS_EXPECTED_TYPES)
 
+    def sanitize_doc_md(self, doc_md: str) -> str:
+        import re
+
+        jinja_regex = r"\{\{.*?\}\}"
+        sanitized_doc_md = re.sub(jinja_regex, SANITIZED_DOC_MD_TEXT, doc_md)
+        return sanitized_doc_md
+
     def get_doc_md(self, doc_md: str | None) -> str | None:
         if doc_md is None:
             return doc_md
 
+        doc_md = self.sanitize_doc_md(doc_md)
         env = self.get_template_env(force_sandboxed=True)
 
         if not doc_md.endswith(".md"):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Adding ability to sanitise doc_md property for DAGs.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
