### PR TITLE
Validating provider documentation urls before displaying in views

### DIFF
--- a/airflow/utils/docs.py
+++ b/airflow/utils/docs.py
@@ -39,17 +39,25 @@ def get_docs_url(page: str | None = None) -> str:
     return result
 
 
+def get_project_url_from_metadata(provider_name: str):
+    """Returns the Project-URL from metadata"""
+    return metadata.metadata(provider_name).get_all("Project-URL")
+
+
 def get_doc_url_for_provider(provider_name: str, provider_version: str) -> str:
     """Prepare link to Airflow Provider documentation."""
     try:
-        metadata_items = metadata.metadata(provider_name).get_all("Project-URL")
+        from urllib.parse import urlparse
+
+        metadata_items = get_project_url_from_metadata(provider_name)
         if isinstance(metadata_items, str):
             metadata_items = [metadata_items]
         if metadata_items:
             for item in metadata_items:
                 if item.lower().startswith("documentation"):
                     _, _, url = item.partition(",")
-                    if url:
+                    parsed_url = urlparse(url)
+                    if url and (parsed_url.scheme in ("http", "https") and bool(parsed_url.netloc)):
                         return url.strip()
     except metadata.PackageNotFoundError:
         pass

--- a/airflow/utils/docs.py
+++ b/airflow/utils/docs.py
@@ -40,7 +40,7 @@ def get_docs_url(page: str | None = None) -> str:
 
 
 def get_project_url_from_metadata(provider_name: str):
-    """Returns the Project-URL from metadata."""
+    """Return the Project-URL from metadata."""
     return metadata.metadata(provider_name).get_all("Project-URL")
 
 

--- a/airflow/utils/docs.py
+++ b/airflow/utils/docs.py
@@ -40,7 +40,7 @@ def get_docs_url(page: str | None = None) -> str:
 
 
 def get_project_url_from_metadata(provider_name: str):
-    """Returns the Project-URL from metadata"""
+    """Returns the Project-URL from metadata."""
     return metadata.metadata(provider_name).get_all("Project-URL")
 
 

--- a/tests/www/views/test_views.py
+++ b/tests/www/views/test_views.py
@@ -32,6 +32,7 @@ from airflow.configuration import (
     write_webserver_configuration_if_needed,
 )
 from airflow.plugins_manager import AirflowPlugin, EntryPointSource
+from airflow.utils.docs import get_doc_url_for_provider
 from airflow.utils.task_group import TaskGroup
 from airflow.www.views import (
     ProviderView,
@@ -177,6 +178,36 @@ def test_should_list_providers_on_page_with_details(admin_client):
 def test__clean_description(admin_client, provider_description, expected):
     p = ProviderView()
     actual = p._clean_description(provider_description)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "provider_name, project_url, expected",
+    [
+        (
+            "apache-airflow-providers-airbyte",
+            "Documentation, https://airflow.apache.org/docs/apache-airflow-providers-airbyte/3.8.1/",
+            "https://airflow.apache.org/docs/apache-airflow-providers-airbyte/3.8.1/",
+        ),
+        (
+            "apache-airflow-providers-amazon",
+            "Documentation, https://airflow.apache.org/docs/apache-airflow-providers-amazon/8.25.0/",
+            "https://airflow.apache.org/docs/apache-airflow-providers-amazon/8.25.0/",
+        ),
+        (
+            "apache-airflow-providers-apache-druid",
+            "Documentation, javascript:prompt(document.domain)",
+            # the default one is returned
+            "https://airflow.apache.org/docs/apache-airflow-providers-apache-druid/1.0.0/",
+        ),
+    ],
+)
+@patch("airflow.utils.docs.get_project_url_from_metadata")
+def test_get_doc_url_for_provider(
+    mock_get_project_url_from_metadata, admin_client, provider_name, project_url, expected
+):
+    mock_get_project_url_from_metadata.return_value = [project_url]
+    actual = get_doc_url_for_provider(provider_name, "1.0.0")
     assert actual == expected
 
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Adding an extra layer of validation for the Project-URL that comes from installed providers

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
