### PR TITLE
Adjust gantt width based on task history dates

### DIFF
--- a/airflow/www/static/js/dag/details/gantt/Row.tsx
+++ b/airflow/www/static/js/dag/details/gantt/Row.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React from "react";
+import React, { useEffect } from "react";
 import { Box } from "@chakra-ui/react";
 import useSelection from "src/dag/useSelection";
 import { boxSize } from "src/dag/StatusBox";
@@ -32,6 +32,11 @@ interface Props {
   task: Task;
   ganttStartDate?: string | null;
   ganttEndDate?: string | null;
+  setGanttDuration?: (
+    queued: string | null | undefined,
+    start: string | null | undefined,
+    end: string | null | undefined
+  ) => void;
 }
 
 const dagId = getMetaValue("dag_id");
@@ -42,6 +47,7 @@ const Row = ({
   task,
   ganttStartDate,
   ganttEndDate,
+  setGanttDuration,
 }: Props) => {
   const {
     selected: { runId, taskId },
@@ -58,6 +64,15 @@ const Row = ({
 
   const isSelected = taskId === instance?.taskId;
   const isOpen = openGroupIds.includes(task.id || "");
+
+  // Adjust gantt start/end if the ti history dates are out of bounds
+  useEffect(() => {
+    tiHistory?.forEach(
+      (tih) =>
+        setGanttDuration &&
+        setGanttDuration(tih.queuedWhen, tih.startDate, tih.endDate)
+    );
+  }, [tiHistory, setGanttDuration]);
 
   return (
     <div>

--- a/airflow/www/static/js/dag/details/gantt/index.tsx
+++ b/airflow/www/static/js/dag/details/gantt/index.tsx
@@ -106,33 +106,51 @@ const Gantt = ({ openGroupIds, gridScrollRef, ganttScrollRef }: Props) => {
 
   const dagRun = dagRuns.find((dr) => dr.runId === runId);
 
-  let startDate = dagRun?.queuedAt || dagRun?.startDate;
-  // @ts-ignore
-  let endDate = dagRun?.endDate ?? moment().add(1, "s").toString();
+  const [startDate, setStartDate] = useState(
+    dagRun?.queuedAt || dagRun?.startDate
+  );
+
+  const [endDate, setEndDate] = useState(
+    // @ts-ignore
+    dagRun?.endDate ?? moment().add(1, "s").toString()
+  );
 
   // Check if any task instance dates are outside the bounds of the dag run dates and update our min start and max end
-  groups.children?.forEach((task) => {
-    const taskInstance = task.instances.find((ti) => ti.runId === runId);
-    if (
-      taskInstance?.queuedDttm &&
-      (!startDate ||
-        Date.parse(taskInstance.queuedDttm) < Date.parse(startDate))
-    ) {
-      startDate = taskInstance.queuedDttm;
-    } else if (
-      taskInstance?.startDate &&
-      (!startDate || Date.parse(taskInstance.startDate) < Date.parse(startDate))
-    ) {
-      startDate = taskInstance.startDate;
-    }
+  const setGanttDuration = useCallback(
+    (
+      queued: string | null | undefined,
+      start: string | null | undefined,
+      end: string | null | undefined
+    ) => {
+      if (
+        queued &&
+        (!startDate || Date.parse(queued) < Date.parse(startDate))
+      ) {
+        setStartDate(queued);
+      } else if (
+        start &&
+        (!startDate || Date.parse(start) < Date.parse(startDate))
+      ) {
+        setStartDate(start);
+      }
 
-    if (
-      taskInstance?.endDate &&
-      (!endDate || Date.parse(taskInstance.endDate) > Date.parse(endDate))
-    ) {
-      endDate = taskInstance.endDate;
-    }
-  });
+      if (end && (!endDate || Date.parse(end) > Date.parse(endDate))) {
+        setEndDate(end);
+      }
+    },
+    [startDate, endDate, setStartDate, setEndDate]
+  );
+
+  useEffect(() => {
+    groups.children?.forEach((task) => {
+      const taskInstance = task.instances.find((ti) => ti.runId === runId);
+      setGanttDuration(
+        taskInstance?.queuedDttm,
+        taskInstance?.startDate,
+        taskInstance?.endDate
+      );
+    });
+  }, [groups.children, runId, setGanttDuration]);
 
   const numBars = Math.round(width / 100);
   const runDuration = getDuration(startDate, endDate);
@@ -195,6 +213,7 @@ const Gantt = ({ openGroupIds, gridScrollRef, ganttScrollRef }: Props) => {
                 task={c}
                 ganttStartDate={startDate}
                 ganttEndDate={endDate}
+                setGanttDuration={setGanttDuration}
                 key={`gantt-${c.id}`}
               />
             ))}


### PR DESCRIPTION
We adjust the gantt chart start and end dates based on the task instances rendered, but we weren't doing that for Task Try History. Sometimes, that led to tries being out-of-bound and not rendering in the gantt chart. This PR fixes that.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
