### PR TITLE
Publish Dataproc Serverless Batch link after it starts if batch_id was provided

### DIFF
--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -3028,6 +3028,14 @@ class DataprocCreateBatchOperator(GoogleCloudBaseOperator):
         if self.batch_id:
             batch_id = self.batch_id
             self.log.info("Starting batch %s", batch_id)
+            # Persist the link earlier so users can observe the progress
+            DataprocBatchLink.persist(
+                context=context,
+                operator=self,
+                project_id=self.project_id,
+                region=self.region,
+                batch_id=self.batch_id,
+            )
         else:
             self.log.info("Starting batch. The batch ID will be generated since it was not provided.")
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Currently the link to Dataproc Serverless Batch is only available after its successful execution.
To improve user experience publish a link right after the batch starts execution if `batch_id` was provided. It makes it easier to observe the progress and find batch logs when it fails.
The only drawback is that if batch creation fails before it starts execution, the link will point to nowhere, but I think it is acceptable considering the gains.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
