### PR TITLE
Have integration points for AIP-69 in Internal API

### DIFF
--- a/airflow/api_internal/endpoints/rpc_api_endpoint.py
+++ b/airflow/api_internal/endpoints/rpc_api_endpoint.py
@@ -39,7 +39,7 @@ log = logging.getLogger(__name__)
 
 
 @functools.lru_cache
-def _initialize_map() -> dict[str, Callable]:
+def initialize_method_map() -> dict[str, Callable]:
     from airflow.cli.commands.task_command import _get_ti_db_access
     from airflow.dag_processing.manager import DagFileProcessorManager
     from airflow.dag_processing.processor import DagFileProcessor
@@ -148,7 +148,7 @@ def internal_airflow_api(body: dict[str, Any]) -> APIResponse:
     if json_rpc != "2.0":
         return log_and_build_error_response(message="Expected jsonrpc 2.0 request.", status=400)
 
-    methods_map = _initialize_map()
+    methods_map = initialize_method_map()
     method_name = body.get("method")
     if method_name not in methods_map:
         return log_and_build_error_response(message=f"Unrecognized method: {method_name}.", status=400)

--- a/airflow/api_internal/internal_api_call.py
+++ b/airflow/api_internal/internal_api_call.py
@@ -91,8 +91,9 @@ class InternalApiConfig:
             url_conf = urlparse(conf.get("core", "internal_api_url"))
             api_path = url_conf.path
             if len(api_path) < 2:
+                # Add the default path if not given in the configuration
                 api_path = "/internal_api/v1/rpcapi"
-            if url_conf.scheme in ["http", "https"]:
+            if url_conf.scheme not in ["http", "https"]:
                 raise AirflowConfigException("[core]internal_api_url must start with http:// or https://")
             InternalApiConfig._internal_api_endpoint = f"{url_conf.scheme}://{url_conf.netloc}{api_path}"
 

--- a/airflow/api_internal/internal_api_call.py
+++ b/airflow/api_internal/internal_api_call.py
@@ -95,7 +95,7 @@ class InternalApiConfig:
                 api_path = "/internal_api/v1/rpcapi"
             if url_conf.scheme not in ["http", "https"]:
                 raise AirflowConfigException("[core]internal_api_url must start with http:// or https://")
-            InternalApiConfig._internal_api_endpoint = f"{url_conf.scheme}://{url_conf.netloc}{api_path}"
+            internal_api_endpoint = f"{url_conf.scheme}://{url_conf.netloc}{api_path}"
 
         InternalApiConfig._initialized = True
         InternalApiConfig._use_internal_api = use_internal_api

--- a/airflow/api_internal/internal_api_call.py
+++ b/airflow/api_internal/internal_api_call.py
@@ -22,6 +22,7 @@ import json
 import logging
 from functools import wraps
 from typing import Callable, TypeVar
+from urllib.parse import urlparse
 
 import requests
 import tenacity
@@ -57,6 +58,18 @@ class InternalApiConfig:
         InternalApiConfig._use_internal_api = False
 
     @staticmethod
+    def force_api_access(api_endpoint: str):
+        """
+        Force using Internal API with provided endpoint.
+
+        All methods decorated with internal_api_call will always be executed remote/via API.
+        This mode is needed for remote setups/remote executor.
+        """
+        InternalApiConfig._initialized = True
+        InternalApiConfig._use_internal_api = True
+        InternalApiConfig._internal_api_endpoint = api_endpoint
+
+    @staticmethod
     def get_use_internal_api():
         if not InternalApiConfig._initialized:
             InternalApiConfig._init_values()
@@ -75,10 +88,13 @@ class InternalApiConfig:
             raise RuntimeError("The AIP_44 is not enabled so you cannot use it.")
         internal_api_endpoint = ""
         if use_internal_api:
-            internal_api_url = conf.get("core", "internal_api_url")
-            internal_api_endpoint = internal_api_url + "/internal_api/v1/rpcapi"
-            if not internal_api_endpoint.startswith("http://"):
-                raise AirflowConfigException("[core]internal_api_url must start with http://")
+            url_conf = urlparse(conf.get("core", "internal_api_url"))
+            api_path = url_conf.path
+            if len(api_path) < 2:
+                api_path = "/internal_api/v1/rpcapi"
+            if url_conf.scheme in ["http", "https"]:
+                raise AirflowConfigException("[core]internal_api_url must start with http:// or https://")
+            InternalApiConfig._internal_api_endpoint = f"{url_conf.scheme}://{url_conf.netloc}{api_path}"
 
         InternalApiConfig._initialized = True
         InternalApiConfig._use_internal_api = use_internal_api

--- a/airflow/api_internal/internal_api_call.py
+++ b/airflow/api_internal/internal_api_call.py
@@ -90,7 +90,7 @@ class InternalApiConfig:
         if use_internal_api:
             url_conf = urlparse(conf.get("core", "internal_api_url"))
             api_path = url_conf.path
-            if len(api_path) < 2:
+            if api_path in ["", "/"]:
                 # Add the default path if not given in the configuration
                 api_path = "/internal_api/v1/rpcapi"
             if url_conf.scheme not in ["http", "https"]:

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -422,7 +422,7 @@ _orm_to_model = {
     LogTemplate: LogTemplatePydantic,
     Dataset: DatasetPydantic,
 }
-_type_to_class: dict[DAT, list] = {
+_type_to_class: dict[DAT | str, list] = {
     DAT.BASE_JOB: [JobPydantic, Job],
     DAT.TASK_INSTANCE: [TaskInstancePydantic, TaskInstance],
     DAT.DAG_RUN: [DagRunPydantic, DagRun],
@@ -431,6 +431,13 @@ _type_to_class: dict[DAT, list] = {
     DAT.DATA_SET: [DatasetPydantic, Dataset],
 }
 _class_to_type = {cls_: type_ for type_, classes in _type_to_class.items() for cls_ in classes}
+
+
+def add_pydantic_class_type_mapping(attribute_type: str, orm_class, pydantic_class):
+    _orm_to_model[orm_class] = pydantic_class
+    _type_to_class[attribute_type] = [pydantic_class, orm_class]
+    _class_to_type[pydantic_class] = attribute_type
+    _class_to_type[orm_class] = attribute_type
 
 
 class BaseSerialization:

--- a/tests/api_internal/endpoints/test_rpc_api_endpoint.py
+++ b/tests/api_internal/endpoints/test_rpc_api_endpoint.py
@@ -75,12 +75,12 @@ class TestRpcApiEndpoint:
         mock_test_method.reset_mock()
         mock_test_method.side_effect = None
         with mock.patch(
-            "airflow.api_internal.endpoints.rpc_api_endpoint._initialize_map"
-        ) as mock_initialize_map:
-            mock_initialize_map.return_value = {
+            "airflow.api_internal.endpoints.rpc_api_endpoint.initialize_method_map"
+        ) as mock_initialize_method_map:
+            mock_initialize_method_map.return_value = {
                 TEST_METHOD_NAME: mock_test_method,
             }
-            yield mock_initialize_map
+            yield mock_initialize_method_map
 
     @pytest.mark.parametrize(
         "input_params, method_result, result_cmp_func, method_params",


### PR DESCRIPTION
In order to leverage the AIP-44 interface for AIP-69 / Remote Executor I need some small adjustments to "hook into" the RPC API. This PR extracts from PoC implementation of AIP-69 (#40900) the needed internal API adjustments:

- The private cached method map `_initialize_map()` needs to be extended, not to replicate the function list I'd like to remove the private tag to extend it with a few methods in remote executor. Would not add it to be a "public" interface though.
- Allowing to use a different API path from the standard internal API URL. For the remote case we would expose the URL to another (plugin hosted or separately operated) path, such a URL with path should be configurable as API endpoint
- For the setup of the CLI for Remote worker a way to force usage of internal API as in the remote case we would configure other config.
- Allow the (Remote Provider Package) to hook-in additional classes for serialization to Pydantic mapping for extended API communication via RPC