### PR TITLE
[AIP-49] OpenTelemetry Traces for Apache Airflow Part 2

### DIFF
--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -380,7 +380,7 @@ class BaseExecutor(LoggingMixin):
         :param key: Unique key for the task instance
         """
         trace_id = Trace.get_current_span().get_span_context().trace_id
-        if trace_id is not 1:
+        if trace_id != 1:
             span_id = int(gen_span_id_from_ti_key(key, as_int=True))
             with Trace.start_span(
                 span_name="fail",
@@ -403,7 +403,7 @@ class BaseExecutor(LoggingMixin):
         :param key: Unique key for the task instance
         """
         trace_id = Trace.get_current_span().get_span_context().trace_id
-        if trace_id is not 1:
+        if trace_id != 1:
             span_id = int(gen_span_id_from_ti_key(key, as_int=True))
             with Trace.start_span(
                 span_name="success",

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -379,8 +379,8 @@ class BaseExecutor(LoggingMixin):
         :param info: Executor information for the task instance
         :param key: Unique key for the task instance
         """
-        if "dag_id" in key:
-            trace_id = Trace.get_current_span().get_span_context().trace_id
+        trace_id = Trace.get_current_span().get_span_context().trace_id
+        if trace_id is not 1:
             span_id = int(gen_span_id_from_ti_key(key, as_int=True))
             with Trace.start_span(
                 span_name="fail",
@@ -402,8 +402,8 @@ class BaseExecutor(LoggingMixin):
         :param info: Executor information for the task instance
         :param key: Unique key for the task instance
         """
-        if "dag_id" in key:
-            trace_id = Trace.get_current_span().get_span_context().trace_id
+        trace_id = Trace.get_current_span().get_span_context().trace_id
+        if trace_id is not 1:
             span_id = int(gen_span_id_from_ti_key(key, as_int=True))
             with Trace.start_span(
                 span_name="success",

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -32,6 +32,8 @@ from airflow.cli.cli_config import DefaultHelpParser
 from airflow.configuration import conf
 from airflow.exceptions import RemovedInAirflow3Warning
 from airflow.stats import Stats
+from airflow.traces.tracer import Trace, gen_context, span
+from airflow.traces.utils import gen_span_id_from_ti_key, gen_trace_id
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.log.task_context_logger import TaskContextLogger
 from airflow.utils.state import TaskInstanceState
@@ -211,6 +213,7 @@ class BaseExecutor(LoggingMixin):
         Executors should override this to perform gather statuses.
         """
 
+    @span
     def heartbeat(self) -> None:
         """Heartbeat sent to trigger new jobs."""
         if not self.parallelism:
@@ -227,6 +230,17 @@ class BaseExecutor(LoggingMixin):
             self.log.info("Executor parallelism limit reached. 0 open slots.")
         else:
             self.log.debug("%s open slots", open_slots)
+
+        span = Trace.get_current_span()
+        if span.is_recording():
+            span.add_event(
+                name="executor",
+                attributes={
+                    "executor.open_slots": open_slots,
+                    "executor.queued_tasks": num_queued_tasks,
+                    "executor.running_tasks": num_running_tasks,
+                },
+            )
 
         Stats.gauge(
             "executor.open_slots", value=open_slots, tags={"status": "open", "name": self.__class__.__name__}
@@ -260,12 +274,14 @@ class BaseExecutor(LoggingMixin):
             reverse=True,
         )
 
+    @span
     def trigger_tasks(self, open_slots: int) -> None:
         """
         Initiate async execution of the queued tasks, up to the number of available slots.
 
         :param open_slots: Number of open slots
         """
+        span = Trace.get_current_span()
         sorted_queue = self.order_queued_tasks_by_priority()
         task_tuples = []
 
@@ -302,15 +318,40 @@ class BaseExecutor(LoggingMixin):
                 if key in self.attempts:
                     del self.attempts[key]
                 task_tuples.append((key, command, queue, ti.executor_config))
+                if span.is_recording():
+                    span.add_event(
+                        name="task to trigger",
+                        attributes={"command": str(command), "conf": str(ti.executor_config)},
+                    )
 
         if task_tuples:
             self._process_tasks(task_tuples)
 
+    @span
     def _process_tasks(self, task_tuples: list[TaskTuple]) -> None:
         for key, command, queue, executor_config in task_tuples:
-            del self.queued_tasks[key]
-            self.execute_async(key=key, command=command, queue=queue, executor_config=executor_config)
-            self.running.add(key)
+            task_instance = self.queued_tasks[key][3]  # TaskInstance in fourth element
+            trace_id = int(gen_trace_id(task_instance.dag_run, as_int=True))
+            span_id = int(gen_span_id_from_ti_key(key, as_int=True))
+            links = [{"trace_id": trace_id, "span_id": span_id}]
+
+            # assuming that the span_id will very likely be unique inside the trace
+            with Trace.start_span(
+                span_name=f"{key.dag_id}.{key.task_id}",
+                component="BaseExecutor",
+                span_id=span_id,
+                links=links,
+            ) as span:
+                span.set_attribute("dag_id", key.dag_id)
+                span.set_attribute("run_id", key.run_id)
+                span.set_attribute("task_id", key.task_id)
+                span.set_attribute("try_number", key.try_number - 1)
+                span.set_attribute("command", str(command))
+                span.set_attribute("queue", str(queue))
+                span.set_attribute("executor_config", str(executor_config))
+                del self.queued_tasks[key]
+                self.execute_async(key=key, command=command, queue=queue, executor_config=executor_config)
+                self.running.add(key)
 
     def change_state(
         self, key: TaskInstanceKey, state: TaskInstanceState, info=None, remove_running=True
@@ -338,6 +379,19 @@ class BaseExecutor(LoggingMixin):
         :param info: Executor information for the task instance
         :param key: Unique key for the task instance
         """
+        trace_id = Trace.get_current_span().get_span_context().trace_id
+        span_id = int(gen_span_id_from_ti_key(key, as_int=True))
+        with Trace.start_span(
+            span_name="fail",
+            component="BaseExecutor",
+            parent_sc=gen_context(trace_id=trace_id, span_id=span_id),
+        ) as span:
+            span.set_attribute("dag_id", key.dag_id)
+            span.set_attribute("run_id", key.run_id)
+            span.set_attribute("task_id", key.task_id)
+            span.set_attribute("try_number", key.try_number - 1)
+            span.set_attribute("error", True)
+
         self.change_state(key, TaskInstanceState.FAILED, info)
 
     def success(self, key: TaskInstanceKey, info=None) -> None:
@@ -347,6 +401,18 @@ class BaseExecutor(LoggingMixin):
         :param info: Executor information for the task instance
         :param key: Unique key for the task instance
         """
+        trace_id = Trace.get_current_span().get_span_context().trace_id
+        span_id = int(gen_span_id_from_ti_key(key, as_int=True))
+        with Trace.start_span(
+            span_name="success",
+            component="BaseExecutor",
+            parent_sc=gen_context(trace_id=trace_id, span_id=span_id),
+        ) as span:
+            span.set_attribute("dag_id", key.dag_id)
+            span.set_attribute("run_id", key.run_id)
+            span.set_attribute("task_id", key.task_id)
+            span.set_attribute("try_number", key.try_number - 1)
+
         self.change_state(key, TaskInstanceState.SUCCESS, info)
 
     def queued(self, key: TaskInstanceKey, info=None) -> None:

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -379,18 +379,19 @@ class BaseExecutor(LoggingMixin):
         :param info: Executor information for the task instance
         :param key: Unique key for the task instance
         """
-        trace_id = Trace.get_current_span().get_span_context().trace_id
-        span_id = int(gen_span_id_from_ti_key(key, as_int=True))
-        with Trace.start_span(
-            span_name="fail",
-            component="BaseExecutor",
-            parent_sc=gen_context(trace_id=trace_id, span_id=span_id),
-        ) as span:
-            span.set_attribute("dag_id", key.dag_id)
-            span.set_attribute("run_id", key.run_id)
-            span.set_attribute("task_id", key.task_id)
-            span.set_attribute("try_number", key.try_number)
-            span.set_attribute("error", True)
+        if "dag_id" in key:
+            trace_id = Trace.get_current_span().get_span_context().trace_id
+            span_id = int(gen_span_id_from_ti_key(key, as_int=True))
+            with Trace.start_span(
+                span_name="fail",
+                component="BaseExecutor",
+                parent_sc=gen_context(trace_id=trace_id, span_id=span_id),
+            ) as span:
+                span.set_attribute("dag_id", key.dag_id)
+                span.set_attribute("run_id", key.run_id)
+                span.set_attribute("task_id", key.task_id)
+                span.set_attribute("try_number", key.try_number)
+                span.set_attribute("error", True)
 
         self.change_state(key, TaskInstanceState.FAILED, info)
 
@@ -401,17 +402,18 @@ class BaseExecutor(LoggingMixin):
         :param info: Executor information for the task instance
         :param key: Unique key for the task instance
         """
-        trace_id = Trace.get_current_span().get_span_context().trace_id
-        span_id = int(gen_span_id_from_ti_key(key, as_int=True))
-        with Trace.start_span(
-            span_name="success",
-            component="BaseExecutor",
-            parent_sc=gen_context(trace_id=trace_id, span_id=span_id),
-        ) as span:
-            span.set_attribute("dag_id", key.dag_id)
-            span.set_attribute("run_id", key.run_id)
-            span.set_attribute("task_id", key.task_id)
-            span.set_attribute("try_number", key.try_number - 1)
+        if "dag_id" in key:
+            trace_id = Trace.get_current_span().get_span_context().trace_id
+            span_id = int(gen_span_id_from_ti_key(key, as_int=True))
+            with Trace.start_span(
+                span_name="success",
+                component="BaseExecutor",
+                parent_sc=gen_context(trace_id=trace_id, span_id=span_id),
+            ) as span:
+                span.set_attribute("dag_id", key.dag_id)
+                span.set_attribute("run_id", key.run_id)
+                span.set_attribute("task_id", key.task_id)
+                span.set_attribute("try_number", key.try_number - 1)
 
         self.change_state(key, TaskInstanceState.SUCCESS, info)
 

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -32,6 +32,7 @@ from airflow.cli.cli_config import DefaultHelpParser
 from airflow.configuration import conf
 from airflow.exceptions import RemovedInAirflow3Warning
 from airflow.stats import Stats
+from airflow.traces import NO_TRACE_ID
 from airflow.traces.tracer import Trace, gen_context, span
 from airflow.traces.utils import gen_span_id_from_ti_key, gen_trace_id
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -380,7 +381,7 @@ class BaseExecutor(LoggingMixin):
         :param key: Unique key for the task instance
         """
         trace_id = Trace.get_current_span().get_span_context().trace_id
-        if trace_id != 1:
+        if trace_id != NO_TRACE_ID:
             span_id = int(gen_span_id_from_ti_key(key, as_int=True))
             with Trace.start_span(
                 span_name="fail",
@@ -403,7 +404,7 @@ class BaseExecutor(LoggingMixin):
         :param key: Unique key for the task instance
         """
         trace_id = Trace.get_current_span().get_span_context().trace_id
-        if trace_id != 1:
+        if trace_id != NO_TRACE_ID:
             span_id = int(gen_span_id_from_ti_key(key, as_int=True))
             with Trace.start_span(
                 span_name="success",

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -345,7 +345,7 @@ class BaseExecutor(LoggingMixin):
                 span.set_attribute("dag_id", key.dag_id)
                 span.set_attribute("run_id", key.run_id)
                 span.set_attribute("task_id", key.task_id)
-                span.set_attribute("try_number", key.try_number - 1)
+                span.set_attribute("try_number", key.try_number)
                 span.set_attribute("command", str(command))
                 span.set_attribute("queue", str(queue))
                 span.set_attribute("executor_config", str(executor_config))
@@ -389,7 +389,7 @@ class BaseExecutor(LoggingMixin):
             span.set_attribute("dag_id", key.dag_id)
             span.set_attribute("run_id", key.run_id)
             span.set_attribute("task_id", key.task_id)
-            span.set_attribute("try_number", key.try_number - 1)
+            span.set_attribute("try_number", key.try_number)
             span.set_attribute("error", True)
 
         self.change_state(key, TaskInstanceState.FAILED, info)

--- a/airflow/executors/local_executor.py
+++ b/airflow/executors/local_executor.py
@@ -270,11 +270,12 @@ class LocalExecutor(BaseExecutor):
                 assert self.executor.result_queue
 
             span = Trace.get_current_span()
-            span.set_attribute("dag_id", key.dag_id)
-            span.set_attribute("run_id", key.run_id)
-            span.set_attribute("task_id", key.task_id)
-            span.set_attribute("try_number", key.try_number - 1)
-            span.set_attribute("commands_to_run", str(command))
+            if span.is_recording():
+                span.set_attribute("dag_id", key.dag_id)
+                span.set_attribute("run_id", key.run_id)
+                span.set_attribute("task_id", key.task_id)
+                span.set_attribute("try_number", key.try_number - 1)
+                span.set_attribute("commands_to_run", str(command))
 
             local_worker = LocalWorker(self.executor.result_queue, key=key, command=command)
             self.executor.workers_used += 1

--- a/airflow/executors/sequential_executor.py
+++ b/airflow/executors/sequential_executor.py
@@ -72,11 +72,12 @@ class SequentialExecutor(BaseExecutor):
         self.commands_to_run.append((key, command))
 
         span = Trace.get_current_span()
-        span.set_attribute("dag_id", key.dag_id)
-        span.set_attribute("run_id", key.run_id)
-        span.set_attribute("task_id", key.task_id)
-        span.set_attribute("try_number", key.try_number - 1)
-        span.set_attribute("commands_to_run", str(self.commands_to_run))
+        if span.is_recording():
+            span.set_attribute("dag_id", key.dag_id)
+            span.set_attribute("run_id", key.run_id)
+            span.set_attribute("task_id", key.task_id)
+            span.set_attribute("try_number", key.try_number - 1)
+            span.set_attribute("commands_to_run", str(self.commands_to_run))
 
     def sync(self) -> None:
         for key, command in self.commands_to_run:

--- a/airflow/executors/sequential_executor.py
+++ b/airflow/executors/sequential_executor.py
@@ -29,6 +29,7 @@ import subprocess
 from typing import TYPE_CHECKING, Any
 
 from airflow.executors.base_executor import BaseExecutor
+from airflow.traces.tracer import Trace, span
 
 if TYPE_CHECKING:
     from airflow.executors.base_executor import CommandType
@@ -59,6 +60,7 @@ class SequentialExecutor(BaseExecutor):
         super().__init__()
         self.commands_to_run = []
 
+    @span
     def execute_async(
         self,
         key: TaskInstanceKey,
@@ -68,6 +70,13 @@ class SequentialExecutor(BaseExecutor):
     ) -> None:
         self.validate_airflow_tasks_run_command(command)
         self.commands_to_run.append((key, command))
+
+        span = Trace.get_current_span()
+        span.set_attribute("dag_id", key.dag_id)
+        span.set_attribute("run_id", key.run_id)
+        span.set_attribute("task_id", key.task_id)
+        span.set_attribute("try_number", key.try_number - 1)
+        span.set_attribute("commands_to_run", str(self.commands_to_run))
 
     def sync(self) -> None:
         for key, command in self.commands_to_run:

--- a/airflow/jobs/job.py
+++ b/airflow/jobs/job.py
@@ -218,7 +218,7 @@ class Job(Base, LoggingMixin):
                     )
                     sleep_for = max(0, seconds_remaining)
                 if span.is_recording():
-                    span.add_event(name="sleep()", attributes={"sleep_for": sleep_for})
+                    span.add_event(name="sleep", attributes={"sleep_for": sleep_for})
                 sleep(sleep_for)
 
                 job = Job._update_heartbeat(job=self, session=session)

--- a/airflow/jobs/job.py
+++ b/airflow/jobs/job.py
@@ -250,11 +250,8 @@ class Job(Base, LoggingMixin):
                     if span.is_recording():
                         span.add_event(name="error", attributes={"message": msg})
                 else:
-                    self.log.error(
-                        "%s heartbeat failed with error. Scheduler is in unhealthy state",
-                        self.__class__.__name__,
-                    )
                     msg = f"{self.__class__.__name__} heartbeat failed with error. Scheduler is in unhealthy state"
+                    self.log.error(msg)
                     if span.is_recording():
                         span.add_event(name="error", attributes={"message": msg})
                 # We didn't manage to heartbeat, so make sure that the timestamp isn't updated

--- a/airflow/jobs/job.py
+++ b/airflow/jobs/job.py
@@ -34,6 +34,7 @@ from airflow.listeners.listener import get_listener_manager
 from airflow.models.base import ID_LEN, Base
 from airflow.serialization.pydantic.job import JobPydantic
 from airflow.stats import Stats
+from airflow.traces.tracer import Trace, span
 from airflow.utils import timezone
 from airflow.utils.helpers import convert_camel_to_snake
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -199,52 +200,65 @@ class Job(Base, LoggingMixin):
         :param session to use for saving the job
         """
         previous_heartbeat = self.latest_heartbeat
+        with Trace.start_span(span_name="heartbeat", component="Job") as span:
+            try:
+                span.set_attribute("heartbeat", str(self.latest_heartbeat))
+                # This will cause it to load from the db
+                self._merge_from(Job._fetch_from_db(self, session))
+                previous_heartbeat = self.latest_heartbeat
 
-        try:
-            # This will cause it to load from the db
-            self._merge_from(Job._fetch_from_db(self, session))
-            previous_heartbeat = self.latest_heartbeat
+                if self.state == JobState.RESTARTING:
+                    self.kill()
 
-            if self.state == JobState.RESTARTING:
-                self.kill()
+                # Figure out how long to sleep for
+                sleep_for = 0
+                if self.latest_heartbeat:
+                    seconds_remaining = (
+                        self.heartrate - (timezone.utcnow() - self.latest_heartbeat).total_seconds()
+                    )
+                    sleep_for = max(0, seconds_remaining)
+                if span.is_recording():
+                    span.add_event(name="sleep()", attributes={"sleep_for": sleep_for})
+                sleep(sleep_for)
 
-            # Figure out how long to sleep for
-            sleep_for = 0
-            if self.latest_heartbeat:
-                seconds_remaining = (
-                    self.heartrate - (timezone.utcnow() - self.latest_heartbeat).total_seconds()
-                )
-                sleep_for = max(0, seconds_remaining)
-            sleep(sleep_for)
+                job = Job._update_heartbeat(job=self, session=session)
+                self._merge_from(job)
+                time_since_last_heartbeat = (timezone.utcnow() - previous_heartbeat).total_seconds()
+                health_check_threshold_value = health_check_threshold(self.job_type, self.heartrate)
+                if time_since_last_heartbeat > health_check_threshold_value:
+                    self.log.info("Heartbeat recovered after %.2f seconds", time_since_last_heartbeat)
+                # At this point, the DB has updated.
+                previous_heartbeat = self.latest_heartbeat
 
-            job = Job._update_heartbeat(job=self, session=session)
-            self._merge_from(job)
-            time_since_last_heartbeat = (timezone.utcnow() - previous_heartbeat).total_seconds()
-            health_check_threshold_value = health_check_threshold(self.job_type, self.heartrate)
-            if time_since_last_heartbeat > health_check_threshold_value:
-                self.log.info("Heartbeat recovered after %.2f seconds", time_since_last_heartbeat)
-            # At this point, the DB has updated.
-            previous_heartbeat = self.latest_heartbeat
-
-            heartbeat_callback(session)
-            self.log.debug("[heartbeat]")
-            self.heartbeat_failed = False
-        except OperationalError:
-            Stats.incr(convert_camel_to_snake(self.__class__.__name__) + "_heartbeat_failure", 1, 1)
-            if not self.heartbeat_failed:
-                self.log.exception("%s heartbeat failed with error", self.__class__.__name__)
-                self.heartbeat_failed = True
-            if self.is_alive():
-                self.log.error(
-                    "%s heartbeat failed with error. Scheduler may go into unhealthy state",
-                    self.__class__.__name__,
-                )
-            else:
-                self.log.error(
-                    "%s heartbeat failed with error. Scheduler is in unhealthy state", self.__class__.__name__
-                )
-            # We didn't manage to heartbeat, so make sure that the timestamp isn't updated
-            self.latest_heartbeat = previous_heartbeat
+                heartbeat_callback(session)
+                self.log.debug("[heartbeat]")
+                self.heartbeat_failed = False
+            except OperationalError:
+                Stats.incr(convert_camel_to_snake(self.__class__.__name__) + "_heartbeat_failure", 1, 1)
+                if not self.heartbeat_failed:
+                    self.log.exception("%s heartbeat failed with error", self.__class__.__name__)
+                    self.heartbeat_failed = True
+                    msg = f"{self.__class__.__name__} heartbeat got an exception"
+                    if span.is_recording():
+                        span.add_event(name="error", attributes={"message": msg})
+                if self.is_alive():
+                    self.log.error(
+                        "%s heartbeat failed with error. Scheduler may go into unhealthy state",
+                        self.__class__.__name__,
+                    )
+                    msg = f"{self.__class__.__name__} heartbeat failed with error. Scheduler may go into unhealthy state"
+                    if span.is_recording():
+                        span.add_event(name="error", attributes={"message": msg})
+                else:
+                    self.log.error(
+                        "%s heartbeat failed with error. Scheduler is in unhealthy state",
+                        self.__class__.__name__,
+                    )
+                    msg = f"{self.__class__.__name__} heartbeat failed with error. Scheduler is in unhealthy state"
+                    if span.is_recording():
+                        span.add_event(name="error", attributes={"message": msg})
+                # We didn't manage to heartbeat, so make sure that the timestamp isn't updated
+                self.latest_heartbeat = previous_heartbeat
 
     @provide_session
     def prepare_for_execution(self, session: Session = NEW_SESSION):
@@ -448,6 +462,7 @@ def execute_job(job: Job, execute_callable: Callable[[], int | None]) -> int | N
     return ret
 
 
+@span
 def perform_heartbeat(
     job: Job, heartbeat_callback: Callable[[Session], None], only_if_necessary: bool
 ) -> None:

--- a/airflow/jobs/local_task_job_runner.py
+++ b/airflow/jobs/local_task_job_runner.py
@@ -207,7 +207,7 @@ class LocalTaskJobRunner(BaseJobRunner, LoggingMixin):
                         return return_code
 
                     if span.is_recording():
-                        span.add_event(name="perform_heartbeat()")
+                        span.add_event(name="perform_heartbeat")
                     perform_heartbeat(
                         job=self.job, heartbeat_callback=self.heartbeat_callback, only_if_necessary=False
                     )

--- a/airflow/jobs/local_task_job_runner.py
+++ b/airflow/jobs/local_task_job_runner.py
@@ -28,6 +28,7 @@ from airflow.jobs.base_job_runner import BaseJobRunner
 from airflow.jobs.job import perform_heartbeat
 from airflow.models.taskinstance import TaskReturnCode
 from airflow.stats import Stats
+from airflow.traces.tracer import Trace
 from airflow.utils import timezone
 from airflow.utils.log.file_task_handler import _set_task_deferred_context_var
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -184,39 +185,55 @@ class LocalTaskJobRunner(BaseJobRunner, LoggingMixin):
             # If LocalTaskJob receives SIGTERM, LocalTaskJob passes SIGTERM to _run_raw_task
             # If the state of task_instance is changed, LocalTaskJob sends SIGTERM to _run_raw_task
             while not self.terminating:
-                # Monitor the task to see if it's done. Wait in a syscall
-                # (`os.wait`) for as long as possible so we notice the
-                # subprocess finishing as quick as we can
-                max_wait_time = max(
-                    0,  # Make sure this value is never negative,
-                    min(
-                        (
-                            heartbeat_time_limit
-                            - (timezone.utcnow() - self.job.latest_heartbeat).total_seconds() * 0.75
+                with Trace.start_span(
+                    span_name="local_task_job_loop", component="LocalTaskJobRunner"
+                ) as span:
+                    # Monitor the task to see if it's done. Wait in a syscall
+                    # (`os.wait`) for as long as possible so we notice the
+                    # subprocess finishing as quick as we can
+                    max_wait_time = max(
+                        0,  # Make sure this value is never negative,
+                        min(
+                            (
+                                heartbeat_time_limit
+                                - (timezone.utcnow() - self.job.latest_heartbeat).total_seconds() * 0.75
+                            ),
+                            self.job.heartrate if self.job.heartrate is not None else heartbeat_time_limit,
                         ),
-                        self.job.heartrate if self.job.heartrate is not None else heartbeat_time_limit,
-                    ),
-                )
-                return_code = self.task_runner.return_code(timeout=max_wait_time)
-                if return_code is not None:
-                    self.handle_task_exit(return_code)
-                    return return_code
-
-                perform_heartbeat(
-                    job=self.job, heartbeat_callback=self.heartbeat_callback, only_if_necessary=False
-                )
-
-                # If it's been too long since we've heartbeat, then it's possible that
-                # the scheduler rescheduled this task, so kill launched processes.
-                # This can only really happen if the worker can't read the DB for a long time
-                time_since_last_heartbeat = (timezone.utcnow() - self.job.latest_heartbeat).total_seconds()
-                if time_since_last_heartbeat > heartbeat_time_limit:
-                    Stats.incr("local_task_job_prolonged_heartbeat_failure", 1, 1)
-                    self.log.error("Heartbeat time limit exceeded!")
-                    raise AirflowException(
-                        f"Time since last heartbeat({time_since_last_heartbeat:.2f}s) exceeded limit "
-                        f"({heartbeat_time_limit}s)."
                     )
+                    return_code = self.task_runner.return_code(timeout=max_wait_time)
+                    if return_code is not None:
+                        self.handle_task_exit(return_code)
+                        return return_code
+
+                    if span.is_recording():
+                        span.add_event(name="perform_heartbeat()")
+                    perform_heartbeat(
+                        job=self.job, heartbeat_callback=self.heartbeat_callback, only_if_necessary=False
+                    )
+
+                    # If it's been too long since we've heartbeat, then it's possible that
+                    # the scheduler rescheduled this task, so kill launched processes.
+                    # This can only really happen if the worker can't read the DB for a long time
+                    time_since_last_heartbeat = (
+                        timezone.utcnow() - self.job.latest_heartbeat
+                    ).total_seconds()
+                    if time_since_last_heartbeat > heartbeat_time_limit:
+                        Stats.incr("local_task_job_prolonged_heartbeat_failure", 1, 1)
+                        self.log.error("Heartbeat time limit exceeded!")
+                        if span.is_recording():
+                            span.add_event(
+                                name="error",
+                                attributes={
+                                    "message": "Heartbeat time limit exceeded",
+                                    "heartbeat_time_limit(s)": heartbeat_time_limit,
+                                    "time_since_last_heartbeat(s)": time_since_last_heartbeat,
+                                },
+                            )
+                        raise AirflowException(
+                            f"Time since last heartbeat({time_since_last_heartbeat:.2f}s) exceeded limit "
+                            f"({heartbeat_time_limit}s)."
+                        )
             return return_code
         finally:
             # Print a marker for log grouping of details before task execution

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -59,7 +59,10 @@ from airflow.models.taskinstance import SimpleTaskInstance, TaskInstance
 from airflow.stats import Stats
 from airflow.ti_deps.dependencies_states import EXECUTION_STATES
 from airflow.timetables.simple import DatasetTriggeredTimetable
+from airflow.traces import utils as trace_utils
+from airflow.traces.tracer import Trace, span
 from airflow.utils import timezone
+from airflow.utils.dates import datetime_to_nano
 from airflow.utils.event_scheduler import EventScheduler
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.log.task_context_logger import TaskContextLogger
@@ -814,6 +817,60 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 ti.pid,
             )
 
+            with Trace.start_span_from_taskinstance(ti=ti) as span:
+                span.set_attribute("category", "scheduler")
+                span.set_attribute("task_id", ti.task_id)
+                span.set_attribute("dag_id", ti.dag_id)
+                span.set_attribute("state", ti.state)
+                if ti.state == TaskInstanceState.FAILED:
+                    span.set_attribute("error", True)
+                span.set_attribute("start_date", str(ti.start_date))
+                span.set_attribute("end_date", str(ti.end_date))
+                span.set_attribute("duration", ti.duration)
+                span.set_attribute("executor_config", str(ti.executor_config))
+                span.set_attribute("execution_date", str(ti.execution_date))
+                span.set_attribute("hostname", ti.hostname)
+                span.set_attribute("log_url", ti.log_url)
+                span.set_attribute("operator", str(ti.operator))
+                span.set_attribute("try_number", ti.try_number - 1)
+                span.set_attribute("executor_state", state)
+                span.set_attribute("job_id", ti.job_id)
+                span.set_attribute("pool", ti.pool)
+                span.set_attribute("queue", ti.queue)
+                span.set_attribute("priority_weight", ti.priority_weight)
+                span.set_attribute("queued_dttm", str(ti.queued_dttm))
+                span.set_attribute("ququed_by_job_id", ti.queued_by_job_id)
+                span.set_attribute("pid", ti.pid)
+                if span.is_recording():
+                    span.add_event(name="queued", timestamp=datetime_to_nano(ti.queued_dttm))
+                    span.add_event(name="started", timestamp=datetime_to_nano(ti.start_date))
+                    span.add_event(name="ended", timestamp=datetime_to_nano(ti.end_date))
+                if conf.has_option("traces", "otel_task_log_event") and conf.getboolean(
+                    "traces", "otel_task_log_event"
+                ):
+                    from airflow.utils.log.log_reader import TaskLogReader
+
+                    task_log_reader = TaskLogReader()
+                    if task_log_reader.supports_read:
+                        metadata: dict[str, Any] = {}
+                        logs, metadata = task_log_reader.read_log_chunks(ti, ti.try_number, metadata)
+                        if ti.hostname in dict(logs[0]):
+                            message = str(dict(logs[0])[ti.hostname]).replace("\\n", "\n")
+                            while metadata["end_of_log"] is False:
+                                logs, metadata = task_log_reader.read_log_chunks(
+                                    ti, ti.try_number - 1, metadata
+                                )
+                                if ti.hostname in dict(logs[0]):
+                                    message = message + str(dict(logs[0])[ti.hostname]).replace("\\n", "\n")
+                            if span.is_recording():
+                                span.add_event(
+                                    name="task_log",
+                                    attributes={
+                                        "message": message,
+                                        "metadata": str(metadata),
+                                    },
+                                )
+
             # There are two scenarios why the same TI with the same try_number is queued
             # after executor is finished with it:
             # 1) the TI was killed externally and it had no time to mark itself failed
@@ -1042,13 +1099,16 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             )
 
         for loop_count in itertools.count(start=1):
-            with Stats.timer("scheduler.scheduler_loop_duration") as timer:
-                if self.using_sqlite and self.processor_agent:
-                    self.processor_agent.run_single_parsing_loop()
-                    # For the sqlite case w/ 1 thread, wait until the processor
-                    # is finished to avoid concurrent access to the DB.
-                    self.log.debug("Waiting for processors to finish since we're using sqlite")
-                    self.processor_agent.wait_until_finished()
+            with Trace.start_span(span_name="scheduler_job_loop", component="SchedulerJobRunner") as span:
+                span.set_attribute("category", "scheduler")
+                span.set_attribute("loop_count", loop_count)
+                with Stats.timer("scheduler.scheduler_loop_duration") as timer:
+                    if self.using_sqlite and self.processor_agent:
+                        self.processor_agent.run_single_parsing_loop()
+                        # For the sqlite case w/ 1 thread, wait until the processor
+                        # is finished to avoid concurrent access to the DB.
+                        self.log.debug("Waiting for processors to finish since we're using sqlite")
+                        self.processor_agent.wait_until_finished()
 
                 with create_session() as session:
                     # This will schedule for as many executors as possible.
@@ -1069,16 +1129,23 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 if self.processor_agent:
                     self.processor_agent.heartbeat()
 
-                # Heartbeat the scheduler periodically
-                perform_heartbeat(
-                    job=self.job, heartbeat_callback=self.heartbeat_callback, only_if_necessary=True
-                )
+                    # Heartbeat the scheduler periodically
+                    perform_heartbeat(
+                        job=self.job, heartbeat_callback=self.heartbeat_callback, only_if_necessary=True
+                    )
 
-                # Run any pending timed events
-                next_event = timers.run(blocking=False)
-                self.log.debug("Next timed event is in %f", next_event)
+                    # Run any pending timed events
+                    next_event = timers.run(blocking=False)
+                    self.log.debug("Next timed event is in %f", next_event)
 
             self.log.debug("Ran scheduling loop in %.2f seconds", timer.duration)
+            if span.is_recording():
+                span.add_event(
+                    name="Ran scheduling loop",
+                    attributes={
+                        "duration in seconds": timer.duration,
+                    },
+                )
 
             if not is_unit_test and not num_queued_tis and not num_finished_events:
                 # If the scheduler is doing things, don't sleep. This means when there is work to do, the
@@ -1092,6 +1159,8 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     self.num_runs,
                     loop_count,
                 )
+                if span.is_recording():
+                    span.add_event("Exiting scheduler loop as requested number of runs has been reached")
                 break
             if self.processor_agent and self.processor_agent.done:
                 self.log.info(
@@ -1100,6 +1169,8 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     self.num_times_parse_dags,
                     loop_count,
                 )
+                if span.is_recording():
+                    span.add_event("Exiting scheduler loop as requested DAG parse count has been reached")
                 break
 
     def _do_scheduling(self, session: Session) -> int:
@@ -1219,6 +1290,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         guard.commit()
         # END: create dagruns
 
+    @span
     def _create_dag_runs(self, dag_models: Collection[DagModel], session: Session) -> None:
         """Create a DAG run and update the dag_model to control if/when the next DAGRun should be created."""
         # Bulk Fetch DagRuns with dag_id and execution_date same
@@ -1426,6 +1498,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             return False
         return True
 
+    @span
     def _start_queued_dagruns(self, session: Session) -> None:
         """Find DagRuns in queued state and decide moving them to running state."""
         # added all() to save runtime, otherwise query is executed more than once
@@ -1435,7 +1508,14 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             DagRun.active_runs_of_dags((dr.dag_id for dr in dag_runs), only_running=True, session=session),
         )
 
+        @span
         def _update_state(dag: DAG, dag_run: DagRun):
+            __span = Trace.get_current_span()
+            __span.set_attribute("state", str(DagRunState.RUNNING))
+            __span.set_attribute("run_id", dag_run.run_id)
+            __span.set_attribute("type", dag_run.run_type)
+            __span.set_attribute("dag_id", dag_run.dag_id)
+
             dag_run.state = DagRunState.RUNNING
             dag_run.start_date = timezone.utcnow()
             if dag.timetable.periodic and not dag_run.external_trigger and dag_run.clear_number < 1:
@@ -1455,12 +1535,18 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     schedule_delay,
                     tags={"dag_id": dag.dag_id},
                 )
