### PR TITLE
Add missing serializations found during provider tests fixing

### DIFF
--- a/airflow/models/trigger.py
+++ b/airflow/models/trigger.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
     from sqlalchemy.sql import Select
 
+    from airflow.serialization.pydantic.trigger import TriggerPydantic
     from airflow.triggers.base import BaseTrigger
 
 
@@ -136,7 +137,8 @@ class Trigger(Base):
 
     @classmethod
     @internal_api_call
-    def from_object(cls, trigger: BaseTrigger) -> Trigger:
+    @provide_session
+    def from_object(cls, trigger: BaseTrigger, session=NEW_SESSION) -> Trigger | TriggerPydantic:
         """Alternative constructor that creates a trigger row based directly off of a Trigger object."""
         classpath, kwargs = trigger.serialize()
         return cls(classpath=classpath, kwargs=kwargs)

--- a/airflow/serialization/enums.py
+++ b/airflow/serialization/enums.py
@@ -72,3 +72,4 @@ class DagAttributeTypes(str, Enum):
     DAG_CALLBACK_REQUEST = "dag_callback_request"
     SLA_CALLBACK_REQUEST = "sla_callback_request"
     TASK_INSTANCE_KEY = "task_instance_key"
+    TRIGGER = "trigger"

--- a/airflow/serialization/pydantic/trigger.py
+++ b/airflow/serialization/pydantic/trigger.py
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import datetime
+from typing import Any, Dict, Optional
+
+from airflow.utils import timezone
+from airflow.utils.pydantic import BaseModel as BaseModelPydantic, ConfigDict
+
+
+class TriggerPydantic(BaseModelPydantic):
+    """Serializable representation of the Trigger ORM SqlAlchemyModel used by internal API."""
+
+    # This is technically non-optional, however when we serialize it in from_object we do not have the ID
+    id: Optional[int]
+    classpath: str
+    encrypted_kwargs: str
+    created_date: datetime.datetime
+    triggerer_id: Optional[int]
+
+    model_config = ConfigDict(from_attributes=True)
+
+    def __init__(self, **kwargs) -> None:
+        from airflow.models.trigger import Trigger
+
+        # Here we have to handle two ways the object can be created:
+        # * when Pydantic recreates it from Trigger model, we need a default __init__ behavior
+        # * when we create it in from_object - the kwargs will contain classpath, kwargs to create it and
+        #   created_date
+        if "kwargs" in kwargs:
+            self.classpath = kwargs.pop("classpath")
+            self.encrypted_kwargs = Trigger._encrypt_kwargs(kwargs.pop("kwargs"))
+            self.created_date = kwargs.pop("created_date", timezone.utcnow())
+        super().__init__(**kwargs)
+
+    @property
+    def kwargs(self) -> Dict[str, Any]:
+        """Return the decrypted kwargs of the trigger."""
+        from airflow.models import Trigger
+
+        return Trigger._decrypt_kwargs(self.encrypted_kwargs)
+
+    @kwargs.setter
+    def kwargs(self, kwargs: Dict[str, Any]) -> None:
+        """Set the encrypted kwargs of the trigger."""
+        from airflow.models import Trigger
+
+        self.encrypted_kwargs = Trigger._encrypt_kwargs(kwargs)

--- a/tests/serialization/test_serialized_objects.py
+++ b/tests/serialization/test_serialized_objects.py
@@ -417,6 +417,7 @@ def test_all_pydantic_models_round_trip():
         "TaskOutletDatasetReferencePydantic",
         "DagOwnerAttributesPydantic",
         "DatasetEventPydantic",
+        "TriggerPydantic",
     }
     for c in sorted(classes, key=str):
         if c.__name__ in exclusion_list:


### PR DESCRIPTION
During AWS provider tests fixing for database isolation, two problems have been found:

* Trigger object did not have TriggerPydantic corresponding pydantic object which did not allow the Trigger object to get serialized for Trigger processing

* Variable and connection accessors were not restored when Context got deserialized.

Related: #41067

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
