### PR TITLE
Fix default behaviour for init function in AppriseNotifier

### DIFF
--- a/airflow/providers/apprise/hooks/apprise.py
+++ b/airflow/providers/apprise/hooks/apprise.py
@@ -74,7 +74,7 @@ class AppriseHook(BaseHook):
         title: str | None = None,
         notify_type: NotifyType = NotifyType.INFO,
         body_format: NotifyFormat = NotifyFormat.TEXT,
-        tag: str | Iterable[str] | None = None,
+        tag: str | Iterable[str] = "all",
         attach: AppriseAttachment | None = None,
         interpret_escapes: bool | None = None,
         config: AppriseConfig | None = None,

--- a/airflow/providers/apprise/hooks/apprise.py
+++ b/airflow/providers/apprise/hooks/apprise.py
@@ -18,11 +18,13 @@
 from __future__ import annotations
 
 import json
+import warnings
 from typing import TYPE_CHECKING, Any, Iterable
 
 import apprise
 from apprise import AppriseConfig, NotifyFormat, NotifyType
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.hooks.base import BaseHook
 
 if TYPE_CHECKING:
@@ -74,7 +76,7 @@ class AppriseHook(BaseHook):
         title: str | None = None,
         notify_type: NotifyType = NotifyType.INFO,
         body_format: NotifyFormat = NotifyFormat.TEXT,
-        tag: str | Iterable[str] = "all",
+        tag: str | Iterable[str] | None = None,
         attach: AppriseAttachment | None = None,
         interpret_escapes: bool | None = None,
         config: AppriseConfig | None = None,
