### PR TITLE
Add string representation to dataset alias

### DIFF
--- a/airflow/models/dataset.py
+++ b/airflow/models/dataset.py
@@ -121,6 +121,9 @@ class DatasetAliasModel(Base):
     def from_public(cls, obj: DatasetAlias) -> DatasetAliasModel:
         return cls(name=obj.name)
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}(name={self.name!r})"
+
 
 class DatasetModel(Base):
     """
@@ -425,6 +428,7 @@ class DatasetEvent(Base):
             "source_dag_id",
             "source_run_id",
             "source_map_index",
+            "source_aliases",
         ]:
             args.append(f"{attr}={getattr(self, attr)!r}")
         return f"{self.__class__.__name__}({', '.join(args)})"


### PR DESCRIPTION
Since https://github.com/apache/airflow/pull/40809, we're able to get dataset events through a dataset alias. But I've not yet added an update to the string representation of dataset events to include dataset aliases. This PR fix the issue.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
