### PR TITLE
Fix Glue system test

### DIFF
--- a/tests/system/providers/amazon/aws/example_glue.py
+++ b/tests/system/providers/amazon/aws/example_glue.py
@@ -207,6 +207,7 @@ with DAG(
         # TEST BODY
         crawl_s3,
         wait_for_crawl,
+        wait_for_catalog_partition,
         submit_glue_job,
         wait_for_job,
         # TEST TEARDOWN


### PR DESCRIPTION
The new Sensor fro https://github.com/apache/airflow/pull/40492 was not added to the chain(), causing it to fire off before the database it is supposed to watch is even created, which in turn causes the test to fail.


Ran the test locally with this change and it passes with this change.