@@ -94,6 +96,14 @@ class AppriseHook(BaseHook):
             sequences such as \n and \r to their respective ascii new-line and carriage return characters
         :param config: Specify one or more configuration
         """
+        if tag is None:
+            warnings.warn(
+                "`tag` cannot be None. Assign it to be MATCH_ALL_TAG",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
+            )
+            tag = "all"
+
         title = title or ""
 
         apprise_obj = apprise.Apprise()

--- a/airflow/providers/apprise/notifications/apprise.py
+++ b/airflow/providers/apprise/notifications/apprise.py
@@ -18,13 +18,12 @@
 from __future__ import annotations
 
 from functools import cached_property
-from typing import TYPE_CHECKING, Iterable
+from typing import Iterable
+
+from apprise import AppriseConfig, NotifyFormat, NotifyType
 
 from airflow.notifications.basenotifier import BaseNotifier
 from airflow.providers.apprise.hooks.apprise import AppriseHook
-
-if TYPE_CHECKING:
-    from apprise import AppriseConfig, NotifyFormat, NotifyType
 
 
 class AppriseNotifier(BaseNotifier):
@@ -52,9 +51,9 @@ class AppriseNotifier(BaseNotifier):
         *,
         body: str,
         title: str | None = None,
-        notify_type: NotifyType | None = None,
-        body_format: NotifyFormat | None = None,
-        tag: str | Iterable[str] | None = None,
+        notify_type: NotifyType = NotifyType.INFO,
+        body_format: NotifyFormat = NotifyFormat.TEXT,
+        tag: str | Iterable[str] = "all",
         attach: str | None = None,
         interpret_escapes: bool | None = None,
         config: AppriseConfig | None = None,

--- a/airflow/providers/apprise/notifications/apprise.py
+++ b/airflow/providers/apprise/notifications/apprise.py
@@ -17,11 +17,13 @@
 
 from __future__ import annotations
 
+import warnings
 from functools import cached_property
 from typing import Iterable
 
 from apprise import AppriseConfig, NotifyFormat, NotifyType
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.notifications.basenotifier import BaseNotifier
 from airflow.providers.apprise.hooks.apprise import AppriseHook
 
@@ -51,14 +53,38 @@ class AppriseNotifier(BaseNotifier):
         *,
         body: str,
         title: str | None = None,
-        notify_type: NotifyType = NotifyType.INFO,
-        body_format: NotifyFormat = NotifyFormat.TEXT,
-        tag: str | Iterable[str] = "all",
+        notify_type: NotifyType | None = None,
+        body_format: NotifyFormat | None = None,
+        tag: str | Iterable[str] | None = None,
         attach: str | None = None,
         interpret_escapes: bool | None = None,
         config: AppriseConfig | None = None,
         apprise_conn_id: str = AppriseHook.default_conn_name,
     ):
+        if tag is None:
+            warnings.warn(
+                "`tag` cannot be None. Assign it to be MATCH_ALL_TAG",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
+            )
+            tag = "all"
+
+        if notify_type is None:
+            warnings.warn(
+                "`notify_type` cannot be None. Assign it to be NotifyType.INFO",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
+            )
+            notify_type = NotifyType.INFO
+
+        if body_format is None:
+            warnings.warn(
+                "`body_format` cannot be None. Assign it to be  NotifyFormat.TEXT",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
+            )
+            body_format = NotifyFormat.TEXT
+
         super().__init__()
         self.apprise_conn_id = apprise_conn_id
         self.body = body

--- a/docs/apache-airflow-providers-apprise/notifications/apprise_notifier_howto_guide.rst
+++ b/docs/apache-airflow-providers-apprise/notifications/apprise_notifier_howto_guide.rst
@@ -40,7 +40,7 @@ Example Code:
         start_date=datetime(2023, 1, 1),
         catchup=False,
         on_success_callback=[
-            send_apprise_notification(body="The dag {{ dag.dag_id }} failed", notify_type=NotifyType.FAILURE)
+            send_apprise_notification(body="The dag {{ dag.dag_id }} succeeded", notify_type=NotifyType.SUCCESS)
         ],
     ):
         BashOperator(
@@ -50,3 +50,4 @@ Example Code:
             ],
             bash_command="fail",
         )
+

--- a/docs/apache-airflow-providers-apprise/notifications/apprise_notifier_howto_guide.rst
+++ b/docs/apache-airflow-providers-apprise/notifications/apprise_notifier_howto_guide.rst
@@ -37,7 +37,7 @@ Example Code:
     with DAG(
         dag_id="apprise_notifier_testing",
         schedule_interval=None,
-        start_date=datetime(2023, 1, 1),
+        start_date=datetime(2024, 1, 1),
         catchup=False,
         on_success_callback=[
             send_apprise_notification(body="The dag {{ dag.dag_id }} succeeded", notify_type=NotifyType.SUCCESS)

--- a/docs/apache-airflow-providers-apprise/notifications/apprise_notifier_howto_guide.rst
+++ b/docs/apache-airflow-providers-apprise/notifications/apprise_notifier_howto_guide.rst
@@ -50,4 +50,3 @@ Example Code:
             ],
             bash_command="fail",
         )
-

--- a/tests/providers/apprise/hooks/test_apprise.py
+++ b/tests/providers/apprise/hooks/test_apprise.py
@@ -24,6 +24,7 @@ import apprise
 import pytest
 from apprise import NotifyFormat, NotifyType
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import Connection
 from airflow.providers.apprise.hooks.apprise import AppriseHook
 
@@ -111,13 +112,14 @@ class TestAppriseHook:
         apprise_obj.add = MagicMock()
         with patch.object(apprise, "Apprise", return_value=apprise_obj):
             hook = AppriseHook()
-            hook.notify(body="test")
-            apprise_obj.notify.assert_called_once_with(
-                body="test",
-                title="",
-                notify_type=NotifyType.INFO,
-                body_format=NotifyFormat.TEXT,
-                tag="all",
-                attach=None,
-                interpret_escapes=None,
-            )
+            with pytest.warns(AirflowProviderDeprecationWarning):
+                hook.notify(body="test")
+                apprise_obj.notify.assert_called_once_with(
+                    body="test",
+                    title="",
+                    notify_type=NotifyType.INFO,
+                    body_format=NotifyFormat.TEXT,
+                    tag="all",
+                    attach=None,
+                    interpret_escapes=None,
+                )

--- a/tests/providers/apprise/hooks/test_apprise.py
+++ b/tests/providers/apprise/hooks/test_apprise.py
@@ -43,13 +43,16 @@ class TestAppriseHook:
     )
     def test_get_config_from_conn(self, config):
         extra = {"config": config}
-        with patch.object(
-            AppriseHook,
-            "get_connection",
-            return_value=Connection(conn_type="apprise", extra=extra),
-        ):
-            hook = AppriseHook()
-            assert hook.get_config_from_conn() == (json.loads(config) if isinstance(config, str) else config)
+        with pytest.warns(AirflowProviderDeprecationWarning):
+            with patch.object(
+                AppriseHook,
+                "get_connection",
+                return_value=Connection(conn_type="apprise", extra=extra),
+            ):
+                hook = AppriseHook()
+                assert hook.get_config_from_conn() == (
+                    json.loads(config) if isinstance(config, str) else config
+                )
 
     def test_set_config_from_conn_with_dict(self):
         """
