### PR TITLE
Bugfix/41067 fix tests operators test python

### DIFF
--- a/airflow/api_internal/internal_api_call.py
+++ b/airflow/api_internal/internal_api_call.py
@@ -158,6 +158,9 @@ def internal_api_call(func: Callable[PS, RT]) -> Callable[PS, RT]:
         result = make_jsonrpc_request(method_name, args_dict)
         if result is None or result == b"":
             return None
-        return BaseSerialization.deserialize(json.loads(result), use_pydantic_models=True)
+        result = BaseSerialization.deserialize(json.loads(result), use_pydantic_models=True)
+        if isinstance(result, AirflowException):
+            raise result
+        return result
 
     return wrapper

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -43,6 +43,10 @@ class AirflowException(Exception):
 
     status_code = HTTPStatus.INTERNAL_SERVER_ERROR
 
+    def serialize(self):
+        cls = self.__class__
+        return f"{cls.__module__}.{cls.__name__}", (str(self),), {}
+
 
 class AirflowBadRequest(AirflowException):
     """Raise when the application or server cannot handle the request."""
@@ -76,7 +80,8 @@ class AirflowRescheduleException(AirflowException):
         self.reschedule_date = reschedule_date
 
     def serialize(self):
-        return "AirflowRescheduleException", (), {"reschedule_date": self.reschedule_date}
+        cls = self.__class__
+        return f"{cls.__module__}.{cls.__name__}", (), {"reschedule_date": self.reschedule_date}
 
 
 class InvalidStatsNameException(AirflowException):
@@ -131,6 +136,14 @@ class XComNotFound(AirflowException):
 
     def __str__(self) -> str:
         return f'XComArg result from {self.task_id} at {self.dag_id} with key="{self.key}" is not found!'
+
+    def serialize(self):
+        cls = self.__class__
+        return (
+            f"{cls.__module__}.{cls.__name__}",
+            (),
+            {"dag_id": self.dag_id, "task_id": self.task_id, "key": self.key},
+        )
 
 
 class UnmappableOperator(AirflowException):
@@ -396,8 +409,9 @@ class TaskDeferred(BaseException):
             raise ValueError("Timeout value must be a timedelta")
 
     def serialize(self):
