### PR TITLE
Make BashOperator compatible with Internal API AIP-44

### DIFF
--- a/airflow/api_internal/endpoints/rpc_api_endpoint.py
+++ b/airflow/api_internal/endpoints/rpc_api_endpoint.py
@@ -48,6 +48,7 @@ def _initialize_map() -> dict[str, Callable]:
     from airflow.models.dag import DAG, DagModel
     from airflow.models.dagrun import DagRun
     from airflow.models.dagwarning import DagWarning
+    from airflow.models.renderedtifields import RenderedTaskInstanceFields
     from airflow.models.serialized_dag import SerializedDagModel
     from airflow.models.skipmixin import SkipMixin
     from airflow.models.taskinstance import (
@@ -110,6 +111,7 @@ def _initialize_map() -> dict[str, Callable]:
         DagRun.get_previous_scheduled_dagrun,
         DagRun.fetch_task_instance,
         DagRun._get_log_template,
+        RenderedTaskInstanceFields.update_runtime_evaluated_template_fields,
         SerializedDagModel.get_serialized_dag,
         SkipMixin._skip,
         SkipMixin._skip_all_except,

--- a/airflow/api_internal/endpoints/rpc_api_endpoint.py
+++ b/airflow/api_internal/endpoints/rpc_api_endpoint.py
@@ -111,7 +111,7 @@ def _initialize_map() -> dict[str, Callable]:
         DagRun.get_previous_scheduled_dagrun,
         DagRun.fetch_task_instance,
         DagRun._get_log_template,
-        RenderedTaskInstanceFields.update_runtime_evaluated_template_fields,
+        RenderedTaskInstanceFields._update_runtime_evaluated_template_fields,
         SerializedDagModel.get_serialized_dag,
         SkipMixin._skip,
         SkipMixin._skip_all_except,

--- a/airflow/models/renderedtifields.py
+++ b/airflow/models/renderedtifields.py
@@ -157,7 +157,7 @@ class RenderedTaskInstanceFields(TaskInstanceDependencies):
     @classmethod
     @internal_api_call
     @provide_session
-    def update_runtime_evaluated_template_fields(
+    def _update_runtime_evaluated_template_fields(
         cls, ti: TaskInstance, session: Session = NEW_SESSION
     ) -> None:
         """Update rendered task instance fields for cases where runtime evaluated, not templated."""

--- a/airflow/models/renderedtifields.py
+++ b/airflow/models/renderedtifields.py
@@ -36,6 +36,7 @@ from sqlalchemy import (
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import relationship
 
+from airflow.api_internal.internal_api_call import internal_api_call
 from airflow.configuration import conf
 from airflow.models.base import StringID, TaskInstanceDependencies
 from airflow.serialization.helpers import serialize_template_field
@@ -152,6 +153,23 @@ class RenderedTaskInstanceFields(TaskInstanceDependencies):
 
         for field, rendered in self.rendered_fields.items():
             self.rendered_fields[field] = redact(rendered, field)
+
+    @classmethod
+    @internal_api_call
+    @provide_session
+    def update_runtime_evaluated_template_fields(
+        cls, ti: TaskInstance, session: Session = NEW_SESSION
+    ) -> None:
+        """Update rendered task instance fields for cases where runtime evaluated, not templated."""
+        # Note: Need lazy import to break the partly loaded class loop
+        from airflow.models.taskinstance import TaskInstance
+
+        # If called via remote API the DAG needs to be re-loaded
+        TaskInstance.ensure_dag(ti, session=session)
+
+        rtif = RenderedTaskInstanceFields(ti)
+        RenderedTaskInstanceFields.write(rtif, session=session)
+        RenderedTaskInstanceFields.delete_old_records(ti.task_id, ti.dag_id, session=session)
 
     @classmethod
     @provide_session

--- a/airflow/operators/bash.py
+++ b/airflow/operators/bash.py
@@ -191,7 +191,7 @@ class BashOperator(BaseOperator):
         """
         from airflow.models.renderedtifields import RenderedTaskInstanceFields
 
-        RenderedTaskInstanceFields.update_runtime_evaluated_template_fields(ti)
+        RenderedTaskInstanceFields._update_runtime_evaluated_template_fields(ti)
 
     def get_env(self, context):
         """Build the set of environment variables to be exposed for the bash command."""

--- a/airflow/operators/bash.py
+++ b/airflow/operators/bash.py
@@ -191,9 +191,7 @@ class BashOperator(BaseOperator):
         """
         from airflow.models.renderedtifields import RenderedTaskInstanceFields
 
-        rtif = RenderedTaskInstanceFields(ti)  # Templates are rendered be default here.
-        RenderedTaskInstanceFields.write(rtif)
-        RenderedTaskInstanceFields.delete_old_records(ti.task_id, ti.dag_id)
+        RenderedTaskInstanceFields.update_runtime_evaluated_template_fields(ti)
 
     def get_env(self, context):
         """Build the set of environment variables to be exposed for the bash command."""


### PR DESCRIPTION
This is another PR as improvement for internal API in relation to implementation of AIP-69 in PoC PR #40224 - I relaized that BashOperator also has a DB access to update template fields.

This PR adds one AIP endpoint to un-bundle the Operator from the DB.

Note: I am aware that a similar endpoint was added with airflow/models/taskinstance.py:_update_rtif() but thepurpose it slightly different. Hard to consolidate w/o the need to have more calls over the API. Therefore I propose to add a new one here.

With this actually the [Integration test](https://github.com/jscheffl/airflow/blob/feature/aip-69-poc/airflow/example_dags/integration_test.py) in my AIP-69 is completely working with all basic features! WOW! 