### PR TITLE
fix: Fixing Helm chart flower ingress service reference

### DIFF
--- a/chart/templates/flower/flower-ingress.yaml
+++ b/chart/templates/flower/flower-ingress.yaml
@@ -72,7 +72,7 @@ spec:
         paths:
           - backend:
               service:
-                name: {{ $.Release.Name }}-flower
+                name: {{ $fullname }}-flower
                 port:
                   name: flower-ui
             {{- if $.Values.ingress.flower.path }}

--- a/chart/templates/flower/flower-ingress.yaml
+++ b/chart/templates/flower/flower-ingress.yaml
@@ -22,10 +22,11 @@
 #################################
 {{- if .Values.flower.enabled }}
 {{- if and (or .Values.ingress.flower.enabled .Values.ingress.enabled) (or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor")) }}
+{{- $fullname := (include "airflow.fullname" .) }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "airflow.fullname" . }}-flower-ingress
+  name: {{ $fullname }}-flower-ingress
   labels:
     tier: airflow
     component: flower-ingress

--- a/helm_tests/webserver/test_ingress_flower.py
+++ b/helm_tests/webserver/test_ingress_flower.py
@@ -232,6 +232,7 @@ class TestIngressFlower:
     def test_backend_service_name_with_fullname_override(self):
         docs = render_chart(
             values={"fullnameOverride": "test-basic",
+                    "useStandardNaming": True,
                     "ingress": {"enabled": True}, "flower": {"enabled": True}},
             show_only=["templates/flower/flower-ingress.yaml"],
 

--- a/helm_tests/webserver/test_ingress_flower.py
+++ b/helm_tests/webserver/test_ingress_flower.py
@@ -220,3 +220,21 @@ class TestIngressFlower:
             "cc.example.com",
             "dd.example.com",
         ] == jmespath.search("spec.rules[*].host", docs[0])
+
+    def test_backend_service_name(self):
+        docs = render_chart(
+            values={"ingress": {"enabled": True}, "flower": {"enabled": True}},
+            show_only=["templates/flower/flower-ingress.yaml"],
+        )
+
+        assert "release-name-flower" == jmespath.search("spec.rules[0].http.paths[0].backend.service.name", docs[0])
+
+    def test_backend_service_name_with_fullname_override(self):
+        docs = render_chart(
+            values={"fullnameOverride": "test-basic",
+                    "ingress": {"enabled": True}, "flower": {"enabled": True}},
+            show_only=["templates/flower/flower-ingress.yaml"],
+
+        )
+
+        assert "test-basic-flower" == jmespath.search("spec.rules[0].http.paths[0].backend.service.name", docs[0])

--- a/helm_tests/webserver/test_ingress_flower.py
+++ b/helm_tests/webserver/test_ingress_flower.py
@@ -227,15 +227,21 @@ class TestIngressFlower:
             show_only=["templates/flower/flower-ingress.yaml"],
         )
 
-        assert "release-name-flower" == jmespath.search("spec.rules[0].http.paths[0].backend.service.name", docs[0])
+        assert "release-name-flower" == jmespath.search(
+            "spec.rules[0].http.paths[0].backend.service.name", docs[0]
+        )
 
     def test_backend_service_name_with_fullname_override(self):
         docs = render_chart(
-            values={"fullnameOverride": "test-basic",
-                    "useStandardNaming": True,
-                    "ingress": {"enabled": True}, "flower": {"enabled": True}},
+            values={
+                "fullnameOverride": "test-basic",
+                "useStandardNaming": True,
+                "ingress": {"enabled": True},
+                "flower": {"enabled": True},
+            },
             show_only=["templates/flower/flower-ingress.yaml"],
-
         )
 
-        assert "test-basic-flower" == jmespath.search("spec.rules[0].http.paths[0].backend.service.name", docs[0])
+        assert "test-basic-flower" == jmespath.search(
+            "spec.rules[0].http.paths[0].backend.service.name", docs[0]
+        )

--- a/helm_tests/webserver/test_ingress_web.py
+++ b/helm_tests/webserver/test_ingress_web.py
@@ -200,3 +200,21 @@ class TestIngressWeb:
             "cc.example.com",
             "dd.example.com",
         ] == jmespath.search("spec.rules[*].host", docs[0])
