### PR TITLE
Bugfix and refactoring of failing and flaky system tests

### DIFF
--- a/tests/system/providers/google/cloud/bigquery/example_bigquery_to_mysql.py
+++ b/tests/system/providers/google/cloud/bigquery/example_bigquery_to_mysql.py
@@ -39,9 +39,9 @@ except ImportError:
     pytest.skip("MySQL not available", allow_module_level=True)
 
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID")
-DAG_ID = "example_bigquery_to_mysql"
+DAG_ID = "bigquery_to_mysql"
 
-DATASET_NAME = f"dataset_{DAG_ID}_{ENV_ID}"
+DATASET_NAME = f"dataset_{DAG_ID}_{ENV_ID}".replace("-", "_")
 DATA_EXPORT_BUCKET_NAME = os.environ.get("GCP_BIGQUERY_EXPORT_BUCKET_NAME", "INVALID BUCKET NAME")
 TABLE = "table_42"
 destination_table = "mysql_table_test"

--- a/tests/system/providers/google/cloud/bigquery/example_bigquery_to_postgres.py
+++ b/tests/system/providers/google/cloud/bigquery/example_bigquery_to_postgres.py
@@ -57,13 +57,13 @@ ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID", "default")
 PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT", "example-project")
 DAG_ID = "bigquery_to_postgres"
 
-REGION = "us-central1"
+REGION = "us-west2"
 ZONE = REGION + "-a"
 NETWORK = "default"
 CONNECTION_ID = f"connection_{DAG_ID}_{ENV_ID}".replace("-", "_")
 CONNECTION_TYPE = "postgres"
 
-BIGQUERY_DATASET_NAME = f"ds_{DAG_ID}_{ENV_ID}"
+BIGQUERY_DATASET_NAME = f"ds_{DAG_ID}_{ENV_ID}".replace("-", "_")
 BIGQUERY_TABLE = "test_table"
 SOURCE_OBJECT_NAME = "gs://airflow-system-tests-resources/bigquery/salaries_1k.csv"
 BATCH_SIZE = 500
@@ -120,13 +120,14 @@ GCE_INSTANCE_BODY = {
         }
     ],
 }
-FIREWALL_RULE_NAME = f"allow-http-{DB_PORT}"
+FIREWALL_RULE_NAME = f"allow-http-{DB_PORT}-{DAG_ID}-{ENV_ID}".replace("_", "-")
+
 CREATE_FIREWALL_RULE_COMMAND = f"""
 if [ $AIRFLOW__API__GOOGLE_KEY_PATH ]; then \
  gcloud auth activate-service-account --key-file=$AIRFLOW__API__GOOGLE_KEY_PATH; \
 fi;
 
-if [ -z gcloud compute firewall-rules list --filter=name:{FIREWALL_RULE_NAME} --format="value(name)" ]; then \
+if [ -z $(gcloud compute firewall-rules list --filter=name:{FIREWALL_RULE_NAME} --format="value(name)" --project={PROJECT_ID}) ]; then \
     gcloud compute firewall-rules create {FIREWALL_RULE_NAME} \
       --project={PROJECT_ID} \
       --direction=INGRESS \
@@ -143,7 +144,7 @@ DELETE_FIREWALL_RULE_COMMAND = f"""
 if [ $AIRFLOW__API__GOOGLE_KEY_PATH ]; then \
  gcloud auth activate-service-account --key-file=$AIRFLOW__API__GOOGLE_KEY_PATH; \
 fi; \