@@ -58,14 +61,15 @@ class TestAppriseHook:
         extra = {"config": {"path": "http://some_path_that_dont_exist/", "tag": "alert"}}
         apprise_obj = apprise.Apprise()
         apprise_obj.add = MagicMock()
-        with patch.object(
-            AppriseHook,
-            "get_connection",
-            return_value=Connection(conn_type="apprise", extra=extra),
-        ):
-            hook = AppriseHook()
-            hook.set_config_from_conn(apprise_obj)
-            apprise_obj.add.assert_called_once_with("http://some_path_that_dont_exist/", tag="alert")
+        with pytest.warns(AirflowProviderDeprecationWarning):
+            with patch.object(
+                AppriseHook,
+                "get_connection",
+                return_value=Connection(conn_type="apprise", extra=extra),
+            ):
+                hook = AppriseHook()
+                hook.set_config_from_conn(apprise_obj)
+                apprise_obj.add.assert_called_once_with("http://some_path_that_dont_exist/", tag="alert")
 
     def test_set_config_from_conn_with_list(self):
         """
@@ -80,19 +84,20 @@ class TestAppriseHook:
 
         apprise_obj = apprise.Apprise()
         apprise_obj.add = MagicMock()
-        with patch.object(
-            AppriseHook,
-            "get_connection",
-            return_value=Connection(conn_type="apprise", extra=extra),
-        ):
-            hook = AppriseHook()
-            hook.set_config_from_conn(apprise_obj)
-            apprise_obj.add.assert_has_calls(
-                [
-                    call("http://some_path_that_dont_exist/", tag="p0"),
-                    call("http://some_other_path_that_dont_exist/", tag="p1"),
-                ]
-            )
+        with pytest.warns(AirflowProviderDeprecationWarning):
+            with patch.object(
+                AppriseHook,
+                "get_connection",
+                return_value=Connection(conn_type="apprise", extra=extra),
+            ):
+                hook = AppriseHook()
+                hook.set_config_from_conn(apprise_obj)
+                apprise_obj.add.assert_has_calls(
+                    [
+                        call("http://some_path_that_dont_exist/", tag="p0"),
+                        call("http://some_other_path_that_dont_exist/", tag="p1"),
+                    ]
+                )
 
     @mock.patch(
         "airflow.providers.apprise.hooks.apprise.AppriseHook.get_connection",

--- a/tests/providers/apprise/hooks/test_apprise.py
+++ b/tests/providers/apprise/hooks/test_apprise.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock, call, patch
 
 import apprise
 import pytest
+from apprise import NotifyFormat, NotifyType
 
 from airflow.models import Connection
 from airflow.providers.apprise.hooks.apprise import AppriseHook
@@ -97,13 +98,13 @@ class TestAppriseHook:
         apprise_obj.add = MagicMock()
         with patch.object(apprise, "Apprise", return_value=apprise_obj):
             hook = AppriseHook()
-            hook.notify(body="test", config=True)
+            hook.notify(body="test")
             apprise_obj.notify.assert_called_once_with(
                 body="test",
                 title="",
-                notify_type="info",
-                body_format="text",
-                tag=None,
+                notify_type=NotifyType.INFO,
+                body_format=NotifyFormat.TEXT,
+                tag="all",
                 attach=None,
                 interpret_escapes=None,
             )

--- a/tests/providers/apprise/hooks/test_apprise.py
+++ b/tests/providers/apprise/hooks/test_apprise.py
@@ -97,10 +97,7 @@ class TestAppriseHook:
         apprise_obj.add = MagicMock()
         with patch.object(apprise, "Apprise", return_value=apprise_obj):
             hook = AppriseHook()
-            hook.notify(
-                body="test",
-                config=True,
-            )
+            hook.notify(body="test", config=True)
             apprise_obj.notify.assert_called_once_with(
                 body="test",
                 title="",

--- a/tests/providers/apprise/hooks/test_apprise.py
+++ b/tests/providers/apprise/hooks/test_apprise.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import json
+from unittest import mock
 from unittest.mock import MagicMock, call, patch
 
 import apprise
@@ -92,7 +93,19 @@ class TestAppriseHook:
                 ]
             )
 
-    def test_notify(self):
+    @mock.patch(
+        "airflow.providers.apprise.hooks.apprise.AppriseHook.get_connection",
+        return_value=Connection(
+            conn_id="apprise",
+            extra={
+                "config": [
+                    {"path": "http://some_path_that_dont_exist/", "tag": "p0"},
+                    {"path": "http://some_other_path_that_dont_exist/", "tag": "p1"},
+                ]
+            },
+        ),
+    )
+    def test_notify(self, connection):
         apprise_obj = apprise.Apprise()
         apprise_obj.notify = MagicMock()
         apprise_obj.add = MagicMock()

--- a/tests/providers/apprise/hooks/test_apprise.py
+++ b/tests/providers/apprise/hooks/test_apprise.py
@@ -43,16 +43,14 @@ class TestAppriseHook:
     )
     def test_get_config_from_conn(self, config):
         extra = {"config": config}
-        with pytest.warns(AirflowProviderDeprecationWarning):
-            with patch.object(
-                AppriseHook,
-                "get_connection",
-                return_value=Connection(conn_type="apprise", extra=extra),
-            ):
+        with patch.object(
+            AppriseHook,
+            "get_connection",
+            return_value=Connection(conn_type="apprise", extra=extra),
+        ):
+            with pytest.warns(AirflowProviderDeprecationWarning):
                 hook = AppriseHook()
-                assert hook.get_config_from_conn() == (
-                    json.loads(config) if isinstance(config, str) else config
-                )
+            assert hook.get_config_from_conn() == (json.loads(config) if isinstance(config, str) else config)
 
     def test_set_config_from_conn_with_dict(self):
         """
