### PR TITLE
Simplify log message for connection retrieval

### DIFF
--- a/airflow/hooks/base.py
+++ b/airflow/hooks/base.py
@@ -81,7 +81,7 @@ class BaseHook(LoggingMixin):
         from airflow.models.connection import Connection
 
         conn = Connection.get_connection_from_secrets(conn_id)
-        log.info("Using connection ID '%s' for task execution.", conn.conn_id)
+        log.info("Retrieving connection '%s'", conn.conn_id)
         return conn
 
     @classmethod


### PR DESCRIPTION
All we know here is that the connection is being retrieved.  We don't know that it is for task execution. It might be for uploading of logs, or callback execution, webserver logs reader, etc.  So let's say less in order to tell the truth.
