### PR TITLE
provide session to PriorityWeightStrategy get_weight method

### DIFF
--- a/airflow/example_dags/plugins/decreasing_priority_weight_strategy.py
+++ b/airflow/example_dags/plugins/decreasing_priority_weight_strategy.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 
 from airflow.plugins_manager import AirflowPlugin
 from airflow.task.priority_strategy import PriorityWeightStrategy
+from airflow.utils.session import NEW_SESSION, provide_session
 
 if TYPE_CHECKING:
     from airflow.models import TaskInstance
@@ -29,7 +30,8 @@ if TYPE_CHECKING:
 class DecreasingPriorityStrategy(PriorityWeightStrategy):
     """A priority weight strategy that decreases the priority weight with each attempt of the DAG task."""
 
-    def get_weight(self, ti: TaskInstance):
+    @provide_session
+    def get_weight(self, ti: TaskInstance, session=NEW_SESSION):
         return max(3 - ti.try_number + 1, 1)
 
 

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -1202,7 +1202,9 @@ class DagRun(Base, LoggingMixin):
             )
 
         created_counts: dict[str, int] = defaultdict(int)
-        task_creator = self._get_task_creator(created_counts, task_instance_mutation_hook, hook_is_noop)
+        task_creator = self._get_task_creator(
+            created_counts, task_instance_mutation_hook, hook_is_noop, session=session
+        )
 
         # Create the missing tasks, including mapped tasks
         tasks_to_create = (task for task in dag.task_dict.values() if task_filter(task))
@@ -1295,6 +1297,7 @@ class DagRun(Base, LoggingMixin):
         created_counts: dict[str, int],
         ti_mutation_hook: Callable,
         hook_is_noop: Literal[True],
+        session: Session,
     ) -> Callable[[Operator, Iterable[int]], Iterator[dict[str, Any]]]: ...
 
     @overload
@@ -1303,6 +1306,7 @@ class DagRun(Base, LoggingMixin):
         created_counts: dict[str, int],
         ti_mutation_hook: Callable,
         hook_is_noop: Literal[False],
+        session: Session,
     ) -> Callable[[Operator, Iterable[int]], Iterator[TI]]: ...
 
     def _get_task_creator(
@@ -1310,6 +1314,7 @@ class DagRun(Base, LoggingMixin):
         created_counts: dict[str, int],
         ti_mutation_hook: Callable,
         hook_is_noop: Literal[True, False],
+        session: Session,
     ) -> Callable[[Operator, Iterable[int]], Iterator[dict[str, Any]] | Iterator[TI]]:
         """
         Get the task creator function.
@@ -1326,7 +1331,7 @@ class DagRun(Base, LoggingMixin):
             def create_ti_mapping(task: Operator, indexes: Iterable[int]) -> Iterator[dict[str, Any]]:
                 created_counts[task.task_type] += 1
                 for map_index in indexes:
-                    yield TI.insert_mapping(self.run_id, task, map_index=map_index)
+                    yield TI.insert_mapping(self.run_id, task, map_index=map_index, session=session)
 
             creator = create_ti_mapping
 

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1924,14 +1924,15 @@ class TaskInstance(Base, LoggingMixin):
         return _stats_tags(task_instance=self)
 
     @staticmethod
-    def insert_mapping(run_id: str, task: Operator, map_index: int) -> dict[str, Any]:
+    def insert_mapping(run_id: str, task: Operator, map_index: int, session: Session) -> dict[str, Any]:
         """
         Insert mapping.
 
         :meta private:
         """
         priority_weight = task.weight_rule.get_weight(
-            TaskInstance(task=task, run_id=run_id, map_index=map_index)
+            TaskInstance(task=task, run_id=run_id, map_index=map_index),
+            session=session,
         )
 
         return {

--- a/airflow/task/priority_strategy.py
+++ b/airflow/task/priority_strategy.py
@@ -23,6 +23,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
 from airflow.exceptions import AirflowException
+from airflow.utils.session import NEW_SESSION, provide_session
 
 if TYPE_CHECKING:
     from airflow.models.taskinstance import TaskInstance
@@ -41,7 +42,8 @@ class PriorityWeightStrategy(ABC):
     """
 
     @abstractmethod
-    def get_weight(self, ti: TaskInstance):
+    @provide_session
+    def get_weight(self, ti: TaskInstance, session=NEW_SESSION) -> int:
         """Get the priority weight of a task."""
         ...
 
@@ -77,7 +79,8 @@ class PriorityWeightStrategy(ABC):
 class _AbsolutePriorityWeightStrategy(PriorityWeightStrategy):
     """Priority weight strategy that uses the task's priority weight directly."""
 
-    def get_weight(self, ti: TaskInstance):
+    @provide_session
+    def get_weight(self, ti: TaskInstance, session=NEW_SESSION) -> int:
         if TYPE_CHECKING:
             assert ti.task
         return ti.task.priority_weight
@@ -86,7 +89,8 @@ class _AbsolutePriorityWeightStrategy(PriorityWeightStrategy):
 class _DownstreamPriorityWeightStrategy(PriorityWeightStrategy):
     """Priority weight strategy that uses the sum of the priority weights of all downstream tasks."""
 
-    def get_weight(self, ti: TaskInstance) -> int:
+    @provide_session
+    def get_weight(self, ti: TaskInstance, session=NEW_SESSION) -> int:
         if TYPE_CHECKING:
             assert ti.task
         dag = ti.task.get_dag()
@@ -101,7 +105,8 @@ class _DownstreamPriorityWeightStrategy(PriorityWeightStrategy):
 class _UpstreamPriorityWeightStrategy(PriorityWeightStrategy):
     """Priority weight strategy that uses the sum of the priority weights of all upstream tasks."""
 
-    def get_weight(self, ti: TaskInstance):
+    @provide_session
+    def get_weight(self, ti: TaskInstance, session=NEW_SESSION) -> int:
         if TYPE_CHECKING:
             assert ti.task
         dag = ti.task.get_dag()


### PR DESCRIPTION
closes: #40773

There is a session created in `DagRun.verify_integrity` method, these statements will be called:
https://github.com/apache/airflow/blob/8de5e7a6755559e2560000ac194153d612dd616e/airflow/models/dagrun.py#L1205-L1207
https://github.com/apache/airflow/blob/8de5e7a6755559e2560000ac194153d612dd616e/airflow/models/dagrun.py#L1334
https://github.com/apache/airflow/blob/8de5e7a6755559e2560000ac194153d612dd616e/airflow/models/taskinstance.py#L1933-L1936

So if the decorator `provide_session` is used in the `PriorityWeightStrategy` class, a nested session will be created and committed, and the session created in `verify_integrity` will be somehow closed.

In this PR I provide the session to `get_weight` method to make it more flexible without the mentioned issue.

P.S: the future is still experimental.