-if [ gcloud compute firewall-rules list --filter=name:{FIREWALL_RULE_NAME} --format="value(name)" ]; then \
+if [ $(gcloud compute firewall-rules list --filter=name:{FIREWALL_RULE_NAME} --format="value(name)" --project={PROJECT_ID}) ]; then \
     gcloud compute firewall-rules delete {FIREWALL_RULE_NAME} --project={PROJECT_ID} --quiet; \
 fi;
 """
@@ -224,9 +225,9 @@ with DAG(
     get_public_ip_task = get_public_ip()
 
     @task
-    def setup_connection(ip_address: str) -> None:
+    def create_connection(connection_id: str, ip_address: str) -> None:
         connection = Connection(
-            conn_id=CONNECTION_ID,
+            conn_id=connection_id,
             description="Example connection",
             conn_type=CONNECTION_TYPE,
             host=ip_address,
@@ -236,15 +237,15 @@ with DAG(
             port=DB_PORT,
         )
         session = Session()
-        log.info("Removing connection %s if it exists", CONNECTION_ID)
-        query = session.query(Connection).filter(Connection.conn_id == CONNECTION_ID)
+        log.info("Removing connection %s if it exists", connection_id)
+        query = session.query(Connection).filter(Connection.conn_id == connection_id)
         query.delete()
 
         session.add(connection)
         session.commit()
-        log.info("Connection %s created", CONNECTION_ID)
+        log.info("Connection %s created", connection_id)
 
-    setup_connection_task = setup_connection(get_public_ip_task)
+    create_connection_task = create_connection(connection_id=CONNECTION_ID, ip_address=get_public_ip_task)
 
     create_pg_table = SQLExecuteQueryOperator(
         task_id="create_pg_table",
@@ -325,35 +326,41 @@ with DAG(
         trigger_rule=TriggerRule.ALL_DONE,
     )
 
-    delete_connection = BashOperator(
-        task_id="delete_connection",
-        bash_command=f"airflow connections delete {CONNECTION_ID}",
-        trigger_rule=TriggerRule.ALL_DONE,
-    )
+    @task(task_id="delete_connection")
+    def delete_connection(connection_id: str) -> None:
+        session = Session()
+        log.info("Removing connection %s", connection_id)
+        query = session.query(Connection).filter(Connection.conn_id == connection_id)
+        query.delete()
+        session.commit()
 
-    # TEST SETUP
-    create_bigquery_dataset >> create_bigquery_table >> insert_bigquery_data
-    create_gce_instance >> setup_postgres
-    create_gce_instance >> get_public_ip_task >> setup_connection_task
-    [setup_postgres, setup_connection_task, create_firewall_rule] >> create_pg_table
+    delete_connection_task = delete_connection(connection_id=CONNECTION_ID)
 
     (
-        [insert_bigquery_data, create_pg_table]
+        # TEST SETUP
+        create_gce_instance
+        >> create_bigquery_dataset
+        >> create_bigquery_table
+        >> insert_bigquery_data
+        >> get_public_ip_task
+        >> create_connection_task
+        >> create_firewall_rule
+        >> setup_postgres
+        >> create_pg_table
         # TEST BODY
         >> bigquery_to_postgres
         >> update_pg_table_data
         >> create_unique_index_in_pg_table
         >> bigquery_to_postgres_upsert
+        # TEST TEARDOWN
+        >> [
+            delete_bigquery_dataset,
+            delete_firewall_rule,
+            delete_gce_instance,
+            delete_connection_task,
+        ]
+        >> delete_persistent_disk
     )
-
-    # TEST TEARDOWN
-    bigquery_to_postgres_upsert >> [
-        delete_bigquery_dataset,
-        delete_firewall_rule,
-        delete_gce_instance,
-        delete_connection,
-    ]
-    delete_gce_instance >> delete_persistent_disk
 
     from tests.system.utils.watcher import watcher
 

--- a/tests/system/providers/google/cloud/cloud_sql/example_cloud_sql_query.py
+++ b/tests/system/providers/google/cloud/cloud_sql/example_cloud_sql_query.py
@@ -47,7 +47,7 @@ from tests.system.providers.google import DEFAULT_GCP_SYSTEM_TEST_PROJECT_ID
 
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID")
 PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT") or DEFAULT_GCP_SYSTEM_TEST_PROJECT_ID
-DAG_ID = "cloudsql-query"
+DAG_ID = "cloudsql_query"
 REGION = "us-central1"
 HOME_DIR = Path.home()
 
@@ -225,8 +225,6 @@ SQL = [
     "DROP TABLE TABLE_TEST",
     "DROP TABLE TABLE_TEST2",
 ]
-
-DELETE_CONNECTION_COMMAND = "airflow connections delete {}"
 
 # [START howto_operator_cloudsql_query_connections_env]
 

--- a/tests/system/providers/google/cloud/cloud_sql/example_cloud_sql_query_ssl.py
+++ b/tests/system/providers/google/cloud/cloud_sql/example_cloud_sql_query_ssl.py
@@ -52,7 +52,7 @@ from tests.system.providers.google import DEFAULT_GCP_SYSTEM_TEST_PROJECT_ID
 
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID")
 PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT") or DEFAULT_GCP_SYSTEM_TEST_PROJECT_ID
-DAG_ID = "cloudsql-query-ssl"
+DAG_ID = "cloudsql_query_ssl"
 REGION = "us-central1"
 HOME_DIR = Path.home()
 
@@ -184,8 +184,6 @@ SQL = [
     "DROP TABLE TABLE_TEST",
     "DROP TABLE TABLE_TEST2",
 ]
-
-DELETE_CONNECTION_COMMAND = "airflow connections delete {}"
 
 SSL_PATH = f"/{DAG_ID}/{ENV_ID}"
 SSL_LOCAL_PATH_PREFIX = "/tmp"

--- a/tests/system/providers/google/cloud/compute/example_compute.py
+++ b/tests/system/providers/google/cloud/compute/example_compute.py
@@ -64,7 +64,7 @@ INSTANCE_TEMPLATE_BODY = {
                 "initialize_params": {
                     "disk_size_gb": "10",
                     "disk_type": "pd-balanced",
-                    "source_image": "projects/debian-cloud/global/images/debian-11-bullseye-v20220621",
+                    "source_image": "projects/debian-cloud/global/images/debian-12-bookworm-v20240611",
                 },
             }
         ],
@@ -81,7 +81,7 @@ GCE_INSTANCE_BODY = {
             "initialize_params": {
                 "disk_size_gb": "10",
                 "disk_type": f"zones/{LOCATION}/diskTypes/pd-balanced",
-                "source_image": "projects/debian-cloud/global/images/debian-11-bullseye-v20220621",
+                "source_image": "projects/debian-cloud/global/images/debian-12-bookworm-v20240611",
             },
         }
     ],

--- a/tests/system/providers/google/cloud/compute/example_compute_igm.py
+++ b/tests/system/providers/google/cloud/compute/example_compute_igm.py
@@ -64,7 +64,7 @@ INSTANCE_TEMPLATE_BODY = {
                 "initialize_params": {
                     "disk_size_gb": "10",
                     "disk_type": "pd-balanced",
-                    "source_image": "projects/debian-cloud/global/images/debian-11-bullseye-v20220621",
+                    "source_image": "projects/debian-cloud/global/images/debian-12-bookworm-v20240611",
                 },
             }
         ],

--- a/tests/system/providers/google/cloud/compute/example_compute_ssh.py
+++ b/tests/system/providers/google/cloud/compute/example_compute_ssh.py
@@ -55,7 +55,7 @@ GCE_INSTANCE_BODY = {
             "initialize_params": {
                 "disk_size_gb": "10",
                 "disk_type": f"zones/{LOCATION}/diskTypes/pd-balanced",
-                "source_image": "projects/debian-cloud/global/images/debian-11-bullseye-v20220621",
+                "source_image": "projects/debian-cloud/global/images/debian-12-bookworm-v20240611",
             },
         }
     ],

--- a/tests/system/providers/google/cloud/compute/example_compute_ssh_os_login.py
+++ b/tests/system/providers/google/cloud/compute/example_compute_ssh_os_login.py
@@ -63,7 +63,7 @@ GCE_INSTANCE_BODY = {
             "initialize_params": {
                 "disk_size_gb": "10",
                 "disk_type": f"zones/{LOCATION}/diskTypes/pd-balanced",
-                "source_image": "projects/debian-cloud/global/images/debian-11-bullseye-v20220621",
+                "source_image": "projects/debian-cloud/global/images/debian-12-bookworm-v20240611",
             },
         }
     ],

--- a/tests/system/providers/google/cloud/compute/example_compute_ssh_parallel.py
+++ b/tests/system/providers/google/cloud/compute/example_compute_ssh_parallel.py
@@ -55,7 +55,7 @@ GCE_INSTANCE_BODY = {
             "initialize_params": {
                 "disk_size_gb": "10",
                 "disk_type": f"zones/{LOCATION}/diskTypes/pd-balanced",
-                "source_image": "projects/debian-cloud/global/images/debian-11-bullseye-v20220621",
+                "source_image": "projects/debian-cloud/global/images/debian-12-bookworm-v20240611",
             },
         }
     ],

--- a/tests/system/providers/google/cloud/gcs/example_calendar_to_gcs.py
+++ b/tests/system/providers/google/cloud/gcs/example_calendar_to_gcs.py
@@ -18,13 +18,13 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 from datetime import datetime
 
 from airflow.decorators import task
 from airflow.models import Connection
 from airflow.models.dag import DAG
-from airflow.operators.bash import BashOperator
 from airflow.providers.google.cloud.operators.gcs import GCSCreateBucketOperator, GCSDeleteBucketOperator
 from airflow.providers.google.cloud.transfers.calendar_to_gcs import GoogleCalendarToGCSOperator
 from airflow.settings import Session
@@ -32,13 +32,16 @@ from airflow.utils.trigger_rule import TriggerRule
 
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID", "default")
 PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT", "default")
-DAG_ID = "example_calendar_to_gcs"
+DAG_ID = "calendar_to_gcs"
 
 BUCKET_NAME = f"bucket_{DAG_ID}_{ENV_ID}"
 CALENDAR_ID = os.environ.get("CALENDAR_ID", "primary")
 API_VERSION = "v3"
 
 CONNECTION_ID = f"connection_{DAG_ID}_{ENV_ID}"
+
+
+log = logging.getLogger(__name__)
 
 
 with DAG(
@@ -53,9 +56,9 @@ with DAG(
     )
 
     @task
-    def create_temp_gcp_connection():
+    def create_connection(connection_id: str):
         conn = Connection(
-            conn_id=CONNECTION_ID,
+            conn_id=connection_id,
             conn_type="google_cloud_platform",
         )
         conn_extra = {
@@ -67,10 +70,15 @@ with DAG(
         conn.set_extra(conn_extra_json)
 
         session = Session()
+        log.info("Removing connection %s if it exists", connection_id)
+        query = session.query(Connection).filter(Connection.conn_id == connection_id)
+        query.delete()
+
         session.add(conn)
         session.commit()
+        log.info("Connection created: '%s'", connection_id)
 
-    create_temp_gcp_connection_task = create_temp_gcp_connection()
+    create_connection_task = create_connection(connection_id=CONNECTION_ID)
 
     # [START upload_calendar_to_gcs]
     upload_calendar_to_gcs = GoogleCalendarToGCSOperator(
@@ -82,10 +90,15 @@ with DAG(
     )
     # [END upload_calendar_to_gcs]
 
-    delete_temp_gcp_connection_task = BashOperator(
-        task_id="delete_temp_gcp_connection",
-        bash_command=f"airflow connections delete {CONNECTION_ID}",
-    )
+    @task(task_id="delete_connection")
+    def delete_connection(connection_id: str) -> None:
+        session = Session()
+        log.info("Removing connection %s", connection_id)
+        query = session.query(Connection).filter(Connection.conn_id == connection_id)
+        query.delete()
+        session.commit()
+
+    delete_connection_task = delete_connection(connection_id=CONNECTION_ID)
 
     delete_bucket = GCSDeleteBucketOperator(
         task_id="delete_bucket", bucket_name=BUCKET_NAME, trigger_rule=TriggerRule.ALL_DONE
@@ -94,11 +107,11 @@ with DAG(
     (
         # TEST SETUP
         create_bucket
-        >> create_temp_gcp_connection_task
+        >> create_connection_task
         # TEST BODY
         >> upload_calendar_to_gcs
         # TEST TEARDOWN
-        >> delete_temp_gcp_connection_task
+        >> delete_connection_task
         >> delete_bucket
     )
 

--- a/tests/system/providers/google/cloud/gcs/example_gcs_to_gdrive.py
+++ b/tests/system/providers/google/cloud/gcs/example_gcs_to_gdrive.py
@@ -33,7 +33,6 @@ from pathlib import Path
 from airflow.decorators import task
 from airflow.models import Connection
 from airflow.models.dag import DAG
-from airflow.operators.bash import BashOperator
 from airflow.providers.google.cloud.operators.gcs import GCSCreateBucketOperator, GCSDeleteBucketOperator
 from airflow.providers.google.cloud.transfers.gcs_to_gcs import GCSToGCSOperator
 from airflow.providers.google.suite.hooks.drive import GoogleDriveHook
@@ -46,7 +45,7 @@ ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID")
 PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT") or DEFAULT_GCP_SYSTEM_TEST_PROJECT_ID
 FOLDER_ID = os.environ.get("GCP_GDRIVE_FOLDER_ID", "root")
 
-DAG_ID = "example_gcs_to_gdrive"
+DAG_ID = "gcs_to_gdrive"
 
 RESOURCES_BUCKET_NAME = "airflow-system-tests-resources"
 BUCKET_NAME = f"bucket_{DAG_ID}_{ENV_ID}"
@@ -71,9 +70,9 @@ with DAG(
 ) as dag:
 
     @task
-    def create_temp_gcp_connection():
+    def create_connection(connection_id: str):
         conn = Connection(
-            conn_id=CONNECTION_ID,
+            conn_id=connection_id,
             conn_type="google_cloud_platform",
         )
         conn_extra_json = json.dumps(
@@ -85,13 +84,15 @@ with DAG(
         conn.set_extra(conn_extra_json)
 
         session = Session()
-        if session.query(Connection).filter(Connection.conn_id == CONNECTION_ID).first():
-            log.warning("Connection %s already exists", CONNECTION_ID)
-            return None
+        log.info("Removing connection %s if it exists", connection_id)
+        query = session.query(Connection).filter(Connection.conn_id == connection_id)
+        query.delete()
+
         session.add(conn)
         session.commit()
+        log.info("Connection created: '%s'", connection_id)
 
-    create_temp_gcp_connection_task = create_temp_gcp_connection()
+    create_connection_task = create_connection(connection_id=CONNECTION_ID)
 
     create_bucket = GCSCreateBucketOperator(
         task_id="create_bucket", bucket_name=BUCKET_NAME, project_id=PROJECT_ID
@@ -178,16 +179,20 @@ with DAG(
         task_id="delete_bucket", bucket_name=BUCKET_NAME, trigger_rule=TriggerRule.ALL_DONE
     )
 
-    delete_temp_gcp_connection_task = BashOperator(
-        task_id="delete_temp_gcp_connection",
-        bash_command=f"airflow connections delete {CONNECTION_ID}",
-        trigger_rule=TriggerRule.ALL_DONE,
-    )
+    @task(task_id="delete_connection")
+    def delete_connection(connection_id: str) -> None:
+        session = Session()
+        log.info("Removing connection %s", connection_id)
+        query = session.query(Connection).filter(Connection.conn_id == connection_id)
+        query.delete()
+        session.commit()
+
+    delete_connection_task = delete_connection(connection_id=CONNECTION_ID)
 
     # TEST SETUP
     create_bucket >> [upload_file_1, upload_file_2]
     (
-        [upload_file_1, upload_file_2, create_temp_gcp_connection_task]
+        [upload_file_1, upload_file_2, create_connection_task]
         # TEST BODY
         >> copy_single_file
         >> copy_single_file_into_folder
@@ -195,7 +200,7 @@ with DAG(
         >> move_files
         # TEST TEARDOWN
         >> remove_files_from_drive_task
-        >> [delete_bucket, delete_temp_gcp_connection_task]
+        >> [delete_bucket, delete_connection_task]
     )
 
     from tests.system.utils.watcher import watcher

--- a/tests/system/providers/google/cloud/gcs/example_gdrive_to_gcs.py
+++ b/tests/system/providers/google/cloud/gcs/example_gdrive_to_gcs.py
@@ -25,7 +25,6 @@ from datetime import datetime
 from airflow.decorators import task
 from airflow.models import Connection
 from airflow.models.dag import DAG
-from airflow.operators.bash import BashOperator
 from airflow.providers.google.cloud.operators.gcs import GCSCreateBucketOperator, GCSDeleteBucketOperator
 from airflow.providers.google.cloud.transfers.gcs_to_gcs import GCSToGCSOperator
 from airflow.providers.google.cloud.transfers.gdrive_to_gcs import GoogleDriveToGCSOperator
@@ -39,7 +38,7 @@ from tests.system.providers.google import DEFAULT_GCP_SYSTEM_TEST_PROJECT_ID
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID")
 PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT") or DEFAULT_GCP_SYSTEM_TEST_PROJECT_ID
 
-DAG_ID = "example_gdrive_to_gcs_with_gdrive_sensor"
+DAG_ID = "gdrive_to_gcs_with_gdrive_sensor"
 
 RESOURCES_BUCKET_NAME = "airflow-system-tests-resources"
 BUCKET_NAME = f"bucket_{DAG_ID}_{ENV_ID}"
@@ -63,9 +62,9 @@ with DAG(
 ) as dag:
 
     @task
-    def create_temp_gcp_connection():
+    def create_connection(connection_id: str):
         conn = Connection(
-            conn_id=CONNECTION_ID,
+            conn_id=connection_id,
             conn_type="google_cloud_platform",
         )
         conn_extra_json = json.dumps(
@@ -77,13 +76,15 @@ with DAG(
         conn.set_extra(conn_extra_json)
 
         session = Session()
-        if session.query(Connection).filter(Connection.conn_id == CONNECTION_ID).first():
-            log.warning("Connection %s already exists", CONNECTION_ID)
-            return None
+        log.info("Removing connection %s if it exists", connection_id)
+        query = session.query(Connection).filter(Connection.conn_id == connection_id)
+        query.delete()
+
         session.add(conn)
         session.commit()
+        log.info("Connection created: '%s'", connection_id)
 
-    create_temp_gcp_connection_task = create_temp_gcp_connection()
+    create_connection_task = create_connection(connection_id=CONNECTION_ID)
 
     create_bucket = GCSCreateBucketOperator(
         task_id="create_bucket", bucket_name=BUCKET_NAME, project_id=PROJECT_ID
@@ -142,21 +143,25 @@ with DAG(
         task_id="delete_bucket", bucket_name=BUCKET_NAME, trigger_rule=TriggerRule.ALL_DONE
     )
 
-    delete_temp_gcp_connection_task = BashOperator(
-        task_id="delete_temp_gcp_connection",
-        bash_command=f"airflow connections delete {CONNECTION_ID}",
-        trigger_rule=TriggerRule.ALL_DONE,
-    )
+    @task(task_id="delete_connection")
+    def delete_connection(connection_id: str) -> None:
+        session = Session()
+        log.info("Removing connection %s", connection_id)
+        query = session.query(Connection).filter(Connection.conn_id == connection_id)
+        query.delete()
+        session.commit()
+
+    delete_connection_task = delete_connection(connection_id=CONNECTION_ID)
 
     (
-        [create_bucket >> upload_file, create_temp_gcp_connection_task]
+        [create_bucket >> upload_file, create_connection_task]
         >> copy_single_file
         # TEST BODY
         >> detect_file
         >> upload_gdrive_to_gcs
         # TEST TEARDOWN
         >> remove_files_from_drive_task
-        >> [delete_bucket, delete_temp_gcp_connection_task]
+        >> [delete_bucket, delete_connection_task]
     )
 
     from tests.system.utils.watcher import watcher

--- a/tests/system/providers/google/cloud/gcs/example_mysql_to_gcs.py
+++ b/tests/system/providers/google/cloud/gcs/example_mysql_to_gcs.py
@@ -55,7 +55,7 @@ try:
 except ImportError:
     pytest.skip("MySQL not available", allow_module_level=True)
 
-DAG_ID = "example_mysql_to_gcs"
+DAG_ID = "mysql_to_gcs"
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID")
 PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT", "example-project")
 
@@ -97,7 +97,7 @@ GCE_INSTANCE_BODY = {
             "initialize_params": {
                 "disk_size_gb": "10",
                 "disk_type": f"zones/{ZONE}/diskTypes/pd-balanced",
-                "source_image": "projects/debian-cloud/global/images/debian-11-bullseye-v20220621",
+                "source_image": "projects/debian-cloud/global/images/debian-12-bookworm-v20240611",
             },
         }
     ],
@@ -109,13 +109,13 @@ GCE_INSTANCE_BODY = {
         }
     ],
 }
-FIREWALL_RULE_NAME = f"allow-http-{DB_PORT}"
+FIREWALL_RULE_NAME = f"allow-http-{DB_PORT}-{DAG_ID}-{ENV_ID}".replace("_", "-")
 CREATE_FIREWALL_RULE_COMMAND = f"""
 if [ $AIRFLOW__API__GOOGLE_KEY_PATH ]; then \
  gcloud auth activate-service-account --key-file=$AIRFLOW__API__GOOGLE_KEY_PATH; \
 fi;
 
