### PR TITLE
Add support for basic authentication on internal API client

### DIFF
--- a/airflow/api_internal/internal_api_call.py
+++ b/airflow/api_internal/internal_api_call.py
@@ -21,16 +21,20 @@ import inspect
 import json
 import logging
 from functools import wraps
-from typing import Callable, TypeVar
+from typing import TYPE_CHECKING, Callable, TypeVar
 
 import requests
 import tenacity
+from requests.auth import HTTPBasicAuth
 from urllib3.exceptions import NewConnectionError
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException, AirflowException
 from airflow.settings import _ENABLE_AIP_44
 from airflow.typing_compat import ParamSpec
+
+if TYPE_CHECKING:
+    from requests.auth import AuthBase
 
 PS = ParamSpec("PS")
 RT = TypeVar("RT")
@@ -44,6 +48,7 @@ class InternalApiConfig:
     _initialized = False
     _use_internal_api = False
     _internal_api_endpoint = ""
+    _internal_api_auth: AuthBase | None = None
 
     @staticmethod
     def force_database_direct_access():
@@ -69,20 +74,30 @@ class InternalApiConfig:
         return InternalApiConfig._internal_api_endpoint
 
     @staticmethod
+    def get_auth() -> AuthBase | None:
+        return InternalApiConfig._internal_api_auth
+
+    @staticmethod
     def _init_values():
         use_internal_api = conf.getboolean("core", "database_access_isolation", fallback=False)
         if use_internal_api and not _ENABLE_AIP_44:
             raise RuntimeError("The AIP_44 is not enabled so you cannot use it.")
-        internal_api_endpoint = ""
         if use_internal_api:
-            internal_api_url = conf.get("core", "internal_api_url")
-            internal_api_endpoint = internal_api_url + "/internal_api/v1/rpcapi"
-            if not internal_api_endpoint.startswith("http://"):
-                raise AirflowConfigException("[core]internal_api_url must start with http://")
+            internal_api_endpoint = conf.get("core", "internal_api_url")
+            if internal_api_endpoint.find("/", 8) == -1:
+                internal_api_endpoint = internal_api_endpoint + "/internal_api/v1/rpcapi"
+            if not internal_api_endpoint.startswith("http://") and not internal_api_endpoint.startswith(
+                "https://"
+            ):
+                raise AirflowConfigException("[core]internal_api_url must start with http:// or https://")
+            InternalApiConfig._internal_api_endpoint = internal_api_endpoint
+            internal_api_user = conf.get("core", "internal_api_user")
+            internal_api_password = conf.get("core", "internal_api_password")
+            if internal_api_user and internal_api_password:
+                InternalApiConfig._internal_api_auth = HTTPBasicAuth(internal_api_user, internal_api_password)
 
         InternalApiConfig._initialized = True
         InternalApiConfig._use_internal_api = use_internal_api
-        InternalApiConfig._internal_api_endpoint = internal_api_endpoint
 
 
 def internal_api_call(func: Callable[PS, RT]) -> Callable[PS, RT]:
@@ -112,7 +127,8 @@ def internal_api_call(func: Callable[PS, RT]) -> Callable[PS, RT]:
     def make_jsonrpc_request(method_name: str, params_json: str) -> bytes:
         data = {"jsonrpc": "2.0", "method": method_name, "params": params_json}
         internal_api_endpoint = InternalApiConfig.get_internal_api_endpoint()
-        response = requests.post(url=internal_api_endpoint, data=json.dumps(data), headers=headers)
+        auth = InternalApiConfig.get_auth()
+        response = requests.post(url=internal_api_endpoint, data=json.dumps(data), headers=headers, auth=auth)
         if response.status_code != 200:
             raise AirflowException(
                 f"Got {response.status_code}:{response.reason} when sending "

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -513,6 +513,22 @@ core:
       type: string
       default: ~
       example: 'http://localhost:8080'
+    internal_api_user:
+      description: |
+        (experimental) If internal API is access-protected the user name for basic authentication.
+      version_added: 2.10.0
+      type: string
+      default: ~
+      example: 'api_user'
+    internal_api_password:
+      description: |
+        (experimental) If internal API is access-protected the password for basic authentication.
+        Note: we expect not to hard-code the password but recommend starting the processes via an env
+        ``AIRFLOW__CORE__INTERNAL_API_PASSWORD``.
+      version_added: 2.10.0
+      type: string
+      default: ~
+      example: 'i_willKeep!thisSecret4All?'
     test_connection:
       description: |
         The ability to allow testing connections across Airflow UI, API and CLI.


### PR DESCRIPTION
During the implementation of authentication protection for AIP-69 I realized that Internal API does not carry support for authentication access.

This PR adds support on the client side with HTTP Basic Authentication. Alongside with the option to define a different access URL to call the back-end.