### PR TITLE
feat: [openlineage] add debug facet to all events

### DIFF
--- a/airflow/providers/openlineage/conf.py
+++ b/airflow/providers/openlineage/conf.py
@@ -145,3 +145,9 @@ def execution_timeout() -> int:
 def include_full_task_info() -> bool:
     """[openlineage] include_full_task_info."""
     return conf.getboolean(_CONFIG_SECTION, "include_full_task_info", fallback="False")
+
+
+@cache
+def debug_mode() -> bool:
+    """[openlineage] debug_mode."""
+    return conf.getboolean(_CONFIG_SECTION, "debug_mode", fallback="False")

--- a/airflow/providers/openlineage/facets/AirflowDebugRunFacet.json
+++ b/airflow/providers/openlineage/facets/AirflowDebugRunFacet.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "AirflowDebugRunFacet": {
+        "allOf": [
+          {
+            "$ref": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunFacet"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "packages": {
+                "description": "The names and versions of all installed Python packages.",
+                "type": "object",
+                "additionalProperties": true
+              }
+            },
+            "required": ["packages"]
+          }
+        ],
+        "type": "object"
+      }
+    },
+    "type": "object",
+    "properties": {
+      "debug": {
+        "$ref": "#/$defs/AirflowDebugRunFacet"
+      }
+    }
+  }

--- a/airflow/providers/openlineage/plugins/adapter.py
+++ b/airflow/providers/openlineage/plugins/adapter.py
@@ -41,6 +41,7 @@ from airflow.providers.openlineage import __version__ as OPENLINEAGE_PROVIDER_VE
 from airflow.providers.openlineage.utils.utils import (
     OpenLineageRedactor,
     get_airflow_dag_run_facet,
+    get_airflow_debug_facet,
     get_airflow_state_run_facet,
 )
 from airflow.stats import Stats
@@ -361,7 +362,7 @@ class OpenLineageAdapter(LoggingMixin):
                     job_name=dag_run.dag_id,
                     nominal_start_time=nominal_start_time,
                     nominal_end_time=nominal_end_time,
-                    run_facets=get_airflow_dag_run_facet(dag_run),
+                    run_facets={**get_airflow_dag_run_facet(dag_run), **get_airflow_debug_facet()},
                 ),
                 inputs=[],
                 outputs=[],
@@ -385,7 +386,7 @@ class OpenLineageAdapter(LoggingMixin):
                         dag_id=dag_run.dag_id,
                         execution_date=dag_run.execution_date,
                     ),
-                    facets={**get_airflow_state_run_facet(dag_run)},
+                    facets={**get_airflow_state_run_facet(dag_run), **get_airflow_debug_facet()},
                 ),
                 inputs=[],
                 outputs=[],
@@ -414,6 +415,7 @@ class OpenLineageAdapter(LoggingMixin):
                             message=msg, programmingLanguage="python"
                         ),
                         **get_airflow_state_run_facet(dag_run),
+                        **get_airflow_debug_facet(),
                     },
                 ),
                 inputs=[],

--- a/airflow/providers/openlineage/plugins/facets.py
+++ b/airflow/providers/openlineage/plugins/facets.py
@@ -102,6 +102,13 @@ class AirflowDagRunFacet(RunFacet):
 
 
 @define
