### PR TITLE
Fix and adjust URL generation for UI grid and older runs

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2164,7 +2164,9 @@ class TaskInstance(Base, LoggingMixin):
     def log_url(self) -> str:
         """Log URL for TaskInstance."""
         run_id = quote(self.run_id)
+        base_date = quote(self.execution_date.strftime("%Y-%m-%dT%H:%M:%S%z"))
         base_url = conf.get_mandatory_value("webserver", "BASE_URL")
+        map_index = f"&map_index={self.map_index}" if self.map_index >= 0 else ""
         return (
             f"{base_url}"
             f"/dags"
@@ -2172,7 +2174,8 @@ class TaskInstance(Base, LoggingMixin):
             f"/grid"
             f"?dag_run_id={run_id}"
             f"&task_id={self.task_id}"
-            f"&map_index={self.map_index}"
+            f"{map_index}"
+            f"&base_date={base_date}"
             "&tab=logs"
         )
 

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2020,7 +2020,7 @@ class TestTaskInstance:
             "/dags/my_dag/grid"
             "?dag_run_id=test"
             "&task_id=op"
-            "&map_index=-1"
+            "&base_date=2018-01-01T00%3A00%3A00%2B0000"
             "&tab=logs"
         )
         assert ti.log_url == expected_url


### PR DESCRIPTION
Even though there was a PR #39642 and linked several others there is a serious regression to have valid and working links for older DAG runs pointing to grid.
I got a report for such a bug during the week and was stumbling into this with a lot of follow-up issues. I think the grid UI needs to be in general improved towards this but could not find a good entry point.

Nevertheless following other PRs attempting to fix I relalized that passing `base_date` helps until the Grid properly is able to handle older run calls. But the `TaskInstance.log_url` property does not generate a compatible URL.

This PR adjusts the URL generated to be working for older runs.

As I had my hands on it, optimized the map_index off if task is not mapped.