### PR TITLE
fix(rest-api): Add order_by query param to TI listing APIs (#41283)

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1517,6 +1517,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/PageLimit"
         - $ref: "#/components/parameters/PageOffset"
+        - $ref: "#/components/parameters/OrderBy"
       responses:
         "200":
           description: Success.
@@ -5177,6 +5178,11 @@ components:
           items:
             type: string
           description: The value can be repeated to retrieve multiple matching values (OR condition).
+        order_by:
+          type: string
+          description: |
+            The name of the field to order the results by. Prefix a field name
+            with `-` to reverse the sort order.
 
     # Common data type
     ScheduleInterval:

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -5182,7 +5182,12 @@ components:
           type: string
           description: |
             The name of the field to order the results by. Prefix a field name
-            with `-` to reverse the sort order.
+            with `-` to reverse the sort order. `order_by` defaults to
+            `map_index` when unspecified.
+            Supported field names: `state`, `duration`, `start_date`, `end_date`
+            and `map_index`.
+
+            *New in version 3.0.0*
 
     # Common data type
     ScheduleInterval:

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1517,7 +1517,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/PageLimit"
         - $ref: "#/components/parameters/PageOffset"
-        - $ref: "#/components/parameters/OrderBy"
+        - $ref: "#/components/parameters/TaskInstanceOrderBy"
       responses:
         "200":
           description: Success.
@@ -1676,7 +1676,7 @@ paths:
         - $ref: "#/components/parameters/FilterPool"
         - $ref: "#/components/parameters/FilterQueue"
         - $ref: "#/components/parameters/FilterExecutor"
-        - $ref: "#/components/parameters/OrderBy"
+        - $ref: "#/components/parameters/TaskInstanceOrderBy"
       responses:
         "200":
           description: Success.
@@ -5812,6 +5812,21 @@ components:
       schema:
         type: integer
       description: Filter on try_number for task instance.
+
+    TaskInstanceOrderBy:
+      in: query
+      name: order_by
+      schema:
+        type: string
+      required: false
+      description: |
+        The name of the field to order the results by. Prefix a field name
+        with `-` to reverse the sort order. `order_by` defaults to
+        `map_index` when unspecified.
+        Supported field names: `state`, `duration`, `start_date`, `end_date`
+        and `map_index`.
+
+        *New in version 3.0.0*
 
     OrderBy:
       in: query

--- a/airflow/api_connexion/schemas/task_instance_schema.py
+++ b/airflow/api_connexion/schemas/task_instance_schema.py
@@ -167,6 +167,7 @@ class TaskInstanceBatchFormSchema(Schema):
     pool = fields.List(fields.Str(), load_default=None)
     queue = fields.List(fields.Str(), load_default=None)
     executor = fields.List(fields.Str(), load_default=None)
+    order_by = fields.Str(load_default=None)
 
 
 class ClearTaskInstanceFormSchema(Schema):

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -2305,14 +2305,14 @@ export interface components {
       /** @description The value can be repeated to retrieve multiple matching values (OR condition). */
       executor?: string[];
       /**
-         * @description The name of the field to order the results by.
-         * Prefix a field name with `-` to reverse the sort order.
-         * `order_by` defaults to `map_index` when unspecified.
-         * Supported field names: `state`, `duration`, `start_date`, `end_date`
-         * and `map_index`.
-         *
-         * *New in version 3.0.0*
-      */
+       * @description The name of the field to order the results by. Prefix a field name
+       * with `-` to reverse the sort order. `order_by` defaults to
+       * `map_index` when unspecified.
+       * Supported field names: `state`, `duration`, `start_date`, `end_date`
+       * and `map_index`.
+       *
+       * *New in version 3.0.0*
+       */
       order_by?: string;
     };
     /**
@@ -2664,6 +2664,17 @@ export interface components {
     FilterMapIndex: number;
     /** @description Filter on try_number for task instance. */
     FilterTryNumber: number;
+    /**
+     * @description The name of the field to order the results by. Prefix a field name
+     * with `-` to reverse the sort order. `order_by` defaults to
+     * `map_index` when unspecified.
+     * Supported field names: `state`, `duration`, `start_date`, `end_date`
+     * and `map_index`.
+     *
+     * *New in version 3.0.0*
+     */
+    TaskInstanceOrderBy: string;
+
     /**
      * @description The name of the field to order the results by.
      * Prefix a field name with `-` to reverse the sort order.
@@ -4067,8 +4078,8 @@ export interface operations {
          * and `map_index`.
          *
          * *New in version 3.0.0*
-         */
-        order_by?: components["parameters"]["OrderBy"];
+       */
+        order_by?: components["parameters"]["TaskInstanceOrderBy"];
       };
     };
     responses: {
@@ -4302,9 +4313,9 @@ export interface operations {
          * Supported field names: `state`, `duration`, `start_date`, `end_date`
          * and `map_index`.
          *
-         * *New in version 2.1.0*
-         */
-        order_by?: components["parameters"]["OrderBy"];
+         * *New in version 3.0.0*
+       */
+        order_by?: components["parameters"]["TaskInstanceOrderBy"];
       };
     };
     responses: {

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -2674,7 +2674,6 @@ export interface components {
      * *New in version 3.0.0*
      */
     TaskInstanceOrderBy: string;
-
     /**
      * @description The name of the field to order the results by.
      * Prefix a field name with `-` to reverse the sort order.
@@ -4078,7 +4077,7 @@ export interface operations {
          * and `map_index`.
          *
          * *New in version 3.0.0*
-       */
+         */
         order_by?: components["parameters"]["TaskInstanceOrderBy"];
       };
     };