+                if __span.is_recording():
+                    __span.add_event(
+                        name="schedule_delay",
+                        attributes={"dag_id": dag.dag_id, "schedule_delay": str(schedule_delay)},
+                    )
 
         # cache saves time during scheduling of many dag_runs for same dag
         cached_get_dag: Callable[[str], DAG | None] = lru_cache()(
             partial(self.dagbag.get_dag, session=session)
         )
 
+        _span = Trace.get_current_span()
         for dag_run in dag_runs:
             dag = dag_run.dag = cached_get_dag(dag_run.dag_id)
 
@@ -1477,6 +1563,15 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     dag_run.execution_date,
                 )
             else:
+                if _span.is_recording():
+                    _span.add_event(
+                        name="dag_run",
+                        attributes={
+                            "run_id": dag_run.run_id,
+                            "dag_id": dag_run.dag_id,
+                            "conf": str(dag_run.conf),
+                        },
+                    )
                 active_runs_of_dags[dag_run.dag_id] += 1
                 _update_state(dag, dag_run)
                 dag_run.notify_dagrun_state_changed()
@@ -1504,70 +1599,101 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         :param dag_run: The DagRun to schedule
         :return: Callback that needs to be executed
         """
-        callback: DagCallbackRequest | None = None
+        trace_id = int(trace_utils.gen_trace_id(dag_run=dag_run, as_int=True))
+        span_id = int(trace_utils.gen_dag_span_id(dag_run=dag_run, as_int=True))
+        links = [{"trace_id": trace_id, "span_id": span_id}]
 
-        dag = dag_run.dag = self.dagbag.get_dag(dag_run.dag_id, session=session)
-        dag_model = DM.get_dagmodel(dag_run.dag_id, session)
+        with Trace.start_span(
+            span_name="_schedule_dag_run", component="SchedulerJobRunner", links=links
+        ) as span:
+            span.set_attribute("dag_id", dag_run.dag_id)
+            span.set_attribute("run_id", dag_run.run_id)
+            span.set_attribute("run_type", dag_run.run_type)
+            callback: DagCallbackRequest | None = None
 
-        if not dag or not dag_model:
-            self.log.error("Couldn't find DAG %s in DAG bag or database!", dag_run.dag_id)
-            return callback
+            dag = dag_run.dag = self.dagbag.get_dag(dag_run.dag_id, session=session)
+            dag_model = DM.get_dagmodel(dag_run.dag_id, session)
 
-        if (
-            dag_run.start_date
-            and dag.dagrun_timeout
-            and dag_run.start_date < timezone.utcnow() - dag.dagrun_timeout
-        ):
-            dag_run.set_state(DagRunState.FAILED)
-            unfinished_task_instances = session.scalars(
-                select(TI)
-                .where(TI.dag_id == dag_run.dag_id)
-                .where(TI.run_id == dag_run.run_id)
-                .where(TI.state.in_(State.unfinished))
-            )
-            for task_instance in unfinished_task_instances:
-                task_instance.state = TaskInstanceState.SKIPPED
-                session.merge(task_instance)
-            session.flush()
-            self.log.info("Run %s of %s has timed-out", dag_run.run_id, dag_run.dag_id)
+            if not dag or not dag_model:
+                self.log.error("Couldn't find DAG %s in DAG bag or database!", dag_run.dag_id)
+                return callback
+
+            if (
+                dag_run.start_date
+                and dag.dagrun_timeout
+                and dag_run.start_date < timezone.utcnow() - dag.dagrun_timeout
+            ):
+                dag_run.set_state(DagRunState.FAILED)
+                unfinished_task_instances = session.scalars(
+                    select(TI)
+                    .where(TI.dag_id == dag_run.dag_id)
+                    .where(TI.run_id == dag_run.run_id)
+                    .where(TI.state.in_(State.unfinished))
+                )
+                for task_instance in unfinished_task_instances:
+                    task_instance.state = TaskInstanceState.SKIPPED
+                    session.merge(task_instance)
+                session.flush()
+                self.log.info("Run %s of %s has timed-out", dag_run.run_id, dag_run.dag_id)
+
+                if self._should_update_dag_next_dagruns(
+                    dag, dag_model, last_dag_run=dag_run, session=session
+                ):
+                    dag_model.calculate_dagrun_date_fields(dag, dag.get_run_data_interval(dag_run))
+
+                callback_to_execute = DagCallbackRequest(
+                    full_filepath=dag.fileloc,
+                    dag_id=dag.dag_id,
+                    run_id=dag_run.run_id,
+                    is_failure_callback=True,
+                    processor_subdir=dag_model.processor_subdir,
+                    msg="timed_out",
+                )
+
+                dag_run.notify_dagrun_state_changed()
+                duration = dag_run.end_date - dag_run.start_date
+                Stats.timing(f"dagrun.duration.failed.{dag_run.dag_id}", duration)
+                Stats.timing("dagrun.duration.failed", duration, tags={"dag_id": dag_run.dag_id})
+                span.set_attribute("error", True)
+                if span.is_recording():
+                    span.add_event(
+                        name="error",
+                        attributes={
+                            "message": f"Run {dag_run.run_id} of {dag_run.dag_id} has timed-out",
+                            "duration": str(duration),
+                        },
+                    )
+                return callback_to_execute
+
+            if dag_run.execution_date > timezone.utcnow() and not dag.allow_future_exec_dates:
+                self.log.error("Execution date is in future: %s", dag_run.execution_date)
+                return callback
+
+            if not self._verify_integrity_if_dag_changed(dag_run=dag_run, session=session):
+                self.log.warning(
+                    "The DAG disappeared before verifying integrity: %s. Skipping.", dag_run.dag_id
+                )
+                return callback
+            # TODO[HA]: Rename update_state -> schedule_dag_run, ?? something else?
+            schedulable_tis, callback_to_run = dag_run.update_state(session=session, execute_callbacks=False)
 
             if self._should_update_dag_next_dagruns(dag, dag_model, last_dag_run=dag_run, session=session):
                 dag_model.calculate_dagrun_date_fields(dag, dag.get_run_data_interval(dag_run))
+            # This will do one query per dag run. We "could" build up a complex
+            # query to update all the TIs across all the execution dates and dag
+            # IDs in a single query, but it turns out that can be _very very slow_
+            # see #11147/commit ee90807ac for more details
+            if span.is_recording():
+                span.add_event(
+                    name="schedule_tis",
+                    attributes={
+                        "message": "dag_run scheduling its tis",
+                        "schedulable_tis": [_ti.task_id for _ti in schedulable_tis],
+                    },
+                )
+            dag_run.schedule_tis(schedulable_tis, session, max_tis_per_query=self.job.max_tis_per_query)
 
-            callback_to_execute = DagCallbackRequest(
-                full_filepath=dag.fileloc,
-                dag_id=dag.dag_id,
-                run_id=dag_run.run_id,
-                is_failure_callback=True,
-                processor_subdir=dag_model.processor_subdir,
-                msg="timed_out",
-            )
-
-            dag_run.notify_dagrun_state_changed()
-            duration = dag_run.end_date - dag_run.start_date
-            Stats.timing(f"dagrun.duration.failed.{dag_run.dag_id}", duration)
-            Stats.timing("dagrun.duration.failed", duration, tags={"dag_id": dag_run.dag_id})
-            return callback_to_execute
-
-        if dag_run.execution_date > timezone.utcnow() and not dag.allow_future_exec_dates:
-            self.log.error("Execution date is in future: %s", dag_run.execution_date)
-            return callback
-
-        if not self._verify_integrity_if_dag_changed(dag_run=dag_run, session=session):
-            self.log.warning("The DAG disappeared before verifying integrity: %s. Skipping.", dag_run.dag_id)
-            return callback
-        # TODO[HA]: Rename update_state -> schedule_dag_run, ?? something else?
-        schedulable_tis, callback_to_run = dag_run.update_state(session=session, execute_callbacks=False)
-
-        if self._should_update_dag_next_dagruns(dag, dag_model, last_dag_run=dag_run, session=session):
-            dag_model.calculate_dagrun_date_fields(dag, dag.get_run_data_interval(dag_run))
-        # This will do one query per dag run. We "could" build up a complex
-        # query to update all the TIs across all the execution dates and dag
-        # IDs in a single query, but it turns out that can be _very very slow_
-        # see #11147/commit ee90807ac for more details
-        dag_run.schedule_tis(schedulable_tis, session, max_tis_per_query=self.job.max_tis_per_query)
-
-        return callback_to_run
+            return callback_to_run
 
     def _verify_integrity_if_dag_changed(self, dag_run: DagRun, session: Session) -> bool:
         """
