### PR TITLE
Bugfix/41067 attempt to fix tests/core/test_core.py

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2732,7 +2732,7 @@ class TaskInstance(Base, LoggingMixin):
         else:  # isinstance(task_instance, TaskInstancePydantic)
             filters = (col == getattr(task_instance, col.name) for col in inspect(TaskInstance).primary_key)
             ti = session.query(TaskInstance).filter(*filters).scalar()
-            dag = ti.dag_model.serialized_dag.dag
+            dag = DagBag(read_dags_from_db=True).get_dag(task_instance.dag_id, session=session)
             task_instance.task = dag.task_dict[ti.task_id]
             ti.task = task_instance.task
         task = task_instance.task

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -905,6 +905,8 @@ def dag_maker(request):
             self.dag_run = dag.create_dagrun(**kwargs)
             for ti in self.dag_run.task_instances:
                 ti.refresh_from_task(dag.get_task(ti.task_id))
+            if self.want_serialized:
+                self.session.commit()
             return self.dag_run
 
         def create_dagrun_after(self, dagrun, **kwargs):

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -78,7 +78,7 @@ class TestCore:
             except Exception:
                 pass
 
-        with dag_maker():
+        with dag_maker(serialized=True):
             op = PythonOperator(
                 task_id="test_timeout",
                 execution_timeout=timedelta(seconds=1),
@@ -90,7 +90,7 @@ class TestCore:
 
     def test_task_fail_duration(self, dag_maker):
         """If a task fails, the duration should be recorded in TaskFail"""
-        with dag_maker() as dag:
+        with dag_maker(serialized=True) as dag:
             op1 = BashOperator(task_id="pass_sleepy", bash_command="sleep 3")
             op2 = BashOperator(
                 task_id="fail_sleepy",
@@ -134,7 +134,7 @@ class TestCore:
         execution_ds = execution_date.strftime("%Y-%m-%d")
         execution_ds_nodash = execution_ds.replace("-", "")
 
-        with dag_maker(schedule=timedelta(weeks=1)):
+        with dag_maker(schedule=timedelta(weeks=1), serialized=True):
             task = EmptyOperator(task_id="test_externally_triggered_dag_context")
         dr = dag_maker.create_dagrun(
             run_type=DagRunType.SCHEDULED,
@@ -163,6 +163,7 @@ class TestCore:
         with dag_maker(
             schedule=timedelta(weeks=1),
             params={"key_1": "value_1", "key_2": "value_2_old"},
+            serialized=True,
         ):
             task1 = EmptyOperator(
                 task_id="task1",


### PR DESCRIPTION
Related: #41067

Attempted to fix `tests/core/test_core.py` but did not make it.
Nevertheless 50% of progress is within this PR: The dag_maker needs to commit changes such that tests fetching data from internal API can find it (ACID in DB needs to commit, else a different connection does not see INSERTs).
Also the internal API loading task instance details failed in loading details from DAG, switched to DagBag.

Afterwards, still the test fails in spaghetti with the following stack - I am not sure how to fix this, I fear there is a new cut as internal API needed but I am unsure on which function. Either I need a hint or somebody needs to make this in a follow-up PR - clearly `refresh_from_db` will fail if not being internal API:
```
____________________________ TestCore.test_timeout _____________________________

self = <tests.core.test_core.TestCore object at 0x7568aaf613d0>
dag_maker = <tests.conftest.dag_maker.<locals>.DagFactory object at 0x7568686dfe80>

    def test_timeout(self, dag_maker):
        def sleep_and_catch_other_exceptions():
            try:
                sleep(5)
                # Catching Exception should NOT catch AirflowTaskTimeout
            except Exception:
                pass
    
        with dag_maker(serialized=True):
            op = PythonOperator(
                task_id="test_timeout",
                execution_timeout=timedelta(seconds=1),
                python_callable=sleep_and_catch_other_exceptions,
            )
        dag_maker.create_dagrun()
        with pytest.raises(AirflowTaskTimeout):
>           op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)

tests/core/test_core.py:89: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
airflow/utils/session.py:97: in wrapper
    return func(*args, session=session, **kwargs)
airflow/models/baseoperator.py:1519: in run
    ti.run(
airflow/utils/session.py:94: in wrapper
    return func(*args, **kwargs)
airflow/models/taskinstance.py:3192: in run
    self._run_raw_task(
airflow/utils/session.py:94: in wrapper
    return func(*args, **kwargs)
airflow/models/taskinstance.py:2959: in _run_raw_task
    return _run_raw_task(
airflow/models/taskinstance.py:244: in _run_raw_task
    ti.refresh_from_db(session=session)
airflow/utils/session.py:94: in wrapper
    return func(*args, **kwargs)
airflow/models/taskinstance.py:2302: in refresh_from_db
    _refresh_from_db(task_instance=self, session=session, lock_for_update=lock_for_update)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    def _refresh_from_db(
        *,
        task_instance: TaskInstance | TaskInstancePydantic,
        session: Session | None = None,
        lock_for_update: bool = False,
    ) -> None:
        """
        Refresh the task instance from the database based on the primary key.
    
        :param task_instance: the task instance
        :param session: SQLAlchemy ORM Session
        :param lock_for_update: if True, indicates that the database should
            lock the TaskInstance (issuing a FOR UPDATE clause) until the
            session is committed.
    
        :meta private:
        """
>       if session and task_instance in session:
E       TypeError: argument of type 'TracebackSessionForTests' is not iterable

airflow/models/taskinstance.py:848: TypeError
```