### PR TITLE
Fix Custom Training Job operators to accept results without a model in def mode

### DIFF
--- a/airflow/providers/google/cloud/hooks/vertex_ai/custom_job.py
+++ b/airflow/providers/google/cloud/hooks/vertex_ai/custom_job.py
@@ -262,7 +262,7 @@ class CustomJobHook(GoogleBaseHook):
 
     @staticmethod
     def extract_model_id_from_training_pipeline(training_pipeline: dict[str, Any]) -> str:
-        """Return a unique Model id from a serialized TrainingPipeline proto."""
+        """Return a unique Model ID from a serialized TrainingPipeline proto."""
         return training_pipeline["model_to_upload"]["name"].rpartition("/")[-1]
 
     @staticmethod

--- a/tests/providers/google/cloud/operators/test_vertex_ai.py
+++ b/tests/providers/google/cloud/operators/test_vertex_ai.py
@@ -202,6 +202,17 @@ TEST_TEMPLATE_PATH = "test_template_path"
 
 SYNC_DEPRECATION_WARNING = "The 'sync' parameter is deprecated and will be removed after {}."
 
+TEST_TRAINING_PIPELINE_DATA = {
+    "model_to_upload": {
+        "name": "projects/test-project/locations/us-central1/models/test-model",
+        "display_name": "test-model",
+    },
+    "training_task_metadata": {"backingCustomJob": "prefix/test-custom-job"},
+}
+TEST_TRAINING_PIPELINE_DATA_NO_MODEL = {
+    "training_task_metadata": {"backingCustomJob": "prefix/test-custom-job"}
+}
+
 
 class TestVertexAICreateCustomContainerTrainingJobOperator:
     @mock.patch(VERTEX_AI_PATH.format("custom_job.Dataset"))
@@ -418,9 +429,15 @@ class TestVertexAICreateCustomContainerTrainingJobOperator:
             exc.value.trigger, CustomContainerTrainingJobTrigger
         ), "Trigger is not a CustomContainerTrainingJobTrigger"
 
+    @mock.patch(VERTEX_AI_LINKS_PATH.format("VertexAIModelLink.persist"))
     @mock.patch(VERTEX_AI_PATH.format("custom_job.CreateCustomContainerTrainingJobOperator.xcom_push"))
+    @mock.patch(
+        VERTEX_AI_PATH.format("custom_job.CreateCustomContainerTrainingJobOperator.hook.extract_model_id")
+    )
     @mock.patch(VERTEX_AI_PATH.format("custom_job.CreateCustomContainerTrainingJobOperator.hook"))
-    def test_execute_complete_success(self, mock_hook, mock_xcom_push):
+    def test_execute_complete_success(
+        self, mock_hook, mock_hook_extract_model_id, mock_xcom_push, mock_link_persist
+    ):
         task = CreateCustomContainerTrainingJobOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
@@ -443,12 +460,18 @@ class TestVertexAICreateCustomContainerTrainingJobOperator:
             project_id=GCP_PROJECT,
             deferrable=True,
         )
-        expected_result = {}
-        mock_hook.return_value.exists.return_value = False
-        mock_xcom_push.return_value = None
+        expected_result = TEST_TRAINING_PIPELINE_DATA["model_to_upload"]
+        mock_hook_extract_model_id.return_value = "test-model"
         actual_result = task.execute_complete(
-            context=None, event={"status": "success", "message": "", "job": {}}
+            context=None,
+            event={
+                "status": "success",
+                "message": "",
+                "job": TEST_TRAINING_PIPELINE_DATA,
+            },
         )
+        mock_xcom_push.assert_called_with(None, key="model_id", value="test-model")
+        mock_link_persist.assert_called_once_with(context=None, task_instance=task, model_id="test-model")
         assert actual_result == expected_result
 
     def test_execute_complete_error_status_raises_exception(self):
@@ -476,6 +499,49 @@ class TestVertexAICreateCustomContainerTrainingJobOperator:
         )
         with pytest.raises(AirflowException):
             task.execute_complete(context=None, event={"status": "error", "message": "test message"})
