### PR TITLE
Fix tests/always/test_secrets_backends.py by adding test_utils/db.py to accepted DB access for Dataset Isolation Mode

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -361,8 +361,11 @@ class TracebackSessionForTests:
             and not tb.filename == AIRFLOW_SETTINGS_PATH
             and not tb.filename == AIRFLOW_UTILS_SESSION_PATH
         ]
-        if any(filename.endswith("conftest.py") for filename, _, _, _ in airflow_frames):
-            # This is a fixture call
+        if any(
+            filename.endswith("conftest.py") or filename.endswith("tests/test_utils/db.py")
+            for filename, _, _, _ in airflow_frames
+        ):
+            # This is a fixture call or testing utilities
             return True, None
         if (
             len(airflow_frames) >= 2


### PR DESCRIPTION
Related: https://github.com/apache/airflow/pull/41067

Some tests are calling tests/test_utils/db.py to clean the DB, permit this in unit tests with database isolation
