### PR TITLE
Add the ability to toggle the unfurl behavior for slack notifier

### DIFF
--- a/airflow/providers/slack/notifications/slack.py
+++ b/airflow/providers/slack/notifications/slack.py
@@ -64,6 +64,8 @@ class SlackNotifier(BaseNotifier):
         proxy: str | None = None,
         timeout: int | None = None,
         retry_handlers: list[RetryHandler] | None = None,
+        unfurl_links: bool = True,
+        unfurl_media: bool = True,
     ):
         super().__init__()
         self.slack_conn_id = slack_conn_id
@@ -77,6 +79,8 @@ class SlackNotifier(BaseNotifier):
         self.timeout = timeout
         self.proxy = proxy
         self.retry_handlers = retry_handlers
+        self.unfurl_links = unfurl_links
+        self.unfurl_media = unfurl_media
 
     @cached_property
     def hook(self) -> SlackHook:
@@ -98,6 +102,8 @@ class SlackNotifier(BaseNotifier):
             "icon_url": self.icon_url,
             "attachments": json.dumps(self.attachments),
             "blocks": json.dumps(self.blocks),
+            "unfurl_links": self.unfurl_links,
+            "unfurl_media": self.unfurl_media,
         }
         self.hook.call("chat.postMessage", json=api_call_params)
 

--- a/tests/providers/slack/notifications/test_slack.py
+++ b/tests/providers/slack/notifications/test_slack.py
@@ -68,6 +68,8 @@ class TestSlackNotifier:
                 "/pin_100.png",
                 "attachments": "[]",
                 "blocks": "[]",
+                "unfurl_links": True,
+                "unfurl_media": True,
             },
         )
         mock_slack_hook.assert_called_once_with(slack_conn_id="test_conn_id", **hook_extra_kwargs)
@@ -89,6 +91,8 @@ class TestSlackNotifier:
                 "/pin_100.png",
                 "attachments": "[]",
                 "blocks": "[]",
+                "unfurl_links": True,
+                "unfurl_media": True,
             },
         )
 
@@ -114,5 +118,33 @@ class TestSlackNotifier:
                 "/pin_100.png",
                 "attachments": '[{"image_url": "test_slack_notifier.png"}]',
                 "blocks": "[]",
+                "unfurl_links": True,
+                "unfurl_media": True,
+            },
+        )
+
+    @mock.patch("airflow.providers.slack.notifications.slack.SlackHook")
+    def test_slack_notifier_unfurl_options(self, mock_slack_hook, dag_maker):
+        with dag_maker("test_slack_notifier_unfurl_options") as dag:
+            EmptyOperator(task_id="task1")
+
+        notifier = send_slack_notification(
+            text="test",
+            unfurl_links=False,
+            unfurl_media=False,
+        )
+        notifier({"dag": dag})
+        mock_slack_hook.return_value.call.assert_called_once_with(
+            "chat.postMessage",
+            json={
+                "channel": "#general",
+                "username": "Airflow",
+                "text": "test",
+                "icon_url": "https://raw.githubusercontent.com/apache/airflow/2.5.0/airflow/www/static"
+                "/pin_100.png",
+                "attachments": "[]",
+                "blocks": "[]",
+                "unfurl_links": False,
+                "unfurl_media": False,
             },
         )


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
Enable toggling the unfurling of media and URLs for the SlackNotifier.

In order to not unfurl media and have alerts messages that are shorter than the unfurling, enable toggling that behavior.

Happy to hear if there are better ways to handle this, thanks!

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
