### PR TITLE
Feature/add token authentication to internal api

### DIFF
--- a/airflow/api_internal/endpoints/rpc_api_endpoint.py
+++ b/airflow/api_internal/endpoints/rpc_api_endpoint.py
@@ -23,16 +23,24 @@ import logging
 from typing import TYPE_CHECKING, Any, Callable
 from uuid import uuid4
 
-from flask import Response
-from itsdangerous import BadSignature, URLSafeSerializer
+from flask import Response, request
+from itsdangerous import BadSignature
+from jwt import (
+    ExpiredSignatureError,
+    ImmatureSignatureError,
+    InvalidAudienceError,
+    InvalidIssuedAtError,
+    InvalidSignatureError,
+)
 
-from airflow.api_connexion.exceptions import BadRequest
+from airflow.api_connexion.exceptions import PermissionDenied
+from airflow.configuration import conf
 from airflow.jobs.job import Job, most_recent_job
 from airflow.models.taskinstance import _record_task_map_for_downstreams
 from airflow.models.xcom_arg import _get_task_map_length
 from airflow.sensors.base import _orig_start_date
 from airflow.serialization.serialized_objects import BaseSerialization
-from airflow.utils.airflow_flask_app import get_airflow_app
+from airflow.utils.jwt_signer import JWTSigner
 from airflow.utils.session import create_session
 
 if TYPE_CHECKING:
@@ -145,14 +153,39 @@ def log_and_build_error_response(message, status):
 
 def internal_airflow_api(body: dict[str, Any]) -> APIResponse:
     """Handle Internal API /internal_api/v1/rpcapi endpoint."""
-    key = get_airflow_app().config["SECRET_KEY"]
-    token = str(body.get("token"))
+    auth = request.headers.get("Authorization", "")
+    signer = JWTSigner(
+        secret_key=conf.get("webserver", "secret_key"),
+        expiration_time_in_seconds=conf.getint("webserver", "internal_api_clock_grace", fallback=30),
+        audience="api",
+    )
     try:
-        caller_name = URLSafeSerializer(key).loads(token)
+        payload = signer.verify_token(auth)
+        signed_method = payload.get("method")
+        if not signed_method or signed_method != body.get("method"):
+            raise BadSignature("Invalid method in token authorization.")
     except BadSignature:
-        raise BadRequest("Bad Signature. Please use only the tokens provided by the API.")
+        raise PermissionDenied("Bad Signature. Please use only the tokens provided by the API.")
+    except InvalidAudienceError:
+        raise PermissionDenied("Invalid audience for the request", exc_info=True)
+    except InvalidSignatureError:
+        raise PermissionDenied("The signature of the request was wrong", exc_info=True)
+    except ImmatureSignatureError:
+        raise PermissionDenied("The signature of the request was sent from the future", exc_info=True)
+    except ExpiredSignatureError:
+        raise PermissionDenied(
+            "The signature of the request has expired. Make sure that all components "
+            "in your system have synchronized clocks.",
+        )
+    except InvalidIssuedAtError:
+        raise PermissionDenied(
+            "The request was issues in the future. Make sure that all components "
+            "in your system have synchronized clocks.",
+        )
+    except Exception:
+        raise PermissionDenied("Unable to authenticate API via token.")
 
-    log.debug("Got request from %s", caller_name)
+    log.debug("Got request")
     json_rpc = body.get("jsonrpc")
     if json_rpc != "2.0":
         return log_and_build_error_response(message="Expected jsonrpc 2.0 request.", status=400)

--- a/airflow/api_internal/endpoints/rpc_api_endpoint.py
+++ b/airflow/api_internal/endpoints/rpc_api_endpoint.py
@@ -155,8 +155,8 @@ def internal_airflow_api(body: dict[str, Any]) -> APIResponse:
     """Handle Internal API /internal_api/v1/rpcapi endpoint."""
     auth = request.headers.get("Authorization", "")
     signer = JWTSigner(
-        secret_key=conf.get("webserver", "secret_key"),
-        expiration_time_in_seconds=conf.getint("webserver", "internal_api_clock_grace", fallback=30),
+        secret_key=conf.get("core", "internal_api_secret_key"),
+        expiration_time_in_seconds=conf.getint("core", "internal_api_clock_grace", fallback=30),
         audience="api",
     )
     try:

