### PR TITLE
fix tests/core/test_sentry.py for internal API tests

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1118,7 +1118,8 @@ function check_run_tests() {
         echo "${COLOR_BLUE}Starting internal API server:${COLOR_RESET}"
         # We need to start the internal API server before running tests
         airflow db migrate
-        airflow internal-api >"${AIRFLOW_HOME}/logs/internal-api.log" 2>&1 &
+        # We set a very large clock grade allowing to have tests running in other time/years
+        AIRFLOW__CORE__INTERNAL_API_CLOCK_GRACE=999999999 airflow internal-api >"${AIRFLOW_HOME}/logs/internal-api.log" 2>&1 &
         echo
         echo -n "${COLOR_YELLOW}Waiting for internal API server to listen on 9080. ${COLOR_RESET}"
         echo

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1118,7 +1118,7 @@ function check_run_tests() {
         echo "${COLOR_BLUE}Starting internal API server:${COLOR_RESET}"
         # We need to start the internal API server before running tests
         airflow db migrate
-        # We set a very large clock grade allowing to have tests running in other time/years
+        # We set a very large clock grace allowing to have tests running in other time/years
         AIRFLOW__CORE__INTERNAL_API_CLOCK_GRACE=999999999 airflow internal-api >"${AIRFLOW_HOME}/logs/internal-api.log" 2>&1 &
         echo
         echo -n "${COLOR_YELLOW}Waiting for internal API server to listen on 9080. ${COLOR_RESET}"

--- a/airflow/api_internal/endpoints/rpc_api_endpoint.py
+++ b/airflow/api_internal/endpoints/rpc_api_endpoint.py
@@ -171,9 +171,11 @@ def internal_airflow_api(body: dict[str, Any]) -> APIResponse:
     if accept != "application/json":
         raise PermissionDenied("Expected Accept: application/json")
     auth = request.headers.get("Authorization", "")
+    clock_grace = conf.getint("core", "internal_api_clock_grace", fallback=30)
     signer = JWTSigner(
         secret_key=conf.get("core", "internal_api_secret_key"),
-        expiration_time_in_seconds=conf.getint("core", "internal_api_clock_grace", fallback=30),
+        expiration_time_in_seconds=clock_grace,
+        leeway_in_seconds=clock_grace,
         audience="api",
     )
     try:

--- a/scripts/docker/entrypoint_ci.sh
+++ b/scripts/docker/entrypoint_ci.sh
@@ -342,7 +342,7 @@ function check_run_tests() {
         echo "${COLOR_BLUE}Starting internal API server:${COLOR_RESET}"
         # We need to start the internal API server before running tests
         airflow db migrate
-        # We set a very large clock grade allowing to have tests running in other time/years
+        # We set a very large clock grace allowing to have tests running in other time/years
         AIRFLOW__CORE__INTERNAL_API_CLOCK_GRACE=999999999 airflow internal-api >"${AIRFLOW_HOME}/logs/internal-api.log" 2>&1 &
         echo
         echo -n "${COLOR_YELLOW}Waiting for internal API server to listen on 9080. ${COLOR_RESET}"

--- a/scripts/docker/entrypoint_ci.sh
+++ b/scripts/docker/entrypoint_ci.sh
@@ -342,7 +342,8 @@ function check_run_tests() {
         echo "${COLOR_BLUE}Starting internal API server:${COLOR_RESET}"
         # We need to start the internal API server before running tests
         airflow db migrate
-        airflow internal-api >"${AIRFLOW_HOME}/logs/internal-api.log" 2>&1 &
+        # We set a very large clock grade allowing to have tests running in other time/years
+        AIRFLOW__CORE__INTERNAL_API_CLOCK_GRACE=999999999 airflow internal-api >"${AIRFLOW_HOME}/logs/internal-api.log" 2>&1 &
         echo
         echo -n "${COLOR_YELLOW}Waiting for internal API server to listen on 9080. ${COLOR_RESET}"
         echo


### PR DESCRIPTION
Related: https://github.com/apache/airflow/pull/41067

Fixes tests/core/test_sentry.py

To make it working, leeway for API token checks need to be extended for tests as timemachine is used for run tests virtually in 2019 - which means that generated API tokens are expired during tests