### PR TITLE
Fail the task if the xcom sidecar container does not start for a long time

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -633,7 +633,9 @@ class KubernetesPodOperator(BaseOperator):
                 )
 
             if self.do_xcom_push:
-                self.pod_manager.await_xcom_sidecar_container_start(pod=self.pod)
+                self.pod_manager.await_xcom_sidecar_container_start(
+                    pod=self.pod, startup_timeout=self.startup_timeout_seconds
+                )
                 result = self.extract_xcom(pod=self.pod)
             istio_enabled = self.is_istio_enabled(self.pod)
             self.remote_pod = self.pod_manager.await_pod_completion(

--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -729,14 +729,14 @@ class PodManager(LoggingMixin):
         :param startup_timeout:  Timeout (in seconds) for startup of the pod
         """
         self.log.info("Checking if xcom sidecar container is started.")
-        curr_time = time.time()
+        start_time = time.time()
         for attempt in itertools.count():
             if self.container_is_running(pod, PodDefaults.SIDECAR_CONTAINER_NAME):
                 self.log.info("The xcom sidecar container is started.")
                 break
             if not attempt:
                 self.log.warning("The xcom sidecar container is not yet started.")
-            if time.time() - curr_time >= startup_timeout:
+            if time.time() - start_time >= startup_timeout:
                 msg = (
                     f"Xcom sidecar container took longer than {startup_timeout} seconds to start. "
                     "Check the container events in kubernetes to determine why."

--- a/tests/providers/cncf/kubernetes/operators/test_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_pod.py
@@ -1507,7 +1507,7 @@ class TestKubernetesPodOperator:
         # check that KPO waits for the base container to complete before proceeding to extract XCom
         mock_await_container_completion.assert_called_once_with(pod=pod, container_name="base")
         # check that we wait for the xcom sidecar to start before extracting XCom
-        mock_await_xcom_sidecar.assert_called_once_with(pod=pod)
+        mock_await_xcom_sidecar.assert_called_once_with(pod=pod, startup_timeout=120)
 
     @patch(HOOK_CLASS, new=MagicMock)
     @patch(KUB_OP_PATH.format("find_pod"))


### PR DESCRIPTION
This PR fixes XCOM_sidecar_container not started results in long running DAG 
Closes: #38115 
 
The following operators are affected:
- KubernetesPodOperator

Although `startup_timeout_seconds` is the timeout for the pod start, there is no parameter to set the timeout for the sidecar container in `KubernetesPodOperator`. Therefore, I have used `startup_timeout_seconds` for xcom sidecar container too.

Instead of above approach, I have also considered the following alternatives:
- Adding a new parameter to KubernetesPodOperator to set the timeout for the XCOM container.
- Raising an Exception if `attempt > 1` instead of using a timeout.

If you have any better suggestions, please let me know.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