+
+    @mock.patch(VERTEX_AI_LINKS_PATH.format("VertexAIModelLink.persist"))
+    @mock.patch(VERTEX_AI_PATH.format("custom_job.CreateCustomContainerTrainingJobOperator.xcom_push"))
+    @mock.patch(
+        VERTEX_AI_PATH.format("custom_job.CreateCustomContainerTrainingJobOperator.hook.extract_model_id")
+    )
+    @mock.patch(VERTEX_AI_PATH.format("custom_job.CreateCustomContainerTrainingJobOperator.hook"))
+    def test_execute_complete_no_model_produced(
+        self,
+        mock_hook,
+        hook_extract_model_id,
+        mock_xcom_push,
+        mock_link_persist,
+    ):
+        task = CreateCustomContainerTrainingJobOperator(
+            task_id=TASK_ID,
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+            staging_bucket=STAGING_BUCKET,
+            display_name=DISPLAY_NAME,
+            args=ARGS,
+            container_uri=CONTAINER_URI,
+            command=COMMAND_2,
+            replica_count=REPLICA_COUNT,
+            machine_type=MACHINE_TYPE,
+            accelerator_type=ACCELERATOR_TYPE,
+            accelerator_count=ACCELERATOR_COUNT,
+            training_fraction_split=TRAINING_FRACTION_SPLIT,
+            validation_fraction_split=VALIDATION_FRACTION_SPLIT,
+            test_fraction_split=TEST_FRACTION_SPLIT,
+            region=GCP_LOCATION,
+            project_id=GCP_PROJECT,
+            deferrable=True,
+        )
+        expected_result = None
+        hook_extract_model_id.return_value = None
+        actual_result = task.execute_complete(
+            context=None,
+            event={"status": "success", "message": "", "job": TEST_TRAINING_PIPELINE_DATA_NO_MODEL},
+        )
+        mock_xcom_push.assert_called_once()
+        mock_link_persist.assert_not_called()
+        assert actual_result == expected_result
 
 
 class TestVertexAICreateCustomPythonPackageTrainingJobOperator:
@@ -698,9 +764,19 @@ class TestVertexAICreateCustomPythonPackageTrainingJobOperator:
             exc.value.trigger, CustomPythonPackageTrainingJobTrigger
         ), "Trigger is not a CustomPythonPackageTrainingJobTrigger"
 
+    @mock.patch(VERTEX_AI_LINKS_PATH.format("VertexAIModelLink.persist"))
     @mock.patch(VERTEX_AI_PATH.format("custom_job.CreateCustomPythonPackageTrainingJobOperator.xcom_push"))
+    @mock.patch(
+        VERTEX_AI_PATH.format("custom_job.CreateCustomPythonPackageTrainingJobOperator.hook.extract_model_id")
+    )
     @mock.patch(VERTEX_AI_PATH.format("custom_job.CreateCustomPythonPackageTrainingJobOperator.hook"))
-    def test_execute_complete_success(self, mock_hook, mock_xcom_push):
+    def test_execute_complete_success(
+        self,
+        mock_hook,
+        hook_extract_model_id,
+        mock_xcom_push,
+        mock_link_persist,
+    ):
         task = CreateCustomPythonPackageTrainingJobOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
@@ -724,12 +800,18 @@ class TestVertexAICreateCustomPythonPackageTrainingJobOperator:
             project_id=GCP_PROJECT,
             deferrable=True,
         )
-        expected_result = {}
-        mock_hook.return_value.exists.return_value = False
-        mock_xcom_push.return_value = None
+        expected_result = TEST_TRAINING_PIPELINE_DATA["model_to_upload"]
+        hook_extract_model_id.return_value = "test-model"
         actual_result = task.execute_complete(
-            context=None, event={"status": "success", "message": "", "job": {}}
+            context=None,
+            event={
+                "status": "success",
+                "message": "",
+                "job": TEST_TRAINING_PIPELINE_DATA,
+            },
         )
+        mock_xcom_push.assert_called_with(None, key="model_id", value="test-model")
+        mock_link_persist.assert_called_once_with(context=None, task_instance=task, model_id="test-model")
         assert actual_result == expected_result
 
     def test_execute_complete_error_status_raises_exception(self):
@@ -758,6 +840,49 @@ class TestVertexAICreateCustomPythonPackageTrainingJobOperator:
         )
         with pytest.raises(AirflowException):
             task.execute_complete(context=None, event={"status": "error", "message": "test message"})
