### PR TITLE
Extend get datasets endpoint to include dataset aliases

### DIFF
--- a/airflow/api_connexion/schemas/dataset_schema.py
+++ b/airflow/api_connexion/schemas/dataset_schema.py
@@ -26,6 +26,7 @@ from airflow.api_connexion.schemas.common_schema import JsonObjectField
 from airflow.models.dagrun import DagRun
 from airflow.models.dataset import (
     DagScheduleDatasetReference,
+    DatasetAliasModel,
     DatasetEvent,
     DatasetModel,
     TaskOutletDatasetReference,
@@ -59,6 +60,18 @@ class DagScheduleDatasetReferenceSchema(SQLAlchemySchema):
     updated_at = auto_field()
 
 
+class DatasetAliasSchema(SQLAlchemySchema):
+    """DatasetAlias DB schema."""
+
+    class Meta:
+        """Meta."""
+
+        model = DatasetAliasModel
+
+    id = auto_field()
+    name = auto_field()
+
+
 class DatasetSchema(SQLAlchemySchema):
     """Dataset DB schema."""
 
@@ -74,6 +87,7 @@ class DatasetSchema(SQLAlchemySchema):
     updated_at = auto_field()
     producing_tasks = fields.List(fields.Nested(TaskOutletDatasetReferenceSchema))
     consuming_dags = fields.List(fields.Nested(DagScheduleDatasetReferenceSchema))
+    aliases = fields.List(fields.Nested(DatasetAliasSchema))
 
 
 class DatasetCollection(NamedTuple):

--- a/tests/api_connexion/endpoints/test_dataset_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dataset_endpoint.py
@@ -109,7 +109,7 @@ class TestGetDatasetEndpoint(TestDatasetEndpoint):
         self._create_dataset(session)
         assert session.query(DatasetModel).count() == 1
 
-        with assert_queries_count(5):
+        with assert_queries_count(6):
             response = self.client.get(
                 f"/api/v1/datasets/{urllib.parse.quote('s3://bucket/key', safe='')}",
                 environ_overrides={"REMOTE_USER": "test"},
@@ -123,6 +123,7 @@ class TestGetDatasetEndpoint(TestDatasetEndpoint):
             "updated_at": self.default_time,
             "consuming_dags": [],
             "producing_tasks": [],
+            "aliases": [],
         }
 
     def test_should_respond_404(self):
@@ -176,7 +177,7 @@ class TestGetDatasets(TestDatasetEndpoint):
         session.commit()
         assert session.query(DatasetModel).count() == 2
 
-        with assert_queries_count(8):
+        with assert_queries_count(10):
             response = self.client.get("/api/v1/datasets", environ_overrides={"REMOTE_USER": "test"})
 
         assert response.status_code == 200
@@ -191,6 +192,7 @@ class TestGetDatasets(TestDatasetEndpoint):
                     "updated_at": self.default_time,
                     "consuming_dags": [],
                     "producing_tasks": [],
+                    "aliases": [],
                 },
                 {
                     "id": 2,
@@ -200,6 +202,7 @@ class TestGetDatasets(TestDatasetEndpoint):
                     "updated_at": self.default_time,
                     "consuming_dags": [],
                     "producing_tasks": [],
+                    "aliases": [],
                 },
             ],
             "total_entries": 2,

--- a/tests/api_connexion/schemas/test_dataset_schema.py
+++ b/tests/api_connexion/schemas/test_dataset_schema.py
@@ -28,7 +28,7 @@ from airflow.api_connexion.schemas.dataset_schema import (
     dataset_schema,
 )
 from airflow.datasets import Dataset
-from airflow.models.dataset import DatasetEvent, DatasetModel
+from airflow.models.dataset import DatasetAliasModel, DatasetEvent, DatasetModel
 from airflow.operators.empty import EmptyOperator
 from tests.test_utils.db import clear_db_dags, clear_db_datasets
 
@@ -87,6 +87,7 @@ class TestDatasetSchema(TestDatasetSchemaBase):
                     "updated_at": self.timestamp,
                 }
             ],
+            "aliases": [],
         }
 
 
@@ -99,13 +100,19 @@ class TestDatasetCollectionSchema(TestDatasetSchemaBase):
             )
             for i in range(2)
         ]
+        dataset_aliases = [DatasetAliasModel(name=f"alias_{i}") for i in range(2)]
+        for dataset_alias in dataset_aliases:
+            dataset_alias.datasets.append(datasets[0])
         session.add_all(datasets)
+        session.add_all(dataset_aliases)
         session.flush()
         serialized_data = dataset_collection_schema.dump(
             DatasetCollection(datasets=datasets, total_entries=2)
         )
         serialized_data["datasets"][0]["id"] = 1
         serialized_data["datasets"][1]["id"] = 2
+        serialized_data["datasets"][0]["aliases"][0]["id"] = 1
+        serialized_data["datasets"][0]["aliases"][1]["id"] = 2
         assert serialized_data == {
             "datasets": [
                 {
@@ -116,6 +123,10 @@ class TestDatasetCollectionSchema(TestDatasetSchemaBase):
                     "updated_at": self.timestamp,
                     "consuming_dags": [],
                     "producing_tasks": [],
+                    "aliases": [
+                        {"id": 1, "name": "alias_0"},
+                        {"id": 2, "name": "alias_1"},
+                    ],
                 },
                 {
                     "id": 2,
@@ -125,6 +136,7 @@ class TestDatasetCollectionSchema(TestDatasetSchemaBase):
                     "updated_at": self.timestamp,
                     "consuming_dags": [],
                     "producing_tasks": [],
+                    "aliases": [],
                 },
             ],
             "total_entries": 2,

--- a/tests/www/views/test_views_dataset.py
+++ b/tests/www/views/test_views_dataset.py
@@ -51,7 +51,7 @@ class TestGetDatasets(TestDatasetEndpoint):
         session.commit()
         assert session.query(DatasetModel).count() == 2
 
-        with assert_queries_count(8):
+        with assert_queries_count(10):
             response = admin_client.get("/object/datasets_summary")
 
         assert response.status_code == 200


### PR DESCRIPTION
Related: https://github.com/apache/airflow/issues/40039
Depend on: https://github.com/apache/airflow/pull/40693

## What
In https://github.com/apache/airflow/pull/40693, we introduce a many to many relationship between dataset and dataset alias. This PR allows `GET /datasets` to retrieve the dataset aliases link to that datasets as well.


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
