### PR TITLE
Restructuring PR classification for providers with misc changes

### DIFF
--- a/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
+++ b/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
@@ -108,16 +108,18 @@ class TypeOfChange(Enum):
     FEATURE = "f"
     BREAKING_CHANGE = "x"
     SKIP = "s"
+    MISC = "m"
 
 
 # defines the precedence order for provider version bumps
-# BREAKING_CHANGE > FEATURE > BUGFIX > DOCUMENTATION > SKIP
+# BREAKING_CHANGE > FEATURE > BUGFIX > MISC > DOCUMENTATION > SKIP
 precedence_order = {
     TypeOfChange.SKIP: 0,
     TypeOfChange.DOCUMENTATION: 1,
-    TypeOfChange.BUGFIX: 2,
-    TypeOfChange.FEATURE: 3,
-    TypeOfChange.BREAKING_CHANGE: 4,
+    TypeOfChange.MISC: 2,
+    TypeOfChange.BUGFIX: 3,
+    TypeOfChange.FEATURE: 4,
+    TypeOfChange.BREAKING_CHANGE: 5,
 }
 
 
@@ -428,7 +430,7 @@ def _ask_the_user_for_the_type_of_changes(non_interactive: bool) -> TypeOfChange
     while True:
         get_console().print(
             "[warning]Type of change (b)ugfix, (f)eature, (x)breaking "
-            f"change, (s)kip, (q)uit [{display_answers}]?[/] ",
+            f"change, (m)misc, (s)kip, (q)uit [{display_answers}]?[/] ",
             end="",
         )
         try:
@@ -899,13 +901,14 @@ def _get_changes_classified(
 
         if type_of_change == TypeOfChange.BUGFIX:
             classified_changes.fixes.append(change)
+        elif type_of_change == TypeOfChange.MISC:
+            classified_changes.misc.append(change)
         elif type_of_change == TypeOfChange.FEATURE and maybe_with_new_features:
             classified_changes.features.append(change)
         elif type_of_change == TypeOfChange.BREAKING_CHANGE and with_breaking_changes:
             classified_changes.breaking_changes.append(change)
         else:
-            # for the changes we do not have a category for, add it to misc
-            classified_changes.misc.append(change)
+            classified_changes.other.append(change)
     return classified_changes
 
 

--- a/dev/breeze/tests/test_provider_documentation.py
+++ b/dev/breeze/tests/test_provider_documentation.py
@@ -236,11 +236,12 @@ def generate_short_hash():
 
 @pytest.mark.parametrize(
     "descriptions, with_breaking_changes, maybe_with_new_features,"
-    "breaking_count, feature_count, bugfix_count, other_count, type_of_change",
+    "breaking_count, feature_count, bugfix_count, other_count, misc_count, type_of_change",
     [
-        (["Added feature x"], True, True, 0, 1, 0, 0, [TypeOfChange.FEATURE]),
-        (["Added feature x"], False, True, 0, 1, 0, 0, [TypeOfChange.FEATURE]),
-        (["Breaking change in"], True, True, 1, 0, 0, 0, [TypeOfChange.BREAKING_CHANGE]),
+        (["Added feature x"], True, True, 0, 1, 0, 0, 0, [TypeOfChange.FEATURE]),
+        (["Added feature x"], False, True, 0, 1, 0, 0, 0, [TypeOfChange.FEATURE]),
+        (["Breaking change in"], True, True, 1, 0, 0, 0, 0, [TypeOfChange.BREAKING_CHANGE]),
+        (["Misc change in"], False, False, 0, 0, 0, 0, 1, [TypeOfChange.MISC]),
         (
             ["Fix change in", "Breaking feature y"],
             True,
@@ -248,6 +249,7 @@ def generate_short_hash():
             1,
             0,
             1,
+            0,
             0,
             [TypeOfChange.BUGFIX, TypeOfChange.BREAKING_CHANGE],
         ),
@@ -261,6 +263,7 @@ def test_classify_changes_automatically(
     feature_count: int,
     bugfix_count: int,
     other_count: int,
+    misc_count: int,
     type_of_change: TypeOfChange,
 ):
     from airflow_breeze.prepare_providers.provider_documentation import SHORT_HASH_TO_TYPE_DICT
@@ -283,3 +286,5 @@ def test_classify_changes_automatically(
     assert len(classified_changes.features) == feature_count
     assert len(classified_changes.fixes) == bugfix_count
     assert len(classified_changes.other) == other_count
+    assert len(classified_changes.other) == other_count
+    assert len(classified_changes.misc) == misc_count


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

There is a gap in the `prepare-provider-documentation` command that doesn't allow categorising the misc kind of changes properly and a hack needs to be used.

This PR corrects that fault and lets you also bifurcate PRs into misc category as well.

Example:
```
NEXT VERSION AFTER + 8.25.0
...........................

Latest change: 2024-07-06

=================================================================================================  ===========  =================================================================================
Commit                                                                                             Committed    Subject
=================================================================================================  ===========  =================================================================================
`c72920af3b <https://github.com/apache/airflow/commit/c72920af3be5f0590c832d23633acbf4765e9eb3>`_  2024-07-06   ``Do not dynamically determine op links for emr serverless (#40627)``
`b7d0bf9800 <https://github.com/apache/airflow/commit/b7d0bf9800974e2029a777e20417e3498e665503>`_  2024-07-04   ``fix OpenLineage extraction for AthenaOperator (#40545)``
`8e04ef088f <https://github.com/apache/airflow/commit/8e04ef088fd2c817800f53b69bff1ac0680ac8b5>`_  2024-07-02   ``Be able to remove ACL in S3 hook's copy_object (#40518)``
`015ac89689 <https://github.com/apache/airflow/commit/015ac89689cb278d78ed4d65825254b67d476db8>`_  2024-07-02   ``Use base aws classes in AWS Glue Data Catalog Sensors (#40492)``
`b8aab5cf63 <https://github.com/apache/airflow/commit/b8aab5cf6332681b797e2aaea67c10e6ddf6bb46>`_  2024-07-02   ``Use base aws classes in AWS Glue Crawlers Operators/Sensors/Triggers (#40504)``
`5ec81b6f95 <https://github.com/apache/airflow/commit/5ec81b6f9536bd4824ff39574ec9602916d06af8>`_  2024-06-28   ``Fix docs build re aws changelog (#40488)``
`8d5dbaae37 <https://github.com/apache/airflow/commit/8d5dbaae37c2bcd0be360fdf8d42c5f72c7629da>`_  2024-06-28   ``Remove todo re bucket_name decorator in s3 hook (#40485)``
`bbfeee4aee <https://github.com/apache/airflow/commit/bbfeee4aee7203e934d50bc455f10d4d6a26f84a>`_  2024-06-28   ``Reduce memory footprint of s3 key trigger (#40473)``
`6c12744dd8 <https://github.com/apache/airflow/commit/6c12744dd8656e1d8b066c7edc8f0ab60ac124d2>`_  2024-06-28   ``Adding cluster to ecs trigger event to avoid defer error (#40482)``
`a62bd83188 <https://github.com/apache/airflow/commit/a62bd831885957c55b073bf309bc59a1d505e8fb>`_  2024-06-27   ``Enable enforcing pydocstyle rule D213 in ruff. (#40448)``
=================================================================================================  ===========  =================================================================================

Does the provider: amazon have any changes apart from 'doc-only'?
Press y/N/q: y

Define the type of change for `Do not dynamically determine op links for emr serverless (https://github.com/apache/airflow/pull/40627)` by referring to the above table
Type of change (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip, (q)uit ? x


Define the type of change for `fix OpenLineage extraction for AthenaOperator (https://github.com/apache/airflow/pull/40545)` by referring to the above table
Type of change (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip, (q)uit ? x


Define the type of change for `Be able to remove ACL in S3 hook's copy_object (https://github.com/apache/airflow/pull/40518)` by referring to the above table
Type of change (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip, (q)uit ? b


Define the type of change for `Use base aws classes in AWS Glue Data Catalog Sensors (https://github.com/apache/airflow/pull/40492)` by referring to the above table
Type of change (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip, (q)uit ? f


Define the type of change for `Use base aws classes in AWS Glue Crawlers Operators/Sensors/Triggers (https://github.com/apache/airflow/pull/40504)` by referring to the above table
Type of change (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip, (q)uit ? m


Define the type of change for `Fix docs build re aws changelog (https://github.com/apache/airflow/pull/40488)` by referring to the above table
Type of change (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip, (q)uit ? m


Define the type of change for `Remove todo re bucket_name decorator in s3 hook (https://github.com/apache/airflow/pull/40485)` by referring to the above table
Type of change (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip, (q)uit ? s


Define the type of change for `Reduce memory footprint of s3 key trigger (https://github.com/apache/airflow/pull/40473)` by referring to the above table
Type of change (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip, (q)uit ? m


Define the type of change for `Adding cluster to ecs trigger event to avoid defer error (https://github.com/apache/airflow/pull/40482)` by referring to the above table
Type of change (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip, (q)uit ? f


Define the type of change for `Enable enforcing pydocstyle rule D213 in ruff. (https://github.com/apache/airflow/pull/40448)` by referring to the above table
Type of change (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip, (q)uit ? f

The version will be bumped because of TypeOfChange.BREAKING_CHANGE kind of change
Provider amazon has been classified as:

Breaking changes - bump in MAJOR version needed

Bumped version to 9.0.0

Updated source-date-epoch to 1720429304

New version of the 'amazon' package is ready to be released!


Do you want to leave the version for amazon with version: 9.0.0 as is?
Press y/N/q: y
 Proceeding with provider: amazon version as 9.0.0
Checking for backticks correctly generated in: /Users/adesai/Documents/OSS/airflow/docs/apache-airflow-providers-amazon/changelog.rst
Generated /Users/adesai/Documents/OSS/airflow/docs/apache-airflow-providers-amazon/changelog.rst for amazon is OK

Generated /Users/adesai/Documents/OSS/airflow/docs/apache-airflow-providers-amazon/commits.rst file for the amazon provider

37a38,57
> 9.0.0
> .....
>
> Latest change: 2024-07-06
>
> =================================================================================================  ===========  =================================================================================
> Commit                                                                                             Committed    Subject
> =================================================================================================  ===========  =================================================================================
> `c72920af3b <https://github.com/apache/airflow/commit/c72920af3be5f0590c832d23633acbf4765e9eb3>`_  2024-07-06   ``Do not dynamically determine op links for emr serverless (#40627)``
> `b7d0bf9800 <https://github.com/apache/airflow/commit/b7d0bf9800974e2029a777e20417e3498e665503>`_  2024-07-04   ``fix OpenLineage extraction for AthenaOperator (#40545)``
> `8e04ef088f <https://github.com/apache/airflow/commit/8e04ef088fd2c817800f53b69bff1ac0680ac8b5>`_  2024-07-02   ``Be able to remove ACL in S3 hook's copy_object (#40518)``
> `015ac89689 <https://github.com/apache/airflow/commit/015ac89689cb278d78ed4d65825254b67d476db8>`_  2024-07-02   ``Use base aws classes in AWS Glue Data Catalog Sensors (#40492)``
> `b8aab5cf63 <https://github.com/apache/airflow/commit/b8aab5cf6332681b797e2aaea67c10e6ddf6bb46>`_  2024-07-02   ``Use base aws classes in AWS Glue Crawlers Operators/Sensors/Triggers (#40504)``
> `5ec81b6f95 <https://github.com/apache/airflow/commit/5ec81b6f9536bd4824ff39574ec9602916d06af8>`_  2024-06-28   ``Fix docs build re aws changelog (#40488)``
> `8d5dbaae37 <https://github.com/apache/airflow/commit/8d5dbaae37c2bcd0be360fdf8d42c5f72c7629da>`_  2024-06-28   ``Remove todo re bucket_name decorator in s3 hook (#40485)``
> `bbfeee4aee <https://github.com/apache/airflow/commit/bbfeee4aee7203e934d50bc455f10d4d6a26f84a>`_  2024-06-28   ``Reduce memory footprint of s3 key trigger (#40473)``
> `6c12744dd8 <https://github.com/apache/airflow/commit/6c12744dd8656e1d8b066c7edc8f0ab60ac124d2>`_  2024-06-28   ``Adding cluster to ecs trigger event to avoid defer error (#40482)``
> `a62bd83188 <https://github.com/apache/airflow/commit/a62bd831885957c55b073bf309bc59a1d505e8fb>`_  2024-06-27   ``Enable enforcing pydocstyle rule D213 in ruff. (#40448)``
> =================================================================================================  ===========  =================================================================================
>
41c61
< Latest change: 2024-06-19
---
> Latest change: 2024-06-22
45a66
> `6e5ae26382 <https://github.com/apache/airflow/commit/6e5ae26382b328e88907e8301d4b2352ef8524c5>`_  2024-06-22   ``Prepare docs 2nd wave June 2024 (#40273)``
Checking for backticks correctly generated in: /Users/adesai/Documents/OSS/airflow/docs/apache-airflow-providers-amazon/commits.rst
Generated /Users/adesai/Documents/OSS/airflow/docs/apache-airflow-providers-amazon/commits.rst for amazon is OK

Updates changelog for last release of package 'amazon'

New version of the 'amazon' package is ready to be released!

***

---

***************

*** 23,32 ****

--- 23,64 ----


  ``apache-airflow-providers-amazon``

  Changelog
  ---------
+
+ 9.0.0
+ .....
+
+ Breaking changes
+ ~~~~~~~~~~~~~~~~
+
+ * ``Do not dynamically determine op links for emr serverless (#40627)``
+ * ``fix OpenLineage extraction for AthenaOperator (#40545)``
+
+ Features
+ ~~~~~~~~
+
+ * ``Use base aws classes in AWS Glue Data Catalog Sensors (#40492)``
+ * ``Adding cluster to ecs trigger event to avoid defer error (#40482)``
+ * ``Enable enforcing pydocstyle rule D213 in ruff. (#40448)``
+
+ Bug Fixes
+ ~~~~~~~~~
+
+ * ``Be able to remove ACL in S3 hook's copy_object (#40518)``
+
+ Misc
+ ~~~~
+
+ * ``Use base aws classes in AWS Glue Crawlers Operators/Sensors/Triggers (#40504)``
+ * ``Fix docs build re aws changelog (#40488)``
+ * ``Reduce memory footprint of s3 key trigger (#40473)``
+
+ .. Below changes are excluded from the changelog. Move them to
+    appropriate section above if needed. Do not delete the lines(!):
+    * ``Remove todo re bucket_name decorator in s3 hook (#40485)``

  main
  ....

  Bug Fixes
The provider amazon changelog for `9.0.0` version is missing. Generating fresh changelog.

Update index.rst for amazon


Generated /Users/adesai/Documents/OSS/airflow/docs/apache-airflow-providers-amazon/index.rst file for the amazon provider

89c89
< Release: 8.25.0
---
> Release: 9.0.0
164,165c164,165
< * `The apache-airflow-providers-amazon 8.25.0 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_amazon-8.25.0.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_amazon-8.25.0.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_amazon-8.25.0.tar.gz.sha512>`__)
< * `The apache-airflow-providers-amazon 8.25.0 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_amazon-8.25.0-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_amazon-8.25.0-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_amazon-8.25.0-py3-none-any.whl.sha512>`__)
---
> * `The apache-airflow-providers-amazon 9.0.0 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_amazon-9.0.0.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_amazon-9.0.0.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_amazon-9.0.0.tar.gz.sha512>`__)
> * `The apache-airflow-providers-amazon 9.0.0 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_amazon-9.0.0-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_amazon-9.0.0-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_amazon-9.0.0-py3-none-any.whl.sha512>`__)


Summary of prepared documentation:

Success: 1

amazon


Successfully prepared documentation for packages!



Please review the updated files, classify the changelog entries and commit the changes.
```

<img width="1723" alt="image" src="https://github.com/apache/airflow/assets/35884252/762d19b8-7a3a-4387-9334-9057d8fe59fb">


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
