### PR TITLE
Removing changelog:skip validation for helm chart issue generation

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -3357,7 +3357,7 @@ def generate_issue_content(
                 continue
             # Ignore doc-only and skipped PRs
             label_names = [label.name for label in pr.labels]
-            if "type:doc-only" in label_names or "changelog:skip" in label_names:
+            if not is_helm_chart and ("type:doc-only" in label_names or "changelog:skip" in label_names):
                 continue
 
             pull_requests[pr_number] = pr


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

For helm chart issue generation, we shouldn't care about the `changelog:skip` label as its not applicable
Output looks like this:
```
➜  airflow git:(changeLogHelm) ✗ breeze release-management generate-issue-content-helm-chart --previous-release helm-chart/1.14.0 --current-release helm-chart/1.15.0rc1
/Users/adesai/.local/pipx/venvs/apache-airflow-breeze/lib/python3.9/site-packages/urllib3/__init__.py:34: NotOpenSSLWarning: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 2.8.3'. See: https://github.com/urllib3/urllib3/issues/3020
  warnings.warn(
/Users/adesai/Documents/OSS/airflow-repos/airflow/dev/breeze/src/airflow_breeze/commands /Users/adesai/Documents/OSS/airflow-repos/airflow
Retrieving PR#40903: https://github.com/apache/airflow/pull/40903
Retrieving PR#39031: https://github.com/apache/airflow/pull/39031
Retrieving PR#40898: https://github.com/apache/airflow/pull/40898
Retrieving PR#40816: https://github.com/apache/airflow/pull/40816
Retrieving PR#40777: https://github.com/apache/airflow/pull/40777
Retrieving PR#40691: https://github.com/apache/airflow/pull/40691
Retrieving Linked issue PR#39936: https://github.com/apache/airflow/issue/39936
Retrieving PR#40554: https://github.com/apache/airflow/pull/40554
Retrieving PR#40635: https://github.com/apache/airflow/pull/40635
Retrieving PR#40614: https://github.com/apache/airflow/pull/40614
Retrieving Linked issue PR#37365: https://github.com/apache/airflow/issue/37365
Retrieving Linked issue PR#40455: https://github.com/apache/airflow/issue/40455
Retrieving PR#40369: https://github.com/apache/airflow/pull/40369
Retrieving PR#40454: https://github.com/apache/airflow/pull/40454
Retrieving PR#40271: https://github.com/apache/airflow/pull/40271
Retrieving PR#40412: https://github.com/apache/airflow/pull/40412
Retrieving PR#40401: https://github.com/apache/airflow/pull/40401
Retrieving PR#40393: https://github.com/apache/airflow/pull/40393
Retrieving PR#40281: https://github.com/apache/airflow/pull/40281
Retrieving Linked issue PR#40279: https://github.com/apache/airflow/issue/40279
Retrieving PR#40294: https://github.com/apache/airflow/pull/40294
Retrieving Linked issue PR#18776: https://github.com/apache/airflow/issue/18776
Retrieving Linked issue PR#17447: https://github.com/apache/airflow/issue/17447
Retrieving PR#40318: https://github.com/apache/airflow/pull/40318
Retrieving Linked issue PR#40303: https://github.com/apache/airflow/issue/40303
Retrieving PR#40303: https://github.com/apache/airflow/pull/40303
Retrieving PR#39936: https://github.com/apache/airflow/pull/39936
Retrieving PR#40313: https://github.com/apache/airflow/pull/40313
Retrieving 21 PRs  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
We are kindly requesting that contributors to [Apache Airflow Helm Chart 1.15.0rc1](https://dist.apache.org/repos/dist/dev/airflow/helm-chart/1.15.0rc1) help test the RC.

Please let us know by commenting if the issue is addressed in the latest RC.

- [ ] [gitSync: add extraEnvFrom to git-sync containers to support proxy settings from k8s secret (#39031)](https://github.com/apache/airflow/pull/39031): @rasulkarimov
- [ ] [add git-sync-ssh secret template (#39936)](https://github.com/apache/airflow/pull/39936): @romsharon98
- [ ] [Add persistent volume claim retention policy (#40271)](https://github.com/apache/airflow/pull/40271): @romsharon98
- [ ] [Add annotations for Redis StatefulSet resource in values.yaml is not … (#40281)](https://github.com/apache/airflow/pull/40281): @cybersavvydev
     Linked issues:
     - [Add annotations for Redis StatefulSet resource in values.yaml is not possible (#40279)](https://github.com/apache/airflow/issues/40279)
- [ ] [Support disabling helm hooks on extraConfigMaps and extraSecrets (#40294)](https://github.com/apache/airflow/pull/40294): @micke-a @Mrngilles @ItaiMeushar
     Linked issues:
     - [Allow disabling the Helm hooks in the helm chart (#18776)](https://github.com/apache/airflow/pull/18776)
     - [Option to exclude default / hard-coded helm annotations for jobs and other relevant templates (#17447)](https://github.com/apache/airflow/issues/17447)
- [ ] [fix a vulnerability in protobuf for pgbouncer_exporter (#40303)](https://github.com/apache/airflow/pull/40303): @andrew-stein-sp
- [ ] [Helm chart 1.14.0 has been released (#40313)](https://github.com/apache/airflow/pull/40313): @jedcunningham
- [ ] [Switch to newer pgbouncer-exporter image as default for Helm Chart (#40318)](https://github.com/apache/airflow/pull/40318): @potiuk @andrew-stein-sp
     Linked issues:
     - [fix a vulnerability in protobuf for pgbouncer_exporter (#40303)](https://github.com/apache/airflow/pull/40303)
- [ ] [ADD git-sync container lifecycle hooks (#40369)](https://github.com/apache/airflow/pull/40369): @getChan
- [ ] [Fix/ unnecessary `or` in git ssh key (#40393)](https://github.com/apache/airflow/pull/40393): @romsharon98
- [ ] [fix: trim leading // character using mysql backend (#40401)](https://github.com/apache/airflow/pull/40401): @claneys
- [ ] [Fix startupProbe timing comment (#40412)](https://github.com/apache/airflow/pull/40412): @jedcunningham
- [ ] [add init containers for job (#40454)](https://github.com/apache/airflow/pull/40454): @romsharon98
- [ ] [fix: duplicated keys in annotations caused by airfowPodAnnotations value being overwritten by safeToEvict value of worker (#40554)](https://github.com/apache/airflow/pull/40554): @rzjfr
- [ ] [Add missing usePgbouncer from values.yaml for triggerer (#40614)](https://github.com/apache/airflow/pull/40614): @amoghrajesh @claneys @gil-tober
     Linked issues:
     - [feat: enable mysql keda support for triggerer (#37365)](https://github.com/apache/airflow/pull/37365)
     - [Missing `usePgbouncer` key for Triggerer (#40455)](https://github.com/apache/airflow/issues/40455)
- [ ] [Enhance User Experience by Opening external UI Links in new Tab on browser. (#40635)](https://github.com/apache/airflow/pull/40635): @VICIWUOHA
- [ ] [Chart: add git-sync-ssh secret template to dagprocessor (#40691)](https://github.com/apache/airflow/pull/40691): @Aakcht @romsharon98
     Linked issues:
     - [add git-sync-ssh secret template (#39936)](https://github.com/apache/airflow/pull/39936)
- [ ] [Clarify PMC members vs PMCs (#40777)](https://github.com/apache/airflow/pull/40777): @potiuk
- [ ] [Chart: Default airflow version to 2.9.3 (#40816)](https://github.com/apache/airflow/pull/40816): @utkarsharma2
- [ ] [Chart: Helm chart 1.15.0 release notes (#40898)](https://github.com/apache/airflow/pull/40898): @jedcunningham
- [ ] [Chart: Update release notes for 1.15.0 (#40903)](https://github.com/apache/airflow/pull/40903): @jedcunningham


Thanks to all who contributed to the release (probably not a complete list!):
@potiuk @getChan @claneys @Mrngilles @gil-tober @jedcunningham @VICIWUOHA @romsharon98 @amoghrajesh @andrew-stein-sp @Aakcht @rasulkarimov @ItaiMeushar @rzjfr @utkarsharma2 @micke-a @cybersavvydev
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
