### PR TITLE
Updating google-cloud-dataproc to version 5.10.1 and above

### DIFF
--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -130,7 +130,7 @@ dependencies:
   - google-cloud-dataflow-client>=0.8.6
   - google-cloud-dataform>=0.5.0
   - google-cloud-dataplex>=1.10.0
-  - google-cloud-dataproc>=5.8.0
+  - google-cloud-dataproc>=5.10.1
   - google-cloud-dataproc-metastore>=1.12.0
   - google-cloud-dlp>=3.12.0
   - google-cloud-kms>=2.15.0

--- a/docs/apache-airflow-providers-google/index.rst
+++ b/docs/apache-airflow-providers-google/index.rst
@@ -136,7 +136,7 @@ PIP package                              Version required
 ``google-cloud-dataflow-client``         ``>=0.8.6``
 ``google-cloud-dataform``                ``>=0.5.0``
 ``google-cloud-dataplex``                ``>=1.10.0``
-``google-cloud-dataproc``                ``>=5.8.0``
+``google-cloud-dataproc``                ``>=5.10.1``
 ``google-cloud-dataproc-metastore``      ``>=1.12.0``
 ``google-cloud-dlp``                     ``>=3.12.0``
 ``google-cloud-kms``                     ``>=2.15.0``

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -622,7 +622,7 @@
       "google-cloud-dataform>=0.5.0",
       "google-cloud-dataplex>=1.10.0",
       "google-cloud-dataproc-metastore>=1.12.0",
-      "google-cloud-dataproc>=5.8.0",
+      "google-cloud-dataproc>=5.10.1",
       "google-cloud-dlp>=3.12.0",
       "google-cloud-kms>=2.15.0",
       "google-cloud-language>=2.9.0",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

The update is to support the new Dataproc Serverless auto-tuning parameters added in version 5.10.1, added in https://github.com/googleapis/google-cloud-python/pull/12823

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
