### PR TITLE
fix(TriggeredDagRuns): fix wrong link in triggered dag run

### DIFF
--- a/airflow/www/static/js/components/TriggeredDagRuns.tsx
+++ b/airflow/www/static/js/components/TriggeredDagRuns.tsx
@@ -43,10 +43,11 @@ const TriggeredDagRuns = ({ createdDagRuns, showLink = true }: CardProps) => {
     <Flex alignItems="center">
       {createdDagRuns.map((run) => {
         const runId = (run as any).dagRunId; // For some reason the type is wrong here
-        const url = `${gridUrl?.replace(
-          "__DAG_ID__",
-          run.dagId || ""
-        )}?dag_run_id=${encodeURIComponent(runId)}`;
+        const splitGridUrl = gridUrl.split("/");
+        splitGridUrl[2] = run.dagId || "";
+        const url = `${splitGridUrl.join("/")}?dag_run_id=${encodeURIComponent(
+          runId
+        )}`;
 
         return (
           <Tooltip


### PR DESCRIPTION
Currently, the link of triggered dag runs won't be able to link the created dag runs. It was due to that `__DAG_ID__` is not correctly replaced 

<img width="1439" alt="Screenshot 2024-08-01 at 10 59 20 AM" src="https://github.com/user-attachments/assets/0366a8d5-0145-46ea-befd-ad4c10ef988e">
<img width="1446" alt="圖片" src="https://github.com/user-attachments/assets/e8d13fe6-0cc4-4574-9c0b-9350fca180b0">


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
