### PR TITLE
Use params instead of dag_run.conf in example

### DIFF
--- a/airflow/example_dags/example_params_trigger_ui.py
+++ b/airflow/example_dags/example_params_trigger_ui.py
@@ -24,16 +24,11 @@ from __future__ import annotations
 
 import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from airflow.decorators import task
 from airflow.models.dag import DAG
-from airflow.models.param import Param
+from airflow.models.param import Param, ParamsDict
 from airflow.utils.trigger_rule import TriggerRule
-
-if TYPE_CHECKING:
-    from airflow.models.dagrun import DagRun
-    from airflow.models.taskinstance import TaskInstance
 
 with DAG(
     dag_id=Path(__file__).stem,
@@ -60,20 +55,18 @@ with DAG(
 
     @task(task_id="get_names", task_display_name="Get names")
     def get_names(**kwargs) -> list[str]:
-        ti: TaskInstance = kwargs["ti"]
-        dag_run: DagRun = ti.dag_run
-        if "names" not in dag_run.conf:
+        params: ParamsDict = kwargs["params"]
+        if "names" not in params:
             print("Uuups, no names given, was no UI used to trigger?")
             return []
-        return dag_run.conf["names"]
+        return params["names"]
 
     @task.branch(task_id="select_languages", task_display_name="Select languages")
     def select_languages(**kwargs) -> list[str]:
-        ti: TaskInstance = kwargs["ti"]
-        dag_run: DagRun = ti.dag_run
+        params: ParamsDict = kwargs["params"]
         selected_languages = []
         for lang in ["english", "german", "french"]:
-            if dag_run.conf.get(lang):
+            if params[lang]:
                 selected_languages.append(f"generate_{lang}_greeting")
         return selected_languages
 


### PR DESCRIPTION
While playing with examples I realized that my own example uses `dag_run.conf` which I would nowadays dis-courage to use - params are much better because defaults and validations are used.

This PR updates using defined params instead of `dag_run.conf`