### PR TITLE
Only orphan datasets once in the scheduler job

### DIFF
--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -2048,9 +2048,12 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         session.flush()
 
     def _set_orphaned(self, dataset: DatasetModel) -> int:
-        self.log.info("Orphaning unreferenced dataset '%s'", dataset.uri)
-        dataset.is_orphaned = expression.true()
-        return 1
+        if not dataset.is_orphaned:
+            self.log.info("Orphaning unreferenced dataset '%s'", dataset.uri)
+            dataset.is_orphaned = expression.true()
+            return 1
+
+        return 0
 
     @provide_session
     def _orphan_unreferenced_datasets(self, session: Session = NEW_SESSION) -> None:

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -2048,12 +2048,12 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         session.flush()
 
     def _set_orphaned(self, dataset: DatasetModel) -> int:
-        if not dataset.is_orphaned:
-            self.log.info("Orphaning unreferenced dataset '%s'", dataset.uri)
-            dataset.is_orphaned = expression.true()
-            return 1
+        if dataset.is_orphaned:
+            return 0
 
-        return 0
+        self.log.info("Orphaning unreferenced dataset '%s'", dataset.uri)
+        dataset.is_orphaned = expression.true()
+        return 1
 
     @provide_session
     def _orphan_unreferenced_datasets(self, session: Session = NEW_SESSION) -> None:


### PR DESCRIPTION
When a dataset is considered orphaned, the current state is never verified. 
Airflow just outputs a line to the log and sets the orphaned status to `True` (possibly for the 100th time).

We use datasets extensively and we also have a large number of datasets considered as orphaned by AF, resulting in about 200 of those "Orphaning unreferenced dataset"-lines in our logs every minute.

This minimal patch simply checks the existing status first instead. 
Noting happens if the dataset is already orphaned.

