### PR TITLE
Disable internal RPC API tests in isolation mode

### DIFF
--- a/tests/api_internal/endpoints/test_rpc_api_endpoint.py
+++ b/tests/api_internal/endpoints/test_rpc_api_endpoint.py
@@ -37,7 +37,10 @@ from airflow.www import app
 from tests.test_utils.config import conf_vars
 from tests.test_utils.decorators import dont_initialize_flask_app_submodules
 
-pytestmark = pytest.mark.db_test
+# Note: Sounds a bit strange to disable internal API tests in isolation mode but...
+# As long as the test is modelled to run its own internal API endpoints, it is conflicting
+# to the test setup with a dedicated internal API server.
+pytestmark = [pytest.mark.db_test, pytest.mark.skip_if_database_isolation_mode]
 
 if TYPE_CHECKING:
     from flask import Flask
@@ -48,10 +51,6 @@ TEST_METHOD_WITH_LOG_NAME = "test_method_with_log"
 mock_test_method = mock.MagicMock()
 
 pytest.importorskip("pydantic", minversion="2.0.0")
-# Note: Sounds a bit strange to disable internal API tests in isolation mode but...
-# As long as the test is modelled to run its own internal API endpoints, it is conflicting
-# to the test setup with a dedicated internal API server.
-pytestmark = pytest.mark.skip_if_database_isolation_mode
 
 
 @pytest.fixture(scope="session")

--- a/tests/api_internal/endpoints/test_rpc_api_endpoint.py
+++ b/tests/api_internal/endpoints/test_rpc_api_endpoint.py
@@ -48,6 +48,9 @@ TEST_METHOD_WITH_LOG_NAME = "test_method_with_log"
 mock_test_method = mock.MagicMock()
 
 pytest.importorskip("pydantic", minversion="2.0.0")
+# Note: Sounds a bit strange to disable internal API tests in isolation mode but...
+# As long as the test is modelled to run its own internal API endpoints, it is conflicting
+# to the test setup with a dedicated internal API server.
 pytestmark = pytest.mark.skip_if_database_isolation_mode
 
 

--- a/tests/api_internal/endpoints/test_rpc_api_endpoint.py
+++ b/tests/api_internal/endpoints/test_rpc_api_endpoint.py
@@ -48,6 +48,7 @@ TEST_METHOD_WITH_LOG_NAME = "test_method_with_log"
 mock_test_method = mock.MagicMock()
 
 pytest.importorskip("pydantic", minversion="2.0.0")
+pytestmark = pytest.mark.skip_if_database_isolation_mode
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Related: https://github.com/apache/airflow/pull/41067

Sounds a bit strange but in the RPC API tests the pytest spawns its own internal flask server which conflicts with the separate started by pytest.
As long as we do not have only/exclusive internal API tests, we must disable these in isolation mode.

I tried to make them working but also if the internal API server is started in pytest, a DB access is needed which heavily conflicts with the traceback session mode. Main conflict is within `minimal_app_for_internal_api()` mock