### PR TITLE
Enhance User Experience by Opening external UI Links in new Tab on browser.

### DIFF
--- a/airflow/www/templates/airflow/providers.html
+++ b/airflow/www/templates/airflow/providers.html
@@ -40,7 +40,7 @@ under the License.
 
     {% for provider in providers %}
       <tr>
-          <td><a href="{{ provider['documentation_url'] }}">{{ provider["package_name"] }}</a></td>
+          <td><a href="{{ provider['documentation_url'] }}" target="_blank" rel="noopener noreferrer">{{ provider["package_name"] }}</a></td>
           <td>{{ provider["version"] }}</td>
           <td>{{ provider["description"]}}</td>
       </tr>

--- a/airflow/www/templates/appbuilder/navbar_menu.html
+++ b/airflow/www/templates/appbuilder/navbar_menu.html
@@ -18,7 +18,12 @@
 #}
 
 {% macro menu_item(item) %}
-  <a href="{{item.get_url()}}">{{_(item.label)}}</a>
+  {% set url = item.get_url() %}
+  {% if 'apache' in url %}
+    <a href="{{ url }}" target="_blank" rel="noopener noreferrer">{{_(item.label)}}</a>
+  {% else %}
+    <a href="{{ url }}">{{_(item.label)}}</a>
+  {% endif %}
 {% endmacro %}
 
 {% for item1 in auth_manager.filter_permitted_menu_items(menu.get_list()) %}

--- a/airflow/www/templates/appbuilder/navbar_menu.html
+++ b/airflow/www/templates/appbuilder/navbar_menu.html
@@ -17,12 +17,19 @@
  under the License.
 #}
 
+{% set external_menu_url_prefixes = [
+  'https://github.com',
+  'https://airflow.apache.org',
+  'http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com']
+%}
+
 {% macro menu_item(item) %}
   {% set url = item.get_url() %}
-  {% if 'apache' in url %}
-    <a href="{{ url }}" target="_blank" rel="noopener noreferrer">{{_(item.label)}}</a>
+  {% set prefix = "/".join(url.split("/")[:3]) %}
+  {% if prefix in external_menu_url_prefixes %}
+      <a href="{{ url }}" target="_blank" rel="noopener noreferrer">{{ item.label }}</a>
   {% else %}
-    <a href="{{ url }}">{{_(item.label)}}</a>
+      <a href="{{ url }}">{{ item.label }}</a>
   {% endif %}
 {% endmacro %}
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -4514,13 +4514,13 @@ class ProviderView(AirflowBaseView):
             text = match_obj.group(1)
             url = match_obj.group(2)
 
-            # parsing the url to check if ita a valid url
+            # parsing the url to check if it's a valid url
             parsed_url = urlparse(url)
             if not (parsed_url.scheme == "http" or parsed_url.scheme == "https"):
                 # returning the original raw text
                 return escape(match_obj.group(0))
 
