### PR TITLE
Show only the source on the consumer DAG page and only triggered DAG run in the producer DAG page 

### DIFF
--- a/airflow/www/static/js/components/DatasetEventCard.tsx
+++ b/airflow/www/static/js/components/DatasetEventCard.tsx
@@ -44,11 +44,17 @@ import TriggeredDagRuns from "./TriggeredDagRuns";
 
 type CardProps = {
   datasetEvent: DatasetEvent;
+  showSource?: boolean;
+  showTriggeredDagRuns?: boolean;
 };
 
 const datasetsUrl = getMetaValue("datasets_url");
 
-const DatasetEventCard = ({ datasetEvent }: CardProps) => {
+const DatasetEventCard = ({
+  datasetEvent,
+  showSource = true,
+  showTriggeredDagRuns = true,
+}: CardProps) => {
   const [searchParams] = useSearchParams();
 
   const selectedUri = decodeURIComponent(searchParams.get("uri") || "");
@@ -92,25 +98,29 @@ const DatasetEventCard = ({ datasetEvent }: CardProps) => {
           </Flex>
         </GridItem>
         <GridItem>
-          Source:
-          {fromRestApi && (
-            <Tooltip
-              portalProps={{ containerRef }}
-              hasArrow
-              placement="top"
-              label="Manually created from REST API"
-            >
-              <Box width="20px">
-                <TbApi size="20px" />
-              </Box>
-            </Tooltip>
-          )}
-          {!!datasetEvent.sourceTaskId && (
-            <SourceTaskInstance datasetEvent={datasetEvent} />
+          {showSource && (
+            <>
+              Source:
+              {fromRestApi && (
+                <Tooltip
+                  portalProps={{ containerRef }}
+                  hasArrow
+                  placement="top"
+                  label="Manually created from REST API"
+                >
+                  <Box width="20px">
+                    <TbApi size="20px" />
+                  </Box>
+                </Tooltip>
+              )}
+              {!!datasetEvent.sourceTaskId && (
+                <SourceTaskInstance datasetEvent={datasetEvent} />
+              )}
+            </>
           )}
         </GridItem>
         <GridItem>
-          {!!datasetEvent?.createdDagruns?.length && (
+          {showTriggeredDagRuns && !!datasetEvent?.createdDagruns?.length && (
             <>
               Triggered Dag Runs:
               <TriggeredDagRuns createdDagRuns={datasetEvent?.createdDagruns} />

--- a/airflow/www/static/js/dag/details/dagRun/DatasetTriggerEvents.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/DatasetTriggerEvents.tsx
@@ -33,7 +33,9 @@ interface Props {
 const dagId = getMetaValue("dag_id");
 
 const cardDef: CardDef<DatasetEvent> = {
-  card: ({ row }) => <DatasetEventCard datasetEvent={row} />,
+  card: ({ row }) => (
+    <DatasetEventCard datasetEvent={row} showTriggeredDagRuns={false} />
+  ),
 };
 
 const DatasetTriggerEvents = ({ runId }: Props) => {
@@ -55,10 +57,6 @@ const DatasetTriggerEvents = ({ runId }: Props) => {
       {
         Header: "Source Task Instance",
         accessor: "sourceTaskId",
-      },
-      {
-        Header: "Triggered Runs",
-        accessor: "createdDagruns",
       },
       {
         Header: "Extra",

--- a/airflow/www/static/js/dag/details/taskInstance/DatasetUpdateEvents.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/DatasetUpdateEvents.tsx
@@ -32,7 +32,7 @@ interface Props {
 }
 
 const cardDef: CardDef<DatasetEvent> = {
-  card: ({ row }) => <DatasetEventCard datasetEvent={row} />,
+  card: ({ row }) => <DatasetEventCard datasetEvent={row} showSource={false} />,
 };
 
 const dagId = getMetaValue("dag_id") || undefined;
@@ -56,10 +56,6 @@ const DatasetUpdateEvents = ({ runId, taskId }: Props) => {
       {
         Header: "Dataset",
         accessor: "datasetUri",
-      },
-      {
-        Header: "Source Task Instance",
-        accessor: "sourceTaskId",
       },
       {
         Header: "Triggered Runs",


### PR DESCRIPTION
## Why
Before this change, the dataset event producer DAG will get information about the source that points to itself and vice versa, which is not useful and might be misleading.

## What
Show only the source on the consumer DAG page and only trigger DAG run in the producer DAG page 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
