### PR TITLE
feat: support polars serde

### DIFF
--- a/airflow/serialization/serializers/polars.py
+++ b/airflow/serialization/serializers/polars.py
@@ -1,0 +1,71 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from airflow.utils.module_loading import qualname
+
+if TYPE_CHECKING:
+    import polars as pl
+
+    from airflow.serialization.serde import U
+
+
+serializers = ["polars.dataframe.frame.DataFrame", "polars.series.series.Series"]
+deserializers = serializers
+__version__ = 1
+
+
+def serialize(o: object) -> tuple[U, str, int, bool]:
+    from io import BytesIO
+
+    import polars as pl
+
+    if not isinstance(o, (pl.DataFrame, pl.Series)):
+        return "", "", 0, False
+
+    if isinstance(o, pl.Series):
+        o = o.to_frame(o.name)
+
+    with BytesIO() as io:
+        o.write_parquet(io, compression="snappy")
+        result = io.getvalue().hex()
+
+    return result, qualname(o), __version__, True
+
+
+def deserialize(classname: str, version: int, data: object) -> pl.DataFrame | pl.Series:
+    if version > __version__:
+        error_msg = f"serialized {version} of {classname} > {__version__}"
+        raise TypeError(error_msg)
+
+    if not isinstance(data, str):
+        error_msg = f"serialized {classname} has wrong data type {type(data)}"
+        raise TypeError(error_msg)
+
+    from io import BytesIO
+
+    import polars as pl
+
+    with BytesIO(bytes.fromhex(data)) as io:
+        frame = pl.read_parquet(io)
+
+    if classname.split(".")[-1] == "Series":
+        return frame.get_column(frame.columns[0])
+    return frame

--- a/airflow/serialization/serializers/polars.py
+++ b/airflow/serialization/serializers/polars.py
@@ -40,6 +40,7 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
     if not isinstance(o, (pl.DataFrame, pl.Series)):
         return "", "", 0, False
 
+    name = qualname(o)
     if isinstance(o, pl.Series):
         o = o.to_frame(o.name)
 
@@ -47,7 +48,7 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
         o.write_parquet(io, compression="snappy")
         result = io.getvalue().hex()
 
