### PR TITLE
Support `PythonVirtualEnvHook`

### DIFF
--- a/airflow/decorators/__init__.pyi
+++ b/airflow/decorators/__init__.pyi
@@ -155,6 +155,8 @@ class TaskDecoratorCollection:
             virtual environment will be cached, creates a sub-folder venv-{hash} whereas hash will be
             replaced with a checksum of requirements. If not provided the virtual environment will be
             created and deleted in a temp folder for every execution.
+        :param venv_conn_id: The ID of Python Virtualenv Connection.
+            If set, the other arguments will override the values from the connection.
         :param templates_dict: a dictionary where the values are templates that
             will get templated by the Airflow engine sometime between
             ``__init__`` and ``execute`` takes place and are made available
@@ -163,8 +165,6 @@ class TaskDecoratorCollection:
             logs. Defaults to True, which allows return value log output.
             It can be set to False to prevent log output of return value when you return huge data
             such as transmission a large amount of XCom to TaskAPI.
-        :param venv_conn_id: The ID of Python Virtualenv Connection.
-            If set, the other arguments will override the values from the connection.
         :param use_dill: Deprecated, use ``serializer`` instead. Whether to use dill to serialize
             the args and result (pickle is default). This allows more complex types
             but requires you to include dill in your requirements.
@@ -240,6 +240,7 @@ class TaskDecoratorCollection:
         skip_on_exit_code: int | Container[int] | None = None,
         index_urls: None | Collection[str] | str = None,
         venv_cache_path: None | str = None,
+        venv_conn_id: None | str = None,
         show_return_value_in_logs: bool = True,
         use_dill: bool = False,
         **kwargs,
@@ -276,6 +277,8 @@ class TaskDecoratorCollection:
             virtual environment will be cached, creates a sub-folder venv-{hash} whereas hash will be replaced
             with a checksum of requirements. If not provided the virtual environment will be created and
             deleted in a temp folder for every execution.
+        :param venv_conn_id: The ID of Python Virtualenv Connection.
+            If set, the other arguments will override the values from the connection.
         :param show_return_value_in_logs: a bool value whether to show return_value
             logs. Defaults to True, which allows return value log output.
             It can be set to False to prevent log output of return value when you return huge data

--- a/airflow/decorators/__init__.pyi
+++ b/airflow/decorators/__init__.pyi
@@ -118,6 +118,7 @@ class TaskDecoratorCollection:
         skip_on_exit_code: int | Container[int] | None = None,
         index_urls: None | Collection[str] | str = None,
         venv_cache_path: None | str = None,
+        venv_conn_id: None | str = None,
         show_return_value_in_logs: bool = True,
         use_dill: bool = False,
         **kwargs,
@@ -162,6 +163,8 @@ class TaskDecoratorCollection:
             logs. Defaults to True, which allows return value log output.
             It can be set to False to prevent log output of return value when you return huge data
             such as transmission a large amount of XCom to TaskAPI.
+        :param venv_conn_id: The ID of Python Virtualenv Connection.
+            If set, the other arguments will override the values from the connection.
         :param use_dill: Deprecated, use ``serializer`` instead. Whether to use dill to serialize
             the args and result (pickle is default). This allows more complex types
             but requires you to include dill in your requirements.

--- a/airflow/hooks/python_virtualenv.py
+++ b/airflow/hooks/python_virtualenv.py
@@ -45,7 +45,12 @@ class PythonVirtualenvHook(BaseHook):
         return {
             "hidden_fields": ["host", "schema", "port", "login", "password", "extra"],
             "relabeling": {},
-            "placeholders": {"python_version": f"{v.major}.{v.minor}"},
+            "placeholders": {
+                "python_version": f"{v.major}.{v.minor}",
+                "requirements": "Example)\nnumpy==1.13.3\npandas==0.20.3",
+                "pip_install_options": "--no-cache-dir",
+                "index_urls": "https://pypi.org/simple/",
+            },
         }
 
     @classmethod
