### PR TITLE
Replace usages of task context logger with the log table

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3372,6 +3372,7 @@ components:
         owner:
           description: Name of the user who triggered these events a.
           type: string
+          nullable: true
           readOnly: true
         extra:
           description: |

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -148,9 +148,9 @@ class BaseExecutor(LoggingMixin):
     def start(self):  # pragma: no cover
         """Executors may need to get things started."""
 
-    def log_task_event(self, *, record: Log):
+    def log_task_event(self, *, event: str, extra: str, ti_key: TaskInstanceKey):
         """Add an event to the log table."""
-        self._task_event_logs.append(record)
+        self._task_event_logs.append(Log(event=event, task_instance=ti_key, extra=extra))
 
     def queue_command(
         self,
@@ -309,13 +309,12 @@ class BaseExecutor(LoggingMixin):
                     attempt.total_tries,
                 )
                 self.log_task_event(
-                    record=Log(
-                        event="task launch failure",
-                        extra=(
-                            "Task was in running set and could not be queued "
-                            f"after {attempt.total_tries} attempts."
-                        ),
-                    )
+                    event="task launch failure",
+                    extra=(
+                        "Task was in running set and could not be queued "
+                        f"after {attempt.total_tries} attempts."
+                    ),
+                    ti_key=key,
                 )
                 del self.attempts[key]
                 del self.queued_tasks[key]

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -149,7 +149,7 @@ class BaseExecutor(LoggingMixin):
         """Executors may need to get things started."""
 
     def log_task_event(self, *, record: Log):
