### PR TITLE
Change DAG Audit log tab to Event Log

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3430,6 +3430,16 @@ components:
           type: string
           readOnly: true
           nullable: true
+        map_index:
+          description: The Map Index
+          type: integer
+          readOnly: true
+          nullable: true
+        try_number:
+          description: The Try Number
+          type: integer
+          readOnly: true
+          nullable: true
         event:
           description: A key describing the type of event.
           type: string
@@ -3459,6 +3469,7 @@ components:
         Collection of event logs.
 
         *Changed in version 2.1.0*&#58; 'total_entries' field is added.
+        *Changed in version 2.10.0*&#58; 'try_number' and 'map_index' fields are added.
       allOf:
         - type: object
           properties:
@@ -3487,7 +3498,7 @@ components:
         stack_trace:
           type: string
           readOnly: true
-          description: The full stackstrace..
+          description: The full stackstrace.
 
     ImportErrorCollection:
       type: object

--- a/airflow/www/static/js/components/NewTable/NewCells.tsx
+++ b/airflow/www/static/js/components/NewTable/NewCells.tsx
@@ -19,15 +19,18 @@
 
 import React from "react";
 import { Code } from "@chakra-ui/react";
+import type { CellContext } from "@tanstack/react-table";
 
 import Time from "src/components/Time";
 
-export const TimeCell = ({ getValue }: any) => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const TimeCell = ({ getValue }: CellContext<any, any>) => {
   const value = getValue();
   return <Time dateTime={value} />;
 };
 
-export const CodeCell = ({ getValue }: any) => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const CodeCell = ({ getValue }: CellContext<any, any>) => {
   const value = getValue();
   return value ? <Code>{value}</Code> : null;
 };

--- a/airflow/www/static/js/dag/details/EventLog.tsx
+++ b/airflow/www/static/js/dag/details/EventLog.tsx
@@ -46,7 +46,7 @@ import { useEventLogs } from "src/api";
 import { getMetaValue, useOffsetTop } from "src/utils";
 import type { DagRun } from "src/types";
 import LinkButton from "src/components/LinkButton";
-import type { EventLog } from "src/types/api-generated";
+import type { EventLog as EventLogType } from "src/types/api-generated";
 import { NewTable } from "src/components/NewTable/NewTable";
 import { useTableURLState } from "src/components/NewTable/useTableUrlState";
 import { CodeCell, TimeCell } from "src/components/NewTable/NewCells";
@@ -60,6 +60,7 @@ const configIncludedEvents = getMetaValue("included_audit_log_events");
 
 interface Props {
   taskId?: string;
+  showMapped?: boolean;
   run?: DagRun;
 }
 
