### PR TITLE
Extend list of folders which are not forced to be a subpackage to templates

### DIFF
--- a/scripts/ci/pre_commit/check_providers_subpackages_all_have_init.py
+++ b/scripts/ci/pre_commit/check_providers_subpackages_all_have_init.py
@@ -23,6 +23,7 @@ from glob import glob
 from pathlib import Path
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, os.pardir))
+ACCEPTED_NON_INIT_DIRS = ["adr", "doc", "templates"]
 
 
 def check_dir_init_file(provider_files: list[str]) -> None:
@@ -32,7 +33,7 @@ def check_dir_init_file(provider_files: list[str]) -> None:
             continue
         path = Path(candidate_path)
         if path.is_dir() and not (path / "__init__.py").exists():
-            if path.name != "adr" and path.name != "doc":
+            if path.name not in ACCEPTED_NON_INIT_DIRS:
                 missing_init_dirs.append(path)
 
     if missing_init_dirs:


### PR DESCRIPTION
Following the discussions in https://github.com/apache/airflow/pull/40224#discussion_r1663951541 this PR adds the folder `templates` to the list of pre-checks not requiring a `__init__.py`.