### PR TITLE
Remove the Experimental flag from OTel Traces

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -119,12 +119,6 @@
       <a href={{ get_docs_url("executor/index.html") }}  target="_blank" rel="noopener noreferrer"><b>Click here</b></a> for more information.
     {% endcall %}
   {% endif %}
-  {% if otel_traces_on | default(false) %}
-    {% call show_message(category='warning', dismissible=false) %}
-      OpenTelemetry tracing support is experimental. <a href="https://github.com/apache/airflow/blob/main/dev/breeze/doc/03_developer_tasks.rst#running-breeze-with-an-opentelemetry-stack" target="_blank" rel="noopener noreferrer">
-        <b>Click here</b></a> for more information.
-    {% endcall %}
-  {% endif %}
 {% endblock %}
 
 {% block content %}

--- a/newsfragments/40874.significant.rst
+++ b/newsfragments/40874.significant.rst
@@ -1,0 +1,1 @@
+Support for OpenTelemetry Traces is no longer "Experimental"


### PR DESCRIPTION
Per discussion on Slack and lazy consensus [here](https://lists.apache.org/thread/oqylmv1jf3yqq0kht1nsrwqqroy728nf), this banner shouldn't have been implemented so we're removing it.

~I'll add a newsfragment once I get a PR number~
