### PR TITLE
Make remaining provider tests pass in DB isolation mode

### DIFF
--- a/airflow/api_internal/endpoints/rpc_api_endpoint.py
+++ b/airflow/api_internal/endpoints/rpc_api_endpoint.py
@@ -121,7 +121,7 @@ def initialize_method_map() -> dict[str, Callable]:
         MetastoreBackend._fetch_variable,
         XCom.get_value,
         XCom.get_one,
-        XCom.get_many,
+        # XCom.get_many, # Not supported because it returns query
         XCom.clear,
         XCom.set,
         Variable.set,

--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -487,9 +487,11 @@ class BaseXCom(TaskInstanceDependencies, LoggingMixin):
         :sphinx-autoapi-skip:
         """
 
+    # The 'get_many` is not supported via database isolation mode. Attempting to use it in DB isolation
+    # mode will result in a crash - Resulting Query object cannot be **really** serialized
+    # TODO(potiuk) - document it in AIP-44 docs
     @staticmethod
     @provide_session
-    @internal_api_call
     def get_many(
         execution_date: datetime.datetime | None = None,
         key: str | None = None,

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -341,7 +341,7 @@ class TracebackSessionForTests:
         raise RuntimeError(
             "TracebackSessionForTests object was used but internal API is enabled. "
             "Only test code is allowed to use this object.\n"
-            f"Called from:\n    {frame_summary.filename}: {frame_summary.lineno}{frame_summary.colno}\n"
+            f"Called from:\n    {frame_summary.filename}: {frame_summary.lineno}\n"
             f"     {frame_summary.line}\n\n"
             "You'll need to ensure you are making only RPC calls with this object. "
             "The stack list below will show where the TracebackSession object was called:\n"

--- a/tests/providers/apache/livy/hooks/test_livy.py
+++ b/tests/providers/apache/livy/hooks/test_livy.py
@@ -31,6 +31,8 @@ from airflow.providers.apache.livy.hooks.livy import BatchState, LivyAsyncHook, 
 from airflow.utils import db
 from tests.test_utils.db import clear_db_connections
 
+pytestmark = pytest.mark.skip_if_database_isolation_mode
+
 LIVY_CONN_ID = LivyHook.default_conn_name
 DEFAULT_CONN_ID = LivyHook.default_conn_name
 DEFAULT_HOST = "livy"

--- a/tests/providers/cncf/kubernetes/operators/test_job.py
+++ b/tests/providers/cncf/kubernetes/operators/test_job.py
@@ -90,7 +90,7 @@ class TestKubernetesJobOperator:
 
         patch.stopall()
 
-    def test_templates(self, create_task_instance_of_operator):
+    def test_templates(self, create_task_instance_of_operator, session):
         dag_id = "TestKubernetesJobOperator"
         ti = create_task_instance_of_operator(
             KubernetesJobOperator,
@@ -117,6 +117,9 @@ class TestKubernetesJobOperator:
             image="{{ dag.dag_id }}",
             annotations={"dag-id": "{{ dag.dag_id }}"},
         )
+
+        session.add(ti)
+        session.commit()
 
         rendered = ti.render_templates()
 

--- a/tests/providers/cncf/kubernetes/operators/test_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_pod.py
@@ -52,7 +52,7 @@ from airflow.utils.session import create_session
 from airflow.utils.types import DagRunType
 from tests.test_utils import db
 
-pytestmark = pytest.mark.db_test
+pytestmark = [pytest.mark.db_test, pytest.mark.skip_if_database_isolation_mode]
 
 
 DEFAULT_DATE = timezone.datetime(2016, 1, 1, 1, 0, 0)
@@ -135,7 +135,7 @@ class TestKubernetesPodOperator:
 
         patch.stopall()
 
-    def test_templates(self, create_task_instance_of_operator):
+    def test_templates(self, create_task_instance_of_operator, session):
         dag_id = "TestKubernetesPodOperator"
         ti = create_task_instance_of_operator(
             KubernetesPodOperator,
@@ -172,6 +172,8 @@ class TestKubernetesPodOperator:
             ],
         )
 
+        session.add(ti)
+        session.commit()
         rendered = ti.render_templates()
 
         assert dag_id == rendered.container_resources.limits["memory"]

--- a/tests/providers/cncf/kubernetes/operators/test_spark_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/operators/test_spark_kubernetes.py
@@ -547,7 +547,7 @@ class TestSparkKubernetesOperator:
 
 
 @pytest.mark.db_test
-def test_template_body_templating(create_task_instance_of_operator):
+def test_template_body_templating(create_task_instance_of_operator, session):
     ti = create_task_instance_of_operator(
         SparkKubernetesOperator,
         template_spec={"foo": "{{ ds }}", "bar": "{{ dag_run.dag_id }}"},
@@ -556,13 +556,15 @@ def test_template_body_templating(create_task_instance_of_operator):
         task_id="test_template_body_templating_task",
         execution_date=timezone.datetime(2024, 2, 1, tzinfo=timezone.utc),
     )
+    session.add(ti)
+    session.commit()
     ti.render_templates()
     task: SparkKubernetesOperator = ti.task
     assert task.template_body == {"spark": {"foo": "2024-02-01", "bar": "test_template_body_templating_dag"}}
 
 
 @pytest.mark.db_test
-def test_resolve_application_file_template_file(dag_maker, tmp_path):
+def test_resolve_application_file_template_file(dag_maker, tmp_path, session):
     execution_date = timezone.datetime(2024, 2, 1, tzinfo=timezone.utc)
     filename = "test-application-file.yml"
     (tmp_path / filename).write_text("foo: {{ ds }}\nbar: {{ dag_run.dag_id }}\nspam: egg")
@@ -577,6 +579,8 @@ def test_resolve_application_file_template_file(dag_maker, tmp_path):
         )
 
     ti = dag_maker.create_dagrun(execution_date=execution_date).task_instances[0]
+    session.add(ti)
+    session.commit()
     ti.render_templates()
     task: SparkKubernetesOperator = ti.task
     assert task.template_body == {
@@ -598,7 +602,7 @@ def test_resolve_application_file_template_file(dag_maker, tmp_path):
         pytest.param(None, id="none"),
     ],
 )
-def test_resolve_application_file_template_non_dictionary(dag_maker, tmp_path, body):
+def test_resolve_application_file_template_non_dictionary(dag_maker, tmp_path, body, session):
     execution_date = timezone.datetime(2024, 2, 1, tzinfo=timezone.utc)
     filename = "test-application-file.yml"
     with open((tmp_path / filename), "w") as fp:
@@ -614,6 +618,8 @@ def test_resolve_application_file_template_non_dictionary(dag_maker, tmp_path, b
         )
 
     ti = dag_maker.create_dagrun(execution_date=execution_date).task_instances[0]
+    session.add(ti)
+    session.commit()
     ti.render_templates()
     task: SparkKubernetesOperator = ti.task
     with pytest.raises(TypeError, match="application_file body can't transformed into the dictionary"):
@@ -627,7 +633,9 @@ def test_resolve_application_file_template_non_dictionary(dag_maker, tmp_path, b
 @pytest.mark.skipif(
     not AIRFLOW_V_2_8_PLUS, reason="Skipping tests that require LiteralValue for Airflow < 2.8.0"
 )
-def test_resolve_application_file_real_file(create_task_instance_of_operator, tmp_path, use_literal_value):
+def test_resolve_application_file_real_file(
+    create_task_instance_of_operator, tmp_path, use_literal_value, session
+):
     application_file = tmp_path / "test-application-file.yml"
     application_file.write_text("foo: bar\nspam: egg")
 
@@ -647,6 +655,8 @@ def test_resolve_application_file_real_file(create_task_instance_of_operator, tm
         dag_id="test_resolve_application_file_real_file",
         task_id="test_template_body_templating_task",
     )
+    session.add(ti)
+    session.commit()
     ti.render_templates()
     task: SparkKubernetesOperator = ti.task
 
@@ -657,7 +667,7 @@ def test_resolve_application_file_real_file(create_task_instance_of_operator, tm
 @pytest.mark.skipif(
     not AIRFLOW_V_2_8_PLUS, reason="Skipping tests that require LiteralValue for Airflow < 2.8.0"
 )
-def test_resolve_application_file_real_file_not_exists(create_task_instance_of_operator, tmp_path):
+def test_resolve_application_file_real_file_not_exists(create_task_instance_of_operator, tmp_path, session):
     application_file = (tmp_path / "test-application-file.yml").resolve().as_posix()
     from airflow.template.templater import LiteralValue
 
@@ -668,6 +678,8 @@ def test_resolve_application_file_real_file_not_exists(create_task_instance_of_o
         dag_id="test_resolve_application_file_real_file_not_exists",
         task_id="test_template_body_templating_task",
     )
+    session.add(ti)
+    session.commit()
     ti.render_templates()
     task: SparkKubernetesOperator = ti.task
     with pytest.raises(TypeError, match="application_file body can't transformed into the dictionary"):

--- a/tests/providers/cncf/kubernetes/test_template_rendering.py
+++ b/tests/providers/cncf/kubernetes/test_template_rendering.py
@@ -29,7 +29,7 @@ from airflow.utils.session import create_session
 from airflow.version import version
 from tests.models import DEFAULT_DATE
 
-pytestmark = pytest.mark.db_test
+pytestmark = [pytest.mark.db_test, pytest.mark.skip_if_database_isolation_mode]
 
 
 @mock.patch.dict(os.environ, {"AIRFLOW_IS_K8S_EXECUTOR_POD": "True"})
@@ -117,7 +117,7 @@ def test_get_rendered_k8s_spec(render_k8s_pod_yaml, rtif_get_k8s_pod_yaml, creat
 @mock.patch.dict(os.environ, {"AIRFLOW_IS_K8S_EXECUTOR_POD": "True"})
 @mock.patch("airflow.utils.log.secrets_masker.redact", autospec=True, side_effect=lambda d, _=None: d)
 @mock.patch("airflow.providers.cncf.kubernetes.template_rendering.render_k8s_pod_yaml")
-def test_get_k8s_pod_yaml(render_k8s_pod_yaml, redact, dag_maker):
+def test_get_k8s_pod_yaml(render_k8s_pod_yaml, redact, dag_maker, session):
     """
     Test that k8s_pod_yaml is rendered correctly, stored in the Database,
     and are correctly fetched using RTIF.get_k8s_pod_yaml

