### PR TITLE
DatabricksPlugin - Fix dag view redirect URL by using url_for redirect

### DIFF
--- a/airflow/providers/databricks/plugins/databricks_workflow.py
+++ b/airflow/providers/databricks/plugins/databricks_workflow.py
@@ -26,7 +26,6 @@ from flask import current_app, flash, redirect, request, url_for
 from flask_appbuilder.api import expose
 from packaging.version import Version
 
-from airflow.configuration import conf
 from airflow.exceptions import AirflowException, TaskInstanceNotFound
 from airflow.models import BaseOperator, BaseOperatorLink
 from airflow.models.dag import DAG, clear_task_instances
@@ -413,8 +412,7 @@ class RepairDatabricksTasks(AirflowBaseView, LoggingMixin):
     @expose("/repair_databricks_job/<string:dag_id>/<string:run_id>", methods=("GET",))
     @get_auth_decorator()
     def repair(self, dag_id: str, run_id: str):
-        view = conf.get("webserver", "dag_default_view")
-        return_url = self._get_return_url(dag_id, view)
+        return_url = self._get_return_url(dag_id, run_id)
 
         tasks_to_repair = request.values.get("tasks_to_repair")
         self.log.info("Tasks to repair: %s", tasks_to_repair)
@@ -450,8 +448,8 @@ class RepairDatabricksTasks(AirflowBaseView, LoggingMixin):
         return redirect(return_url)
 
     @staticmethod
-    def _get_return_url(dag_id: str, view) -> str:
-        return f"/dags/{dag_id}/{view}"
+    def _get_return_url(dag_id: str, run_id: str) -> str:
+        return url_for("Airflow.grid", dag_id=dag_id, dag_run_id=run_id)
 
 
 repair_databricks_view = RepairDatabricksTasks()

--- a/tests/providers/databricks/plugins/test_databricks_workflow.py
+++ b/tests/providers/databricks/plugins/test_databricks_workflow.py
@@ -145,6 +145,7 @@ def test_get_task_instance(app):
             assert result == dag_run
 
 
+@pytest.mark.db_test
 def test_get_return_url_dag_id_run_id(app):
     dag_id = "example_dag"
     run_id = "example_run"

--- a/tests/providers/databricks/plugins/test_databricks_workflow.py
+++ b/tests/providers/databricks/plugins/test_databricks_workflow.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from flask import url_for
 
 from airflow.exceptions import AirflowException
 from airflow.models.dagrun import DagRun
@@ -142,6 +143,17 @@ def test_get_task_instance(app):
         ):
             result = get_task_instance(operator, dttm, session)
             assert result == dag_run
+
+
+def test_get_return_url_dag_id_run_id(app):
+    dag_id = "example_dag"
+    run_id = "example_run"
+
+    expected_url = url_for("Airflow.grid", dag_id=dag_id, dag_run_id=run_id)
+
+    with app.app_context():
+        actual_url = RepairDatabricksTasks._get_return_url(dag_id, run_id)
+    assert actual_url == expected_url, f"Expected {expected_url}, got {actual_url}"
 
 
 @pytest.mark.db_test


### PR DESCRIPTION
We observed that the redirect does not work well on deployments
that are not rooted at "/". Following the pattern of using the
flask helper `url_for` in our other views, it resolves this issue and 
redirects to the dag view page now work well with this fix.
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
