### PR TITLE
Update external_task.py to forward `failed_states`

### DIFF
--- a/airflow/sensors/external_task.py
+++ b/airflow/sensors/external_task.py
@@ -355,6 +355,7 @@ class ExternalTaskSensor(BaseSensorOperator):
                     external_task_ids=self.external_task_ids,
                     execution_dates=self._get_dttm_filter(context),
                     allowed_states=self.allowed_states,
+                    failed_states=self.failed_states,
                     poke_interval=self.poll_interval,
                     soft_fail=self.soft_fail,
                 ),

--- a/airflow/triggers/external_task.py
+++ b/airflow/triggers/external_task.py
@@ -104,9 +104,6 @@ class WorkflowTrigger(BaseTrigger):
                 if failed_count > 0:
                     yield TriggerEvent({"status": "failed"})
                     return
-                else:
-                    yield TriggerEvent({"status": "success"})
-                    return
             if self.skipped_states:
                 skipped_count = await self._get_count(self.skipped_states)
                 if skipped_count > 0:

--- a/tests/triggers/test_external_task.py
+++ b/tests/triggers/test_external_task.py
@@ -110,7 +110,7 @@ class TestWorkflowTrigger:
     @mock.patch("airflow.triggers.external_task._get_count")
     @pytest.mark.asyncio
     async def test_task_workflow_trigger_fail_count_eq_0(self, mock_get_count):
-        mock_get_count.return_value = 0
+        mock_get_count.return_value = 1
         trigger = WorkflowTrigger(
             external_dag_id=self.DAG_ID,
             execution_dates=[timezone.datetime(2022, 1, 1)],
@@ -125,7 +125,7 @@ class TestWorkflowTrigger:
         assert trigger_task.done()
         result = trigger_task.result()
         assert isinstance(result, TriggerEvent)
-        assert result.payload == {"status": "success"}
+        assert result.payload == {"status": "failed"}
         mock_get_count.assert_called_once_with(
             dttm_filter=[timezone.datetime(2022, 1, 1)],
             external_task_ids=["external_task_op"],

--- a/tests/triggers/test_external_task.py
+++ b/tests/triggers/test_external_task.py
@@ -109,7 +109,7 @@ class TestWorkflowTrigger:
 
     @mock.patch("airflow.triggers.external_task._get_count")
     @pytest.mark.asyncio
-    async def test_task_workflow_trigger_fail_count_eq_0(self, mock_get_count):
+    async def test_task_workflow_trigger_fail_count_eq_1(self, mock_get_count):
         mock_get_count.return_value = 1
         trigger = WorkflowTrigger(
             external_dag_id=self.DAG_ID,


### PR DESCRIPTION
It seems there is a bug with `ExternalTaskSensor` when using deferrable mode. It continuously loops and pokes the upstream task/DAG even if it's `failed`. I would expect the deferrable sensor to exit as failed as soon as the upstream task fails.

This change updates the deferrable mode branch to pass the `failed_states` on to the `WorkflowTrigger`.

https://github.com/apache/airflow/issues/41140

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