+
+    def test_backend_service_name(self):
+        docs = render_chart(
+            values={"ingress": {"web": {"enabled": True}}},
+            show_only=["templates/webserver/webserver-ingress.yaml"],
+        )
+
+        assert "release-name-webserver" == jmespath.search("spec.rules[0].http.paths[0].backend.service.name", docs[0])
+
+    def test_backend_service_name_with_fullname_override(self):
+        docs = render_chart(
+            values={"fullnameOverride": "test-basic",
+                    "ingress": {"web": {"enabled": True}}},
+            show_only=["templates/webserver/webserver-ingress.yaml"],
+
+        )
+
+        assert "test-basic-webserver" == jmespath.search("spec.rules[0].http.paths[0].backend.service.name", docs[0])

--- a/helm_tests/webserver/test_ingress_web.py
+++ b/helm_tests/webserver/test_ingress_web.py
@@ -207,15 +207,20 @@ class TestIngressWeb:
             show_only=["templates/webserver/webserver-ingress.yaml"],
         )
 
-        assert "release-name-webserver" == jmespath.search("spec.rules[0].http.paths[0].backend.service.name", docs[0])
+        assert "release-name-webserver" == jmespath.search(
+            "spec.rules[0].http.paths[0].backend.service.name", docs[0]
+        )
 
     def test_backend_service_name_with_fullname_override(self):
         docs = render_chart(
-            values={"fullnameOverride": "test-basic",
-                    "useStandardNaming": True,
-                    "ingress": {"web": {"enabled": True}}},
+            values={
+                "fullnameOverride": "test-basic",
+                "useStandardNaming": True,
+                "ingress": {"web": {"enabled": True}},
+            },
             show_only=["templates/webserver/webserver-ingress.yaml"],
-
         )
 
-        assert "test-basic-webserver" == jmespath.search("spec.rules[0].http.paths[0].backend.service.name", docs[0])
+        assert "test-basic-webserver" == jmespath.search(
+            "spec.rules[0].http.paths[0].backend.service.name", docs[0]
+        )

--- a/helm_tests/webserver/test_ingress_web.py
+++ b/helm_tests/webserver/test_ingress_web.py
@@ -212,6 +212,7 @@ class TestIngressWeb:
     def test_backend_service_name_with_fullname_override(self):
         docs = render_chart(
             values={"fullnameOverride": "test-basic",
+                    "useStandardNaming": True,
                     "ingress": {"web": {"enabled": True}}},
             show_only=["templates/webserver/webserver-ingress.yaml"],
 


### PR DESCRIPTION
closes #41175

### What happened

We are sub charting the official airflow chart and for this reason we need to use `fullnameOverride: "airflow"` settings to achieve the desired k8s resource names. However when we are using it the flower ingress becomes invalid because it want's to connect to non existing service name. Root cause are in the ingress.yaml. The webserver ingress can handle it with no problem.

Incorrect code section

`flower-ingress.yaml` - [code section](https://github.com/apache/airflow/blob/daccc75b064c735636027b20f3edb82da69ffab1/chart/templates/flower/flower-ingress.yaml#L75)
```yaml
spec:
  rules:
    - http:
        paths:
          - backend:
              service:
                name: {{ $.Release.Name }}-flower
                port:
                  name: flower-ui
```

While in the correct code section

`webserver-ingress.yaml` - [code section](https://github.com/apache/airflow/blob/daccc75b064c735636027b20f3edb82da69ffab1/chart/templates/webserver/webserver-ingress.yaml#L83)

```yaml
spec:
  rules:
    - http:
        paths:
          - backend:
              service:
                name: {{ $fullname }}-webserver
                port:
                  name: airflow-ui
```


To overcome this issue we need to run this command on every deployment
```bash
kubectl patch ingress airflow-flower-ingress \
    --namespace "airflow" \
    --type='json' \
    -p='[{"op": "replace", "path": "/spec/rules/0/http/paths/0/backend/service/name", "value":"airflow-flower"}]'
```

### What you think should happen instead

The following code should be updated to match how webserver ingress works
`flower-ingress.yaml` - [code section](https://github.com/apache/airflow/blob/daccc75b064c735636027b20f3edb82da69ffab1/chart/templates/flower/flower-ingress.yaml#L75)
```yaml
spec:
  rules:
    - http:
        paths:
          - backend:
              service:
                name: {{ $fullname }}-flower
                port:
                  name: flower-ui
```

