### PR TITLE
docs: Add `filesystems` and `dataset-uris` items in create your own provider page

### DIFF
--- a/docs/apache-airflow-providers/howto/create-custom-providers.rst
+++ b/docs/apache-airflow-providers/howto/create-custom-providers.rst
@@ -93,6 +93,13 @@ Exposing customized functionality to the Airflow's core:
   ``airflow/config_templates/config.yml.schema.json`` with configuration contributed by the providers
   See :doc:`apache-airflow:howto/set-config` for details about setting configuration.
 
+* ``filesystems`` - this field should contain the list of all the filesystem module names.
+  See :doc:`apache-airflow:core-concepts/objectstorage` for description of the filesystems.
+
+* ``dataset-uris`` - this field should contain the list of the URI schemes together with
+  class names implementing normalization functions.
+  See :doc:`apache-airflow:authoring-and-scheduling/datasets` for description of the dataset URIs.
+
 .. note:: Deprecated values
 
   * ``hook-class-names`` (deprecated) - this field should contain the list of all hook class names that provide


### PR DESCRIPTION
This PR adds two missing items with the guidance how to create your own provider. Entries were added as a result of implementation of AIP-58 and AIP-60.
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
