### PR TITLE
Disable processor tests in internal DB test set which have code-under-test that makes direct DB access

### DIFF
--- a/tests/dag_processing/test_processor.py
+++ b/tests/dag_processing/test_processor.py
@@ -502,6 +502,7 @@ class TestDagFileProcessor:
 
         DagFileProcessor.manage_slas(dag_folder=dag.fileloc, dag_id="test_sla_miss", session=session)
 
+    @pytest.mark.skip_if_database_isolation_mode
     @patch.object(TaskInstance, "handle_failure")
     def test_execute_on_failure_callbacks(self, mock_ti_handle_failure):
         dagbag = DagBag(dag_folder="/dev/null", include_examples=True, read_dags_from_db=False)
@@ -532,6 +533,7 @@ class TestDagFileProcessor:
             error="Message", test_mode=conf.getboolean("core", "unit_test_mode"), session=session
         )
 
+    @pytest.mark.skip_if_database_isolation_mode
     @pytest.mark.parametrize(
         ["has_serialized_dag"],
         [pytest.param(True, id="dag_in_db"), pytest.param(False, id="no_dag_found")],
@@ -570,6 +572,7 @@ class TestDagFileProcessor:
             error="Message", test_mode=conf.getboolean("core", "unit_test_mode"), session=session
         )
 
