### PR TITLE
Skip tests in DB isolation mode in `tests/providers/amazon/aws/operators/test_base_aws.py`

### DIFF
--- a/tests/providers/amazon/aws/operators/test_base_aws.py
+++ b/tests/providers/amazon/aws/operators/test_base_aws.py
@@ -180,6 +180,7 @@ class TestAwsBaseOperator:
         with pytest.raises(AttributeError, match=error_match):
             SoWrongOperator(task_id="fake-task-id")
 
+    @pytest.mark.skip_if_database_isolation_mode
     @pytest.mark.parametrize(
         "region, region_name, expected_region_name",
         [
@@ -203,6 +204,7 @@ class TestAwsBaseOperator:
                 ti.run()
             assert ti.task.region_name == expected_region_name
 
+    @pytest.mark.skip_if_database_isolation_mode
     @pytest.mark.db_test
     def test_ambiguous_region_in_partial_operator(self, dag_maker):
         with dag_maker("test_ambiguous_region_in_partial_operator", serialized=True):


### PR DESCRIPTION
Relates #41067

These tests expect deprecation warning which happens on the internal API side in DB isolation mode. No need to test that in DB isolation mode.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