@@ -70,9 +71,9 @@ interface Option extends OptionBase {
 
 const dagId = getMetaValue("dag_id") || undefined;
 
-const columnHelper = createColumnHelper<EventLog>();
+const columnHelper = createColumnHelper<EventLogType>();
 
-const AuditLog = ({ taskId, run }: Props) => {
+const EventLog = ({ taskId, run, showMapped }: Props) => {
   const logRef = useRef<HTMLDivElement>(null);
   const offsetTop = useOffsetTop(logRef);
   const { tableURLState, setTableURLState } = useTableURLState({
@@ -138,7 +139,21 @@ const AuditLog = ({ taskId, run }: Props) => {
     const runId = columnHelper.accessor("runId", {
       header: "Run Id",
     });
+
+    const mapIndex = columnHelper.accessor("mapIndex", {
+      header: "Map Index",
+      meta: {
+        skeletonWidth: 10,
+      },
+      cell: (props) => (props.getValue() === -1 ? undefined : props.getValue()),
+    });
     const rest = [
+      columnHelper.accessor("tryNumber", {
+        header: "Try Number",
+        meta: {
+          skeletonWidth: 10,
+        },
+      }),
       columnHelper.accessor("event", {
         header: "Event",
         meta: {
@@ -146,13 +161,13 @@ const AuditLog = ({ taskId, run }: Props) => {
         },
       }),
       columnHelper.accessor("owner", {
-        header: "Owner",
+        header: "User",
         meta: {
           skeletonWidth: 20,
         },
       }),
       columnHelper.accessor("extra", {
-        header: "Extra",
+        header: "Details",
         cell: CodeCell,
       }),
     ];
@@ -160,9 +175,10 @@ const AuditLog = ({ taskId, run }: Props) => {
       when,
       ...(!run ? [runId] : []),
       ...(!taskId ? [task] : []),
+      ...(showMapped ? [mapIndex] : []),
       ...rest,
     ];
-  }, [taskId, run]);
+  }, [taskId, run, showMapped]);
 
   const memoData = useMemo(() => data?.eventLogs, [data?.eventLogs]);
 
@@ -262,4 +278,4 @@ const AuditLog = ({ taskId, run }: Props) => {
   );
 };
 
-export default AuditLog;
+export default EventLog;

--- a/airflow/www/static/js/dag/details/EventLog.tsx
+++ b/airflow/www/static/js/dag/details/EventLog.tsx
@@ -142,6 +142,7 @@ const EventLog = ({ taskId, run, showMapped }: Props) => {
 
     const mapIndex = columnHelper.accessor("mapIndex", {
       header: "Map Index",
+      enableSorting: false,
       meta: {
         skeletonWidth: 10,
       },
@@ -150,6 +151,7 @@ const EventLog = ({ taskId, run, showMapped }: Props) => {
     const rest = [
       columnHelper.accessor("tryNumber", {
         header: "Try Number",
+        enableSorting: false,
         meta: {
           skeletonWidth: 10,
         },

--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -90,6 +90,7 @@ const tabToIndex = (tab?: string) => {
       return 2;
     case "code":
       return 3;
+    case "event_log":
     case "audit_log":
       return 4;
     case "logs":
@@ -130,7 +131,7 @@ const indexToTab = (
     case 3:
       return "code";
     case 4:
-      return "audit_log";
+      return "event_log";
     case 5:
       if (isMappedTaskSummary) return "mapped_tasks";
       if (isTaskInstance) return "logs";

--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -42,8 +42,8 @@ import {
   MdOutlineViewTimeline,
   MdSyncAlt,
   MdHourglassBottom,
-  MdPlagiarism,
   MdEvent,
+  MdOutlineEventNote,
 } from "react-icons/md";
 import { BiBracket, BiLogoKubernetes } from "react-icons/bi";
 import URLSearchParamsWrapper from "src/utils/URLSearchParamWrapper";
@@ -65,7 +65,7 @@ import ClearInstance from "./taskInstance/taskActions/ClearInstance";
 import MarkInstanceAs from "./taskInstance/taskActions/MarkInstanceAs";
 import XcomCollection from "./taskInstance/Xcom";
 import TaskDetails from "./task";
-import AuditLog from "./AuditLog";
+import EventLog from "./EventLog";
 import RunDuration from "./dag/RunDuration";
 import Calendar from "./dag/Calendar";
 import RenderedK8s from "./taskInstance/RenderedK8s";
@@ -323,9 +323,9 @@ const Details = ({
             </Text>
           </Tab>
           <Tab>
-            <MdPlagiarism size={16} />
+            <MdOutlineEventNote size={16} />
             <Text as="strong" ml={1}>
-              Audit Log
+              Event Log
             </Text>
           </Tab>
           {isDag && (
@@ -438,8 +438,9 @@ const Details = ({
             <DagCode />
           </TabPanel>
           <TabPanel height="100%">
-            <AuditLog
+            <EventLog
               taskId={isGroup || !taskId ? undefined : taskId}
+              showMapped={isMapped || !taskId}
               run={run}
             />
           </TabPanel>

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
@@ -19,7 +19,7 @@
 
 import React, { useState, useEffect, useMemo } from "react";
 import { Text, Box, Flex, Checkbox, Icon, Spinner } from "@chakra-ui/react";
-import { MdWarning } from "react-icons/md";
+import { MdInfo, MdWarning } from "react-icons/md";
 
 import { getMetaValue } from "src/utils";
 import useTaskLog from "src/api/useTaskLog";
@@ -248,9 +248,25 @@ const Logs = ({
           borderColor="gray.400"
           alignItems="center"
           p={2}
+          mb={2}
         >
           <Icon as={MdWarning} color="yellow.500" mr={2} />
           <Text fontSize="sm">{warning}</Text>
+        </Flex>
+      )}
+      {(!data || !parsedLogs) && !isLoading && (
+        <Flex
+          bg="blue.100"
+          borderRadius={2}
+          borderColor="gray.400"
+          alignItems="center"
+          p={2}
+          mb={2}
+        >
+          <Icon as={MdInfo} color="blue.600" mr={2} />
+          <Text fontSize="sm">
+            No task logs found. Try the Event Log tab for more context.
+          </Text>
         </Flex>
       )}
       {isLoading ? (

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1284,6 +1284,10 @@ export interface components {
       task_id?: string | null;
       /** @description The DAG Run ID */
       run_id?: string | null;
+      /** @description The Map Index */
+      map_index?: number | null;
+      /** @description The Try Number */
+      try_number?: number | null;
       /** @description A key describing the type of event. */
       event?: string;
       /**
@@ -1300,6 +1304,7 @@ export interface components {
      * @description Collection of event logs.
      *
      * *Changed in version 2.1.0*&#58; 'total_entries' field is added.
+     * *Changed in version 2.10.0*&#58; 'try_number' and 'map_index' fields are added.
      */
     EventLogCollection: {
       event_logs?: components["schemas"]["EventLog"][];
@@ -1314,7 +1319,7 @@ export interface components {
       timestamp?: string;
       /** @description The filename */
       filename?: string;
-      /** @description The full stackstrace.. */
+      /** @description The full stackstrace. */
       stack_trace?: string;
     };
     /**


### PR DESCRIPTION
Continuing @dstandish's changes to add more events to the Audit Log. We figured we should have some UI changes.

For the DAG details page. Audit Log becomes Event Log, which is aligned with the REST API nomenclature

"Extra" becomes "Details"
"Owner" becomes "User"

Added map index and try number as table columns

<img width="1031" alt="Screenshot 2024-07-23 at 2 46 15 PM" src="https://github.com/user-attachments/assets/6d9e022f-bc16-49b6-8cd0-0d724860216b">



Finally, added a banner when there are no logs for the user to check the Event Log tab
<img width="820" alt="Screenshot 2024-07-23 at 2 39 00 PM" src="https://github.com/user-attachments/assets/9a751cca-10b7-4aca-9a7e-ca879f17ab5d">



---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