-if [ -z gcloud compute firewall-rules list --filter=name:{FIREWALL_RULE_NAME} --format="value(name)" ]; then \
+if [ -z $(gcloud compute firewall-rules list --filter=name:{FIREWALL_RULE_NAME} --format="value(name)" --project={PROJECT_ID}) ]; then \
     gcloud compute firewall-rules create {FIREWALL_RULE_NAME} \
       --project={PROJECT_ID} \
       --direction=INGRESS \
@@ -132,7 +132,7 @@ DELETE_FIREWALL_RULE_COMMAND = f"""
 if [ $AIRFLOW__API__GOOGLE_KEY_PATH ]; then \
  gcloud auth activate-service-account --key-file=$AIRFLOW__API__GOOGLE_KEY_PATH; \
 fi; \
-if [ gcloud compute firewall-rules list --filter=name:{FIREWALL_RULE_NAME} --format="value(name)" ]; then \
+if [ $(gcloud compute firewall-rules list --filter=name:{FIREWALL_RULE_NAME} --format="value(name)" --project={PROJECT_ID}) ]; then \
     gcloud compute firewall-rules delete {FIREWALL_RULE_NAME} --project={PROJECT_ID} --quiet; \
 fi;
 """
@@ -191,9 +191,9 @@ with DAG(
     get_public_ip_task = get_public_ip()
 
     @task
-    def setup_connection(ip_address: str) -> None:
+    def create_connection(connection_id: str, ip_address: str) -> None:
         connection = Connection(
-            conn_id=CONNECTION_ID,
+            conn_id=connection_id,
             description="Example connection",
             conn_type=CONNECTION_TYPE,
             host=ip_address,
@@ -202,15 +202,15 @@ with DAG(
             port=DB_PORT,
         )
         session = Session()
-        log.info("Removing connection %s if it exists", CONNECTION_ID)
-        query = session.query(Connection).filter(Connection.conn_id == CONNECTION_ID)
+        log.info("Removing connection %s if it exists", connection_id)
+        query = session.query(Connection).filter(Connection.conn_id == connection_id)
         query.delete()
 
         session.add(connection)
         session.commit()
-        log.info("Connection %s created", CONNECTION_ID)
+        log.info("Connection %s created", connection_id)
 
-    setup_connection_task = setup_connection(get_public_ip_task)
+    create_connection_task = create_connection(connection_id=CONNECTION_ID, ip_address=get_public_ip_task)
 
     create_sql_table = SQLExecuteQueryOperator(
         task_id="create_sql_table",
@@ -267,25 +267,32 @@ with DAG(
         trigger_rule=TriggerRule.ALL_DONE,
     )
 
-    delete_connection = BashOperator(
-        task_id="delete_connection",
-        bash_command=f"airflow connections delete {CONNECTION_ID}",
-        trigger_rule=TriggerRule.ALL_DONE,
-    )
+    @task(task_id="delete_connection")
+    def delete_connection(connection_id: str) -> None:
+        session = Session()
+        log.info("Removing connection %s", connection_id)
+        query = session.query(Connection).filter(Connection.conn_id == connection_id)
+        query.delete()
+        session.commit()
 
-    # TEST SETUP
-    create_gce_instance >> setup_mysql
-    create_gce_instance >> get_public_ip_task >> setup_connection_task
-    [setup_mysql, setup_connection_task, create_firewall_rule] >> create_sql_table >> insert_sql_data
+    delete_connection_task = delete_connection(connection_id=CONNECTION_ID)
 
     (
-        [create_gcs_bucket, insert_sql_data]
+        # TEST SETUP
+        create_gce_instance
+        >> setup_mysql
+        >> create_firewall_rule
+        >> get_public_ip_task
+        >> create_connection_task
+        >> create_sql_table
+        >> insert_sql_data
+        >> create_gcs_bucket
         # TEST BODY
         >> mysql_to_gcs
     )
 
     # TEST TEARDOWN
-    mysql_to_gcs >> [delete_gcs_bucket, delete_firewall_rule, delete_gce_instance, delete_connection]
+    mysql_to_gcs >> [delete_gcs_bucket, delete_firewall_rule, delete_gce_instance, delete_connection_task]
     delete_gce_instance >> delete_persistent_disk
 
     from tests.system.utils.watcher import watcher

--- a/tests/system/providers/google/cloud/sql_to_sheets/example_sql_to_sheets.py
+++ b/tests/system/providers/google/cloud/sql_to_sheets/example_sql_to_sheets.py
@@ -48,7 +48,7 @@ from airflow.providers.ssh.operators.ssh import SSHOperator
 from airflow.settings import Session, json
 from airflow.utils.trigger_rule import TriggerRule
 
-DAG_ID = "example_sql_to_sheets"
+DAG_ID = "sql_to_sheets"
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID")
 PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT", "example-project")
 
@@ -92,7 +92,7 @@ GCE_INSTANCE_BODY = {
             "initialize_params": {
                 "disk_size_gb": "10",
                 "disk_type": f"zones/{ZONE}/diskTypes/pd-balanced",
-                "source_image": "projects/debian-cloud/global/images/debian-11-bullseye-v20220621",
+                "source_image": "projects/debian-cloud/global/images/debian-12-bookworm-v20240611",
             },
         }
     ],
@@ -104,13 +104,13 @@ GCE_INSTANCE_BODY = {
         }
     ],
 }
