### PR TITLE
Render Dataset Conditions in DAG Graph view

### DIFF
--- a/airflow/www/static/js/dag/details/graph/DatasetNode.tsx
+++ b/airflow/www/static/js/dag/details/graph/DatasetNode.tsx
@@ -58,8 +58,8 @@ const DatasetNode = ({
       <PopoverTrigger>
         <Box
           borderRadius={isZoomedOut ? 10 : 5}
-          borderWidth={1}
-          borderColor="gray.400"
+          borderWidth={datasetEvent ? 2 : 1}
+          borderColor={datasetEvent ? "green" : "gray.400"}
           bg="white"
           height={`${height}px`}
           width={`${width}px`}

--- a/airflow/www/static/js/dag/details/graph/Node.tsx
+++ b/airflow/www/static/js/dag/details/graph/Node.tsx
@@ -18,14 +18,18 @@
  */
 
 import React from "react";
-import { Box } from "@chakra-ui/react";
+import { Box, useTheme } from "@chakra-ui/react";
 import { Handle, NodeProps, Position } from "reactflow";
+import { TbLogicAnd, TbLogicOr } from "react-icons/tb";
 
 import type { DepNode, DagRun, Task, TaskInstance } from "src/types";
 import type { DatasetEvent } from "src/types/api-generated";
 
-import DagNode from "./DagNode";
+import Tooltip from "src/components/Tooltip";
+import { useContainerRef } from "src/context/containerRef";
+import { hoverDelay } from "src/utils";
 import DatasetNode from "./DatasetNode";
+import DagNode from "./DagNode";
 
 export interface CustomNodeProps {
   label: string;
@@ -49,7 +53,9 @@ export interface CustomNodeProps {
 }
 
 const Node = (props: NodeProps<CustomNodeProps>) => {
+  const { colors } = useTheme();
   const { data } = props;
+  const containerRef = useContainerRef();
 
   if (data.isJoinNode) {
     return (
@@ -59,6 +65,32 @@ const Node = (props: NodeProps<CustomNodeProps>) => {
         borderRadius={data.width}
         bg="gray.400"
       />
+    );
+  }
+
+  if (data.class === "or-gate" || data.class === "and-gate") {
+    return (
+      <Box
+        height={`${data.height}px`}
+        width={`${data.width}px`}
+        borderRadius={4}
+        borderWidth={1}
+      >
+        <Tooltip
+          label={data.class === "or-gate" ? "Or" : "And"}
+          portalProps={{ containerRef }}
+          hasArrow
+          openDelay={hoverDelay}
+        >
+          <Box>
+            {data.class === "or-gate" ? (
+              <TbLogicOr size="30px" stroke={colors.gray[600]} />
+            ) : (
+              <TbLogicAnd size="30px" stroke={colors.gray[600]} />
+            )}
+          </Box>
+        </Tooltip>
+      </Box>
     );
   }
 

--- a/airflow/www/static/js/dag/details/graph/index.tsx
+++ b/airflow/www/static/js/dag/details/graph/index.tsx
@@ -31,6 +31,7 @@ import ReactFlow, {
 } from "reactflow";
 
 import {
+  useDagDetails,
   useDatasetEvents,
   useDatasets,
   useGraphData,
@@ -57,6 +58,79 @@ interface Props {
 
 const dagId = getMetaValue("dag_id");
 
+type DatasetExpression = {
+  all?: (string | DatasetExpression)[];
+  any?: (string | DatasetExpression)[];
+};
+
+const getUpstreamDatasets = (
+  datasetExpression: DatasetExpression,
+  firstChildId: string,
+  level = 0
+) => {
+  let edges: WebserverEdge[] = [];
+  let nodes: DepNode[] = [];
+  let type: DepNode["value"]["class"] | undefined;
+  const datasetIds: string[] = [];
+  let nestedExpression: DatasetExpression | undefined;
+  if (datasetExpression?.any) {
+    type = "or-gate";
+    datasetExpression.any.forEach((de) => {
+      if (typeof de === "string") datasetIds.push(de);
+      else nestedExpression = de;
+    });
+  } else if (datasetExpression?.all) {
+    type = "and-gate";
+    datasetExpression.all.forEach((de) => {
+      if (typeof de === "string") datasetIds.push(de);
+      else nestedExpression = de;
+    });
+  }
+
+  if (type && datasetIds.length) {
+    edges.push({
+      sourceId: `${type}-${level}`,
+      // Point upstream datasets to the first task
+      targetId: firstChildId,
+      isSourceDataset: level === 0,
+    });
+    nodes.push({
+      id: `${type}-${level}`,
+      value: {
+        class: type,
+        label: "",
+      },
+    });
+    datasetIds.forEach((d: string) => {
+      nodes.push({
+        id: d,
+        value: {
+          class: "dataset",
+          label: d,
+        },
+      });
+      edges.push({
+        sourceId: d,
+        targetId: `${type}-${level}`,
+      });
+    });
+
+    if (nestedExpression) {
+      const data = getUpstreamDatasets(
+        nestedExpression,
+        `${type}-${level}`,
+        (level += 1)
+      );
+      edges = [...edges, ...data.edges];
+      nodes = [...nodes, ...data.nodes];
+    }
+  }
+  return {
+    nodes,
+    edges,
+  };
+};
+
 const Graph = ({ openGroupIds, onToggleGroups, hoveredTaskState }: Props) => {
   const graphRef = useRef(null);
   const { data } = useGraphData();
@@ -69,16 +143,15 @@ const Graph = ({ openGroupIds, onToggleGroups, hoveredTaskState }: Props) => {
     data: { dagRuns, groups },
   } = useGridData();
 
+  const { data: dagDetails } = useDagDetails();
+
   useEffect(() => {
     setArrange(data?.arrange || "LR");
   }, [data?.arrange]);
 
-  const { data: datasetsCollection } = useDatasets({
-    dagIds: [dagId],
-  });
-
-  const enabledDatasets = !!(
-    selected.runId && datasetsCollection?.datasets?.length
+  const { nodes: datasetsNodes, edges: datasetEdges } = getUpstreamDatasets(
+    dagDetails.datasetExpression as DatasetExpression,
+    data?.nodes?.children ? data.nodes.children[0].id : ""
   );
 
   const {
@@ -86,7 +159,7 @@ const Graph = ({ openGroupIds, onToggleGroups, hoveredTaskState }: Props) => {
   } = useUpstreamDatasetEvents({
     dagId,
     dagRunId: selected.runId || "",
-    options: { enabled: enabledDatasets },
+    options: { enabled: !!datasetsNodes.length },
   });
 
   const {
@@ -94,60 +167,73 @@ const Graph = ({ openGroupIds, onToggleGroups, hoveredTaskState }: Props) => {
   } = useDatasetEvents({
     sourceDagId: dagId,
     sourceRunId: selected.runId || undefined,
-    options: { enabled: enabledDatasets },
+    options: { enabled: !!selected.runId },
   });
 
-  const datasetEdges: WebserverEdge[] = [];
-  const rawNodes =
-    data?.nodes && datasetsCollection?.datasets?.length
-      ? {
-          ...data.nodes,
-          children: [
-            ...(data.nodes.children || []),
-            ...(datasetsCollection?.datasets || []).map(
-              (dataset) =>
-                ({
-                  id: dataset?.id?.toString() || "",
-                  value: {
-                    class: "dataset",
-                    label: dataset.uri,
-                  },
-                } as DepNode)
-            ),
-          ],
-        }
-      : data?.nodes;
+  const { data: datasetsCollection } = useDatasets({
+    dagIds: [dagId],
+  });
+
+  const downstreamDatasetNodes: DepNode[] = [];
+  const downstreamDatasetEdges: WebserverEdge[] = [];
 
   datasetsCollection?.datasets?.forEach((dataset) => {
     const producingTask = dataset?.producingTasks?.find(
       (t) => t.dagId === dagId
     );
-    const consumingDag = dataset?.consumingDags?.find((d) => d.dagId === dagId);
-    if (dataset.id) {
+    if (dataset.uri) {
       // check that the task is in the graph
       if (
         producingTask?.taskId &&
         getTask({ taskId: producingTask?.taskId, task: groups })
       ) {
-        datasetEdges.push({
+        downstreamDatasetEdges.push({
           sourceId: producingTask.taskId,
-          targetId: dataset.id.toString(),
+          targetId: dataset.uri,
         });
-      }
-      if (consumingDag && data?.nodes?.children?.length) {
-        datasetEdges.push({
-          sourceId: dataset.id.toString(),
-          // Point upstream datasets to the first task
-          targetId: data.nodes?.children[0].id,
-          isSourceDataset: true,
+        downstreamDatasetNodes.push({
+          id: dataset.uri,
+          value: {
+            class: "dataset",
+            label: dataset.uri,
+          },
         });
       }
     }
   });
 
+  // Check if there is a dataset event even though we did not find a dataset
+  downstreamDatasetEvents.forEach((de) => {
+    const hasNode = downstreamDatasetNodes.find(
+      (node) => node.id === de.datasetUri
+    );
+    if (!hasNode && de.sourceTaskId && de.datasetUri) {
+      downstreamDatasetEdges.push({
+        sourceId: de.sourceTaskId,
+        targetId: de.datasetUri,
+      });
+      downstreamDatasetNodes.push({
+        id: de.datasetUri,
+        value: {
+          class: "dataset",
+          label: de.datasetUri,
+        },
+      });
+    }
+  });
+
   const { data: graphData } = useGraphLayout({
-    edges: [...(data?.edges || []), ...datasetEdges],
-    nodes: rawNodes,
+    edges: [...(data?.edges || []), ...datasetEdges, ...downstreamDatasetEdges],
+    nodes: data?.nodes
+      ? {
+          ...data.nodes,
+          children: [
+            ...(data?.nodes.children || []),
+            ...datasetsNodes,
+            ...downstreamDatasetNodes,
+          ],
+        }
+      : data?.nodes,
     openGroupIds,
     arrange,
   });

--- a/airflow/www/static/js/dag/details/graph/index.tsx
+++ b/airflow/www/static/js/dag/details/graph/index.tsx
@@ -159,7 +159,7 @@ const Graph = ({ openGroupIds, onToggleGroups, hoveredTaskState }: Props) => {
   } = useUpstreamDatasetEvents({
     dagId,
     dagRunId: selected.runId || "",
-    options: { enabled: !!datasetsNodes.length },
+    options: { enabled: !!datasetsNodes.length && !!selected.runId },
   });
 
   const {

--- a/airflow/www/static/js/types/index.ts
+++ b/airflow/www/static/js/types/index.ts
@@ -133,7 +133,14 @@ interface DepNode {
   id: string;
   value: {
     id?: string;
-    class: "dag" | "dataset" | "trigger" | "sensor";
+    class:
+      | "dag"
+      | "dataset"
+      | "trigger"
+      | "sensor"
+      | "or-gate"
+      | "and-gate"
+      | "dataset-alias";
     label: string;
     rx?: number;
     ry?: number;

--- a/airflow/www/static/js/utils/graph.ts
+++ b/airflow/www/static/js/utils/graph.ts
@@ -154,6 +154,8 @@ const generateGraph = ({
           .map((e) => formatEdge(e, font, node)),
       };
     }
+    const isGate =
+      node.value.class === "or-gate" || node.value.class === "and-gate";
     const isJoinNode = id.includes("join_id");
     if (!isOpen && children?.length) {
       filteredEdges = filteredEdges
@@ -176,7 +178,16 @@ const generateGraph = ({
 
     const label = value.isMapped ? `${value.label} [100]` : value.label;
     const labelLength = getTextWidth(label, font);
-    const width = labelLength > 200 ? labelLength : 200;
+    let width = labelLength > 200 ? labelLength : 200;
+    let height = 80;
+
+    if (isJoinNode) {
+      width = 10;
+      height = 10;
+    } else if (isGate) {
+      width = 30;
+      height = 30;
+    }
 
     return {
       id,
@@ -186,8 +197,8 @@ const generateGraph = ({
         isJoinNode,
         childCount,
       },
-      width: isJoinNode ? 10 : width,
-      height: isJoinNode ? 10 : 80,
+      width,
+      height,
     };
   };
 


### PR DESCRIPTION
Before we were just rendering a json object of the any/all conditions of dataset events for a dag to run. Now, we interpret that and render it in the graph view with logical gates.

Datasets that actually had events will be highlighted with a different border so it's easy to see what triggered the selected run.

Also, added a check to still create a dataset node if there is a dataset event even if the getDatasets endpoint didnt return anything.

These are both workarounds. It would best to refactor the dag graph python code to accept a `with_datasets` param and handle this logic and include dataset aliases too. Hopefully, I can make that a follow-up PR.


<img width="1118" alt="Screenshot 2024-07-30 at 5 36 47 PM" src="https://github.com/user-attachments/assets/6bc7b88e-5748-4ade-9bd3-a9ac9d26dc08">



---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
