### PR TITLE
Don't reserialize DAG if no revision's applied

### DIFF
--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -1660,16 +1660,16 @@ def upgradedb(
     if errors_seen:
         exit(1)
 
-    current_revision = _get_current_revision(session=session)
-    if not to_revision and not current_revision and not use_migration_files:
+    if not to_revision and not _get_current_revision(session=session) and not use_migration_files:
         # Don't load default connections
         # New DB; initialize and exit
         initdb(session=session, load_connections=False)
         return
 
-    previous_revision = current_revision
     with create_global_lock(session=session, lock=DBLocks.MIGRATIONS):
         import sqlalchemy.pool
+
+        previous_revision = _get_current_revision(session=session)
 
         log.info("Creating tables")
         val = os.environ.get("AIRFLOW__DATABASE__SQL_ALCHEMY_MAX_SIZE")
@@ -1686,12 +1686,12 @@ def upgradedb(
                 os.environ["AIRFLOW__DATABASE__SQL_ALCHEMY_MAX_SIZE"] = val
             settings.reconfigure_orm()
 
-    current_revision = to_revision or _get_current_revision(session=session)
-    if reserialize_dags and current_revision != previous_revision:
-        _reserialize_dags(session=session)
+        current_revision = _get_current_revision(session=session)
 
-    add_default_pool_if_not_exists(session=session)
-    synchronize_log_template(session=session)
+        if reserialize_dags and current_revision != previous_revision:
+            _reserialize_dags(session=session)
+        add_default_pool_if_not_exists(session=session)
+        synchronize_log_template(session=session)
 
 
 @provide_session


### PR DESCRIPTION
This saves some resource and helps avoid issues in dynamic DAG generation from the user.

Close #40082.