### PR TITLE
added nested task groups to task_group.group_id in OL event

### DIFF
--- a/airflow/providers/openlineage/utils/utils.py
+++ b/airflow/providers/openlineage/utils/utils.py
@@ -156,9 +156,10 @@ def is_selective_lineage_enabled(obj: DAG | BaseOperator | MappedOperator) -> bo
 
 
 def extract_nested_task_group_id(task):
-    task.task_group._group_id = (
-        f"{task.task_id.split(task.task_group._group_id, 1)[0]}{task.task_group._group_id}"
-    )
+    if len(task.task_id.split("." + task.task_group._group_id + ".", 1)) != 1:  # check for nested task group
+        task.task_group._group_id = (
+            f"{task.task_id.split('.' + task.task_group._group_id + '.', 1)[0]}.{task.task_group._group_id}"
+        )
     return task.task_group
 
 

--- a/airflow/providers/openlineage/utils/utils.py
+++ b/airflow/providers/openlineage/utils/utils.py
@@ -155,6 +155,13 @@ def is_selective_lineage_enabled(obj: DAG | BaseOperator | MappedOperator) -> bo
         raise TypeError("is_selective_lineage_enabled can only be used on DAG or Operator objects")
 
 
+def extract_nested_task_group_id(task):
+    task.task_group._group_id = (
+        f"{task.task_id.split(task.task_group._group_id, 1)[0]}{task.task_group._group_id}"
+    )
+    return task.task_group
+
+
 class InfoJsonEncodable(dict):
     """
     Airflow objects might not be json-encodable overall.
@@ -319,7 +326,7 @@ class TaskInfo(InfoJsonEncodable):
         "operator_class": lambda task: task.task_type,
         "operator_class_path": lambda task: get_fully_qualified_class_name(task),
         "task_group": lambda task: (
-            TaskGroupInfo(task.task_group)
+            TaskGroupInfo(extract_nested_task_group_id(task))
             if hasattr(task, "task_group") and getattr(task.task_group, "_group_id", None)
             else None
         ),


### PR DESCRIPTION
Closes: #41261 

I have used task_id to extract the suffix and get the nested task group name.

delimiting using ".group_id." if nested task groups are present

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
