### PR TITLE
Use clearer event naming for UI task instance actions

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2373,7 +2373,7 @@ class Airflow(AirflowBaseView):
 
     @expose("/clear", methods=["POST"])
     @auth.has_access_dag("PUT", DagAccessEntity.TASK_INSTANCE)
-    @action_logging(event="marked cleared")
+    @action_logging(event="cleared")
     @provide_session
     def clear(self, *, session: Session = NEW_SESSION):
         """Clear DAG tasks."""

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2373,7 +2373,7 @@ class Airflow(AirflowBaseView):
 
     @expose("/clear", methods=["POST"])
     @auth.has_access_dag("PUT", DagAccessEntity.TASK_INSTANCE)
-    @action_logging
+    @action_logging(event="marked cleared")
     @provide_session
     def clear(self, *, session: Session = NEW_SESSION):
         """Clear DAG tasks."""
@@ -2805,7 +2805,7 @@ class Airflow(AirflowBaseView):
 
     @expose("/failed", methods=["POST"])
     @auth.has_access_dag("PUT", DagAccessEntity.TASK_INSTANCE)
-    @action_logging
+    @action_logging(event="marked failed")
     def failed(self):
         """Mark task or task_group as failed."""
         args = request.form
@@ -2856,7 +2856,7 @@ class Airflow(AirflowBaseView):
 
     @expose("/success", methods=["POST"])
     @auth.has_access_dag("PUT", DagAccessEntity.TASK_INSTANCE)
-    @action_logging
+    @action_logging(event="marked success")
     def success(self):
         """Mark task or task_group as success."""
         args = request.form


### PR DESCRIPTION
This makes it a little clearer to the user what actually happened.  Here is an example

<img width="870" alt="image" src="https://github.com/user-attachments/assets/21f144a1-17ea-4ca9-88cc-3fc30add3605">

See there it says "marked cleared" instead of just `clear`.

