### PR TITLE
Fix tasks API endpoint when DAG doesn't have `start_date`

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -4070,6 +4070,7 @@ components:
           type: string
           format: "date-time"
           readOnly: true
+          nullable: true
         end_date:
           type: string
           format: "date-time"

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1684,7 +1684,7 @@ export interface components {
       task_display_name?: string;
       owner?: string;
       /** Format: date-time */
-      start_date?: string;
+      start_date?: string | null;
       /** Format: date-time */
       end_date?: string | null;
       trigger_rule?: components["schemas"]["TriggerRule"];


### PR DESCRIPTION
`start_date` is now optional, if there is no schedule for the DAG (#35356). Tasks, however, inherit the `start_date` of their DAG by default. So it's now possible for tasks to have no `start_date` as well.

Closes: #40828

I chose not to add a test for this case, but if someone feels strongly that I should, I can.