### PR TITLE
Add task duration plot across dagruns

### DIFF
--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -28,7 +28,6 @@ import {
   Tab,
   Text,
   Button,
-  Box,
   Checkbox,
 } from "@chakra-ui/react";
 import InfoTooltip from "src/components/InfoTooltip";

--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -64,12 +64,12 @@ import MarkRunAs from "./dagRun/MarkRunAs";
 import ClearInstance from "./taskInstance/taskActions/ClearInstance";
 import MarkInstanceAs from "./taskInstance/taskActions/MarkInstanceAs";
 import XcomCollection from "./taskInstance/Xcom";
+import AllTaskDuration from "./task/AllTaskDuration";
 import TaskDetails from "./task";
 import EventLog from "./EventLog";
 import RunDuration from "./dag/RunDuration";
 import Calendar from "./dag/Calendar";
 import RenderedK8s from "./taskInstance/RenderedK8s";
-import AllTaskDuration from "./task/AllTaskDuration";
 
 const dagId = getMetaValue("dag_id")!;
 

--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import {
   Flex,
   Divider,
@@ -28,7 +28,10 @@ import {
   Tab,
   Text,
   Button,
+  Box,
+  Checkbox,
 } from "@chakra-ui/react";
+import InfoTooltip from "src/components/InfoTooltip";
 import { useSearchParams } from "react-router-dom";
 
 import useSelection from "src/dag/useSelection";
@@ -175,6 +178,7 @@ const Details = ({
   const children = group?.children;
   const isMapped = group?.isMapped;
   const isGroup = !!children;
+  const [showBar, setShowBar] = useState(false);
 
   const isMappedTaskSummary = !!(
     taskId &&
@@ -465,7 +469,17 @@ const Details = ({
           )}
           {isDag && (
             <TabPanel height="80%">
-              <AllTaskDuration />
+              <Flex justifyContent="right" pr="30px">
+                <Checkbox
+                  isChecked={showBar}
+                  onChange={() => setShowBar(!showBar)}
+                  size="lg"
+                >
+                  Show Bar Chart
+                </Checkbox>
+                <InfoTooltip label="Show bar chart" size={16} />
+              </Flex>
+              <AllTaskDuration showBar={showBar} />
             </TabPanel>
           )}
           {isDag && (

--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -69,6 +69,7 @@ import EventLog from "./EventLog";
 import RunDuration from "./dag/RunDuration";
 import Calendar from "./dag/Calendar";
 import RenderedK8s from "./taskInstance/RenderedK8s";
+import AllTaskDuration from "./task/AllTaskDuration";
 
 const dagId = getMetaValue("dag_id")!;
 
@@ -98,8 +99,9 @@ const tabToIndex = (tab?: string) => {
     case "run_duration":
       return 5;
     case "xcom":
-    case "calendar":
+    case "task_duration":
       return 6;
+    case "calendar":
     case "rendered_k8s":
       return 7;
     case "details":
@@ -138,10 +140,11 @@ const indexToTab = (
       if (!runId && !taskId) return "run_duration";
       return undefined;
     case 6:
-      if (!runId && !taskId) return "calendar";
+      if (!runId && !taskId) return "task_duration";
       if (isTaskInstance) return "xcom";
       return undefined;
     case 7:
+      if (!runId && !taskId) return "calendar";
       if (isTaskInstance && isK8sExecutor) return "rendered_k8s";
       return undefined;
     default:
@@ -341,6 +344,14 @@ const Details = ({
           )}
           {isDag && (
             <Tab>
+              <MdHourglassBottom size={16} />
+              <Text as="strong" ml={1}>
+                Task Duration
+              </Text>
+            </Tab>
+          )}
+          {isDag && (
+            <Tab>
               <MdEvent size={16} />
               <Text as="strong" ml={1}>
                 Calendar
@@ -450,6 +461,11 @@ const Details = ({
           {isDag && (
             <TabPanel height="100%">
               <RunDuration />
+            </TabPanel>
+          )}
+          {isDag && (
+            <TabPanel height="80%">
+              <AllTaskDuration />
             </TabPanel>
           )}
           {isDag && (

--- a/airflow/www/static/js/dag/details/task/AllTaskDuration.tsx
+++ b/airflow/www/static/js/dag/details/task/AllTaskDuration.tsx
@@ -32,6 +32,10 @@ import URLSearchParamsWrapper from "src/utils/URLSearchParamWrapper";
 
 const TAB_PARAM = "tab";
 
+interface Props {
+  showBar: boolean;
+}
+
 const AllTaskDuration = ({ showBar }: Props) => {
   const { onSelect } = useSelection();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -61,7 +65,7 @@ const AllTaskDuration = ({ showBar }: Props) => {
 
     if (showBar) {
       seriesData.push({
-        name: children.runId,
+        name: taskId,
         type: "bar",
         stack: "x",
       } as SeriesOption);
@@ -73,6 +77,7 @@ const AllTaskDuration = ({ showBar }: Props) => {
     }
 
     source[taskId] = children.instances.map((instance) => {
+      // @ts-ignore
       const runDuration = moment
         .duration(
           instance.startDate
@@ -89,6 +94,7 @@ const AllTaskDuration = ({ showBar }: Props) => {
 
   // @ts-ignore
   function formatTooltip(value) {
+    // @ts-ignore
     return moment.utc(value * 1000).format("HH[h]:mm[m]:ss[s]");
   }
 
@@ -133,6 +139,7 @@ const AllTaskDuration = ({ showBar }: Props) => {
       name: `Duration`,
       axisLabel: {
         formatter(value: number) {
+          // @ts-ignore
           const duration = moment.utc(value * 1000);
           return duration.format("HH[h]:mm[m]:ss[s]");
         },

--- a/airflow/www/static/js/dag/details/task/AllTaskDuration.tsx
+++ b/airflow/www/static/js/dag/details/task/AllTaskDuration.tsx
@@ -1,0 +1,125 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* global moment */
+
+import React from "react";
+
+import { useGridData } from "src/api";
+import { startCase } from "lodash";
+import { getDuration, defaultFormat } from "src/datetime_utils";
+import ReactECharts, { ReactEChartsProps } from "src/components/ReactECharts";
+
+interface SeriesData {
+  name?: string | null;
+  type: string;
+  data: Array<number>;
+}
+
+const AllTaskDuration = () => {
+  const {
+    data: { dagRuns, groups, ordering },
+  } = useGridData();
+  let maxDuration = 0;
+  let unit = "seconds";
+  let unitDivisor = 1;
+
+  const seriesData: Array<SeriesData> = [];
+  const legendData: Array<string | null> = [];
+  const orderingLabel = ordering[0] || ordering[1] || "startDate";
+
+  groups.children?.forEach((children) => {
+    legendData.push(children.id);
+    seriesData.push({
+      name: children.id,
+      type: "line",
+      data: children.instances.map((instance) => {
+        const runDuration = moment
+          .duration(
+            instance.startDate
+              ? getDuration(instance.startDate, instance?.endDate)
+              : 0
+          )
+          .asSeconds();
+
+        if (runDuration > maxDuration) {
+          maxDuration = runDuration;
+        }
+
+        return runDuration;
+      }),
+    });
+  });
+
+  if (maxDuration <= 60 * 2) {
+    unit = "seconds";
+    unitDivisor = 1;
+  } else if (maxDuration <= 60 * 60 * 2) {
+    unit = "minutes";
+    unitDivisor = 60;
+  } else if (maxDuration <= 24 * 60 * 60 * 2) {
+    unit = "hours";
+    unitDivisor = 60 * 60;
+  } else {
+    unit = "days";
+    unitDivisor = 60 * 60 * 24;
+  }
+
+  seriesData.forEach((series) => {
+    series.data = series.data.map((duration) =>
+      (duration / unitDivisor).toFixed(2)
+    );
+  });
+
+  const option: ReactEChartsProps["option"] = {
+    legend: {
+      orient: "horizontal",
+      icon: "circle",
+      data: legendData,
+    },
+    tooltip: {
+      trigger: "axis",
+    },
+    series: seriesData,
+    xAxis: {
+      type: "category",
+      show: true,
+      data: dagRuns.map((dagRun) =>
+        // @ts-ignore
+        moment(dagRun[orderingLabel]).format(defaultFormat)
+      ),
+      name: startCase(orderingLabel),
+      nameLocation: "end",
+      nameGap: 0,
+      nameTextStyle: {
+        align: "right",
+        verticalAlign: "top",
+        padding: [30, 0, 0, 0],
+      },
+    },
+    yAxis: {
+      type: "value",
+      name: `Duration (${unit})`,
+    },
+  };
+
+  return <ReactECharts option={option} />;
+};
+
+export default AllTaskDuration;

--- a/airflow/www/static/js/dag/details/task/AllTaskDuration.tsx
+++ b/airflow/www/static/js/dag/details/task/AllTaskDuration.tsx
@@ -32,7 +32,7 @@ import URLSearchParamsWrapper from "src/utils/URLSearchParamWrapper";
 
 const TAB_PARAM = "tab";
 
-const AllTaskDuration = () => {
+const AllTaskDuration = ({ showBar }: Props) => {
   const { onSelect } = useSelection();
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -58,10 +58,19 @@ const AllTaskDuration = () => {
 
     const taskId = children.id;
     legendData.push(taskId);
-    seriesData.push({
-      name: taskId,
-      type: "line",
-    } as SeriesOption);
+
+    if (showBar) {
+      seriesData.push({
+        name: children.runId,
+        type: "bar",
+        stack: "x",
+      } as SeriesOption);
+    } else {
+      seriesData.push({
+        name: taskId,
+        type: "line",
+      } as SeriesOption);
+    }
 
     source[taskId] = children.instances.map((instance) => {
       const runDuration = moment


### PR DESCRIPTION
closes: #40337
related: #40337

This implements multi-line chart to plot task duration across all dagruns in the grid. The duration includes only run duration and is stored as seconds. During rendering the y-axis value is converted to hh:mm:ss format along with the tooltip. In task duration for a specific task we can calculate max duration but calculating it across all instances means when an outlier task ran in hours that takes only seconds then deselecting the task from legend will still display all others in hours. Clicking on the data point takes the user to specific task instance detail tab.

I am facing an issue with moment import which I couldn't figure out. Any help is appreciated.

```
static/js/dag/details/task/AllTaskDuration.tsx:67:27 - error TS2686: 'moment' refers to a UMD global, but the current file is a module. Consider adding an import instead.

67       const runDuration = moment
                             ~~~~~~

static/js/dag/details/task/AllTaskDuration.tsx:83:12 - error TS2686: 'moment' refers to a UMD global, but the current file is a module. Consider adding an import instead.

83     return moment.utc(value * 1000).format("HH[h]:mm[m]:ss[s]");
              ~~~~~~

static/js/dag/details/task/AllTaskDuration.tsx:127:28 - error TS2686: 'moment' refers to a UMD global, but the current file is a module. Consider adding an import instead.

127           const duration = moment.utc(value * 1000);

```

Screenshot

![image](https://github.com/user-attachments/assets/7b806d7e-22f3-487d-9a9b-dfe379faa82f)


echarts example : https://echarts.apache.org/examples/en/editor.html?c=line-stack&lang=js