### PR TITLE
Fix manually deleted pod behaviour in SparkKubernetesOperator

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/custom_object_launcher.py
+++ b/airflow/providers/cncf/kubernetes/operators/custom_object_launcher.py
@@ -316,13 +316,13 @@ class CustomObjectLauncher(LoggingMixin):
 
     def get_value_from_spark_job_info(self, spark_job_info, value_keys: list):
         """
-            Get spark job info from driver pod.
-            Example Call:
-                get_spark_job_info_from_driver_pod(spark_job_info, ["status", "applicationState", "state"])
+        Get spark job info from driver pod.
+        Example Call:
+            get_spark_job_info_from_driver_pod(spark_job_info, ["status", "applicationState", "state"])
 
-            :param spark_job_info: spark job info.
-            :param value_keys: search keys. Ordered list of keys to search in spark job info.
-            :return: spark job info in string format.
+        :param spark_job_info: spark job info.
+        :param value_keys: search keys. Ordered list of keys to search in spark job info.
+        :return: spark job info in string format.
         """
         if value_keys is None:
             return None
@@ -348,14 +348,12 @@ class CustomObjectLauncher(LoggingMixin):
             plural=self.plural,
         )
         driver_state = self.get_value_from_spark_job_info(
-            spark_job_info=spark_job_info,
-            value_keys=["status", "applicationState", "state"]
+            spark_job_info=spark_job_info, value_keys=["status", "applicationState", "state"]
         )
         if driver_state:
             if driver_state == CustomObjectStatus.FAILED:
                 err = self.get_value_from_spark_job_info(
-                    spark_job_info=spark_job_info,
-                    value_keys=["status", "applicationState", "errorMessage"]
+                    spark_job_info=spark_job_info, value_keys=["status", "applicationState", "errorMessage"]
                 )
                 err = err if err else "N/A"
                 try:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

The problem might be related to when there is no `state` in `spark_job_info` since the pod is deleted manually or externally from the Kubernetes environment, the default always went into SUBMITTED even though the keys don't exist in the spark_job_info.
I still haven't fully tested yet if it solves the issue. I will test and make the MR ready.

----
Update, I am suspecting from a broad issue. Waiting for an answer.

closes: #41212

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
