### PR TITLE
Fix latest botocore tests conflicting dependencies

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1022,11 +1022,16 @@ function check_boto_upgrade() {
     echo "${COLOR_BLUE}Upgrading boto3, botocore to latest version to run Amazon tests with them${COLOR_RESET}"
     echo
     # shellcheck disable=SC2086
-    ${PACKAGING_TOOL_CMD} uninstall ${EXTRA_UNINSTALL_FLAGS} aiobotocore s3fs || true
+    ${PACKAGING_TOOL_CMD} uninstall ${EXTRA_UNINSTALL_FLAGS} aiobotocore s3fs yandexcloud || true
     # We need to include few dependencies to pass pip check with other dependencies:
     #   * oss2 as dependency as otherwise jmespath will be bumped (sync with alibaba provider)
     #   * gcloud-aio-auth limit is needed to be included as it bumps cryptography (sync with google provider)
     #   * requests needs to be limited to be compatible with apache beam (sync with apache-beam provider)
+    #   * yandexcloud requirements for requests does not match those of apache.beam and latest botocore
+    #   Both requests and yandexcloud exclusion above might be removed after
+    #   https://github.com/apache/beam/issues/32080 is addressed
+    #   When you remove yandexcloud from the above list, also remove it from "test_example_dags.py"
+    #   in "tests/always".
     set -x
     # shellcheck disable=SC2086
     ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} --upgrade boto3 botocore \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -409,6 +409,7 @@ combine-as-imports = true
 "tests/providers/qdrant/hooks/test_qdrant.py" = ["E402"]
 "tests/providers/qdrant/operators/test_qdrant.py" = ["E402"]
 "tests/providers/snowflake/operators/test_snowflake_sql.py" = ["E402"]
+"tests/providers/yandex/*/*.py" = ["E402"]
 
 # All the modules which do not follow B028 yet: https://docs.astral.sh/ruff/rules/no-explicit-stacklevel/
 "helm_tests/airflow_aux/test_basic_helm_chart.py" = ["B028"]

--- a/scripts/docker/entrypoint_ci.sh
+++ b/scripts/docker/entrypoint_ci.sh
@@ -242,11 +242,16 @@ function check_boto_upgrade() {
     echo "${COLOR_BLUE}Upgrading boto3, botocore to latest version to run Amazon tests with them${COLOR_RESET}"
     echo
     # shellcheck disable=SC2086
-    ${PACKAGING_TOOL_CMD} uninstall ${EXTRA_UNINSTALL_FLAGS} aiobotocore s3fs || true
+    ${PACKAGING_TOOL_CMD} uninstall ${EXTRA_UNINSTALL_FLAGS} aiobotocore s3fs yandexcloud || true
     # We need to include few dependencies to pass pip check with other dependencies:
     #   * oss2 as dependency as otherwise jmespath will be bumped (sync with alibaba provider)
     #   * gcloud-aio-auth limit is needed to be included as it bumps cryptography (sync with google provider)
     #   * requests needs to be limited to be compatible with apache beam (sync with apache-beam provider)
+    #   * yandexcloud requirements for requests does not match those of apache.beam and latest botocore
+    #   Both requests and yandexcloud exclusion above might be removed after
+    #   https://github.com/apache/beam/issues/32080 is addressed
+    #   When you remove yandexcloud from the above list, also remove it from "test_example_dags.py"
+    #   in "tests/always".
     set -x
     # shellcheck disable=SC2086
     ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} --upgrade boto3 botocore \

--- a/tests/always/test_example_dags.py
+++ b/tests/always/test_example_dags.py
@@ -124,6 +124,13 @@ def example_not_excluded_dags(xfail_db_exception: bool = False):
         for prefix in PROVIDERS_PREFIXES
         for provider in suspended_providers_folders
     ]