@@ -58,13 +63,16 @@ class PythonVirtualenvHook(BaseHook):
         return {
             "requirements": StringField(
                 lazy_gettext("Requirements"),
-                description=lazy_gettext("Python requirement strings separated by newline."),
+                description=lazy_gettext("Python Requirements follows PEP 508 format."),
                 widget=BS3TextAreaFieldWidget(),
                 validators=[InputRequired()],
             ),
             "python_version": StringField(
                 lazy_gettext("Python Version"),
-                description=lazy_gettext("The Python version to run the virtual environment with."),
+                description=lazy_gettext(
+                    "The Python version to run the virtual environment with. "
+                    "If left empty, the python executable used at runtime will be used."
+                ),
                 widget=BS3TextFieldWidget(),
                 validators=[Optional()],
             ),

--- a/airflow/hooks/python_virtualenv.py
+++ b/airflow/hooks/python_virtualenv.py
@@ -1,0 +1,144 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import logging
+import sys
+from functools import cached_property
+from typing import Any
+
+from airflow.hooks.base import BaseHook
+
+log = logging.getLogger(__name__)
+
+
+class PythonVirtualenvHook(BaseHook):
+    """
+    Interact with Python Virtualenv.
+
+    :param venv_conn_id: The ID of Python Virtualenv Connection.
+    """
+
+    conn_name_attr = "venv_conn_id"
+    default_conn_name = "venv_default"
+    conn_type = "python_venv"
+    hook_name = "Python Virtualenv"
+
+    @classmethod
+    def get_ui_field_behaviour(cls) -> dict[str, Any]:
+        v = sys.version_info
+        return {
+            "hidden_fields": ["host", "schema", "port", "login", "password", "extra"],
+            "relabeling": {},
+            "placeholders": {"python_version": f"{v.major}.{v.minor}"},
+        }
+
+    @classmethod
+    def get_connection_form_widgets(cls) -> dict[str, Any]:
+        from flask_appbuilder.fieldwidgets import BS3TextAreaFieldWidget, BS3TextFieldWidget
+        from flask_babel import lazy_gettext
+        from wtforms import BooleanField, StringField
+        from wtforms.validators import InputRequired, Optional
+
+        return {
+            "requirements": StringField(
+                lazy_gettext("Requirements"),
+                description=lazy_gettext("Python requirement strings separated by newline."),
+                widget=BS3TextAreaFieldWidget(),
+                validators=[InputRequired()],
+            ),
+            "python_version": StringField(
+                lazy_gettext("Python Version"),
+                description=lazy_gettext("The Python version to run the virtual environment with."),
+                widget=BS3TextFieldWidget(),
+                validators=[Optional()],
+            ),
+            "system_site_packages": BooleanField(
+                lazy_gettext("System Site Packages"),
+                description=lazy_gettext(
+                    "Whether to include system_site_packages in the virtual environment."
+                ),
+                default=False,
+            ),
+            "pip_install_options": StringField(
+                lazy_gettext("Pip Install Options"),
+                description=lazy_gettext("A list of pip install options when installing requirements."),
+                widget=BS3TextFieldWidget(),
+                validators=[Optional()],
+            ),
+            "index_urls": StringField(
+                lazy_gettext("Index URLs"),
+                description=lazy_gettext("Comma separated list of URLs to search for packages."),
+                widget=BS3TextFieldWidget(),
+                validators=[Optional()],
+            ),
+            "venv_cache_path": StringField(
+                lazy_gettext("Virtual Environment Cache Path"),
+                description=lazy_gettext("Path to cache the virtual environment."),
+                widget=BS3TextFieldWidget(),
+                validators=[Optional()],
+            ),
+        }
+
+    def __init__(self, venv_conn_id: str | None = default_conn_name, **kwargs) -> None:
+        super().__init__(**kwargs)
+
+        self._venv_conn_id = venv_conn_id
+        self._conn = self.get_connection(venv_conn_id) if venv_conn_id else None
+
+    def get_conn(self) -> None:
+        pass
+
+    @cached_property
+    def extra(self) -> dict[str, Any]:
+        if self._conn:
+            return self._conn.extra_dejson
+        return {}
+
+    @cached_property
+    def requirements(self) -> list[str]:
+        """Get the list of requirements to install in the virtual environment."""
+        if self.extra.get("requirements"):
+            return [requirement.strip() for requirement in self.extra["requirements"].split("\n")]
+        return []
+
+    @cached_property
+    def python_version(self) -> str | None:
+        return self.extra.get("python_version")
+
+    @cached_property
+    def pip_install_options(self) -> list[str] | None:
+        if self.extra.get("pip_install_options"):
+            return self.extra["pip_install_options"].split()
+        return []
+
+    @cached_property
+    def index_urls(self) -> list[str] | None:
+        if self.extra.get("index_urls"):
+            return [index_url.strip() for index_url in self.extra["index_urls"].split(",")]
+        return None
+
+    @cached_property
+    def venv_cache_path(self) -> str | None:
+        if self.extra.get("venv_cache_path"):
+            return self.extra["venv_cache_path"]
+        return None
+
+    @cached_property
+    def system_site_packages(self) -> bool:
+        return self.extra.get("system_site_packages", True)

--- a/airflow/providers_manager.py
+++ b/airflow/providers_manager.py
@@ -38,6 +38,7 @@ from packaging.utils import canonicalize_name
 from airflow.exceptions import AirflowOptionalProviderFeatureException
 from airflow.hooks.filesystem import FSHook
 from airflow.hooks.package_index import PackageIndexHook
+from airflow.hooks.python_virtualenv import PythonVirtualenvHook
 from airflow.typing_compat import ParamSpec
 from airflow.utils import yaml
 from airflow.utils.entry_points import entry_points_with_dist
@@ -470,7 +471,7 @@ class ProvidersManager(LoggingMixin, metaclass=Singleton):
                 connection_type=None,
                 connection_testable=False,
             )
