### PR TITLE
EKS Overrides for AWS Batch submit_job

### DIFF
--- a/airflow/providers/amazon/aws/hooks/batch_client.py
+++ b/airflow/providers/amazon/aws/hooks/batch_client.py
@@ -103,6 +103,7 @@ class BatchProtocol(Protocol):
         parameters: dict,
         containerOverrides: dict,
         ecsPropertiesOverride: dict,
+        eksPropertiesOverride: dict,
         tags: dict,
     ) -> dict:
         """
@@ -122,6 +123,8 @@ class BatchProtocol(Protocol):
 
         :param ecsPropertiesOverride: the same parameter that boto3 will receive
 
+        :param eksPropertiesOverride: the same parameter that boto3 will receive
+        
         :param tags: the same parameter that boto3 will receive
 
         :return: an API response

--- a/airflow/providers/amazon/aws/hooks/batch_client.py
+++ b/airflow/providers/amazon/aws/hooks/batch_client.py
@@ -124,7 +124,7 @@ class BatchProtocol(Protocol):
         :param ecsPropertiesOverride: the same parameter that boto3 will receive
 
         :param eksPropertiesOverride: the same parameter that boto3 will receive
-        
+
         :param tags: the same parameter that boto3 will receive
 
         :return: an API response

--- a/airflow/providers/amazon/aws/operators/batch.py
+++ b/airflow/providers/amazon/aws/operators/batch.py
@@ -68,6 +68,7 @@ class BatchOperator(BaseOperator):
     :param overrides: DEPRECATED, use container_overrides instead with the same value.
     :param container_overrides: the `containerOverrides` parameter for boto3 (templated)
     :param ecs_properties_override: the `ecsPropertiesOverride` parameter for boto3 (templated)
+    :param eks_properties_override: the `eksPropertiesOverride` parameter for boto3 (templated)
     :param node_overrides: the `nodeOverrides` parameter for boto3 (templated)
     :param share_identifier: The share identifier for the job. Don't specify this parameter if the job queue
         doesn't have a scheduling policy.
@@ -116,6 +117,7 @@ class BatchOperator(BaseOperator):
         "container_overrides",
         "array_properties",
         "ecs_properties_override",
+        "eks_properties_override",
         "node_overrides",
         "parameters",
         "retry_strategy",
@@ -129,6 +131,7 @@ class BatchOperator(BaseOperator):
         "container_overrides": "json",
         "parameters": "json",
         "ecs_properties_override": "json",
+        "eks_properties_override": "json",
         "node_overrides": "json",
         "retry_strategy": "json",
     }
@@ -166,6 +169,7 @@ class BatchOperator(BaseOperator):
         container_overrides: dict | None = None,
         array_properties: dict | None = None,
         ecs_properties_override: dict | None = None,
+        eks_properties_override: dict | None = None,
         node_overrides: dict | None = None,
         share_identifier: str | None = None,
         scheduling_priority_override: int | None = None,
@@ -208,6 +212,7 @@ class BatchOperator(BaseOperator):
             )
 
         self.ecs_properties_override = ecs_properties_override
+        self.eks_properties_override = eks_properties_override
         self.node_overrides = node_overrides
         self.share_identifier = share_identifier
         self.scheduling_priority_override = scheduling_priority_override
@@ -307,6 +312,8 @@ class BatchOperator(BaseOperator):
             self.log.info("AWS Batch job - array properties: %s", self.array_properties)
         if self.ecs_properties_override:
             self.log.info("AWS Batch job - ECS properties: %s", self.ecs_properties_override)
+        if self.eks_properties_override:
+            self.log.info("AWS Batch job - EKS properties: %s", self.eks_properties_override)
         if self.node_overrides:
             self.log.info("AWS Batch job - node properties: %s", self.node_overrides)
 
@@ -319,6 +326,7 @@ class BatchOperator(BaseOperator):
             "tags": self.tags,
             "containerOverrides": self.container_overrides,
             "ecsPropertiesOverride": self.ecs_properties_override,
+            "eksPropertiesOverride": self.eks_properties_override,
             "nodeOverrides": self.node_overrides,
             "retryStrategy": self.retry_strategy,
             "shareIdentifier": self.share_identifier,

--- a/tests/providers/amazon/aws/operators/test_batch.py
+++ b/tests/providers/amazon/aws/operators/test_batch.py
@@ -133,6 +133,7 @@ class TestBatchOperator:
         assert batch_job.container_overrides is None
         assert batch_job.array_properties is None
         assert batch_job.ecs_properties_override is None
+        assert batch_job.eks_properties_override is None
         assert batch_job.node_overrides is None
         assert batch_job.share_identifier is None
         assert batch_job.scheduling_priority_override is None
@@ -151,6 +152,7 @@ class TestBatchOperator:
             "container_overrides",
             "array_properties",
             "ecs_properties_override",
+            "eks_properties_override",
             "node_overrides",
             "parameters",
             "retry_strategy",
@@ -262,6 +264,120 @@ class TestBatchOperator:
             tags={},
         )
 
+    
+    @mock.patch.object(BatchClientHook, "get_job_description")
+    @mock.patch.object(BatchClientHook, "wait_for_job")
+    @mock.patch.object(BatchClientHook, "check_job_success")
+    def test_execute_with_eks_overrides(self, check_mock, wait_mock, job_description_mock):
+        self.batch.container_overrides = None
+        self.batch.eks_properties_override = {
+            "podProperties": [
+                {
+                    "containers": [
+                        {
+                            "image": "string",
+                            "command": [
+                                "string",
+                            ],
+                            "args": [
+                                "string",
+                            ],
+                            "env": [
+                                {"name": "string", "value": "string"},
+                            ],
+                            "resources": [
+                                {"limits": {"string": "string"},
+                                 "requests": {"string": "string"}
+                                }
+                            ],
+                        },
+                    ],
+                    "initContainers": [
+                        {
+                            "image": "string",
+                            "command": [
+                                "string",
+                            ],
+                            "args": [
+                                "string",
+                            ],
+                            "env": [
+                                {"name": "string", "value": "string"},
+                            ],
+                            "resources": [
+                                {
+                                    "limits": {"string": "string"},
+                                    "requests": {"string": "string"},
+                                },
+                            ]
+                        },
+                    ]
+                    "metadata": {
+                        "labels": {
+                            "string": "string"
+                        },
+                    },
+                },
+            ]
+        }
+        self.batch.execute(self.mock_context)
+
+        self.client_mock.submit_job.assert_called_once_with(
+            jobQueue="queue",
+            jobName=JOB_NAME,
+            jobDefinition="hello-world",
+            eksPropertiesOverride={
+                "podProperties": [
+                    {
+                        "containers": [
+                            {
+                                "image": "string",
+                                "command": [
+                                    "string",
+                                ],
+                                "args": [
+                                    "string",
+                                ],
+                                "env": [
+                                    {"name": "string", "value": "string"},
+                                ],
+                                "resources": [
+                                    {"limits": {"string": "string"},
+                                     "requests": {"string": "string"}
+                                    }
+                                ],
+                            },
+                        ],
+                        "initContainers": [
+                            {
+                                "image": "string",
+                                "command": [
+                                    "string",
+                                ],
+                                "args": [
+                                    "string",
+                                ],
+                                "env": [
+                                    {"name": "string", "value": "string"},
+                                ],
+                                "resources": [
+                                    {
+                                        "limits": {"string": "string"},
+                                        "requests": {"string": "string"},
+                                    },
+                                ]
+                            },
+                        ]
+                        "metadata": {
+                            "labels": {
+                                "string": "string"
+                            },
+                        },
+                    },
+                ]
+            }
+        )
+
     @mock.patch.object(BatchClientHook, "check_job_success")
     def test_wait_job_complete_using_waiters(self, check_mock):
         mock_waiters = mock.Mock()
@@ -296,7 +412,7 @@ class TestBatchOperator:
         self.batch.on_kill()
         self.client_mock.terminate_job.assert_called_once_with(jobId=JOB_ID, reason="Task killed by the user")
 
-    @pytest.mark.parametrize("override", ["overrides", "node_overrides", "ecs_properties_override"])
+    @pytest.mark.parametrize("override", ["overrides", "node_overrides", "ecs_properties_override", "eks_properties_override"])
     @patch(
         "airflow.providers.amazon.aws.hooks.batch_client.BatchClientHook.client",
         new_callable=mock.PropertyMock,
@@ -348,6 +464,7 @@ class TestBatchOperator:
             "overrides": "containerOverrides",
             "node_overrides": "nodeOverrides",
             "ecs_properties_override": "ecsPropertiesOverride",
+            "eks_properties_override": "eksPropertiesOverride",
         }
 
         expected_args[py2api[override]] = {"a": "a"}

--- a/tests/providers/amazon/aws/operators/test_batch.py
+++ b/tests/providers/amazon/aws/operators/test_batch.py
@@ -376,11 +376,11 @@ class TestBatchOperator:
                     },
                 ]
             },
-            "parameters": {},                                              
-            "retryStrategy": {                                             
+            parameters: {},                                              
+            retryStrategy: {                                             
                 "attempts": 1,                                               
             },                                                             
-            "tags": {},   
+            tags: {},   
         )
 
     @mock.patch.object(BatchClientHook, "check_job_success")

--- a/tests/providers/amazon/aws/operators/test_batch.py
+++ b/tests/providers/amazon/aws/operators/test_batch.py
@@ -264,7 +264,6 @@ class TestBatchOperator:
             tags={},
         )
 
-
     @mock.patch.object(BatchClientHook, "get_job_description")
     @mock.patch.object(BatchClientHook, "wait_for_job")
     @mock.patch.object(BatchClientHook, "check_job_success")
@@ -285,9 +284,7 @@ class TestBatchOperator:
                             "env": [
                                 {"name": "string", "value": "string"},
                             ],
-                            "resources": [
-                                {"limits": {"string": "string"}, "requests": {"string": "string"}}
-                            ],
+                            "resources": [{"limits": {"string": "string"}, "requests": {"string": "string"}}],
                         },
                     ],
                     "initContainers": [
@@ -302,9 +299,7 @@ class TestBatchOperator:
                             "env": [
                                 {"name": "string", "value": "string"},
                             ],
-                            "resources": [
-                                {"limits": {"string": "string"}, "requests": {"string": "string"}}
-                            ],
+                            "resources": [{"limits": {"string": "string"}, "requests": {"string": "string"}}],
                         },
                     ],
                     "metadata": {

--- a/tests/providers/amazon/aws/operators/test_batch.py
+++ b/tests/providers/amazon/aws/operators/test_batch.py
@@ -372,10 +372,15 @@ class TestBatchOperator:
                             "labels": {
                                 "string": "string"
                             },
-                        },
+                        }, 
                     },
                 ]
-            }
+            },
+            "parameters": {},                                              
+            "retryStrategy": {                                             
+                "attempts": 1,                                               
+            },                                                             
+            "tags": {},   
         )
 
     @mock.patch.object(BatchClientHook, "check_job_success")

--- a/tests/providers/amazon/aws/operators/test_batch.py
+++ b/tests/providers/amazon/aws/operators/test_batch.py
@@ -264,7 +264,7 @@ class TestBatchOperator:
             tags={},
         )
 
-    
+
     @mock.patch.object(BatchClientHook, "get_job_description")
     @mock.patch.object(BatchClientHook, "wait_for_job")
     @mock.patch.object(BatchClientHook, "check_job_success")

--- a/tests/providers/amazon/aws/operators/test_batch.py
+++ b/tests/providers/amazon/aws/operators/test_batch.py
@@ -286,9 +286,7 @@ class TestBatchOperator:
                                 {"name": "string", "value": "string"},
                             ],
                             "resources": [
-                                {"limits": {"string": "string"},
-                                 "requests": {"string": "string"}
-                                }
+                                {"limits": {"string": "string"}, "requests": {"string": "string"}}
                             ],
                         },
                     ],
@@ -305,17 +303,12 @@ class TestBatchOperator:
                                 {"name": "string", "value": "string"},
                             ],
                             "resources": [
-                                {
-                                    "limits": {"string": "string"},
-                                    "requests": {"string": "string"},
-                                },
-                            ]
+                                {"limits": {"string": "string"}, "requests": {"string": "string"}}
+                            ],
                         },
                     ],
                     "metadata": {
-                        "labels": {
-                            "string": "string"
-                        },
+                        "labels": {"string": "string"},
                     },
                 },
             ]
@@ -342,9 +335,7 @@ class TestBatchOperator:
                                     {"name": "string", "value": "string"},
                                 ],
                                 "resources": [
-                                    {"limits": {"string": "string"},
-                                     "requests": {"string": "string"}
-                                    }
+                                    {"limits": {"string": "string"}, "requests": {"string": "string"}}
                                 ],
                             },
                         ],
@@ -361,17 +352,12 @@ class TestBatchOperator:
                                     {"name": "string", "value": "string"},
                                 ],
                                 "resources": [
-                                    {
-                                        "limits": {"string": "string"},
-                                        "requests": {"string": "string"},
-                                    },
-                                ]
+                                    {"limits": {"string": "string"}, "requests": {"string": "string"}}
+                                ],
                             },
                         ],
                         "metadata": {
-                            "labels": {
-                                "string": "string"
-                            },
+                            "labels": {"string": "string"},
                         },
                     },
                 ]
@@ -415,7 +401,9 @@ class TestBatchOperator:
         self.batch.on_kill()
         self.client_mock.terminate_job.assert_called_once_with(jobId=JOB_ID, reason="Task killed by the user")
 
-    @pytest.mark.parametrize("override", ["overrides", "node_overrides", "ecs_properties_override", "eks_properties_override"])
+    @pytest.mark.parametrize(
+        "override", ["overrides", "node_overrides", "ecs_properties_override", "eks_properties_override"]
+    )
     @patch(
         "airflow.providers.amazon.aws.hooks.batch_client.BatchClientHook.client",
         new_callable=mock.PropertyMock,

--- a/tests/providers/amazon/aws/operators/test_batch.py
+++ b/tests/providers/amazon/aws/operators/test_batch.py
@@ -311,7 +311,7 @@ class TestBatchOperator:
                                 },
                             ]
                         },
-                    ]
+                    ],
                     "metadata": {
                         "labels": {
                             "string": "string"
@@ -367,7 +367,7 @@ class TestBatchOperator:
                                     },
                                 ]
                             },
-                        ]
+                        ],
                         "metadata": {
                             "labels": {
                                 "string": "string"

--- a/tests/providers/amazon/aws/operators/test_batch.py
+++ b/tests/providers/amazon/aws/operators/test_batch.py
@@ -372,15 +372,13 @@ class TestBatchOperator:
                             "labels": {
                                 "string": "string"
                             },
-                        }, 
+                        },
                     },
                 ]
             },
-            parameters: {},                                              
-            retryStrategy: {                                             
-                "attempts": 1,                                               
-            },                                                             
-            tags: {},   
+            parameters={},
+            retryStrategy={"attempts": 1},
+            tags={},
         )
 
     @mock.patch.object(BatchClientHook, "check_job_success")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

aws batch operator has no eks_properties_override. so I added it.

I found [this](https://github.com/apache/airflow/pull/39903)

Closes: https://github.com/apache/airflow/issues/40117

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