@@ -1662,20 +1788,27 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
     def _emit_pool_metrics(self, session: Session = NEW_SESSION) -> None:
         from airflow.models.pool import Pool
 
-        pools = Pool.slots_stats(session=session)
-        for pool_name, slot_stats in pools.items():
-            Stats.gauge(f"pool.open_slots.{pool_name}", slot_stats["open"])
-            Stats.gauge(f"pool.queued_slots.{pool_name}", slot_stats["queued"])
-            Stats.gauge(f"pool.running_slots.{pool_name}", slot_stats["running"])
-            Stats.gauge(f"pool.deferred_slots.{pool_name}", slot_stats["deferred"])
-            Stats.gauge(f"pool.scheduled_slots.{pool_name}", slot_stats["scheduled"])
+        with Trace.start_span(span_name="emit_pool_metrics", component="SchedulerJobRunner") as span:
+            pools = Pool.slots_stats(session=session)
+            for pool_name, slot_stats in pools.items():
+                Stats.gauge(f"pool.open_slots.{pool_name}", slot_stats["open"])
+                Stats.gauge(f"pool.queued_slots.{pool_name}", slot_stats["queued"])
+                Stats.gauge(f"pool.running_slots.{pool_name}", slot_stats["running"])
+                Stats.gauge(f"pool.deferred_slots.{pool_name}", slot_stats["deferred"])
+                Stats.gauge(f"pool.scheduled_slots.{pool_name}", slot_stats["scheduled"])
 
