### PR TITLE
DataflowStartFlexTemplateOperator. Check for Dataflow job type each check cycle.

### DIFF
--- a/tests/providers/google/cloud/hooks/test_dataflow.py
+++ b/tests/providers/google/cloud/hooks/test_dataflow.py
@@ -1507,14 +1507,18 @@ class TestDataflowJob:
                     (None, DataflowJobStatus.JOB_STATE_QUEUED),
                     (None, DataflowJobStatus.JOB_STATE_PENDING),
                     (DataflowJobType.JOB_TYPE_STREAMING, DataflowJobStatus.JOB_STATE_RUNNING),
-                ], None, True
+                ],
+                None,
+                True
             ),
             (
                 [
                     (None, DataflowJobStatus.JOB_STATE_QUEUED),
                     (None, DataflowJobStatus.JOB_STATE_PENDING),
                     (DataflowJobType.JOB_TYPE_STREAMING, DataflowJobStatus.JOB_STATE_RUNNING),
-                ], True, False
+                ],
+                True,
+                False
             ),
             # BATCH
             (
@@ -1522,26 +1526,32 @@ class TestDataflowJob:
                     (None, DataflowJobStatus.JOB_STATE_QUEUED),
                     (None, DataflowJobStatus.JOB_STATE_PENDING),
                     (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_RUNNING),
-                ], False, True
+                ],
+                False,
+                True
             ),
             (
                 [
                     (None, DataflowJobStatus.JOB_STATE_QUEUED),
                     (None, DataflowJobStatus.JOB_STATE_PENDING),
                     (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_RUNNING),
-                ], None, False
+                ],
+                None,
+                False
             ),
             (
                 [
                     (None, DataflowJobStatus.JOB_STATE_QUEUED),
                     (None, DataflowJobStatus.JOB_STATE_PENDING),
                     (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_DONE),
-                ], None, True
+                ],
+                None,
+                True
             ),
         ],
     )
     def test_check_dataflow_job_state_without_job_type_changed_on_terminal_state(
-        self, jobs,wait_until_finished, expected_result
+        self, jobs, wait_until_finished, expected_result
     ):
         dataflow_job = _DataflowJobsController(
             dataflow=self.mock_dataflow,

--- a/tests/providers/google/cloud/hooks/test_dataflow.py
+++ b/tests/providers/google/cloud/hooks/test_dataflow.py
@@ -1499,6 +1499,68 @@ class TestDataflowJob:
         assert result == expected_result
 
     @pytest.mark.parametrize(
+        "jobs, wait_until_finished, expected_result",
+        [
+            # STREAMING
+            (
+                [
+                    (None, DataflowJobStatus.JOB_STATE_QUEUED),
+                    (None, DataflowJobStatus.JOB_STATE_PENDING),
+                    (DataflowJobType.JOB_TYPE_STREAMING, DataflowJobStatus.JOB_STATE_RUNNING),
+                ], None, True
+            ),
+            (
+                [
+                    (None, DataflowJobStatus.JOB_STATE_QUEUED),
+                    (None, DataflowJobStatus.JOB_STATE_PENDING),
+                    (DataflowJobType.JOB_TYPE_STREAMING, DataflowJobStatus.JOB_STATE_RUNNING),
+                ], True, False
+            ),
+            # BATCH
+            (
+                [
+                    (None, DataflowJobStatus.JOB_STATE_QUEUED),
+                    (None, DataflowJobStatus.JOB_STATE_PENDING),
+                    (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_RUNNING),
+                ], False, True
+            ),
+            (
+                [
+                    (None, DataflowJobStatus.JOB_STATE_QUEUED),
+                    (None, DataflowJobStatus.JOB_STATE_PENDING),
+                    (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_RUNNING),
+                ], None, False
+            ),
+            (
+                [
+                    (None, DataflowJobStatus.JOB_STATE_QUEUED),
+                    (None, DataflowJobStatus.JOB_STATE_PENDING),
+                    (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_DONE),
+                ], None, True
+            ),
+        ],
+    )
+    def test_check_dataflow_job_state_without_job_type_changed_on_terminal_state(
+        self, jobs,wait_until_finished, expected_result
+    ):
+        dataflow_job = _DataflowJobsController(
+            dataflow=self.mock_dataflow,
+            project_number=TEST_PROJECT,
+            name="name-",
+            location=TEST_LOCATION,
+            poll_sleep=0,
+            job_id=None,
+            num_retries=20,
+            multiple_jobs=True,
+            wait_until_finished=wait_until_finished,
+        )
+        result = False
+        for current_job in jobs:
+            job = {"id": "id-2", "name": "name-2", "type": current_job[0], "currentState": current_job[1]}
+            result = dataflow_job._check_dataflow_job_state(job)
+        assert result == expected_result
+
+    @pytest.mark.parametrize(
         "job_state, wait_until_finished, expected_result",
         [
             # DONE

--- a/tests/providers/google/cloud/hooks/test_dataflow.py
+++ b/tests/providers/google/cloud/hooks/test_dataflow.py
@@ -1509,7 +1509,7 @@ class TestDataflowJob:
                     (DataflowJobType.JOB_TYPE_STREAMING, DataflowJobStatus.JOB_STATE_RUNNING),
                 ],
                 None,
-                True
+                True,
             ),
             (
                 [
@@ -1518,7 +1518,7 @@ class TestDataflowJob:
                     (DataflowJobType.JOB_TYPE_STREAMING, DataflowJobStatus.JOB_STATE_RUNNING),
                 ],
                 True,
-                False
+                False,
             ),
             # BATCH
             (
@@ -1528,7 +1528,7 @@ class TestDataflowJob:
                     (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_RUNNING),
                 ],
                 False,
-                True
+                True,
             ),
             (
                 [
@@ -1537,7 +1537,7 @@ class TestDataflowJob:
                     (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_RUNNING),
                 ],
                 None,
-                False
+                False,
             ),
             (
                 [
@@ -1546,7 +1546,7 @@ class TestDataflowJob:
                     (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_DONE),
                 ],
                 None,
-                True
+                True,
             ),
         ],
     )


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
With expected status is not set,  _DataflowJobsController during first check sets terminal state for job like if it was BATCH.


https://github.com/apache/airflow/blob/c5c50cc07f6fcd704981139beb54095d8b9938c7/airflow/providers/google/cloud/hooks/dataflow.py#L419-L426

`self._expected_terminal_state  = JOB_STATE_DONE`
But it is common practice to use FlexTemplate for Datatflow job deployment, in that case job type could be set to STREAMING during job startup.

After streaming job is successfully started its state changed to `JOB_STATE_RUNNING` and flag `is_streaming` equals to `True`:
following branch is executed:
https://github.com/apache/airflow/blob/c5c50cc07f6fcd704981139beb54095d8b9938c7/airflow/providers/google/cloud/hooks/dataflow.py#L435-L439

which terminates operator with error because streaming is expected to have `expected_status` RUNNING and not DONE.

After this change `expected_state` inferred each cycle using up-to-date job type.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
