### PR TITLE
openlineage: make OL conf use getboolean consistently with rest of Airflow

### DIFF
--- a/airflow/providers/openlineage/conf.py
+++ b/airflow/providers/openlineage/conf.py
@@ -70,11 +70,10 @@ def config_path(check_legacy_env_var: bool = True) -> str:
 @cache
 def is_source_enabled() -> bool:
     """[openlineage] disable_source_code."""
-    option = conf.get(_CONFIG_SECTION, "disable_source_code", fallback="")
+    option = conf.getboolean(_CONFIG_SECTION, "disable_source_code", fallback="False")
     if not option:
-        option = os.getenv("OPENLINEAGE_AIRFLOW_DISABLE_SOURCE_CODE", "")
-    # when disable_source_code is True, is_source_enabled() should be False
-    return not _is_true(option)
+        option = _is_true(os.getenv("OPENLINEAGE_AIRFLOW_DISABLE_SOURCE_CODE", ""))
+    return not option
 
 
 @cache
@@ -87,8 +86,7 @@ def disabled_operators() -> set[str]:
 @cache
 def selective_enable() -> bool:
     """[openlineage] selective_enable."""
-    option = conf.get(_CONFIG_SECTION, "selective_enable", fallback="")
-    return _is_true(option)
+    return conf.getboolean(_CONFIG_SECTION, "selective_enable", fallback="False")
 
 
 @cache
@@ -121,16 +119,14 @@ def transport() -> dict[str, Any]:
 @cache
 def is_disabled() -> bool:
     """[openlineage] disabled + check if any configuration is present."""
-    option = conf.get(_CONFIG_SECTION, "disabled", fallback="")
-    if _is_true(option):
-        return True
-
-    option = os.getenv("OPENLINEAGE_DISABLED", "")
-    if _is_true(option):
-        return True
-    # Check if both 'transport' and 'config_path' are not present and also
-    # if legacy 'OPENLINEAGE_URL' environment variables is not set
-    return transport() == {} and config_path(True) == "" and os.getenv("OPENLINEAGE_URL", "") == ""
+    option = conf.getboolean(_CONFIG_SECTION, "disabled", fallback="False")
+    if not option:
+        option = _is_true(os.getenv("OPENLINEAGE_DISABLED", ""))
+    if not option:
+        # Check if both 'transport' and 'config_path' are not present and also
+        # if legacy 'OPENLINEAGE_URL' environment variables is not set
+        return transport() == {} and config_path(True) == "" and os.getenv("OPENLINEAGE_URL", "") == ""
+    return option
 
 
 @cache

--- a/airflow/providers/openlineage/conf.py
+++ b/airflow/providers/openlineage/conf.py
@@ -145,3 +145,8 @@ def execution_timeout() -> int:
     """[openlineage] execution_timeout."""
     option = conf.get(_CONFIG_SECTION, "execution_timeout", fallback="")
     return _safe_int_convert(str(option).strip(), default=10)
+
+
+@cache
+def include_full_task_info() -> bool:
+    return conf.getboolean(_CONFIG_SECTION, "include_full_task_info", fallback="False")

--- a/airflow/providers/openlineage/provider.yaml
+++ b/airflow/providers/openlineage/provider.yaml
@@ -153,3 +153,10 @@ config:
         example: ~
         type: integer
         version_added: 1.9.0
+      include_full_task_info:
+        description: |
+          If true, OpenLineage event will include full task info - potentially containing large fields.
+        default: "False"
+        example: ~
+        type: boolean
+        version_added: 1.10.0

--- a/airflow/providers/openlineage/utils/utils.py
+++ b/airflow/providers/openlineage/utils/utils.py
@@ -272,6 +272,25 @@ class TaskInfo(InfoJsonEncodable):
     }
 
 
+class TaskInfoComplete(TaskInfo):
+    """Defines encoding BaseOperator/AbstractOperator object to JSON used when user enables full task info."""
+
+    includes = []
+    excludes = [
+        "_BaseOperator__instantiated",
+        "_dag",
+        "_hook",
+        "_log",
+        "_outlets",
+        "_inlets",
+        "_lock_for_execution",
+        "handler",
+        "params",
+        "python_callable",
+        "retry_delay",
+    ]
+
+
 class TaskGroupInfo(InfoJsonEncodable):
     """Defines encoding TaskGroup object to JSON."""
 
