### PR TITLE
Fix `RdsStopDbOperator` operator in deferrable mode

### DIFF
--- a/airflow/providers/amazon/aws/hooks/rds.py
+++ b/airflow/providers/amazon/aws/hooks/rds.py
@@ -259,7 +259,7 @@ class RdsHook(AwsGenericHook["RDSClient"]):
             return self.get_db_instance_state(db_instance_id)
 
         target_state = target_state.lower()
-        if target_state in ("available", "deleted"):
+        if target_state in ("available", "deleted", "stopped"):
             waiter = self.conn.get_waiter(f"db_instance_{target_state}")  # type: ignore
             wait(
                 waiter=waiter,
@@ -272,7 +272,7 @@ class RdsHook(AwsGenericHook["RDSClient"]):
             )
         else:
             self._wait_for_state(poke, target_state, check_interval, max_attempts)
-            self.log.info("DB cluster snapshot '%s' reached the '%s' state", db_instance_id, target_state)
+            self.log.info("DB cluster '%s' reached the '%s' state", db_instance_id, target_state)
 
     def get_db_cluster_state(self, db_cluster_id: str) -> str:
         """
@@ -310,7 +310,7 @@ class RdsHook(AwsGenericHook["RDSClient"]):
             return self.get_db_cluster_state(db_cluster_id)
 
         target_state = target_state.lower()
-        if target_state in ("available", "deleted"):
+        if target_state in ("available", "deleted", "stopped"):
             waiter = self.conn.get_waiter(f"db_cluster_{target_state}")  # type: ignore
             waiter.wait(
                 DBClusterIdentifier=db_cluster_id,

--- a/airflow/providers/amazon/aws/waiters/rds.json
+++ b/airflow/providers/amazon/aws/waiters/rds.json
@@ -1,0 +1,253 @@
+{
+    "version": 2,
+    "waiters": {
+        "db_instance_stopped": {
+            "operation": "DescribeDBInstances",
+            "delay": 30,
+            "maxAttempts": 60,
+            "acceptors": [
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "stopped",
+                    "state": "success"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "available",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "backing-up",
+                    "state": "retry"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "creating",
+                    "state": "retry"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "delete-precheck",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "deleting",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "failed",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "inaccessible-encryption-credentials",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "inaccessible-encryption-credentials-recoverable",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "incompatible-network",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "incompatible-option-group",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "incompatible-parameters",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "incompatible-restore",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "insufficient-capacity",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "maintenance",
+                    "state": "retry"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "modifying",
+                    "state": "retry"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "rebooting",
+                    "state": "retry"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "renaming",
+                    "state": "retry"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "restore-error",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "starting",
+                    "state": "retry"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "stopping",
+                    "state": "retry"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "storage-full",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "upgrading",
+                    "state": "retry"
+                }
+            ]
+        },
+        "db_cluster_stopped": {
+            "operation": "DescribeDBClusters",
+            "delay": 30,
+            "maxAttempts": 60,
+            "acceptors": [
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBClusters[].Status",
+                    "expected": "stopped",
+                    "state": "success"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "available",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "backing-up",
+                    "state": "retry"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "cloning-failed",
+                    "state": "retry"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "creating",
+                    "state": "retry"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "deleting",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "failing-over",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "inaccessible-encryption-credentials",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "inaccessible-encryption-credentials-recoverable",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "maintenance",
+                    "state": "retry"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "migrating",
+                    "state": "retry"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "migration-failed",
+                    "state": "failure"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "modifying",
+                    "state": "retry"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "renaming",
+                    "state": "retry"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "starting",
+                    "state": "retry"
+                },
+                {
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "stopping",
+                    "state": "retry"
+                }
+            ]
+        }
+    }
+}

--- a/tests/providers/amazon/aws/hooks/test_rds.py
+++ b/tests/providers/amazon/aws/hooks/test_rds.py
@@ -150,7 +150,7 @@ class TestRdsHook:
 
     def test_wait_for_db_instance_state_boto_waiters(self, rds_hook: RdsHook, db_instance_id: str):
         """Checks that the DB instance waiter uses AWS boto waiters where possible"""
-        for state in ("available", "deleted"):
+        for state in ("available", "deleted", "stopped"):
             with patch.object(rds_hook.conn, "get_waiter") as mock:
                 rds_hook.wait_for_db_instance_state(db_instance_id, target_state=state, **self.waiter_args)
                 mock.assert_called_once_with(f"db_instance_{state}")
@@ -161,16 +161,6 @@ class TestRdsHook:
                     },
                 )
 
-    def test_wait_for_db_instance_state_custom_waiter(self, rds_hook: RdsHook, db_instance_id: str):
-        """Checks that the DB instance waiter uses custom wait logic when AWS boto waiters aren't available"""
-        with patch.object(rds_hook, "_wait_for_state") as mock:
-            rds_hook.wait_for_db_instance_state(db_instance_id, target_state="stopped", **self.waiter_args)
-            mock.assert_called_once()
-
-        with patch.object(rds_hook, "get_db_instance_state", return_value="stopped") as mock:
-            rds_hook.wait_for_db_instance_state(db_instance_id, target_state="stopped", **self.waiter_args)
-            mock.assert_called_once_with(db_instance_id)
-
     def test_get_db_cluster_state(self, rds_hook: RdsHook, db_cluster_id: str):
         response = rds_hook.conn.describe_db_clusters(DBClusterIdentifier=db_cluster_id)
         state_expected = response["DBClusters"][0]["Status"]