+    temporary_excluded_upgrade_boto_providers_folders = [
+        AIRFLOW_SOURCES_ROOT.joinpath(prefix, provider).as_posix()
+        for prefix in PROVIDERS_PREFIXES
+        # TODO - remove me when https://github.com/apache/beam/issues/32080 is addressed
+        #        and we bring back yandex to be run in case of upgrade boto
+        for provider in ["yandex"]
+    ]
     current_python_excluded_providers_folders = [
         AIRFLOW_SOURCES_ROOT.joinpath(prefix, provider).as_posix()
         for prefix in PROVIDERS_PREFIXES
@@ -138,6 +145,11 @@ def example_not_excluded_dags(xfail_db_exception: bool = False):
 
             if candidate.startswith(tuple(suspended_providers_folders)):
                 param_marks.append(pytest.mark.skip(reason="Suspended provider"))
+
+            if os.environ.get("UPGRADE_BOTO", "false") == "true" and candidate.startswith(
+                tuple(temporary_excluded_upgrade_boto_providers_folders)
+            ):
+                param_marks.append(pytest.mark.skip(reason="Temporary excluded upgrade boto provider"))
 
             if candidate.startswith(tuple(current_python_excluded_providers_folders)):
                 param_marks.append(

--- a/tests/providers/yandex/hooks/test_dataproc.py
+++ b/tests/providers/yandex/hooks/test_dataproc.py
@@ -19,6 +19,10 @@ from __future__ import annotations
 import json
 from unittest import mock
 
+import pytest
+
+yandexlcloud = pytest.importorskip("yandexcloud")
+
 from airflow.models import Connection
 from airflow.providers.yandex.hooks.dataproc import DataprocHook
 

--- a/tests/providers/yandex/hooks/test_yandex.py
+++ b/tests/providers/yandex/hooks/test_yandex.py
@@ -23,6 +23,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+yandexcloud = pytest.importorskip("yandexcloud")
+
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.yandex.hooks.yandex import YandexCloudBaseHook
 from tests.test_utils.config import conf_vars

--- a/tests/providers/yandex/hooks/test_yq.py
+++ b/tests/providers/yandex/hooks/test_yq.py
@@ -20,6 +20,10 @@ import json
 from datetime import timedelta
 from unittest import mock
 
+import pytest
+
+yandexcloud = pytest.importorskip("yandexcloud")
+
 import responses
 from responses import matchers
 

--- a/tests/providers/yandex/links/test_yq.py
+++ b/tests/providers/yandex/links/test_yq.py
@@ -18,10 +18,14 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
+
 from airflow.models.taskinstance import TaskInstance
 from airflow.models.xcom import XCom
 from airflow.providers.yandex.links.yq import YQLink
 from tests.test_utils.mock_operators import MockOperator
+
+yandexcloud = pytest.importorskip("yandexcloud")
 
 
 def test_persist():

--- a/tests/providers/yandex/operators/test_dataproc.py
+++ b/tests/providers/yandex/operators/test_dataproc.py
@@ -19,6 +19,10 @@ from __future__ import annotations
 import datetime
 from unittest.mock import MagicMock, call, patch
 
+import pytest
+
+yandexcloud = pytest.importorskip("yandexcloud")
+
 from airflow.models.dag import DAG
 from airflow.providers.yandex.operators.dataproc import (
     DataprocCreateClusterOperator,

--- a/tests/providers/yandex/operators/test_yq.py
+++ b/tests/providers/yandex/operators/test_yq.py
@@ -21,6 +21,9 @@ from datetime import datetime, timedelta
 from unittest.mock import MagicMock, call, patch
 
 import pytest
+
+yandexcloud = pytest.importorskip("yandexcloud")
+
 import responses
 from responses import matchers
 

--- a/tests/providers/yandex/secrets/test_lockbox.py
+++ b/tests/providers/yandex/secrets/test_lockbox.py
@@ -20,6 +20,9 @@ import json
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+
+yandexcloud = pytest.importorskip("yandexcloud")
+
 import yandex.cloud.lockbox.v1.payload_pb2 as payload_pb
 import yandex.cloud.lockbox.v1.secret_pb2 as secret_pb
 import yandex.cloud.lockbox.v1.secret_service_pb2 as secret_service_pb

--- a/tests/providers/yandex/utils/test_user_agent.py
+++ b/tests/providers/yandex/utils/test_user_agent.py
@@ -18,6 +18,10 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
+
+yandexcloud = pytest.importorskip("yandexcloud")
+
 from airflow.providers.yandex.utils.user_agent import provider_user_agent
 
 


### PR DESCRIPTION
The "latest botocore" tests have conflicting dependencies for latest yandexcloud provider - their "requests" support conflicts with apache.beam and latest botocore.

For now we remove yandexcloud for those tests hoping that soon apache.beam will support higher requests versions.

And issue has been created in apache.beam to remove the limitation as the root cause seems to be already fixed.

See https://github.com/apache/beam/issues/32080

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