--- a/airflow/api_internal/internal_api_call.py
+++ b/airflow/api_internal/internal_api_call.py
@@ -128,8 +128,8 @@ def internal_api_call(func: Callable[PS, RT]) -> Callable[PS, RT]:
     )
     def make_jsonrpc_request(method_name: str, params_json: str) -> bytes:
         signer = JWTSigner(
-            secret_key=conf.get("webserver", "secret_key"),
-            expiration_time_in_seconds=conf.getint("webserver", "internal_api_clock_grace", fallback=30),
+            secret_key=conf.get("core", "internal_api_secret_key"),
+            expiration_time_in_seconds=conf.getint("core", "internal_api_clock_grace", fallback=30),
             audience="api",
         )
         headers = {

--- a/airflow/api_internal/internal_api_call.py
+++ b/airflow/api_internal/internal_api_call.py
@@ -26,13 +26,13 @@ from urllib.parse import urlparse
 
 import requests
 import tenacity
-from itsdangerous import URLSafeSerializer
 from urllib3.exceptions import NewConnectionError
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException, AirflowException
 from airflow.settings import _ENABLE_AIP_44
 from airflow.typing_compat import ParamSpec
+from airflow.utils.jwt_signer import JWTSigner
 
 PS = ParamSpec("PS")
 RT = TypeVar("RT")
@@ -118,9 +118,6 @@ def internal_api_call(func: Callable[PS, RT]) -> Callable[PS, RT]:
     See [AIP-44](https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-44+Airflow+Internal+API)
     for more information .
     """
-    headers = {
-        "Content-Type": "application/json",
-    }
     from requests.exceptions import ConnectionError
 
     @tenacity.retry(
@@ -130,9 +127,16 @@ def internal_api_call(func: Callable[PS, RT]) -> Callable[PS, RT]:
         before_sleep=tenacity.before_log(logger, logging.WARNING),
     )
     def make_jsonrpc_request(method_name: str, params_json: str) -> bytes:
-        key = conf.get("webserver", "secret_key")
-        token = URLSafeSerializer(key).dumps("Internal API")
-        data = {"jsonrpc": "2.0", "method": method_name, "params": params_json, "token": token}
+        signer = JWTSigner(
+            secret_key=conf.get("webserver", "secret_key"),
+            expiration_time_in_seconds=conf.getint("webserver", "internal_api_clock_grace", fallback=30),
+            audience="api",
+        )
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": signer.generate_signed_token({"method": method_name}),
+        }
+        data = {"jsonrpc": "2.0", "method": method_name, "params": params_json}
         internal_api_endpoint = InternalApiConfig.get_internal_api_endpoint()
         response = requests.post(url=internal_api_endpoint, data=json.dumps(data), headers=headers)
         if response.status_code != 200:

--- a/airflow/api_internal/openapi/internal_api_v1.yaml
+++ b/airflow/api_internal/openapi/internal_api_v1.yaml
@@ -36,7 +36,6 @@ servers:
 paths:
   "/rpcapi":
     post:
-      operationId: rpcapi
       deprecated: false
       x-openapi-router-controller: airflow.api_internal.endpoints.rpc_api_endpoint
       operationId: internal_airflow_api

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -513,6 +513,19 @@ core:
       type: string
       default: ~
       example: 'http://localhost:8080'
+    internal_api_secret_key:
+      description: |
+        Secret key used authenticate internal API clients to core. It should be as random as possible.
+        However, when running more than 1 instances of webserver / internal API services, make sure all
+        of them use the same ``secret_key`` otherwise calls will fail on authentication.
+        The authentication token generated using the secret key has a short expiry time though - make
+        sure that time on ALL the machines that you run airflow components on is synchronized
+        (for example using ntpd) otherwise you might get "forbidden" errors when the logs are accessed.
+      version_added: 2.10.0
+      type: string
+      sensitive: true
+      example: ~
+      default: "{SECRET_KEY}"
     test_connection:
       description: |
         The ability to allow testing connections across Airflow UI, API and CLI.

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -515,7 +515,7 @@ core:
       example: 'http://localhost:8080'
     internal_api_secret_key:
       description: |
-        Secret key used authenticate internal API clients to core. It should be as random as possible.
+        Secret key used to authenticate internal API clients to core. It should be as random as possible.
         However, when running more than 1 instances of webserver / internal API services, make sure all
         of them use the same ``secret_key`` otherwise calls will fail on authentication.
         The authentication token generated using the secret key has a short expiry time though - make

--- a/tests/api_internal/test_internal_api_call.py
+++ b/tests/api_internal/test_internal_api_call.py
@@ -138,11 +138,12 @@ class TestInternalApiCall:
                 "params": BaseSerialization.serialize({}),
             }
         )
-        mock_requests.post.assert_called_once_with(
-            url="http://localhost:8888/internal_api/v1/rpcapi",
-            data=expected_data,
-            headers={"Content-Type": "application/json"},
-        )
+        mock_requests.post.assert_called_once()
+        call_kwargs: dict = mock_requests.post.call_args.kwargs
+        assert call_kwargs["url"] == "http://localhost:8888/internal_api/v1/rpcapi"
+        assert call_kwargs["data"] == expected_data
+        assert call_kwargs["headers"]["Content-Type"] == "application/json"
+        assert "Authorization" in call_kwargs["headers"]
 
     @conf_vars(
         {
@@ -192,11 +193,12 @@ class TestInternalApiCall:
                 ),
             }
         )
-        mock_requests.post.assert_called_once_with(
-            url="http://localhost:8888/internal_api/v1/rpcapi",
-            data=expected_data,
-            headers={"Content-Type": "application/json"},
-        )
+        mock_requests.post.assert_called_once()
+        call_kwargs: dict = mock_requests.post.call_args.kwargs
+        assert call_kwargs["url"] == "http://localhost:8888/internal_api/v1/rpcapi"
+        assert call_kwargs["data"] == expected_data
+        assert call_kwargs["headers"]["Content-Type"] == "application/json"
+        assert "Authorization" in call_kwargs["headers"]
 
     @conf_vars(
         {
@@ -228,11 +230,12 @@ class TestInternalApiCall:
                 ),
             }
         )
-        mock_requests.post.assert_called_once_with(
-            url="http://localhost:8888/internal_api/v1/rpcapi",
-            data=expected_data,
-            headers={"Content-Type": "application/json"},
-        )
+        mock_requests.post.assert_called_once()
+        call_kwargs: dict = mock_requests.post.call_args.kwargs
+        assert call_kwargs["url"] == "http://localhost:8888/internal_api/v1/rpcapi"
+        assert call_kwargs["data"] == expected_data
+        assert call_kwargs["headers"]["Content-Type"] == "application/json"
+        assert "Authorization" in call_kwargs["headers"]
 
     @conf_vars(
         {
@@ -261,8 +264,9 @@ class TestInternalApiCall:
                 "params": BaseSerialization.serialize({"ti": ti}, use_pydantic_models=True),
             }
         )
-        mock_requests.post.assert_called_once_with(
-            url="http://localhost:8888/internal_api/v1/rpcapi",
-            data=expected_data,
-            headers={"Content-Type": "application/json"},
-        )
+        mock_requests.post.assert_called_once()
+        call_kwargs: dict = mock_requests.post.call_args.kwargs
+        assert call_kwargs["url"] == "http://localhost:8888/internal_api/v1/rpcapi"
+        assert call_kwargs["data"] == expected_data
+        assert call_kwargs["headers"]["Content-Type"] == "application/json"
+        assert "Authorization" in call_kwargs["headers"]

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -1623,6 +1623,7 @@ def test_sensitive_values():
     sensitive_values = {
         ("database", "sql_alchemy_conn"),
         ("core", "fernet_key"),
+        ("core", "internal_api_secret_key"),
         ("smtp", "smtp_password"),
         ("webserver", "secret_key"),
         ("secrets", "backend_kwargs"),


### PR DESCRIPTION
During the implementation of authentication protection for AIP-69 I realized that Internal API does not carry support for authentication access.

Due to review of #40897 - alternative PR using token authentication on internal API

Noteworthy: Compared to other use I just added the token to the JSON request body dict, thought this is "simpler" than adding a POST/request parameter to the call, API is internal anyway.