+
+    @mock.patch(VERTEX_AI_LINKS_PATH.format("VertexAIModelLink.persist"))
+    @mock.patch(VERTEX_AI_PATH.format("custom_job.CreateCustomPythonPackageTrainingJobOperator.xcom_push"))
+    @mock.patch(
+        VERTEX_AI_PATH.format("custom_job.CreateCustomPythonPackageTrainingJobOperator.hook.extract_model_id")
+    )
+    @mock.patch(VERTEX_AI_PATH.format("custom_job.CreateCustomPythonPackageTrainingJobOperator.hook"))
+    def test_execute_complete_no_model_produced(
+        self,
+        mock_hook,
+        hook_extract_model_id,
+        mock_xcom_push,
+        mock_link_persist,
+    ):
+        task = CreateCustomPythonPackageTrainingJobOperator(
+            task_id=TASK_ID,
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+            staging_bucket=STAGING_BUCKET,
+            display_name=DISPLAY_NAME,
+            python_package_gcs_uri=PYTHON_PACKAGE_GCS_URI,
+            python_module_name=PYTHON_MODULE_NAME,
+            container_uri=CONTAINER_URI,
+            args=ARGS,
+            replica_count=REPLICA_COUNT,
+            machine_type=MACHINE_TYPE,
+            accelerator_type=ACCELERATOR_TYPE,
+            accelerator_count=ACCELERATOR_COUNT,
+            training_fraction_split=TRAINING_FRACTION_SPLIT,
+            validation_fraction_split=VALIDATION_FRACTION_SPLIT,
+            test_fraction_split=TEST_FRACTION_SPLIT,
+            region=GCP_LOCATION,
+            project_id=GCP_PROJECT,
+            deferrable=True,
+        )
+        expected_result = None
+        actual_result = task.execute_complete(
+            context=None,
+            event={"status": "success", "message": "", "job": TEST_TRAINING_PIPELINE_DATA_NO_MODEL},
+        )
+        mock_xcom_push.assert_called_once()
+        mock_link_persist.assert_not_called()
+        assert actual_result == expected_result
 
 
 class TestVertexAICreateCustomTrainingJobOperator:
@@ -959,9 +1084,17 @@ class TestVertexAICreateCustomTrainingJobOperator:
             exc.value.trigger, CustomTrainingJobTrigger
         ), "Trigger is not a CustomTrainingJobTrigger"
 
+    @mock.patch(VERTEX_AI_LINKS_PATH.format("VertexAIModelLink.persist"))
     @mock.patch(VERTEX_AI_PATH.format("custom_job.CreateCustomTrainingJobOperator.xcom_push"))
+    @mock.patch(VERTEX_AI_PATH.format("custom_job.CreateCustomTrainingJobOperator.hook.extract_model_id"))
     @mock.patch(VERTEX_AI_PATH.format("custom_job.CreateCustomTrainingJobOperator.hook"))
-    def test_execute_complete_success(self, mock_hook, mock_xcom_push):
+    def test_execute_complete_success(
+        self,
+        mock_hook,
+        hook_extract_model_id,
+        mock_xcom_push,
+        mock_link_persist,
+    ):
         task = CreateCustomTrainingJobOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
@@ -978,12 +1111,18 @@ class TestVertexAICreateCustomTrainingJobOperator:
             project_id=GCP_PROJECT,
             deferrable=True,
         )
-        expected_result = {}
-        mock_hook.return_value.exists.return_value = False
-        mock_xcom_push.return_value = None
+        expected_result = TEST_TRAINING_PIPELINE_DATA["model_to_upload"]
+        hook_extract_model_id.return_value = "test-model"
         actual_result = task.execute_complete(
-            context=None, event={"status": "success", "message": "", "job": {}}
+            context=None,
+            event={
+                "status": "success",
+                "message": "",
+                "job": TEST_TRAINING_PIPELINE_DATA,
+            },
         )
+        mock_xcom_push.assert_called_with(None, key="model_id", value="test-model")
+        mock_link_persist.assert_called_once_with(context=None, task_instance=task, model_id="test-model")
         assert actual_result == expected_result
 
     def test_execute_complete_error_status_raises_exception(self):
@@ -1005,6 +1144,41 @@ class TestVertexAICreateCustomTrainingJobOperator:
         )
         with pytest.raises(AirflowException):
             task.execute_complete(context=None, event={"status": "error", "message": "test message"})
+
+    @mock.patch(VERTEX_AI_LINKS_PATH.format("VertexAIModelLink.persist"))
+    @mock.patch(VERTEX_AI_PATH.format("custom_job.CreateCustomTrainingJobOperator.xcom_push"))
+    @mock.patch(VERTEX_AI_PATH.format("custom_job.CreateCustomTrainingJobOperator.hook.extract_model_id"))
+    @mock.patch(VERTEX_AI_PATH.format("custom_job.CreateCustomTrainingJobOperator.hook"))
+    def test_execute_complete_no_model_produced(
+        self,
+        mock_hook,
+        hook_extract_model_id,
+        mock_xcom_push,
+        mock_link_persist,
+    ):
+        task = CreateCustomTrainingJobOperator(
+            task_id=TASK_ID,
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+            staging_bucket=STAGING_BUCKET,
+            display_name=DISPLAY_NAME,
+            script_path=PYTHON_PACKAGE,
+            args=PYTHON_PACKAGE_CMDARGS,
+            container_uri=CONTAINER_URI,
+            requirements=[],
+            replica_count=1,
+            region=GCP_LOCATION,
+            project_id=GCP_PROJECT,
+            deferrable=True,
+        )
+        expected_result = None
+        hook_extract_model_id.return_value = None
+        actual_result = task.execute_complete(
+            context=None, event={"status": "success", "message": "", "job": {}}
+        )
+        mock_xcom_push.assert_called_once()
+        mock_link_persist.assert_not_called()
+        assert actual_result == expected_result
 
 
 class TestVertexAIDeleteCustomTrainingJobOperator:

