### PR TITLE
Add log_url to OpenLineage AirflowRunFacet

### DIFF
--- a/airflow/providers/openlineage/facets/AirflowRunFacet.json
+++ b/airflow/providers/openlineage/facets/AirflowRunFacet.json
@@ -205,6 +205,10 @@
         "queued_dttm": {
           "type": "string",
           "format": "date-time"
+        },
+        "log_url": {
+          "type": "string",
+          "format": "uri"
         }
       },
       "additionalProperties": true,

--- a/airflow/providers/openlineage/utils/utils.py
+++ b/airflow/providers/openlineage/utils/utils.py
@@ -207,7 +207,7 @@ class DagRunInfo(InfoJsonEncodable):
 class TaskInstanceInfo(InfoJsonEncodable):
     """Defines encoding TaskInstance object to JSON."""
 
-    includes = ["duration", "try_number", "pool", "queued_dttm"]
+    includes = ["duration", "try_number", "pool", "queued_dttm", "log_url"]
     casts = {
         "map_index": lambda ti: (
             ti.map_index if hasattr(ti, "map_index") and getattr(ti, "map_index") != -1 else None


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

Related: https://github.com/OpenLineage/OpenLineage/pull/2852

It is quite useful to have an URL of Airflow task log as a part of `AirflowRunFacet`. Currently I have to reimplement the logic present in Airflow on OpenLineage backend side, and keep it in sync with a particular Airflow version, e.g.:
https://github.com/apache/airflow/blob/2.9.0/airflow/models/taskinstance.py#L1719-L1731
https://github.com/apache/airflow/blob/2.1.0/airflow/models/taskinstance.py#L524-L528

Add TaskInstances's `log_url` field to `AirflowRunFacet`.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
