### PR TITLE
Fix weaviate changelog to bring back 1.4.2

### DIFF
--- a/airflow/providers/weaviate/CHANGELOG.rst
+++ b/airflow/providers/weaviate/CHANGELOG.rst
@@ -23,7 +23,6 @@ Changelog
 2.0.0
 ......
 
-
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
@@ -46,7 +45,10 @@ Breaking changes
 Bug Fixes
 ~~~~~~~~~
 
-* ``Fix mypy problems in new waeviate client (#40330)``
+* ``Fix mypy problems in new weaviate client (#40330)``
+
+1.4.2
+.....
 
 Misc
 ~~~~


### PR DESCRIPTION
The #40194 by mistake replaced 1.4.2 version with 2.0.0 rather than adding it - this caused that 1.4.2 changes have been incorporated into 2.0.0 and 1.4.2 is missing from the changelog.

This PR brings 1.4.2 back.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
