### PR TITLE
Time zone is not taken into account in run_id and execution_date

### DIFF
--- a/airflow/api_connexion/schemas/task_instance_schema.py
+++ b/airflow/api_connexion/schemas/task_instance_schema.py
@@ -82,6 +82,10 @@ class TaskInstanceSchema(SQLAlchemySchema):
             return get_value(slamiss_instance, attr, default)
         elif attr == "rendered_fields":
             return get_value(obj[0], "rendered_task_instance_fields.rendered_fields", default)
+        elif attr == "execution_date":
+            from airflow.utils import timezone
+            return timezone.coerce_datetime(get_value(obj[0], "execution_date", None))
+
         return get_value(obj[0], attr, default)
 
 

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -242,8 +242,9 @@ class DagRun(Base, LoggingMixin):
 
     def __repr__(self):
         return (
-            f"<DagRun {self.dag_id} @ {self.execution_date}: {self.run_id}, state:{self.state}, "
-            f"queued_at: {self.queued_at}. externally triggered: {self.external_trigger}>"
+            f"<DagRun {self.dag_id} @ {timezone.coerce_datetime(self.execution_date)}: {self.run_id}, "
+            f"state:{self.state}, queued_at: {timezone.coerce_datetime(self.queued_at)}. "
+            f"externally triggered: {self.external_trigger}>"
         )
 
     @validates("run_id")

--- a/airflow/utils/timezone.py
+++ b/airflow/utils/timezone.py
@@ -217,20 +217,21 @@ def coerce_datetime(v: dt.datetime, tz: dt.tzinfo | None = None) -> DateTime: ..
 
 
 def coerce_datetime(v: dt.datetime | None, tz: dt.tzinfo | None = None) -> DateTime | None:
-    """Convert ``v`` into a timezone-aware ``pendulum.DateTime``.
+    """Convert ``v`` into a timezone-aware ``pendulum.DateTime`` and then adjust it to specified tz.
 
     * If ``v`` is *None*, *None* is returned.
     * If ``v`` is a naive datetime, it is converted to an aware Pendulum DateTime.
     * If ``v`` is an aware datetime, it is converted to a Pendulum DateTime.
-      Note that ``tz`` is **not** taken into account in this case; the datetime
-      will maintain its original tzinfo!
     """
     if v is None:
         return None
+    if tz is None:
+        from airflow.settings import TIMEZONE
+        tz = TIMEZONE
     if isinstance(v, DateTime):
-        return v if v.tzinfo else make_aware(v, tz)
+        return v.astimezone(tz) if v.tzinfo else make_aware(v, tz).astimezone(tz)
     # Only dt.datetime is left here.
-    return pendulum.instance(v if v.tzinfo else make_aware(v, tz))
+    return pendulum.instance(v if v.tzinfo else make_aware(v, tz)).astimezone(tz)
 
 
 def td_format(td_object: None | dt.timedelta | float | int) -> str | None:

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -181,7 +181,7 @@ def encode_dag_run(
         "start_date": datetime_to_string(dag_run.start_date),
         "end_date": datetime_to_string(dag_run.end_date),
         "state": dag_run.state,
-        "execution_date": datetime_to_string(dag_run.execution_date),
+        "execution_date": datetime_to_string(timezone.coerce_datetime(dag_run.execution_date)),
         "data_interval_start": datetime_to_string(dag_run.data_interval_start),
         "data_interval_end": datetime_to_string(dag_run.data_interval_end),
         "run_type": dag_run.run_type,

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1739,12 +1739,21 @@ class Airflow(AirflowBaseView):
                 "trigger",
                 "triggerer_job",
             ]
+
+            def get_value_field(obj, name):
+                if name == "try_number":
+                    return getattr(obj, "_try_number")
+                elif name == 'execution_date':
+                    return timezone.coerce_datetime(ti.execution_date)
+                else:
+                    return getattr(obj, name)
+
             # Some fields on TI are deprecated, but we don't want those warnings here.
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", RemovedInAirflow3Warning)
                 all_ti_attrs = (
-                    # fetching the value of _try_number to be shown under name try_number in UI
-                    (name, getattr(ti, "_try_number" if name == "try_number" else name))
+                    # fetching values of task_instance to be shown under fixed names in UI
+                    (name, get_value_field(ti, name))
                     for name in dir(ti)
                     if not name.startswith("_") and name not in ti_attrs_to_skip
                 )

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1740,11 +1740,11 @@ class Airflow(AirflowBaseView):
                 "triggerer_job",
             ]
 
-            def get_value_field(obj, name):
+            def get_field_value(obj, name):
                 if name == "try_number":
                     return getattr(obj, "_try_number")
                 elif name == 'execution_date':
-                    return timezone.coerce_datetime(ti.execution_date)
+                    return timezone.coerce_datetime(obj.execution_date)
                 else:
                     return getattr(obj, name)
 
@@ -1753,7 +1753,7 @@ class Airflow(AirflowBaseView):
                 warnings.simplefilter("ignore", RemovedInAirflow3Warning)
                 all_ti_attrs = (
                     # fetching values of task_instance to be shown under fixed names in UI
-                    (name, get_value_field(ti, name))
+                    (name, get_field_value(ti, name))
                     for name in dir(ti)
                     if not name.startswith("_") and name not in ti_attrs_to_skip
                 )


### PR DESCRIPTION
Hi,

We noticed that time zone from config ("default_timezone = Europe/Moscow") is not taken into account when generating "run_id". 
Also "execution_date" field is always shown in UTC in Airflow UI, see my screenshots.

I created this patch to generate "run_id" and to display "execution_date" in specified default time zone (get "default_timezone" option from configuration). 
Moreover I call "coerce_datetime()" function in api, thus links to task instances will have "execution_date" parameter with correct time zone in UI.

See other discussion:
https://github.com/apache/airflow/discussions/27471

![Screenshot from 2024-08-01 23-28-24](https://github.com/user-attachments/assets/00b56ff0-b80f-47ed-9a1d-9af5ed18a016)
![Screenshot from 2024-08-01 23-29-42](https://github.com/user-attachments/assets/5f0894f4-112f-4ae6-84a2-961deec78eed)