@@ -300,7 +319,7 @@ def get_airflow_run_facet(
             dag=DagInfo(dag),
             dagRun=DagRunInfo(dag_run),
             taskInstance=TaskInstanceInfo(task_instance),
-            task=TaskInfo(task),
+            task=TaskInfoComplete(task) if conf.include_full_task_info() else TaskInfo(task),
             taskUuid=task_uuid,
         )
     }

--- a/tests/providers/openlineage/plugins/test_utils.py
+++ b/tests/providers/openlineage/plugins/test_utils.py
@@ -21,7 +21,7 @@ import json
 import uuid
 from json import JSONEncoder
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from attrs import define
@@ -34,6 +34,7 @@ from airflow.providers.openlineage.utils.utils import (
     InfoJsonEncodable,
     OpenLineageRedactor,
     _is_name_redactable,
+    get_airflow_run_facet,
     get_fully_qualified_class_name,
     is_operator_disabled,
 )
@@ -227,3 +228,39 @@ def test_is_operator_disabled(mock_disabled_operators):
         "airflow.operators.python.PythonOperator",
     }
     assert is_operator_disabled(op) is True
+
+
+@patch("airflow.providers.openlineage.conf.include_full_task_info")
+def test_includes_full_task_info(mock_include_full_task_info):
+    mock_include_full_task_info.return_value = True
+    # There should be no 'bash_command' in excludes and it's not in includes - so
+    # it's a good choice for checking TaskInfo vs TaskInfoComplete
+    assert (
+        "bash_command"
+        in get_airflow_run_facet(
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            BashOperator(task_id="bash_op", bash_command="sleep 1"),
+            MagicMock(),
+        )["airflow"].task
+    )
+
+
+@patch("airflow.providers.openlineage.conf.include_full_task_info")
+def test_does_not_include_full_task_info(mock_include_full_task_info):
+    from airflow.operators.bash import BashOperator
+
+    mock_include_full_task_info.return_value = False
+    # There should be no 'bash_command' in excludes and it's not in includes - so
+    # it's a good choice for checking TaskInfo vs TaskInfoComplete
+    assert (
+        "bash_command"
+        not in get_airflow_run_facet(
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            BashOperator(task_id="bash_op", bash_command="sleep 1"),
+            MagicMock(),
+        )["airflow"].task
+    )

--- a/tests/providers/openlineage/test_conf.py
+++ b/tests/providers/openlineage/test_conf.py
@@ -159,20 +159,22 @@ def test_disable_source_code_conf_option_has_precedence_over_legacy_env_var():
     assert is_source_enabled() is False
 
 
-@conf_vars({(_CONFIG_SECTION, _CONFIG_OPTION_DISABLE_SOURCE_CODE): "asdadawlaksnd"})
-def test_disable_source_code_conf_option_not_working_for_random_string():
-    assert is_source_enabled() is True
-
-
 @env_vars({_VAR_DISABLE_SOURCE_CODE: "asdadawlaksnd"})
 @conf_vars({(_CONFIG_SECTION, _CONFIG_OPTION_DISABLE_SOURCE_CODE): None})
 def test_disable_source_code_legacy_env_var_not_working_for_random_string():
     assert is_source_enabled() is True
 
 
+@conf_vars({(_CONFIG_SECTION, _CONFIG_OPTION_DISABLE_SOURCE_CODE): "asdadawlaksnd"})
+def test_disable_source_code_conf_option_not_working_for_random_string():
+    with pytest.raises(AirflowConfigException):
+        is_source_enabled()
+
+
 @conf_vars({(_CONFIG_SECTION, _CONFIG_OPTION_DISABLE_SOURCE_CODE): ""})
 def test_disable_source_code_empty_conf_option():
-    assert is_source_enabled() is True
+    with pytest.raises(AirflowConfigException):
+        is_source_enabled()
 
 
 @conf_vars({(_CONFIG_SECTION, _CONFIG_OPTION_DISABLE_SOURCE_CODE): None})
@@ -192,12 +194,14 @@ def test_selective_enable(var_string, expected):
 
 @conf_vars({(_CONFIG_SECTION, _CONFIG_OPTION_SELECTIVE_ENABLE): "asdadawlaksnd"})
 def test_selective_enable_not_working_for_random_string():
