### PR TITLE
Prevent NoneType Error at plugin loading with database isolation mode

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -725,7 +725,7 @@ class AirflowBaseView(BaseView):
 
     if not conf.getboolean("core", "unit_test_mode"):
         executor, _ = ExecutorLoader.import_default_executor_cls()
-        extra_args["sqlite_warning"] = settings.engine.dialect.name == "sqlite"
+        extra_args["sqlite_warning"] = settings.engine and (settings.engine.dialect.name == "sqlite")
         if not executor.is_production:
             extra_args["production_executor_warning"] = executor.__name__
         extra_args["otel_metrics_on"] = conf.getboolean("metrics", "otel_on")


### PR DESCRIPTION
After merge of #39999 and the addition of the Databricks plugin (again) in #40724 I realized that in the chain of loading plugins with examples the loading of the databricks plugin fails is database isolation mode is on (AIP-44).

Background is that importing from views, here BaseView checks for DB Engine, which is not initialized.
Make check for SQlite conditional only if DB engine is initialized.