### PR TITLE
Deprecate `SageMakerTrainingPrintLogTrigger`

### DIFF
--- a/airflow/providers/amazon/aws/triggers/sagemaker.py
+++ b/airflow/providers/amazon/aws/triggers/sagemaker.py
@@ -25,8 +25,9 @@ from functools import cached_property
 from typing import Any, AsyncIterator
 
 from botocore.exceptions import WaiterError
+from deprecated import deprecated
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.providers.amazon.aws.hooks.sagemaker import LogState, SageMakerHook
 from airflow.providers.amazon.aws.utils.waiter_with_logging import async_wait
 from airflow.triggers.base import BaseTrigger, TriggerEvent
@@ -199,6 +200,13 @@ class SageMakerPipelineTrigger(BaseTrigger):
             raise AirflowException("Waiter error: max attempts reached")
 
 
+@deprecated(
+    reason=(
+        "`airflow.providers.amazon.aws.triggers.sagemaker.SageMakerTrainingPrintLogTrigger` "
+        "has been deprecated and will be removed in future. Please use ``SageMakerTrigger`` instead."
+    ),
+    category=AirflowProviderDeprecationWarning,
+)
 class SageMakerTrainingPrintLogTrigger(BaseTrigger):
     """
     SageMakerTrainingPrintLogTrigger is fired as deferred class with params to run the task in triggerer.


### PR DESCRIPTION
This trigger is supposed to do the same job as `SageMakerTrigger` but with printing logs. The reasons to deprecate it:
- Printing logs in a trigger does not add much value to the DAG author since logs go to the triggerer and not task logs
- The trigger `SageMakerTrainingPrintLogTrigger` contains some bugs since the operator `SageMakerTrainingOperator` does not work when created with `deferrable=True` and `print_log=True`. The trigger wait indefinitely for the job to complete
- Having two different triggers to achieve the same thing with the only difference one is pushing more logs than the other does not make a lot of sense

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