-            # Same metrics with tagging
-            Stats.gauge("pool.open_slots", slot_stats["open"], tags={"pool_name": pool_name})
-            Stats.gauge("pool.queued_slots", slot_stats["queued"], tags={"pool_name": pool_name})
-            Stats.gauge("pool.running_slots", slot_stats["running"], tags={"pool_name": pool_name})
-            Stats.gauge("pool.deferred_slots", slot_stats["deferred"], tags={"pool_name": pool_name})
-            Stats.gauge("pool.scheduled_slots", slot_stats["scheduled"], tags={"pool_name": pool_name})
+                # Same metrics with tagging
+                Stats.gauge("pool.open_slots", slot_stats["open"], tags={"pool_name": pool_name})
+                Stats.gauge("pool.queued_slots", slot_stats["queued"], tags={"pool_name": pool_name})
+                Stats.gauge("pool.running_slots", slot_stats["running"], tags={"pool_name": pool_name})
+                Stats.gauge("pool.deferred_slots", slot_stats["deferred"], tags={"pool_name": pool_name})
+                Stats.gauge("pool.scheduled_slots", slot_stats["scheduled"], tags={"pool_name": pool_name})
+
+                span.set_attribute("category", "scheduler")
+                span.set_attribute(f"pool.open_slots.{pool_name}", slot_stats["open"])
+                span.set_attribute(f"pool.queued_slots.{pool_name}", slot_stats["queued"])
+                span.set_attribute(f"pool.running_slots.{pool_name}", slot_stats["running"])
+                span.set_attribute(f"pool.deferred_slots.{pool_name}", slot_stats["deferred"])
 
     @provide_session
     def adopt_or_reset_orphaned_tasks(self, session: Session = NEW_SESSION) -> int:

