### PR TITLE
Documentation: Warning for _AIRFLOW_PATCH_GEVENT 

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1688,6 +1688,9 @@ webserver:
             When using ``gevent`` you might also want to set the ``_AIRFLOW_PATCH_GEVENT``
             environment variable to ``"1"`` to make sure gevent patching is done as early as possible.
 
+            Be careful to set ``_AIRFLOW_PATCH_GEVENT`` only on webserver as gevent patching may
+            affect the scheduler behavior via the ``multiprocessing`` sockets module.
+
             See related Issues / PRs for more details:
 
             * https://github.com/benoitc/gunicorn/issues/2796

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1688,8 +1688,8 @@ webserver:
             When using ``gevent`` you might also want to set the ``_AIRFLOW_PATCH_GEVENT``
             environment variable to ``"1"`` to make sure gevent patching is done as early as possible.
 
-            Be careful to set ``_AIRFLOW_PATCH_GEVENT`` only on webserver as gevent patching may
-            affect the scheduler behavior via the ``multiprocessing`` sockets module.
+            Be careful to set ``_AIRFLOW_PATCH_GEVENT`` only on the web server as gevent patching may
+            affect the scheduler behavior via the ``multiprocessing`` sockets module and cause crash.
 
             See related Issues / PRs for more details:
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

Hi,

I recently had a huge pain point with Airflow running on ECS via the official airflow Docker image (`apache/airflow:2.9.2`).

For the configuration I have a scheduler (4 vCPU, 8 Gib), some workers (4 vCPU, 8 Gib) and a webserver (2 vCPU, 4 Gib).

Every containers are sharing the same environment variables to apply the same configuration anywhere.

The problem was that at some point, the scheduler were non-stop crashing with the following error:

```
File ""/home/airflow/.local/lib/python3.12/site-packages/airflow/jobs/scheduler_job_runner.py"", line 1738, in _find_zombies
 self.job.executor.send_callback(request)
File ""/home/airflow/.local/lib/python3.12/site-packages/airflow/executors/base_executor.py"", line 499, in send_callback
 self.callback_sink.send(request)
File ""/home/airflow/.local/lib/python3.12/site-packages/airflow/callbacks/pipe_callback_sink.py"", line 47, in send
 self._get_sink_pipe().send(callback)
File ""/usr/local/lib/python3.12/multiprocessing/connection.py"", line 206, in send
 self._send_bytes(_ForkingPickler.dumps(obj))
File ""/usr/local/lib/python3.12/multiprocessing/connection.py"", line 427, in _send_bytes
 self._send(header + buf)
File ""/usr/local/lib/python3.12/multiprocessing/connection.py"", line 384, in _send
  n = write(self._handle, buf)
     ^^^^^^^^^^^^^^^^^^^^^^^^
BlockingIOError: [Errno 11] Resource temporarily unavailable
```

The first attempt was to increase the maximum file descriptor for the `airflow` user from 1000 (default) to 65535 (root limit) which works some time but after some days the problem came back.

After many (many) unsuccessful attempts, I saw some content related with this error and the gevent patching.

The webserver is using `AIRFLOW__WEBSERVER__WORKER_CLASS=gevent` so it naturally came with `_AIRFLOW_PATCH_GEVENT=1`.

As the environment variables are shared between all containers, it means that the `_AIRFLOW_PATCH_GEVENT` environment variable was applied on the webserver but **also on the scheduler**.

I'm not a Python expert but the conclusion was that the gevent patching was affecting the `multiprocessing` module via the duplex sockets then causing troubles on the scheduler internal communications.

As it was a painful problem to solve I'm proposing this documentation upgrade to warn anyone to apply this setup.

I'm not sure if it's the right way to do it but feel free to take/modify/close this merge request the way you want, as it can already serve anyone searching for this error via Google.

Thanks

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
