### PR TITLE
Fix `RedshiftCreateClusterOperator` to always specify `PubliclyAccessible`

### DIFF
--- a/airflow/providers/amazon/aws/operators/redshift_cluster.py
+++ b/airflow/providers/amazon/aws/operators/redshift_cluster.py
@@ -256,8 +256,6 @@ class RedshiftCreateClusterOperator(BaseOperator):
             params["ClusterVersion"] = self.cluster_version
         if self.allow_version_upgrade:
             params["AllowVersionUpgrade"] = self.allow_version_upgrade
-        if self.publicly_accessible:
-            params["PubliclyAccessible"] = self.publicly_accessible
         if self.encrypted:
             params["Encrypted"] = self.encrypted
         if self.hsm_client_certificate_identifier:
@@ -286,6 +284,8 @@ class RedshiftCreateClusterOperator(BaseOperator):
             params["AquaConfigurationStatus"] = self.aqua_configuration_status
         if self.default_iam_role_arn:
             params["DefaultIamRoleArn"] = self.default_iam_role_arn
+
+        params["PubliclyAccessible"] = self.publicly_accessible
 
         cluster = redshift_hook.create_cluster(
             self.cluster_identifier,

--- a/airflow/providers/amazon/aws/operators/redshift_cluster.py
+++ b/airflow/providers/amazon/aws/operators/redshift_cluster.py
@@ -285,6 +285,8 @@ class RedshiftCreateClusterOperator(BaseOperator):
         if self.default_iam_role_arn:
             params["DefaultIamRoleArn"] = self.default_iam_role_arn
 
+        # PubliclyAccessible is True by default on Redshift side, hence, we should always set it regardless
+        # of its value
         params["PubliclyAccessible"] = self.publicly_accessible
 
         cluster = redshift_hook.create_cluster(


### PR DESCRIPTION
`PubliclyAccessible` needs to be always specified because the default value (if not provided) is `True` on `Redshift` service side

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
