### PR TITLE
40559: fix add project_id to submit_batch_job hook

### DIFF
--- a/airflow/providers/google/cloud/operators/cloud_batch.py
+++ b/airflow/providers/google/cloud/operators/cloud_batch.py
@@ -86,7 +86,9 @@ class CloudBatchSubmitJobOperator(GoogleCloudBaseOperator):
 
     def execute(self, context: Context):
         hook: CloudBatchHook = CloudBatchHook(self.gcp_conn_id, self.impersonation_chain)
-        job = hook.submit_batch_job(job_name=self.job_name, job=self.job, region=self.region, project_id=self.project_id)
+        job = hook.submit_batch_job(
+            job_name=self.job_name, job=self.job, region=self.region, project_id=self.project_id
+        )
 
         if not self.deferrable:
             completed_job = hook.wait_for_job(

--- a/airflow/providers/google/cloud/operators/cloud_batch.py
+++ b/airflow/providers/google/cloud/operators/cloud_batch.py
@@ -86,7 +86,7 @@ class CloudBatchSubmitJobOperator(GoogleCloudBaseOperator):
 
     def execute(self, context: Context):
         hook: CloudBatchHook = CloudBatchHook(self.gcp_conn_id, self.impersonation_chain)
-        job = hook.submit_batch_job(job_name=self.job_name, job=self.job, region=self.region)
+        job = hook.submit_batch_job(job_name=self.job_name, job=self.job, region=self.region, project_id=self.project_id)
 
         if not self.deferrable:
             completed_job = hook.wait_for_job(

--- a/tests/providers/google/cloud/operators/test_cloud_batch.py
+++ b/tests/providers/google/cloud/operators/test_cloud_batch.py
@@ -51,7 +51,9 @@ class TestCloudBatchSubmitJobOperator:
 
         assert completed_job["name"] == JOB_NAME
 
-        mock.return_value.submit_batch_job.assert_called_with(job_name=JOB_NAME, job=JOB, region=REGION, project_id=PROJECT_ID)
+        mock.return_value.submit_batch_job.assert_called_with(
+            job_name=JOB_NAME, job=JOB, region=REGION, project_id=PROJECT_ID
+        )
         mock.return_value.wait_for_job.assert_called()
 
     @mock.patch(CLOUD_BATCH_HOOK_PATH)

--- a/tests/providers/google/cloud/operators/test_cloud_batch.py
+++ b/tests/providers/google/cloud/operators/test_cloud_batch.py
@@ -51,7 +51,7 @@ class TestCloudBatchSubmitJobOperator:
 
         assert completed_job["name"] == JOB_NAME
 
-        mock.return_value.submit_batch_job.assert_called_with(job_name=JOB_NAME, job=JOB, region=REGION)
+        mock.return_value.submit_batch_job.assert_called_with(job_name=JOB_NAME, job=JOB, region=REGION, project_id=PROJECT_ID)
         mock.return_value.wait_for_job.assert_called()
 
     @mock.patch(CLOUD_BATCH_HOOK_PATH)


### PR DESCRIPTION
Fix project_id  missing when calling submit_batch_job hook in the CloudBatchSubmitJobOperator
related: #40559

---