### PR TITLE
Chart: add a specific internal IP address for the ClusterIP service

### DIFF
--- a/chart/templates/pgbouncer/pgbouncer-service.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-service.yaml
@@ -42,8 +42,8 @@ metadata:
     {{- end }}
 spec:
   type: ClusterIP
-  {{- if .Values.pgbouncer.service.ip }}
-  clusterIP: {{ .Values.pgbouncer.service.ip }}
+  {{- if .Values.pgbouncer.service.clusterIp }}
+  clusterIP: {{ .Values.pgbouncer.clusterIp }}
   {{- end }}
   selector:
     tier: airflow

--- a/chart/templates/pgbouncer/pgbouncer-service.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-service.yaml
@@ -42,6 +42,9 @@ metadata:
     {{- end }}
 spec:
   type: ClusterIP
+  {{- if .Values.pgbouncer.service.ip }}
+  clusterIP: {{- .Values.pgbouncer.service.ip }}
+  {{- end }}
   selector:
     tier: airflow
     component: pgbouncer

--- a/chart/templates/pgbouncer/pgbouncer-service.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-service.yaml
@@ -43,7 +43,7 @@ metadata:
 spec:
   type: ClusterIP
   {{- if .Values.pgbouncer.service.ip }}
-  clusterIP: {{- .Values.pgbouncer.service.ip }}
+  clusterIP: {{ .Values.pgbouncer.service.ip }}
   {{- end }}
   selector:
     tier: airflow

--- a/chart/templates/pgbouncer/pgbouncer-service.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-service.yaml
@@ -43,7 +43,7 @@ metadata:
 spec:
   type: ClusterIP
   {{- if .Values.pgbouncer.service.clusterIp }}
-  clusterIP: {{ .Values.pgbouncer.clusterIp }}
+  clusterIP: {{ .Values.pgbouncer.service.clusterIp }}
   {{- end }}
   selector:
     tier: airflow

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -7030,7 +7030,7 @@
                                 "type": "string"
                             }
                         },
-                        "ip": {
+                        "clusterIp": {
                             "description": "Specific ClusterIP for the PgBouncer Service.",
                             "type": [
                                 "string",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -7029,6 +7029,14 @@
                             "additionalProperties": {
                                 "type": "string"
                             }
+                        },
+                        "ip": {
+                            "description": "Specific ClusterIP for the PgBouncer Service.",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "default": null
                         }
                     }
                 },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2144,7 +2144,7 @@ pgbouncer:
 
   service:
     extraAnnotations: {}
-    ip: ~
+    clusterIp: ~
 
   # https://www.pgbouncer.org/config.html
   verbose: 0

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2144,6 +2144,7 @@ pgbouncer:
 
   service:
     extraAnnotations: {}
+    ip: ~
 
   # https://www.pgbouncer.org/config.html
   verbose: 0

--- a/helm_tests/other/test_pgbouncer.py
+++ b/helm_tests/other/test_pgbouncer.py
@@ -101,7 +101,7 @@ class TestPgbouncer:
     def test_pgbouncer_service_static_cluster_ip(self):
         docs = render_chart(
             values={
-                "pgbouncer": {"enabled": True, "service": {"ip": "10.10.10.10"}},
+                "pgbouncer": {"enabled": True, "service": {"clusterIp": "10.10.10.10"}},
             },
             show_only=["templates/pgbouncer/pgbouncer-service.yaml"],
         )

--- a/helm_tests/other/test_pgbouncer.py
+++ b/helm_tests/other/test_pgbouncer.py
@@ -97,7 +97,7 @@ class TestPgbouncer:
             "prometheus.io/port": "9127",
             "foo": "bar",
         } == jmespath.search("metadata.annotations", docs[0])
-    
+
     def test_pgbouncer_service_static_cluster_ip(self):
         docs = render_chart(
             values={

--- a/helm_tests/other/test_pgbouncer.py
+++ b/helm_tests/other/test_pgbouncer.py
@@ -97,6 +97,16 @@ class TestPgbouncer:
             "prometheus.io/port": "9127",
             "foo": "bar",
         } == jmespath.search("metadata.annotations", docs[0])
+    
+    def test_pgbouncer_service_static_cluster_ip(self):
+        docs = render_chart(
+            values={
+                "pgbouncer": {"enabled": True, "service": {"ip": "10.10.10.10"}},
+            },
+            show_only=["templates/pgbouncer/pgbouncer-service.yaml"],
+        )
+
+        assert "10.10.10.10" == jmespath.search("spec.clusterIP", docs[0])
 
     @pytest.mark.parametrize(
         "revision_history_limit, global_revision_history_limit",


### PR DESCRIPTION
## Related issue:

closes: #40676

add a specific internal IP address for the ClusterIP service in helm chart.
