### PR TITLE
Update await_pod_completion and affected unit tests

### DIFF
--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -65,6 +65,10 @@ class PodLaunchFailedException(AirflowException):
     """When pod launching fails in KubernetesPodOperator."""
 
 
+class ResourceNotReadyException(AirflowException):
+    """When pod or cluster has not reached a ready state."""
+
+
 def should_retry_start_pod(exception: BaseException) -> bool:
     """Check if an Exception indicates a transient error and warrants retrying."""
     if isinstance(exception, ApiException):
@@ -603,6 +607,10 @@ class PodManager(LoggingMixin):
             self.log.info("Waiting for container '%s' state to be completed", container_name)
             time.sleep(1)
 
+    @tenacity.retry(
+        retry=tenacity.retry_if_exception_type(ResourceNotReadyException),
+        wait=tenacity.wait_fixed(2),
+    )
     def await_pod_completion(
         self, pod: V1Pod, istio_enabled: bool = False, container_name: str = "base"
     ) -> V1Pod:
@@ -614,15 +622,18 @@ class PodManager(LoggingMixin):
         :param container_name: name of the container within the pod
         :return: tuple[State, str | None]
         """
-        while True:
-            remote_pod = self.read_pod(pod)
-            if remote_pod.status.phase in PodPhase.terminal_states:
-                break
-            if istio_enabled and container_is_completed(remote_pod, container_name):
-                break
-            self.log.info("Pod %s has phase %s", pod.metadata.name, remote_pod.status.phase)
-            time.sleep(2)
-        return remote_pod
+        remote_pod = self._client.read_namespaced_pod_status(pod.metadata.name, pod.metadata.namespace)
+        self.log.info("Pod %s has phase %s", pod.metadata.name, remote_pod.status.phase)
+
+        if any(
+            [
+                remote_pod.status.phase in PodPhase.terminal_states,
+                istio_enabled and container_is_completed(remote_pod, container_name),
+            ]
+        ):
+            return self.read_pod(pod)
+
+        raise ResourceNotReadyException
 
     def parse_log_line(self, line: str) -> tuple[DateTime | None, str]:
         """

