### PR TITLE
Add D1 pydocstyle rules to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -276,8 +276,7 @@ extend-select = [
     "RUF019", # Checks for unnecessary key check
     "RUF100", # Unused noqa (auto-fixable)
     # We ignore more pydocstyle than we enable, so be more selective at what we enable
-    "D101",
-    "D106",
+    "D1",
     "D2",
     "D213", # Conflicts with D212.  Both can not be enabled.
     "D3",
@@ -299,6 +298,12 @@ extend-select = [
     "TRY002", # Prohibit use of `raise Exception`, use specific exceptions instead.
 ]
 ignore = [
+    "D100", # TODO: Missing docstring in public module
+    "D102", # TODO: Missing docstring in public method
+    "D103", # TODO: Missing docstring in public function
+    "D104", # TODO: Missing docstring in public package
+    "D105", # Do not want.  See https://lists.apache.org/thread/8jbg1dd2lr2cfydtqbjxsd6pb6q2wkc3
+    "D107", # TODO: Missing docstring in __init__
     "D203",
     "D212", # Conflicts with D213.  Both can not be enabled.
     "D214",


### PR DESCRIPTION
Step 0 for https://github.com/apache/airflow/issues/40567

Followup to the discussion [here](https://github.com/apache/airflow/issues/10742#issuecomment-2204392752), I'm explicitly adding the D1## rules to the exclude list and making them more obvious that we want to implement them.

I included D107 because it was part of the initial plan but I'd actually suggest that we do not want D107 enabled.  Forcing docstrings in `__init__` methods feels like a bad idea to me, personally, but I'll go with the community consensus on this one.