@@ -179,7 +169,7 @@ class TestRdsHook:
 
     def test_wait_for_db_cluster_state_boto_waiters(self, rds_hook: RdsHook, db_cluster_id: str):
         """Checks that the DB cluster waiter uses AWS boto waiters where possible"""
-        for state in ("available", "deleted"):
+        for state in ("available", "deleted", "stopped"):
             with patch.object(rds_hook.conn, "get_waiter") as mock:
                 rds_hook.wait_for_db_cluster_state(db_cluster_id, target_state=state, **self.waiter_args)
                 mock.assert_called_once_with(f"db_cluster_{state}")
@@ -190,16 +180,6 @@ class TestRdsHook:
                         "MaxAttempts": self.waiter_args["max_attempts"],
                     },
                 )
-
-    def test_wait_for_db_cluster_state_custom_waiter(self, rds_hook: RdsHook, db_cluster_id: str):
-        """Checks that the DB cluster waiter uses custom wait logic when AWS boto waiters aren't available"""
-        with patch.object(rds_hook, "_wait_for_state") as mock_wait_for_state:
-            rds_hook.wait_for_db_cluster_state(db_cluster_id, target_state="stopped", **self.waiter_args)
-            mock_wait_for_state.assert_called_once()
-
-        with patch.object(rds_hook, "get_db_cluster_state", return_value="stopped") as mock:
-            rds_hook.wait_for_db_cluster_state(db_cluster_id, target_state="stopped", **self.waiter_args)
-            mock.assert_called_once_with(db_cluster_id)
 
     def test_get_db_snapshot_state(self, rds_hook: RdsHook, db_snapshot_id: str):
         response = rds_hook.conn.describe_db_snapshots(DBSnapshotIdentifier=db_snapshot_id)

--- a/tests/providers/amazon/aws/operators/test_rds.py
+++ b/tests/providers/amazon/aws/operators/test_rds.py
@@ -813,8 +813,7 @@ class TestRdsStopDbOperator:
         del cls.hook
 
     @mock_aws
-    @patch.object(RdsHook, "wait_for_db_instance_state")
-    def test_stop_db_instance(self, mock_await_status):
+    def test_stop_db_instance(self):
         _create_db_instance(self.hook)
         stop_db_instance = RdsStopDbOperator(task_id="test_stop_db_instance", db_identifier=DB_INSTANCE_NAME)
         _patch_hook_get_connection(stop_db_instance.hook)
@@ -822,11 +821,10 @@ class TestRdsStopDbOperator:
         result = self.hook.conn.describe_db_instances(DBInstanceIdentifier=DB_INSTANCE_NAME)
         status = result["DBInstances"][0]["DBInstanceStatus"]
         assert status == "stopped"
-        mock_await_status.assert_called()
 
     @mock_aws
-    @patch.object(RdsHook, "wait_for_db_instance_state")
-    def test_stop_db_instance_no_wait(self, mock_await_status):
+    @patch.object(RdsHook, "get_waiter")
+    def test_stop_db_instance_no_wait(self, mock_get_waiter):
         _create_db_instance(self.hook)
         stop_db_instance = RdsStopDbOperator(
             task_id="test_stop_db_instance_no_wait", db_identifier=DB_INSTANCE_NAME, wait_for_completion=False
@@ -836,7 +834,7 @@ class TestRdsStopDbOperator:
         result = self.hook.conn.describe_db_instances(DBInstanceIdentifier=DB_INSTANCE_NAME)
         status = result["DBInstances"][0]["DBInstanceStatus"]
         assert status == "stopped"
-        mock_await_status.assert_not_called()
+        mock_get_waiter.assert_not_called()
 
     @mock.patch.object(RdsHook, "conn")
     def test_deferred(self, conn_mock):
@@ -872,8 +870,7 @@ class TestRdsStopDbOperator:
         assert len(instance_snapshots) == 1
 
     @mock_aws
-    @patch.object(RdsHook, "wait_for_db_cluster_state")
-    def test_stop_db_cluster(self, mock_await_status):
+    def test_stop_db_cluster(self):
         _create_db_cluster(self.hook)
         stop_db_cluster = RdsStopDbOperator(
             task_id="test_stop_db_cluster", db_identifier=DB_CLUSTER_NAME, db_type="cluster"
@@ -884,7 +881,6 @@ class TestRdsStopDbOperator:
         describe_result = self.hook.conn.describe_db_clusters(DBClusterIdentifier=DB_CLUSTER_NAME)
         status = describe_result["DBClusters"][0]["Status"]
         assert status == "stopped"
-        mock_await_status.assert_called()
 
     @mock_aws
     def test_stop_db_cluster_create_snapshot_logs_warning_message(self, caplog):


### PR DESCRIPTION
The operator `RdsStopDbOperator` when used in deferrable mode does not work because it uses a waiter that does not exist. I also fixed some inconsistencies in RDS operators

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