+        cls = self.__class__
         return (
-            self.__class__.__name__,
+            f"{cls.__module__}.{cls.__name__}",
             (),
             {
                 "trigger": self.trigger,

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -840,7 +840,7 @@ class BaseSerialization:
             args = deser["args"]
             kwargs = deser["kwargs"]
             del deser
-            exc_cls = import_string(f"airflow.exceptions.{exc_cls_name}")
+            exc_cls = import_string(exc_cls_name)
             return exc_cls(*args, **kwargs)
         elif type_ == DAT.BASE_TRIGGER:
             tr_cls_name, kwargs = cls.deserialize(var, use_pydantic_models=use_pydantic_models)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1121,6 +1121,28 @@ def create_task_instance(dag_maker, create_dummy_dag):
 
 
 @pytest.fixture
+def create_serialized_task_instance_of_operator(dag_maker):
+    def _create_task_instance(
+        operator_class,
+        *,
+        dag_id,
+        execution_date=None,
+        session=None,
+        **operator_kwargs,
+    ) -> TaskInstance:
+        with dag_maker(dag_id=dag_id, serialized=True, session=session):
+            operator_class(**operator_kwargs)
+        if execution_date is None:
+            dagrun_kwargs = {}
+        else:
+            dagrun_kwargs = {"execution_date": execution_date}
+        (ti,) = dag_maker.create_dagrun(**dagrun_kwargs).task_instances
+        return ti
+
+    return _create_task_instance
+
+
+@pytest.fixture
 def create_task_instance_of_operator(dag_maker):
     def _create_task_instance(
         operator_class,

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -95,14 +95,14 @@ class BasePythonTest:
     default_date: datetime = DEFAULT_DATE
 
     @pytest.fixture(autouse=True)
-    def base_tests_setup(self, request, create_task_instance_of_operator, dag_maker):
+    def base_tests_setup(self, request, create_serialized_task_instance_of_operator, dag_maker):
         self.dag_id = f"dag_{slugify(request.cls.__name__)}"
         self.task_id = f"task_{slugify(request.node.name, max_length=40)}"
         self.run_id = f"run_{slugify(request.node.name, max_length=40)}"
         self.ds_templated = self.default_date.date().isoformat()
-        self.ti_maker = create_task_instance_of_operator
+        self.ti_maker = create_serialized_task_instance_of_operator
         self.dag_maker = dag_maker
-        self.dag = self.dag_maker(self.dag_id, template_searchpath=TEMPLATE_SEARCHPATH).dag
+        self.dag_non_serialized = self.dag_maker(self.dag_id, template_searchpath=TEMPLATE_SEARCHPATH).dag
         clear_db_runs()
         yield
         clear_db_runs()
@@ -129,7 +129,7 @@ class BasePythonTest:
         return kwargs
 
     def create_dag_run(self) -> DagRun:
-        return self.dag.create_dagrun(
+        return self.dag_maker.create_dagrun(
             state=DagRunState.RUNNING,
             start_date=self.dag_maker.start_date,
             session=self.dag_maker.session,
@@ -151,10 +151,12 @@ class BasePythonTest:
 
     def run_as_operator(self, fn, **kwargs):
         """Run task by direct call ``run`` method."""
-        with self.dag:
+        clear_db_runs()
+        with self.dag_maker(self.dag_id, template_searchpath=TEMPLATE_SEARCHPATH, serialized=True):
             task = self.opcls(task_id=self.task_id, python_callable=fn, **self.default_kwargs(**kwargs))
-
+        self.dag_maker.create_dagrun()
         task.run(start_date=self.default_date, end_date=self.default_date)
+        clear_db_runs()
         return task
 
     def run_as_task(self, fn, return_ti=False, **kwargs):
@@ -324,13 +326,13 @@ class TestPythonOperator(BasePythonTest):
         def func():
             return "test_return_value"
 
-        python_operator = PythonOperator(
-            task_id="python_operator",
-            python_callable=func,
-            dag=self.dag,
-            show_return_value_in_logs=False,
-            templates_exts=["test_ext"],
-        )
+        with self.dag_maker(self.dag_id, template_searchpath=TEMPLATE_SEARCHPATH, serialized=True):
+            python_operator = PythonOperator(
+                task_id="python_operator",
+                python_callable=func,
+                show_return_value_in_logs=False,
+                templates_exts=["test_ext"],
+            )
 
         assert python_operator.template_ext == ["test_ext"]
 
@@ -369,7 +371,8 @@ class TestBranchOperator(BasePythonTest):
         self.branch_2 = EmptyOperator(task_id="branch_2")
 
     def test_with_dag_run(self):
-        with self.dag:
+        clear_db_runs()
+        with self.dag_maker(self.dag_id, template_searchpath=TEMPLATE_SEARCHPATH, serialized=True):
 
             def f():
                 return "branch_1"
@@ -384,7 +387,8 @@ class TestBranchOperator(BasePythonTest):
         )
 
     def test_with_skip_in_branch_downstream_dependencies(self):
-        with self.dag:
+        clear_db_runs()
+        with self.dag_maker(self.dag_id, template_searchpath=TEMPLATE_SEARCHPATH, serialized=True):
 
             def f():
                 return "branch_1"
@@ -400,7 +404,8 @@ class TestBranchOperator(BasePythonTest):
         )
 
     def test_with_skip_in_branch_downstream_dependencies2(self):
-        with self.dag:
+        clear_db_runs()
+        with self.dag_maker(self.dag_id, template_searchpath=TEMPLATE_SEARCHPATH, serialized=True):
 
             def f():
                 return "branch_2"
@@ -416,7 +421,8 @@ class TestBranchOperator(BasePythonTest):
         )
 
     def test_xcom_push(self):
-        with self.dag:
+        clear_db_runs()
+        with self.dag_maker(self.dag_id, template_searchpath=TEMPLATE_SEARCHPATH, serialized=True):
 
             def f():
                 return "branch_1"
@@ -433,12 +439,13 @@ class TestBranchOperator(BasePythonTest):
         else:
             pytest.fail(f"{self.task_id!r} not found.")
 
+    @pytest.mark.skip_if_database_isolation_mode  # tests logic with clear_task_instances(), this needs DB access
     def test_clear_skipped_downstream_task(self):
         """
         After a downstream task is skipped by BranchPythonOperator, clearing the skipped task
         should not cause it to be executed.
         """
-        with self.dag:
+        with self.dag_non_serialized:
 
             def f():
                 return "branch_1"
@@ -492,6 +499,7 @@ class TestBranchOperator(BasePythonTest):
         with pytest.raises(AirflowException, match="Invalid tasks found: {'some_task_id'}"):
             ti.run()
 
+    @pytest.mark.skip_if_database_isolation_mode  # tests pure logic with run() method, can not run in isolation mode
     @pytest.mark.parametrize(
         "choice,expected_states",
         [
@@ -503,7 +511,7 @@ class TestBranchOperator(BasePythonTest):
         """
         Tests that BranchPythonOperator handles empty branches properly.
         """
-        with self.dag:
+        with self.dag_non_serialized:
 
             def f():
                 return choice
@@ -521,7 +529,7 @@ class TestBranchOperator(BasePythonTest):
 
         for task_id in task_ids:  # Mimic the specific order the scheduling would run the tests.
             task_instance = tis[task_id]
-            task_instance.refresh_from_task(self.dag.get_task(task_id))
+            task_instance.refresh_from_task(self.dag_non_serialized.get_task(task_id))
             task_instance.run()
 
         def get_state(ti):
@@ -547,6 +555,7 @@ class TestShortCircuitOperator(BasePythonTest):
     }
     all_success_states = {"short_circuit": State.SUCCESS, "op1": State.SUCCESS, "op2": State.SUCCESS}
 
+    @pytest.mark.skip_if_database_isolation_mode  # tests pure logic with run() method, can not run in isolation mode
     @pytest.mark.parametrize(
         argnames=(
             "callable_return, test_ignore_downstream_trigger_rules, test_trigger_rule, expected_task_states"
@@ -645,7 +654,7 @@ class TestShortCircuitOperator(BasePythonTest):
         Checking the behavior of the ShortCircuitOperator in several scenarios enabling/disabling the skipping
         of downstream tasks, both short-circuiting modes, and various trigger rules of downstream tasks.
         """
-        with self.dag:
+        with self.dag_non_serialized:
             short_circuit = ShortCircuitOperator(
                 task_id="short_circuit",
                 python_callable=lambda: callable_return,
@@ -665,12 +674,13 @@ class TestShortCircuitOperator(BasePythonTest):
         assert self.op2.trigger_rule == test_trigger_rule
         self.assert_expected_task_states(dr, expected_task_states)
 
+    @pytest.mark.skip_if_database_isolation_mode  # tests logic with clear_task_instances(), this needs DB access
     def test_clear_skipped_downstream_task(self):
         """
         After a downstream task is skipped by ShortCircuitOperator, clearing the skipped task
         should not cause it to be executed.
         """
-        with self.dag:
+        with self.dag_non_serialized:
             short_circuit = ShortCircuitOperator(task_id="short_circuit", python_callable=lambda: False)
             short_circuit >> self.op1 >> self.op2
         dr = self.create_dag_run()
@@ -700,7 +710,8 @@ class TestShortCircuitOperator(BasePythonTest):
         self.assert_expected_task_states(dr, expected_states)
 
     def test_xcom_push(self):
-        with self.dag:
+        clear_db_runs()
+        with self.dag_maker(self.dag_id, template_searchpath=TEMPLATE_SEARCHPATH, serialized=True):
             short_op_push_xcom = ShortCircuitOperator(
                 task_id="push_xcom_from_shortcircuit", python_callable=lambda: "signature"
             )
@@ -716,8 +727,9 @@ class TestShortCircuitOperator(BasePythonTest):
         assert tis[0].xcom_pull(task_ids=short_op_push_xcom.task_id, key="return_value") == "signature"
         assert tis[0].xcom_pull(task_ids=short_op_no_push_xcom.task_id, key="return_value") is False
 
+    @pytest.mark.skip_if_database_isolation_mode  # tests pure logic with run() method, can not run in isolation mode
     def test_xcom_push_skipped_tasks(self):
-        with self.dag:
+        with self.dag_non_serialized:
             short_op_push_xcom = ShortCircuitOperator(
                 task_id="push_xcom_from_shortcircuit", python_callable=lambda: False
             )
@@ -730,8 +742,9 @@ class TestShortCircuitOperator(BasePythonTest):
             "skipped": ["empty_task"]
         }
 
+    @pytest.mark.skip_if_database_isolation_mode  # tests pure logic with run() method, can not run in isolation mode
     def test_mapped_xcom_push_skipped_tasks(self, session):
-        with self.dag:
+        with self.dag_non_serialized:
 
             @task_group
             def group(x):
@@ -1394,7 +1407,7 @@ class TestExternalPythonOperator(BaseTestPythonVirtualenvOperator):
             python_callable=f,
             task_id="task",
             python=sys.executable,
-            dag=self.dag,
+            dag=self.dag_non_serialized,
         )
 
         loads_mock.side_effect = DeserializingResultError
@@ -1491,7 +1504,8 @@ class BaseTestBranchPythonVirtualenvOperator(BaseTestPythonVirtualenvOperator):
             self.run_as_task(f, do_not_use_caching=True)
 
     def test_with_dag_run(self):
-        with self.dag:
+        clear_db_runs()
+        with self.dag_maker(self.dag_id, template_searchpath=TEMPLATE_SEARCHPATH, serialized=True):
 
             def f():
                 return "branch_1"
@@ -1506,7 +1520,8 @@ class BaseTestBranchPythonVirtualenvOperator(BaseTestPythonVirtualenvOperator):
         )
 
     def test_with_skip_in_branch_downstream_dependencies(self):
-        with self.dag:
+        clear_db_runs()
+        with self.dag_maker(self.dag_id, template_searchpath=TEMPLATE_SEARCHPATH, serialized=True):
 
             def f():
                 return "branch_1"
@@ -1522,7 +1537,8 @@ class BaseTestBranchPythonVirtualenvOperator(BaseTestPythonVirtualenvOperator):
         )
 
     def test_with_skip_in_branch_downstream_dependencies2(self):
-        with self.dag:
+        clear_db_runs()
+        with self.dag_maker(self.dag_id, template_searchpath=TEMPLATE_SEARCHPATH, serialized=True):
 
             def f():
                 return "branch_2"
@@ -1538,7 +1554,8 @@ class BaseTestBranchPythonVirtualenvOperator(BaseTestPythonVirtualenvOperator):
         )
 
     def test_xcom_push(self):
-        with self.dag:
+        clear_db_runs()
+        with self.dag_maker(self.dag_id, template_searchpath=TEMPLATE_SEARCHPATH, serialized=True):
 
             def f():
                 return "branch_1"
@@ -1555,12 +1572,14 @@ class BaseTestBranchPythonVirtualenvOperator(BaseTestPythonVirtualenvOperator):
         else:
             pytest.fail(f"{self.task_id!r} not found.")
 
+    @pytest.mark.skip_if_database_isolation_mode  # tests logic with clear_task_instances(), this needs DB access
     def test_clear_skipped_downstream_task(self):
         """
         After a downstream task is skipped by BranchPythonOperator, clearing the skipped task
         should not cause it to be executed.
         """
-        with self.dag:
+        clear_db_runs()
+        with self.dag_maker(self.dag_id, template_searchpath=TEMPLATE_SEARCHPATH, serialized=True):
 
             def f():
                 return "branch_1"
@@ -1721,6 +1740,7 @@ DEFAULT_ARGS = {
 }
 
 
+@pytest.mark.skip_if_database_isolation_mode  # tests pure logic with run() method, can not run in isolation mode
 @pytest.mark.usefixtures("clear_db")
 class TestCurrentContextRuntime:
     def test_context_in_task(self):
@@ -1736,6 +1756,7 @@ class TestCurrentContextRuntime:
 
 @pytest.mark.need_serialized_dag(False)
 class TestShortCircuitWithTeardown:
+    @pytest.mark.skip_if_database_isolation_mode  # tests pure logic with run() method, mix of pydantic and mock fails
     @pytest.mark.parametrize(
         "ignore_downstream_trigger_rules, with_teardown, should_skip, expected",
         [
@@ -1777,6 +1798,7 @@ class TestShortCircuitWithTeardown:
         else:
             op1.skip.assert_not_called()
 
+    @pytest.mark.skip_if_database_isolation_mode  # tests pure logic with run() method, mix of pydantic and mock fails
     @pytest.mark.parametrize("config", ["sequence", "parallel"])
     def test_short_circuit_with_teardowns_complicated(self, dag_maker, config):
         with dag_maker():
@@ -1804,6 +1826,7 @@ class TestShortCircuitWithTeardown:
             actual_skipped = set(op1.skip.call_args.kwargs["tasks"])
             assert actual_skipped == {s2, op2}
 
+    @pytest.mark.skip_if_database_isolation_mode  # tests pure logic with run() method, mix of pydantic and mock fails
     def test_short_circuit_with_teardowns_complicated_2(self, dag_maker):
         with dag_maker():
             s1 = PythonOperator(task_id="s1", python_callable=print).as_setup()
@@ -1833,6 +1856,7 @@ class TestShortCircuitWithTeardown:
             assert actual_kwargs["execution_date"] == dagrun.logical_date
             assert actual_skipped == {op3}
 
+    @pytest.mark.skip_if_database_isolation_mode  # tests pure logic with run() method, mix of pydantic and mock fails
     @pytest.mark.parametrize("level", [logging.DEBUG, logging.INFO])
     def test_short_circuit_with_teardowns_debug_level(self, dag_maker, level, clear_db):
         """

--- a/tests/sensors/test_python.py
+++ b/tests/sensors/test_python.py
@@ -45,7 +45,7 @@ class TestPythonSensor(BasePythonTest):
             self.run_as_task(lambda: 1 / 0)
 
     def test_python_sensor_xcom(self):
-        with self.dag:
+        with self.dag_non_serialized:
             task = self.opcls(
                 task_id=self.task_id,
                 python_callable=lambda: PokeReturnValue(True, "xcom"),

--- a/tests/serialization/test_serialized_objects.py
+++ b/tests/serialization/test_serialized_objects.py
@@ -31,7 +31,13 @@ from kubernetes.client import models as k8s
 from pendulum.tz.timezone import Timezone
 
 from airflow.datasets import Dataset, DatasetAlias, DatasetAliasEvent
-from airflow.exceptions import AirflowRescheduleException, SerializationError, TaskDeferred
+from airflow.exceptions import (
+    AirflowException,
+    AirflowFailException,
+    AirflowRescheduleException,
+    SerializationError,
+    TaskDeferred,
+)
 from airflow.jobs.job import Job
 from airflow.models.connection import Connection
 from airflow.models.dag import DAG, DagModel, DagTag
@@ -152,6 +158,10 @@ def equal_time(a: datetime, b: datetime) -> bool:
     return a.strftime("%s") == b.strftime("%s")
 
 
+def equal_exception(a: AirflowException, b: AirflowException) -> bool:
+    return a.__class__ == b.__class__ and str(a) == str(b)
+
+
 def equal_outlet_event_accessor(a: OutletEventAccessor, b: OutletEventAccessor) -> bool:
     return a.raw_key == b.raw_key and a.extra == b.extra and a.dataset_alias_event == b.dataset_alias_event
 
@@ -251,6 +261,16 @@ class MockLazySelectSequence(LazySelectSequence):
             OutletEventAccessor(raw_key="test", extra={"key": "value"}),
             DAT.DATASET_EVENT_ACCESSOR,
             equal_outlet_event_accessor,
+        ),
+        (
+            AirflowException("test123 wohoo!"),
+            DAT.AIRFLOW_EXC_SER,
+            equal_exception,
+        ),
+        (
+            AirflowFailException("uuups, failed :-("),
+            DAT.AIRFLOW_EXC_SER,
+            equal_exception,
         ),
     ],
 )


### PR DESCRIPTION
Related: https://github.com/apache/airflow/pull/41067

Attempt to fix all or most of tests/operators/test_python.py code.

With this to make a success, Internal API also was changed to return AirflowException as Exception class, previously this raised HTTP 500 Internal Server Error. But there are valid use cases where AirflowException is raised by the backend.