### PR TITLE
Add start execution from trigger support for existing core sensors

### DIFF
--- a/airflow/sensors/date_time.py
+++ b/airflow/sensors/date_time.py
@@ -21,6 +21,7 @@ import datetime
 from typing import TYPE_CHECKING, Any, NoReturn, Sequence
 
 from airflow.sensors.base import BaseSensorOperator
+from airflow.triggers.base import StartTriggerArgs
 from airflow.triggers.temporal import DateTimeTrigger
 from airflow.utils import timezone
 
@@ -85,18 +86,36 @@ class DateTimeSensorAsync(DateTimeSensor):
     It is a drop-in replacement for DateTimeSensor.
 
     :param target_time: datetime after which the job succeeds. (templated)
+    :param start_from_trigger: Start the task directly from the triggerer without going into the worker.
     :param end_from_trigger: End the task directly from the triggerer without going into the worker.
     """
 
-    def __init__(self, *, end_from_trigger: bool = False, **kwargs) -> None:
+    start_trigger_args = StartTriggerArgs(
+        trigger_cls="airflow.triggers.temporal.DateTimeTrigger",
+        trigger_kwargs={"moment": "", "end_from_trigger": False},
+        next_method="execute_complete",
+        next_kwargs=None,
+        timeout=None,
+    )
+    start_from_trigger = False
+
+    def __init__(self, *, start_from_trigger: bool = False, end_from_trigger: bool = False, **kwargs) -> None:
         super().__init__(**kwargs)
         self.end_from_trigger = end_from_trigger
+
+        self.start_from_trigger = start_from_trigger
+        if self.start_from_trigger:
+            self.start_trigger_args.trigger_kwargs = dict(
+                moment=timezone.parse(self.target_time),
+                end_from_trigger=self.end_from_trigger,
+            )
 
     def execute(self, context: Context) -> NoReturn:
         self.defer(
             method_name="execute_complete",
             trigger=DateTimeTrigger(
-                moment=timezone.parse(self.target_time), end_from_trigger=self.end_from_trigger
+                moment=timezone.parse(self.target_time),
+                end_from_trigger=self.end_from_trigger,
             ),
         )
 


### PR DESCRIPTION
After https://github.com/apache/airflow/pull/38674, https://github.com/apache/airflow/pull/39585 and https://github.com/apache/airflow/pull/40935, we allow tasks to be executed directly from trigger. This PR added this feature to TimeSensorAsync, FileSensor and DateTimeSensorAsync

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
