### PR TITLE
Fix Utils Tests for Dataset Isolation Mode

### DIFF
--- a/tests/www/test_utils.py
+++ b/tests/www/test_utils.py
@@ -210,6 +210,7 @@ class TestUtils:
 
         assert epoch_time == expected_epoch_time
 
+    @pytest.mark.skip_if_database_isolation_mode
     @pytest.mark.db_test
     def test_make_cache_key(self):
         from airflow.www.app import cached_app
@@ -222,6 +223,7 @@ class TestUtils:
             result_cache_key = utils.make_cache_key()
             assert result_cache_key == expected_cache_key
 
+    @pytest.mark.skip_if_database_isolation_mode
     @pytest.mark.db_test
     def test_task_instance_link(self):
         from airflow.www.app import cached_app
@@ -251,6 +253,7 @@ class TestUtils:
         assert "<a&1>" not in html_map_index_none
         assert "<b2>" not in html_map_index_none
 
+    @pytest.mark.skip_if_database_isolation_mode
     @pytest.mark.db_test
     def test_dag_link(self):
         from airflow.www.app import cached_app
@@ -261,6 +264,7 @@ class TestUtils:
         assert "%3Ca%261%3E" in html
         assert "<a&1>" not in html
 
+    @pytest.mark.skip_if_database_isolation_mode
     @pytest.mark.db_test
     def test_dag_link_when_dag_is_none(self):
         """Test that when there is no dag_id, dag_link does not contain hyperlink"""
@@ -272,6 +276,7 @@ class TestUtils:
         assert "None" in html
         assert "<a href=" not in html
 
+    @pytest.mark.skip_if_database_isolation_mode
     @pytest.mark.db_test
     def test_dag_run_link(self):
         from airflow.www.app import cached_app
@@ -664,6 +669,7 @@ def test_get_col_default_not_existing(session):
     assert default_value is None
 
 
+@pytest.mark.skip_if_database_isolation_mode
 @pytest.mark.db_test
 def test_dag_run_custom_sqla_interface_delete_no_collateral_damage(dag_maker, session):
     interface = DagRunCustomSQLAInterface(obj=DagRun, session=session)


### PR DESCRIPTION
Realted https://github.com/apache/airflow/pull/41067

The failed utils tests are all legacy or WWW related. We can safely skip them in isolation mode.