### PR TITLE
Change `task_id` from `send_email` to `send_email_notification` in `taskflow.rst`

### DIFF
--- a/docs/apache-airflow/core-concepts/taskflow.rst
+++ b/docs/apache-airflow/core-concepts/taskflow.rst
@@ -41,17 +41,17 @@ TaskFlow takes care of moving inputs and outputs between your Tasks using XComs 
     email_info = compose_email(get_ip())
 
     EmailOperator(
-        task_id='send_email',
+        task_id='send_email_notification',
         to='example@example.com',
         subject=email_info['subject'],
         html_content=email_info['body']
     )
 
-Here, there are three tasks - ``get_ip``, ``compose_email``, and ``send_email``.
+Here, there are three tasks - ``get_ip``, ``compose_email``, and ``send_email_notification``.
 
 The first two are declared using TaskFlow, and automatically pass the return value of ``get_ip`` into ``compose_email``, not only linking the XCom across, but automatically declaring that ``compose_email`` is *downstream* of ``get_ip``.
 
-``send_email`` is a more traditional Operator, but even it can use the return value of ``compose_email`` to set its parameters, and again, automatically work out that it must be *downstream* of ``compose_email``.
+``send_email_notification`` is a more traditional Operator, but even it can use the return value of ``compose_email`` to set its parameters, and again, automatically work out that it must be *downstream* of ``compose_email``.
 
 You can also use a plain value or variable to call a TaskFlow function - for example, this will work as you expect (but, of course, won't run the code inside the task until the DAG is executed - the ``name`` value is persisted as a task parameter until that time)::
 


### PR DESCRIPTION
Renaming the `task_id` within the `EmailOperator` example from `send_email` to `send_email_notification`.  `send_email` is an existing method within `airflow.utils.email`.  Changing the duplicate name to something unique will help new users by removing confusion.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
