### PR TITLE
Add RedriveExecution support to StepFunctionStartExecutionOperator

### DIFF
--- a/airflow/providers/amazon/aws/hooks/step_function.py
+++ b/airflow/providers/amazon/aws/hooks/step_function.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import json
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowFailException
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 
 
@@ -61,7 +61,7 @@ class StepFunctionHook(AwsBaseHook):
         """
         if is_redrive_execution:
             if not name:
-                raise AirflowException(
+                raise AirflowFailException(
                     "Execution name is required to start RedriveExecution for %s.", state_machine_arn
                 )
             elements = state_machine_arn.split(":stateMachine:")

--- a/airflow/providers/amazon/aws/hooks/step_function.py
+++ b/airflow/providers/amazon/aws/hooks/step_function.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 
+from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 
 
@@ -43,6 +44,7 @@ class StepFunctionHook(AwsBaseHook):
         state_machine_arn: str,
         name: str | None = None,
         state_machine_input: dict | str | None = None,
+        is_redrive_execution: bool = False,
     ) -> str:
         """
         Start Execution of the State Machine.
@@ -51,10 +53,26 @@ class StepFunctionHook(AwsBaseHook):
             - :external+boto3:py:meth:`SFN.Client.start_execution`
 
         :param state_machine_arn: AWS Step Function State Machine ARN.
+        :param is_redrive_execution: Restarts unsuccessful executions of Standard workflows that did not
+            complete successfully in the last 14 days.
         :param name: The name of the execution.
         :param state_machine_input: JSON data input to pass to the State Machine.
         :return: Execution ARN.
         """
+        if is_redrive_execution:
+            if not name:
+                raise AirflowException(
+                    "Execution name is required to start RedriveExecution for %s.", state_machine_arn
+                )
+            elements = state_machine_arn.split(":stateMachine:")
+            execution_arn = f"{elements[0]}:execution:{elements[1]}:{name}"
+            self.conn.redrive_execution(executionArn=execution_arn)
+            self.log.info(
+                "Successfully started RedriveExecution for Step Function State Machine: %s.",
+                state_machine_arn,
+            )
+            return execution_arn
+
         execution_args = {"stateMachineArn": state_machine_arn}
         if name is not None:
             execution_args["name"] = name

--- a/tests/providers/amazon/aws/hooks/test_step_function.py
+++ b/tests/providers/amazon/aws/hooks/test_step_function.py
@@ -23,7 +23,7 @@ from unittest import mock
 import pytest
 from moto import mock_aws
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowFailException
 from airflow.providers.amazon.aws.hooks.step_function import StepFunctionHook
 
 
@@ -64,7 +64,9 @@ class TestStepFunctionHook:
     def test_redrive_execution_without_name_should_fail(self, mock_conn):
         mock_conn.redrive_execution.return_value = {"redriveDate": datetime(2024, 1, 1)}
 
-        with pytest.raises(AirflowException, match="Execution name is required to start RedriveExecution"):
+        with pytest.raises(
+            AirflowFailException, match="Execution name is required to start RedriveExecution"
+        ):
             StepFunctionHook().start_execution(
                 state_machine_arn="arn:aws:states:us-east-1:123456789012:stateMachine:test-state-machine",
                 is_redrive_execution=True,

--- a/tests/providers/amazon/aws/hooks/test_step_function.py
+++ b/tests/providers/amazon/aws/hooks/test_step_function.py
@@ -17,8 +17,13 @@
 # under the License.
 from __future__ import annotations
 
+from datetime import datetime
+from unittest import mock
+
+import pytest
 from moto import mock_aws
 
+from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.step_function import StepFunctionHook
 
 
@@ -41,6 +46,29 @@ class TestStepFunctionHook:
         )
 
         assert execution_arn is not None
+
+    @mock.patch.object(StepFunctionHook, "conn")
+    def test_redrive_execution(self, mock_conn):
+        mock_conn.redrive_execution.return_value = {"redriveDate": datetime(2024, 1, 1)}
+        StepFunctionHook().start_execution(
+            state_machine_arn="arn:aws:states:us-east-1:123456789012:stateMachine:test-state-machine",
+            name="random-123",
+            is_redrive_execution=True,
+        )
+
+        mock_conn.redrive_execution.assert_called_once_with(
+            executionArn="arn:aws:states:us-east-1:123456789012:execution:test-state-machine:random-123"
+        )
+
+    @mock.patch.object(StepFunctionHook, "conn")
+    def test_redrive_execution_without_name_should_fail(self, mock_conn):
+        mock_conn.redrive_execution.return_value = {"redriveDate": datetime(2024, 1, 1)}
+
+        with pytest.raises(AirflowException, match="Execution name is required to start RedriveExecution"):
+            StepFunctionHook().start_execution(
+                state_machine_arn="arn:aws:states:us-east-1:123456789012:stateMachine:test-state-machine",
+                is_redrive_execution=True,
+            )
 
     def test_describe_execution(self):
         hook = StepFunctionHook(aws_conn_id="aws_default", region_name="us-east-1")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
Adding RedriveExecution support to StepFunctionStartExecutionOperator. 
This is very useful in instances like where user want to restart step function from the last failure step.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
