### PR TITLE
Add some context comments to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -303,7 +303,7 @@ ignore = [
     "D103", # TODO: Missing docstring in public function
     "D104", # Unwanted; Docstring at the top of every `__init__.py` file.
     "D105", # Unwanted; See https://lists.apache.org/thread/8jbg1dd2lr2cfydtqbjxsd6pb6q2wkc3
-    "D107", # Unwanted; Docstring in every constructor is unnecesary if the class has a docstring.
+    "D107", # Unwanted; Docstring in every constructor is unnecessary if the class has a docstring.
     "D203",
     "D212", # Conflicts with D213.  Both can not be enabled.
     "D214",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -298,12 +298,12 @@ extend-select = [
     "TRY002", # Prohibit use of `raise Exception`, use specific exceptions instead.
 ]
 ignore = [
-    "D100", # TODO: Missing docstring in public module
+    "D100", # Unwanted; Docstring at the top of every file.
     "D102", # TODO: Missing docstring in public method
     "D103", # TODO: Missing docstring in public function
-    "D104", # TODO: Missing docstring in public package
-    "D105", # Do not want.  See https://lists.apache.org/thread/8jbg1dd2lr2cfydtqbjxsd6pb6q2wkc3
-    "D107", # TODO: Missing docstring in __init__
+    "D104", # Unwanted; Docstring at the top of every `__init__.py` file.
+    "D105", # Unwanted; See https://lists.apache.org/thread/8jbg1dd2lr2cfydtqbjxsd6pb6q2wkc3
+    "D107", # Unwanted; Docstring in every constructor is unnecesary if the class has a docstring.
     "D203",
     "D212", # Conflicts with D213.  Both can not be enabled.
     "D214",


### PR DESCRIPTION
Just adding some context to the pydocstyle rules we do not want to enable so nobody wastes time looking into them in the future.   See [Slack thread](https://apache-airflow.slack.com/archives/C06K9Q5G2UA/p1720718693521769)( for a little more discussion and context if desired.