### PR TITLE
Speed up SBOM generation by using newest features

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/cdxgen.py
+++ b/dev/breeze/src/airflow_breeze/utils/cdxgen.py
@@ -414,6 +414,7 @@ class SbomCoreJob(SbomApplicationJob):
         url = (
             f"http://127.0.0.1:{port}/sbom?path=/app/{file_url}&"
             f"projectName=apache-airflow&installDeps=false&"
+            f"lifecycle=pre-build&"
             f"projectVersion={self.airflow_version}&"
             f"multiProject=true"
         )


### PR DESCRIPTION
The SBOM generation with cdxgen was slow-ish because cdxgen tried to install all requirements of airflow (and failed) - and then had fallen back to just using what is provided.

After opening discussion in
https://github.com/CycloneDX/cdxgen/discussions/1270 the maintainer of cdxgen implemented a fix in the latest version where he exposed lifecycle parameter to cdxgen server which we are using.

With lifecycle=pre-built the whole step of installation is skipped and 25 SBOMS for one airflow version (after pulling the latest cdxgen image) takes ~ 2 minutes instead of 6 minutes previously.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
