### PR TITLE
Render changelog sections only if they contain content

### DIFF
--- a/dev/breeze/src/airflow_breeze/templates/CHANGELOG_TEMPLATE.rst.jinja2
+++ b/dev/breeze/src/airflow_breeze/templates/CHANGELOG_TEMPLATE.rst.jinja2
@@ -20,7 +20,7 @@
 {{ version }}
 {{ version_header }}
 
-{%- if WITH_BREAKING_CHANGES %}
+{%- if WITH_BREAKING_CHANGES and classified_changes.breaking_changes %}
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
@@ -29,7 +29,8 @@ Breaking changes
 {%- endfor %}
 {%- endif %}
 
-{%- if MAYBE_WITH_NEW_FEATURES %}
+
+{%- if MAYBE_WITH_NEW_FEATURES and classified_changes.features %}
 
 Features
 ~~~~~~~~
@@ -38,20 +39,31 @@ Features
 {%- endfor %}
 {%- endif %}
 
+
+{%- if classified_changes.fixes %}
+
 Bug Fixes
 ~~~~~~~~~
 {% for fix in classified_changes.fixes %}
 * ``{{ fix.message_without_backticks | safe }}``
 {%- endfor %}
+{%- endif %}
+
+
+{%- if classified_changes.misc %}
 
 Misc
 ~~~~
 {% for misc in classified_changes.misc %}
 * ``{{ misc.message_without_backticks | safe }}``
 {%- endfor %}
+{%- endif %}
+
 
 .. Below changes are excluded from the changelog. Move them to
    appropriate section above if needed. Do not delete the lines(!):
+{%- if classified_changes.other %}
    {%- for other in classified_changes.other %}
    * ``{{ other.message_without_backticks | safe }}``
    {%- endfor %}
+{%- endif %}


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

While categorising PRs for providers, if a section didn't have any content, empty headers were rendered. This PR makes that content conditional.

Example output:
```
NEXT VERSION AFTER + 8.1.2
..........................

Latest change: 2024-06-27

=================================================================================================  ===========  ===========================================================
Commit                                                                                             Committed    Subject
=================================================================================================  ===========  ===========================================================
`a62bd83188 <https://github.com/apache/airflow/commit/a62bd831885957c55b073bf309bc59a1d505e8fb>`_  2024-06-27   ``Enable enforcing pydocstyle rule D213 in ruff. (#40448)``
=================================================================================================  ===========  ===========================================================

Does the provider: apache.hive have any changes apart from 'doc-only'?
Press y/N/q: y

Define the type of change for `Enable enforcing pydocstyle rule D213 in ruff. (https://github.com/apache/airflow/pull/40448)` by referring to the above table
Type of change (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip, (q)uit ? x

The version will be bumped because of TypeOfChange.BREAKING_CHANGE kind of change
Provider apache.hive has been classified as:

Breaking changes - bump in MAJOR version needed

Bumped version to 9.0.0

Updated source-date-epoch to 1720505379

New version of the 'apache.hive' package is ready to be released!


Do you want to leave the version for apache.hive with version: 9.0.0 as is for the release?
Press y/N/q: y
 Proceeding with provider: apache.hive version as 9.0.0
Checking for backticks correctly generated in: /Users/adesai/Documents/OSS/airflow/docs/apache-airflow-providers-apache-hive/changelog.rst
Generated /Users/adesai/Documents/OSS/airflow/docs/apache-airflow-providers-apache-hive/changelog.rst for apache.hive is OK

Generated /Users/adesai/Documents/OSS/airflow/docs/apache-airflow-providers-apache-hive/commits.rst file for the apache.hive provider

36a37,47
>
> 9.0.0
> .....
>
> Latest change: 2024-06-27
>
> =================================================================================================  ===========  ===========================================================
> Commit                                                                                             Committed    Subject
> =================================================================================================  ===========  ===========================================================
> `a62bd83188 <https://github.com/apache/airflow/commit/a62bd831885957c55b073bf309bc59a1d505e8fb>`_  2024-06-27   ``Enable enforcing pydocstyle rule D213 in ruff. (#40448)``
> =================================================================================================  ===========  ===========================================================
41c52
< Latest change: 2024-06-17
---
> Latest change: 2024-06-22
45a57
> `6e5ae26382 <https://github.com/apache/airflow/commit/6e5ae26382b328e88907e8301d4b2352ef8524c5>`_  2024-06-22   ``Prepare docs 2nd wave June 2024 (#40273)``
Checking for backticks correctly generated in: /Users/adesai/Documents/OSS/airflow/docs/apache-airflow-providers-apache-hive/commits.rst
Generated /Users/adesai/Documents/OSS/airflow/docs/apache-airflow-providers-apache-hive/commits.rst for apache.hive is OK

Updates changelog for last release of package 'apache.hive'

New version of the 'apache.hive' package is ready to be released!

***

---

***************

*** 24,33 ****

--- 24,45 ----

  ``apache-airflow-providers-apache-hive``


  Changelog
  ---------
+
+ 9.0.0
+ .....
+
+ Breaking changes
+ ~~~~~~~~~~~~~~~~
+
+ * ``Enable enforcing pydocstyle rule D213 in ruff. (#40448)``
+
+
+ .. Below changes are excluded from the changelog. Move them to
+    appropriate section above if needed. Do not delete the lines(!):

  8.1.2
  .....

  Misc
The provider apache.hive changelog for `9.0.0` version is missing. Generating fresh changelog.

Update index.rst for apache.hive


Generated /Users/adesai/Documents/OSS/airflow/docs/apache-airflow-providers-apache-hive/index.rst file for the apache.hive provider

82c82
< Release: 8.1.2
---
> Release: 9.0.0
146,147c146,147
< * `The apache-airflow-providers-apache-hive 8.1.2 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_hive-8.1.2.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_hive-8.1.2.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_hive-8.1.2.tar.gz.sha512>`__)
< * `The apache-airflow-providers-apache-hive 8.1.2 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_hive-8.1.2-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_hive-8.1.2-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_hive-8.1.2-py3-none-any.whl.sha512>`__)
---
> * `The apache-airflow-providers-apache-hive 9.0.0 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_hive-9.0.0.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_hive-9.0.0.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_hive-9.0.0.tar.gz.sha512>`__)
> * `The apache-airflow-providers-apache-hive 9.0.0 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_hive-9.0.0-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_hive-9.0.0-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_hive-9.0.0-py3-none-any.whl.sha512>`__)


Summary of prepared documentation:

Success: 1

apache.hive


Successfully prepared documentation for packages!



Please review the updated files, classify the changelog entries and commit the changes.
```

<img width="1723" alt="image" src="https://github.com/apache/airflow/assets/35884252/97cd1e44-51c8-4a2d-a117-4d8096b2d5e1">



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
