### PR TITLE
State the limitation of the newly added start execution from trigger feature

### DIFF
--- a/docs/apache-airflow/authoring-and-scheduling/deferring.rst
+++ b/docs/apache-airflow/authoring-and-scheduling/deferring.rst
@@ -202,8 +202,8 @@ The ``self.defer`` call raises the ``TaskDeferred`` exception, so it can work an
 
 ``execution_timeout`` on operators is determined from the *total runtime*, not individual executions between deferrals. This means that if ``execution_timeout`` is set, an operator can fail while it's deferred or while it's running after a deferral, even if it's only been resumed for a few seconds.
 
-Triggering Deferral from Start
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Triggering Deferral from Task Start
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
  .. versionadded:: 2.10.0
 
@@ -236,6 +236,7 @@ This is particularly useful when deferring is the only thing the ``execute`` met
 In the sensor part, we'll need to provide the path to ``HourDeltaTrigger`` as ``trigger_cls``.
 
 .. code-block:: python
+
     from __future__ import annotations
 
     from typing import Any
@@ -246,8 +247,8 @@ In the sensor part, we'll need to provide the path to ``HourDeltaTrigger`` as ``
 
 
     class WaitOneHourSensor(BaseSensorOperator):
+        # You'll need to change trigger_cls to the actual path to HourDeltaTrigger.
         start_trigger_args = StartTriggerArgs(
-            # you'll need to change the actual path to the Trigger above
             trigger_cls="airflow.triggers.temporal.HourDeltaTrigger",
             trigger_kwargs={"hours": 1},
             next_method="execute_complete",
@@ -274,8 +275,8 @@ In the sensor part, we'll need to provide the path to ``HourDeltaTrigger`` as ``
 
 
     class WaitTwoHourSensor(BaseSensorOperator):
+        # You'll need to change trigger_cls to the actual path to HourDeltaTrigger.
         start_trigger_args = StartTriggerArgs(
-            # you'll need to change the actual path to the Trigger above
             trigger_cls="airflow.triggers.temporal.HourDeltaTrigger",
             trigger_kwargs={"hours": 1},
             next_method="execute_complete",
@@ -305,8 +306,8 @@ To enable Dynamic Task Mapping support, you can define ``start_from_trigger`` an
 
 
     class WaitHoursSensor(BaseSensorOperator):
+        # You'll need to change trigger_cls to the actual path to HourDeltaTrigger.
         start_trigger_args = StartTriggerArgs(
-            # you'll need to change the actual path to the Trigger above
             trigger_cls="airflow.triggers.temporal.HourDeltaTrigger",
             trigger_kwargs={"hours": 1},
             next_method="execute_complete",

--- a/docs/apache-airflow/authoring-and-scheduling/deferring.rst
+++ b/docs/apache-airflow/authoring-and-scheduling/deferring.rst
@@ -206,7 +206,7 @@ Triggering Deferral from Task Start
 
  .. versionadded:: 2.10.0
 
-If you want to defer your task directly to the triggerer without going into the worker, you can set class level attribute ``start_with_trigger`` to ``True`` and add a class level attribute ``start_trigger_args`` with an ``StartTriggerArgs`` object with the following 4 attributes to your deferrable operator:
+If you want to defer your task directly to the triggerer without going into the worker, you can set class level attribute ``start_from_trigger`` to ``True`` and add a class level attribute ``start_trigger_args`` with an ``StartTriggerArgs`` object with the following 4 attributes to your deferrable operator:
 
 * ``trigger_cls``: An importable path to your trigger class.
 * ``trigger_kwargs``: Keyword arguments to pass to the ``trigger_cls`` when it's initialized. **Note that all the arguments need to be serializable. It's the main limitation of this feature.**


### PR DESCRIPTION
In https://github.com/apache/airflow/pull/38674, https://github.com/apache/airflow/pull/39585 and https://github.com/apache/airflow/pull/39912, we introduce `start_from_trigger` and `start_trigger_args` to allow OP author/ DAG author to run task directly from triggerer without going into worker. However, the limitation is that all the kwargs passed to the trigger_cls need to be serializable. This PR add the description and update example to the deferring doc

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
