### PR TITLE
Make google_analytics_admin system tests self sufficient

### DIFF
--- a/airflow/providers/google/marketing_platform/operators/analytics_admin.py
+++ b/airflow/providers/google/marketing_platform/operators/analytics_admin.py
@@ -530,6 +530,7 @@ class GoogleAnalyticsAdminGetGoogleAdsLinkOperator(GoogleCloudBaseOperator):
         "gcp_conn_id",
         "impersonation_chain",
         "google_ads_link_id",
+        "property_id",
     )
 
     def __init__(


### PR DESCRIPTION
- Refactored the DAG_ID to make it consistent with the others
- Moved required IDs from Google Analytics and Google Ads to the Google Cloud Secret Manager 