### PR TITLE
Disable DAG Stats API Endpoint test in Database Isolation Mode

### DIFF
--- a/tests/api_connexion/endpoints/test_dag_stats_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_stats_endpoint.py
@@ -30,7 +30,7 @@ from airflow.utils.types import DagRunType
 from tests.test_utils.api_connexion_utils import create_user, delete_user
 from tests.test_utils.db import clear_db_dags, clear_db_runs, clear_db_serialized_dags
 
-pytestmark = pytest.mark.db_test
+pytestmark = [pytest.mark.db_test, pytest.mark.skip_if_database_isolation_mode]
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Related: https://github.com/apache/airflow/pull/41067

DAG Stats API fails in DB Isolation Tests - but this is only executed on Webserver, thus a test with isolation is not needed. Also failure are in FAB initialization.