### PR TITLE
Temporarily switch to public github runners

### DIFF
--- a/.github/workflows/additional-ci-image-checks.yml
+++ b/.github/workflows/additional-ci-image-checks.yml
@@ -145,26 +145,26 @@ jobs:
       - name: "Check that image builds quickly"
         run: breeze shell --max-time 600 --platform "linux/amd64"
 
-  # This is only a check if ARM images are successfully building when committer runs PR from
-  # Apache repository. This is needed in case you want to fix failing cache job in "canary" run
-  # There is no point in running this one in "canary" run, because the above step is doing the
-  # same build anyway.
-  build-ci-arm-images:
-    name: Build CI ARM images (in-workflow)
-    uses: ./.github/workflows/ci-image-build.yml
-    permissions:
-      contents: read
-      packages: write
-    secrets: inherit
-    with:
-      push-image: "false"
-      runs-on-as-json-public: ${{ inputs.runs-on-as-json-public }}
-      runs-on-as-json-self-hosted: ${{ inputs.runs-on-as-json-self-hosted }}
-      image-tag: ${{ inputs.image-tag }}
-      python-versions: ${{ inputs.python-versions }}
-      platform: "linux/arm64"
-      branch: ${{ inputs.branch }}
-      constraints-branch: ${{ inputs.constraints-branch }}
-      use-uv: "true"
-      upgrade-to-newer-dependencies: ${{ inputs.upgrade-to-newer-dependencies }}
-      docker-cache: ${{ inputs.docker-cache }}
+#  # This is only a check if ARM images are successfully building when committer runs PR from
+#  # Apache repository. This is needed in case you want to fix failing cache job in "canary" run
+#  # There is no point in running this one in "canary" run, because the above step is doing the
+#  # same build anyway.
+#  build-ci-arm-images:
+#    name: Build CI ARM images (in-workflow)
+#    uses: ./.github/workflows/ci-image-build.yml
+#    permissions:
+#      contents: read
+#      packages: write
+#    secrets: inherit
+#    with:
+#      push-image: "false"
+#      runs-on-as-json-public: ${{ inputs.runs-on-as-json-public }}
+#      runs-on-as-json-self-hosted: ${{ inputs.runs-on-as-json-self-hosted }}
+#      image-tag: ${{ inputs.image-tag }}
+#      python-versions: ${{ inputs.python-versions }}
+#      platform: "linux/arm64"
+#      branch: ${{ inputs.branch }}
+#      constraints-branch: ${{ inputs.constraints-branch }}
+#      use-uv: "true"
+#      upgrade-to-newer-dependencies: ${{ inputs.upgrade-to-newer-dependencies }}
+#      docker-cache: ${{ inputs.docker-cache }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,12 @@
 name: Tests
 on:  # yamllint disable-line rule:truthy
   schedule:
-    - cron: '28 0 * * *'
+    - cron: '28 7,15 * * *'
   push:
-    branches: ['main', 'v[0-9]+-[0-9]+-test']
+    branches: ['v[0-9]+-[0-9]+-test']
   pull_request:
     branches: ['main']
+  workflow_dispatch:
 permissions:
   # All other permissions are set to none
   contents: read

--- a/.github/workflows/finalize-tests.yml
+++ b/.github/workflows/finalize-tests.yml
@@ -150,28 +150,28 @@ jobs:
       docker-cache: ${{ inputs.docker-cache }}
     if: inputs.canary-run == 'true'
 
-  push-buildx-cache-to-github-registry-arm:
-    name: Push Regular ARM Image Cache
-    needs: [update-constraints]
-    uses: ./.github/workflows/push-image-cache.yml
-    permissions:
-      contents: read
-      packages: write
-    secrets: inherit
-    with:
-      runs-on-as-json-public: ${{ inputs.runs-on-as-json-public }}
-      runs-on-as-json-self-hosted: ${{ inputs.runs-on-as-json-self-hosted }}
-      cache-type: "Regular ARM"
-      include-prod-images: "true"
-      push-latest-images: "true"
-      platform: "linux/arm64"
-      python-versions: ${{ inputs.python-versions }}
-      branch: ${{ inputs.branch }}
-      constraints-branch: ${{ inputs.constraints-branch }}
-      use-uv: "true"
-      include-success-outputs: ${{ inputs.include-success-outputs }}
-      docker-cache: ${{ inputs.docker-cache }}
-    if: inputs.canary-run == 'true'
+  #  push-buildx-cache-to-github-registry-arm:
+  #    name: Push Regular ARM Image Cache
+  #    needs: [update-constraints]
+  #    uses: ./.github/workflows/push-image-cache.yml
+  #    permissions:
+  #      contents: read
+  #      packages: write
+  #    secrets: inherit
+  #    with:
+  #      runs-on-as-json-public: ${{ inputs.runs-on-as-json-public }}
+  #      runs-on-as-json-self-hosted: ${{ inputs.runs-on-as-json-self-hosted }}
+  #      cache-type: "Regular ARM"
+  #      include-prod-images: "true"
+  #      push-latest-images: "true"
+  #      platform: "linux/arm64"
+  #      python-versions: ${{ inputs.python-versions }}
+  #      branch: ${{ inputs.branch }}
+  #      constraints-branch: ${{ inputs.constraints-branch }}
+  #      use-uv: "true"
+  #      include-success-outputs: ${{ inputs.include-success-outputs }}
+  #      docker-cache: ${{ inputs.docker-cache }}
+  #    if: inputs.canary-run == 'true'
 
   summarize-warnings:
     timeout-minutes: 15

