### PR TITLE
Mark db tests for tests introduced in PR #40724 for the Databricks Plugin

### DIFF
--- a/tests/providers/databricks/plugins/test_databricks_workflow.py
+++ b/tests/providers/databricks/plugins/test_databricks_workflow.py
@@ -126,6 +126,7 @@ def app():
         yield app
 
 
+@pytest.mark.db_test
 def test_get_task_instance(app):
     with app.app_context():
         operator = Mock()
@@ -143,6 +144,7 @@ def test_get_task_instance(app):
             assert result == dag_run
 
 
+@pytest.mark.db_test
 def test_workflow_job_run_link(app):
     with app.app_context():
         link = WorkflowJobRunLink()
@@ -177,6 +179,7 @@ def test_workflow_job_run_link(app):
                         assert "https://mockhost/#job/1/run/1" in result
 
 
+@pytest.mark.db_test
 def test_workflow_job_repair_single_failed_link(app):
     with app.app_context():
         link = WorkflowJobRepairSingleTaskLink()


### PR DESCRIPTION
Mark the required tests introduced in #40724 as db tests.
They seem to be failing otherwise as observed in PR #40864.


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
