### PR TITLE
Update `is_called_from_test_code`

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -331,7 +331,7 @@ class TracebackSessionForTests:
         raise RuntimeError(
             "TracebackSessionForTests object was used but internal API is enabled. "
             "Only test code is allowed to use this object.\n"
-            f"Called from:\n    {frame_summary.filename}: {frame_summary.lineno}{frame_summary.colno}\n"
+            f"Called from:\n    {frame_summary.filename}: {frame_summary.lineno}\n"
             f"     {frame_summary.line}\n\n"
             "You'll need to ensure you are making only RPC calls with this object. "
             "The stack list below will show where the TracebackSession object was called:\n"
@@ -382,8 +382,6 @@ class TracebackSessionForTests:
                 if tb.filename.startswith(AIRFLOW_TESTS_PATH):
                     # this is a session created directly in the test code
                     return True, None
-                else:
-                    return False, tb
         # if it is from elsewhere.... Why???? We should return False in order to crash to find out
         # The traceback line will be always 3rd (two bottom ones are Airflow)
         return False, self.traceback[-2]


### PR DESCRIPTION
Related #41067.

The way I see it is, if the stacktrace where the session has been created contains one test file, it means the session has been created in tests?

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