--- a/tests/system/providers/google/cloud/vertex_ai/example_vertex_ai_custom_container.py
+++ b/tests/system/providers/google/cloud/vertex_ai/example_vertex_ai_custom_container.py
@@ -17,9 +17,7 @@
 # under the License.
 
 
-"""
-Example Airflow DAG for Google Vertex AI service testing Custom Jobs operations.
-"""
+"""Example Airflow DAG for Google Vertex AI service testing Custom Jobs operations."""
 
 from __future__ import annotations
 
@@ -48,7 +46,7 @@ from airflow.utils.trigger_rule import TriggerRule
 
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID", "default")
 PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT", "default")
-DAG_ID = "example_vertex_ai_custom_job_operations"
+DAG_ID = "vertex_ai_custom_job_operations"
 REGION = "us-central1"
 CONTAINER_DISPLAY_NAME = f"train-housing-container-{ENV_ID}"
 MODEL_DISPLAY_NAME = f"container-housing-model-{ENV_ID}"
@@ -140,13 +138,13 @@ with DAG(
     create_custom_container_training_job_deferrable = CreateCustomContainerTrainingJobOperator(
         task_id="custom_container_task_deferrable",
         staging_bucket=f"gs://{CUSTOM_CONTAINER_GCS_BUCKET_NAME}",
-        display_name=f"{CONTAINER_DISPLAY_NAME}_DEF",
+        display_name=f"{CONTAINER_DISPLAY_NAME}-def",
         container_uri=CUSTOM_CONTAINER_URI,
         model_serving_container_image_uri=MODEL_SERVING_CONTAINER_URI,
         # run params
         dataset_id=tabular_dataset_id,
         command=["python3", "task.py"],
-        model_display_name=f"{MODEL_DISPLAY_NAME}_DEF",
+        model_display_name=f"{MODEL_DISPLAY_NAME}-def",
         replica_count=REPLICA_COUNT,
         machine_type=MACHINE_TYPE,
         accelerator_type=ACCELERATOR_TYPE,

--- a/tests/system/providers/google/cloud/vertex_ai/example_vertex_ai_custom_job_python_package.py
+++ b/tests/system/providers/google/cloud/vertex_ai/example_vertex_ai_custom_job_python_package.py
@@ -17,9 +17,7 @@
 # under the License.
 
 
-"""
-Example Airflow DAG for Google Vertex AI service testing Custom Jobs operations.
-"""
+"""Example Airflow DAG for Google Vertex AI service testing Custom Jobs operations."""
 
 from __future__ import annotations
 
@@ -48,7 +46,7 @@ from airflow.utils.trigger_rule import TriggerRule
 
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID", "default")
 PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT", "default")
-DAG_ID = "example_vertex_ai_custom_job_operations"
+DAG_ID = "vertex_ai_custom_job_operations"
 REGION = "us-central1"
 PACKAGE_DISPLAY_NAME = f"train-housing-py-package-{ENV_ID}"
 MODEL_DISPLAY_NAME = f"py-package-housing-model-{ENV_ID}"
@@ -143,14 +141,14 @@ with DAG(
     create_custom_python_package_training_job_deferrable = CreateCustomPythonPackageTrainingJobOperator(
         task_id="python_package_task_deferrable",
         staging_bucket=f"gs://{CUSTOM_PYTHON_GCS_BUCKET_NAME}",
-        display_name=f"{PACKAGE_DISPLAY_NAME}_DEF",
+        display_name=f"{PACKAGE_DISPLAY_NAME}-def",
         python_package_gcs_uri=PYTHON_PACKAGE_GCS_URI,
         python_module_name=PYTHON_MODULE_NAME,
         container_uri=CONTAINER_URI,
         model_serving_container_image_uri=MODEL_SERVING_CONTAINER_URI,
         # run params
         dataset_id=tabular_dataset_id,
-        model_display_name=f"{MODEL_DISPLAY_NAME}_DEF",
+        model_display_name=f"{MODEL_DISPLAY_NAME}-def",
         replica_count=REPLICA_COUNT,
         machine_type=MACHINE_TYPE,
         accelerator_type=ACCELERATOR_TYPE,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Closes: #40476

- Fix the deferrable mode for Custom Training Job operators so that they could process training pipeline results that do not produce a managed model due to incorrect configuration. This feature was present in the sync mode, but was not originally included into the deferrable mode.

- Update the return values of the operators in the deferrable mode to return only the model data instead of the training pipeline data. This makes the deferrable mode behavior more similar to the sync mode.

- Refactor the operators by moving repeating code blocks into their base class.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
