### PR TITLE
Add `languages` field to `get_ui_field_behaviour`

### DIFF
--- a/airflow/customized_form_field_behaviours.schema.json
+++ b/airflow/customized_form_field_behaviours.schema.json
@@ -23,10 +23,10 @@
         "type": "string"
       }
     },
-    "json_fields": {
-      "description": "List of fields that are in JSON format.",
-      "type": "array",
-      "items": {
+    "languages": {
+      "type": "object",
+      "description": "Languages that are used to fill the values. ``json``, ``text`` are possible.",
+      "additionalProperties": {
         "type": "string"
       }
     }

--- a/airflow/customized_form_field_behaviours.schema.json
+++ b/airflow/customized_form_field_behaviours.schema.json
@@ -22,6 +22,13 @@
       "additionalProperties": {
         "type": "string"
       }
+    },
+    "json_fields": {
+      "description": "List of fields that are in JSON format.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "additionalProperties": true,

--- a/airflow/providers/apprise/hooks/apprise.py
+++ b/airflow/providers/apprise/hooks/apprise.py
@@ -146,4 +146,7 @@ class AppriseHook(BaseHook):
         return {
             "hidden_fields": ["host", "schema", "login", "password", "port", "extra"],
             "relabeling": {},
+            "languages": {
+                "config": "json",
+            },
         }

--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -129,6 +129,10 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
         return {
             "hidden_fields": ["host", "schema", "login", "password", "port", "extra"],
             "relabeling": {},
+            "languages": {
+                "kube_config": "json",
+                "xcom_sidecar_container_resources": "json",
+            },
         }
 
     def __init__(

--- a/airflow/providers/google/common/hooks/base_google.py
+++ b/airflow/providers/google/common/hooks/base_google.py
@@ -274,6 +274,9 @@ class GoogleBaseHook(BaseHook):
         return {
             "hidden_fields": ["host", "schema", "login", "password", "port", "extra"],
             "relabeling": {},
+            "languages": {
+                "keyfile_dict": "json",
+            },
         }
 
     def __init__(

--- a/airflow/providers/yandex/hooks/yandex.py
+++ b/airflow/providers/yandex/hooks/yandex.py
@@ -112,6 +112,7 @@ class YandexCloudBaseHook(BaseHook):
         return {
             "hidden_fields": ["host", "schema", "login", "password", "port", "extra"],
             "relabeling": {},
+            "languages": {"service_account_json": "json"},
         }
 
     def __init__(

--- a/airflow/providers/ydb/hooks/ydb.py
+++ b/airflow/providers/ydb/hooks/ydb.py
@@ -218,6 +218,9 @@ class YDBHook(DbApiHook):
                 "service_account_json": 'e.g. {"id": "...", "service_account_id": "...", "private_key": "..."}',
                 "token": "t1.9....AAQ",
             },
+            "languages": {
+                "service_account_json": "json",
+            },
         }
 
     @property

--- a/airflow/providers_manager.py
+++ b/airflow/providers_manager.py
@@ -1111,6 +1111,11 @@ class ProvidersManager(LoggingMixin, metaclass=Singleton):
         try:
             connection_type = getattr(hook_class, "conn_type")
 
+            if not customized_fields.get("languages"):
+                customized_fields["languages"] = {}
+            if not customized_fields["languages"].get("extra"):
+                customized_fields["languages"]["extra"] = "json"
+
             self._customized_form_fields_schema_validator.validate(customized_fields)
 
             if connection_type:
@@ -1125,9 +1130,6 @@ class ProvidersManager(LoggingMixin, metaclass=Singleton):
                     hook_class.__name__,
                 )
                 return
-
-            if not customized_fields.get("json_fields"):
-                customized_fields["json_fields"] = ["extra"]
 
             self._field_behaviours[connection_type] = customized_fields
         except Exception as e:

--- a/airflow/providers_manager.py
+++ b/airflow/providers_manager.py
@@ -1125,6 +1125,10 @@ class ProvidersManager(LoggingMixin, metaclass=Singleton):
                     hook_class.__name__,
                 )
                 return
+
+            if not customized_fields.get("json_fields"):
+                customized_fields["json_fields"] = ["extra"]
+
             self._field_behaviours[connection_type] = customized_fields
         except Exception as e:
             log.warning(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #41010 

Following the context of https://github.com/apache/airflow/issues/41010, add languages to get_ui_field_behaviour to enable the CodeMirror JSON editor for a specific field on the Connection Add/Edit page.

I considered YAML support, but JSON alone should be sufficient for users to define the Connection in the connection hook. I've left room for future modifications if the need arises.

### screenshot: Add Connection for `Kubernetes Cluster Connection`

![image](https://github.com/user-attachments/assets/fe19bc0c-1dec-4b8f-9b30-180577a71a5f)

Previously, the entire textarea was set to be changed to CodeMirror, but now only the fields set with json in languages and `extra` will be changed to CodeMirror.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