--- a/tests/providers/common/io/xcom/test_backend.py
+++ b/tests/providers/common/io/xcom/test_backend.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import pytest
 
 from tests.test_utils.compat import AIRFLOW_V_2_9_PLUS, ignore_provider_compatibility_error
+from tests.www.test_utils import is_db_isolation_mode
 
 pytestmark = [
     pytest.mark.db_test,
@@ -88,6 +89,8 @@ class TestXComObjectStorageBackend:
             yield
 
     def test_value_db(self, task_instance, session):
+        session.add(task_instance)
+        session.commit()
         XCom = resolve_xcom_backend()
         airflow.models.xcom.XCom = XCom
 
@@ -107,16 +110,19 @@ class TestXComObjectStorageBackend:
         )
         assert value == {"key": "value"}
 
-        qry = XCom.get_many(
-            key=XCOM_RETURN_KEY,
-            dag_ids=task_instance.dag_id,
-            task_ids=task_instance.task_id,
-            run_id=task_instance.run_id,
-            session=session,
-        )
-        assert qry.first().value == {"key": "value"}
+        if not is_db_isolation_mode():
+            qry = XCom.get_many(
+                key=XCOM_RETURN_KEY,
+                dag_ids=task_instance.dag_id,
+                task_ids=task_instance.task_id,
+                run_id=task_instance.run_id,
+                session=session,
+            )
+            assert qry.first().value == {"key": "value"}
 
     def test_value_storage(self, task_instance, session):
