### PR TITLE
Make EMR Container Trigger max attempts retries match the Operator

### DIFF
--- a/airflow/providers/amazon/aws/triggers/emr.py
+++ b/airflow/providers/amazon/aws/triggers/emr.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import sys
 import warnings
 from typing import TYPE_CHECKING
 
@@ -174,6 +175,7 @@ class EmrContainerTrigger(AwsBaseWaiterTrigger):
     :param job_id:  job_id to check the state
     :param aws_conn_id: Reference to AWS connection id
     :param waiter_delay: polling period in seconds to check for the status
+    :param waiter_max_attempts: The maximum number of attempts to be made. Defaults to an infinite wait.
     """
 
     def __init__(
@@ -183,7 +185,7 @@ class EmrContainerTrigger(AwsBaseWaiterTrigger):
         aws_conn_id: str | None = "aws_default",
         poll_interval: int | None = None,  # deprecated
         waiter_delay: int = 30,
-        waiter_max_attempts: int = 600,
+        waiter_max_attempts: int = sys.maxsize,
     ):
         if poll_interval is not None:
             warnings.warn(

--- a/tests/providers/amazon/aws/triggers/test_emr.py
+++ b/tests/providers/amazon/aws/triggers/test_emr.py
@@ -16,6 +16,8 @@
 # under the License.
 from __future__ import annotations
 
+import sys
+
 from airflow.providers.amazon.aws.triggers.emr import (
     EmrAddStepsTrigger,
     EmrContainerTrigger,
@@ -206,6 +208,28 @@ class TestEmrContainerTrigger:
             "job_id": "test_job_id",
             "waiter_delay": 30,
             "waiter_max_attempts": 600,
+            "aws_conn_id": "aws_default",
+        }
+
+    def test_serialization_default_max_attempts(self):
+        virtual_cluster_id = "test_virtual_cluster_id"
+        job_id = "test_job_id"
+        waiter_delay = 30
+        aws_conn_id = "aws_default"
+
+        trigger = EmrContainerTrigger(
+            virtual_cluster_id=virtual_cluster_id,
+            job_id=job_id,
+            waiter_delay=waiter_delay,
+            aws_conn_id=aws_conn_id,
+        )
+        classpath, kwargs = trigger.serialize()
+        assert classpath == "airflow.providers.amazon.aws.triggers.emr.EmrContainerTrigger"
+        assert kwargs == {
+            "virtual_cluster_id": "test_virtual_cluster_id",
+            "job_id": "test_job_id",
+            "waiter_delay": 30,
+            "waiter_max_attempts": sys.maxsize,
             "aws_conn_id": "aws_default",
         }
 


### PR DESCRIPTION
The EMR Container Operator will wait indefinitely by default (on the wait for completion path) however when it is deferred the Trigger has a default timeout of 600s which does not match the user's expectations when using the operator.

Update the Trigger to have an infinite try count by default to match the Operator behaviour.

fixes #40483

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
