### PR TITLE
XCom tests pass DB isolation mode

### DIFF
--- a/tests/models/test_xcom.py
+++ b/tests/models/test_xcom.py
@@ -36,6 +36,7 @@ from airflow.utils import timezone
 from airflow.utils.session import create_session
 from airflow.utils.xcom import XCOM_RETURN_KEY
 from tests.test_utils.config import conf_vars
+from tests.www.test_utils import is_db_isolation_mode
 
 pytestmark = pytest.mark.db_test
 
@@ -140,6 +141,7 @@ class TestXCom:
             ret_value = XCom.get_value(key="xcom_test3", ti_key=ti_key, session=session)
         assert ret_value == {"key": "value"}
 
+    @pytest.mark.skip_if_database_isolation_mode
     def test_xcom_deserialize_pickle_when_xcom_pickling_is_disabled(self, task_instance, session):
         with conf_vars({("core", "enable_xcom_pickling"): "True"}):
             XCom.set(
@@ -160,6 +162,7 @@ class TestXCom:
                     session=session,
                 )
 
+    @pytest.mark.skip_if_database_isolation_mode
     @conf_vars({("core", "xcom_enable_pickling"): "False"})
     def test_xcom_disable_pickle_type_fail_on_non_json(self, task_instance, session):
         class PickleRce:
@@ -211,6 +214,7 @@ class TestXCom:
         assert value == {"key": "value"}
         XCom.orm_deserialize_value.assert_not_called()
 
+    @pytest.mark.skip_if_database_isolation_mode
     @conf_vars({("core", "enable_xcom_pickling"): "False"})
     @mock.patch("airflow.models.xcom.conf.getimport")
     def test_set_serialize_call_old_signature(self, get_import, task_instance):
@@ -237,6 +241,7 @@ class TestXCom:
         )
         serialize_watcher.assert_called_once_with(value={"my_xcom_key": "my_xcom_value"})
 
+    @pytest.mark.skip_if_database_isolation_mode
     @conf_vars({("core", "enable_xcom_pickling"): "False"})
     @mock.patch("airflow.models.xcom.conf.getimport")
     def test_set_serialize_call_current_signature(self, get_import, task_instance):
@@ -330,6 +335,7 @@ class TestXComGet:
         )
         assert stored_value == {"key": "value"}
 
+    @pytest.mark.skip_if_database_isolation_mode
     @pytest.mark.usefixtures("setup_for_xcom_get_one")
     def test_xcom_get_one_with_execution_date(self, session, task_instance):
         with pytest.deprecated_call():
@@ -370,6 +376,7 @@ class TestXComGet:
         )
         assert retrieved_value == {"key": "value"}
 
+    @pytest.mark.skip_if_database_isolation_mode
     def test_xcom_get_one_from_prior_with_execution_date(
         self,
         session,
@@ -387,10 +394,12 @@ class TestXComGet:
             )
         assert retrieved_value == {"key": "value"}
 
+    @pytest.mark.skip_if_database_isolation_mode
     @pytest.fixture
     def setup_for_xcom_get_many_single_argument_value(self, task_instance, push_simple_json_xcom):
         push_simple_json_xcom(ti=task_instance, key="xcom_1", value={"key": "value"})
 