-            return Markup(f'<a href="{url}">{text}</a>')
+            return Markup(f'<a href="{url}" target="_blank" rel="noopener noreferrer">{text}</a>')
 
         cd = escape(description)
         cd = re2.sub(r"`(.*)[\s+]+&lt;(.*)&gt;`__", _build_link, cd)

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -245,7 +245,8 @@ airflowLocalSettings: |-
     UIAlert(
       'Usage of a dynamic webserver secret key detected. We recommend a static webserver secret key instead.'
       ' See the <a href='
-      '"https://airflow.apache.org/docs/helm-chart/stable/production-guide.html#webserver-secret-key">'
+      '"https://airflow.apache.org/docs/helm-chart/stable/production-guide.html#webserver-secret-key" 
+      target="_blank" rel="noopener noreferrer">'
       'Helm Chart Production Guide</a> for more details.',
       category="warning",
       roles=["Admin"],

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -245,8 +245,8 @@ airflowLocalSettings: |-
     UIAlert(
       'Usage of a dynamic webserver secret key detected. We recommend a static webserver secret key instead.'
       ' See the <a href='
-      '"https://airflow.apache.org/docs/helm-chart/stable/production-guide.html#webserver-secret-key" 
-      target="_blank" rel="noopener noreferrer">'
+      '"https://airflow.apache.org/docs/helm-chart/stable/production-guide.html#webserver-secret-key" '
+      'target="_blank" rel="noopener noreferrer">'
       'Helm Chart Production Guide</a> for more details.',
       category="warning",
       roles=["Admin"],

--- a/tests/www/views/test_views.py
+++ b/tests/www/views/test_views.py
@@ -149,7 +149,7 @@ def test_should_list_providers_on_page_with_details(admin_client):
     [
         (
             "`Airbyte <https://airbyte.com/>`__",
-            Markup('<a href="https://airbyte.com/" ' 'target="_blank" rel="noopener noreferrer">Airbyte</a>'),
+            Markup('<a href="https://airbyte.com/" target="_blank" rel="noopener noreferrer">Airbyte</a>'),
         ),
         (
             "Amazon integration (including `Amazon Web Services (AWS) <https://aws.amazon.com/>`__).",

--- a/tests/www/views/test_views.py
+++ b/tests/www/views/test_views.py
@@ -149,10 +149,7 @@ def test_should_list_providers_on_page_with_details(admin_client):
     [
         (
             "`Airbyte <https://airbyte.com/>`__",
-            Markup(
-                '<a href="https://airbyte.com/" '
-                'target="_blank" rel="noopener noreferrer">Airbyte</a>'
-            ),
+            Markup('<a href="https://airbyte.com/" ' 'target="_blank" rel="noopener noreferrer">Airbyte</a>'),
         ),
         (
             "Amazon integration (including `Amazon Web Services (AWS) <https://aws.amazon.com/>`__).",

--- a/tests/www/views/test_views.py
+++ b/tests/www/views/test_views.py
@@ -137,7 +137,9 @@ def test_should_list_providers_on_page_with_details(admin_client):
     resp = admin_client.get("/provider")
     beam_href = '<a href="https://airflow.apache.org/docs/apache-airflow-providers-apache-beam/'
     beam_text = "apache-airflow-providers-apache-beam</a>"
-    beam_description = '<a href="https://beam.apache.org/">Apache Beam</a>'
+    beam_description = (
+        '<a href="https://beam.apache.org/" target="_blank" rel="noopener noreferrer">Apache Beam</a>'
+    )
     check_content_in_response(beam_href, resp)
     check_content_in_response(beam_text, resp)
     check_content_in_response(beam_description, resp)

--- a/tests/www/views/test_views.py
+++ b/tests/www/views/test_views.py
@@ -147,20 +147,22 @@ def test_should_list_providers_on_page_with_details(admin_client):
 @pytest.mark.parametrize(
     "provider_description, expected",
     [
-        ("`Airbyte <https://airbyte.com/>`__", Markup('<a href="https://airbyte.com/">Airbyte</a>')),
+        (
+            "`Airbyte <https://airbyte.com/>`__",
+            Markup('<a href="https://airbyte.com/" target="_blank" rel="noopener noreferrer">Airbyte</a>')),
         (
             "Amazon integration (including `Amazon Web Services (AWS) <https://aws.amazon.com/>`__).",
             Markup(
-                'Amazon integration (including <a href="https://aws.amazon.com/">Amazon Web Services ('
-                "AWS)</a>)."
+                'Amazon integration (including <a href="https://aws.amazon.com/" '
+                'target="_blank" rel="noopener noreferrer">Amazon Web Services (AWS)</a>).'
             ),
         ),
         (
             "`Java Database Connectivity (JDBC) <https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc"
             "/>`__",
             Markup(
-                '<a href="https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/">Java '
-                "Database Connectivity (JDBC)</a>"
+                '<a href="https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/" '
+                'target="_blank" rel="noopener noreferrer">Java Database Connectivity (JDBC)</a>'
             ),
         ),
         (

--- a/tests/www/views/test_views.py
+++ b/tests/www/views/test_views.py
@@ -149,7 +149,8 @@ def test_should_list_providers_on_page_with_details(admin_client):
     [
         (
             "`Airbyte <https://airbyte.com/>`__",
-            Markup('<a href="https://airbyte.com/" target="_blank" rel="noopener noreferrer">Airbyte</a>')),
+            Markup('<a href="https://airbyte.com/" target="_blank" rel="noopener noreferrer">Airbyte</a>')
+        ),
         (
             "Amazon integration (including `Amazon Web Services (AWS) <https://aws.amazon.com/>`__).",
             Markup(

--- a/tests/www/views/test_views.py
+++ b/tests/www/views/test_views.py
@@ -149,7 +149,10 @@ def test_should_list_providers_on_page_with_details(admin_client):
     [
         (
             "`Airbyte <https://airbyte.com/>`__",
-            Markup('<a href="https://airbyte.com/" target="_blank" rel="noopener noreferrer">Airbyte</a>')
+            Markup(
+                '<a href="https://airbyte.com/" '
+                'target="_blank" rel="noopener noreferrer">Airbyte</a>'
+            ),
         ),
         (
             "Amazon integration (including `Amazon Web Services (AWS) <https://aws.amazon.com/>`__).",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

**DESCRIPTION**

In the Airflow UI today, a couple of pages on the Menu bar have links that point to **external Apache Airflow related links** eg; documentation/github Repo as outlined [here](https://github.com/apache/airflow/blob/e827bfbd2c79f3432411e14351c245a06410766a/airflow/www/extensions/init_appbuilder_links.py#L61) . 

**Issue:**
At the moment, when a user clicks on them, it literally removes you from the UI on the same browser tab. Users now need to click back to return to the UI, it gets more tricky when you've clicked so many links on the docs page. This is same for the [prompt ](https://github.com/apache/airflow/blob/e827bfbd2c79f3432411e14351c245a06410766a/chart/values.yaml#L247)that comes up when no webserverSecretKey has been set. 

**Included**: Also open provider links in new tab.

**Proposed Solution:**
Simply enrich the <a href></a> html tags to open in a new tab, easier to modify this via jinja.

**Concerns:** As at today, we have very few external links directly in the Menu Bar. Coincidentally containing "apache", if this changes in future, then users would experience the same issue.
- For third party provider links, this implementation ensures that no referrer/origin information is sent to the external website, improving security of user platforms.

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