-    return result, qualname(o), __version__, True
+    return result, name, __version__, True
 
 
 def deserialize(classname: str, version: int, data: object) -> pl.DataFrame | pl.Series:

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -194,6 +194,9 @@ DOC_EXTRAS: dict[str, list[str]] = {
 
 DEVEL_EXTRAS: dict[str, list[str]] = {
     # START OF devel extras
+    "devel-polars": [
+        "polars>=1.0.0",
+    ],
     "devel-debuggers": [
         "ipdb>=0.13.13",
     ],
@@ -286,6 +289,7 @@ DEVEL_EXTRAS: dict[str, list[str]] = {
         "apache-airflow[devel-sentry]",
         "apache-airflow[devel-static-checks]",
         "apache-airflow[devel-tests]",
+        "apache-airflow[devel-polars]",
     ],
     "devel-all-dbs": [
         "apache-airflow[apache-cassandra]",

--- a/tests/serialization/serializers/test_serializers.py
+++ b/tests/serialization/serializers/test_serializers.py
@@ -384,3 +384,71 @@ class TestSerializers:
     def test_pendulum_3_to_2(self, ser_value, expected):
         """Test deserialize objects in pendulum 2 which serialised in pendulum 3."""
         assert deserialize(ser_value) == expected
+
+    def test_polars_frame(self):
+        import polars as pl
+
+        frame = pl.DataFrame(
+            {
+                "integer": [1, 2, 3],
+                "float": [1.1, 2.2, 3.3],
+                "string": ["a", "b", "c"],
+                "binary": [b"a", b"b", b"c"],
+                "boolean": [True, False, True],
+                "date": [pl.date(2021, 1, 1), pl.date(2021, 1, 2), pl.date(2021, 1, 3)],
+                "time": [pl.time(12, 0, 0), pl.time(12, 0, 1), pl.time(12, 0, 2)],
+                "timestamp": [
+                    pl.datetime(2021, 1, 1, 12, 0, 0),
+                    pl.datetime(2021, 1, 1, 12, 0, 1),
+                    pl.datetime(2021, 1, 1, 12, 0, 2),
+                ],
+            },
+            schema_overrides={
+                "integer": pl.Int64(),
+                "float": pl.Float64(),
+                "string": pl.String(),
+                "binary": pl.Binary(),
+                "boolean": pl.Boolean(),
+                "date": pl.Date(),
+                "time": pl.Time(),
+                "timestamp": pl.Datetime(),
+            },
+        )
+        dump = serialize(frame)
+        load = deserialize(dump)
+        assert frame.equals(load)
+
+    def test_polars_series(self):
+        import polars as pl
+
+        frame = pl.DataFrame(
+            {
+                "integer": [1, 2, 3],
+                "float": [1.1, 2.2, 3.3],
+                "string": ["a", "b", "c"],
+                "binary": [b"a", b"b", b"c"],
+                "boolean": [True, False, True],
+                "date": [pl.date(2021, 1, 1), pl.date(2021, 1, 2), pl.date(2021, 1, 3)],
+                "time": [pl.time(12, 0, 0), pl.time(12, 0, 1), pl.time(12, 0, 2)],
+                "timestamp": [
+                    pl.datetime(2021, 1, 1, 12, 0, 0),
+                    pl.datetime(2021, 1, 1, 12, 0, 1),
+                    pl.datetime(2021, 1, 1, 12, 0, 2),
+                ],
+            },
+            schema_overrides={
+                "integer": pl.Int64(),
+                "float": pl.Float64(),
+                "string": pl.String(),
+                "binary": pl.Binary(),
+                "boolean": pl.Boolean(),
+                "date": pl.Date(),
+                "time": pl.Time(),
+                "timestamp": pl.Datetime(),
+            },
+        )
+        for field in frame.iter_columns():
+            dump = serialize(field)
+            load = deserialize(dump)
+
+            assert field.equals(load)

--- a/tests/serialization/serializers/test_serializers.py
+++ b/tests/serialization/serializers/test_serializers.py
@@ -386,6 +386,8 @@ class TestSerializers:
         assert deserialize(ser_value) == expected
 
     def test_polars_frame(self):
+        from datetime import date, datetime, time
+
         import polars as pl
 
         frame = pl.DataFrame(
@@ -395,12 +397,12 @@ class TestSerializers:
                 "string": ["a", "b", "c"],
                 "binary": [b"a", b"b", b"c"],
                 "boolean": [True, False, True],
-                "date": [pl.date(2021, 1, 1), pl.date(2021, 1, 2), pl.date(2021, 1, 3)],
-                "time": [pl.time(12, 0, 0), pl.time(12, 0, 1), pl.time(12, 0, 2)],
+                "date": [date(2021, 1, 1), date(2021, 1, 2), date(2021, 1, 3)],
+                "time": [time(12, 0, 0), time(12, 0, 1), time(12, 0, 2)],
                 "timestamp": [
-                    pl.datetime(2021, 1, 1, 12, 0, 0),
-                    pl.datetime(2021, 1, 1, 12, 0, 1),
-                    pl.datetime(2021, 1, 1, 12, 0, 2),
+                    datetime(2021, 1, 1, 12, 0, 0),
+                    datetime(2021, 1, 1, 12, 0, 1),
+                    datetime(2021, 1, 1, 12, 0, 2),
                 ],
             },
             schema_overrides={
@@ -416,9 +418,12 @@ class TestSerializers:
         )
         dump = serialize(frame)
         load = deserialize(dump)
+        assert isinstance(load, pl.DataFrame)
         assert frame.equals(load)
 
     def test_polars_series(self):
+        from datetime import date, datetime, time
+
         import polars as pl
 
         frame = pl.DataFrame(
@@ -428,12 +433,12 @@ class TestSerializers:
                 "string": ["a", "b", "c"],
                 "binary": [b"a", b"b", b"c"],
                 "boolean": [True, False, True],
-                "date": [pl.date(2021, 1, 1), pl.date(2021, 1, 2), pl.date(2021, 1, 3)],
-                "time": [pl.time(12, 0, 0), pl.time(12, 0, 1), pl.time(12, 0, 2)],
+                "date": [date(2021, 1, 1), date(2021, 1, 2), date(2021, 1, 3)],
+                "time": [time(12, 0, 0), time(12, 0, 1), time(12, 0, 2)],
                 "timestamp": [
-                    pl.datetime(2021, 1, 1, 12, 0, 0),
-                    pl.datetime(2021, 1, 1, 12, 0, 1),
-                    pl.datetime(2021, 1, 1, 12, 0, 2),
+                    datetime(2021, 1, 1, 12, 0, 0),
+                    datetime(2021, 1, 1, 12, 0, 1),
+                    datetime(2021, 1, 1, 12, 0, 2),
                 ],
             },
             schema_overrides={
@@ -451,4 +456,5 @@ class TestSerializers:
             dump = serialize(field)
             load = deserialize(dump)
 
+            assert isinstance(load, pl.Series)
             assert field.equals(load)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

`polars` has an advantage over `pandas` when dealing with large amounts of data.
Serializing `polars` can be supported in much the same way as `pandas`. 

However, rather than supporting `polars` objects, it may be better to convert them to `pandas` objects.
A `polars` can be converted to a zero-copy `pandas` frame in the following way
```python
pd_frame = frame.to_pandas(use_pyarrow_extension_array=True)
```
(but, I have not verified that deserializing to a `pandas` object and then converting to a `polars` object is efficient.)


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