-FIREWALL_RULE_NAME = f"allow-http-{DB_PORT}"
+FIREWALL_RULE_NAME = f"allow-http-{DB_PORT}-{DAG_ID}-{ENV_ID}".replace("_", "-")
 CREATE_FIREWALL_RULE_COMMAND = f"""
 if [ $AIRFLOW__API__GOOGLE_KEY_PATH ]; then \
  gcloud auth activate-service-account --key-file=$AIRFLOW__API__GOOGLE_KEY_PATH; \
 fi;
 
-if [ -z gcloud compute firewall-rules list --filter=name:{FIREWALL_RULE_NAME} --format="value(name)" ]; then \
+if [ -z $(gcloud compute firewall-rules list --filter=name:{FIREWALL_RULE_NAME} --format="value(name)" --project={PROJECT_ID}) ]; then \
     gcloud compute firewall-rules create {FIREWALL_RULE_NAME} \
       --project={PROJECT_ID} \
       --direction=INGRESS \
@@ -127,7 +127,7 @@ DELETE_FIREWALL_RULE_COMMAND = f"""
 if [ $AIRFLOW__API__GOOGLE_KEY_PATH ]; then \
  gcloud auth activate-service-account --key-file=$AIRFLOW__API__GOOGLE_KEY_PATH; \
 fi; \
