### PR TITLE
Add ability to set labels specific to dag processor objects and pods

### DIFF
--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -42,8 +42,8 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    {{- with .Values.labels }}
-      {{- toYaml . | nindent 4 }}
+    {{- if or (.Values.labels) (.Values.dagProcessor.labels) }}
+    {{- mustMerge .Values.dagProcessor.labels .Values.labels | toYaml | nindent 4 }}
     {{- end }}
   {{- if .Values.dagProcessor.annotations }}
   annotations: {{- toYaml .Values.dagProcessor.annotations | nindent 4 }}

--- a/chart/templates/dag-processor/dag-processor-serviceaccount.yaml
+++ b/chart/templates/dag-processor/dag-processor-serviceaccount.yaml
@@ -33,8 +33,8 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    {{- with .Values.labels }}
-      {{- toYaml . | nindent 4 }}
+    {{- if or (.Values.labels) (.Values.dagProcessor.labels) }}
+    {{- mustMerge .Values.dagProcessor.labels .Values.labels | toYaml | nindent 4 }}
     {{- end }}
   {{- with .Values.dagProcessor.serviceAccount.annotations}}
   annotations: {{- toYaml . | nindent 4 }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3625,6 +3625,14 @@
                         "type": "string"
                     }
                 },
+                "labels": {
+                    "description": "Labels to add to the dag processor objects and pods.",
+                    "type": "object",
+                    "default": {},
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "securityContext": {
                     "description": "Security context for the dag processor pod (deprecated, use `securityContexts` instead). If not set, the values from `securityContext` will be used.",
                     "type": "object",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1803,6 +1803,9 @@ dagProcessor:
   # annotations for the dag processor deployment
   annotations: {}
 
+  # Labels specific to dag processor objects and pods
+  labels: {}
+
   podAnnotations: {}
 
   logGroomerSidecar:

--- a/helm_tests/airflow_core/test_dag_processor.py
+++ b/helm_tests/airflow_core/test_dag_processor.py
@@ -772,7 +772,7 @@ class TestDagProcessorServiceAccount:
                     "labels": {"test_specific_label": "test_specific_label_value"},
                 },
             },
-            show_only=["templates/jobs/dag-processor-serviceaccount.yaml"],
+            show_only=["templates/dag-processor/dag-processor-serviceaccount.yaml"],
         )
         assert "test_common_label" in jmespath.search("metadata.labels", docs[0])
         assert jmespath.search("metadata.labels", docs[0])["test_common_label"] == "test_common_label_value"

--- a/helm_tests/airflow_core/test_dag_processor.py
+++ b/helm_tests/airflow_core/test_dag_processor.py
@@ -668,6 +668,39 @@ class TestDagProcessor:
         assert "annotations" in jmespath.search("metadata", docs[0])
         assert jmespath.search("metadata.annotations", docs[0])["test_annotation"] == "test_annotation_value"
 
+    def test_should_add_component_specific_labels(self):
+        docs = render_chart(
+            values={
+                "dagProcessor": {
+                    "labels": {"test_label": "test_label_value"},
+                },
+            },
+            show_only=["templates/dag-processor/dag-processor-deployment.yaml"],
+        )
+        assert "test_label" in jmespath.search("spec.template.metadata.labels", docs[0])
+        assert jmespath.search("spec.template.metadata.labels", docs[0])["test_label"] == "test_label_value"
+
+    def test_should_merge_common_labels_and_component_specific_labels(self):
+        docs = render_chart(
+            values={
+                "labels": {"test_common_label": "test_common_label_value"},
+                "dagProcessor": {
+                    "labels": {"test_specific_label": "test_specific_label_value"},
+                },
+            },
+            show_only=["templates/dag-processor/dag-processor-deployment.yaml"],
+        )
+        assert "test_common_label" in jmespath.search("spec.template.metadata.labels", docs[0])
+        assert (
+            jmespath.search("spec.template.metadata.labels", docs[0])["test_common_label"]
+            == "test_common_label_value"
+        )
+        assert "test_specific_label" in jmespath.search("spec.template.metadata.labels", docs[0])
+        assert (
+            jmespath.search("spec.template.metadata.labels", docs[0])["test_specific_label"]
+            == "test_specific_label_value"
+        )
+
     @pytest.mark.parametrize(
         "webserver_config, should_add_volume",
         [
@@ -717,6 +750,36 @@ class TestDagProcessorLogGroomer(LogGroomerTestBase):
 
 class TestDagProcessorServiceAccount:
     """Tests DAG processor service account."""
+
+    def test_should_add_component_specific_labels(self):
+        docs = render_chart(
+            values={
+                "dagProcessor": {
+                    "labels": {"test_label": "test_label_value"},
+                },
+            },
+            show_only=["templates/dag-processor/dag-processor-serviceaccount.yaml"],
+        )
+
+        assert "test_label" in jmespath.search("metadata.labels", docs[0])
+        assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
+
+    def test_should_merge_common_labels_and_component_specific_labels(self):
+        docs = render_chart(
+            values={
+                "labels": {"test_common_label": "test_common_label_value"},
+                "dagProcessor": {
+                    "labels": {"test_specific_label": "test_specific_label_value"},
+                },
+            },
+            show_only=["templates/jobs/dag-processor-serviceaccount.yaml"],
+        )
+        assert "test_common_label" in jmespath.search("metadata.labels", docs[0])
+        assert jmespath.search("metadata.labels", docs[0])["test_common_label"] == "test_common_label_value"
+        assert "test_specific_label" in jmespath.search("metadata.labels", docs[0])
+        assert (
+            jmespath.search("metadata.labels", docs[0])["test_specific_label"] == "test_specific_label_value"
+        )
 
     def test_default_automount_service_account_token(self):
         docs = render_chart(

--- a/helm_tests/airflow_core/test_dag_processor.py
+++ b/helm_tests/airflow_core/test_dag_processor.py
@@ -672,6 +672,7 @@ class TestDagProcessor:
         docs = render_chart(
             values={
                 "dagProcessor": {
+                    "enabled": True,
                     "labels": {"test_label": "test_label_value"},
                 },
             },
@@ -685,6 +686,7 @@ class TestDagProcessor:
             values={
                 "labels": {"test_common_label": "test_common_label_value"},
                 "dagProcessor": {
+                    "enabled": True,
                     "labels": {"test_specific_label": "test_specific_label_value"},
                 },
             },
@@ -755,6 +757,7 @@ class TestDagProcessorServiceAccount:
         docs = render_chart(
             values={
                 "dagProcessor": {
+                    "enabled": True,
                     "labels": {"test_label": "test_label_value"},
                 },
             },
@@ -769,6 +772,7 @@ class TestDagProcessorServiceAccount:
             values={
                 "labels": {"test_common_label": "test_common_label_value"},
                 "dagProcessor": {
+                    "enabled": True,
                     "labels": {"test_specific_label": "test_specific_label_value"},
                 },
             },


### PR DESCRIPTION
Add the ability to set labels specific to dag processor objects and pods. 

Release 1.7.0 of the Helm chart included:

 - Added labels to specific Airflow components (https://github.com/apache/airflow/pull/25031)
 - Provision Standalone Dag Processor (https://github.com/apache/airflow/pull/23711)

Given both features were added in the same release, extending the ability to label dag processor specific pods and objects was (presumably) missed.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