+        session.add(task_instance)
+        session.commit()
         XCom = resolve_xcom_backend()
         airflow.models.xcom.XCom = XCom
 
@@ -129,21 +135,22 @@ class TestXComObjectStorageBackend:
             session=session,
         )
 
-        res = (
-            XCom.get_many(
-                key=XCOM_RETURN_KEY,
-                dag_ids=task_instance.dag_id,
-                task_ids=task_instance.task_id,
-                run_id=task_instance.run_id,
-                session=session,
+        if not is_db_isolation_mode():
+            res = (
+                XCom.get_many(
+                    key=XCOM_RETURN_KEY,
+                    dag_ids=task_instance.dag_id,
+                    task_ids=task_instance.task_id,
+                    run_id=task_instance.run_id,
+                    session=session,
+                )
+                .with_entities(BaseXCom.value)
+                .first()
             )
-            .with_entities(BaseXCom.value)
-            .first()
-        )
 
-        data = BaseXCom.deserialize_value(res)
-        p = XComObjectStorageBackend._get_full_path(data)
-        assert p.exists() is True
+            data = BaseXCom.deserialize_value(res)
+            p = XComObjectStorageBackend._get_full_path(data)
+            assert p.exists() is True
 
         value = XCom.get_value(
             key=XCOM_RETURN_KEY,
@@ -152,16 +159,19 @@ class TestXComObjectStorageBackend:
         )
         assert value == {"key": "bigvaluebigvaluebigvalue" * 100}
 
-        qry = XCom.get_many(
-            key=XCOM_RETURN_KEY,
-            dag_ids=task_instance.dag_id,
-            task_ids=task_instance.task_id,
-            run_id=task_instance.run_id,
-            session=session,
-        )
-        assert str(p) == qry.first().value
+        if not is_db_isolation_mode():
+            qry = XCom.get_many(
+                key=XCOM_RETURN_KEY,
+                dag_ids=task_instance.dag_id,
+                task_ids=task_instance.task_id,
+                run_id=task_instance.run_id,
+                session=session,
+            )
+            assert str(p) == qry.first().value
 
     def test_clear(self, task_instance, session):
+        session.add(task_instance)
+        session.commit()
         XCom = resolve_xcom_backend()
         airflow.models.xcom.XCom = XCom
 
@@ -174,21 +184,29 @@ class TestXComObjectStorageBackend:
             session=session,
         )
 