+    @pytest.mark.skip_if_database_isolation_mode
     @pytest.mark.usefixtures("setup_for_xcom_get_many_single_argument_value")
     def test_xcom_get_many_single_argument_value(self, session, task_instance):
         stored_xcoms = XCom.get_many(
@@ -404,6 +413,7 @@ class TestXComGet:
         assert stored_xcoms[0].key == "xcom_1"
         assert stored_xcoms[0].value == {"key": "value"}
 
+    @pytest.mark.skip_if_database_isolation_mode
     @pytest.mark.usefixtures("setup_for_xcom_get_many_single_argument_value")
     def test_xcom_get_many_single_argument_value_with_execution_date(self, session, task_instance):
         with pytest.deprecated_call():
@@ -418,12 +428,14 @@ class TestXComGet:
         assert stored_xcoms[0].key == "xcom_1"
         assert stored_xcoms[0].value == {"key": "value"}
 
+    @pytest.mark.skip_if_database_isolation_mode
     @pytest.fixture
     def setup_for_xcom_get_many_multiple_tasks(self, task_instances, push_simple_json_xcom):
         ti1, ti2 = task_instances
         push_simple_json_xcom(ti=ti1, key="xcom_1", value={"key1": "value1"})
         push_simple_json_xcom(ti=ti2, key="xcom_1", value={"key2": "value2"})
 
+    @pytest.mark.skip_if_database_isolation_mode
     @pytest.mark.usefixtures("setup_for_xcom_get_many_multiple_tasks")
     def test_xcom_get_many_multiple_tasks(self, session, task_instance):
         stored_xcoms = XCom.get_many(
@@ -436,6 +448,7 @@ class TestXComGet:
         sorted_values = [x.value for x in sorted(stored_xcoms, key=operator.attrgetter("task_id"))]
         assert sorted_values == [{"key1": "value1"}, {"key2": "value2"}]
 
+    @pytest.mark.skip_if_database_isolation_mode
     @pytest.mark.usefixtures("setup_for_xcom_get_many_multiple_tasks")
     def test_xcom_get_many_multiple_tasks_with_execution_date(self, session, task_instance):
         with pytest.deprecated_call():
@@ -459,6 +472,7 @@ class TestXComGet:
         push_simple_json_xcom(ti=ti2, key="xcom_1", value={"key2": "value2"})
         return ti1, ti2
 
+    @pytest.mark.skip_if_database_isolation_mode
     def test_xcom_get_many_from_prior_dates(self, session, tis_for_xcom_get_many_from_prior_dates):
         ti1, ti2 = tis_for_xcom_get_many_from_prior_dates
         stored_xcoms = XCom.get_many(
@@ -474,6 +488,8 @@ class TestXComGet:
         assert [x.value for x in stored_xcoms] == [{"key2": "value2"}, {"key1": "value1"}]
         assert [x.execution_date for x in stored_xcoms] == [ti2.execution_date, ti1.execution_date]
 
+    @pytest.mark.skip_if_database_isolation_mode
+    @pytest.mark.skip_if_database_isolation_mode
     def test_xcom_get_many_from_prior_dates_with_execution_date(
         self,
         session,
@@ -513,6 +529,7 @@ class TestXComSet:
         assert stored_xcoms[0].task_id == "task_1"
         assert stored_xcoms[0].execution_date == task_instance.execution_date
 
+    @pytest.mark.skip_if_database_isolation_mode
     def test_xcom_set_with_execution_date(self, session, task_instance):
         with pytest.deprecated_call():
             XCom.set(
@@ -547,6 +564,7 @@ class TestXComSet:
         )
         assert session.query(XCom).one().value == {"key2": "value2"}
 
+    @pytest.mark.skip_if_database_isolation_mode
     @pytest.mark.usefixtures("setup_for_xcom_set_again_replace")
     def test_xcom_set_again_replace_with_execution_date(self, session, task_instance):
         assert session.query(XCom).one().value == {"key1": "value1"}
@@ -579,8 +597,9 @@ class TestXComClear:
             session=session,
         )
         assert session.query(XCom).count() == 0
-        assert mock_purge.call_count == 1
+        assert mock_purge.call_count == 0 if is_db_isolation_mode() else 1
 
+    @pytest.mark.skip_if_database_isolation_mode
     @pytest.mark.usefixtures("setup_for_xcom_clear")
     def test_xcom_clear_with_execution_date(self, session, task_instance):
         assert session.query(XCom).count() == 1
@@ -603,6 +622,7 @@ class TestXComClear:
         )
         assert session.query(XCom).count() == 1
 
+    @pytest.mark.skip_if_database_isolation_mode
     @pytest.mark.usefixtures("setup_for_xcom_clear")
     def test_xcom_clear_different_execution_date(self, session, task_instance):
         with pytest.deprecated_call():

--- a/tests/models/test_xcom.py
+++ b/tests/models/test_xcom.py
@@ -489,7 +489,6 @@ class TestXComGet:
         assert [x.execution_date for x in stored_xcoms] == [ti2.execution_date, ti1.execution_date]
 
     @pytest.mark.skip_if_database_isolation_mode
-    @pytest.mark.skip_if_database_isolation_mode
     def test_xcom_get_many_from_prior_dates_with_execution_date(
         self,
         session,


### PR DESCRIPTION
The tests are disabled that are not supposed to work:

* warnings are raised on internal API side
* get_many is excluded

Related: #41067

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