+    @pytest.mark.skip_if_database_isolation_mode
     def test_failure_callbacks_should_not_drop_hostname(self):
         dagbag = DagBag(dag_folder="/dev/null", include_examples=True, read_dags_from_db=False)
         dag_file_processor = DagFileProcessor(
@@ -602,6 +605,7 @@ class TestDagFileProcessor:
             tis = session.query(TaskInstance)
             assert tis[0].hostname == "test_hostname"
 
+    @pytest.mark.skip_if_database_isolation_mode
     def test_process_file_should_failure_callback(self, monkeypatch, tmp_path, get_test_dag):
         callback_file = tmp_path.joinpath("callback.txt")
         callback_file.touch()
@@ -636,6 +640,7 @@ class TestDagFileProcessor:
         msg = " ".join([str(k) for k in ti.key.primary]) + " fired callback"
         assert msg in callback_file.read_text()
 
+    @pytest.mark.skip_if_database_isolation_mode
     @conf_vars({("core", "dagbag_import_error_tracebacks"): "False"})
     def test_add_unparseable_file_before_sched_start_creates_import_error(self, tmp_path):
         unparseable_filename = tmp_path.joinpath(TEMP_DAG_FILENAME).as_posix()
@@ -652,6 +657,7 @@ class TestDagFileProcessor:
             assert import_error.stacktrace == f"invalid syntax ({TEMP_DAG_FILENAME}, line 1)"
             session.rollback()
 
+    @pytest.mark.skip_if_database_isolation_mode
     @conf_vars({("core", "dagbag_import_error_tracebacks"): "False"})
     def test_add_unparseable_zip_file_creates_import_error(self, tmp_path):
         zip_filename = (tmp_path / "test_zip.zip").as_posix()
@@ -669,6 +675,7 @@ class TestDagFileProcessor:
             assert import_error.stacktrace == f"invalid syntax ({TEMP_DAG_FILENAME}, line 1)"
             session.rollback()
 
+    @pytest.mark.skip_if_database_isolation_mode
     @conf_vars({("core", "dagbag_import_error_tracebacks"): "False"})
     def test_dag_model_has_import_error_is_true_when_import_error_exists(self, tmp_path, session):
         dag_file = os.path.join(TEST_DAGS_FOLDER, "test_example_bash_operator.py")
@@ -695,6 +702,7 @@ class TestDagFileProcessor:
         dm = session.query(DagModel).filter(DagModel.fileloc == temp_dagfile).first()
         assert dm.has_import_errors
 
+    @pytest.mark.skip_if_database_isolation_mode
     def test_no_import_errors_with_parseable_dag(self, tmp_path):
         parseable_filename = tmp_path / TEMP_DAG_FILENAME
         parseable_filename.write_text(PARSEABLE_DAG_FILE_CONTENTS)
@@ -707,6 +715,7 @@ class TestDagFileProcessor:
 
             session.rollback()
 
+    @pytest.mark.skip_if_database_isolation_mode
     def test_no_import_errors_with_parseable_dag_in_zip(self, tmp_path):
         zip_filename = (tmp_path / "test_zip.zip").as_posix()
         with ZipFile(zip_filename, "w") as zip_file:
@@ -720,6 +729,7 @@ class TestDagFileProcessor:
 
             session.rollback()
 
+    @pytest.mark.skip_if_database_isolation_mode
     @conf_vars({("core", "dagbag_import_error_tracebacks"): "False"})
     def test_new_import_error_replaces_old(self, tmp_path):
         unparseable_filename = tmp_path / TEMP_DAG_FILENAME
@@ -744,6 +754,7 @@ class TestDagFileProcessor:
 
         session.rollback()
 
+    @pytest.mark.skip_if_database_isolation_mode
     def test_import_error_record_is_updated_not_deleted_and_recreated(self, tmp_path):
         """
         Test that existing import error is updated and new record not created
@@ -771,6 +782,7 @@ class TestDagFileProcessor:
         # assert that the ID of the import error did not change
         assert import_error_1.id == import_error_2.id
 
+    @pytest.mark.skip_if_database_isolation_mode
     def test_remove_error_clears_import_error(self, tmp_path):
         filename_to_parse = tmp_path.joinpath(TEMP_DAG_FILENAME).as_posix()
 
@@ -791,6 +803,7 @@ class TestDagFileProcessor:
 
         session.rollback()
 
+    @pytest.mark.skip_if_database_isolation_mode
     def test_remove_error_clears_import_error_zip(self, tmp_path):
         session = settings.Session()
 
@@ -813,6 +826,7 @@ class TestDagFileProcessor:
 
         session.rollback()
 
+    @pytest.mark.skip_if_database_isolation_mode
     def test_import_error_tracebacks(self, tmp_path):
         unparseable_filename = (tmp_path / TEMP_DAG_FILENAME).as_posix()
         with open(unparseable_filename, "w") as unparseable_file:
@@ -849,6 +863,7 @@ class TestDagFileProcessor:
             )
             session.rollback()
 
+    @pytest.mark.skip_if_database_isolation_mode
     @conf_vars({("core", "dagbag_import_error_traceback_depth"): "1"})
     def test_import_error_traceback_depth(self, tmp_path):
         unparseable_filename = tmp_path.joinpath(TEMP_DAG_FILENAME).as_posix()
@@ -881,6 +896,7 @@ class TestDagFileProcessor:
 
             session.rollback()
 
+    @pytest.mark.skip_if_database_isolation_mode
     def test_import_error_tracebacks_zip(self, tmp_path):
         invalid_zip_filename = (tmp_path / "test_zip_invalid.zip").as_posix()
         invalid_dag_filename = os.path.join(invalid_zip_filename, TEMP_DAG_FILENAME)
@@ -918,6 +934,7 @@ class TestDagFileProcessor:
             )
             session.rollback()
 
+    @pytest.mark.skip_if_database_isolation_mode
     @conf_vars({("core", "dagbag_import_error_traceback_depth"): "1"})
     def test_import_error_tracebacks_zip_depth(self, tmp_path):
         invalid_zip_filename = (tmp_path / "test_zip_invalid.zip").as_posix()
@@ -950,6 +967,7 @@ class TestDagFileProcessor:
             assert import_error.stacktrace == expected_stacktrace.format(invalid_dag_filename)
             session.rollback()
 
+    @pytest.mark.skip_if_database_isolation_mode
     @conf_vars({("logging", "dag_processor_log_target"): "stdout"})
     @mock.patch("airflow.dag_processing.processor.settings.dispose_orm", MagicMock)
     @mock.patch("airflow.dag_processing.processor.redirect_stdout")
@@ -973,6 +991,7 @@ class TestDagFileProcessor:
         )
         mock_redirect_stdout_for_file.assert_not_called()
 
+    @pytest.mark.skip_if_database_isolation_mode
     @conf_vars({("logging", "dag_processor_log_target"): "file"})
     @mock.patch("airflow.dag_processing.processor.settings.dispose_orm", MagicMock)
     @mock.patch("airflow.dag_processing.processor.redirect_stdout")
@@ -1030,6 +1049,7 @@ class TestDagFileProcessor:
         )
         processor.start()
 
+    @pytest.mark.skip_if_database_isolation_mode
     def test_counter_for_last_num_of_db_queries(self):
         dag_filepath = TEST_DAG_FOLDER / "test_dag_for_db_queries_counter.py"
 


### PR DESCRIPTION
Related: https://github.com/apache/airflow/pull/41067

I checked the failed tests in `test_processor.py` but all logic under test needs direct DB access to work. I disabled the tests which fail because of this.
I'm not fully sure if this affects the function of the DAG file processor if running in isolation mode... if yes then a set of additional internal API methods must be cut to make callback handling working in DB isolation mode.