-    assert selective_enable() is False
+    with pytest.raises(AirflowConfigException):
+        selective_enable()
 
 
 @conf_vars({(_CONFIG_SECTION, _CONFIG_OPTION_SELECTIVE_ENABLE): ""})
 def test_selective_enable_empty_conf_option():
-    assert selective_enable() is False
+    with pytest.raises(AirflowConfigException):
+        selective_enable()
 
 
 @conf_vars({(_CONFIG_SECTION, _CONFIG_OPTION_SELECTIVE_ENABLE): None})
@@ -346,8 +350,9 @@ def test_is_disabled_possible_values_for_disabling(disabled):
         (_CONFIG_SECTION, _CONFIG_OPTION_DISABLED): "asdadawlaksnd",
     }
 )
-def test_is_disabled_is_not_disabled_by_random_string():
-    assert is_disabled() is False
+def test_is_disabled_raises_for_random_string():
+    with pytest.raises(AirflowConfigException):
+        is_disabled()
 
 
 @mock.patch.dict(os.environ, {_VAR_URL: "https://test.com"}, clear=True)
@@ -358,8 +363,9 @@ def test_is_disabled_is_not_disabled_by_random_string():
         (_CONFIG_SECTION, _CONFIG_OPTION_DISABLED): "",
     }
 )
-def test_is_disabled_is_false_when_not_explicitly_disabled_and_url_set():
-    assert is_disabled() is False
+def test_is_disabled_raises_when_not_explicitly_disabled_and_url_set():
+    with pytest.raises(AirflowConfigException):
+        is_disabled()
 
 
 @mock.patch.dict(os.environ, {_VAR_URL: ""}, clear=True)
@@ -370,8 +376,9 @@ def test_is_disabled_is_false_when_not_explicitly_disabled_and_url_set():
         (_CONFIG_SECTION, _CONFIG_OPTION_DISABLED): "",
     }
 )
-def test_is_disabled_is_false_when_not_explicitly_disabled_and_transport_set():
-    assert is_disabled() is False
+def test_is_disabled_raoses_when_not_explicitly_disabled_and_transport_set():
+    with pytest.raises(AirflowConfigException):
+        is_disabled()
 
 
 @mock.patch.dict(os.environ, {_VAR_URL: ""}, clear=True)
@@ -382,7 +389,19 @@ def test_is_disabled_is_false_when_not_explicitly_disabled_and_transport_set():
         (_CONFIG_SECTION, _CONFIG_OPTION_DISABLED): "",
     }
 )
-def test_is_disabled_is_false_when_not_explicitly_disabled_and_config_path_set():
+def test_is_disabled_raises_when_not_explicitly_disabled_and_config_path_set():
+    with pytest.raises(AirflowConfigException):
+        is_disabled()
+
+
+@mock.patch.dict(os.environ, {_VAR_URL: ""}, clear=True)
+@conf_vars(
+    {
+        (_CONFIG_SECTION, _CONFIG_OPTION_CONFIG_PATH): "some/path.yml",
+        (_CONFIG_SECTION, _CONFIG_OPTION_TRANSPORT): "",
+    }
+)
+def test_is_disabled_does_not_raise_when_not_explicitly_disabled_and_config_path_set():
     assert is_disabled() is False
 
 
@@ -403,7 +422,6 @@ def test_is_disabled_conf_option_is_enough_to_disable():
     {
         (_CONFIG_SECTION, _CONFIG_OPTION_CONFIG_PATH): "some/path.yml",
         (_CONFIG_SECTION, _CONFIG_OPTION_TRANSPORT): '{"valid": "transport"}',
-        (_CONFIG_SECTION, _CONFIG_OPTION_DISABLED): "",
     }
 )
 def test_is_disabled_legacy_env_var_is_enough_to_disable():
@@ -451,7 +469,6 @@ def test_is_disabled_env_var_true_has_precedence_over_conf_false():
     {
         (_CONFIG_SECTION, _CONFIG_OPTION_CONFIG_PATH): "",
         (_CONFIG_SECTION, _CONFIG_OPTION_TRANSPORT): "",
-        (_CONFIG_SECTION, _CONFIG_OPTION_DISABLED): "",
     }
 )
 def test_is_disabled_empty_conf_option():


### PR DESCRIPTION
Followup to discussion in: https://github.com/apache/airflow/pull/40589#discussion_r1668920281

This changes the config semantics slightly, as it's now possible to have exception due to wrong config of OL. 

@kacpermuda please doublecheck the semantics 🙂 