### PR TITLE
Do not dynamically determine op links for emr serverless start job operator

### DIFF
--- a/docs/apache-airflow-providers-amazon/operators/emr/emr_serverless.rst
+++ b/docs/apache-airflow-providers-amazon/operators/emr/emr_serverless.rst
@@ -72,7 +72,8 @@ Open Application UIs
 
 The operator can also be configured to generate one-time links to the application UIs and Spark stdout logs
 by passing the ``enable_application_ui_links=True`` as a parameter. Once the job starts running, these links
-are available in the Details section of the relevant Task.
+are available in the Details section of the relevant Task. If ``enable_application_ui_links=False`` then the
+links will be present but grayed out.
 
 You need to ensure you have the following IAM permissions to generate the dashboard link.
 

--- a/tests/providers/amazon/aws/operators/test_emr_serverless.py
+++ b/tests/providers/amazon/aws/operators/test_emr_serverless.py
@@ -25,23 +25,13 @@ from botocore.exceptions import WaiterError
 
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning, TaskDeferred
 from airflow.providers.amazon.aws.hooks.emr import EmrServerlessHook
-from airflow.providers.amazon.aws.links.emr import (
-    EmrServerlessCloudWatchLogsLink,
-    EmrServerlessDashboardLink,
-    EmrServerlessLogsLink,
-    EmrServerlessS3LogsLink,
-)
 from airflow.providers.amazon.aws.operators.emr import (
     EmrServerlessCreateApplicationOperator,
     EmrServerlessDeleteApplicationOperator,
     EmrServerlessStartJobOperator,
     EmrServerlessStopApplicationOperator,
 )
-from airflow.serialization.serialized_objects import (
-    BaseSerialization,
-)
 from airflow.utils.types import NOTSET
-from tests.test_utils.compat import deserialize_operator
 
 if TYPE_CHECKING:
     from unittest.mock import MagicMock
@@ -1151,50 +1141,6 @@ class TestEmrServerlessStartJobOperator:
             application_id=application_id,
             job_run_id=job_run_id,
         )
-
-    def test_operator_extra_links_mapped_without_applicationui_enabled(
-        self,
-    ):
-        operator = EmrServerlessStartJobOperator.partial(
-            task_id=task_id,
-            application_id=application_id,
-            execution_role_arn=execution_role_arn,
-            job_driver=spark_job_driver,
-            enable_application_ui_links=False,
-        ).expand(
-            configuration_overrides=[s3_configuration_overrides, cloudwatch_configuration_overrides],
-        )
-
-        ser_operator = BaseSerialization.serialize(operator)
-        deser_operator = deserialize_operator(ser_operator)
-
-        assert deser_operator.operator_extra_links == [
-            EmrServerlessS3LogsLink(),
-            EmrServerlessCloudWatchLogsLink(),
-        ]
-
-    def test_operator_extra_links_mapped_with_applicationui_enabled_at_partial(
-        self,
-    ):
-        operator = EmrServerlessStartJobOperator.partial(
-            task_id=task_id,
-            application_id=application_id,
-            execution_role_arn=execution_role_arn,
-            job_driver=spark_job_driver,
-            enable_application_ui_links=True,
-        ).expand(
-            configuration_overrides=[s3_configuration_overrides, cloudwatch_configuration_overrides],
-        )
-
-        ser_operator = BaseSerialization.serialize(operator)
-        deser_operator = deserialize_operator(ser_operator)
-
-        assert deser_operator.operator_extra_links == [
-            EmrServerlessS3LogsLink(),
-            EmrServerlessCloudWatchLogsLink(),
-            EmrServerlessDashboardLink(),
-            EmrServerlessLogsLink(),
-        ]
 
 
 class TestEmrServerlessDeleteOperator:


### PR DESCRIPTION
The dynamic determination of which extra link to include for the EmrServerlessStartJobOperator does not work with templated fields, since that evaluation was happening at DAG parsing time. This dynamic determination has been completely removed because:

1) If using templated fields for some inputs it needed, DAG parsing
   would fail.
2) Changing the DAG definition relating to those links, would often
   remove links for all previous DAG runs.
3) It overly complicates the code.

The new behaviour is to add all links to the TI and only those that are enabled will be "persisted" (i.e. actually have a link) and those that are not will be present but greyed out and will link back to the TI (the Airflow default).


![Screenshot from 2024-07-05 10-50-23](https://github.com/apache/airflow/assets/65743084/01df1ba6-4db1-4211-83b3-8cbcd9f59051)

fixes #40103

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