@@ -61,15 +59,16 @@ class TestAppriseHook:
         extra = {"config": {"path": "http://some_path_that_dont_exist/", "tag": "alert"}}
         apprise_obj = apprise.Apprise()
         apprise_obj.add = MagicMock()
-        with pytest.warns(AirflowProviderDeprecationWarning):
-            with patch.object(
-                AppriseHook,
-                "get_connection",
-                return_value=Connection(conn_type="apprise", extra=extra),
-            ):
+        with patch.object(
+            AppriseHook,
+            "get_connection",
+            return_value=Connection(conn_type="apprise", extra=extra),
+        ):
+            with pytest.warns(AirflowProviderDeprecationWarning):
                 hook = AppriseHook()
-                hook.set_config_from_conn(apprise_obj)
-                apprise_obj.add.assert_called_once_with("http://some_path_that_dont_exist/", tag="alert")
+            hook.set_config_from_conn(apprise_obj)
+
+        apprise_obj.add.assert_called_once_with("http://some_path_that_dont_exist/", tag="alert")
 
     def test_set_config_from_conn_with_list(self):
         """
@@ -84,20 +83,21 @@ class TestAppriseHook:
 
         apprise_obj = apprise.Apprise()
         apprise_obj.add = MagicMock()
-        with pytest.warns(AirflowProviderDeprecationWarning):
-            with patch.object(
-                AppriseHook,
-                "get_connection",
-                return_value=Connection(conn_type="apprise", extra=extra),
-            ):
+        with patch.object(
+            AppriseHook,
+            "get_connection",
+            return_value=Connection(conn_type="apprise", extra=extra),
+        ):
+            with pytest.warns(AirflowProviderDeprecationWarning):
                 hook = AppriseHook()
-                hook.set_config_from_conn(apprise_obj)
-                apprise_obj.add.assert_has_calls(
-                    [
-                        call("http://some_path_that_dont_exist/", tag="p0"),
-                        call("http://some_other_path_that_dont_exist/", tag="p1"),
-                    ]
-                )
+            hook.set_config_from_conn(apprise_obj)
+
+        apprise_obj.add.assert_has_calls(
+            [
+                call("http://some_path_that_dont_exist/", tag="p0"),
+                call("http://some_other_path_that_dont_exist/", tag="p1"),
+            ]
+        )
 
     @mock.patch(
         "airflow.providers.apprise.hooks.apprise.AppriseHook.get_connection",
@@ -119,12 +119,13 @@ class TestAppriseHook:
             hook = AppriseHook()
             with pytest.warns(AirflowProviderDeprecationWarning):
                 hook.notify(body="test")
-                apprise_obj.notify.assert_called_once_with(
-                    body="test",
-                    title="",
-                    notify_type=NotifyType.INFO,
-                    body_format=NotifyFormat.TEXT,
-                    tag="all",
-                    attach=None,
-                    interpret_escapes=None,
-                )
+
+        apprise_obj.notify.assert_called_once_with(
+            body="test",
+            title="",
+            notify_type=NotifyType.INFO,
+            body_format=NotifyFormat.TEXT,
+            tag="all",
+            attach=None,
+            interpret_escapes=None,
+        )

--- a/tests/providers/apprise/hooks/test_apprise.py
+++ b/tests/providers/apprise/hooks/test_apprise.py
@@ -48,8 +48,7 @@ class TestAppriseHook:
             "get_connection",
             return_value=Connection(conn_type="apprise", extra=extra),
         ):
-            with pytest.warns(AirflowProviderDeprecationWarning):
-                hook = AppriseHook()
+            hook = AppriseHook()
             assert hook.get_config_from_conn() == (json.loads(config) if isinstance(config, str) else config)
 
     def test_set_config_from_conn_with_dict(self):
@@ -64,8 +63,7 @@ class TestAppriseHook:
             "get_connection",
             return_value=Connection(conn_type="apprise", extra=extra),
         ):
-            with pytest.warns(AirflowProviderDeprecationWarning):
-                hook = AppriseHook()
+            hook = AppriseHook()
             hook.set_config_from_conn(apprise_obj)
 
         apprise_obj.add.assert_called_once_with("http://some_path_that_dont_exist/", tag="alert")
@@ -88,8 +86,7 @@ class TestAppriseHook:
             "get_connection",
             return_value=Connection(conn_type="apprise", extra=extra),
         ):
-            with pytest.warns(AirflowProviderDeprecationWarning):
-                hook = AppriseHook()
+            hook = AppriseHook()
             hook.set_config_from_conn(apprise_obj)
 
         apprise_obj.add.assert_has_calls(

--- a/tests/providers/apprise/notifications/test_apprise.py
+++ b/tests/providers/apprise/notifications/test_apprise.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from unittest import mock
 
 import pytest
-from apprise import NotifyType
+from apprise import NotifyFormat, NotifyType
 
 from airflow.operators.empty import EmptyOperator
 from airflow.providers.apprise.notifications.apprise import (
@@ -42,8 +42,8 @@ class TestAppriseNotifier:
             body="DISK at 99%",
             notify_type=NotifyType.FAILURE,
             title=None,
-            body_format=None,
-            tag=None,
+            body_format=NotifyFormat.TEXT,
+            tag="all",
             attach=None,
             interpret_escapes=None,
             config=None,
@@ -59,8 +59,8 @@ class TestAppriseNotifier:
             body="DISK at 99%",
             notify_type=NotifyType.FAILURE,
             title=None,
-            body_format=None,
-            tag=None,
+            body_format=NotifyFormat.TEXT,
+            tag="all",
             attach=None,
             interpret_escapes=None,
             config=None,
@@ -82,8 +82,8 @@ class TestAppriseNotifier:
             notify_type=NotifyType.FAILURE,
             title="DISK at 99% test_notifier",
             body="System can crash soon test_notifier",
-            body_format=None,
-            tag=None,
+            body_format=NotifyFormat.TEXT,
+            tag="all",
             attach=None,
             interpret_escapes=None,
             config=None,

--- a/tests/providers/apprise/notifications/test_apprise.py
+++ b/tests/providers/apprise/notifications/test_apprise.py
@@ -37,7 +37,8 @@ class TestAppriseNotifier:
     def test_notifier(self, mock_apprise_hook, dag_maker):
         with dag_maker("test_notifier") as dag:
             EmptyOperator(task_id="task1")
-        notifier = send_apprise_notification(body="DISK at 99%", notify_type=NotifyType.FAILURE)
+        with pytest.warns(AirflowProviderDeprecationWarning):
+            notifier = send_apprise_notification(body="DISK at 99%", notify_type=NotifyType.FAILURE)
         notifier({"dag": dag})
         mock_apprise_hook.return_value.notify.assert_called_once_with(
             body="DISK at 99%",
@@ -54,7 +55,8 @@ class TestAppriseNotifier:
     def test_notifier_with_notifier_class(self, mock_apprise_hook, dag_maker):
         with dag_maker("test_notifier") as dag:
             EmptyOperator(task_id="task1")
-        notifier = AppriseNotifier(body="DISK at 99%", notify_type=NotifyType.FAILURE)
+        with pytest.warns(AirflowProviderDeprecationWarning):
+            notifier = AppriseNotifier(body="DISK at 99%", notify_type=NotifyType.FAILURE)
         notifier({"dag": dag})
         mock_apprise_hook.return_value.notify.assert_called_once_with(
             body="DISK at 99%",
@@ -72,11 +74,12 @@ class TestAppriseNotifier:
         with dag_maker("test_notifier") as dag:
             EmptyOperator(task_id="task1")
 
-        notifier = AppriseNotifier(
-            notify_type=NotifyType.FAILURE,
-            title="DISK at 99% {{dag.dag_id}}",
-            body="System can crash soon {{dag.dag_id}}",
-        )
+        with pytest.warns(AirflowProviderDeprecationWarning):
+            notifier = AppriseNotifier(
+                notify_type=NotifyType.FAILURE,
+                title="DISK at 99% {{dag.dag_id}}",
+                body="System can crash soon {{dag.dag_id}}",
+            )
         context = {"dag": dag}
         notifier(context)
         mock_apprise_hook.return_value.notify.assert_called_once_with(


### PR DESCRIPTION
closes: https://github.com/apache/airflow/pull/38593/
with cherry-picking from @rrr2rrr 
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