--- a/tests/providers/cncf/kubernetes/operators/test_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_pod.py
@@ -2248,8 +2248,9 @@ def test_async_kpo_wait_termination_before_cleanup_on_success(
     metadata = {"metadata.name": TEST_NAME, "metadata.namespace": TEST_NAMESPACE}
     running_state = mock.MagicMock(**metadata, **{"status.phase": "Running"})
     succeeded_state = mock.MagicMock(**metadata, **{"status.phase": "Succeeded"})
-    read_pod_status_mock = mocked_hook.return_value.core_v1_client.read_namespaced_pod_status
-    read_pod_status_mock.side_effect = [
+    mocked_hook.return_value.get_pod.return_value = running_state
+    read_pod_mock = mocked_hook.return_value.core_v1_client.read_namespaced_pod
+    read_pod_mock.side_effect = [
         running_state,
         running_state,
         succeeded_state,
@@ -2275,7 +2276,7 @@ def test_async_kpo_wait_termination_before_cleanup_on_success(
         mock_extract_xcom.assert_not_called()
 
     # check if it waits for the pod to complete
-    assert read_pod_status_mock.call_count == 3
+    assert read_pod_mock.call_count == 3
 
     # assert that the cleanup is called
     post_complete_action.assert_called_once()
@@ -2291,8 +2292,9 @@ def test_async_kpo_wait_termination_before_cleanup_on_failure(
     metadata = {"metadata.name": TEST_NAME, "metadata.namespace": TEST_NAMESPACE}
     running_state = mock.MagicMock(**metadata, **{"status.phase": "Running"})
     failed_state = mock.MagicMock(**metadata, **{"status.phase": "Failed"})
-    read_pod_status_mock = mocked_hook.return_value.core_v1_client.read_namespaced_pod_status
-    read_pod_status_mock.side_effect = [
+    mocked_hook.return_value.get_pod.return_value = running_state
+    read_pod_mock = mocked_hook.return_value.core_v1_client.read_namespaced_pod
+    read_pod_mock.side_effect = [
         running_state,
         running_state,
         failed_state,
@@ -2316,15 +2318,15 @@ def test_async_kpo_wait_termination_before_cleanup_on_failure(
     ti_mock.xcom_push.assert_not_called()
 
     if do_xcom_push:
-        # assert that the xcom are not extracted if do_xcom_push is False
+        # assert that the xcom are not extracted if do_xcom_push is Fale
         mock_extract_xcom.assert_called_once()
     else:
-        # but that it is extracted when do_xcom_push is true because the sidecar
+        # but that it is extracted when do_xcom_push is true because the sidecare
         # needs to be terminated
         mock_extract_xcom.assert_not_called()
 
     # check if it waits for the pod to complete
-    assert read_pod_status_mock.call_count == 3
+    assert read_pod_mock.call_count == 3
 
     # assert that the cleanup is called
     post_complete_action.assert_called_once()

--- a/tests/providers/cncf/kubernetes/operators/test_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_pod.py
@@ -2248,9 +2248,8 @@ def test_async_kpo_wait_termination_before_cleanup_on_success(
     metadata = {"metadata.name": TEST_NAME, "metadata.namespace": TEST_NAMESPACE}
     running_state = mock.MagicMock(**metadata, **{"status.phase": "Running"})
     succeeded_state = mock.MagicMock(**metadata, **{"status.phase": "Succeeded"})
-    mocked_hook.return_value.get_pod.return_value = running_state
-    read_pod_mock = mocked_hook.return_value.core_v1_client.read_namespaced_pod
-    read_pod_mock.side_effect = [
+    read_pod_status_mock = mocked_hook.return_value.core_v1_client.read_namespaced_pod_status
+    read_pod_status_mock.side_effect = [
         running_state,
         running_state,
         succeeded_state,
@@ -2276,7 +2275,7 @@ def test_async_kpo_wait_termination_before_cleanup_on_success(
         mock_extract_xcom.assert_not_called()
 
     # check if it waits for the pod to complete
-    assert read_pod_mock.call_count == 3
+    assert read_pod_status_mock.call_count == 3
 
     # assert that the cleanup is called
     post_complete_action.assert_called_once()
@@ -2292,9 +2291,8 @@ def test_async_kpo_wait_termination_before_cleanup_on_failure(
     metadata = {"metadata.name": TEST_NAME, "metadata.namespace": TEST_NAMESPACE}
     running_state = mock.MagicMock(**metadata, **{"status.phase": "Running"})
     failed_state = mock.MagicMock(**metadata, **{"status.phase": "Failed"})
-    mocked_hook.return_value.get_pod.return_value = running_state
-    read_pod_mock = mocked_hook.return_value.core_v1_client.read_namespaced_pod
-    read_pod_mock.side_effect = [
+    read_pod_status_mock = mocked_hook.return_value.core_v1_client.read_namespaced_pod_status
+    read_pod_status_mock.side_effect = [
         running_state,
         running_state,
         failed_state,
@@ -2318,15 +2316,15 @@ def test_async_kpo_wait_termination_before_cleanup_on_failure(
     ti_mock.xcom_push.assert_not_called()
 
     if do_xcom_push:
-        # assert that the xcom are not extracted if do_xcom_push is Fale
+        # assert that the xcom are not extracted if do_xcom_push is False
         mock_extract_xcom.assert_called_once()
     else:
-        # but that it is extracted when do_xcom_push is true because the sidecare
+        # but that it is extracted when do_xcom_push is true because the sidecar
         # needs to be terminated
         mock_extract_xcom.assert_not_called()
 
     # check if it waits for the pod to complete
-    assert read_pod_mock.call_count == 3
+    assert read_pod_status_mock.call_count == 3
 
     # assert that the cleanup is called
     post_complete_action.assert_called_once()


### PR DESCRIPTION
Follow-up to https://github.com/apache/airflow/pull/40360

Only modifying one of the methods at the moment.  If we like what I did here, I'll do the same for the others.  Please triple check my unit test changes to make sure I didn't inadvertently break the underlying mocks.

For the tenacity part of the change, note that I did away with the idea of using exponential backoff from the previous attempt (for now??) and just re-implemented the existing sleep(2) as a tenacity retry to align it with the other methods in this module which were already converted to tenacity.  We may go back to trying different retry periods later, but for now that part of the change is just for consistency.

@dstandish and @potiuk :  You both made good suggestions in the previous attempt at this, let me know what you think.  