### PR TITLE
Add missing unit tests for redis provider.

### DIFF
--- a/tests/always/test_project_structure.py
+++ b/tests/always/test_project_structure.py
@@ -151,8 +151,6 @@ class TestProjectStructure:
             "tests/providers/microsoft/azure/operators/test_adls.py",
             "tests/providers/microsoft/azure/transfers/test_azure_blob_to_gcs.py",
             "tests/providers/mongo/sensors/test_mongo.py",
-            "tests/providers/redis/operators/test_redis_publish.py",
-            "tests/providers/redis/sensors/test_redis_key.py",
             "tests/providers/slack/notifications/test_slack_notifier.py",
             "tests/providers/snowflake/triggers/test_snowflake_trigger.py",
             "tests/providers/yandex/hooks/test_yandexcloud_dataproc.py",

--- a/tests/providers/redis/operators/test_redis_publish.py
+++ b/tests/providers/redis/operators/test_redis_publish.py
@@ -1,0 +1,49 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from airflow.models.dag import DAG
+from airflow.providers.redis.operators.redis_publish import RedisPublishOperator
+from airflow.utils import timezone
+
+DEFAULT_DATE = timezone.datetime(2017, 1, 1)
+
+
+class TestRedisPublishOperator:
+    def setup_method(self):
+        args = {"owner": "airflow", "start_date": DEFAULT_DATE}
+
+        self.dag = DAG("test_dag_id", default_args=args)
+
+        self.mock_context = MagicMock()
+
+    @patch("airflow.providers.redis.hooks.redis.RedisHook.get_conn")
+    def test_execute_operator(self, mock_redis_conn):
+        operator = RedisPublishOperator(
+            task_id="test_task",
+            dag=self.dag,
+            channel="test_channel",
+            message="test_message",
+            redis_conn_id="redis_default",
+        )
+        operator.execute(self.mock_context)
+
+        mock_redis_conn.assert_called_once_with()
+        mock_redis_conn().publish.assert_called_once_with(channel="test_channel", message="test_message")

--- a/tests/providers/redis/sensors/test_redis_key.py
+++ b/tests/providers/redis/sensors/test_redis_key.py
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from airflow.models.dag import DAG
+from airflow.providers.redis.sensors.redis_key import RedisKeySensor
+from airflow.utils import timezone
+
+DEFAULT_DATE = timezone.datetime(2017, 1, 1)
+
+
+class TestRedisPublishOperator:
+    def setup_method(self):
+        args = {"owner": "airflow", "start_date": DEFAULT_DATE}
+
+        self.dag = DAG("test_dag_id", default_args=args)
+
+        self.mock_context = MagicMock()
+
+    @patch("airflow.providers.redis.hooks.redis.RedisHook.get_conn")
+    def test_execute_operator(self, mock_redis_conn):
+        sensor = RedisKeySensor(
+            key="test_key", redis_conn_id="redis_default", task_id="test_task", dag=self.dag
+        )
+        sensor.poke(self.mock_context)
+
+        mock_redis_conn.assert_called_once_with()
+        mock_redis_conn().exists.assert_called_once_with("test_key")


### PR DESCRIPTION
This PR adds a simple tests for RedisKeySensor and RedisPublishOperator.

Part of https://github.com/apache/airflow/issues/35442

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
