### PR TITLE
Provider Airbyte: breaking change, update provider to use Airbyte API Python SDK

### DIFF
--- a/airflow/providers/airbyte/CHANGELOG.rst
+++ b/airflow/providers/airbyte/CHANGELOG.rst
@@ -26,6 +26,22 @@
 Changelog
 ---------
 
+4.0.0
+.....
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+.. note::
+  This version introduce a new way to handle the connection to Airbyte using ``client_id`` and ``client_secret`` instead of ``login`` and ``password``.
+  You can get them accessing the Airbyte UI and creating a new Application in the Settings page.
+  You must remove the ``api_type`` parameter from your DAG it isn't required anymore.
+  The default scheme is now ``https`` instead of ``http``.
+
+.. Below changes are excluded from the changelog. Move them to
+   appropriate section above if needed. Do not delete the lines(!):
+   * ``Breaking change, update provider to use Airbyte API Python SDK (#41122)``
+
 3.9.0
 .....
 
@@ -40,7 +56,6 @@ Misc
 
 
 .. Below changes are excluded from the changelog. Move them to
-   appropriate section above if needed. Do not delete the lines(!):
 
 3.8.1
 .....

--- a/airflow/providers/airbyte/CHANGELOG.rst
+++ b/airflow/providers/airbyte/CHANGELOG.rst
@@ -55,6 +55,7 @@ Misc
 
 
 .. Below changes are excluded from the changelog. Move them to
+   appropriate section above if needed. Do not delete the lines(!):
 
 3.8.1
 .....

--- a/airflow/providers/airbyte/CHANGELOG.rst
+++ b/airflow/providers/airbyte/CHANGELOG.rst
@@ -41,8 +41,6 @@ Breaking changes
   The ``token_url`` parameter is optional and it is used to create the access token, the default value is ``v1/applications/token`` used by Airbyte Cloud.
   You must remove the ``api_type`` parameter from your DAG it isn't required anymore.
 
-
-
 3.9.0
 .....
 

--- a/airflow/providers/airbyte/CHANGELOG.rst
+++ b/airflow/providers/airbyte/CHANGELOG.rst
@@ -38,9 +38,6 @@ Breaking changes
   You must remove the ``api_type`` parameter from your DAG it isn't required anymore.
   The default scheme is now ``https`` instead of ``http``.
 
-.. Below changes are excluded from the changelog. Move them to
-   appropriate section above if needed. Do not delete the lines(!):
-   * ``Breaking change, update provider to use Airbyte API Python SDK (#41122)``
 
 3.9.0
 .....

--- a/airflow/providers/airbyte/CHANGELOG.rst
+++ b/airflow/providers/airbyte/CHANGELOG.rst
@@ -35,8 +35,12 @@ Breaking changes
 .. note::
   This version introduce a new way to handle the connection to Airbyte using ``client_id`` and ``client_secret`` instead of ``login`` and ``password``.
   You can get them accessing the Airbyte UI and creating a new Application in the Settings page.
+
+  There is a large refactor to create a connection.
+  You must specify the Full Qualified Domain Name in the ``host`` parameter, eg: ``https://my.company:8000/airbyte/v1/``.
+  The ``token_url`` parameter is optional and it is used to create the access token, the default value is ``v1/applications/token`` used by Airbyte Cloud.
   You must remove the ``api_type`` parameter from your DAG it isn't required anymore.
-  The default scheme is now ``https`` instead of ``http``.
+
 
 
 3.9.0

--- a/airflow/providers/airbyte/hooks/airbyte.py
+++ b/airflow/providers/airbyte/hooks/airbyte.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING, Any, Literal, TypeVar
+from typing import Any, TypeVar
 from urllib.parse import urljoin
 
 from airbyte_api import AirbyteAPI
@@ -27,10 +27,6 @@ from airbyte_api.models import JobCreateRequest, JobStatusEnum, JobTypeEnum, Sch
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
-
-if TYPE_CHECKING:
-    from airflow.models import Connection
-
 
 T = TypeVar("T", bound=Any)
 
@@ -72,7 +68,6 @@ class AirbyteHook(BaseHook):
 
     def create_airbyte_api_session(self) -> AirbyteAPI:
         """Create Airbyte API session."""
-
         credentials = SchemeClientCredentials(
             client_id=self.conn.login,
             client_secret=self.conn.password,

--- a/airflow/providers/airbyte/hooks/airbyte.py
+++ b/airflow/providers/airbyte/hooks/airbyte.py
@@ -103,14 +103,14 @@ class AirbyteHook(BaseHook):
         except Exception as e:
             raise AirflowException(e)
 
-    async def get_job_status(self, job_id: int) -> str:
+    def get_job_status(self, job_id: int) -> str:
         """
         Retrieve the status for a specific job of an Airbyte Sync.
 
         :param job_id: The ID of an Airbyte Sync Job.
         """
         self.log.info("Getting the status of job run %s.", job_id)
-        response = await self.get_job_details(job_id=job_id)
+        response = self.get_job_details(job_id=job_id)
         return response.status
 
     def wait_for_job(self, job_id: str | int, wait_seconds: float = 3, timeout: float | None = 3600) -> None:

--- a/airflow/providers/airbyte/hooks/airbyte.py
+++ b/airflow/providers/airbyte/hooks/airbyte.py
@@ -158,7 +158,7 @@ class AirbyteHook(BaseHook):
             )
             return res.job_response
         except Exception as e:
-            raise AirflowException(str(e))
+            raise AirflowException(e)
 
     def cancel_job(self, job_id: int) -> Any:
         """
@@ -174,7 +174,7 @@ class AirbyteHook(BaseHook):
             )
             return cancel_job_res.job_response
         except Exception as e:
-            raise AirflowException(str(e))
+            raise AirflowException(e)
 
     def test_connection(self):
         """Tests the Airbyte connection by hitting the health API."""

--- a/airflow/providers/airbyte/hooks/airbyte.py
+++ b/airflow/providers/airbyte/hooks/airbyte.py
@@ -38,7 +38,6 @@ class AirbyteHook(BaseHook):
     :param airbyte_conn_id: Optional. The name of the Airflow connection to get
         connection information for Airbyte. Defaults to "airbyte_default".
     :param api_version: Optional. Airbyte API version. Defaults to "v1".
-    :param api_type: Optional. The type of Airbyte API to use. Either "config" or "cloud". Defaults to "config".
     """
 
     conn_name_attr = "airbyte_conn_id"

--- a/airflow/providers/airbyte/hooks/airbyte.py
+++ b/airflow/providers/airbyte/hooks/airbyte.py
@@ -52,10 +52,10 @@ class AirbyteHook(BaseHook):
         super().__init__()
         self.api_version: str = api_version
         self.airbyte_conn_id = airbyte_conn_id
-        self.conn = self.get_conn(self.airbyte_conn_id)
+        self.conn = self.get_conn_params(self.airbyte_conn_id)
         self.airbyte_api = self.create_api_session()
 
-    def get_conn(self, conn_id: str) -> Any:
+    def get_conn_params(self, conn_id: str) -> Any:
         conn = self.get_connection(conn_id)
 
         conn_params: dict = {}

--- a/airflow/providers/airbyte/hooks/airbyte.py
+++ b/airflow/providers/airbyte/hooks/airbyte.py
@@ -68,6 +68,15 @@ class AirbyteHook(HttpHook):
         self.api_version: str = api_version
         self.api_type: str = api_type
 
+    @classmethod
+    def get_ui_field_behaviour(cls) -> dict[str, Any]:
+        """Return custom field behaviour."""
+        return {
+            "hidden_fields": ["extra"],
+            "relabeling": {"login": "Client ID", "password": "Client Secret"},
+            "placeholders": {},
+        }
+
     async def get_headers_tenants_from_connection(self) -> tuple[dict[str, Any], str]:
         """Get Headers, tenants from the connection details."""
         connection: Connection = await sync_to_async(self.get_connection)(self.http_conn_id)

--- a/airflow/providers/airbyte/hooks/airbyte.py
+++ b/airflow/providers/airbyte/hooks/airbyte.py
@@ -17,25 +17,25 @@
 # under the License.
 from __future__ import annotations
 
-import base64
-import json
 import time
 from typing import TYPE_CHECKING, Any, Literal, TypeVar
+from urllib.parse import urljoin
 
-import aiohttp
-from aiohttp import ClientResponseError
-from asgiref.sync import sync_to_async
+from airbyte_api import AirbyteAPI
+from airbyte_api.api import CancelJobRequest, GetJobRequest
+from airbyte_api.models import JobCreateRequest, JobStatusEnum, JobTypeEnum, SchemeClientCredentials, Security
 
 from airflow.exceptions import AirflowException
-from airflow.providers.http.hooks.http import HttpHook
+from airflow.hooks.base import BaseHook
 
 if TYPE_CHECKING:
     from airflow.models import Connection
 
+
 T = TypeVar("T", bound=Any)
 
 
-class AirbyteHook(HttpHook):
+class AirbyteHook(BaseHook):
     """
     Hook for Airbyte API.
 
@@ -50,23 +50,37 @@ class AirbyteHook(HttpHook):
     conn_type = "airbyte"
     hook_name = "Airbyte"
 
-    RUNNING = "running"
-    SUCCEEDED = "succeeded"
-    CANCELLED = "cancelled"
-    PENDING = "pending"
-    FAILED = "failed"
-    ERROR = "error"
-    INCOMPLETE = "incomplete"
-
     def __init__(
         self,
         airbyte_conn_id: str = "airbyte_default",
         api_version: str = "v1",
-        api_type: Literal["config", "cloud"] = "config",
     ) -> None:
-        super().__init__(http_conn_id=airbyte_conn_id)
+        super().__init__()
         self.api_version: str = api_version
-        self.api_type: str = api_type
+        self.airbyte_conn_id = airbyte_conn_id
+
+        self.create_airbyte_api_session()
+
+    def create_airbyte_api_session(self) -> None:
+        """Create Airbyte API session."""
+        conn = self.get_connection(self.airbyte_conn_id)
+        schema = conn.schema if conn.schema else "https"
+        server_url = f"{schema}://{conn.host}"
+        if conn.port:
+            server_url += f":{conn.port}/"
+
+        server_url = urljoin(server_url, self.api_version)
+
+        credentials = SchemeClientCredentials(
+            client_id=conn.login,
+            client_secret=conn.password,
+            TOKEN_URL="v1/applications/token",
+        )
+
+        self.airbyte_api = AirbyteAPI(
+            server_url=server_url,
+            security=Security(client_credentials=credentials),
+        )
 
     @classmethod
     def get_ui_field_behaviour(cls) -> dict[str, Any]:
@@ -77,75 +91,31 @@ class AirbyteHook(HttpHook):
             "placeholders": {},
         }
 
-    async def get_headers_tenants_from_connection(self) -> tuple[dict[str, Any], str]:
-        """Get Headers, tenants from the connection details."""
-        connection: Connection = await sync_to_async(self.get_connection)(self.http_conn_id)
-        # schema defaults to HTTP
-        schema = connection.schema if connection.schema else "http"
-        base_url = f"{schema}://{connection.host}"
-
-        if connection.port:
-            base_url += f":{connection.port}"
-
-        if self.api_type == "config":
-            credentials = f"{connection.login}:{connection.password}"
-            credentials_base64 = base64.b64encode(credentials.encode("utf-8")).decode("utf-8")
-            authorized_headers = {
-                "accept": "application/json",
-                "content-type": "application/json",
-                "authorization": f"Basic {credentials_base64}",
-            }
-        else:
-            authorized_headers = {
-                "accept": "application/json",
-                "content-type": "application/json",
-                "authorization": f"Bearer {connection.password}",
-            }
-
-        return authorized_headers, base_url
-
-    async def get_job_details(self, job_id: int) -> Any:
+    def get_job_details(self, job_id: int) -> Any:
         """
         Use Http async call to retrieve metadata for a specific job of an Airbyte Sync.
 
         :param job_id: The ID of an Airbyte Sync Job.
         """
-        headers, base_url = await self.get_headers_tenants_from_connection()
-        if self.api_type == "config":
-            url = f"{base_url}/api/{self.api_version}/jobs/get"
-            self.log.info("URL for api request: %s", url)
-            async with aiohttp.ClientSession(headers=headers) as session:
-                async with session.post(url=url, data=json.dumps({"id": job_id})) as response:
-                    try:
-                        response.raise_for_status()
-                        return await response.json()
-                    except ClientResponseError as e:
-                        msg = f"{e.status}: {e.message} - {e.request_info}"
-                        raise AirflowException(msg)
-        else:
-            url = f"{base_url}/{self.api_version}/jobs/{job_id}"
-            self.log.info("URL for api request: %s", url)
-            async with aiohttp.ClientSession(headers=headers) as session:
-                async with session.get(url=url) as response:
-                    try:
-                        response.raise_for_status()
-                        return await response.json()
-                    except ClientResponseError as e:
-                        msg = f"{e.status}: {e.message} - {e.request_info}"
-                        raise AirflowException(msg)
+        try:
+            get_job_res = self.airbyte_api.jobs.get_job(
+                request=GetJobRequest(
+                    job_id=job_id,
+                )
+            )
+            return get_job_res.job_response
+        except Exception as e:
+            raise AirflowException(e)
 
-    async def get_job_status(self, job_id: int) -> str:
+    def get_job_status(self, job_id: int) -> str:
         """
         Retrieve the status for a specific job of an Airbyte Sync.
 
         :param job_id: The ID of an Airbyte Sync Job.
         """
         self.log.info("Getting the status of job run %s.", job_id)
-        response = await self.get_job_details(job_id=job_id)
-        if self.api_type == "config":
-            return str(response["job"]["status"])
-        else:
-            return str(response["status"])
+        response = self.get_job_details(job_id=job_id)
+        return response.status
 
     def wait_for_job(self, job_id: str | int, wait_seconds: float = 3, timeout: float | None = 3600) -> None:
         """
@@ -164,69 +134,35 @@ class AirbyteHook(HttpHook):
                 raise AirflowException(f"Timeout: Airbyte job {job_id} is not ready after {timeout}s")
             time.sleep(wait_seconds)
             try:
-                job = self.get_job(job_id=(int(job_id)))
-                if self.api_type == "config":
-                    state = job.json()["job"]["status"]
-                else:
-                    state = job.json()["status"]
+                job = self.get_job_details(job_id=(int(job_id)))
+                state = job.status
+
             except AirflowException as err:
                 self.log.info("Retrying. Airbyte API returned server error when waiting for job: %s", err)
                 continue
 
-            if state in (self.RUNNING, self.PENDING, self.INCOMPLETE):
+            if state in (JobStatusEnum.RUNNING, JobStatusEnum.PENDING, JobStatusEnum.INCOMPLETE):
                 continue
-            if state == self.SUCCEEDED:
+            if state == JobStatusEnum.SUCCEEDED:
                 break
-            if state == self.ERROR:
+            if state == JobStatusEnum.FAILED:
                 raise AirflowException(f"Job failed:\n{job}")
-            elif state == self.CANCELLED:
+            elif state == JobStatusEnum.CANCELLED:
                 raise AirflowException(f"Job was cancelled:\n{job}")
             else:
                 raise AirflowException(f"Encountered unexpected state `{state}` for job_id `{job_id}`")
 
     def submit_sync_connection(self, connection_id: str) -> Any:
-        """
-        Submit a job to a Airbyte server.
-
-        :param connection_id: Required. The ConnectionId of the Airbyte Connection.
-        """
-        if self.api_type == "config":
-            return self.run(
-                endpoint=f"api/{self.api_version}/connections/sync",
-                json={"connectionId": connection_id},
-                headers={"accept": "application/json"},
+        try:
+            res = self.airbyte_api.jobs.create_job(
+                request=JobCreateRequest(
+                    connection_id=connection_id,
+                    job_type=JobTypeEnum.SYNC,
+                )
             )
-        else:
-            conn = self.get_connection(self.http_conn_id)
-            self.method = "POST"
-            return self.run(
-                endpoint=f"{self.api_version}/jobs",
-                headers={"accept": "application/json", "authorization": f"Bearer {conn.password}"},
-                json={
-                    "jobType": "sync",
-                    "connectionId": connection_id,
-                },  # TODO: add an option to pass jobType = reset
-            )
-
-    def get_job(self, job_id: int) -> Any:
-        """
-        Get the resource representation for a job in Airbyte.
-
-        :param job_id: Required. Id of the Airbyte job
-        """
-        if self.api_type == "config":
-            return self.run(
-                endpoint=f"api/{self.api_version}/jobs/get",
-                json={"id": job_id},
-                headers={"accept": "application/json"},
-            )
-        else:
-            self.method = "GET"
-            conn = self.get_connection(self.http_conn_id)
-            return self.run(
-                endpoint=f"{self.api_version}/jobs/{job_id}",
-                headers={"accept": "application/json", "authorization": f"Bearer {conn.password}"},
-            )
+            return res.job_response
+        except Exception as e:
+            raise AirflowException(str(e))
 
     def cancel_job(self, job_id: int) -> Any:
         """
@@ -234,35 +170,23 @@ class AirbyteHook(HttpHook):
 
         :param job_id: Required. Id of the Airbyte job
         """
-        if self.api_type == "config":
-            return self.run(
-                endpoint=f"api/{self.api_version}/jobs/cancel",
-                json={"id": job_id},
-                headers={"accept": "application/json"},
+        try:
+            cancel_job_res = self.airbyte_api.jobs.cancel_job(
+                request=CancelJobRequest(
+                    job_id=job_id,
+                )
             )
-        else:
-            self.method = "DELETE"
-            conn = self.get_connection(self.http_conn_id)
-            return self.run(
-                endpoint=f"{self.api_version}/jobs/{job_id}",
-                headers={"accept": "application/json", "authorization": f"Bearer {conn.password}"},
-            )
+            return cancel_job_res.job_response
+        except Exception as e:
+            raise AirflowException(str(e))
 
     def test_connection(self):
         """Tests the Airbyte connection by hitting the health API."""
-        self.method = "GET"
         try:
-            res = self.run(
-                endpoint=f"api/{self.api_version}/health",
-                headers={"accept": "application/json"},
-                extra_options={"check_response": False},
-            )
-
-            if res.status_code == 200:
+            health_check = self.airbyte_api.health.get_health_check()
+            if health_check.status_code == 200:
                 return True, "Connection successfully tested"
             else:
-                return False, res.text
+                return False, str(health_check.raw_response)
         except Exception as e:
             return False, str(e)
-        finally:
-            self.method = "POST"

--- a/airflow/providers/airbyte/hooks/airbyte.py
+++ b/airflow/providers/airbyte/hooks/airbyte.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import time
 from typing import Any, TypeVar
-from urllib.parse import urljoin
 
 from airbyte_api import AirbyteAPI
 from airbyte_api.api import CancelJobRequest, GetJobRequest

--- a/airflow/providers/airbyte/operators/airbyte.py
+++ b/airflow/providers/airbyte/operators/airbyte.py
@@ -75,16 +75,12 @@ class AirbyteTriggerSyncOperator(BaseOperator):
         self.connection_id = connection_id
         self.timeout = timeout
         self.api_version = api_version
-        self.api_type = api_type
         self.wait_seconds = wait_seconds
         self.asynchronous = asynchronous
         self.deferrable = deferrable
 
     def execute(self, context: Context) -> None:
         """Create Airbyte Job and wait to finish."""
-        if self.api_type:
-            self.log.warning("`api_type` is deprecated please remove this parameter from your DAG.")
-
         hook = AirbyteHook(airbyte_conn_id=self.airbyte_conn_id, api_version=self.api_version)
         job_object = hook.submit_sync_connection(connection_id=self.connection_id)
         self.job_id = job_object.job_id
@@ -100,7 +96,6 @@ class AirbyteTriggerSyncOperator(BaseOperator):
                         timeout=self.execution_timeout,
                         trigger=AirbyteSyncTrigger(
                             conn_id=self.airbyte_conn_id,
-                            api_type=self.api_type,
                             job_id=self.job_id,
                             end_time=end_time,
                             poll_interval=60,

--- a/airflow/providers/airbyte/operators/airbyte.py
+++ b/airflow/providers/airbyte/operators/airbyte.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING, Any, Literal, Sequence
+from typing import TYPE_CHECKING, Any, Sequence
 
 from airbyte_api.models import JobStatusEnum
 

--- a/airflow/providers/airbyte/operators/airbyte.py
+++ b/airflow/providers/airbyte/operators/airbyte.py
@@ -48,7 +48,6 @@ class AirbyteTriggerSyncOperator(BaseOperator):
         waiting on them asynchronously using the AirbyteJobSensor. Defaults to False.
     :param deferrable: Run operator in the deferrable mode.
     :param api_version: Optional. Airbyte API version. Defaults to "v1".
-    :param api_type: Optional. The type of Airbyte API to use. Either "config" or "cloud". Defaults to "config".
     :param wait_seconds: Optional. Number of seconds between checks. Only used when ``asynchronous`` is False.
         Defaults to 3 seconds.
     :param timeout: Optional. The amount of time, in seconds, to wait for the request to complete.

--- a/airflow/providers/airbyte/provider.yaml
+++ b/airflow/providers/airbyte/provider.yaml
@@ -51,6 +51,7 @@ versions:
 dependencies:
   - apache-airflow>=2.8.0
   - apache-airflow-providers-http
+  - airbyte-api
 
 integrations:
   - integration-name: Airbyte

--- a/airflow/providers/airbyte/provider.yaml
+++ b/airflow/providers/airbyte/provider.yaml
@@ -51,7 +51,7 @@ versions:
 dependencies:
   - apache-airflow>=2.8.0
   - apache-airflow-providers-http
-  - airbyte-api
+  - airbyte-api>=0.51.0
 
 integrations:
   - integration-name: Airbyte

--- a/airflow/providers/airbyte/provider.yaml
+++ b/airflow/providers/airbyte/provider.yaml
@@ -25,6 +25,7 @@ state: ready
 source-date-epoch: 1723968864
 # note that those versions are maintained by release manager - do not update them manually
 versions:
+  - 4.0.0
   - 3.9.0
   - 3.8.1
   - 3.8.0
@@ -50,7 +51,6 @@ versions:
 
 dependencies:
   - apache-airflow>=2.8.0
-  - apache-airflow-providers-http
   - airbyte-api>=0.51.0
 
 integrations:

--- a/airflow/providers/airbyte/sensors/airbyte.py
+++ b/airflow/providers/airbyte/sensors/airbyte.py
@@ -44,7 +44,6 @@ class AirbyteJobSensor(BaseSensorOperator):
     :param deferrable: Run sensor in the deferrable mode.
         connection information for Airbyte. Defaults to "airbyte_default".
     :param api_version: Optional. Airbyte API version. Defaults to "v1".
-    :param api_type: Optional. The type of Airbyte API to use. Either "config" or "cloud". Defaults to "config".
     """
 
     template_fields: Sequence[str] = ("airbyte_job_id",)

--- a/airflow/providers/airbyte/sensors/airbyte.py
+++ b/airflow/providers/airbyte/sensors/airbyte.py
@@ -87,11 +87,9 @@ class AirbyteJobSensor(BaseSensorOperator):
         status = job.status
 
         if status == JobStatusEnum.FAILED:
-            # TODO: remove this if block when min_airflow_version is set to higher than 2.7.1
             message = f"Job failed: \n{job}"
             raise AirflowException(message)
         elif status == JobStatusEnum.CANCELLED:
-            # TODO: remove this if block when min_airflow_version is set to higher than 2.7.1
             message = f"Job was cancelled: \n{job}"
             raise AirflowException(message)
         elif status == JobStatusEnum.SUCCEEDED:

--- a/airflow/providers/airbyte/sensors/airbyte.py
+++ b/airflow/providers/airbyte/sensors/airbyte.py
@@ -29,7 +29,7 @@ from airflow.configuration import conf
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.airbyte.hooks.airbyte import AirbyteHook
 from airflow.providers.airbyte.triggers.airbyte import AirbyteSyncTrigger
-from airflow.sensors.base import BaseSensorOperator, SkipPolicy
+from airflow.sensors.base import BaseSensorOperator
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
@@ -81,7 +81,6 @@ class AirbyteJobSensor(BaseSensorOperator):
         self.airbyte_conn_id = airbyte_conn_id
         self.airbyte_job_id = airbyte_job_id
         self.api_version = api_version
-        self.skip_policy = SkipPolicy.SKIP_ON_SOFT_ERROR
 
     def poke(self, context: Context) -> bool:
         hook = AirbyteHook(airbyte_conn_id=self.airbyte_conn_id, api_version=self.api_version)

--- a/airflow/providers/airbyte/sensors/airbyte.py
+++ b/airflow/providers/airbyte/sensors/airbyte.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import time
 import warnings
-from typing import TYPE_CHECKING, Any, Literal, Sequence
+from typing import TYPE_CHECKING, Any, Sequence
 
 from airbyte_api.models import JobStatusEnum
 
@@ -109,7 +109,7 @@ class AirbyteJobSensor(BaseSensorOperator):
             super().execute(context)
         else:
             hook = AirbyteHook(airbyte_conn_id=self.airbyte_conn_id, api_version=self.api_version)
-            job = hook.get_job(job_id=(int(self.airbyte_job_id)))
+            job = hook.get_job_details(job_id=(int(self.airbyte_job_id)))
             state = job.status
             end_time = time.time() + self.timeout
 

--- a/airflow/providers/airbyte/triggers/airbyte.py
+++ b/airflow/providers/airbyte/triggers/airbyte.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from typing import Any, AsyncIterator, Literal
+from typing import Any, AsyncIterator
 
 from airbyte_api.models import JobStatusEnum
 

--- a/airflow/providers/airbyte/triggers/airbyte.py
+++ b/airflow/providers/airbyte/triggers/airbyte.py
@@ -80,7 +80,7 @@ class AirbyteSyncTrigger(BaseTrigger):
                     )
                     return
                 await asyncio.sleep(self.poll_interval)
-            job_run_status = await hook.get_job_status(self.job_id)
+            job_run_status = hook.get_job_status(self.job_id)
             if job_run_status == JobStatusEnum.SUCCEEDED:
                 yield TriggerEvent(
                     {
@@ -114,7 +114,7 @@ class AirbyteSyncTrigger(BaseTrigger):
 
         If job is in running state returns True if it is still running else return False
         """
-        job_run_status = await hook.get_job_status(self.job_id)
+        job_run_status = hook.get_job_status(self.job_id)
         if job_run_status in (JobStatusEnum.RUNNING, JobStatusEnum.PENDING, JobStatusEnum.INCOMPLETE):
             return True
         return False

--- a/airflow/providers/airbyte/triggers/airbyte.py
+++ b/airflow/providers/airbyte/triggers/airbyte.py
@@ -20,6 +20,8 @@ import asyncio
 import time
 from typing import Any, AsyncIterator, Literal
 
+from airbyte_api.models import JobStatusEnum
+
 from airflow.providers.airbyte.hooks.airbyte import AirbyteHook
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 
@@ -32,7 +34,6 @@ class AirbyteSyncTrigger(BaseTrigger):
     makes use of asynchronous communication to check the progress of a job run over time.
 
     :param conn_id: The connection identifier for connecting to Airbyte.
-    :param api_type: The type of Airbyte API to use. Either "config" or "cloud".
     :param job_id: The ID of an Airbyte Sync job.
     :param end_time: Time in seconds to wait for a job run to reach a terminal status. Defaults to 7 days.
     :param poll_interval:  polling period in seconds to check for the status.
@@ -42,14 +43,12 @@ class AirbyteSyncTrigger(BaseTrigger):
         self,
         job_id: int,
         conn_id: str,
-        api_type: Literal["config", "cloud"],
         end_time: float,
         poll_interval: float,
     ):
         super().__init__()
         self.job_id = job_id
         self.conn_id = conn_id
-        self.api_type = api_type
         self.end_time = end_time
         self.poll_interval = poll_interval
 
@@ -60,7 +59,6 @@ class AirbyteSyncTrigger(BaseTrigger):
             {
                 "job_id": self.job_id,
                 "conn_id": self.conn_id,
-                "api_type": self.api_type,
                 "end_time": self.end_time,
                 "poll_interval": self.poll_interval,
             },
@@ -68,7 +66,7 @@ class AirbyteSyncTrigger(BaseTrigger):
 
     async def run(self) -> AsyncIterator[TriggerEvent]:
         """Make async connection to Airbyte, polls for the pipeline run status."""
-        hook = AirbyteHook(airbyte_conn_id=self.conn_id, api_type=self.api_type)
+        hook = AirbyteHook(airbyte_conn_id=self.conn_id)
         try:
             while await self.is_still_running(hook):
                 if self.end_time < time.time():
@@ -83,7 +81,7 @@ class AirbyteSyncTrigger(BaseTrigger):
                     return
                 await asyncio.sleep(self.poll_interval)
             job_run_status = await hook.get_job_status(self.job_id)
-            if job_run_status == hook.SUCCEEDED:
+            if job_run_status == JobStatusEnum.SUCCEEDED:
                 yield TriggerEvent(
                     {
                         "status": "success",
@@ -91,7 +89,7 @@ class AirbyteSyncTrigger(BaseTrigger):
                         "job_id": self.job_id,
                     }
                 )
-            elif job_run_status == hook.CANCELLED:
+            elif job_run_status == JobStatusEnum.CANCELLED:
                 yield TriggerEvent(
                     {
                         "status": "cancelled",
@@ -117,6 +115,6 @@ class AirbyteSyncTrigger(BaseTrigger):
         If job is in running state returns True if it is still running else return False
         """
         job_run_status = await hook.get_job_status(self.job_id)
-        if job_run_status in (AirbyteHook.RUNNING, AirbyteHook.PENDING, AirbyteHook.INCOMPLETE):
+        if job_run_status in (JobStatusEnum.RUNNING, JobStatusEnum.PENDING, JobStatusEnum.INCOMPLETE):
             return True
         return False

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -421,7 +421,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "tests/providers/http/file.py",
                 ),
                 {
-                    "affected-providers-list-as-string": "airbyte amazon apache.livy "
+                    "affected-providers-list-as-string": "amazon apache.livy "
                     "dbt.cloud dingding discord http",
                     "all-python-versions": "['3.8']",
                     "all-python-versions-list-as-string": "3.8",
@@ -437,9 +437,9 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "run-kubernetes-tests": "true",
                     "upgrade-to-newer-dependencies": "false",
                     "parallel-test-types-list-as-string": "Always "
-                    "Providers[airbyte,apache.livy,dbt.cloud,dingding,discord,http] Providers[amazon]",
-                    "providers-test-types-list-as-string": "Providers[airbyte,apache.livy,dbt.cloud,dingding,discord,http] Providers[amazon]",
-                    "separate-test-types-list-as-string": "Always Providers[airbyte] Providers[amazon] "
+                    "Providers[amazon] Providers[apache.livy,dbt.cloud,dingding,discord,http]",
+                    "providers-test-types-list-as-string": "Providers[amazon] Providers[apache.livy,dbt.cloud,dingding,discord,http]",
+                    "separate-test-types-list-as-string": "Always Providers[amazon] "
                     "Providers[apache.livy] Providers[dbt.cloud] "
                     "Providers[dingding] Providers[discord] Providers[http]",
                     "needs-mypy": "true",
@@ -457,7 +457,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "tests/providers/airbyte/file.py",
                 ),
                 {
-                    "affected-providers-list-as-string": "airbyte http",
+                    "affected-providers-list-as-string": "airbyte",
                     "all-python-versions": "['3.8']",
                     "all-python-versions-list-as-string": "3.8",
                     "python-versions": "['3.8']",
@@ -471,12 +471,12 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "skip-pre-commits": "identity,mypy-airflow,mypy-dev,mypy-docs,mypy-providers,ts-compile-format-lint-www",
                     "run-kubernetes-tests": "true",
                     "upgrade-to-newer-dependencies": "false",
-                    "parallel-test-types-list-as-string": "Always Providers[airbyte,http]",
-                    "providers-test-types-list-as-string": "Providers[airbyte,http]",
+                    "parallel-test-types-list-as-string": "Always Providers[airbyte]",
+                    "providers-test-types-list-as-string": "Providers[airbyte]",
                     "needs-mypy": "true",
                     "mypy-folders": "['providers']",
                 },
-                id="Helm tests, airbyte/http providers, kubernetes tests and "
+                id="Helm tests, airbyte providers, kubernetes tests and "
                 "docs should run even if unimportant files were added",
             )
         ),
@@ -595,7 +595,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
         pytest.param(
             ("tests/providers/airbyte/__init__.py",),
             {
-                "affected-providers-list-as-string": "airbyte http",
+                "affected-providers-list-as-string": "airbyte",
                 "all-python-versions": "['3.8']",
                 "all-python-versions-list-as-string": "3.8",
                 "python-versions": "['3.8']",
@@ -609,7 +609,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                 "skip-pre-commits": "identity,lint-helm-chart,mypy-airflow,mypy-dev,mypy-docs,mypy-providers,ts-compile-format-lint-www",
                 "run-kubernetes-tests": "false",
                 "upgrade-to-newer-dependencies": "false",
-                "parallel-test-types-list-as-string": "Always Providers[airbyte,http]",
+                "parallel-test-types-list-as-string": "Always Providers[airbyte]",
                 "needs-mypy": "true",
                 "mypy-folders": "['providers']",
             },
@@ -1532,9 +1532,9 @@ def test_no_commit_provided_trigger_full_build_for_any_event_type(github_event):
             "run-tests": "true",
             "docs-build": "true",
             "skip-pre-commits": "identity,mypy-airflow,mypy-dev,mypy-docs,mypy-providers",
-            "upgrade-to-newer-dependencies": "true"
-            if github_event in [GithubEvents.PUSH, GithubEvents.SCHEDULE]
-            else "false",
+            "upgrade-to-newer-dependencies": (
+                "true" if github_event in [GithubEvents.PUSH, GithubEvents.SCHEDULE] else "false"
+            ),
             "parallel-test-types-list-as-string": ALL_CI_SELECTIVE_TEST_TYPES,
             "needs-mypy": "true",
             "mypy-folders": "['airflow', 'providers', 'docs', 'dev']",
@@ -1636,14 +1636,14 @@ def test_upgrade_to_newer_dependencies(
         pytest.param(
             ("docs/apache-airflow-providers-airbyte/docs.rst",),
             {
-                "docs-list-as-string": "airbyte http",
+                "docs-list-as-string": "airbyte",
             },
             id="Airbyte provider docs changed",
         ),
         pytest.param(
             ("docs/apache-airflow-providers-airbyte/docs.rst", "docs/apache-airflow/docs.rst"),
             {
-                "docs-list-as-string": "apache-airflow airbyte http",
+                "docs-list-as-string": "apache-airflow airbyte",
             },
             id="Airbyte provider and airflow core docs changed",
         ),
@@ -1654,7 +1654,7 @@ def test_upgrade_to_newer_dependencies(
                 "docs/apache-airflow-providers/docs.rst",
             ),
             {
-                "docs-list-as-string": "apache-airflow apache-airflow-providers airbyte http",
+                "docs-list-as-string": "apache-airflow apache-airflow-providers airbyte",
             },
             id="Airbyte provider and airflow core and common provider docs changed",
         ),

--- a/docs/apache-airflow-providers-airbyte/connections.rst
+++ b/docs/apache-airflow-providers-airbyte/connections.rst
@@ -19,26 +19,24 @@
 
 Airbyte Connection
 ==================
-The Airbyte connection type use the HTTP protocol.
+The Airbyte connection type use the Airbyte API Python SDK to authenticate to the server.
 
-Configuring the Connection - Config API
----------------------------------------
 Host(required)
     The host to connect to the Airbyte server.
+    If you are using Airbyte Cloud: `api.airbyte.com`.
 
-Port (required)
+Scheme (optional)
+    The HTTP scheme of your server.
+    Default value is `https`.
+
+Port (optional)
     The port for the Airbyte server.
+    If you are using Airbyte Cloud you don't need to provide the port.
 
-Login (optional)
-    Specify the user name to connect.
+Client ID (required)
+    The Client ID to connect to the Airbyte server.
+    You can find this information in the Settings / Applications page in Airbyte UI.
 
-Password (optional)
-    Specify the password to connect.
-
-Configuring the Connection - Cloud API
---------------------------------------
-Host(required)
-    The host to connect to the Airbyte Cloud. (Typically ``https://api.airbyte.com``)
-
-Password (required)
-    Cloud API Key obtained from https://portal.airbyte.com/
+Client Secret (required)
+    The Client Secret to connect to the Airbyte server.
+    You can find this information in the Settings / Applications page in Airbyte UI.

--- a/docs/apache-airflow-providers-airbyte/connections.rst
+++ b/docs/apache-airflow-providers-airbyte/connections.rst
@@ -22,16 +22,16 @@ Airbyte Connection
 The Airbyte connection type use the Airbyte API Python SDK to authenticate to the server.
 
 Host(required)
-    The host to connect to the Airbyte server.
-    If you are using Airbyte Cloud: `api.airbyte.com`.
+    The full qualified host domain to connect to the Airbyte server.
+    If you are using Airbyte Cloud: `https://api.airbyte.com/v1/`
+    If you are using Airbyte OSS: `http://localhost:8000/api/public/v1/`
+    Be aware: if you're changing the API path using an engress rule you must.
 
-Scheme (optional)
-    The HTTP scheme of your server.
-    Default value is `https`.
-
-Port (optional)
-    The port for the Airbyte server.
-    If you are using Airbyte Cloud you don't need to provide the port.
+Token URL (optional)
+    The prefix for URL used to create the access token.
+    If you are using Airbyte Cloud: `v1/applications/token` (default value)
+    If you are using Airbyte OSS: `/api/public/v1/applications/token`
+    Be aware: if you're changing the API path using an engress rule you must.
 
 Client ID (required)
     The Client ID to connect to the Airbyte server.

--- a/docs/apache-airflow-providers-airbyte/connections.rst
+++ b/docs/apache-airflow-providers-airbyte/connections.rst
@@ -23,15 +23,15 @@ The Airbyte connection type use the Airbyte API Python SDK to authenticate to th
 
 Host(required)
     The full qualified host domain to connect to the Airbyte server.
-    If you are using Airbyte Cloud: `https://api.airbyte.com/v1/`
-    If you are using Airbyte OSS: `http://localhost:8000/api/public/v1/`
-    Be aware: if you're changing the API path using an engress rule you must.
+    If you are using Airbyte Cloud: ``https://api.airbyte.com/v1/``
+    If you are using Airbyte OSS: ``http://localhost:8000/api/public/v1/``
+    Be aware: If you're changing the API path, you must update the value accordingly.
 
 Token URL (optional)
     The prefix for URL used to create the access token.
-    If you are using Airbyte Cloud: `v1/applications/token` (default value)
-    If you are using Airbyte OSS: `/api/public/v1/applications/token`
-    Be aware: if you're changing the API path using an engress rule you must.
+    If you are using Airbyte Cloud: ``v1/applications/token`` (default value)
+    If you are using Airbyte OSS: ``/api/public/v1/applications/token```
+    Be aware: If you're changing the API path, you must update the value accordingly.
 
 Client ID (required)
     The Client ID to connect to the Airbyte server.

--- a/docs/apache-airflow-providers-airbyte/operators/airbyte.rst
+++ b/docs/apache-airflow-providers-airbyte/operators/airbyte.rst
@@ -38,10 +38,8 @@ create in Airbyte between a source and destination synchronization job.
 Use the ``airbyte_conn_id`` parameter to specify the Airbyte connection to use to
 connect to your account.
 
-Airbyte currently supports two different API's. The first one is the `Config API <https://airbyte-public-api-docs.s3.us-east-2.amazonaws.com/rapidoc-api-docs.html>`_
-which is specifically used for Open Source Airbyte Instances. The second is the `Cloud API <https://reference.airbyte.com/reference/start>`_
-which is used for the Airbyte Cloud Service. If you are using Airbyte's Cloud service,
-then you will need to specify ``api_type="cloud"`` as part of the Operator's parameters.
+Airbyte now offers a single method to authenticate for Cloud and OSS users.
+You need to provide the ``client_id`` and ``client_secret`` to authenticate with the Airbyte server.
 
 You can trigger a synchronization job in Airflow in two ways with the Operator. The first one is a synchronous process.
 This Operator will initiate the Airbyte job, and the Operator manages the job status. Another way is to use the flag

--- a/docs/apache-airflow-providers-airbyte/operators/airbyte.rst
+++ b/docs/apache-airflow-providers-airbyte/operators/airbyte.rst
@@ -38,7 +38,7 @@ create in Airbyte between a source and destination synchronization job.
 Use the ``airbyte_conn_id`` parameter to specify the Airbyte connection to use to
 connect to your account.
 
-Airbyte now offers a single method to authenticate for Cloud and OSS users.
+Airbyte offers a single method to authenticate for Cloud and OSS users.
 You need to provide the ``client_id`` and ``client_secret`` to authenticate with the Airbyte server.
 
 You can trigger a synchronization job in Airflow in two ways with the Operator. The first one is a synchronous process.

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -2,7 +2,7 @@
   "airbyte": {
     "deps": [
       "airbyte-api>=0.51.0",
-      "apache-airflow>=2.8.0"
+      "apache-airflow>=2.7.0"
     ],
     "devel-deps": [],
     "plugins": [],

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -2,7 +2,6 @@
   "airbyte": {
     "deps": [
       "airbyte-api>=0.51.0",
-      "apache-airflow-providers-http",
       "apache-airflow>=2.8.0"
     ],
     "devel-deps": [],

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -1,8 +1,7 @@
 {
   "airbyte": {
     "deps": [
-      "airbyte-api",
-      "apache-airflow-providers-http",
+      "airbyte-api>=0.51.0",
       "apache-airflow>=2.8.0"
     ],
     "devel-deps": [],

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -1,7 +1,7 @@
 {
   "airbyte": {
     "deps": [
-      "airbyte-api",
+      "airbyte-api>=0.51.0",
       "apache-airflow-providers-http",
       "apache-airflow>=2.8.0"
     ],

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -1,6 +1,7 @@
 {
   "airbyte": {
     "deps": [
+      "airbyte-api",
       "apache-airflow-providers-http",
       "apache-airflow>=2.8.0"
     ],

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -1,8 +1,9 @@
 {
   "airbyte": {
     "deps": [
-      "airbyte-api>=0.51.0",
-      "apache-airflow>=2.7.0"
+      "airbyte-api",
+      "apache-airflow-providers-http",
+      "apache-airflow>=2.8.0"
     ],
     "devel-deps": [],
     "plugins": [],

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -7,9 +7,7 @@
     ],
     "devel-deps": [],
     "plugins": [],
-    "cross-providers-deps": [
-      "http"
-    ],
+    "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "ready"
   },

--- a/tests/providers/airbyte/hooks/test_airbyte.py
+++ b/tests/providers/airbyte/hooks/test_airbyte.py
@@ -93,10 +93,9 @@ class TestAirbyteHook:
         base_url = hook.get_server_url()
         assert base_url == expected_base_url
 
-    @pytest.mark.asyncio
     @mock.patch("airbyte_api.jobs.Jobs.get_job")
-    async def test_get_job_status(self, get_job_mock):
-        mock_response = mock.Mock()
+    def test_get_job_status(self, get_job_mock):
+        mock_response = mock.AsyncMock()
         mock_response.job_response = JobResponse(
             connection_id="connection-mock",
             job_id="1",
@@ -105,8 +104,7 @@ class TestAirbyteHook:
             status=JobStatusEnum.RUNNING,
         )
         get_job_mock.return_value = mock_response
-
-        resp = await self.hook.get_job_status(job_id=self.job_id)
+        resp = self.hook.get_job_status(job_id=self.job_id)
         assert resp == JobStatusEnum.RUNNING
 
     @mock.patch("airbyte_api.jobs.Jobs.cancel_job")

--- a/tests/providers/airbyte/hooks/test_airbyte.py
+++ b/tests/providers/airbyte/hooks/test_airbyte.py
@@ -52,7 +52,10 @@ class TestAirbyteHook:
     def setup_method(self):
         db.merge_conn(
             Connection(
-                conn_id="airbyte_conn_id_test", conn_type="airbyte", host="http://test-airbyte", port=8001
+                conn_id="airbyte_conn_id_test",
+                conn_type="airbyte",
+                host="http://test-airbyte:8000/public/v1/api/",
+                port=8001,
             )
         )
         self.hook = AirbyteHook(airbyte_conn_id=self.airbyte_conn_id)
@@ -76,22 +79,6 @@ class TestAirbyteHook:
 
         resp = self.hook.submit_sync_connection(connection_id=self.connection_id)
         assert resp == self._mock_sync_conn_success_response_body
-
-    @pytest.mark.parametrize(
-        "host, port, schema, expected_base_url, description",
-        [
-            ("test-airbyte", 8001, "http", "http://test-airbyte:8001/v1", "uri_with_port_and_schema"),
-            ("test-airbyte", None, "https", "https://test-airbyte/v1", "uri_with_schema"),
-            ("test-airbyte", None, None, "https://test-airbyte/v1", "uri_without_port_and_schema"),
-        ],
-    )
-    def test_get_base_url(self, host, port, schema, expected_base_url, description):
-        conn_id = f"test_conn_{description}"
-        conn = Connection(conn_id=conn_id, conn_type="airbyte", host=host, port=port, schema=schema)
-        db.merge_conn(conn)
-        hook = AirbyteHook(airbyte_conn_id=conn_id)
-        base_url = hook.get_server_url()
-        assert base_url == expected_base_url
 
     @mock.patch("airbyte_api.jobs.Jobs.get_job")
     def test_get_job_status(self, get_job_mock):

--- a/tests/providers/airbyte/hooks/test_airbyte.py
+++ b/tests/providers/airbyte/hooks/test_airbyte.py
@@ -94,7 +94,7 @@ class TestAirbyteHook:
         assert base_url == expected_base_url
 
     @mock.patch("airbyte_api.jobs.Jobs.get_job")
-    def test_get_job_status(self, get_job_mock):
+    async def test_get_job_status(self, get_job_mock):
         mock_response = mock.Mock()
         mock_response.job_response = JobResponse(
             connection_id="connection-mock",
@@ -105,7 +105,7 @@ class TestAirbyteHook:
         )
         get_job_mock.return_value = mock_response
 
-        resp = self.hook.get_job_status(job_id=self.job_id)
+        resp = await self.hook.get_job_status(job_id=self.job_id)
         assert resp == JobStatusEnum.RUNNING
 
     @mock.patch("airbyte_api.jobs.Jobs.cancel_job")

--- a/tests/providers/airbyte/hooks/test_airbyte.py
+++ b/tests/providers/airbyte/hooks/test_airbyte.py
@@ -49,6 +49,7 @@ class TestAirbyteHook:
     _mock_job_status_success_response_body = {"job": {"status": "succeeded"}}
     _mock_job_cancel_status = "cancelled"
 
+    @pytest.mark.db_test
     def setup_method(self):
         db.merge_conn(
             Connection(

--- a/tests/providers/airbyte/hooks/test_airbyte.py
+++ b/tests/providers/airbyte/hooks/test_airbyte.py
@@ -32,6 +32,7 @@ from airflow.utils import db
 pytestmark = [pytest.mark.db_test, pytest.mark.skip_if_database_isolation_mode]
 
 
+@pytest.mark.db_test
 class TestAirbyteHook:
     """
     Test all functions from Airbyte Hook
@@ -49,7 +50,6 @@ class TestAirbyteHook:
     _mock_job_status_success_response_body = {"job": {"status": "succeeded"}}
     _mock_job_cancel_status = "cancelled"
 
-    @pytest.mark.db_test
     def setup_method(self):
         db.merge_conn(
             Connection(

--- a/tests/providers/airbyte/hooks/test_airbyte.py
+++ b/tests/providers/airbyte/hooks/test_airbyte.py
@@ -93,6 +93,7 @@ class TestAirbyteHook:
         base_url = hook.get_server_url()
         assert base_url == expected_base_url
 
+    @pytest.mark.asyncio
     @mock.patch("airbyte_api.jobs.Jobs.get_job")
     async def test_get_job_status(self, get_job_mock):
         mock_response = mock.Mock()

--- a/tests/providers/airbyte/operators/test_airbyte.py
+++ b/tests/providers/airbyte/operators/test_airbyte.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
 from airbyte_api.models import JobCreateRequest, JobResponse, JobStatusEnum, JobTypeEnum
 
 from airflow.models import Connection
@@ -26,6 +27,7 @@ from airflow.providers.airbyte.operators.airbyte import AirbyteTriggerSyncOperat
 from airflow.utils import db
 
 
+@pytest.mark.db_test
 class TestAirbyteTriggerSyncOp:
     """
     Test execute function from Airbyte Operator

--- a/tests/providers/airbyte/operators/test_airbyte.py
+++ b/tests/providers/airbyte/operators/test_airbyte.py
@@ -40,9 +40,7 @@ class TestAirbyteTriggerSyncOp:
     @mock.patch("airbyte_api.jobs.Jobs.create_job")
     @mock.patch("airflow.providers.airbyte.hooks.airbyte.AirbyteHook.wait_for_job", return_value=None)
     def test_execute(self, mock_wait_for_job, mock_submit_sync_connection):
-        conn = Connection(
-            conn_id=self.airbyte_conn_id, conn_type="airbyte", host="airbyte.com", port="9000", schema="http"
-        )
+        conn = Connection(conn_id=self.airbyte_conn_id, conn_type="airbyte", host="airbyte.com")
         db.merge_conn(conn)
         mock_response = mock.Mock()
         mock_response.job_response = JobResponse(

--- a/tests/providers/airbyte/operators/test_airbyte.py
+++ b/tests/providers/airbyte/operators/test_airbyte.py
@@ -19,7 +19,11 @@ from __future__ import annotations
 
 from unittest import mock
 
+from airbyte_api.models import JobCreateRequest, JobResponse, JobStatusEnum, JobTypeEnum
+
+from airflow.models import Connection
 from airflow.providers.airbyte.operators.airbyte import AirbyteTriggerSyncOperator
+from airflow.utils import db
 
 
 class TestAirbyteTriggerSyncOp:
@@ -33,12 +37,22 @@ class TestAirbyteTriggerSyncOp:
     wait_seconds = 0
     timeout = 360
 
-    @mock.patch("airflow.providers.airbyte.hooks.airbyte.AirbyteHook.submit_sync_connection")
+    @mock.patch("airbyte_api.jobs.Jobs.create_job")
     @mock.patch("airflow.providers.airbyte.hooks.airbyte.AirbyteHook.wait_for_job", return_value=None)
     def test_execute(self, mock_wait_for_job, mock_submit_sync_connection):
-        mock_submit_sync_connection.return_value = mock.Mock(
-            **{"json.return_value": {"job": {"id": self.job_id, "status": "running"}}}
+        conn = Connection(
+            conn_id=self.airbyte_conn_id, conn_type="airbyte", host="airbyte.com", port="9000", schema="http"
         )
+        db.merge_conn(conn)
+        mock_response = mock.Mock()
+        mock_response.job_response = JobResponse(
+            connection_id="connection-mock",
+            job_id=1,
+            start_time="today",
+            job_type=JobTypeEnum.SYNC,
+            status=JobStatusEnum.RUNNING,
+        )
+        mock_submit_sync_connection.return_value = mock_response
 
         op = AirbyteTriggerSyncOperator(
             task_id="test_Airbyte_op",
@@ -49,7 +63,9 @@ class TestAirbyteTriggerSyncOp:
         )
         op.execute({})
 
-        mock_submit_sync_connection.assert_called_once_with(connection_id=self.connection_id)
+        mock_submit_sync_connection.assert_called_once_with(
+            request=JobCreateRequest(connection_id=self.connection_id, job_type=JobTypeEnum.SYNC)
+        )
         mock_wait_for_job.assert_called_once_with(
             job_id=self.job_id, wait_seconds=self.wait_seconds, timeout=self.timeout
         )

--- a/tests/providers/airbyte/sensors/test_airbyte.py
+++ b/tests/providers/airbyte/sensors/test_airbyte.py
@@ -28,6 +28,7 @@ from airflow.providers.airbyte.sensors.airbyte import AirbyteJobSensor
 from airflow.utils import db
 
 
+@pytest.mark.db_test
 class TestAirbyteJobSensor:
     task_id = "task-id"
     airbyte_conn_id = "airbyte-conn-test"
@@ -45,7 +46,6 @@ class TestAirbyteJobSensor:
         )
         return response
 
-    @pytest.mark.db_test
     def setup_method(self):
         db.merge_conn(
             Connection(conn_id=self.airbyte_conn_id, conn_type="airbyte", host="http://test-airbyte")

--- a/tests/providers/airbyte/sensors/test_airbyte.py
+++ b/tests/providers/airbyte/sensors/test_airbyte.py
@@ -47,9 +47,7 @@ class TestAirbyteJobSensor:
 
     def setup_method(self):
         db.merge_conn(
-            Connection(
-                conn_id=self.airbyte_conn_id, conn_type="airbyte", host="http://test-airbyte", port=8001
-            )
+            Connection(conn_id=self.airbyte_conn_id, conn_type="airbyte", host="http://test-airbyte")
         )
 
     @mock.patch("airbyte_api.jobs.Jobs.get_job")

--- a/tests/providers/airbyte/sensors/test_airbyte.py
+++ b/tests/providers/airbyte/sensors/test_airbyte.py
@@ -45,6 +45,7 @@ class TestAirbyteJobSensor:
         )
         return response
 
+    @pytest.mark.db_test
     def setup_method(self):
         db.merge_conn(
             Connection(conn_id=self.airbyte_conn_id, conn_type="airbyte", host="http://test-airbyte")

--- a/tests/providers/airbyte/sensors/test_airbyte.py
+++ b/tests/providers/airbyte/sensors/test_airbyte.py
@@ -19,9 +19,13 @@ from __future__ import annotations
 from unittest import mock
 
 import pytest
+from airbyte_api.api import GetJobRequest
+from airbyte_api.models import JobResponse, JobStatusEnum, JobTypeEnum
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, RemovedInAirflow3Warning
+from airflow.models import Connection
 from airflow.providers.airbyte.sensors.airbyte import AirbyteJobSensor
+from airflow.utils import db
 
 
 class TestAirbyteJobSensor:
@@ -32,12 +36,25 @@ class TestAirbyteJobSensor:
 
     def get_job(self, status):
         response = mock.Mock()
-        response.json.return_value = {"job": {"status": status}}
+        response.job_response = JobResponse(
+            connection_id="connection-mock",
+            job_id=self.job_id,
+            start_time="today",
+            job_type=JobTypeEnum.SYNC,
+            status=status,
+        )
         return response
 
-    @mock.patch("airflow.providers.airbyte.hooks.airbyte.AirbyteHook.get_job")
+    def setup_method(self):
+        db.merge_conn(
+            Connection(
+                conn_id=self.airbyte_conn_id, conn_type="airbyte", host="http://test-airbyte", port=8001
+            )
+        )
+
+    @mock.patch("airbyte_api.jobs.Jobs.get_job")
     def test_done(self, mock_get_job):
-        mock_get_job.return_value = self.get_job("succeeded")
+        mock_get_job.return_value = self.get_job(JobStatusEnum.SUCCEEDED)
 
         sensor = AirbyteJobSensor(
             task_id=self.task_id,
@@ -45,12 +62,12 @@ class TestAirbyteJobSensor:
             airbyte_conn_id=self.airbyte_conn_id,
         )
         ret = sensor.poke(context={})
-        mock_get_job.assert_called_once_with(job_id=self.job_id)
+        mock_get_job.assert_called_once_with(request=GetJobRequest(job_id=self.job_id))
         assert ret
 
-    @mock.patch("airflow.providers.airbyte.hooks.airbyte.AirbyteHook.get_job")
+    @mock.patch("airbyte_api.jobs.Jobs.get_job")
     def test_failed(self, mock_get_job):
-        mock_get_job.return_value = self.get_job("failed")
+        mock_get_job.return_value = self.get_job(JobStatusEnum.FAILED)
 
         sensor = AirbyteJobSensor(
             task_id=self.task_id,
@@ -60,11 +77,11 @@ class TestAirbyteJobSensor:
         with pytest.raises(AirflowException, match="Job failed"):
             sensor.poke(context={})
 
-        mock_get_job.assert_called_once_with(job_id=self.job_id)
+        mock_get_job.assert_called_once_with(request=GetJobRequest(job_id=self.job_id))
 
-    @mock.patch("airflow.providers.airbyte.hooks.airbyte.AirbyteHook.get_job")
+    @mock.patch("airbyte_api.jobs.Jobs.get_job")
     def test_running(self, mock_get_job):
-        mock_get_job.return_value = self.get_job("running")
+        mock_get_job.return_value = self.get_job(JobStatusEnum.RUNNING)
 
         sensor = AirbyteJobSensor(
             task_id=self.task_id,
@@ -73,13 +90,13 @@ class TestAirbyteJobSensor:
         )
         ret = sensor.poke(context={})
 
-        mock_get_job.assert_called_once_with(job_id=self.job_id)
+        mock_get_job.assert_called_once_with(request=GetJobRequest(job_id=self.job_id))
 
         assert not ret
 
-    @mock.patch("airflow.providers.airbyte.hooks.airbyte.AirbyteHook.get_job")
+    @mock.patch("airbyte_api.jobs.Jobs.get_job")
     def test_cancelled(self, mock_get_job):
-        mock_get_job.return_value = self.get_job("cancelled")
+        mock_get_job.return_value = self.get_job(JobStatusEnum.CANCELLED)
 
         sensor = AirbyteJobSensor(
             task_id=self.task_id,
@@ -89,4 +106,4 @@ class TestAirbyteJobSensor:
         with pytest.raises(AirflowException, match="Job was cancelled"):
             sensor.poke(context={})
 
-        mock_get_job.assert_called_once_with(job_id=self.job_id)
+        mock_get_job.assert_called_once_with(request=GetJobRequest(job_id=self.job_id))

--- a/tests/providers/airbyte/sensors/test_airbyte.py
+++ b/tests/providers/airbyte/sensors/test_airbyte.py
@@ -22,7 +22,7 @@ import pytest
 from airbyte_api.api import GetJobRequest
 from airbyte_api.models import JobResponse, JobStatusEnum, JobTypeEnum
 
-from airflow.exceptions import AirflowException, RemovedInAirflow3Warning
+from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.providers.airbyte.sensors.airbyte import AirbyteJobSensor
 from airflow.utils import db

--- a/tests/providers/airbyte/triggers/test_airbyte.py
+++ b/tests/providers/airbyte/triggers/test_airbyte.py
@@ -21,6 +21,7 @@ import time
 from unittest import mock
 
 import pytest
+from airbyte_api.models import JobStatusEnum
 
 from airflow.providers.airbyte.hooks.airbyte import AirbyteHook
 from airflow.providers.airbyte.triggers.airbyte import AirbyteSyncTrigger
@@ -31,7 +32,6 @@ class TestAirbyteSyncTrigger:
     DAG_ID = "airbyte_sync_run"
     TASK_ID = "airbyte_sync_run_task_op"
     JOB_ID = 1234
-    API_TYPE = "config"
     CONN_ID = "airbyte_default"
     END_TIME = time.time() + 60 * 60 * 24 * 7
     POLL_INTERVAL = 3.0
@@ -39,7 +39,6 @@ class TestAirbyteSyncTrigger:
     def test_serialization(self):
         """Assert TestAirbyteSyncTrigger correctly serializes its arguments and classpath."""
         trigger = AirbyteSyncTrigger(
-            api_type=self.API_TYPE,
             conn_id=self.CONN_ID,
             poll_interval=self.POLL_INTERVAL,
             end_time=self.END_TIME,
@@ -50,7 +49,6 @@ class TestAirbyteSyncTrigger:
         assert kwargs == {
             "job_id": self.JOB_ID,
             "conn_id": self.CONN_ID,
-            "api_type": self.API_TYPE,
             "end_time": self.END_TIME,
             "poll_interval": self.POLL_INTERVAL,
         }
@@ -61,7 +59,6 @@ class TestAirbyteSyncTrigger:
         """Test AirbyteSyncTrigger is triggered with mocked details and run successfully."""
         mocked_is_still_running.return_value = True
         trigger = AirbyteSyncTrigger(
-            api_type=self.API_TYPE,
             conn_id=self.CONN_ID,
             poll_interval=self.POLL_INTERVAL,
             end_time=self.END_TIME,
@@ -78,7 +75,7 @@ class TestAirbyteSyncTrigger:
     @pytest.mark.parametrize(
         "mock_value, mock_status, mock_message",
         [
-            (AirbyteHook.SUCCEEDED, "success", "Job run 1234 has completed successfully."),
+            (JobStatusEnum.SUCCEEDED, "success", "Job run 1234 has completed successfully."),
         ],
     )
     @mock.patch("airflow.providers.airbyte.triggers.airbyte.AirbyteSyncTrigger.is_still_running")
@@ -90,7 +87,6 @@ class TestAirbyteSyncTrigger:
         mocked_is_still_running.return_value = False
         mock_get_job_status.return_value = mock_value
         trigger = AirbyteSyncTrigger(
-            api_type=self.API_TYPE,
             conn_id=self.CONN_ID,
             poll_interval=self.POLL_INTERVAL,
             end_time=self.END_TIME,
@@ -110,7 +106,7 @@ class TestAirbyteSyncTrigger:
     @pytest.mark.parametrize(
         "mock_value, mock_status, mock_message",
         [
-            (AirbyteHook.CANCELLED, "cancelled", "Job run 1234 has been cancelled."),
+            (JobStatusEnum.CANCELLED, "cancelled", "Job run 1234 has been cancelled."),
         ],
     )
     @mock.patch("airflow.providers.airbyte.triggers.airbyte.AirbyteSyncTrigger.is_still_running")
@@ -122,7 +118,6 @@ class TestAirbyteSyncTrigger:
         mocked_is_still_running.return_value = False
         mock_get_job_status.return_value = mock_value
         trigger = AirbyteSyncTrigger(
-            api_type=self.API_TYPE,
             conn_id=self.CONN_ID,
             poll_interval=self.POLL_INTERVAL,
             end_time=self.END_TIME,
@@ -142,7 +137,7 @@ class TestAirbyteSyncTrigger:
     @pytest.mark.parametrize(
         "mock_value, mock_status, mock_message",
         [
-            (AirbyteHook.ERROR, "error", "Job run 1234 has failed."),
+            (JobStatusEnum.FAILED, "failed", "Job run 1234 has failed."),
         ],
     )
     @mock.patch("airflow.providers.airbyte.triggers.airbyte.AirbyteSyncTrigger.is_still_running")
@@ -154,7 +149,6 @@ class TestAirbyteSyncTrigger:
         mocked_is_still_running.return_value = False
         mock_get_job_status.return_value = mock_value
         trigger = AirbyteSyncTrigger(
-            api_type=self.API_TYPE,
             conn_id=self.CONN_ID,
             poll_interval=self.POLL_INTERVAL,
             end_time=self.END_TIME,
@@ -178,7 +172,6 @@ class TestAirbyteSyncTrigger:
         mocked_is_still_running.return_value = False
         mock_get_job_status.side_effect = Exception("Test exception")
         trigger = AirbyteSyncTrigger(
-            api_type=self.API_TYPE,
             conn_id=self.CONN_ID,
             poll_interval=self.POLL_INTERVAL,
             end_time=self.END_TIME,
@@ -204,7 +197,6 @@ class TestAirbyteSyncTrigger:
         mock_get_job_status.side_effect = Exception("Test exception")
         end_time = time.time()
         trigger = AirbyteSyncTrigger(
-            api_type=self.API_TYPE,
             conn_id=self.CONN_ID,
             poll_interval=self.POLL_INTERVAL,
             end_time=end_time,
@@ -226,7 +218,7 @@ class TestAirbyteSyncTrigger:
     @pytest.mark.parametrize(
         "mock_response, expected_status",
         [
-            (AirbyteHook.SUCCEEDED, False),
+            (JobStatusEnum.SUCCEEDED, False),
         ],
     )
     @mock.patch("airflow.providers.airbyte.hooks.airbyte.AirbyteHook.get_job_status")
@@ -238,20 +230,19 @@ class TestAirbyteSyncTrigger:
         hook = mock.AsyncMock(AirbyteHook)
         hook.get_job_status.return_value = mock_response
         trigger = AirbyteSyncTrigger(
-            api_type=self.API_TYPE,
             conn_id=self.CONN_ID,
             poll_interval=self.POLL_INTERVAL,
             end_time=self.END_TIME,
             job_id=self.JOB_ID,
         )
-        response = await trigger.is_still_running(hook)
+        response = trigger.is_still_running(hook)
         assert response == expected_status
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "mock_response, expected_status",
         [
-            (AirbyteHook.RUNNING, True),
+            (JobStatusEnum.RUNNING, True),
         ],
     )
     @mock.patch("airflow.providers.airbyte.hooks.airbyte.AirbyteHook.get_job_status")
@@ -263,11 +254,10 @@ class TestAirbyteSyncTrigger:
         airbyte_hook = mock.AsyncMock(AirbyteHook)
         airbyte_hook.get_job_status.return_value = mock_response
         trigger = AirbyteSyncTrigger(
-            api_type=self.API_TYPE,
             conn_id=self.CONN_ID,
             poll_interval=self.POLL_INTERVAL,
             end_time=self.END_TIME,
             job_id=self.JOB_ID,
         )
-        response = await trigger.is_still_running(airbyte_hook)
+        response = trigger.is_still_running(airbyte_hook)
         assert response == expected_status

--- a/tests/providers/airbyte/triggers/test_airbyte.py
+++ b/tests/providers/airbyte/triggers/test_airbyte.py
@@ -30,6 +30,7 @@ from airflow.triggers.base import TriggerEvent
 from airflow.utils import db
 
 
+@pytest.mark.db_test
 class TestAirbyteSyncTrigger:
     DAG_ID = "airbyte_sync_run"
     TASK_ID = "airbyte_sync_run_task_op"
@@ -38,7 +39,6 @@ class TestAirbyteSyncTrigger:
     END_TIME = time.time() + 60 * 60 * 24 * 7
     POLL_INTERVAL = 3.0
 
-    @pytest.mark.db_test
     def setup_method(self):
         db.merge_conn(Connection(conn_id=self.CONN_ID, conn_type="airbyte", host="http://test-airbyte"))
 

--- a/tests/providers/airbyte/triggers/test_airbyte.py
+++ b/tests/providers/airbyte/triggers/test_airbyte.py
@@ -38,6 +38,7 @@ class TestAirbyteSyncTrigger:
     END_TIME = time.time() + 60 * 60 * 24 * 7
     POLL_INTERVAL = 3.0
 
+    @pytest.mark.db_test
     def setup_method(self):
         db.merge_conn(Connection(conn_id=self.CONN_ID, conn_type="airbyte", host="http://test-airbyte"))
 

--- a/tests/providers/airbyte/triggers/test_airbyte.py
+++ b/tests/providers/airbyte/triggers/test_airbyte.py
@@ -39,9 +39,7 @@ class TestAirbyteSyncTrigger:
     POLL_INTERVAL = 3.0
 
     def setup_method(self):
-        db.merge_conn(
-            Connection(conn_id=self.CONN_ID, conn_type="airbyte", host="http://test-airbyte", port=8001)
-        )
+        db.merge_conn(Connection(conn_id=self.CONN_ID, conn_type="airbyte", host="http://test-airbyte"))
 
     def test_serialization(self):
         """Assert TestAirbyteSyncTrigger correctly serializes its arguments and classpath."""


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Hello 👋, Airbyte has finally consolidated API access across the open-source, cloud, and enterprise versions. 
This means all of them have a single method `client_id` and `client_secret` to [authenticate to the API](https://reference.airbyte.com/reference/authentication) now. 
This pull request remove the dependency of `HttpHook` and uses the `airbyte-api` Python SDK library to execute all operations (create job, cancel job, etc). 
The change is a breaking change to users as it removed the `api_type` parameter as it isn't required anymore. 
The new authentication method will become soon the unique method to auth to the API so this is a required changed.
Unit tests were updated to run using the new code.

---