### PR TITLE
Fix AWS Redshift operators and sensors

### DIFF
--- a/tests/providers/amazon/aws/operators/test_redshift_cluster.py
+++ b/tests/providers/amazon/aws/operators/test_redshift_cluster.py
@@ -369,7 +369,7 @@ class TestResumeClusterOperator:
         mock_get_waiter.assert_called_with("cluster_resumed")
         assert mock_get_waiter.call_count == 2
         mock_get_waiter().wait.assert_called_once_with(
-            ClusterIdentifier="test_cluster", WaiterConfig={"Delay": 15, "MaxAttempts": 20}
+            ClusterIdentifier="test_cluster", WaiterConfig={"Delay": 30, "MaxAttempts": 30}
         )
 
     def test_resume_cluster_failure(self):

--- a/tests/providers/amazon/aws/operators/test_redshift_cluster.py
+++ b/tests/providers/amazon/aws/operators/test_redshift_cluster.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 from unittest import mock
+from unittest.mock import Mock
 
 import boto3
 import pytest
@@ -318,6 +319,7 @@ class TestResumeClusterOperator:
             task_id="task_test",
             cluster_identifier="test_cluster",
             aws_conn_id="aws_conn_test",
+            wait_for_completion=True,
             deferrable=True,
         )
 
@@ -340,6 +342,7 @@ class TestResumeClusterOperator:
             task_id="task_test",
             cluster_identifier="test_cluster",
             aws_conn_id="aws_conn_test",
+            wait_for_completion=True,
             deferrable=True,
         )
 
@@ -366,7 +369,7 @@ class TestResumeClusterOperator:
         mock_get_waiter.assert_called_with("cluster_resumed")
         assert mock_get_waiter.call_count == 2
         mock_get_waiter().wait.assert_called_once_with(
-            ClusterIdentifier="test_cluster", WaiterConfig={"Delay": 10, "MaxAttempts": 10}
+            ClusterIdentifier="test_cluster", WaiterConfig={"Delay": 15, "MaxAttempts": 20}
         )
 
     def test_resume_cluster_failure(self):
@@ -437,6 +440,22 @@ class TestPauseClusterOperator:
             redshift_operator.execute(None)
         assert mock_conn.pause_cluster.call_count == 10
 
+    @mock.patch.object(RedshiftHook, "get_waiter")
+    @mock.patch.object(RedshiftHook, "get_conn")
+    def test_pause_cluster_wait_for_completion(self, mock_get_conn, mock_get_waiter):
+        """Test Pause cluster operator with defer when deferrable param is true"""
+        mock_get_conn.return_value.pause_cluster.return_value = True
+        waiter = Mock()
+        mock_get_waiter.return_value = waiter
+
+        redshift_operator = RedshiftPauseClusterOperator(
+            task_id="task_test", cluster_identifier="test_cluster", wait_for_completion=True
+        )
+
+        redshift_operator.execute(context=None)
+
+        waiter.wait.assert_called_once()
+
     @mock.patch.object(RedshiftHook, "cluster_status")
     @mock.patch.object(RedshiftHook, "get_conn")
     def test_pause_cluster_deferrable_mode(self, mock_get_conn, mock_cluster_status):
@@ -445,7 +464,7 @@ class TestPauseClusterOperator:
         mock_cluster_status.return_value = "available"
 
         redshift_operator = RedshiftPauseClusterOperator(
-            task_id="task_test", cluster_identifier="test_cluster", deferrable=True
+            task_id="task_test", cluster_identifier="test_cluster", wait_for_completion=True, deferrable=True
         )
 
         with pytest.raises(TaskDeferred) as exc:
@@ -466,7 +485,7 @@ class TestPauseClusterOperator:
         mock_cluster_status.return_value = "deleting"
 
         redshift_operator = RedshiftPauseClusterOperator(
-            task_id="task_test", cluster_identifier="test_cluster", deferrable=True
+            task_id="task_test", cluster_identifier="test_cluster", wait_for_completion=True, deferrable=True
         )
 
         with pytest.raises(AirflowException):

--- a/tests/system/providers/amazon/aws/example_redshift.py
+++ b/tests/system/providers/amazon/aws/example_redshift.py
@@ -121,7 +121,7 @@ with DAG(
         task_id="wait_cluster_paused",
         cluster_identifier=redshift_cluster_identifier,
         target_status="paused",
-        poke_interval=15,
+        poke_interval=30,
         timeout=60 * 30,
     )
 
@@ -136,7 +136,7 @@ with DAG(
         task_id="wait_cluster_available_after_resume",
         cluster_identifier=redshift_cluster_identifier,
         target_status="available",
-        poke_interval=15,
+        poke_interval=30,
         timeout=60 * 30,
     )
 


### PR DESCRIPTION
Some Redshift operators assume that when `deferrable` is `True`, it means the operator should wait. This is wrong. This is usually a flag `wait_for_completion` that set this behavior. I also updated some default values in operators/sensors depending on the underlying API called

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