-        res = (
-            XCom.get_many(
-                key=XCOM_RETURN_KEY,
-                dag_ids=task_instance.dag_id,
-                task_ids=task_instance.task_id,
-                run_id=task_instance.run_id,
-                session=session,
+        if not is_db_isolation_mode():
+            res = (
+                XCom.get_many(
+                    key=XCOM_RETURN_KEY,
+                    dag_ids=task_instance.dag_id,
+                    task_ids=task_instance.task_id,
+                    run_id=task_instance.run_id,
+                    session=session,
+                )
+                .with_entities(BaseXCom.value)
+                .first()
             )
-            .with_entities(BaseXCom.value)
-            .first()
-        )
 
-        data = BaseXCom.deserialize_value(res)
-        p = XComObjectStorageBackend._get_full_path(data)
-        assert p.exists() is True
+            data = BaseXCom.deserialize_value(res)
+            p = XComObjectStorageBackend._get_full_path(data)
+            assert p.exists() is True
+
+        value = XCom.get_value(
+            key=XCOM_RETURN_KEY,
+            ti_key=task_instance.key,
+            session=session,
+        )
+        assert value
 
         XCom.clear(
             dag_id=task_instance.dag_id,
@@ -197,10 +215,20 @@ class TestXComObjectStorageBackend:
             session=session,
         )
 
-        assert p.exists() is False
+        if not is_db_isolation_mode():
+            assert p.exists() is False
+
+        value = XCom.get_value(
+            key=XCOM_RETURN_KEY,
+            ti_key=task_instance.key,
+            session=session,
+        )
+        assert not value
 
     @conf_vars({("common.io", "xcom_objectstorage_compression"): "gzip"})
     def test_compression(self, task_instance, session):
+        session.add(task_instance)
+        session.commit()
         XCom = resolve_xcom_backend()
         airflow.models.xcom.XCom = XCom
 
@@ -213,22 +241,23 @@ class TestXComObjectStorageBackend:
             session=session,
         )
 
