### PR TITLE
Add Tasks API endpoint tests for DAG without start_date

### DIFF
--- a/tests/api_connexion/endpoints/test_task_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_endpoint.py
@@ -58,10 +58,13 @@ def configured_app(minimal_app_for_api):
 class TestTaskEndpoint:
     dag_id = "test_dag"
     mapped_dag_id = "test_mapped_task"
+    unscheduled_dag_id = "test_unscheduled_dag"
     task_id = "op1"
     task_id2 = "op2"
     task_id3 = "op3"
     mapped_task_id = "mapped_task"
+    unscheduled_task_id1 = "unscheduled_task_1"
+    unscheduled_task_id2 = "unscheduled_task_2"
     task1_start_date = datetime(2020, 6, 15)
     task2_start_date = datetime(2020, 6, 16)
 
@@ -77,9 +80,18 @@ class TestTaskEndpoint:
             # We don't care about how the operator runs here, only its presence.
             EmptyOperator.partial(task_id=self.mapped_task_id)._expand(EXPAND_INPUT_EMPTY, strict=False)
 
+        with DAG(self.unscheduled_dag_id, start_date=None, schedule=None) as unscheduled_dag:
+            task4 = EmptyOperator(task_id=self.unscheduled_task_id1, params={"is_unscheduled": True})
+            task5 = EmptyOperator(task_id=self.unscheduled_task_id2, params={"is_unscheduled": True})
+
         task1 >> task2
+        task4 >> task5
         dag_bag = DagBag(os.devnull, include_examples=False)
-        dag_bag.dags = {dag.dag_id: dag, mapped_dag.dag_id: mapped_dag}
+        dag_bag.dags = {
+            dag.dag_id: dag,
+            mapped_dag.dag_id: mapped_dag,
+            unscheduled_dag.dag_id: unscheduled_dag,
+        }
         configured_app.dag_bag = dag_bag  # type:ignore
 
     @staticmethod
@@ -181,6 +193,61 @@ class TestGetTask(TestTaskEndpoint):
         )
         assert response.status_code == 200
         assert response.json == expected
+
+    def test_unscheduled_task(self):
+        expected = {
+            "class_ref": {
+                "class_name": "EmptyOperator",
+                "module_path": "airflow.operators.empty",
+            },
+            "depends_on_past": False,
+            "downstream_task_ids": [],
+            "end_date": None,
+            "execution_timeout": None,
+            "extra_links": [],
+            "operator_name": "EmptyOperator",
+            "owner": "airflow",
+            "params": {
+                "is_unscheduled": {
+                    "__class": "airflow.models.param.Param",
+                    "value": True,
+                    "description": None,
+                    "schema": {},
+                }
+            },
+            "pool": "default_pool",
+            "pool_slots": 1.0,
+            "priority_weight": 1.0,
+            "queue": "default",
+            "retries": 0.0,
+            "retry_delay": {"__type": "TimeDelta", "days": 0, "seconds": 300, "microseconds": 0},
+            "retry_exponential_backoff": False,
+            "start_date": None,
+            "task_id": None,
+            "task_display_name": None,
+            "template_fields": [],
+            "trigger_rule": "all_success",
+            "ui_color": "#e8f7e4",
+            "ui_fgcolor": "#000",
+            "wait_for_downstream": False,
+            "weight_rule": "downstream",
+            "is_mapped": False,
+            "doc_md": None,
+        }
+        downstream_dict = {
+            self.unscheduled_task_id1: self.unscheduled_task_id2,
+            self.unscheduled_task_id2: None,
+        }
+        for task_id, downstream_task_id in downstream_dict.items():
+            response = self.client.get(
+                f"/api/v1/dags/{self.unscheduled_dag_id}/tasks/{task_id}",
+                environ_overrides={"REMOTE_USER": "test"},
+            )
+            assert response.status_code == 200
+            expected["downstream_task_ids"] = [downstream_task_id] if downstream_task_id else []
+            expected["task_id"] = task_id
+            expected["task_display_name"] = task_id
+            assert response.json == expected
 
     def test_should_respond_200_serialized(self):
         # Get the dag out of the dagbag before we patch it to an empty one
@@ -416,6 +483,62 @@ class TestGetTasks(TestTaskEndpoint):
         }
         response = self.client.get(
             f"/api/v1/dags/{self.mapped_dag_id}/tasks", environ_overrides={"REMOTE_USER": "test"}
+        )
+        assert response.status_code == 200
+        assert response.json == expected
+
+    def test_get_unscheduled_tasks(self):
+        downstream_dict = {
+            self.unscheduled_task_id1: self.unscheduled_task_id2,
+            self.unscheduled_task_id2: None,
+        }
+        expected = {
+            "tasks": [
+                {
+                    "class_ref": {
+                        "class_name": "EmptyOperator",
+                        "module_path": "airflow.operators.empty",
+                    },
+                    "depends_on_past": False,
+                    "downstream_task_ids": [downstream_task_id] if downstream_task_id else [],
+                    "end_date": None,
+                    "execution_timeout": None,
+                    "extra_links": [],
+                    "operator_name": "EmptyOperator",
+                    "owner": "airflow",
+                    "params": {
+                        "is_unscheduled": {
+                            "__class": "airflow.models.param.Param",
+                            "value": True,
+                            "description": None,
+                            "schema": {},
+                        }
+                    },
+                    "pool": "default_pool",
+                    "pool_slots": 1.0,
+                    "priority_weight": 1.0,
+                    "queue": "default",
+                    "retries": 0.0,
+                    "retry_delay": {"__type": "TimeDelta", "days": 0, "seconds": 300, "microseconds": 0},
+                    "retry_exponential_backoff": False,
+                    "start_date": None,
+                    "task_id": task_id,
+                    "task_display_name": task_id,
+                    "template_fields": [],
+                    "trigger_rule": "all_success",
+                    "ui_color": "#e8f7e4",
+                    "ui_fgcolor": "#000",
+                    "wait_for_downstream": False,
+                    "weight_rule": "downstream",
+                    "is_mapped": False,
+                    "doc_md": None,
+                }
+                for (task_id, downstream_task_id) in downstream_dict.items()
+            ],
+            "total_entries": len(downstream_dict),
+        }
+        response = self.client.get(
+            f"/api/v1/dags/{self.unscheduled_dag_id}/tasks", environ_overrides={"REMOTE_USER": "test"}
         )
         assert response.status_code == 200
         assert response.json == expected


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

related: https://github.com/apache/airflow/issues/40828

<!-- Please keep an empty line above the dashes. -->

---

This PR adds tests to cover Tasks API endpoint cases where the DAG doesn't have a `start_date` and is defined with `schedule=None` (it's unscheduled). Tests in this PR support the fix in https://github.com/apache/airflow/pull/40878.

~~Additionally, this PR fixes the `Provider` KeyError that occurs in breeze selective checks for API tests as mentioned in the [comment below](https://github.com/apache/airflow/pull/40881#issuecomment-2238570589).~~ **Update:** This is fixed in https://github.com/apache/airflow/pull/40904.

<!--
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
-->