-if [ gcloud compute firewall-rules list --filter=name:{FIREWALL_RULE_NAME} --format="value(name)" ]; then \
+if [ $(gcloud compute firewall-rules list --filter=name:{FIREWALL_RULE_NAME} --format="value(name)" --project={PROJECT_ID}) ]; then \
     gcloud compute firewall-rules delete {FIREWALL_RULE_NAME} --project={PROJECT_ID} --quiet; \
 fi;
 """
@@ -192,9 +192,9 @@ with DAG(
     get_public_ip_task = get_public_ip()
 
     @task
-    def setup_connection(ip_address: str) -> None:
+    def create_connection(connection_id: str, ip_address: str) -> None:
         connection = Connection(
-            conn_id=CONNECTION_ID,
+            conn_id=connection_id,
             description="Example connection",
             conn_type=CONNECTION_TYPE,
             schema=DB_NAME,
@@ -204,15 +204,15 @@ with DAG(
             port=DB_PORT,
         )
         session = Session()
-        log.info("Removing connection %s if it exists", CONNECTION_ID)
-        query = session.query(Connection).filter(Connection.conn_id == CONNECTION_ID)
+        log.info("Removing connection %s if it exists", connection_id)
+        query = session.query(Connection).filter(Connection.conn_id == connection_id)
         query.delete()
 
         session.add(connection)
         session.commit()
-        log.info("Connection %s created", CONNECTION_ID)
+        log.info("Connection %s created", connection_id)
 
-    setup_connection_task = setup_connection(get_public_ip_task)
+    create_connection_task = create_connection(connection_id=CONNECTION_ID, ip_address=get_public_ip_task)
 
     create_sql_table = SQLExecuteQueryOperator(
         task_id="create_sql_table",
@@ -283,21 +283,21 @@ with DAG(
         trigger_rule=TriggerRule.ALL_DONE,
     )
 
-    delete_connection = BashOperator(
-        task_id="delete_connection",
-        bash_command=f"airflow connections delete {CONNECTION_ID}",
-        trigger_rule=TriggerRule.ALL_DONE,
-    )
+    @task(task_id="delete_connection")
+    def delete_connection(connection_id: str) -> None:
+        session = Session()
+        log.info("Removing connection %s", connection_id)
+        query = session.query(Connection).filter(Connection.conn_id == connection_id)
+        query.delete()
+        session.commit()
 
-    delete_sheets_connection = BashOperator(
-        task_id="delete_sheets_connection",
-        bash_command=f"airflow connections delete {SHEETS_CONNECTION_ID}",
-        trigger_rule=TriggerRule.ALL_DONE,
-    )
+    delete_connection_task = delete_connection(connection_id=CONNECTION_ID)
+    delete_connection_sheets_task = delete_connection(connection_id=SHEETS_CONNECTION_ID)
+
     # TEST SETUP
-    create_gce_instance >> setup_postgres
-    create_gce_instance >> get_public_ip_task >> setup_connection_task
-    [setup_postgres, setup_connection_task, create_firewall_rule] >> create_sql_table >> insert_sql_data
+    create_gce_instance >> get_public_ip_task >> create_connection_task
+    [create_gce_instance, create_firewall_rule] >> setup_postgres
+    [setup_postgres, create_connection_task, create_firewall_rule] >> create_sql_table >> insert_sql_data
     setup_sheets_connection_task >> create_spreadsheet
 
     (
@@ -310,8 +310,8 @@ with DAG(
     upload_sql_to_sheet >> [
         delete_firewall_rule,
         delete_gce_instance,
-        delete_connection,
-        delete_sheets_connection,
+        delete_connection_task,
+        delete_connection_sheets_task,
     ]
     delete_gce_instance >> delete_persistent_disk
 


### PR DESCRIPTION
Fixed failing and flaky system tests:
1. bigquery_to_mssql
1. bigquery_to_postgres
1. cloud_compute
1. cloud_compute_igm
1. cloud_compute_ssh
2. cloud_compute_ssh_os_login
3. cloud_compute_ssh_parallel

Refactored system tests:
1. bigquery_to_mysql
2. cloudsql_query
3. cloudsql_query_ssl
4. dataprep
5. calendar_to_gcs
6. gcs_to_gdrive
7. gcs_to_sheets
8. gdrive_to_gcs_with_gdrive_sensor
9. mysql_to_gcs
10. sheets_gcs
11. sheets_to_gcs
12. sql_to_sheets
13. gdrive_to_local
14. postgres_to_gcs
15. google_analytics_admin
16. local_to_drive