### PR TITLE
openlineage: make value of slots in attrs.define consistent

### DIFF
--- a/airflow/providers/openlineage/plugins/facets.py
+++ b/airflow/providers/openlineage/plugins/facets.py
@@ -28,7 +28,7 @@ from airflow.exceptions import AirflowProviderDeprecationWarning
     reason="To be removed in the next release. Make sure to use information from AirflowRunFacet instead.",
     category=AirflowProviderDeprecationWarning,
 )
-@define(slots=False)
+@define
 class AirflowMappedTaskRunFacet(RunFacet):
     """Run facet containing information about mapped tasks."""
 
@@ -47,7 +47,7 @@ class AirflowMappedTaskRunFacet(RunFacet):
         )
 
 
-@define(slots=True)
+@define
 class AirflowJobFacet(JobFacet):
     """
     Composite Airflow job facet.
@@ -70,7 +70,7 @@ class AirflowJobFacet(JobFacet):
     tasks: dict
 
 
-@define(slots=True)
+@define
 class AirflowStateRunFacet(RunFacet):
     """
     Airflow facet providing state information.
@@ -89,7 +89,7 @@ class AirflowStateRunFacet(RunFacet):
     tasksState: dict[str, str]
 
 
-@define(slots=False)
+@define
 class AirflowRunFacet(RunFacet):
     """Composite Airflow run facet."""
 
@@ -100,7 +100,7 @@ class AirflowRunFacet(RunFacet):
     taskUuid: str
 
 
-@define(slots=True)
+@define
 class AirflowDagRunFacet(RunFacet):
     """Composite Airflow DAG run facet."""
 
@@ -108,7 +108,7 @@ class AirflowDagRunFacet(RunFacet):
     dagRun: dict
 
 
-@define(slots=False)
+@define
 class UnknownOperatorInstance(RedactMixin):
     """
     Describes an unknown operator.
@@ -127,7 +127,7 @@ class UnknownOperatorInstance(RedactMixin):
     reason="To be removed in the next release. Make sure to use information from AirflowRunFacet instead.",
     category=AirflowProviderDeprecationWarning,
 )
-@define(slots=False)
+@define
 class UnknownOperatorAttributeRunFacet(RunFacet):
     """RunFacet that describes unknown operators in an Airflow DAG."""
 

--- a/docs/apache-airflow-providers-openlineage/guides/developer.rst
+++ b/docs/apache-airflow-providers-openlineage/guides/developer.rst
@@ -481,7 +481,7 @@ Writing a custom facet function
     from airflow.providers.common.compat.openlineage.facet import RunFacet
 
 
-    @attrs.define(slots=False)
+    @attrs.define
     class MyCustomRunFacet(RunFacet):
         """Define a custom facet."""
 

--- a/tests/providers/openlineage/plugins/test_utils.py
+++ b/tests/providers/openlineage/plugins/test_utils.py
@@ -102,6 +102,28 @@ def test_info_json_encodable():
         casts = {"iwanttobeint": lambda x: int(x.imastring)}
         renames = {"_faulty_name": "goody_name"}
 
+    @define
+    class Test:
+        exclude_1: str
+        imastring: str
+        _faulty_name: str
+        donotcare: str
+
+    obj = Test("val", "123", "not_funny", "abc")
+
+    assert json.loads(json.dumps(TestInfo(obj))) == {
+        "iwanttobeint": 123,
+        "goody_name": "not_funny",
+        "donotcare": "abc",
+    }
+
+
+def test_info_json_encodable_without_slots():
+    class TestInfo(InfoJsonEncodable):
+        excludes = ["exclude_1", "exclude_2", "imastring"]
+        casts = {"iwanttobeint": lambda x: int(x.imastring)}
+        renames = {"_faulty_name": "goody_name"}
+
     @define(slots=False)
     class Test:
         exclude_1: str
@@ -122,7 +144,7 @@ def test_info_json_encodable_list_does_not_flatten():
     class TestInfo(InfoJsonEncodable):
         includes = ["alist"]
 
-    @define(slots=False)
+    @define
     class Test:
         alist: list[str]
 
@@ -135,7 +157,7 @@ def test_info_json_encodable_list_does_include_nonexisting():
     class TestInfo(InfoJsonEncodable):
         includes = ["exists", "doesnotexist"]
 
-    @define(slots=False)
+    @define
     class Test:
         exists: str
 
@@ -191,7 +213,7 @@ def test_redact_with_exclusions(monkeypatch):
             self.password = "passwd"
             self.transparent = "123"
 
-    @define(slots=False)
+    @define
     class NestedMixined(RedactMixin):
         _skip_redact = ["nested_field"]
         password: str

--- a/tests/providers/openlineage/utils/custom_facet_fixture.py
+++ b/tests/providers/openlineage/utils/custom_facet_fixture.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from airflow.models.taskinstance import TaskInstance, TaskInstanceState
 
 
-@attrs.define(slots=False)
+@attrs.define
 class MyCustomRunFacet(RunFacet):
     """Define a custom run facet."""
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Followup to #40972. Across the whole codebase, we are using `attrs.define` sometimes with default value of `slots=True`, sometimes with explicit set to `False`. This PR makes sure it's consistent and use default value of `slots=True`.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
