### PR TITLE
Fix pydantic dataset serialization test in Database Isolation Mode

### DIFF
--- a/tests/serialization/test_pydantic_models.py
+++ b/tests/serialization/test_pydantic_models.py
@@ -40,7 +40,7 @@ from airflow.serialization.pydantic.dataset import DatasetEventPydantic
 from airflow.serialization.pydantic.job import JobPydantic
 from airflow.serialization.pydantic.taskinstance import TaskInstancePydantic
 from airflow.serialization.serialized_objects import BaseSerialization
-from airflow.settings import _ENABLE_AIP_44
+from airflow.settings import _ENABLE_AIP_44, TracebackSessionForTests
 from airflow.utils import timezone
 from airflow.utils.state import State
 from airflow.utils.types import AttributeRemoved, DagRunType
@@ -229,6 +229,7 @@ def test_serializing_pydantic_dataset_event(session, create_task_instance, creat
         session=session,
     )
     execution_date = timezone.utcnow()
+    TracebackSessionForTests.set_allow_db_access(session, True)
     dr = dag.create_dagrun(
         run_id="test2",
         run_type=DagRunType.DATASET_TRIGGERED,
@@ -252,6 +253,7 @@ def test_serializing_pydantic_dataset_event(session, create_task_instance, creat
     dr.consumed_dataset_events.append(ds2_event_1)
     dr.consumed_dataset_events.append(ds2_event_2)
     session.commit()
+    TracebackSessionForTests.set_allow_db_access(session, False)
 
     print(ds2_event_2.dataset.consuming_dags)
     pydantic_dse1 = DatasetEventPydantic.model_validate(ds1_event)


### PR DESCRIPTION
Related: https://github.com/apache/airflow/pull/41067

Some pytests need specific DB access which is not covered by current Traceback mechanism. Therefore added a specific "hook" allowing temporary DB access for setup of mock data for testing... and fixed serialization tests with this.

@potiuk  Is this acceptable? Or should we re-model the mock or traceback-detection?