### PR TITLE
Improve handling for params serialization for AIP-44

### DIFF
--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -855,7 +855,7 @@ class BaseSerialization:
             if class_identity == "airflow.models.param.Param":
                 serialized_params.append((k, cls._serialize_param(v)))
             else:
-                # Auto-boy other values into Params object like it is done by DAG parsing as well
+                # Auto-box other values into Params object like it is done by DAG parsing as well
                 serialized_params.append((k, cls._serialize_param(Param(v))))
         return serialized_params
 


### PR DESCRIPTION
During tests of AIP-69 I realized that DAG params are not correctly serialized and execution of tasks fail with parameters.

This PR removes one TODO in the serialization of params:
- If ParamsDict is used to iterate the value it taken native before resolving
- If a parameter was resolved somewhere before it is auto-boxed into a Params() class like it is made with other values in https://github.com/apache/airflow/blob/main/airflow/models/param.py#L245