### PR TITLE
Add a check in BigQueryInsertJobOperator to verify the Job state before marking it as success

### DIFF
--- a/providers/src/airflow/providers/google/cloud/operators/bigquery.py
+++ b/providers/src/airflow/providers/google/cloud/operators/bigquery.py
@@ -2685,6 +2685,15 @@ class BigQueryInsertJobOperator(GoogleCloudBaseOperator, _BigQueryOpenLineageMix
             job.result(timeout=self.result_timeout, retry=self.result_retry)
             self._handle_job_error(job)
 
+            while job.state in ("PENDING", "RUNNING"):
+                job.result(timeout=self.result_timeout, retry=self.result_retry)
+                self._handle_job_error(job)
+                job = hook.get_job(
+                    project_id=self.project_id,
+                    location=self.location,
+                    job_id=self.job_id,
+                )
+
             return self.job_id
         else:
             if job.running():

--- a/providers/src/airflow/providers/google/cloud/operators/bigquery.py
+++ b/providers/src/airflow/providers/google/cloud/operators/bigquery.py
@@ -2686,14 +2686,13 @@ class BigQueryInsertJobOperator(GoogleCloudBaseOperator, _BigQueryOpenLineageMix
             self._handle_job_error(job)
 
             while job.state in ("PENDING", "RUNNING"):
-                job.result(timeout=self.result_timeout, retry=self.result_retry)
-                self._handle_job_error(job)
                 job = hook.get_job(
                     project_id=self.project_id,
                     location=self.location,
                     job_id=self.job_id,
                 )
-
+                job.result(timeout=self.result_timeout, retry=self.result_retry)
+                self._handle_job_error(job)
             return self.job_id
         else:
             if job.running():

--- a/providers/tests/google/cloud/operators/test_bigquery.py
+++ b/providers/tests/google/cloud/operators/test_bigquery.py
@@ -899,7 +899,7 @@ class TestBigQueryInsertJobOperator:
         # Validate the number of calls
         assert mock_hook.return_value.get_job.call_count == 2
         assert job_running.result.call_count == 1
-        assert job_completed.result.call_count == 0
+        assert job_completed.result.call_count == 1
 
         mock_hook.return_value.get_job.assert_any_call(
             location=TEST_DATASET_LOCATION,
@@ -1098,8 +1098,8 @@ class TestBigQueryInsertJobOperator:
         result = op.execute(context=MagicMock())
 
         assert mock_hook.return_value.get_job.call_count == 2
-        assert job_running.result.call_count == 2
-        assert job_completed.result.call_count == 0
+        assert job_running.result.call_count == 1
+        assert job_completed.result.call_count == 1
 
         mock_hook.return_value.get_job.assert_any_call(
             location=TEST_DATASET_LOCATION,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Closes: [40839](https://github.com/apache/airflow/issues/40839)

Occasionally, Airflow marks the BigQueryInsertJobOperator task as successful before it has actually completed in BigQuery. To resolve this issue, we will add a condition to check the job's state and wait until it is successfully completed in BigQuery.

<!-- Please keep an empty line above the dashes. -->
---
