### PR TITLE
Fix after 41238: Left 2 print statements in code

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -348,8 +348,6 @@ class TracebackSessionForTests:
     @staticmethod
     def set_allow_db_access(session, flag: bool):
         """Temporarily, e.g. for pytests allow access to DB to prepare stuff."""
-        print(session)
-        print(session.__class__)
         if isinstance(session, TracebackSessionForTests):
             session.allow_db_access = flag
 


### PR DESCRIPTION
Related: https://github.com/apache/airflow/pull/41067

As a follow-up uups, I realized that I left two print() statements in PR #41238 - sorry. THis PR cleans-up.