### PR TITLE
Improve docs build speed in canary runs

### DIFF
--- a/.github/workflows/static-checks-mypy-docs.yml
+++ b/.github/workflows/static-checks-mypy-docs.yml
@@ -181,9 +181,7 @@ jobs:
   build-docs:
     timeout-minutes: 150
     name: "Build documentation"
-    # For canary runs we need to push documentation to AWS S3 and preparing it takes a lot of space
-    # So we should use self-hosted ASF runners for this
-    runs-on: ${{ fromJSON(inputs.runs-on-as-json-docs-build) }}
+    runs-on: ${{ fromJSON(inputs.runs-on-as-json-default) }}
     strategy:
       fail-fast: false
       matrix:
@@ -220,28 +218,65 @@ jobs:
       - name: "Building docs with ${{ matrix.flag }} flag"
         run: >
           breeze build-docs ${{ inputs.docs-list-as-string }} ${{ matrix.flag }}
+      - name: "Upload build docs"
+        uses: actions/upload-artifact@v4
+        with:
+          name: airflow-docs
+          path: './docs/_build'
+          retention-days: 7
+          if-no-files-found: error
+        if: matrix.flag == '--docs-only'
+
+  publish-docs:
+    timeout-minutes: 150
+    name: "Publish documentation"
+    needs: build-docs
+    # For canary runs we need to push documentation to AWS S3 and preparing it takes a lot of space
+    # So we should use self-hosted ASF runners for this
+    runs-on: ${{ fromJSON(inputs.runs-on-as-json-docs-build) }}
+    env:
+      GITHUB_REPOSITORY: ${{ github.repository }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_USERNAME: ${{ github.actor }}
+      IMAGE_TAG: "${{ inputs.image-tag }}"
+      INCLUDE_NOT_READY_PROVIDERS: "true"
+      INCLUDE_SUCCESS_OUTPUTS: "${{ inputs.include-success-outputs }}"
+      PYTHON_MAJOR_MINOR_VERSION: "${{ inputs.default-python-version }}"
+      VERBOSE: "true"
+    if: inputs.canary-run == 'true'
+    steps:
+      - name: "Cleanup repo"
+        shell: bash
+        run: docker run -v "${GITHUB_WORKSPACE}:/workspace" -u 0:0 bash -c "rm -rf /workspace/*"
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: "Cleanup docker"
+        run: ./scripts/ci/cleanup_docker.sh
+      - name: "Download docs prepared as artifacts"
+        uses: actions/download-artifact@v4
+        with:
+          name: airflow-docs
+          path: './docs/_build'
       - name: "Clone airflow-site"
         run: >
           git clone https://github.com/apache/airflow-site.git ${GITHUB_WORKSPACE}/airflow-site &&
           echo "AIRFLOW_SITE_DIRECTORY=${GITHUB_WORKSPACE}/airflow-site" >> "$GITHUB_ENV"
-        if: inputs.canary-run == 'true' && matrix.flag == '--docs-only'
+      - name: "Prepare breeze & CI image: ${{ inputs.default-python-version }}:${{ inputs.image-tag }}"
+        uses: ./.github/actions/prepare_breeze_and_image
       - name: "Publish docs"
         run: >
           breeze release-management publish-docs --override-versioned --run-in-parallel
           ${{ inputs.docs-list-as-string }}
-        if: inputs.canary-run == 'true' && matrix.flag == '--docs-only'
       - name: "Generate back references for providers"
         run: breeze release-management add-back-references all-providers
-        if: inputs.canary-run == 'true' && matrix.flag == '--docs-only'
       - name: "Generate back references for apache-airflow"
         run: breeze release-management add-back-references apache-airflow
-        if: inputs.canary-run == 'true' && matrix.flag == '--docs-only'
       - name: "Generate back references for docker-stack"
         run: breeze release-management add-back-references docker-stack
-        if: inputs.canary-run == 'true' && matrix.flag == '--docs-only'
       - name: "Generate back references for helm-chart"
         run: breeze release-management add-back-references helm-chart
-        if: inputs.canary-run == 'true' && matrix.flag == '--docs-only'
       - name: Install AWS CLI v2
         run: |
           curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
@@ -249,23 +284,14 @@ jobs:
           rm /tmp/awscliv2.zip
           sudo /tmp/aws/install --update
           rm -rf /tmp/aws/
-        if: >
-          inputs.canary-run == 'true' &&
-          inputs.branch == 'main' &&
-          matrix.flag == '--docs-only'
+        if: inputs.branch == 'main'
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a  # v4.0.1
-        if: >
-          inputs.canary-run == 'true' &&
-          inputs.branch == 'main' &&
-          matrix.flag == '--docs-only'
+        if: inputs.branch == 'main'
         with:
           aws-access-key-id: ${{ secrets.DOCS_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.DOCS_AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-central-1
       - name: "Upload documentation to AWS S3"
-        if: >
-          inputs.canary-run == 'true' &&
-          inputs.branch == 'main' &&
-          matrix.flag == '--docs-only'
-        run: aws s3 sync --delete ./files/documentation s3://apache-airflow-docs
+        if: inputs.branch == 'main'
+        run: aws s3 sync --delete ./docs/_build s3://apache-airflow-docs


### PR DESCRIPTION
Self-hosted runners on ASF are SLOW to build docs (much slower than
regular public runners) but they have more disk space which is needed
to publish documentation. This PR splits docs building process to two
steps:

* First step that builds docs and uploads them as artifacts run on
  public runners

* Publish step that downloads the artifact and publishes them to
  S3 (this one needs more space and runs on ASF self-hosted runners)

This has the nice side effect that docs built in PR are available
as artifacts in PRs and main build.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
