### PR TITLE
Add gauge metric for 'last_num_of_db_queries' parameter

### DIFF
--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -885,6 +885,7 @@ class DagFileProcessorManager(LoggingMixin):
                 seconds_ago = (now - last_run).total_seconds()
                 Stats.gauge(f"dag_processing.last_run.seconds_ago.{file_name}", seconds_ago)
             last_num_of_db_queries = self.get_last_num_of_db_queries(file_path)
+            Stats.gauge(f"dag_processing.last_num_of_db_queries.{file_name}", last_num_of_db_queries)
 
             rows.append(
                 (

--- a/docs/apache-airflow/administration-and-deployment/logging-monitoring/metrics.rst
+++ b/docs/apache-airflow/administration-and-deployment/logging-monitoring/metrics.rst
@@ -214,40 +214,41 @@ Name                                                                   Descripti
 Gauges
 ------
 
-=================================================== ========================================================================
-Name                                                Description
-=================================================== ========================================================================
-``dagbag_size``                                     Number of DAGs found when the scheduler ran a scan based on its
-                                                    configuration
-``dag_processing.import_errors``                    Number of errors from trying to parse DAG files
-``dag_processing.total_parse_time``                 Seconds taken to scan and import ``dag_processing.file_path_queue_size`` DAG files
-``dag_processing.file_path_queue_size``             Number of DAG files to be considered for the next scan
-``dag_processing.last_run.seconds_ago.<dag_file>``  Seconds since ``<dag_file>`` was last processed
-``scheduler.tasks.starving``                        Number of tasks that cannot be scheduled because of no open slot in pool
-``scheduler.tasks.executable``                      Number of tasks that are ready for execution (set to queued)
-                                                    with respect to pool limits, DAG concurrency, executor state,
-                                                    and priority.
-``executor.open_slots``                             Number of open slots on executor
-``executor.queued_tasks``                           Number of queued tasks on executor
-``executor.running_tasks``                          Number of running tasks on executor
-``pool.open_slots.<pool_name>``                     Number of open slots in the pool
-``pool.open_slots``                                 Number of open slots in the pool. Metric with pool_name tagging.
-``pool.queued_slots.<pool_name>``                   Number of queued slots in the pool
-``pool.queued_slots``                               Number of queued slots in the pool. Metric with pool_name tagging.
-``pool.running_slots.<pool_name>``                  Number of running slots in the pool
-``pool.running_slots``                              Number of running slots in the pool. Metric with pool_name tagging.
-``pool.deferred_slots.<pool_name>``                 Number of deferred slots in the pool
-``pool.deferred_slots``                             Number of deferred slots in the pool. Metric with pool_name tagging.
-``pool.scheduled_tasks.<pool_name>``                Number of scheduled tasks in the pool
-``pool.scheduled_tasks``                            Number of scheduled tasks in the pool. Metric with pool_name tagging.
-``pool.starving_tasks.<pool_name>``                 Number of starving tasks in the pool
-``pool.starving_tasks``                             Number of starving tasks in the pool. Metric with pool_name tagging.
-``task.cpu_usage_percent.<dag_id>.<task_id>``       Percentage of CPU used by a task
-``task.mem_usage_percent.<dag_id>.<task_id>``       Percentage of memory used by a task
-``triggers.running.<hostname>``                     Number of triggers currently running for a triggerer (described by hostname)
-``triggers.running``                                Number of triggers currently running for a triggerer (described by hostname).
-                                                    Metric with hostname tagging.
-=================================================== ========================================================================
+==================================================== ========================================================================
+Name                                                 Description
+==================================================== ========================================================================
+``dagbag_size``                                      Number of DAGs found when the scheduler ran a scan based on its
+                                                     configuration
+``dag_processing.import_errors``                     Number of errors from trying to parse DAG files
+``dag_processing.total_parse_time``                  Seconds taken to scan and import ``dag_processing.file_path_queue_size`` DAG files
+``dag_processing.file_path_queue_size``              Number of DAG files to be considered for the next scan
+``dag_processing.last_run.seconds_ago.<dag_file>``   Seconds since ``<dag_file>`` was last processed
+``dag_processing.last_num_of_db_queries.<dag_file>`` Number of queries to Airflow database during parsing per ``<dag_file>``
+``scheduler.tasks.starving``                         Number of tasks that cannot be scheduled because of no open slot in pool
+``scheduler.tasks.executable``                       Number of tasks that are ready for execution (set to queued)
+                                                     with respect to pool limits, DAG concurrency, executor state,
+                                                     and priority.
+``executor.open_slots``                              Number of open slots on executor
+``executor.queued_tasks``                            Number of queued tasks on executor
+``executor.running_tasks``                           Number of running tasks on executor
+``pool.open_slots.<pool_name>``                      Number of open slots in the pool
+``pool.open_slots``                                  Number of open slots in the pool. Metric with pool_name tagging.
+``pool.queued_slots.<pool_name>``                    Number of queued slots in the pool
+``pool.queued_slots``                                Number of queued slots in the pool. Metric with pool_name tagging.
+``pool.running_slots.<pool_name>``                   Number of running slots in the pool
+``pool.running_slots``                               Number of running slots in the pool. Metric with pool_name tagging.
+``pool.deferred_slots.<pool_name>``                  Number of deferred slots in the pool
+``pool.deferred_slots``                              Number of deferred slots in the pool. Metric with pool_name tagging.
+``pool.scheduled_tasks.<pool_name>``                 Number of scheduled tasks in the pool
+``pool.scheduled_tasks``                             Number of scheduled tasks in the pool. Metric with pool_name tagging.
+``pool.starving_tasks.<pool_name>``                  Number of starving tasks in the pool
+``pool.starving_tasks``                              Number of starving tasks in the pool. Metric with pool_name tagging.
+``task.cpu_usage_percent.<dag_id>.<task_id>``        Percentage of CPU used by a task
+``task.mem_usage_percent.<dag_id>.<task_id>``        Percentage of memory used by a task
+``triggers.running.<hostname>``                      Number of triggers currently running for a triggerer (described by hostname)
+``triggers.running``                                 Number of triggers currently running for a triggerer (described by hostname).
+                                                     Metric with hostname tagging.
+==================================================== ========================================================================
 
 Timers
 ------


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

In this PR I have added a new gauge metric for `last_num_of_db_queries` parameter

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
