### PR TITLE
Improve detection of tests vs. airflow code for internal API

### DIFF
--- a/airflow/api_internal/internal_api_call.py
+++ b/airflow/api_internal/internal_api_call.py
@@ -137,6 +137,12 @@ def internal_api_call(func: Callable[PS, RT]) -> Callable[PS, RT]:
         use_internal_api = InternalApiConfig.get_use_internal_api()
         if not use_internal_api:
             return func(*args, **kwargs)
+        import traceback
+
+        tb = traceback.extract_stack()
+        if any(filename.endswith("conftest.py") for filename, _, _, _ in tb):
+            # This is a test fixture, we should not use internal API for it
+            return func(*args, **kwargs)
 
         from airflow.serialization.serialized_objects import BaseSerialization  # avoid circular import
 

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -306,7 +306,6 @@ def _triggerer_is_healthy():
     return job and job.is_alive()
 
 
-@internal_api_call
 @provide_session
 def _create_orm_dagrun(
     dag,


### PR DESCRIPTION
In case of database isolation, some of our tests are running a number of fixtures that allow for example to create dag runs as setup code - this code, however sometimes runs methods that are used for internal_api calls and those calls are not needed to be run via internal_api.

This PR adds capability of detecting such case - by checking if any of the "callers" of the internal_api are `conftest.py` which means that this is a test fixture - and in this case, direct method call is used rather than internal API call.

This way we better separate test code from "airflow" code in DB isolation tests - and internal API is only used by the tested methods and not the test code that manages setup/teardown

Also orm_create_dagrun which should only be used in scheduler is unmarked as "internal_api" method - it is heavily used in the fixtures, but neither DAGFileProcessor, Triggerer nor Worker should create new DAGRuns.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
