### PR TITLE
Remove datatables.net

### DIFF
--- a/airflow/www/package.json
+++ b/airflow/www/package.json
@@ -118,8 +118,6 @@
     "d3-shape": "^2.1.0",
     "d3-tip": "^0.9.1",
     "dagre-d3": "^0.6.4",
-    "datatables.net": "^1.11.4",
-    "datatables.net-bs": "^1.11.4",
     "echarts": "^5.4.2",
     "elkjs": "^0.7.1",
     "eonasdan-bootstrap-datetimepicker": "^4.17.47",

--- a/airflow/www/webpack.config.js
+++ b/airflow/www/webpack.config.js
@@ -97,14 +97,6 @@ const config = {
   module: {
     rules: [
       {
-        test: /datatables\.net.*/,
-        use: [
-          {
-            loader: "imports-loader?define=>false",
-          },
-        ],
-      },
-      {
         test: /\.(js|jsx|tsx|ts)$/,
         exclude: /node_modules/,
         use: [
@@ -219,14 +211,6 @@ const config = {
         },
         {
           from: "node_modules/bootstrap-3-typeahead/*min.*",
-          flatten: true,
-        },
-        {
-          from: "node_modules/datatables.net/**/**.min.*",
-          flatten: true,
-        },
-        {
-          from: "node_modules/datatables.net-bs/**/**.min.*",
           flatten: true,
         },
         {

--- a/airflow/www/yarn.lock
+++ b/airflow/www/yarn.lock
@@ -5574,21 +5574,6 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-datatables.net-bs@^1.11.4:
-  version "1.11.4"
-  resolved "https://registry.yarnpkg.com/datatables.net-bs/-/datatables.net-bs-1.11.4.tgz#96a5f4e8cdff5d5e819476d1986f99b026ea3e47"
-  integrity sha512-lQaytqSOcSv51jFoT7RyDbaoziCStSDl5Ym1yOBP+ZXIOsS9fd4zOFZyDQlmGFyUpa8JAy84C4r8jM1GQ3/olA==
-  dependencies:
-    datatables.net ">=1.11.3"
-    jquery ">=1.7"
-
-datatables.net@>=1.11.3, datatables.net@^1.11.4:
-  version "1.11.4"
-  resolved "https://registry.yarnpkg.com/datatables.net/-/datatables.net-1.11.4.tgz#5f3e1ec134fa532e794fbd47c13f8333d7a5c455"
-  integrity sha512-z9LG4O0VYOYzp+rnArLExvnUWV8ikyWBcHYZEKDfVuz7BKxQdEq4a/tpO0Trbm+FL1+RY7UEIh+UcYNY/hwGxA==
-  dependencies:
-    jquery ">=1.7"
-
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
@@ -8033,7 +8018,7 @@ jest@^27.3.1:
     import-local "^3.0.2"
     jest-cli "^27.3.1"
 
-jquery@>=1.7, jquery@>=3.5.0, jquery@^3.5.1:
+jquery@>=3.5.0, jquery@^3.5.1:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
   integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==


### PR DESCRIPTION
We don't appear to use these libraries anymore. Let's get rid of them.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
