### PR TITLE
Attempt to fix async sensor test flakiness

### DIFF
--- a/tests/sensors/test_time_delta.py
+++ b/tests/sensors/test_time_delta.py
@@ -58,7 +58,6 @@ class TestTimeDeltaSensorAsync:
         "data_interval_end, delta, should_deffer",
         [
             (REFERENCE_TIME.add(hours=-1, minutes=-1), timedelta(hours=1), False),
-            # add 20 seconds to the reference time to account for slow running tests
             (REFERENCE_TIME, timedelta(hours=1), True),
         ],
     )

--- a/tests/sensors/test_time_delta.py
+++ b/tests/sensors/test_time_delta.py
@@ -57,7 +57,8 @@ class TestTimeDeltaSensorAsync:
     @pytest.mark.parametrize(
         "data_interval_end, delta, should_deffer",
         [
-            (REFERENCE_TIME.add(hours=-1), timedelta(hours=1), False),
+            (REFERENCE_TIME.add(hours=-1, minutes=-1), timedelta(hours=1), False),
+            # add 20 seconds to the reference time to account for slow running tests
             (REFERENCE_TIME, timedelta(hours=1), True),
         ],
     )


### PR DESCRIPTION
The #40719 introduce flakiness that only shows with self-hosted runners - likely because the reference_time is modified in-place by ".add" and that introduces a subtle timing issue even if the tests are designed to avoid the timing issue.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
