### PR TITLE
Implemented Query Band Support for the Teradata provider

### DIFF
--- a/airflow/providers/teradata/hooks/teradata.py
+++ b/airflow/providers/teradata/hooks/teradata.py
@@ -19,6 +19,7 @@
 
 from __future__ import annotations
 
+import re
 import warnings
 from typing import TYPE_CHECKING, Any
 
@@ -42,6 +43,42 @@ def _map_param(value):
         # in the out parameter mapping mechanism.
         value = value()
     return value
+
+
+def _handle_user_query_band_text(query_band_text) -> str:
+    """Validate given query_band and append if required values missed in query_band."""
+    # Ensures 'appname=airflow' and 'org=teradata-internal-telem' are in query_band_text.
+    if query_band_text is not None:
+        # checking org doesn't exist in query_band, appending 'org=teradata-internal-telem'
+        #  If it exists, user might have set some value of their own, so doing nothing in that case
+        pattern = r"org\s*=\s*([^;]*)"
+        match = re.search(pattern, query_band_text)
+        if not match:
+            if not query_band_text.endswith(";"):
+                query_band_text += ";"
+            query_band_text += "org=teradata-internal-telem;"
+        # Making sure appname in query_band contains 'airflow'
+        pattern = r"appname\s*=\s*([^;]*)"
+        # Search for the pattern in the query_band_text
+        match = re.search(pattern, query_band_text)
+        if match:
+            appname_value = match.group(1).strip()
+            # if appname exists and airflow not exists in appname then appending 'airflow' to existing
+            # appname value
+            if "airflow" not in appname_value.lower():
+                new_appname_value = appname_value + "_airflow"
+                # Optionally, you can replace the original value in the query_band_text
+                updated_query_band_text = re.sub(pattern, f"appname={new_appname_value}", query_band_text)
+                query_band_text = updated_query_band_text
+        else:
+            # if appname doesn't exist in query_band, adding 'appname=airflow'
+            if len(query_band_text.strip()) > 0 and not query_band_text.endswith(";"):
+                query_band_text += ";"
+            query_band_text += "appname=airflow;"
+    else:
+        query_band_text = "org=teradata-internal-telem;appname=airflow;"
+
+    return query_band_text
 
 
 class TeradataHook(DbApiHook):
@@ -105,8 +142,23 @@ class TeradataHook(DbApiHook):
         :return: a Teradata connection object
         """
         teradata_conn_config: dict = self._get_conn_config_teradatasql()
+        query_band_text = None
+        if "query_band" in teradata_conn_config:
+            query_band_text = teradata_conn_config.pop("query_band")
         teradata_conn = teradatasql.connect(**teradata_conn_config)
+        # setting query band
+        self.set_query_band(query_band_text, teradata_conn)
         return teradata_conn
+
+    def set_query_band(self, query_band_text, teradata_conn):
+        """Set SESSION Query Band for each connection session."""
+        try:
+            query_band_text = _handle_user_query_band_text(query_band_text)
+            set_query_band_sql = f"SET QUERY_BAND='{query_band_text}' FOR SESSION"
+            with teradata_conn.cursor() as cur:
+                cur.execute(set_query_band_sql)
+        except Exception as ex:
+            self.log.error("Error occurred while setting session query band: %s ", str(ex))
 
     def bulk_insert_rows(
         self,
@@ -171,6 +223,8 @@ class TeradataHook(DbApiHook):
             conn_config["sslcrc"] = conn.extra_dejson["sslcrc"]
         if conn.extra_dejson.get("sslprotocol", False):
             conn_config["sslprotocol"] = conn.extra_dejson["sslprotocol"]
+        if conn.extra_dejson.get("query_band", False):
+            conn_config["query_band"] = conn.extra_dejson["query_band"]
 
         return conn_config
 

--- a/docs/apache-airflow-providers-teradata/connections/teradata.rst
+++ b/docs/apache-airflow-providers-teradata/connections/teradata.rst
@@ -80,3 +80,21 @@ Extra (optional)
     .. code-block:: bash
 
         export AIRFLOW_CONN_TERADATA_DEFAULT='teradata://teradata_user:XXXXXXXXXXXX@1.1.1.1:/teradatadb?tmode=tera&sslmode=verify-ca&sslca=%2Ftmp%2Fserver-ca.pem'
+
+Setting QueryBand
+-----------------
+QueryBand can be specified using extra connection configuration parameter as below. The value specified in query_band will be set as session query band.
+
+    .. code-block:: json
+
+       {
+          "query_band": "appname=airflow;org=test;"
+       }
+
+When specifying the connection as URI (in :envvar:`AIRFLOW_CONN_{CONN_ID}` variable) you should specify query_band as URL-encoded as below.
+
+For example:
+
+    .. code-block:: bash
+
+        export AIRFLOW_CONN_TERADATA_DEFAULT='teradata://teradata_user:XXXXXXXXXXXX@1.1.1.1:/teradatadb?query_band=appname%3Dairflow%3Borg%3Dtest%3B'


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
Implemented Query Band Support to Airflow Teradata Provider. 

- User can specify Query Band in Teradata connection as an extra parameter. 
- Added documentation in teradata.rst on how to specify `query_band` in teradata connection.
- Implemented Unit tests for corresponding changes.

Teradata Provider System Health Dashboard: https://teradata.github.io/airflow/

> tests.system.providers.teradata.example_teradata_compute_cluster - This system test is failing in public repository as the test teradata lake instance is not accessible by public repository. We have tested this test in house and working as expected


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
