### PR TITLE
Pass mapIndex to LogLink component for external log systems

### DIFF
--- a/airflow/www/static/js/dag/details/taskInstance/Logs/LogLink.test.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/LogLink.test.tsx
@@ -49,12 +49,14 @@ describe("Test LogLink Component.", () => {
 
   test("External Link", () => {
     const tryNumber = 1;
+    const mapIndex = 2;
     const { getByText, container } = render(
       <LogLink
         tryNumber={tryNumber}
         dagId="dummyDagId"
         taskId="dummyTaskId"
         executionDate="2020:01:01T01:00+00:00"
+        mapIndex={mapIndex}
       />
     );
 
@@ -64,7 +66,7 @@ describe("Test LogLink Component.", () => {
     expect(linkElement).toHaveAttribute("target", "_blank");
     expect(
       linkElement?.href.includes(
-        `?dag_id=dummyDagId&task_id=dummyTaskId&execution_date=2020%3A01%3A01T01%3A00%2B00%3A00&map_index=-1&try_number=${tryNumber}`
+        `?dag_id=dummyDagId&task_id=dummyTaskId&execution_date=2020%3A01%3A01T01%3A00%2B00%3A00&map_index=${mapIndex}&try_number=${tryNumber}`
       )
     ).toBeTruthy();
   });

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
@@ -166,6 +166,7 @@ const Logs = ({
                   taskId={taskId}
                   executionDate={executionDate}
                   tryNumber={tryNumber}
+                  mapIndex={mapIndex}
                 />
               )
             )}


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

---

When Airflow is configured with a log system such as Elasticsearch/Kibana that can be externally linked to, the `Logs` component did not pass mapIndex to the `LogLink` component 

closes: #40655 

