### PR TITLE
Fix classifying of changes for multiple providers

### DIFF
--- a/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
+++ b/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
@@ -132,10 +132,8 @@ class Change(NamedTuple):
     pr: str | None
 
 
-def get_most_impactful_change(changes):
-    changes_types = list(changes.values())
-    changes_enum = [TypeOfChange(change) for change in changes_types]
-    return max(changes_enum, key=lambda change: precedence_order[change])
+def get_most_impactful_change(changes: list[TypeOfChange]):
+    return max(changes, key=lambda change: precedence_order[change])
 
 
 def format_message_for_classification(message):
@@ -736,6 +734,7 @@ def update_release_notes(
             change_table_len = len(list_of_list_of_changes[0])
             table_iter = 0
             global SHORT_HASH_TO_TYPE_DICT
+            type_of_current_package_changes: list[TypeOfChange] = []
             while table_iter < change_table_len:
                 get_console().print()
                 formatted_message = format_message_for_classification(
@@ -747,12 +746,12 @@ def update_release_notes(
                     f" by referring to the above table[/]"
                 )
                 type_of_change = _ask_the_user_for_the_type_of_changes(non_interactive=non_interactive)
-                # update the type of change for every short_hash in the global dict
-                SHORT_HASH_TO_TYPE_DICT[list_of_list_of_changes[0][table_iter].short_hash] = type_of_change
+                change_hash = list_of_list_of_changes[0][table_iter].short_hash
+                SHORT_HASH_TO_TYPE_DICT[change_hash] = type_of_change
+                type_of_current_package_changes.append(type_of_change)
                 table_iter += 1
                 print()
-
-            most_impactful = get_most_impactful_change(SHORT_HASH_TO_TYPE_DICT)
+            most_impactful = get_most_impactful_change(type_of_current_package_changes)
             get_console().print(
                 f"[info]The version will be bumped because of {most_impactful} kind of change"
             )


### PR DESCRIPTION
When classifying the changes, hashes are stored in a dictionary to provide defaults for the same hash appearing in another provider, however the code to find most impactful change was using all previously classified hashes (even those not appearing in the current provider) to decide what is the most impactful change.

This PR changes it to use only classification for current provider changes to determine the most impactful change.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