@@ -4314,7 +4313,7 @@ export interface operations {
          * and `map_index`.
          *
          * *New in version 3.0.0*
-       */
+         */
         order_by?: components["parameters"]["TaskInstanceOrderBy"];
       };
     };

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -2305,9 +2305,14 @@ export interface components {
       /** @description The value can be repeated to retrieve multiple matching values (OR condition). */
       executor?: string[];
       /**
-       * @description The name of the field to order the results by. Prefix a field name
-       * with `-` to reverse the sort order.
-       */
+         * @description The name of the field to order the results by.
+         * Prefix a field name with `-` to reverse the sort order.
+         * `order_by` defaults to `map_index` when unspecified.
+         * Supported field names: `state`, `duration`, `start_date`, `end_date`
+         * and `map_index`.
+         *
+         * *New in version 3.0.0*
+      */
       order_by?: string;
     };
     /**
@@ -4055,10 +4060,13 @@ export interface operations {
         /** The number of items to skip before starting to collect the result set. */
         offset?: components["parameters"]["PageOffset"];
         /**
-         * The name of the field to order the results by.
-         * Prefix a field name with `-` to reverse the sort order.
+         * The name of the field to order the results by. Prefix a field name
+         * with `-` to reverse the sort order. `order_by` defaults to
+         * `map_index` when unspecified.
+         * Supported field names: `state`, `duration`, `start_date`, `end_date`
+         * and `map_index`.
          *
-         * *New in version 2.1.0*
+         * *New in version 3.0.0*
          */
         order_by?: components["parameters"]["OrderBy"];
       };
@@ -4288,8 +4296,11 @@ export interface operations {
         /** The value can be repeated to retrieve multiple matching values (OR condition). */
         executor?: components["parameters"]["FilterExecutor"];
         /**
-         * The name of the field to order the results by.
-         * Prefix a field name with `-` to reverse the sort order.
+         * The name of the field to order the results by. Prefix a field name
+         * with `-` to reverse the sort order. `order_by` defaults to
+         * `map_index` when unspecified.
+         * Supported field names: `state`, `duration`, `start_date`, `end_date`
+         * and `map_index`.
          *
          * *New in version 2.1.0*
          */

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -2304,6 +2304,11 @@ export interface components {
       queue?: string[];
       /** @description The value can be repeated to retrieve multiple matching values (OR condition). */
       executor?: string[];
+      /**
+       * @description The name of the field to order the results by. Prefix a field name
+       * with `-` to reverse the sort order.
+       */
+      order_by?: string;
     };
     /**
      * @description Schedule interval. Defines how often DAG runs, this object gets added to your latest task instance's
@@ -4049,6 +4054,13 @@ export interface operations {
         limit?: components["parameters"]["PageLimit"];
         /** The number of items to skip before starting to collect the result set. */
         offset?: components["parameters"]["PageOffset"];
+        /**
+         * The name of the field to order the results by.
+         * Prefix a field name with `-` to reverse the sort order.
+         *
+         * *New in version 2.1.0*
+         */
+        order_by?: components["parameters"]["OrderBy"];
       };
     };
     responses: {


### PR DESCRIPTION
closes #41283.

This adds db-level sorting with order_by query param to the following TI listing APIs:
1. List task instances - `/api/v1/dags/~/dagRuns/~/taskInstances`
2. List task instances (batch) - `/api/v1/dags/~/dagRuns/~/taskInstances/list`

order_by defaults to sorting by start_date (ascending) for above mentioned 2 APIs. Please note that this does NOT change the default sorting param for the List mapped task instances API.

This also adds corresponding unit tests.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
