### PR TITLE
openlineage: Add AirflowDagRunFacet to dag runEvents

### DIFF
--- a/airflow/providers/openlineage/facets/AirflowDagRunFacet.json
+++ b/airflow/providers/openlineage/facets/AirflowDagRunFacet.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "AirflowDagRunFacet": {
+      "allOf": [
+        {
+          "$ref": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunFacet"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "dag": {
+              "$ref": "#/$defs/DAG"
+            },
+            "dagRun": {
+              "$ref": "#/$defs/DagRun"
+            }
+          },
+          "required": [
+            "dag",
+            "dagRun"
+          ]
+        }
+      ]
+    },
+    "DAG": {
+      "type": "object",
+      "properties": {
+        "dag_id": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "owner": {
+          "type": "string"
+        },
+        "schedule_interval": {
+          "type": "string"
+        },
+        "start_date": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "tags": {
+          "type": "string"
+        },
+        "timetable": {
+          "description": "Describes timetable (successor of schedule_interval)",
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "dag_id",
+        "start_date"
+      ]
+    },
+    "DagRun": {
+      "type": "object",
+      "properties": {
+        "conf": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "dag_id": {
+          "type": "string"
+        },
+        "data_interval_start": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "data_interval_end": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "external_trigger": {
+          "type": "boolean"
+        },
+        "run_id": {
+          "type": "string"
+        },
+        "run_type": {
+          "type": "string"
+        },
+        "start_date": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "dag_id",
+        "run_id"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "airflowDagRun": {
+      "$ref": "#/$defs/AirflowDagRunFacet"
+    }
+  }
+}

--- a/airflow/providers/openlineage/plugins/facets.py
+++ b/airflow/providers/openlineage/plugins/facets.py
@@ -91,13 +91,21 @@ class AirflowStateRunFacet(BaseFacet):
 
 @define(slots=False)
 class AirflowRunFacet(BaseFacet):
-    """Composite Airflow run facet."""
+    """Composite Airflow task run facet."""
 
     dag: dict
     dagRun: dict
     task: dict
     taskInstance: dict
     taskUuid: str
+
+
+@define(slots=False)
+class AirflowDagRunFacet(BaseFacet):
+    """Composite Airflow DAG run facet."""
+
+    dag: dict
+    dagRun: dict
 
 
 @define(slots=False)

--- a/airflow/providers/openlineage/plugins/listener.py
+++ b/airflow/providers/openlineage/plugins/listener.py
@@ -420,7 +420,7 @@ class OpenLineageListener:
             nominal_end_time=data_interval_end,
             # AirflowJobFacet should be created outside ProcessPoolExecutor that pickles objects,
             # as it causes lack of some TaskGroup attributes and crashes event emission.
-            job_facets={**get_airflow_job_facet(dag_run=dag_run)},
+            job_facets=get_airflow_job_facet(dag_run=dag_run),
         )
 
     @hookimpl

--- a/airflow/providers/openlineage/utils/utils.py
+++ b/airflow/providers/openlineage/utils/utils.py
@@ -37,6 +37,7 @@ from airflow.exceptions import AirflowProviderDeprecationWarning  # TODO: move t
 from airflow.models import DAG, BaseOperator, MappedOperator
 from airflow.providers.openlineage import conf
 from airflow.providers.openlineage.plugins.facets import (
+    AirflowDagRunFacet,
     AirflowJobFacet,
     AirflowMappedTaskRunFacet,
     AirflowRunFacet,
@@ -305,6 +306,17 @@ class TaskGroupInfo(InfoJsonEncodable):
         "upstream_group_ids",
         "upstream_task_ids",
     ]
