### PR TITLE
Fix dataset_with_extra_from_classic_operator example DAG

### DIFF
--- a/airflow/example_dags/example_outlet_event_extra.py
+++ b/airflow/example_dags/example_outlet_event_extra.py
@@ -69,8 +69,8 @@ with DAG(
     tags=["produces"],
 ):
 
-    def _dataset_with_extra_from_classic_operator_post_execute(context):
-        context["outlet_events"].extra = {"hi": "bye"}
+    def _dataset_with_extra_from_classic_operator_post_execute(context, results):
+        context["outlet_events"][ds].extra = {"hi": "bye"}
 
     BashOperator(
         task_id="dataset_with_extra_from_classic_operator",

--- a/airflow/example_dags/example_outlet_event_extra.py
+++ b/airflow/example_dags/example_outlet_event_extra.py
@@ -69,7 +69,7 @@ with DAG(
     tags=["produces"],
 ):
 
-    def _dataset_with_extra_from_classic_operator_post_execute(context, results):
+    def _dataset_with_extra_from_classic_operator_post_execute(context, result):
         context["outlet_events"][ds].extra = {"hi": "bye"}
 
     BashOperator(


### PR DESCRIPTION
Noticed DAG `dataset_with_extra_from_classic_operator` failing with error `TypeError: _dataset_with_extra_from_classic_operator_post_execute() takes 1 positional argument but 2 were given`.  This PR addresses this issue.
![image](https://github.com/user-attachments/assets/5e1e59b2-97f5-4801-9795-ab9a49389d58)


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
