### PR TITLE
Make traceback for DB isolation mode way smaller and useful

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -267,6 +267,15 @@ class SkipDBTestsSession:
         pass
 
 
+def get_cleaned_traceback(stack_summary: traceback.StackSummary) -> str:
+    clened_traceback = [
+        frame
+        for frame in stack_summary[:-2]
+        if "/_pytest" not in frame.filename and "/pluggy" not in frame.filename
+    ]
+    return "".join(traceback.format_list(clened_traceback))
+
+
 class TracebackSession:
     """
     Session that throws error when you try to use it.
@@ -284,7 +293,7 @@ class TracebackSession:
             "TracebackSession object was used but internal API is enabled. "
             "You'll need to ensure you are making only RPC calls with this object. "
             "The stack list below will show where the TracebackSession object was created."
-            + "\n".join(traceback.format_list(self.traceback))
+            + get_cleaned_traceback(self.traceback)
         )
 
     def remove(*args, **kwargs):
@@ -324,9 +333,9 @@ class TracebackSessionForTests:
             f"     {frame_summary.line}\n\n"
             "You'll need to ensure you are making only RPC calls with this object. "
             "The stack list below will show where the TracebackSession object was called:\n"
-            + "".join(traceback.format_list(self.traceback))
+            + get_cleaned_traceback(self.traceback)
             + "\n\nThe stack list below will show where the TracebackSession object was created:\n"
-            + "".join(traceback.format_list(self.created_traceback))
+            + get_cleaned_traceback(self.created_traceback)
         )
 
     def remove(*args, **kwargs):


### PR DESCRIPTION
Removes a lot of useless frames from the traceback:

* pytest and pluggy
* last two "create_session" tracebacks

This way it is immediately visible where we should look for problems

Related: #41067

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
