### PR TITLE
[WIP] - Allow deferrable SFTPSensor to return files as xcom

### DIFF
--- a/airflow/providers/sftp/triggers/sftp.py
+++ b/airflow/providers/sftp/triggers/sftp.py
@@ -111,6 +111,7 @@ class SFTPTrigger(BaseTrigger):
                             {
                                 "status": "success",
                                 "message": f"Sensed {len(files_sensed)} files: {files_sensed}",
+                                "files": files_sensed
                             }
                         )
                         return
@@ -119,10 +120,18 @@ class SFTPTrigger(BaseTrigger):
                     if _newer_than:
                         mod_time_utc = convert_to_utc(datetime.strptime(mod_time, "%Y%m%d%H%M%S"))
                         if _newer_than <= mod_time_utc:
-                            yield TriggerEvent({"status": "success", "message": f"Sensed file: {self.path}"})
+                            yield TriggerEvent({
+                                "status": "success",
+                                "message": f"Sensed file: {self.path}",
+                                "files": [self.path]
+                            })
                             return
                     else:
-                        yield TriggerEvent({"status": "success", "message": f"Sensed file: {self.path}"})
+                        yield TriggerEvent({
+                            "status": "success",
+                            "message": f"Sensed file: {self.path}",
+                            "files": [self.path]
+                        })
                         return
                 await asyncio.sleep(self.poke_interval)
             except AirflowException:

--- a/tests/system/providers/sftp/example_sftp_sensor.py
+++ b/tests/system/providers/sftp/example_sftp_sensor.py
@@ -51,10 +51,15 @@ with DAG(
         path=FULL_FILE_PATH,
         poke_interval=10,
     )
-    def sftp_sensor_decorator():
+    def sftp_sensor_decorator(files_found: list[str]):
         print("Files were successfully found!")
-        # add your logic
-        return "done"
+        files_to_keep = []
+        for file in files_found:
+            print(f"Found file: {file}")
+            if 'example_test_sftp' in file:
+                print('Found the file we were looking for!')
+                files_to_keep.append(file)
+        return files_to_keep
 
     # [END howto_operator_sftp_sensor_decorator]
 


### PR DESCRIPTION
- Allow deferrable sftp_sensor to return found files
- update example in docs to show python callable doing something with files that were found
- modify return to push an xcom for both `decorator_return_value` and `return_value` (did it work previously without this? Isn't that the default key?) 
- Pass in the found files to the python callable, even if no `op_kwargs` are supplied

---

- Should not cause any behavioral regression, as I only _added_ functionality. 
- [ ] Still need to add or modify tests