-        """Log an event to the task instance event log."""
+        """Add an event to the log table."""
         self._task_event_logs.append(record)
 
     def queue_command(

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -44,6 +44,7 @@ from airflow.exceptions import RemovedInAirflow3Warning, UnknownExecutorExceptio
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.jobs.base_job_runner import BaseJobRunner
 from airflow.jobs.job import Job, perform_heartbeat
+from airflow.models import Log
 from airflow.models.dag import DAG, DagModel
 from airflow.models.dagbag import DagBag
 from airflow.models.dagrun import DagRun
@@ -62,7 +63,6 @@ from airflow.timetables.simple import DatasetTriggeredTimetable
 from airflow.utils import timezone
 from airflow.utils.event_scheduler import EventScheduler
 from airflow.utils.log.logging_mixin import LoggingMixin
-from airflow.utils.log.task_context_logger import TaskContextLogger
 from airflow.utils.retries import MAX_DB_RETRIES, retry_db_transaction, run_with_db_retries
 from airflow.utils.session import NEW_SESSION, create_session, provide_session
 from airflow.utils.sqlalchemy import (
@@ -85,7 +85,6 @@ if TYPE_CHECKING:
     from airflow.dag_processing.manager import DagFileProcessorAgent
     from airflow.executors.base_executor import BaseExecutor
     from airflow.executors.executor_utils import ExecutorName
-    from airflow.models import Log
     from airflow.models.taskinstance import TaskInstanceKey
     from airflow.utils.sqlalchemy import (
         CommitProhibitorGuard,
@@ -238,10 +237,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         self.processor_agent: DagFileProcessorAgent | None = None
 
         self.dagbag = DagBag(dag_folder=self.subdir, read_dags_from_db=True, load_op_links=False)
-        self._task_context_logger: TaskContextLogger = TaskContextLogger(
-            component_name=self.job_type,
-            call_site_logger=self.log,
-        )
 
     @provide_session
     def heartbeat_callback(self, session: Session = NEW_SESSION) -> None:
@@ -848,7 +843,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 )
                 if info is not None:
                     msg += " Extra info: %s" % info  # noqa: RUF100, UP031, flynt
-                self._task_context_logger.error(msg, ti=ti)
+                session.add(Log(event="task state mismatch", extra=msg, task_instance=ti.key))
 
                 # Get task from the Serialized DAG
                 try:
@@ -1663,11 +1658,15 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 cleaned_up_task_instances = set(executor.cleanup_stuck_queued_tasks(tis=stuck_tis))
                 for ti in stuck_tis:
                     if repr(ti) in cleaned_up_task_instances:
-                        self._task_context_logger.warning(
-                            "Marking task instance %s stuck in queued as failed. "
-                            "If the task instance has available retries, it will be retried.",
-                            ti,
-                            ti=ti,
+                        session.add(
+                            Log(
+                                event="stuck in queued",
+                                task_instance=ti.key,
+                                extra=(
+                                    "Task will be marked as failed. If the task instance has "
+                                    "available retries, it will be retried."
+                                ),
+                            )
                         )
             except NotImplementedError:
                 self.log.debug("Executor doesn't support cleanup of stuck queued tasks. Skipping.")
@@ -1831,22 +1830,34 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         if zombies:
             self.log.warning("Failing (%s) jobs without heartbeat after %s", len(zombies), limit_dttm)
 
-        for ti, file_loc, processor_subdir in zombies:
-            zombie_message_details = self._generate_zombie_message_details(ti)
-            request = TaskCallbackRequest(
-                full_filepath=file_loc,
-                processor_subdir=processor_subdir,
-                simple_task_instance=SimpleTaskInstance.from_ti(ti),
-                msg=str(zombie_message_details),
-            )
-            log_message = (
-                f"Detected zombie job: {request} "
-                "(See https://airflow.apache.org/docs/apache-airflow/"
-                "stable/core-concepts/tasks.html#zombie-undead-tasks)"
-            )
-            self._task_context_logger.error(log_message, ti=ti)
-            self.job.executor.send_callback(request)
-            Stats.incr("zombies_killed", tags={"dag_id": ti.dag_id, "task_id": ti.task_id})
+        with create_session() as session:
+            for ti, file_loc, processor_subdir in zombies:
+                zombie_message_details = self._generate_zombie_message_details(ti)
+                request = TaskCallbackRequest(
+                    full_filepath=file_loc,
+                    processor_subdir=processor_subdir,
+                    simple_task_instance=SimpleTaskInstance.from_ti(ti),
+                    msg=str(zombie_message_details),
+                )
+                log_message = (
+                    f"Detected zombie job: {request} "
+                    "(See https://airflow.apache.org/docs/apache-airflow/"
+                    "stable/core-concepts/tasks.html#zombie-undead-tasks)"
+                )
+                session.add(
+                    Log(
+                        event="stale heartbeat",
+                        task_instance=ti.key,
+                        extra=(
+                            "Task has stale heartbeat and will be terminated. "
+                            "See https://airflow.apache.org/docs/apache-airflow/"
+                            "stable/core-concepts/tasks.html#zombie-undead-tasks"
+                        ),
+                    )
+                )
+                self.log.error(log_message)
+                self.job.executor.send_callback(request)
+                Stats.incr("zombies_killed", tags={"dag_id": ti.dag_id, "task_id": ti.task_id})
 
     # [END find_zombies]
 

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1660,7 +1660,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     if repr(ti) in cleaned_up_task_instances:
                         session.add(
                             Log(
-                                event="stuck in queued",
+                                event="task stuck in queued",
                                 task_instance=ti.key,
                                 extra=(
                                     "Task will be marked as failed. If the task instance has "

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -843,6 +843,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 )
                 if info is not None:
                     msg += " Extra info: %s" % info  # noqa: RUF100, UP031, flynt
+                self.log.error(msg)
                 session.add(Log(event="state mismatch", extra=msg, task_instance=ti.key))
 
                 # Get task from the Serialized DAG
@@ -1658,6 +1659,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 cleaned_up_task_instances = set(executor.cleanup_stuck_queued_tasks(tis=stuck_tis))
                 for ti in stuck_tis:
                     if repr(ti) in cleaned_up_task_instances:
+                        self.log.warning(
+                            "Marking task instance %s stuck in queued as failed. "
+                            "If the task instance has available retries, it will be retried.",
+                            ti,
+                        )
                         session.add(
                             Log(
                                 event="stuck in queued",

--- a/airflow/models/log.py
+++ b/airflow/models/log.py
@@ -56,10 +56,12 @@ class Log(Base):
 
         task_owner = None
 
+        self.execution_date = None
         if task_instance:
             self.dag_id = task_instance.dag_id
             self.task_id = task_instance.task_id
-            self.execution_date = task_instance.execution_date
+            if hasattr(task_instance, "execution_date"):
+                self.execution_date = task_instance.execution_date
             self.run_id = task_instance.run_id
             self.try_number = task_instance.try_number
             self.map_index = task_instance.map_index

--- a/airflow/providers/amazon/aws/executors/batch/batch_executor.py
+++ b/airflow/providers/amazon/aws/executors/batch/batch_executor.py
@@ -294,7 +294,7 @@ class AwsBatchExecutor(BaseExecutor):
                 if attempt_number >= int(self.__class__.MAX_SUBMIT_JOB_ATTEMPTS):
                     self.log_task_event(
                         record=Log(
-                            event="executor queue failure",
+                            event="batch job submit failure",
                             extra=f"This job has been unsuccessfully attempted too many times ({attempt_number}). "
                             f"Dropping the task. Reason: {failure_reason}",
                             task_instance=key,

--- a/airflow/providers/amazon/aws/executors/ecs/ecs_executor.py
+++ b/airflow/providers/amazon/aws/executors/ecs/ecs_executor.py
@@ -388,7 +388,7 @@ class AwsEcsExecutor(BaseExecutor):
                     reasons_str = ", ".join(failure_reasons)
                     self.log_task_event(
                         record=Log(
-                            event="ecs executor queue error",
+                            event="ecs task submit failure",
                             task_instance=task_key,
                             extra=(
                                 f"Task could not be queued after {attempt_number} attempts. "
@@ -400,7 +400,7 @@ class AwsEcsExecutor(BaseExecutor):
             elif not run_task_response["tasks"]:
                 self.log_task_event(
                     record=Log(
-                        event="ecs runtime error",
+                        event="ecs task submit failure",
                         extra=f"ECS RunTask Response: {run_task_response}",
                         task_instance=task_key,
                     )

--- a/airflow/providers/celery/executors/celery_executor.py
+++ b/airflow/providers/celery/executors/celery_executor.py
@@ -479,6 +479,13 @@ class CeleryExecutor(BaseExecutor):
             ),
         ]
 
+    def log_task_event(self, record: Log):
+        # TODO: remove this method when min_airflow_version is set to higher than 2.10.0
+        try:
+            super().log_task_event(record=record)
+        except AttributeError:
+            self.log.error("Could not log task event; feature only available in Airflow 2.10.0. %s", record)
+
 
 def _get_parser() -> argparse.ArgumentParser:
     """

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1276,7 +1276,7 @@ export interface components {
        */
       execution_date?: string | null;
       /** @description Name of the user who triggered these events a. */
-      owner?: string;
+      owner?: string | null;
       /** @description Other information that was not included in the other fields, e.g. the complete CLI command. */
       extra?: string | null;
     };

--- a/tests/providers/amazon/aws/executors/batch/test_batch_executor.py
+++ b/tests/providers/amazon/aws/executors/batch/test_batch_executor.py
@@ -44,10 +44,11 @@ from airflow.providers.amazon.aws.executors.batch.utils import (
 )
 from airflow.utils.helpers import convert_camel_to_snake
 from airflow.utils.state import State
-from docs.conf import airflow_version
+from airflow.version import version as airflow_version_str
 from tests.conftest import RUNNING_TESTS_AGAINST_AIRFLOW_PACKAGES
 from tests.test_utils.config import conf_vars
 
+airflow_version = VersionInfo(*map(int, airflow_version_str.split(".")[:3]))
 ARN1 = "arn1"
 
 MOCK_JOB_ID = "batch-job-id"
@@ -261,7 +262,7 @@ class TestAwsBatchExecutor:
         mock_executor.attempt_submit_jobs()
         submit_job_args["containerOverrides"]["command"] = airflow_commands[0]
         assert mock_executor.batch.submit_job.call_args_list[5].kwargs == submit_job_args
-        if VersionInfo.parse(str(airflow_version)) >= (2, 10, 0):
+        if airflow_version >= (2, 10, 0):
             log_record = mock_executor._task_event_logs[0]
             assert log_record.event == "batch job submit failure"
 

--- a/tests/providers/amazon/aws/executors/ecs/test_ecs_executor.py
+++ b/tests/providers/amazon/aws/executors/ecs/test_ecs_executor.py
@@ -31,6 +31,7 @@ import pytest
 import yaml
 from botocore.exceptions import ClientError
 from inflection import camelize
+from semver import VersionInfo
 
 from airflow.exceptions import AirflowException
 from airflow.executors.base_executor import BaseExecutor
@@ -54,6 +55,7 @@ from airflow.providers.amazon.aws.hooks.ecs import EcsHook
 from airflow.utils.helpers import convert_camel_to_snake
 from airflow.utils.state import State, TaskInstanceState
 from airflow.utils.timezone import utcnow
+from docs.conf import airflow_version
 from tests.conftest import RUNNING_TESTS_AGAINST_AIRFLOW_PACKAGES
 from tests.test_utils.compat import AIRFLOW_V_2_10_PLUS
 from tests.test_utils.config import conf_vars
@@ -515,11 +517,12 @@ class TestAwsEcsExecutor:
         assert len(mock_executor.active_workers.get_all_arns()) == 0
         assert len(mock_executor.pending_tasks) == 0
 
-        events = [(x.event, x.task_id, x.try_number) for x in mock_executor._task_event_logs]
-        assert events == [
-            ("ecs task submit failure", "task_a", 1),
-            ("ecs task submit failure", "task_b", 1),
-        ]
+        if VersionInfo.parse(str(airflow_version)) >= (2, 10, 0):
+            events = [(x.event, x.task_id, x.try_number) for x in mock_executor._task_event_logs]
+            assert events == [
+                ("ecs task submit failure", "task_a", 1),
+                ("ecs task submit failure", "task_b", 1),
+            ]
 
     @mock.patch.object(ecs_executor, "calculate_next_attempt_delay", return_value=dt.timedelta(seconds=0))
     def test_attempt_task_runs_attempts_when_some_tasks_fal(self, _, mock_executor):
@@ -596,11 +599,13 @@ class TestAwsEcsExecutor:
 
         RUN_TASK_KWARGS["overrides"]["containerOverrides"][0]["command"] = airflow_commands[0]
         assert mock_executor.ecs.run_task.call_args_list[0].kwargs == RUN_TASK_KWARGS
-        events = [(x.event, x.task_id, x.try_number) for x in mock_executor._task_event_logs]
-        assert events == [
-            ("ecs task submit failure", "task_a", 1),
-            ("ecs task submit failure", "task_b", 1),
-        ]
+
+        if VersionInfo.parse(str(airflow_version)) >= (2, 10, 0):
+            events = [(x.event, x.task_id, x.try_number) for x in mock_executor._task_event_logs]
+            assert events == [
+                ("ecs task submit failure", "task_a", 1),
+                ("ecs task submit failure", "task_b", 1),
+            ]
 
     @mock.patch.object(ecs_executor, "calculate_next_attempt_delay", return_value=dt.timedelta(seconds=0))
     def test_task_retry_on_api_failure_all_tasks_fail(self, _, mock_executor, caplog):

--- a/tests/providers/amazon/aws/executors/ecs/test_ecs_executor.py
+++ b/tests/providers/amazon/aws/executors/ecs/test_ecs_executor.py
@@ -25,7 +25,7 @@ import time
 from functools import partial
 from typing import Callable
 from unittest import mock
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock
 
 import pytest
 import yaml
@@ -462,11 +462,8 @@ class TestAwsEcsExecutor:
             # Task is not stored in active workers.
             assert len(mock_executor.active_workers) == 0
 
-    @mock.patch.object(AwsEcsExecutor, "send_message_to_task_logs")
     @mock.patch.object(ecs_executor, "calculate_next_attempt_delay", return_value=dt.timedelta(seconds=0))
-    def test_attempt_task_runs_attempts_when_tasks_fail(
-        self, _, mock_send_message_to_task_logs, mock_executor
-    ):
+    def test_attempt_task_runs_attempts_when_tasks_fail(self, _, mock_executor):
         """
         Test case when all tasks fail to run.
 
@@ -474,7 +471,10 @@ class TestAwsEcsExecutor:
         It should preserve the order of tasks, and attempt each task up to
         `MAX_RUN_TASK_ATTEMPTS` times before dropping the task.
         """
-        airflow_keys = [mock.Mock(spec=tuple), mock.Mock(spec=tuple)]
+        airflow_keys = [
+            TaskInstanceKey("a", "task_a", "c", 1, -1),
+            TaskInstanceKey("a", "task_b", "c", 1, -1),
+        ]
         airflow_cmd1 = mock.Mock(spec=list)
         airflow_cmd2 = mock.Mock(spec=list)
         commands = [airflow_cmd1, airflow_cmd2]
@@ -515,25 +515,14 @@ class TestAwsEcsExecutor:
         assert len(mock_executor.active_workers.get_all_arns()) == 0
         assert len(mock_executor.pending_tasks) == 0
 
-        calls = []
-        for i in range(2):
-            calls.append(
-                call(
-                    logging.ERROR,
-                    "ECS task %s has failed a maximum of %s times. Marking as failed. Reasons: %s",
-                    airflow_keys[i],
-                    3,
-                    f"Failure {i + 1}",
-                    ti=airflow_keys[i],
-                )
-            )
-        mock_send_message_to_task_logs.assert_has_calls(calls)
+        events = [(x.event, x.task_id, x.try_number) for x in mock_executor._task_event_logs]
+        assert events == [
+            ("ecs task submit failure", "task_a", 1),
+            ("ecs task submit failure", "task_b", 1),
+        ]
 
-    @mock.patch.object(AwsEcsExecutor, "send_message_to_task_logs")
     @mock.patch.object(ecs_executor, "calculate_next_attempt_delay", return_value=dt.timedelta(seconds=0))
-    def test_attempt_task_runs_attempts_when_some_tasks_fal(
-        self, _, mock_send_message_to_task_logs, mock_executor
-    ):
+    def test_attempt_task_runs_attempts_when_some_tasks_fal(self, _, mock_executor):
         """
         Test case when one task fail to run, and a new task gets queued.
 
@@ -542,7 +531,10 @@ class TestAwsEcsExecutor:
         `MAX_RUN_TASK_ATTEMPTS` times before dropping the task. If a task succeeds, the task
         should be removed from pending_jobs and into active_workers.
         """
-        airflow_keys = [mock.Mock(spec=tuple), mock.Mock(spec=tuple)]
+        airflow_keys = [
+            TaskInstanceKey("a", "task_a", "c", 1, -1),
+            TaskInstanceKey("a", "task_b", "c", 1, -1),
+        ]
         airflow_cmd1 = mock.Mock(spec=list)
         airflow_cmd2 = mock.Mock(spec=list)
         airflow_commands = [airflow_cmd1, airflow_cmd2]
@@ -604,15 +596,11 @@ class TestAwsEcsExecutor:
 
         RUN_TASK_KWARGS["overrides"]["containerOverrides"][0]["command"] = airflow_commands[0]
         assert mock_executor.ecs.run_task.call_args_list[0].kwargs == RUN_TASK_KWARGS
-
-        mock_send_message_to_task_logs.assert_called_once_with(
-            logging.ERROR,
-            "ECS task %s has failed a maximum of %s times. Marking as failed. Reasons: %s",
-            airflow_keys[0],
-            3,
-            "Failure 1",
-            ti=airflow_keys[0],
-        )
+        events = [(x.event, x.task_id, x.try_number) for x in mock_executor._task_event_logs]
+        assert events == [
+            ("ecs task submit failure", "task_a", 1),
+            ("ecs task submit failure", "task_b", 1),
+        ]
 
     @mock.patch.object(ecs_executor, "calculate_next_attempt_delay", return_value=dt.timedelta(seconds=0))
     def test_task_retry_on_api_failure_all_tasks_fail(self, _, mock_executor, caplog):


### PR DESCRIPTION
Shipping messages to TI logs, which unfortunately in many cases means uploading to s3, is inefficient, and not really something the scheduler should be doing.

Instead we can use an old but underutilized feature: the Log table.

I have to do some trickery to save log events from executors, namely store them in a queue and consume them in the scheduler loop.