-        for cls in [FSHook, PackageIndexHook]:
+        for cls in [FSHook, PackageIndexHook, PythonVirtualenvHook]:
             package_name = cls.__module__
             hook_class_name = f"{cls.__module__}.{cls.__name__}"
             hook_info = self._import_hook(

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -709,6 +709,17 @@ def create_default_connections(session: Session = NEW_SESSION):
     )
     merge_conn(
         Connection(
+            conn_id="venv_default",
+            conn_type="python_venv",
+            extra="""{
+    "requirements": "colorama==0.4.0",
+    "venv_cache_path": "/tmp/airflow"
+}""",
+        ),
+        session,
+    )
+    merge_conn(
+        Connection(
             conn_id="vertica_default",
             conn_type="vertica",
             host="localhost",

--- a/tests/always/test_providers_manager.py
+++ b/tests/always/test_providers_manager.py
@@ -379,6 +379,9 @@ class TestProviderManager:
     def test_field_behaviours(self):
         provider_manager = ProvidersManager()
         connections_with_field_behaviours = list(provider_manager.field_behaviours.keys())
+        from pprint import pprint
+
+        pprint(provider_manager.field_behaviours)
         assert len(connections_with_field_behaviours) > 16
 
     def test_extra_links(self):

--- a/tests/hooks/test_python_virtualenv.py
+++ b/tests/hooks/test_python_virtualenv.py
@@ -1,0 +1,75 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from airflow.exceptions import AirflowNotFoundException
+from airflow.hooks.python_virtualenv import PythonVirtualenvHook
+
+
+class TestPythonVirtualenvHook:
+    def test_python_virtualenv_set_connection_with_wrong_connection(self):
+        with pytest.raises(AirflowNotFoundException):
+            PythonVirtualenvHook(venv_conn_id="some_conn")
+
+    @mock.patch("airflow.hooks.python_virtualenv.PythonVirtualenvHook.get_connection")
+    def test_python_virtualenv_set_connection_with_connection(self, mock_conn):
+        PythonVirtualenvHook(venv_conn_id="some_conn")
+        mock_conn.assert_called_once_with("some_conn")
+
+    @mock.patch("airflow.hooks.python_virtualenv.PythonVirtualenvHook.get_connection")
+    def test_parse_requirements_in_python_virtualenv_hook(self, mock_conn):
+        mock_obj = mock.Mock()
+        mock_obj.extra_dejson = {"requirements": "apache-airflow==2.1.0\nfuncsigs==1.0.2"}
+        mock_conn.return_value = mock_obj
+
+        hook = PythonVirtualenvHook(venv_conn_id="some_conn")
+        assert "apache-airflow==2.1.0" in hook.requirements
+        assert "funcsigs==1.0.2" in hook.requirements
+
+    @mock.patch("airflow.hooks.python_virtualenv.PythonVirtualenvHook.get_connection")
+    def test_parse_system_site_packages_in_python_virtualenv_hook(self, mock_conn):
+        mock_obj = mock.Mock()
+        mock_obj.extra_dejson = {"system_site_packages": True}
+        mock_conn.return_value = mock_obj
+
+        hook = PythonVirtualenvHook(venv_conn_id="some_conn")
+        assert hook.system_site_packages
+
+    @mock.patch("airflow.hooks.python_virtualenv.PythonVirtualenvHook.get_connection")
+    def test_parse_pip_install_options_in_python_virtualenv_hook(self, mock_conn):
+        mock_obj = mock.Mock()
+        mock_obj.extra_dejson = {"pip_install_options": "--no-cache-dir --proxy=http://proxy:3128"}
+        mock_conn.return_value = mock_obj
+
+        hook = PythonVirtualenvHook(venv_conn_id="some_conn")
+        assert "--no-cache-dir" in hook.pip_install_options
+        assert "--proxy=http://proxy:3128" in hook.pip_install_options
+
+    @mock.patch("airflow.hooks.python_virtualenv.PythonVirtualenvHook.get_connection")
+    def test_parse_index_urls_in_python_virtualenv_hook(self, mock_conn):
+        mock_obj = mock.Mock()
+        mock_obj.extra_dejson = {"index_urls": "https://pypi.org/simple,https://pypi.example.com/simple"}
+        mock_conn.return_value = mock_obj
+
+        hook = PythonVirtualenvHook(venv_conn_id="some_conn")
+        assert "https://pypi.org/simple" in hook.index_urls
+        assert "https://pypi.example.com/simple" in hook.index_urls

--- a/tests/hooks/test_python_virtualenv.py
+++ b/tests/hooks/test_python_virtualenv.py
@@ -28,6 +28,8 @@ from airflow.models import Connection
 from airflow.utils import db
 from tests.test_utils.db import clear_db_connections
 
+pytestmark = pytest.mark.db_test
+
 
 class TestPythonVirtualenvHook:
     @classmethod


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->



<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


Hello,

I have made some modifications to the existing `PythonVirtualenvOperator` to upgrade a few areas. 
I am currently working on deploying Airflow on a k8s cluster using Helm, and using the `venv_cache_path` of PythonVirtualenvOperator to utilize Airflow in a multi-python environment.

Although it is possible to pre-configure Python and use ExternalPythonOperator, in a Helm environment this would require building the image first. 
Therefore, we typically use the PythonVirtualenvOperator along with the `venv_cache_path`.
> A major advantage is the ability to set the requirements directly within the DAG file, not by building k8s pod image.
> It's a great feature!

Since Python-executable settings are often shared and reused among various tasks, I used to define a custom PythonVirtualenvOperator, but I thought it could be improved with a hook.
It could allow control via the web UI. 

### Ideas

Just like SparkSubmitHook and SparkSubmitOperator, I separated the methods embedded in PythonVirtualenvOperator into a PythonVirtualenvHook, allowing the operator to call the hook.
I will upload the draft first and add the test code later.


### Connection edit screenshot


![image](https://github.com/user-attachments/assets/cf992e28-c740-401d-abae-68ee5ef3359e)





<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