--- a/dev/breeze/src/airflow_breeze/commands/ci_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_commands.py
@@ -373,6 +373,10 @@ def workflow_info(context: str) -> WorkflowInfo:
         target_repo = ctx["repository"]
         head_repo = ctx["repository"]
         event_name = ctx["event_name"]
+    elif event_name == "workflow_dispatch":
+        target_repo = ctx["repository"]
+        head_repo = ctx["repository"]
+        event_name = ctx["event_name"]
     elif event_name == "pull_request_target":
         target_repo = ctx["repository"]
         head_repo = ctx["repository"]

--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -32,9 +32,11 @@ from airflow_breeze.utils.path_utils import AIRFLOW_SOURCES_ROOT
 RUNS_ON_PUBLIC_RUNNER = '["ubuntu-22.04"]'
 # we should get more sophisticated logic here in the future, but for now we just check if
 # we use self airflow, vm-based, amd hosted runner as a default
+# TODO: temporarily we need to switch to public runners to avoid issues with self-hosted runners
+RUNS_ON_SELF_HOSTED_RUNNER = '["ubuntu-22.04"]'
 # TODO: when we have it properly set-up with labels we should change it to
 # RUNS_ON_SELF_HOSTED_RUNNER = '["self-hosted", "airflow-runner", "vm-runner", "X64"]'
-RUNS_ON_SELF_HOSTED_RUNNER = '["self-hosted", "Linux", "X64"]'
+# RUNS_ON_SELF_HOSTED_RUNNER = '["self-hosted", "Linux", "X64"]'
 SELF_HOSTED_RUNNERS_CPU_COUNT = 8
 
 ANSWER = ""

--- a/dev/breeze/tests/test_pr_info.py
+++ b/dev/breeze/tests/test_pr_info.py
@@ -81,7 +81,9 @@ def test_runs_on_self_hosted():
         assert wi.head_repo == "apache/airflow"
         assert wi.event_name == "pull_request"
         assert wi.pr_number == 1234
-        assert wi.get_runs_on() == '["self-hosted", "Linux", "X64"]'
+        # TODO: fix it when we fix self-hosted runners
+        assert wi.get_runs_on() == '["ubuntu-22.04"]'
+        # assert wi.get_runs_on() == '["self-hosted", "Linux", "X64"]'
         assert wi.is_canary_run() == "false"
         assert wi.run_coverage() == "false"
 
@@ -123,7 +125,9 @@ def test_runs_on_push_other_branch():
         assert wi.head_repo == "apache/airflow"
         assert wi.event_name == "push"
         assert wi.pr_number is None
-        assert wi.get_runs_on() == '["self-hosted", "Linux", "X64"]'
+        # TODO: revert it when we fix self-hosted runners
+        assert wi.get_runs_on() == '["ubuntu-22.04"]'
+        # assert wi.get_runs_on() == '["self-hosted", "Linux", "X64"]'
         assert wi.is_canary_run() == "false"
         assert wi.run_coverage() == "false"
 
@@ -137,6 +141,8 @@ def test_runs_on_push_v_test_branch():
         assert wi.head_repo == "apache/airflow"
         assert wi.event_name == "push"
         assert wi.pr_number is None
-        assert wi.get_runs_on() == '["self-hosted", "Linux", "X64"]'
+        # TODO: revert it when we fix self-hosted runners
+        assert wi.get_runs_on() == '["ubuntu-22.04"]'
+        # assert wi.get_runs_on() == '["self-hosted", "Linux", "X64"]'
         assert wi.is_canary_run() == "true"
         assert wi.run_coverage() == "false"

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -1732,12 +1732,19 @@ def test_helm_tests_trigger_ci_build(files: tuple[str, ...], expected_outputs: d
             "apache/airflow",
             (),
             dict(),
-            '["self-hosted", "Linux", "X64"]',
-            "true",
-            "true",
+            # TODO: revert it when we fix self-hosted runners
+            '["ubuntu-22.04"]',
+            # '["self-hosted", "Linux", "X64"]',
+            # TODO: revert it when we fix self-hosted runners
+            "false",
+            "false",
+            # "true",
+            # "true",
             "true",
             "false",
-            "true",
+            # TODO: revert it when we fix self-hosted runners
+            "false",
+            # "true",
             "false",
             False,
             id="Push event",


### PR DESCRIPTION
We are having problems with self-hosted runners and until we fix the problems we switch main builds to only run on main with regular schedule 1x day to serve as a canary build. They will run longer than on self-hosted runners.

We also add option to trigger the workflow manually from GitHub interface (by maintainers).

This should cover most tests with the following limitations:

* ARM builds and cache are not going to run (we can still refresh cache manually periodicaly to get cache for mac OS Breeze users

* Releasing images via workflow will not work - we can still do it manually from preparing workstations

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
