### PR TITLE
openlineage: remove deprecated parentRun facet key

### DIFF
--- a/airflow/providers/openlineage/plugins/adapter.py
+++ b/airflow/providers/openlineage/plugins/adapter.py
@@ -434,12 +434,7 @@ class OpenLineageAdapter(LoggingMixin):
                 namespace=conf.namespace(),
                 name=parent_job_name or job_name,
             )
-            facets.update(
-                {
-                    "parent": parent_run_facet,
-                    "parentRun": parent_run_facet,  # Keep sending this for the backward compatibility
-                }
-            )
+            facets.update({"parent": parent_run_facet})
 
         if run_facets:
             facets.update(run_facets)

--- a/tests/providers/openlineage/plugins/test_adapter.py
+++ b/tests/providers/openlineage/plugins/test_adapter.py
@@ -243,10 +243,6 @@ def test_emit_start_event_with_additional_information(mock_stats_incr, mock_stat
                             run={"runId": "parent_run_id"},
                             job={"namespace": namespace(), "name": "parent_job_name"},
                         ),
-                        "parentRun": ParentRunFacet(
-                            run={"runId": "parent_run_id"},
-                            job={"namespace": namespace(), "name": "parent_job_name"},
-                        ),
                         "externalQuery1": ExternalQueryRunFacet(externalQueryId="123", source="source"),
                         "externalQuery2": ExternalQueryRunFacet(externalQueryId="999", source="source"),
                     },
@@ -361,10 +357,6 @@ def test_emit_complete_event_with_additional_information(mock_stats_incr, mock_s
                             run={"runId": "parent_run_id"},
                             job={"namespace": namespace(), "name": "parent_job_name"},
                         ),
-                        "parentRun": ParentRunFacet(
-                            run={"runId": "parent_run_id"},
-                            job={"namespace": namespace(), "name": "parent_job_name"},
-                        ),
                         "externalQuery": ExternalQueryRunFacet(externalQueryId="123", source="source"),
                     },
                 ),
@@ -469,10 +461,6 @@ def test_emit_failed_event_with_additional_information(mock_stats_incr, mock_sta
                     runId=run_id,
                     facets={
                         "parent": ParentRunFacet(
-                            run={"runId": "parent_run_id"},
-                            job={"namespace": namespace(), "name": "parent_job_name"},
-                        ),
-                        "parentRun": ParentRunFacet(
                             run={"runId": "parent_run_id"},
                             job={"namespace": namespace(), "name": "parent_job_name"},
                         ),


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
This PR removes deprecated `parentRun` key for ParentRunFacet, leaving only `parent` key.

related: https://github.com/OpenLineage/OpenLineage/pull/2660

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
