### PR TITLE
Remove Dataset Alias Condition Tests from Dataset Isolation Mode

### DIFF
--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -517,6 +517,7 @@ def test_normalize_uri_valid_uri():
     assert dataset.normalized_uri == "valid_aip60_uri"
 
 
+@pytest.mark.skip_if_database_isolation_mode
 @pytest.mark.db_test
 @pytest.mark.usefixtures("clear_datasets")
 class Test_DatasetAliasCondition:


### PR DESCRIPTION
Realted #41067

Remove/Skip some tests for Dataset Alias Evaluation... which are not actively running from worker, as far as I see this is only interpreted by Scheduler, no isolation mode needed.