-        res = (
-            XCom.get_many(
-                key=XCOM_RETURN_KEY,
-                dag_ids=task_instance.dag_id,
-                task_ids=task_instance.task_id,
-                run_id=task_instance.run_id,
-                session=session,
+        if not is_db_isolation_mode():
+            res = (
+                XCom.get_many(
+                    key=XCOM_RETURN_KEY,
+                    dag_ids=task_instance.dag_id,
+                    task_ids=task_instance.task_id,
+                    run_id=task_instance.run_id,
+                    session=session,
+                )
+                .with_entities(BaseXCom.value)
+                .first()
             )
-            .with_entities(BaseXCom.value)
-            .first()
-        )
 
-        data = BaseXCom.deserialize_value(res)
-        p = XComObjectStorageBackend._get_full_path(data)
-        assert p.exists() is True
-        assert p.suffix == ".gz"
+            data = BaseXCom.deserialize_value(res)
+            p = XComObjectStorageBackend._get_full_path(data)
+            assert p.exists() is True
+            assert p.suffix == ".gz"
 
         value = XCom.get_value(
             key=XCOM_RETURN_KEY,

--- a/tests/providers/common/sql/operators/test_sql.py
+++ b/tests/providers/common/sql/operators/test_sql.py
@@ -48,6 +48,7 @@ from tests.test_utils.compat import AIRFLOW_V_2_8_PLUS
 pytestmark = [
     pytest.mark.db_test,
     pytest.mark.skipif(not AIRFLOW_V_2_8_PLUS, reason="Tests for Airflow 2.8.0+ only"),
+    pytest.mark.skip_if_database_isolation_mode,
 ]
 
 

--- a/tests/providers/common/sql/sensors/test_sql.py
+++ b/tests/providers/common/sql/sensors/test_sql.py
@@ -30,6 +30,7 @@ from tests.test_utils.compat import AIRFLOW_V_2_9_PLUS
 
 pytestmark = [
     pytest.mark.skipif(not AIRFLOW_V_2_9_PLUS, reason="Tests for Airflow 2.8.0+ only"),
+    pytest.mark.skip_if_database_isolation_mode,
 ]
 
 DEFAULT_DATE = datetime(2015, 1, 1)

--- a/tests/providers/databricks/operators/test_databricks_copy.py
+++ b/tests/providers/databricks/operators/test_databricks_copy.py
@@ -246,6 +246,8 @@ def test_templating(create_task_instance_of_operator, session):
         task_id="test_template_body_templating_task",
         execution_date=timezone.datetime(2024, 2, 1, tzinfo=timezone.utc),
     )
+    session.add(ti)
+    session.commit()
     ti.render_templates()
     task: DatabricksCopyIntoOperator = ti.task
     assert task.file_location == "file-location"

--- a/tests/providers/openlineage/plugins/test_execution.py
+++ b/tests/providers/openlineage/plugins/test_execution.py
@@ -39,6 +39,9 @@ from airflow.utils.state import State
 from tests.test_utils.compat import AIRFLOW_V_2_10_PLUS
 from tests.test_utils.config import conf_vars
 
+# TODO(potiuk): Document that openlineage is not supported in DB isolation mode
+pytestmark = pytest.mark.skip_if_database_isolation_mode
+
 TEST_DAG_FOLDER = os.environ["AIRFLOW__CORE__DAGS_FOLDER"]
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 

--- a/tests/www/test_utils.py
+++ b/tests/www/test_utils.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import itertools
+import os
 import re
 import time
 from datetime import datetime
@@ -761,3 +762,7 @@ class TestWidgets:
 
         assert 'readonly="true"' in html_output
         assert "form-control" in html_output
+
+
+def is_db_isolation_mode():
+    return os.environ.get("RUN_TESTS_WITH_DATABASE_ISOLATION", "false").lower() == "true"


### PR DESCRIPTION
All provider's tests should pass now in DB isolation mode

* some tests are fixed
* some modules are excluded as it makes no sense
* some modules are excluded and note about adding information about incompatibilities left to be added in the documentation

Related: #41067

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
