### PR TITLE
Skip tests in DB isolation mode in `tests/providers/amazon/aws/sensors/test_base_aws.py`

### DIFF
--- a/tests/providers/amazon/aws/sensors/test_base_aws.py
+++ b/tests/providers/amazon/aws/sensors/test_base_aws.py
@@ -116,13 +116,14 @@ class TestAwsBaseSensor:
         ],
     )
     def test_execute(self, dag_maker, op_kwargs):
-        with dag_maker("test_aws_base_sensor"):
+        with dag_maker("test_aws_base_sensor", serialized=True):
             FakeDynamoDBSensor(task_id="fake-task-id", **op_kwargs, poke_interval=1)
 
         dagrun = dag_maker.create_dagrun(execution_date=timezone.utcnow())
         tis = {ti.task_id: ti for ti in dagrun.task_instances}
         tis["fake-task-id"].run()
 
+    @pytest.mark.skip_if_database_isolation_mode
     @pytest.mark.parametrize(
         "region, region_name",
         [
@@ -180,6 +181,7 @@ class TestAwsBaseSensor:
         with pytest.raises(AttributeError, match=error_match):
             SoWrongSensor(task_id="fake-task-id")
 
+    @pytest.mark.skip_if_database_isolation_mode
     @pytest.mark.parametrize(
         "region, region_name, expected_region_name",
         [
@@ -189,7 +191,7 @@ class TestAwsBaseSensor:
     )
     @pytest.mark.db_test
     def test_region_in_partial_sensor(self, region, region_name, expected_region_name, dag_maker):
-        with dag_maker("test_region_in_partial_sensor"):
+        with dag_maker("test_region_in_partial_sensor", serialized=True):
             FakeDynamoDBSensor.partial(
                 task_id="fake-task-id",
                 region=region,
@@ -203,9 +205,10 @@ class TestAwsBaseSensor:
                 ti.run()
             assert ti.task.region_name == expected_region_name
 
+    @pytest.mark.skip_if_database_isolation_mode
     @pytest.mark.db_test
     def test_ambiguous_region_in_partial_sensor(self, dag_maker):
-        with dag_maker("test_ambiguous_region_in_partial_sensor"):
+        with dag_maker("test_ambiguous_region_in_partial_sensor", serialized=True):
             FakeDynamoDBSensor.partial(
                 task_id="fake-task-id",
                 region="eu-west-1",


### PR DESCRIPTION
Relates #41067

These tests expect deprecation warning which happens on the internal API side in DB isolation mode. No need to test that in DB isolation mode.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