+
+
+def get_airflow_dag_run_facet(dag_run: DagRun) -> dict[str, BaseFacet]:
+    if not dag_run.dag:
+        return {}
+    return {
+        "airflowDagRun": AirflowDagRunFacet(
+            dag=DagInfo(dag_run.dag),
+            dagRun=DagRunInfo(dag_run),
+        )
+    }
 
 
 def get_airflow_run_facet(

--- a/tests/providers/openlineage/plugins/test_facets.py
+++ b/tests/providers/openlineage/plugins/test_facets.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from airflow.providers.openlineage.plugins.facets import AirflowRunFacet
+from airflow.providers.openlineage.plugins.facets import AirflowDagRunFacet, AirflowRunFacet
 
 
 def test_airflow_run_facet():
@@ -27,7 +27,11 @@ def test_airflow_run_facet():
     task_uuid = "XXX"
 
     airflow_run_facet = AirflowRunFacet(
-        dag=dag, dagRun=dag_run, task=task, taskInstance=task_instance, taskUuid=task_uuid
+        dag=dag,
+        dagRun=dag_run,
+        task=task,
+        taskInstance=task_instance,
+        taskUuid=task_uuid,
     )
 
     assert airflow_run_facet.dag == dag
@@ -35,3 +39,16 @@ def test_airflow_run_facet():
     assert airflow_run_facet.task == task
     assert airflow_run_facet.taskInstance == task_instance
     assert airflow_run_facet.taskUuid == task_uuid
+
+
+def test_airflow_dag_run_facet():
+    dag = {"dag_id": "123"}
+    dag_run = {"dag_run_id": "456"}
+
+    airflow_dag_run_facet = AirflowDagRunFacet(
+        dag=dag,
+        dagRun=dag_run,
+    )
+
+    assert airflow_dag_run_facet.dag == dag
+    assert airflow_dag_run_facet.dagRun == dag_run

--- a/tests/providers/openlineage/utils/test_utils.py
+++ b/tests/providers/openlineage/utils/test_utils.py
@@ -23,16 +23,18 @@ from unittest.mock import MagicMock
 from airflow import DAG
 from airflow.decorators import task
 from airflow.models.baseoperator import BaseOperator
+from airflow.models.dagrun import DagRun
 from airflow.models.mappedoperator import MappedOperator
 from airflow.operators.bash import BashOperator
 from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import PythonOperator
-from airflow.providers.openlineage.plugins.facets import AirflowJobFacet
+from airflow.providers.openlineage.plugins.facets import AirflowDagRunFacet, AirflowJobFacet
 from airflow.providers.openlineage.utils.utils import (
     _get_parsed_dag_tree,
     _get_task_groups_details,
     _get_tasks_details,
     _safe_get_dag_tree_view,
+    get_airflow_dag_run_facet,
     get_airflow_job_facet,
     get_fully_qualified_class_name,
     get_job_name,
@@ -40,6 +42,7 @@ from airflow.providers.openlineage.utils.utils import (
 )
 from airflow.serialization.serialized_objects import SerializedBaseOperator
 from airflow.utils.task_group import TaskGroup
+from airflow.utils.types import DagRunType
 from tests.test_utils.mock_operators import MockOperator
 
 
@@ -60,7 +63,7 @@ def test_get_airflow_job_facet():
 
         task_0 >> task_10
 
-    dagrun_mock = MagicMock()
+    dagrun_mock = MagicMock(DagRun)
     dagrun_mock.dag = dag
 
     result = get_airflow_job_facet(dagrun_mock)
@@ -97,6 +100,57 @@ def test_get_airflow_job_facet():
                     "is_setup": False,
                     "is_teardown": False,
                 },
+            },
+        )
+    }
+
+
+def test_get_airflow_dag_run_facet():
+    with DAG(
+        dag_id="dag",
+        schedule="@once",
+        start_date=datetime.datetime(2024, 6, 1),
+        tags=["test"],
+    ) as dag:
+        task_0 = BashOperator(task_id="task_0", bash_command="exit 0;")
+
+        with TaskGroup("section_1", prefix_group_id=True):
+            task_10 = PythonOperator(task_id="task_3", python_callable=lambda: 1)
+
+        task_0 >> task_10
+
+    dagrun_mock = MagicMock(DagRun)
+    dagrun_mock.dag = dag
+    dagrun_mock.conf = {}
+    dagrun_mock.dag_id = dag.dag_id
+    dagrun_mock.data_interval_start = datetime.datetime(2024, 6, 1, 1, 2, 3, tzinfo=datetime.timezone.utc)
+    dagrun_mock.data_interval_end = datetime.datetime(2024, 6, 1, 2, 3, 4, tzinfo=datetime.timezone.utc)
+    dagrun_mock.external_trigger = True
+    dagrun_mock.run_id = "manual_2024-06-01T00:00:00+00:00"
+    dagrun_mock.run_type = DagRunType.MANUAL
+    dagrun_mock.start_date = datetime.datetime(2024, 6, 1, 1, 2, 4, tzinfo=datetime.timezone.utc)
+
+    result = get_airflow_dag_run_facet(dagrun_mock)
+    assert result == {
+        "airflowDagRun": AirflowDagRunFacet(
+            dag={
+                "dag_id": "dag",
+                "description": None,
+                "owner": "airflow",
+                "timetable": {},
+                "schedule_interval": "@once",
+                "start_date": "2024-06-01T00:00:00+00:00",
+                "tags": ["test"],
+            },
+            dagRun={
+                "conf": {},
+                "dag_id": "dag",
+                "data_interval_start": "2024-06-01T01:02:03+00:00",
+                "data_interval_end": "2024-06-01T02:03:04+00:00",
+                "external_trigger": True,
+                "run_id": "manual_2024-06-01T00:00:00+00:00",
+                "run_type": "manual",
+                "start_date": "2024-06-01T01:02:04+00:00",
             },
         )
     }


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

closes: #40798

* Add `AirflowDagRunFacet` which copies `AirflowRunFacet`, but without fields `task`, `taskInstance`, `taskUuid`.
* Add the same facet to DAG run events with `eventType=START`.

This allows to collect data like dag tags, dag schedule interval, dagRun id and type on OpenLineage consumer side. Before that, this information was available only for task events.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
