### PR TITLE
Move Create Dataset Event button above tabs

### DIFF
--- a/airflow/www/static/js/datasets/CreateDatasetEvent.tsx
+++ b/airflow/www/static/js/datasets/CreateDatasetEvent.tsx
@@ -34,13 +34,12 @@ import {
 } from "@chakra-ui/react";
 
 import { useContainerRef } from "src/context/containerRef";
-import { useCreateDatasetEvent } from "src/api";
-import type { Dataset } from "src/types/api-generated";
+import { useCreateDatasetEvent, useDataset } from "src/api";
 
 interface Props {
   isOpen: boolean;
   onClose: () => void;
-  dataset: Dataset;
+  uri: string;
 }
 
 function checkJsonString(str: string) {
@@ -52,22 +51,25 @@ function checkJsonString(str: string) {
   return true;
 }
 
-const CreateDatasetEventModal = ({ dataset, isOpen, onClose }: Props) => {
+const CreateDatasetEventModal = ({ uri, isOpen, onClose }: Props) => {
   const containerRef = useContainerRef();
   const [extra, setExtra] = useState("");
+  const { data: dataset } = useDataset({ uri });
 
   const isJson = checkJsonString(extra);
   const isDisabled = !!extra && !isJson;
 
   const { mutate: createDatasetEvent, isLoading } = useCreateDatasetEvent({
-    datasetId: dataset.id,
-    uri: dataset.uri,
+    datasetId: dataset?.id,
+    uri: dataset?.uri,
   });
 
   const onSubmit = () => {
     createDatasetEvent(extra ? JSON.parse(extra) : undefined);
     onClose();
   };
+
+  if (!dataset) return null;
 
   return (
     <Modal
@@ -78,7 +80,7 @@ const CreateDatasetEventModal = ({ dataset, isOpen, onClose }: Props) => {
     >
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>Manually create event for {dataset.uri}</ModalHeader>
+        <ModalHeader>Manually create event for {dataset?.uri}</ModalHeader>
         <ModalCloseButton />
         <ModalBody>
           <FormControl isInvalid={isDisabled}>

--- a/airflow/www/static/js/datasets/DatasetDetails.tsx
+++ b/airflow/www/static/js/datasets/DatasetDetails.tsx
@@ -21,24 +21,18 @@ import React from "react";
 import {
   Spinner,
   Flex,
-  IconButton,
-  useDisclosure,
   Grid,
   GridItem,
   Heading,
   Link,
   Box,
 } from "@chakra-ui/react";
-import { MdPlayArrow } from "react-icons/md";
 import { isEmpty } from "lodash";
 
 import { useDataset } from "src/api";
-import { useContainerRef } from "src/context/containerRef";
-import Tooltip from "src/components/Tooltip";
 import { getMetaValue } from "src/utils";
 import RenderedJsonField from "src/components/RenderedJsonField";
 
-import CreateDatasetEventModal from "./CreateDatasetEvent";
 import Events from "./DatasetEvents";
 
 const gridUrl = getMetaValue("grid_url");
@@ -49,8 +43,6 @@ interface Props {
 
 const DatasetDetails = ({ uri }: Props) => {
   const { data: dataset, isLoading } = useDataset({ uri });
-  const { isOpen, onToggle, onClose } = useDisclosure();
-  const containerRef = useContainerRef();
 
   const hasProducingTasks = !!dataset?.producingTasks?.length;
   const hasConsumingDags = !!dataset?.consumingDags?.length;
@@ -100,22 +92,6 @@ const DatasetDetails = ({ uri }: Props) => {
             })}
           </GridItem>
         )}
-        <GridItem colSpan={1} display="flex" justifyContent="flex-end">
-          <Tooltip
-            label="Manually create dataset event"
-            hasArrow
-            portalProps={{ containerRef }}
-          >
-            <IconButton
-              variant="outline"
-              colorScheme="blue"
-              aria-label="Manually create dataset event"
-              onClick={onToggle}
-            >
-              <MdPlayArrow />
-            </IconButton>
-          </Tooltip>
-        </GridItem>
       </Grid>
       {dataset?.extra && !isEmpty(dataset?.extra) && (
         <RenderedJsonField
@@ -128,13 +104,6 @@ const DatasetDetails = ({ uri }: Props) => {
       <Box mt={2}>
         {dataset && dataset.id && <Events datasetId={dataset.id} showLabel />}
       </Box>
-      {dataset && (
-        <CreateDatasetEventModal
-          isOpen={isOpen}
-          onClose={onClose}
-          dataset={dataset}
-        />
-      )}
     </Flex>
   );
 };

--- a/airflow/www/static/js/datasets/Main.tsx
+++ b/airflow/www/static/js/datasets/Main.tsx
@@ -32,15 +32,20 @@ import {
   TabPanel,
   TabPanels,
   Text,
+  Flex,
+  useDisclosure,
+  IconButton,
 } from "@chakra-ui/react";
 import { HiDatabase } from "react-icons/hi";
-import { MdEvent, MdAccountTree, MdDetails } from "react-icons/md";
+import { MdEvent, MdAccountTree, MdDetails, MdPlayArrow } from "react-icons/md";
 
 import Time from "src/components/Time";
 import BreadcrumbText from "src/components/BreadcrumbText";
 import { useOffsetTop } from "src/utils";
 import { useDatasetDependencies } from "src/api";
 import URLSearchParamsWrapper from "src/utils/URLSearchParamWrapper";
+import Tooltip from "src/components/Tooltip";
+import { useContainerRef } from "src/context/containerRef";
 
 import DatasetEvents from "./DatasetEvents";
 import DatasetsList from "./DatasetsList";
@@ -48,6 +53,7 @@ import DatasetDetails from "./DatasetDetails";
 import type { OnSelectProps } from "./types";
 import Graph from "./Graph";
 import SearchBar from "./SearchBar";
+import CreateDatasetEventModal from "./CreateDatasetEvent";
 
 const DATASET_URI_PARAM = "uri";
 const DAG_ID_PARAM = "dag_id";
@@ -88,6 +94,9 @@ const Datasets = () => {
 
   const { data: datasetDependencies, isLoading } = useDatasetDependencies();
   const [searchParams, setSearchParams] = useSearchParams();
+
+  const { isOpen, onToggle, onClose } = useDisclosure();
+  const containerRef = useContainerRef();
 
   const selectedUri = decodeURIComponent(
     searchParams.get(DATASET_URI_PARAM) || ""
@@ -133,46 +142,68 @@ const Datasets = () => {
 
   return (
     <Box alignItems="flex-start" justifyContent="space-between">
-      <Breadcrumb
-        ml={3}
-        pt={2}
-        mt={4}
-        separator={
-          <Heading as="h3" size="md" color="gray.300">
-            /
-          </Heading>
-        }
+      <Flex
+        grow={1}
+        justifyContent="space-between"
+        alignItems="flex-end"
+        p={3}
+        pb={0}
       >
-        <BreadcrumbItem>
-          <BreadcrumbLink
-            onClick={() => onSelect()}
-            isCurrentPage={!selectedUri}
-          >
-            <Heading as="h3" size="md">
-              Datasets
+        <Breadcrumb
+          mt={4}
+          separator={
+            <Heading as="h3" size="md" color="gray.300">
+              /
             </Heading>
-          </BreadcrumbLink>
-        </BreadcrumbItem>
+          }
+        >
+          <BreadcrumbItem>
+            <BreadcrumbLink
+              onClick={() => onSelect()}
+              isCurrentPage={!selectedUri}
+            >
+              <Heading as="h3" size="md">
+                Datasets
+              </Heading>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
 
+          {selectedUri && (
+            <BreadcrumbItem isCurrentPage={!!selectedUri && !selectedTimestamp}>
+              <BreadcrumbLink onClick={() => onSelect({ uri: selectedUri })}>
+                <BreadcrumbText label="URI" value={selectedUri} />
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+          )}
+
+          {selectedTimestamp && (
+            <BreadcrumbItem isCurrentPage={!!selectedTimestamp}>
+              <BreadcrumbLink>
+                <BreadcrumbText
+                  label="Timestamp"
+                  value={<Time dateTime={selectedTimestamp} />}
+                />
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+          )}
+        </Breadcrumb>
         {selectedUri && (
-          <BreadcrumbItem isCurrentPage={!!selectedUri && !selectedTimestamp}>
-            <BreadcrumbLink onClick={() => onSelect({ uri: selectedUri })}>
-              <BreadcrumbText label="URI" value={selectedUri} />
-            </BreadcrumbLink>
-          </BreadcrumbItem>
+          <Tooltip
+            label="Manually create dataset event"
+            hasArrow
+            portalProps={{ containerRef }}
+          >
+            <IconButton
+              variant="outline"
+              colorScheme="blue"
+              aria-label="Manually create dataset event"
+              onClick={onToggle}
+            >
+              <MdPlayArrow />
+            </IconButton>
+          </Tooltip>
         )}
-
-        {selectedTimestamp && (
-          <BreadcrumbItem isCurrentPage={!!selectedTimestamp}>
-            <BreadcrumbLink>
-              <BreadcrumbText
-                label="Timestamp"
-                value={<Time dateTime={selectedTimestamp} />}
-              />
-            </BreadcrumbLink>
-          </BreadcrumbItem>
-        )}
-      </Breadcrumb>
+      </Flex>
       <Tabs ref={contentRef} isLazy index={tabIndex} onChange={onChangeTab}>
         <TabList>
           {!selectedUri && (
@@ -249,6 +280,13 @@ const Datasets = () => {
           )}
         </TabPanels>
       </Tabs>
+      {selectedUri && (
+        <CreateDatasetEventModal
+          isOpen={isOpen}
+          onClose={onClose}
+          uri={selectedUri}
+        />
+      )}
     </Box>
   );
 };


### PR DESCRIPTION
We moved the datasets view into a tab layout. The button to manually create a dataset event was only under the Dataset Details tab. Now it is moved to be on the same level as the breadcrumb when a dataset is selected. Now you can create a new dataset event from any tab and have to click back-and-forth.

<img width="371" alt="Screenshot 2024-08-01 at 11 15 23 AM" src="https://github.com/user-attachments/assets/6f770c60-075a-4760-aafb-6a136e5d2086">

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