--- a/airflow/jobs/triggerer_job_runner.py
+++ b/airflow/jobs/triggerer_job_runner.py
@@ -37,6 +37,7 @@ from airflow.jobs.base_job_runner import BaseJobRunner
 from airflow.jobs.job import perform_heartbeat
 from airflow.models.trigger import Trigger
 from airflow.stats import Stats
+from airflow.traces.tracer import Trace, span
 from airflow.triggers.base import TriggerEvent
 from airflow.typing_compat import TypedDict
 from airflow.utils import timezone
@@ -362,26 +363,43 @@ class TriggererJobRunner(BaseJobRunner, LoggingMixin):
             if not self.trigger_runner.is_alive():
                 self.log.error("Trigger runner thread has died! Exiting.")
                 break
-            # Clean out unused triggers
-            Trigger.clean_unused()
-            # Load/delete triggers
-            self.load_triggers()
-            # Handle events
-            self.handle_events()
-            # Handle failed triggers
-            self.handle_failed_triggers()
-            perform_heartbeat(self.job, heartbeat_callback=self.heartbeat_callback, only_if_necessary=True)
-            # Collect stats
-            self.emit_metrics()
+            with Trace.start_span(span_name="triggerer_job_loop", component="TriggererJobRunner") as span:
+                # Clean out unused triggers
+                if span.is_recording():
+                    span.add_event(name="Trigger.clean_unused()")
+                Trigger.clean_unused()
+                # Load/delete triggers
+                if span.is_recording():
+                    span.add_event(name="load_triggers()")
+                self.load_triggers()
+                # Handle events
+                if span.is_recording():
+                    span.add_event(name="handle_events()")
+                self.handle_events()
+                # Handle failed triggers
+                if span.is_recording():
+                    span.add_event(name="handle_failed_triggers()")
+                self.handle_failed_triggers()
+                if span.is_recording():
+                    span.add_event(name="perform_heartbeat()")
+                perform_heartbeat(
+                    self.job, heartbeat_callback=self.heartbeat_callback, only_if_necessary=True
+                )
+                # Collect stats
+                if span.is_recording():
+                    span.add_event(name="emit_metrics()")
+                self.emit_metrics()
             # Idle sleep
             time.sleep(1)
 
