### PR TITLE
Skip highlighting lines that contain log group markers.

### DIFF
--- a/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
@@ -48,6 +48,14 @@ const warningKeywords = getMetaValue("color_log_warning_keywords")
   .filter((keyword) => keyword.length > 0)
   .map((keyword) => keyword.toLowerCase());
 
+// Detect log groups which can be collapsed
+// Either in Github like format '::group::<group name>' to '::endgroup::'
+// see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines
+// Or in ADO pipeline like format '##[group]<group name>' to '##[endgroup]'
+// see https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=powershell#formatting-commands
+export const logGroupStart = / INFO - (::|##\[])group(::|\])([^\n])*/g;
+export const logGroupEnd = / INFO - (::|##\[])endgroup(::|\])/g;
+
 export const parseLogs = (
   data: string | undefined,
   timezone: string | null,
@@ -75,13 +83,6 @@ export const parseLogs = (
   ansiUp.url_allowlist = {};
 
   const urlRegex = /((https?:\/\/|http:\/\/)(?:(?!&#x27;|&quot;)[^\s])+)/g;
-  // Detect log groups which can be collapsed
-  // Either in Github like format '::group::<group name>' to '::endgroup::'
-  // see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines
-  // Or in ADO pipeline like format '##[group]<group name>' to '##[endgroup]'
-  // see https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=powershell#formatting-commands
-  const logGroupStart = / INFO - (::|##\[])group(::|\])([^\n])*/g;
-  const logGroupEnd = / INFO - (::|##\[])endgroup(::|\])/g;
   // Coloring (blue-60 as chakra style, is #0060df) and style such that log group appears like a link
   const logGroupStyle = "color:#0060df;cursor:pointer;font-weight:bold;";
 
@@ -125,7 +126,9 @@ export const parseLogs = (
       parsedLine = highlightByKeywords(
         parsedLine,
         errorKeywords,
-        warningKeywords
+        warningKeywords,
+        logGroupStart,
+        logGroupEnd
       );
       // for lines with color convert to nice HTML
       const coloredLine = ansiUp.ansi_to_html(parsedLine);

--- a/airflow/www/static/js/utils/index.test.ts
+++ b/airflow/www/static/js/utils/index.test.ts
@@ -25,6 +25,10 @@ import {
   getTaskSummary,
   highlightByKeywords,
 } from ".";
+import {
+  logGroupStart,
+  logGroupEnd,
+} from "../dag/details/taskInstance/Logs/utils";
 
 const sampleTasks = {
   id: null,
@@ -160,7 +164,9 @@ describe("Test highlightByKeywords", () => {
     const highlightedLine = highlightByKeywords(
       originalLine,
       ["error"],
-      ["warn"]
+      ["warn"],
+      logGroupStart,
+      logGroupEnd
     );
     expect(highlightedLine).toBe(expected);
   });
@@ -170,7 +176,9 @@ describe("Test highlightByKeywords", () => {
     const highlightedLine = highlightByKeywords(
       originalLine,
       ["error"],
-      ["warn"]
+      ["warn"],
+      logGroupStart,
+      logGroupEnd
     );
     expect(highlightedLine).toBe(expected);
   });
@@ -180,16 +188,42 @@ describe("Test highlightByKeywords", () => {
     const highlightedLine = highlightByKeywords(
       originalLine,
       ["error"],
-      ["warn"]
+      ["warn"],
+      logGroupStart,
+      logGroupEnd
     );
     expect(highlightedLine).toBe(expected);
+  });
+  test("No highlight for line with start log marker", async () => {
+    const originalLine = " INFO - ::group::error";
+    const highlightedLine = highlightByKeywords(
+      originalLine,
+      ["error"],
+      ["warn"],
+      logGroupStart,
+      logGroupEnd
+    );
+    expect(highlightedLine).toBe(originalLine);
+  });
+  test("No highlight for line with end log marker", async () => {
+    const originalLine = " INFO - ::endgroup::";
+    const highlightedLine = highlightByKeywords(
+      originalLine,
+      ["endgroup"],
+      ["warn"],
+      logGroupStart,
+      logGroupEnd
+    );
+    expect(highlightedLine).toBe(originalLine);
   });
   test("No highlight", async () => {
     const originalLine = "sample line";
     const highlightedLine = highlightByKeywords(
       originalLine,
       ["error"],
-      ["warn"]
+      ["warn"],
+      logGroupStart,
+      logGroupEnd
     );
     expect(highlightedLine).toBe(originalLine);
   });

--- a/airflow/www/static/js/utils/index.ts
+++ b/airflow/www/static/js/utils/index.ts
@@ -25,6 +25,8 @@ import useOffsetTop from "./useOffsetTop";
 // Delay in ms for various hover actions
 const hoverDelay = 200;
 
+const logMarkers = ["::group::", "::endgroup::"];
+
 function getMetaValue(name: string) {
   const elem = document.querySelector(`meta[name="${name}"]`);
   if (!elem) {
@@ -190,6 +192,15 @@ const highlightByKeywords = (
   errorKeywords: string[],
   warningKeywords: string[]
 ): string => {
+  const containsLogMarker = logMarkers.some((marker) =>
+    parsedLine.includes(marker)
+  );
+
+  // Don't color log marker lines that are already highlighted.
+  if (containsLogMarker) {
+    return parsedLine;
+  }
+
   const lowerParsedLine = parsedLine.toLowerCase();
   const red = (line: string) => `\x1b[1m\x1b[31m${line}\x1b[39m\x1b[0m`;
   const yellow = (line: string) => `\x1b[1m\x1b[33m${line}\x1b[39m\x1b[0m`;

--- a/airflow/www/static/js/utils/index.ts
+++ b/airflow/www/static/js/utils/index.ts
@@ -25,8 +25,6 @@ import useOffsetTop from "./useOffsetTop";
 // Delay in ms for various hover actions
 const hoverDelay = 200;
 
-const logMarkers = ["::group::", "::endgroup::"];
-
 function getMetaValue(name: string) {
   const elem = document.querySelector(`meta[name="${name}"]`);
   if (!elem) {
@@ -190,14 +188,12 @@ const toSentenceCase = (camelCase: string): string => {
 const highlightByKeywords = (
   parsedLine: string,
   errorKeywords: string[],
-  warningKeywords: string[]
+  warningKeywords: string[],
+  logGroupStart: RegExp,
+  logGroupEnd: RegExp
 ): string => {
-  const containsLogMarker = logMarkers.some((marker) =>
-    parsedLine.includes(marker)
-  );
-
   // Don't color log marker lines that are already highlighted.
-  if (containsLogMarker) {
+  if (logGroupStart.test(parsedLine) || logGroupEnd.test(parsedLine)) {
     return parsedLine;
   }
 


### PR DESCRIPTION
Skip highlighting lines that contain log group markers since they already contain html markup which causes issues. The group is automatically expanded and not clickable. We found this since we had a log group to display exception traceback from other systems and named it exception log.

Before : (Note log group named exception is highlighted by red which we used internally to display exception log from external tasks)

![image](https://github.com/user-attachments/assets/996c069d-b80c-4d58-af51-35acbae889ca)

After : 

![image](https://github.com/user-attachments/assets/f91ca95d-d55d-4a24-a671-f95594986800)

Sample dag : 

```python
from datetime import datetime, timedelta

from airflow import DAG
from airflow.decorators import task


with DAG(
    dag_id="error_color",
    start_date=datetime(2024, 1, 1),
    catchup=False,
    schedule_interval="@once",
) as dag:

    @task
    def empty():
        try:
            print("::group::exception")
            1 / 0
        except Exception as e:
            print(e)
        finally:
            print("::endgroup::")


    empty()

```