### PR TITLE
Add dataset event info to dag graph

### DIFF
--- a/airflow/www/static/js/api/useDatasetEvents.ts
+++ b/airflow/www/static/js/api/useDatasetEvents.ts
@@ -17,14 +17,21 @@
  * under the License.
  */
 
-import axios, { AxiosResponse } from "axios";
-import { useQuery } from "react-query";
+import axios from "axios";
+import { useQuery, UseQueryOptions } from "react-query";
 
 import { getMetaValue } from "src/utils";
-import type { API } from "src/types";
 import URLSearchParamsWrapper from "src/utils/URLSearchParamWrapper";
+import type {
+  DatasetEventCollection,
+  GetDatasetEventsVariables,
+} from "src/types/api-generated";
 
-export default function useDatasetEvents({
+interface Props extends GetDatasetEventsVariables {
+  options?: UseQueryOptions<DatasetEventCollection>;
+}
+
+const useDatasetEvents = ({
   datasetId,
   sourceDagId,
   sourceRunId,
@@ -33,8 +40,9 @@ export default function useDatasetEvents({
   limit,
   offset,
   orderBy,
-}: API.GetDatasetEventsVariables) {
-  const query = useQuery(
+  options,
+}: Props) => {
+  const query = useQuery<DatasetEventCollection>(
     [
       "datasets-events",
       datasetId,
@@ -61,16 +69,19 @@ export default function useDatasetEvents({
       if (sourceMapIndex)
         params.set("source_map_index", sourceMapIndex.toString());
 
-      return axios.get<AxiosResponse, API.DatasetEventCollection>(datasetsUrl, {
+      return axios.get(datasetsUrl, {
         params,
       });
     },
     {
       keepPreviousData: true,
+      ...options,
     }
   );
   return {
     ...query,
     data: query.data ?? { datasetEvents: [], totalEntries: 0 },
   };
-}
+};
+
+export default useDatasetEvents;

--- a/airflow/www/static/js/api/useTaskInstance.ts
+++ b/airflow/www/static/js/api/useTaskInstance.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import axios, { AxiosResponse } from "axios";
+import axios from "axios";
 import type { API } from "src/types";
 import { useQuery, UseQueryOptions } from "react-query";
 import { useAutoRefresh } from "src/context/autorefresh";
@@ -55,7 +55,7 @@ const useTaskInstance = ({
 
   return useQuery<API.TaskInstance>(
     ["taskInstance", dagId, dagRunId, taskId, mapIndex],
-    () => axios.get<AxiosResponse, API.TaskInstance>(url),
+    () => axios.get(url),
     {
       refetchInterval: isRefreshOn && (autoRefreshInterval || 1) * 1000,
       ...options,

--- a/airflow/www/static/js/components/DatasetEventCard.tsx
+++ b/airflow/www/static/js/components/DatasetEventCard.tsx
@@ -32,23 +32,20 @@ import {
   Link,
 } from "@chakra-ui/react";
 import { HiDatabase } from "react-icons/hi";
-import { FiLink } from "react-icons/fi";
 import { useSearchParams } from "react-router-dom";
 
 import { getMetaValue } from "src/utils";
 import Time from "src/components/Time";
 import { useContainerRef } from "src/context/containerRef";
-import { SimpleStatus } from "src/dag/StatusBox";
-import { formatDuration, getDuration } from "src/datetime_utils";
 import RenderedJsonField from "src/components/RenderedJsonField";
 
 import SourceTaskInstance from "./SourceTaskInstance";
+import TriggeredDagRuns from "./TriggeredDagRuns";
 
 type CardProps = {
   datasetEvent: DatasetEvent;
 };
 
-const gridUrl = getMetaValue("grid_url");
 const datasetsUrl = getMetaValue("datasets_url");
 
 const DatasetEventCard = ({ datasetEvent }: CardProps) => {
@@ -116,51 +113,7 @@ const DatasetEventCard = ({ datasetEvent }: CardProps) => {
           {!!datasetEvent?.createdDagruns?.length && (
             <>
               Triggered Dag Runs:
-              <Flex alignItems="center">
-                {datasetEvent?.createdDagruns.map((run) => {
-                  const runId = (run as any).dagRunId; // For some reason the type is wrong here
-                  const url = `${gridUrl?.replace(
-                    "__DAG_ID__",
-                    run.dagId || ""
-                  )}?dag_run_id=${encodeURIComponent(runId)}`;
-
-                  return (
-                    <Tooltip
-                      key={runId}
-                      label={
-                        <Box>
-                          <Text>DAG Id: {run.dagId}</Text>
-                          <Text>Status: {run.state || "no status"}</Text>
-                          <Text>
-                            Duration:{" "}
-                            {formatDuration(
-                              getDuration(run.startDate, run.endDate)
-                            )}
-                          </Text>
-                          <Text>
-                            Start Date: <Time dateTime={run.startDate} />
-                          </Text>
-                          {run.endDate && (
-                            <Text>
-                              End Date: <Time dateTime={run.endDate} />
-                            </Text>
-                          )}
-                        </Box>
-                      }
-                      portalProps={{ containerRef }}
-                      hasArrow
-                      placement="top"
-                    >
-                      <Flex width="30px">
-                        <SimpleStatus state={run.state} mx={1} />
-                        <Link color="blue.600" href={url}>
-                          <FiLink size="12px" />
-                        </Link>
-                      </Flex>
-                    </Tooltip>
-                  );
-                })}
-              </Flex>
+              <TriggeredDagRuns createdDagRuns={datasetEvent?.createdDagruns} />
             </>
           )}
         </GridItem>

--- a/airflow/www/static/js/components/SourceTaskInstance.tsx
+++ b/airflow/www/static/js/components/SourceTaskInstance.tsx
@@ -31,11 +31,15 @@ import { getMetaValue } from "src/utils";
 
 type SourceTIProps = {
   datasetEvent: DatasetEvent;
+  showLink?: boolean;
 };
 
 const gridUrl = getMetaValue("grid_url");
 
-const SourceTaskInstance = ({ datasetEvent }: SourceTIProps) => {
+const SourceTaskInstance = ({
+  datasetEvent,
+  showLink = true,
+}: SourceTIProps) => {
   const containerRef = useContainerRef();
   const { sourceDagId, sourceRunId, sourceTaskId, sourceMapIndex } =
     datasetEvent;
@@ -80,11 +84,13 @@ const SourceTaskInstance = ({ datasetEvent }: SourceTIProps) => {
           hasArrow
           placement="top"
         >
-          <Flex width="30px">
+          <Flex width={showLink ? "30px" : "16px"}>
             <SimpleStatus state={taskInstance.state} mx={1} />
-            <Link color="blue.600" href={url}>
-              <FiLink size="12px" />
-            </Link>
+            {showLink && (
+              <Link color="blue.600" href={url}>
+                <FiLink size="12px" />
+              </Link>
+            )}
           </Flex>
         </Tooltip>
       )}

--- a/airflow/www/static/js/components/TriggeredDagRuns.tsx
+++ b/airflow/www/static/js/components/TriggeredDagRuns.tsx
@@ -1,0 +1,91 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from "react";
+
+import type { DAGRun } from "src/types/api-generated";
+import { Box, Flex, Tooltip, Text, Link } from "@chakra-ui/react";
+import { FiLink } from "react-icons/fi";
+
+import { getMetaValue } from "src/utils";
+import Time from "src/components/Time";
+import { useContainerRef } from "src/context/containerRef";
+import { SimpleStatus } from "src/dag/StatusBox";
+import { formatDuration, getDuration } from "src/datetime_utils";
+
+type CardProps = {
+  createdDagRuns: DAGRun[];
+  showLink?: boolean;
+};
+
+const gridUrl = getMetaValue("grid_url");
+
+const TriggeredDagRuns = ({ createdDagRuns, showLink = true }: CardProps) => {
+  const containerRef = useContainerRef();
+
+  return (
+    <Flex alignItems="center">
+      {createdDagRuns.map((run) => {
+        const runId = (run as any).dagRunId; // For some reason the type is wrong here
+        const url = `${gridUrl?.replace(
+          "__DAG_ID__",
+          run.dagId || ""
+        )}?dag_run_id=${encodeURIComponent(runId)}`;
+
+        return (
+          <Tooltip
+            key={runId}
+            label={
+              <Box>
+                <Text>DAG Id: {run.dagId}</Text>
+                <Text>Status: {run.state || "no status"}</Text>
+                <Text>
+                  Duration:{" "}
+                  {formatDuration(getDuration(run.startDate, run.endDate))}
+                </Text>
+                <Text>
+                  Start Date: <Time dateTime={run.startDate} />
+                </Text>
+                {run.endDate && (
+                  <Text>
+                    End Date: <Time dateTime={run.endDate} />
+                  </Text>
+                )}
+              </Box>
+            }
+            portalProps={{ containerRef }}
+            hasArrow
+            placement="top"
+          >
+            <Flex width={showLink ? "30px" : "16px"}>
+              <SimpleStatus state={run.state} mx={1} />
+              {showLink && (
+                <Link color="blue.600" href={url}>
+                  <FiLink size="12px" />
+                </Link>
+              )}
+            </Flex>
+          </Tooltip>
+        );
+      })}
+    </Flex>
+  );
+};
+
+export default TriggeredDagRuns;

--- a/airflow/www/static/js/dag/details/dagRun/DatasetTriggerEvents.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/DatasetTriggerEvents.tsx
@@ -24,10 +24,13 @@ import type { DagRun as DagRunType } from "src/types";
 import { CardDef, CardList } from "src/components/Table";
 import type { DatasetEvent } from "src/types/api-generated";
 import DatasetEventCard from "src/components/DatasetEventCard";
+import { getMetaValue } from "src/utils";
 
 interface Props {
   runId: DagRunType["runId"];
 }
+
+const dagId = getMetaValue("dag_id");
 
 const cardDef: CardDef<DatasetEvent> = {
   card: ({ row }) => <DatasetEventCard datasetEvent={row} />,
@@ -37,7 +40,7 @@ const DatasetTriggerEvents = ({ runId }: Props) => {
   const {
     data: { datasetEvents = [] },
     isLoading,
-  } = useUpstreamDatasetEvents({ runId });
+  } = useUpstreamDatasetEvents({ dagRunId: runId, dagId });
 
   const columns = useMemo(
     () => [

--- a/airflow/www/static/js/dag/details/graph/DatasetNode.tsx
+++ b/airflow/www/static/js/dag/details/graph/DatasetNode.tsx
@@ -26,6 +26,7 @@ import {
   PopoverBody,
   PopoverCloseButton,
   PopoverContent,
+  PopoverFooter,
   PopoverHeader,
   PopoverTrigger,
   Portal,
@@ -33,17 +34,24 @@ import {
 } from "@chakra-ui/react";
 import { HiDatabase } from "react-icons/hi";
 import type { NodeProps } from "reactflow";
+import { TbApi } from "react-icons/tb";
 
 import { getMetaValue } from "src/utils";
 import { useContainerRef } from "src/context/containerRef";
+import Time from "src/components/Time";
+import SourceTaskInstance from "src/components/SourceTaskInstance";
+import TriggeredDagRuns from "src/components/TriggeredDagRuns";
+
 import type { CustomNodeProps } from "./Node";
 
 const datasetsUrl = getMetaValue("datasets_url");
 
 const DatasetNode = ({
-  data: { label, height, width, latestDagRunId, isZoomedOut },
+  data: { label, height, width, latestDagRunId, isZoomedOut, datasetEvent },
 }: NodeProps<CustomNodeProps>) => {
   const containerRef = useContainerRef();
+
+  const { fromRestApi } = (datasetEvent?.extra || {}) as Record<string, string>;
 
   return (
     <Popover>
@@ -70,23 +78,37 @@ const DatasetNode = ({
             {label}
           </Text>
           {!isZoomedOut && (
-            <Text
-              maxWidth={`calc(${width}px - 12px)`}
-              fontWeight={400}
-              fontSize="md"
-              textAlign="justify"
-              color="gray.500"
-            >
-              <HiDatabase
-                size="16px"
-                style={{
-                  display: "inline",
-                  verticalAlign: "middle",
-                  marginRight: "3px",
-                }}
-              />
-              Dataset
-            </Text>
+            <>
+              <Text
+                maxWidth={`calc(${width}px - 12px)`}
+                fontWeight={400}
+                fontSize="md"
+                textAlign="justify"
+                color="gray.500"
+              >
+                <HiDatabase
+                  size="16px"
+                  style={{
+                    display: "inline",
+                    verticalAlign: "middle",
+                    marginRight: "3px",
+                  }}
+                />
+                Dataset
+              </Text>
+              {!!datasetEvent && (
+                <Text
+                  fontWeight={400}
+                  fontSize="md"
+                  textAlign="justify"
+                  color="gray.500"
+                  alignSelf="flex-end"
+                >
+                  {/* @ts-ignore */}
+                  {moment(datasetEvent.timestamp).fromNow()}
+                </Text>
+              )}
+            </>
           )}
         </Box>
       </PopoverTrigger>
@@ -95,14 +117,38 @@ const DatasetNode = ({
           <PopoverArrow bg="gray.100" />
           <PopoverCloseButton />
           <PopoverHeader>{label}</PopoverHeader>
-          <PopoverBody>
+          {!!datasetEvent && (
+            <PopoverBody>
+              <Time dateTime={datasetEvent?.timestamp} />
+              <Box>
+                Source:
+                {fromRestApi && <TbApi size="20px" />}
+                {!!datasetEvent?.sourceTaskId && (
+                  <SourceTaskInstance
+                    datasetEvent={datasetEvent}
+                    showLink={false}
+                  />
+                )}
+                {!!datasetEvent?.createdDagruns?.length && (
+                  <>
+                    Triggered Dag Runs:
+                    <TriggeredDagRuns
+                      createdDagRuns={datasetEvent?.createdDagruns}
+                      showLink={false}
+                    />
+                  </>
+                )}
+              </Box>
+            </PopoverBody>
+          )}
+          <PopoverFooter>
             <Link
               color="blue"
               href={`${datasetsUrl}?uri=${encodeURIComponent(label)}`}
             >
               View Dataset
             </Link>
-          </PopoverBody>
+          </PopoverFooter>
         </PopoverContent>
       </Portal>
     </Popover>

--- a/airflow/www/static/js/dag/details/graph/Node.tsx
+++ b/airflow/www/static/js/dag/details/graph/Node.tsx
@@ -22,6 +22,7 @@ import { Box } from "@chakra-ui/react";
 import { Handle, NodeProps, Position } from "reactflow";
 
 import type { DepNode, DagRun, Task, TaskInstance } from "src/types";
+import type { DatasetEvent } from "src/types/api-generated";
 
 import DagNode from "./DagNode";
 import DatasetNode from "./DatasetNode";
@@ -44,6 +45,7 @@ export interface CustomNodeProps {
   style?: string;
   isZoomedOut: boolean;
   class: DepNode["value"]["class"];
+  datasetEvent?: DatasetEvent;
 }
 
 const Node = (props: NodeProps<CustomNodeProps>) => {

--- a/airflow/www/static/js/dag/details/graph/utils.ts
+++ b/airflow/www/static/js/dag/details/graph/utils.ts
@@ -24,6 +24,7 @@ import type { ElkExtendedEdge } from "elkjs";
 import type { SelectionProps } from "src/dag/useSelection";
 import { getTask } from "src/utils";
 import type { Task, TaskInstance, NodeType } from "src/types";
+import type { DatasetEvent } from "src/types/api-generated";
 
 import type { CustomNodeProps } from "./Node";
 
@@ -37,6 +38,7 @@ interface FlattenNodesProps {
   onToggleGroups: (groupIds: string[]) => void;
   hoveredTaskState?: string | null;
   isZoomedOut: boolean;
+  datasetEvents?: DatasetEvent[];
 }
 
 // Generate a flattened list of nodes for react-flow to render
@@ -50,6 +52,7 @@ export const flattenNodes = ({
   parent,
   hoveredTaskState,
   isZoomedOut,
+  datasetEvents,
 }: FlattenNodesProps) => {
   let nodes: ReactFlowNode<CustomNodeProps>[] = [];
   let edges: ElkExtendedEdge[] = [];
@@ -88,6 +91,10 @@ export const flattenNodes = ({
           }
           onToggleGroups(newGroupIds);
         },
+        datasetEvent:
+          node.value.class === "dataset"
+            ? datasetEvents?.find((de) => de.datasetUri === node.value.label)
+            : undefined,
         ...node.value,
       },
       type: "custom",


### PR DESCRIPTION
When a dag run is selected. Show the dataset events connected to that dagrun.

<img width="973" alt="Screenshot 2024-07-24 at 2 43 09 PM" src="https://github.com/user-attachments/assets/2094129a-a4fd-4817-a836-02c9286c519c">

<img width="1012" alt="Screenshot 2024-07-24 at 2 43 25 PM" src="https://github.com/user-attachments/assets/788295b8-ac60-4043-8502-1c700785bf19">


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
