### PR TITLE
fix: return empty data instead of None when OpenLineage on_start method is missing

### DIFF
--- a/airflow/providers/openlineage/extractors/base.py
+++ b/airflow/providers/openlineage/extractors/base.py
@@ -113,7 +113,7 @@ class DefaultExtractor(BaseExtractor):
                 "Operator %s does not have the get_openlineage_facets_on_start method.",
                 self.operator.task_type,
             )
-            return None
+            return OperatorLineage()
 
     def extract_on_complete(self, task_instance) -> OperatorLineage | None:
         failed_states = [TaskInstanceState.FAILED, TaskInstanceState.UP_FOR_RETRY]

--- a/tests/providers/openlineage/extractors/test_base.py
+++ b/tests/providers/openlineage/extractors/test_base.py
@@ -224,7 +224,7 @@ def test_extraction_without_on_start():
         task_instance=task_instance
     )
 
-    assert metadata is None
+    assert metadata == OperatorLineage()
 
     assert metadata_on_complete == OperatorLineage(
         inputs=INPUTS,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
When DefaultExtractor is used, so the operator has OpenLineage methods implemented (at least one of: on_start, on_complete) we are logging a WARNING each time there is no on_start method. This happens because we are validating OL metadata returned by extractor, [here](https://github.com/apache/airflow/blob/d6bc1f69a36dd0ee08f02fb6e6f0388342f5fb1b/airflow/providers/openlineage/extractors/manager.py#L105). This validation makes sense and we should keep it, but imho the default extractor should return empty data when there is no on_start method defined, because it means that the on_complete method will be called. 

There is no need to return None ourselves and then log a warning because we found a None 😄 

Some logs of current behaviour:
```
[2024-08-05, 15:04:30 UTC] {listener.py:383} DEBUG - Executing OpenLineage process - on_running - pid 376
[2024-08-05, 15:04:30 UTC] {manager.py:149} DEBUG - extractor for CustomOperator is <class 'airflow.providers.openlineage.extractors.base.DefaultExtractor'>
[2024-08-05, 15:04:30 UTC] {manager.py:98} DEBUG - Using extractor DefaultExtractor task_type=CustomOperator airflow_dag_id=dag task_id=task airflow_run_id=manual__2024-08-05T15:04:29.761674+00:00 
[2024-08-05, 15:04:30 UTC] {base.py:101} DEBUG - Trying to execute `get_openlineage_facets_on_start` for CustomOperator.
[2024-08-05, 15:04:30 UTC] {base.py:112} DEBUG - Operator CustomOperator does not have the get_openlineage_facets_on_start method.
[2024-08-05, 15:04:30 UTC] {manager.py:104} DEBUG - Found task metadata for operation task: None
[2024-08-05, 15:04:30 UTC] {manager.py:267} WARNING - Extractor returns non-valid metadata: None
```

After the change, we would get rid of this warning. We would still get the information that there is no on_start method and metadata found would be `OperatorLineage()`

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
