### PR TITLE
Update styles for renderedjson component

### DIFF
--- a/airflow/www/static/js/components/RenderedJsonField.tsx
+++ b/airflow/www/static/js/components/RenderedJsonField.tsx
@@ -21,9 +21,17 @@ import React from "react";
 
 import ReactJson from "react-json-view";
 
-import { Flex, Button, Code, Spacer, useClipboard } from "@chakra-ui/react";
+import {
+  Flex,
+  Button,
+  Code,
+  Spacer,
+  useClipboard,
+  useTheme,
+  FlexProps,
+} from "@chakra-ui/react";
 
-interface Props {
+interface Props extends FlexProps {
   content: string;
 }
 
@@ -41,12 +49,13 @@ const JsonParse = (content: string) => {
   return [isJson, contentJson, contentFormatted];
 };
 
-const RenderedJsonField = ({ content }: Props) => {
+const RenderedJsonField = ({ content, ...rest }: Props) => {
   const [isJson, contentJson, contentFormatted] = JsonParse(content);
   const { onCopy, hasCopied } = useClipboard(contentFormatted);
+  const theme = useTheme();
 
   return isJson ? (
-    <Flex>
+    <Flex {...rest} p={2}>
       <ReactJson
         src={contentJson}
         name={false}
@@ -55,7 +64,11 @@ const RenderedJsonField = ({ content }: Props) => {
         indentWidth={2}
         displayDataTypes={false}
         enableClipboard={false}
-        style={{ backgroundColor: "inherit" }}
+        style={{
+          backgroundColor: "inherit",
+          fontSize: theme.fontSizes.md,
+          font: theme.fonts.mono,
+        }}
       />
       <Spacer />
       <Button aria-label="Copy" onClick={onCopy}>


### PR DESCRIPTION
Make sure the RenderedJson component matches the font and font size of the rest of the UI. And allow it to accept custom styling of its wrapper component


Before:
<img width="710" alt="Screenshot 2024-07-23 at 11 52 11 AM" src="https://github.com/user-attachments/assets/65a864f7-e3b0-4bdb-9b88-91f01af482d0">


After:
<img width="710" alt="Screenshot 2024-07-23 at 11 51 40 AM" src="https://github.com/user-attachments/assets/4a91040f-7917-454f-ba9e-8db37c237ab8">


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