+class AirflowDebugRunFacet(RunFacet):
+    """Airflow Debug run facet."""
+
+    packages: dict
+
+
+@define
 class UnknownOperatorInstance(RedactMixin):
     """
     Describes an unknown operator.

--- a/airflow/providers/openlineage/provider.yaml
+++ b/airflow/providers/openlineage/provider.yaml
@@ -168,3 +168,11 @@ config:
         example: ~
         type: boolean
         version_added: 1.10.0
+      debug_mode:
+        description: |
+          If true, OpenLineage events will include information useful for debugging - potentially
+          containing large fields e.g. all installed packages and their versions.
+        default: "False"
+        example: ~
+        type: boolean
+        version_added: 1.11.0

--- a/docs/apache-airflow-providers-openlineage/guides/developer.rst
+++ b/docs/apache-airflow-providers-openlineage/guides/developer.rst
@@ -137,7 +137,7 @@ Authors of tests need to remember the condition of calling different OL methods 
 ``get_openlineage_facets_on_start`` is called before ``execute``, and as such, must not depend on values
 that are set there.
 
-See :ref:`local_troubleshooting:openlineage` for details on how to troubleshoot OpenLineage locally.
+See :ref:`troubleshooting:openlineage` for details on how to troubleshoot OpenLineage locally.
 
 There is no existing framework for system testing OpenLineage integration, but the easiest way it can be achieved is
 by comparing emitted events (f.e. with ``FileTransport``) against expected ones.
@@ -299,7 +299,7 @@ creating a gap in pipeline observability.
 Even with unit tests, an Extractor may still not be operating as expected.
 The easiest way to tell if data isn't coming through correctly is if the UI elements are not showing up correctly in the Lineage tab.
 
-See :ref:`local_troubleshooting:openlineage` for details on how to troubleshoot OpenLineage locally.
+See :ref:`troubleshooting:openlineage` for details on how to troubleshoot OpenLineage locally.
 
 Example
 ^^^^^^^
@@ -573,9 +573,9 @@ OpenLineage reflects this structure in its Job Hierarchy model.
 
 TaskInstance events' ParentRunFacet references the originating DAG run.
 
-.. _local_troubleshooting:openlineage:
+.. _troubleshooting:openlineage:
 
-Local troubleshooting
+Troubleshooting
 =====================
 
 When testing code locally, `Marquez <https://marquezproject.ai/docs/quickstart>`_ can be used to inspect the data being emitted—or not being emitted.
@@ -584,6 +584,19 @@ If data is being emitted from the Extractor as expected but isn't making it to t
 then the Extractor is fine and an issue should be opened up in OpenLineage. However, if data is not being emitted properly,
 it is likely that more unit tests are needed to cover Extractor behavior.
 Marquez can help you pinpoint which facets are not being formed properly so you know where to add test coverage.
+
+Debug settings
+^^^^^^^^^^^^^^
+For debugging purposes, ensure that the `Airflow logging level <https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#logging-level>`_
+is set to ``DEBUG`` and that the :ref:`debug_mode <options:debug_mode>` is enabled for OpenLineage integration.
+This will increase the detail in Airflow logs and include additional environmental information in OpenLineage events.
+
+When seeking help with debugging, always try to provide the following:
+
+-    Airflow scheduler logs with the logging level set to DEBUG
+-    Airflow worker logs (task logs) with the logging level set to DEBUG
+-    OpenLineage events with debug_mode enabled
+
 
 Where can I learn more?
 =======================

--- a/docs/apache-airflow-providers-openlineage/guides/user.rst
+++ b/docs/apache-airflow-providers-openlineage/guides/user.rst
@@ -189,8 +189,6 @@ If not set, it's using ``default`` namespace. Provide the name of the namespace 
 
   AIRFLOW__OPENLINEAGE__NAMESPACE='my-team-airflow-instance'
 
-.. _options:disable:
-
 Timeout
 ^^^^^^^
 
@@ -210,6 +208,7 @@ The code runs with default timeout of 10 seconds. You can increase this by setti
 
   AIRFLOW__OPENLINEAGE__EXECUTION_TIMEOUT=60
 
+.. _options:disable:
 
 Disable
 ^^^^^^^
@@ -283,6 +282,10 @@ serializing only a few known attributes, we exclude certain non-serializable ele
 
 ``AIRFLOW__OPENLINEAGE__INCLUDE_FULL_TASK_INFO`` environment variable is an equivalent.
 
+.. code-block:: ini
+
+  AIRFLOW__OPENLINEAGE__INCLUDE_FULL_TASK_INFO=true
+
 .. warning::
 
   By setting this variable to true, OpenLineage integration does not control the size of event you sent. It can potentially include elements that are megabytes in size or larger, depending on the size of data you pass to the task.
@@ -324,6 +327,31 @@ a string of semicolon separated full import paths to ``custom_run_facets`` optio
 
   AIRFLOW__OPENLINEAGE__CUSTOM_RUN_FACETS='full.path.to.get_my_custom_facet;full.path.to.another_custom_facet_function'
 
+.. _options:debug_mode:
+
+Debug Mode
+^^^^^^^^^^
+
+You can enable sending additional information in OpenLineage events that can be useful for debugging and
+reproducing your environment setup by setting ``debug_mode`` option to ``true`` in Airflow configuration.
+
+.. code-block:: ini
+
+    [openlineage]
+    transport = {"type": "http", "url": "http://example.com:5000", "endpoint": "api/v1/lineage"}
+    debug_mode = true
+
+``AIRFLOW__OPENLINEAGE__DEBUG_MODE`` environment variable is an equivalent.
+
+.. code-block:: ini
+
+  AIRFLOW__OPENLINEAGE__DEBUG_MODE=true
+
+.. warning::
+
+  By setting this variable to true, OpenLineage integration may log and emit extensive details. It should only be enabled temporary for debugging purposes.
+
+
 Enabling OpenLineage on DAG/task level
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -334,6 +362,12 @@ To enable this policy, set the ``selective_enable`` option to True in the [openl
 
     [openlineage]
     selective_enable = True
+
+``AIRFLOW__OPENLINEAGE__SELECTIVE_ENABLE`` environment variable is an equivalent.
+
+.. code-block:: ini
+
+  AIRFLOW__OPENLINEAGE__SELECTIVE_ENABLE=true
 
 
 While ``selective_enable`` enables selective control, the ``disabled`` :ref:`option <options:disable>` still has precedence.
@@ -383,7 +417,7 @@ Disabling DAG-level lineage while enabling task-level lineage might cause errors
 Troubleshooting
 ===============
 
-See :ref:`local_troubleshooting:openlineage` for details on how to troubleshoot OpenLineage locally.
+See :ref:`troubleshooting:openlineage` for details on how to troubleshoot OpenLineage.
 
 
 Adding support for custom Operators

--- a/tests/providers/openlineage/plugins/test_adapter.py
+++ b/tests/providers/openlineage/plugins/test_adapter.py
@@ -47,6 +47,7 @@ from airflow.providers.openlineage.extractors import OperatorLineage
 from airflow.providers.openlineage.plugins.adapter import _PRODUCER, OpenLineageAdapter
 from airflow.providers.openlineage.plugins.facets import (
     AirflowDagRunFacet,
+    AirflowDebugRunFacet,
     AirflowStateRunFacet,
 )
 from airflow.providers.openlineage.utils.utils import get_airflow_job_facet
@@ -527,10 +528,11 @@ def test_emit_failed_event_with_additional_information(mock_stats_incr, mock_sta
     mock_stats_timer.assert_called_with("ol.emit.attempts")
 
 
+@mock.patch("airflow.providers.openlineage.conf.debug_mode", return_value=True)
 @mock.patch("airflow.providers.openlineage.plugins.adapter.generate_static_uuid")
 @mock.patch("airflow.providers.openlineage.plugins.adapter.Stats.timer")
 @mock.patch("airflow.providers.openlineage.plugins.adapter.Stats.incr")
-def test_emit_dag_started_event(mock_stats_incr, mock_stats_timer, generate_static_uuid):
+def test_emit_dag_started_event(mock_stats_incr, mock_stats_timer, generate_static_uuid, mock_debug_mode):
     random_uuid = "9d3b14f7-de91-40b6-aeef-e887e2c7673e"
     client = MagicMock()
     adapter = OpenLineageAdapter(client)
@@ -600,6 +602,7 @@ def test_emit_dag_started_event(mock_stats_incr, mock_stats_timer, generate_stat
                                 "start_date": event_time.isoformat(),
                             },
                         ),
+                        "debug": AirflowDebugRunFacet(packages=ANY),
                     },
                 ),
                 job=Job(
@@ -630,11 +633,14 @@ def test_emit_dag_started_event(mock_stats_incr, mock_stats_timer, generate_stat
     mock_stats_timer.assert_called_with("ol.emit.attempts")
 
 
+@mock.patch("airflow.providers.openlineage.conf.debug_mode", return_value=True)
 @mock.patch.object(DagRun, "get_task_instances")
 @mock.patch("airflow.providers.openlineage.plugins.adapter.generate_static_uuid")
 @mock.patch("airflow.providers.openlineage.plugins.adapter.Stats.timer")
 @mock.patch("airflow.providers.openlineage.plugins.adapter.Stats.incr")
-def test_emit_dag_complete_event(mock_stats_incr, mock_stats_timer, generate_static_uuid, mocked_get_tasks):
+def test_emit_dag_complete_event(
+    mock_stats_incr, mock_stats_timer, generate_static_uuid, mocked_get_tasks, mock_debug_mode
+):
     random_uuid = "9d3b14f7-de91-40b6-aeef-e887e2c7673e"
     client = MagicMock()
     adapter = OpenLineageAdapter(client)
@@ -684,7 +690,8 @@ def test_emit_dag_complete_event(mock_stats_incr, mock_stats_timer, generate_sta
                                 task_1.task_id: TaskInstanceState.SKIPPED,
                                 task_2.task_id: TaskInstanceState.FAILED,
                             },
-                        )
+                        ),
+                        "debug": AirflowDebugRunFacet(packages=ANY),
                     },
                 ),
                 job=Job(
@@ -708,11 +715,14 @@ def test_emit_dag_complete_event(mock_stats_incr, mock_stats_timer, generate_sta
     mock_stats_timer.assert_called_with("ol.emit.attempts")
 
 
+@mock.patch("airflow.providers.openlineage.conf.debug_mode", return_value=True)
 @mock.patch.object(DagRun, "get_task_instances")
 @mock.patch("airflow.providers.openlineage.plugins.adapter.generate_static_uuid")
 @mock.patch("airflow.providers.openlineage.plugins.adapter.Stats.timer")
 @mock.patch("airflow.providers.openlineage.plugins.adapter.Stats.incr")
-def test_emit_dag_failed_event(mock_stats_incr, mock_stats_timer, generate_static_uuid, mocked_get_tasks):
+def test_emit_dag_failed_event(
+    mock_stats_incr, mock_stats_timer, generate_static_uuid, mocked_get_tasks, mock_debug_mode
+):
     random_uuid = "9d3b14f7-de91-40b6-aeef-e887e2c7673e"
     client = MagicMock()
     adapter = OpenLineageAdapter(client)
@@ -764,6 +774,7 @@ def test_emit_dag_failed_event(mock_stats_incr, mock_stats_timer, generate_stati
                                 task_2.task_id: TaskInstanceState.FAILED,
                             },
                         ),
+                        "debug": AirflowDebugRunFacet(packages=ANY),
                     },
                 ),
                 job=Job(

--- a/tests/providers/openlineage/test_conf.py
+++ b/tests/providers/openlineage/test_conf.py
@@ -28,6 +28,7 @@ from airflow.providers.openlineage.conf import (
     custom_extractors,
     custom_run_facets,
     dag_state_change_process_pool_size,
+    debug_mode,
     disabled_operators,
     execution_timeout,
     include_full_task_info,
@@ -58,6 +59,7 @@ _VAR_URL = "OPENLINEAGE_URL"
 _CONFIG_OPTION_SELECTIVE_ENABLE = "selective_enable"
 _CONFIG_OPTION_DAG_STATE_CHANGE_PROCESS_POOL_SIZE = "dag_state_change_process_pool_size"
 _CONFIG_OPTION_INCLUDE_FULL_TASK_INFO = "include_full_task_info"
+_CONFIG_OPTION_DEBUG_MODE = "debug_mode"
 
 _BOOL_PARAMS = (
     ("1", True),
@@ -577,3 +579,35 @@ def test_include_full_task_info_invalid_value_raise_error(var_string):
 @conf_vars({(_CONFIG_SECTION, _CONFIG_OPTION_INCLUDE_FULL_TASK_INFO): None})
 def test_include_full_task_info_do_not_fail_if_conf_option_missing():
     assert include_full_task_info() is False
+
+
+@pytest.mark.parametrize(
+    ("var_string", "expected"),
+    _BOOL_PARAMS,
+)
+def test_debug_mode(var_string, expected):
+    with conf_vars({(_CONFIG_SECTION, _CONFIG_OPTION_DEBUG_MODE): var_string}):
+        result = debug_mode()
+        assert result is expected
+
+
+@pytest.mark.parametrize(
+    "var_string",
+    (
+        "a",
+        "asdf",
+        "None",
+        "31",
+        "",
+        " ",
+    ),
+)
+def test_debug_mode_invalid_value_raise_error(var_string):
+    with conf_vars({(_CONFIG_SECTION, _CONFIG_OPTION_DEBUG_MODE): var_string}):
+        with pytest.raises(AirflowConfigException):
+            debug_mode()
+
+
+@conf_vars({(_CONFIG_SECTION, _CONFIG_OPTION_DEBUG_MODE): None})
+def test_debug_mode_do_not_fail_if_conf_option_missing():
+    assert debug_mode() is False


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
## Problem
Whenever we are trying to debug issues related to OpenLineage coming from users, we usually require information about versions of other providers used in the process, for reproducing purposes. It would be great to have that information in the events already to reduce the time and effort needed for debugging, but only when some flag is turned on explicitly on the user side (f.e. airflow log level is set to debug). This PR adds a DebugRun facet to Airflow, that contains information about all packages and their versions. In the future, we could possibly extend that facet with other useful information.

### Questions:

- I'm not sure, if we should add this facet to all events (current implementation), or only add it to some specific events (which?).
- Can we rely on the Airflow logging level when deciding whether or not to attach this facet? I wanted to avoid creating another flag, that would basically had to be set together with DEBUG logging level. (Whenever debugging user issues, we are asking for debug logs anyway)


## Background:
Initially, I aimed to include package information in the producer field for specific facets but wanted to keep it hassle-free for both users and developers. I created some POC for each solution, but this debug facet seems the best for now.

We could automatically track where a facet is created and assign the producer, but the complexity and maintenance effort are not worth it for such a simple feature.

I also considered resetting the producer for facets after creation using a decorator or function in common.compat provider, but this would require additional code from developers when adding OL support for operators. With hook level lineage coming, it could become even more complex. This is something we might revisit in the future, as having the producer field identify the actual provider of the facet at all times is beneficial (regardless of OL configuration, logging level, etc.).

For now, the simple debug facet should suffice.

Please let me know your thoughts.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
