### PR TITLE
Fix: Pass hook parameters to SnowflakeSqlApiHook and prep them for AP…

### DIFF
--- a/airflow/providers/snowflake/hooks/snowflake_sql_api.py
+++ b/airflow/providers/snowflake/hooks/snowflake_sql_api.py
@@ -158,10 +158,13 @@ class SnowflakeSqlApiHook(SnowflakeHook):
         data = {
             "statement": sql,
             "resultSetMetaData": {"format": "json"},
-            "database": conn_config["database"],
-            "schema": conn_config["schema"],
-            "warehouse": conn_config["warehouse"],
-            "role": conn_config["role"],
+            #If database, schema, warehouse, role parameters have been provided set them accordingly
+            #If either of them has been not (Parent class initilalizes them to None in that case)
+            #set them to what in the Airflow connection configuration
+            "database": self.database if self.database else conn_config["database"],
+            "schema": self.schema if self.schema else conn_config["schema"],
+            "warehouse": self.warehouse if self.warehouse else conn_config["warehouse"],
+            "role": self.role if self.role else conn_config["role"],
             "bindings": bindings,
             "parameters": {
                 "MULTI_STATEMENT_COUNT": statement_count,

--- a/airflow/providers/snowflake/hooks/snowflake_sql_api.py
+++ b/airflow/providers/snowflake/hooks/snowflake_sql_api.py
@@ -161,10 +161,10 @@ class SnowflakeSqlApiHook(SnowflakeHook):
             # If database, schema, warehouse, role parameters have been provided set them accordingly
             # If either of them has been not (Parent class initializes them to None in that case)
             # set them to what in the Airflow connection configuration
-            "database": self.database if self.database else conn_config["database"],
-            "schema": self.schema if self.schema else conn_config["schema"],
-            "warehouse": self.warehouse if self.warehouse else conn_config["warehouse"],
-            "role": self.role if self.role else conn_config["role"],
+            "database": self.database or conn_config["database"],
+            "schema": self.schema or conn_config["schema"],
+            "warehouse": self.warehouse or conn_config["warehouse"],
+            "role": self.role or conn_config["role"],
             "bindings": bindings,
             "parameters": {
                 "MULTI_STATEMENT_COUNT": statement_count,

--- a/airflow/providers/snowflake/hooks/snowflake_sql_api.py
+++ b/airflow/providers/snowflake/hooks/snowflake_sql_api.py
@@ -158,9 +158,9 @@ class SnowflakeSqlApiHook(SnowflakeHook):
         data = {
             "statement": sql,
             "resultSetMetaData": {"format": "json"},
-            #If database, schema, warehouse, role parameters have been provided set them accordingly
-            #If either of them has been not (Parent class initilalizes them to None in that case)
-            #set them to what in the Airflow connection configuration
+            # If database, schema, warehouse, role parameters have been provided set them accordingly
+            # If either of them has been not (Parent class initializes them to None in that case)
+            # set them to what in the Airflow connection configuration
             "database": self.database if self.database else conn_config["database"],
             "schema": self.schema if self.schema else conn_config["schema"],
             "warehouse": self.warehouse if self.warehouse else conn_config["warehouse"],

--- a/airflow/providers/snowflake/operators/snowflake.py
+++ b/airflow/providers/snowflake/operators/snowflake.py
@@ -505,6 +505,7 @@ class SnowflakeSqlApiOperator(SQLExecuteQueryOperator):
             token_life_time=self.token_life_time,
             token_renewal_delta=self.token_renewal_delta,
             deferrable=self.deferrable,
+            **self.hook_params
         )
         self.query_ids = self._hook.execute_query(
             self.sql,  # type: ignore[arg-type]

--- a/airflow/providers/snowflake/operators/snowflake.py
+++ b/airflow/providers/snowflake/operators/snowflake.py
@@ -505,7 +505,7 @@ class SnowflakeSqlApiOperator(SQLExecuteQueryOperator):
             token_life_time=self.token_life_time,
             token_renewal_delta=self.token_renewal_delta,
             deferrable=self.deferrable,
-            **self.hook_params
+            **self.hook_params,
         )
         self.query_ids = self._hook.execute_query(
             self.sql,  # type: ignore[arg-type]

--- a/tests/providers/snowflake/hooks/test_snowflake_sql_api.py
+++ b/tests/providers/snowflake/hooks/test_snowflake_sql_api.py
@@ -600,7 +600,7 @@ class TestSnowflakeSqlApiHook:
         assert hook.role == hook_params.get("role", None)
 
     @pytest.mark.parametrize(
-        "test_hook_params,sql,statement_count,expected_payload,expected_response",
+        "test_hook_params, sql, statement_count, expected_payload, expected_response",
         [
             (
                 {},

--- a/tests/providers/snowflake/hooks/test_snowflake_sql_api.py
+++ b/tests/providers/snowflake/hooks/test_snowflake_sql_api.py
@@ -145,7 +145,7 @@ HOOK_PARAMS: dict = {
     "database": "airflow_db",
     "schema": "airflow_schema",
     "warehouse": "airflow_warehouse",
-    "role": "airflow_role"
+    "role": "airflow_role",
 }
 
 
@@ -587,82 +587,97 @@ class TestSnowflakeSqlApiHook:
         hook = SnowflakeSqlApiHook(snowflake_conn_id="test_conn")
         response = await hook.get_sql_api_query_status_async("uuid")
         assert response == expected_response
-    
-    @pytest.mark.parametrize(
-        "hook_params",
-        [(HOOK_PARAMS), ({})]
-    )
-    def test_hook_parameter_propagation(
-            self, hook_params
-    ):
+
+    @pytest.mark.parametrize("hook_params", [(HOOK_PARAMS), ({})])
+    def test_hook_parameter_propagation(self, hook_params):
         """
         This tests the proper propagation of unpacked hook params into the SnowflakeSqlApiHook object.
         """
         hook = SnowflakeSqlApiHook(snowflake_conn_id="test_conn", **hook_params)
-        assert hook.database == hook_params.get('database', None)
-        assert hook.schema == hook_params.get('schema', None)
-        assert hook.warehouse == hook_params.get('warehouse', None)
-        assert hook.role == hook_params.get('role', None)
+        assert hook.database == hook_params.get("database", None)
+        assert hook.schema == hook_params.get("schema", None)
+        assert hook.warehouse == hook_params.get("warehouse", None)
+        assert hook.role == hook_params.get("role", None)
 
     @pytest.mark.parametrize(
         "test_hook_params,sql,statement_count,expected_payload,expected_response",
         [
-            ({}, SINGLE_STMT, 1, {
-                "statement": SINGLE_STMT,
-                "resultSetMetaData": {"format": "json"},
-                "database": CONN_PARAMS["database"],
-                "schema": CONN_PARAMS["schema"],
-                "warehouse": CONN_PARAMS["warehouse"],
-                "role": CONN_PARAMS["role"],
-                "bindings": {},
-                "parameters": {
-                    "MULTI_STATEMENT_COUNT": 1,
-                    "query_tag": "",
+            (
+                {},
+                SINGLE_STMT,
+                1,
+                {
+                    "statement": SINGLE_STMT,
+                    "resultSetMetaData": {"format": "json"},
+                    "database": CONN_PARAMS["database"],
+                    "schema": CONN_PARAMS["schema"],
+                    "warehouse": CONN_PARAMS["warehouse"],
+                    "role": CONN_PARAMS["role"],
+                    "bindings": {},
+                    "parameters": {
+                        "MULTI_STATEMENT_COUNT": 1,
+                        "query_tag": "",
+                    },
                 },
-            },
-            {"statementHandle": "uuid"}),
-            ({},SQL_MULTIPLE_STMTS, 4, {
-                "statement": SQL_MULTIPLE_STMTS,
-                "resultSetMetaData": {"format": "json"},
-                "database": CONN_PARAMS["database"],
-                "schema": CONN_PARAMS["schema"],
-                "warehouse": CONN_PARAMS["warehouse"],
-                "role": CONN_PARAMS["role"],
-                "bindings": {},
-                "parameters": {
-                    "MULTI_STATEMENT_COUNT": 4,
-                    "query_tag": "",
+                {"statementHandle": "uuid"},
+            ),
+            (
+                {},
+                SQL_MULTIPLE_STMTS,
+                4,
+                {
+                    "statement": SQL_MULTIPLE_STMTS,
+                    "resultSetMetaData": {"format": "json"},
+                    "database": CONN_PARAMS["database"],
+                    "schema": CONN_PARAMS["schema"],
+                    "warehouse": CONN_PARAMS["warehouse"],
+                    "role": CONN_PARAMS["role"],
+                    "bindings": {},
+                    "parameters": {
+                        "MULTI_STATEMENT_COUNT": 4,
+                        "query_tag": "",
+                    },
                 },
-            },
-            {"statementHandles": ["uuid", "uuid1"]}),
-            (HOOK_PARAMS,SINGLE_STMT, 1, {
-                "statement": SINGLE_STMT,
-                "resultSetMetaData": {"format": "json"},
-                "database": HOOK_PARAMS["database"],
-                "schema": HOOK_PARAMS["schema"],
-                "warehouse": HOOK_PARAMS["warehouse"],
-                "role": HOOK_PARAMS["role"],
-                "bindings": {},
-                "parameters": {
-                    "MULTI_STATEMENT_COUNT": 1,
-                    "query_tag": "",
+                {"statementHandles": ["uuid", "uuid1"]},
+            ),
+            (
+                HOOK_PARAMS,
+                SINGLE_STMT,
+                1,
+                {
+                    "statement": SINGLE_STMT,
+                    "resultSetMetaData": {"format": "json"},
+                    "database": HOOK_PARAMS["database"],
+                    "schema": HOOK_PARAMS["schema"],
+                    "warehouse": HOOK_PARAMS["warehouse"],
+                    "role": HOOK_PARAMS["role"],
+                    "bindings": {},
+                    "parameters": {
+                        "MULTI_STATEMENT_COUNT": 1,
+                        "query_tag": "",
+                    },
                 },
-            },
-            {"statementHandle": "uuid"}),
-            (HOOK_PARAMS,SQL_MULTIPLE_STMTS, 4, {
-                "statement": SQL_MULTIPLE_STMTS,
-                "resultSetMetaData": {"format": "json"},
-                "database": HOOK_PARAMS["database"],
-                "schema": HOOK_PARAMS["schema"],
-                "warehouse": HOOK_PARAMS["warehouse"],
-                "role": HOOK_PARAMS["role"],
-                "bindings": {},
-                "parameters": {
-                    "MULTI_STATEMENT_COUNT": 4,
-                    "query_tag": "",
+                {"statementHandle": "uuid"},
+            ),
+            (
+                HOOK_PARAMS,
+                SQL_MULTIPLE_STMTS,
+                4,
+                {
+                    "statement": SQL_MULTIPLE_STMTS,
+                    "resultSetMetaData": {"format": "json"},
+                    "database": HOOK_PARAMS["database"],
+                    "schema": HOOK_PARAMS["schema"],
+                    "warehouse": HOOK_PARAMS["warehouse"],
+                    "role": HOOK_PARAMS["role"],
+                    "bindings": {},
+                    "parameters": {
+                        "MULTI_STATEMENT_COUNT": 4,
+                        "query_tag": "",
+                    },
                 },
-            },
-            {"statementHandles": ["uuid", "uuid1"]}),
+                {"statementHandles": ["uuid", "uuid1"]},
+            ),
         ],
     )
     @mock.patch("uuid.uuid4")
@@ -682,13 +697,13 @@ class TestSnowflakeSqlApiHook:
         sql,
         statement_count,
         expected_payload,
-        expected_response
+        expected_response,
     ):
         """
         This tests if the query execution ordered by POST request to Snowflake API
         is sent with proper context parameters (database, schema, warehouse, role)
         """
-        mock_uuid.return_value="uuid"
+        mock_uuid.return_value = "uuid"
         params = {"requestId": "uuid", "async": True, "pageSize": 10}
         mock_conn_param.return_value = CONN_PARAMS
         mock_get_headers.return_value = HEADERS
@@ -705,5 +720,3 @@ class TestSnowflakeSqlApiHook:
         hook.execute_query(sql, statement_count)
 
         mock_requests.post.assert_called_once_with(url, headers=HEADERS, json=expected_payload, params=params)
-
-    


### PR DESCRIPTION
This PR is a resolution to the given issue #39622. The main bug here was that the hook parameters were not properly given to the SnowflakeSqlAPIHook and then they were not properly assigned. The query execution method of the hook statically assigned configuration from Airflow connection. In this PR it is changed so that:
1. hook_params from SnowflakeSqlApiOperator object is passed into the hook object through unpacking the variable.
2. In SnowflakeSqlApiHook, for each of the parameter (database, role, schema, warehouse) there is a check performed for whether they were provided in the parameters (in their parent class SnowflakeHook, they are initialized to None, hence the if self.database|schema|role|warehouse) and if not, they are taken from connection definition.

closes: #39622 

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
