### PR TITLE
SSHHook: check if existing connection is still alive

### DIFF
--- a/airflow/providers/ssh/operators/ssh.py
+++ b/airflow/providers/ssh/operators/ssh.py
@@ -148,7 +148,6 @@ class SSHOperator(BaseOperator):
 
     def get_ssh_client(self) -> SSHClient:
         # Remember to use context manager or call .close() on this when done
-        self.log.info("Creating ssh_client")
         return self.hook.get_conn()
 
     @deprecated(

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -1092,3 +1092,26 @@ class TestSSHHook:
         status, msg = hook.test_connection()
         assert status is False
         assert msg == "Test failure case"
+
+    def test_ssh_connection_client_is_reused_if_open(self):
+        hook = SSHHook(ssh_conn_id="ssh_default")
+        client1 = hook.get_conn()
+        client2 = hook.get_conn()
+        assert client1 is client2
+        assert client2.get_transport().is_active()
+
+    def test_ssh_connection_client_is_recreated_if_closed(self):
+        hook = SSHHook(ssh_conn_id="ssh_default")
+        client1 = hook.get_conn()
+        client1.close()
+        client2 = hook.get_conn()
+        assert client1 is not client2
+        assert client2.get_transport().is_active()
+
+    def test_ssh_connection_client_is_recreated_if_transport_closed(self):
+        hook = SSHHook(ssh_conn_id="ssh_default")
+        client1 = hook.get_conn()
+        client1.get_transport().close()
+        client2 = hook.get_conn()
+        assert client1 is not client2
+        assert client2.get_transport().is_active()


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

#40377 started reusing in `get_conn()` the same paramiko SSHClient, which drastically improves performance of sequential execution of SSH commands. But connection could be already closed (e.g. network issue), and once it is closed, SSHHook will not be able to do anything.

Always check if connection is still alive before returning it. Also move the large block of code out of `if` clause.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