+    @span
     def load_triggers(self):
         """Query the database for the triggers we're supposed to be running and update the runner."""
         Trigger.assign_unassigned(self.job.id, self.capacity, self.health_check_threshold)
         ids = Trigger.ids_for_triggerer(self.job.id)
         self.trigger_runner.update_triggers(set(ids))
 
+    @span
     def handle_events(self):
         """Dispatch outbound events to the Trigger model which pushes them to the relevant task instances."""
         while self.trigger_runner.events:
@@ -392,6 +410,7 @@ class TriggererJobRunner(BaseJobRunner, LoggingMixin):
             # Emit stat event
             Stats.incr("triggers.succeeded")
 
+    @span
     def handle_failed_triggers(self):
         """
         Handle "failed" triggers. - ones that errored or exited before they sent an event.
@@ -405,11 +424,15 @@ class TriggererJobRunner(BaseJobRunner, LoggingMixin):
             # Emit stat event
             Stats.incr("triggers.failed")
 
+    @span
     def emit_metrics(self):
         Stats.gauge(f"triggers.running.{self.job.hostname}", len(self.trigger_runner.triggers))
         Stats.gauge(
             "triggers.running", len(self.trigger_runner.triggers), tags={"hostname": self.job.hostname}
         )
+        span = Trace.get_current_span()
+        span.set_attribute("trigger host", self.job.hostname)
+        span.set_attribute("triggers running", len(self.trigger_runner.triggers))
 
 
 class TriggerDetails(TypedDict):

--- a/airflow/jobs/triggerer_job_runner.py
+++ b/airflow/jobs/triggerer_job_runner.py
@@ -366,28 +366,28 @@ class TriggererJobRunner(BaseJobRunner, LoggingMixin):
             with Trace.start_span(span_name="triggerer_job_loop", component="TriggererJobRunner") as span:
                 # Clean out unused triggers
                 if span.is_recording():
-                    span.add_event(name="Trigger.clean_unused()")
+                    span.add_event(name="Trigger.clean_unused")
                 Trigger.clean_unused()
                 # Load/delete triggers
                 if span.is_recording():
-                    span.add_event(name="load_triggers()")
+                    span.add_event(name="load_triggers")
                 self.load_triggers()
                 # Handle events
                 if span.is_recording():
-                    span.add_event(name="handle_events()")
+                    span.add_event(name="handle_events")
                 self.handle_events()
                 # Handle failed triggers
                 if span.is_recording():
-                    span.add_event(name="handle_failed_triggers()")
+                    span.add_event(name="handle_failed_triggers")
                 self.handle_failed_triggers()
                 if span.is_recording():
-                    span.add_event(name="perform_heartbeat()")
+                    span.add_event(name="perform_heartbeat")
                 perform_heartbeat(
                     self.job, heartbeat_callback=self.heartbeat_callback, only_if_necessary=True
                 )
                 # Collect stats
                 if span.is_recording():
-                    span.add_event(name="emit_metrics()")
+                    span.add_event(name="emit_metrics")
                 self.emit_metrics()
             # Idle sleep
             time.sleep(1)

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -108,6 +108,7 @@ from airflow.stats import Stats
 from airflow.templates import SandboxedEnvironment
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies_deps import REQUEUEABLE_DEPS, RUNNING_DEPS
+from airflow.traces.tracer import Trace
 from airflow.utils import timezone
 from airflow.utils.context import (
     ConnectionAccessor,
@@ -1210,6 +1211,27 @@ def _handle_failure(
 
     if not test_mode:
         TaskInstance.save_to_db(failure_context["ti"], session)
+
+    with Trace.start_span_from_taskinstance(ti=task_instance) as span:
+        # ---- error info ----
+        span.set_attribute("error", "true")
+        span.set_attribute("error_msg", str(error))
+        span.set_attribute("context", context)
+        span.set_attribute("force_fail", force_fail)
+        # ---- common info ----
+        span.set_attribute("category", "DAG runs")
+        span.set_attribute("task_id", task_instance.task_id)
+        span.set_attribute("dag_id", task_instance.dag_id)
+        span.set_attribute("state", task_instance.state)
+        span.set_attribute("start_date", str(task_instance.start_date))
+        span.set_attribute("end_date", str(task_instance.end_date))
+        span.set_attribute("duration", task_instance.duration)
+        span.set_attribute("executor_config", str(task_instance.executor_config))
+        span.set_attribute("execution_date", str(task_instance.execution_date))
+        span.set_attribute("hostname", task_instance.hostname)
+        if isinstance(task_instance, TaskInstance):
+            span.set_attribute("log_url", task_instance.log_url)
+        span.set_attribute("operator", str(task_instance.operator))
 
 
 def _refresh_from_task(

--- a/airflow/traces/__init__.py
+++ b/airflow/traces/__init__.py
@@ -18,3 +18,4 @@ from __future__ import annotations
 
 TRACEPARENT = "traceparent"
 TRACESTATE = "tracestate"
+NO_TRACE_ID = 1

--- a/airflow/traces/tracer.py
+++ b/airflow/traces/tracer.py
@@ -96,6 +96,9 @@ class EmptySpan:
         """Set multiple attributes at once."""
         pass
 
+    def is_recording(self):
+        return True
+
     def add_event(
         self,
         name: str,

--- a/airflow/traces/tracer.py
+++ b/airflow/traces/tracer.py
@@ -97,7 +97,7 @@ class EmptySpan:
         pass
 
     def is_recording(self):
-        return True
+        return False
 
     def add_event(
         self,

--- a/airflow/traces/utils.py
+++ b/airflow/traces/utils.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from airflow.traces import NO_TRACE_ID
 from airflow.utils.hashlib_wrapper import md5
 from airflow.utils.state import TaskInstanceState
 
@@ -41,7 +42,7 @@ def _gen_id(seeds: list[str], as_int: bool = False, type: int = TRACE_ID) -> str
 
 def gen_trace_id(dag_run: DagRun, as_int: bool = False) -> str | int:
     if dag_run.start_date is None:
-        return 1
+        return NO_TRACE_ID
 
     """Generate trace id from DagRun."""
     return _gen_id(
@@ -62,7 +63,7 @@ def gen_span_id_from_ti_key(ti_key: TaskInstanceKey, as_int: bool = False) -> st
 def gen_dag_span_id(dag_run: DagRun, as_int: bool = False) -> str | int:
     """Generate dag's root span id using dag_run."""
     if dag_run.start_date is None:
-        return 1
+        return NO_TRACE_ID
 
     return _gen_id(
         [dag_run.dag_id, str(dag_run.run_id), str(dag_run.start_date.timestamp())],

--- a/airflow/traces/utils.py
+++ b/airflow/traces/utils.py
@@ -40,6 +40,9 @@ def _gen_id(seeds: list[str], as_int: bool = False, type: int = TRACE_ID) -> str
 
 
 def gen_trace_id(dag_run: DagRun, as_int: bool = False) -> str | int:
+    if dag_run.start_date is None:
+        return 1
+
     """Generate trace id from DagRun."""
     return _gen_id(
         [dag_run.dag_id, str(dag_run.run_id), str(dag_run.start_date.timestamp())],
@@ -58,6 +61,9 @@ def gen_span_id_from_ti_key(ti_key: TaskInstanceKey, as_int: bool = False) -> st
 
 def gen_dag_span_id(dag_run: DagRun, as_int: bool = False) -> str | int:
     """Generate dag's root span id using dag_run."""
+    if dag_run.start_date is None:
+        return 1
+
     return _gen_id(
         [dag_run.dag_id, str(dag_run.run_id), str(dag_run.start_date.timestamp())],
         as_int,

--- a/airflow/traces/utils.py
+++ b/airflow/traces/utils.py
@@ -42,7 +42,7 @@ def _gen_id(seeds: list[str], as_int: bool = False, type: int = TRACE_ID) -> str
 def gen_trace_id(dag_run: DagRun, as_int: bool = False) -> str | int:
     """Generate trace id from DagRun."""
     return _gen_id(
-        [dag_run.dag_id, dag_run.run_id, str(dag_run.start_date.timestamp())],
+        [dag_run.dag_id, str(dag_run.run_id), str(dag_run.start_date.timestamp())],
         as_int,
     )
 
@@ -50,7 +50,7 @@ def gen_trace_id(dag_run: DagRun, as_int: bool = False) -> str | int:
 def gen_span_id_from_ti_key(ti_key: TaskInstanceKey, as_int: bool = False) -> str | int:
     """Generate span id from TI key."""
     return _gen_id(
-        [ti_key.dag_id, ti_key.run_id, ti_key.task_id, str(ti_key.try_number)],
+        [ti_key.dag_id, str(ti_key.run_id), ti_key.task_id, str(ti_key.try_number)],
         as_int,
         SPAN_ID,
     )
@@ -59,7 +59,7 @@ def gen_span_id_from_ti_key(ti_key: TaskInstanceKey, as_int: bool = False) -> st
 def gen_dag_span_id(dag_run: DagRun, as_int: bool = False) -> str | int:
     """Generate dag's root span id using dag_run."""
     return _gen_id(
-        [dag_run.dag_id, dag_run.run_id, str(dag_run.start_date.timestamp())],
+        [dag_run.dag_id, str(dag_run.run_id), str(dag_run.start_date.timestamp())],
         as_int,
         SPAN_ID,
     )

--- a/scripts/ci/docker-compose/integration-otel.yml
+++ b/scripts/ci/docker-compose/integration-otel.yml
@@ -54,7 +54,7 @@ services:
       - ./grafana/volume/provisioning:/grafana/provisioning
 
   jaeger:
-    image: jaegertracing/all-in-one
+    image: jaegertracing/all-in-one:1.57
     container_name: "breeze-jaeger"
     environment:
       COLLECTOR_OTLP_ENABLED: true


### PR DESCRIPTION
closes #37752 

This is a PR PART 2 for [AIP-49](https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-49+OpenTelemetry+Support+for+Apache+Airflow) which is Open Telemetry support for Airflow. In last year, a group of contributors pushed out the first release of Airflow's commitment to OpenTelemetry by providing OTEL metrics support. This PR addresses the PART 2 of second phase of the OTEL implementation for Airflow, which provides instrumentation that produces spans and span logs for the traces in Airflow.