### PR TITLE
Enable scrolling on legend with high number of tasks.

### DIFF
--- a/airflow/www/static/js/dag/details/task/AllTaskDuration.tsx
+++ b/airflow/www/static/js/dag/details/task/AllTaskDuration.tsx
@@ -101,6 +101,7 @@ const AllTaskDuration = ({ showBar }: Props) => {
   const option: ReactEChartsProps["option"] = {
     legend: {
       orient: "horizontal",
+      type: "scroll",
       icon: "circle",
       data: legendData,
     },


### PR DESCRIPTION
In the task duration page across all tasks the legend can overlap with the chart when there are more tasks in the dag. Enable scrolling to ensure the legend doesn't enter chart

Current : 

![image](https://github.com/user-attachments/assets/fd566540-8f5e-4a23-be2b-dd0ac6786827)

With PR : 

![image](https://github.com/user-attachments/assets/1a20dcc7-df74-4d49-a4f3-5ad6bacb3c18)
