### PR TITLE
Support the unpack operator in signature

### DIFF
--- a/airflow/utils/operator_helpers.py
+++ b/airflow/utils/operator_helpers.py
@@ -163,6 +163,13 @@ class KeywordParameters:
         has_wildcard_kwargs = any(p.kind == p.VAR_KEYWORD for p in signature.parameters.values())
 
         for name in itertools.islice(signature.parameters.keys(), len(args)):
+            if signature.parameters[name].kind in [
+                inspect.Parameter.KEYWORD_ONLY,
+                inspect.Parameter.VAR_KEYWORD,
+            ]:
+                # this is only checking positional arguments
+                continue
+
             # Check if args conflict with names in kwargs.
             if name in kwargs:
                 raise ValueError(f"The key {name!r} in args is a part of kwargs and therefore reserved.")

--- a/airflow/utils/operator_helpers.py
+++ b/airflow/utils/operator_helpers.py
@@ -162,12 +162,11 @@ class KeywordParameters:
         signature = inspect.signature(func)
         has_wildcard_kwargs = any(p.kind == p.VAR_KEYWORD for p in signature.parameters.values())
 
-        for name in itertools.islice(signature.parameters.keys(), len(args)):
-            if signature.parameters[name].kind in [
-                inspect.Parameter.KEYWORD_ONLY,
-                inspect.Parameter.VAR_KEYWORD,
-            ]:
-                # this is only checking positional arguments
+        for name, param in itertools.islice(signature.parameters.items(), len(args)):
+            # Keyword-only arguments can't be passed positionally and are not checked.
+            if param.kind == inspect.Parameter.KEYWORD_ONLY:
+                continue
+            if param.kind == inspect.Parameter.VAR_KEYWORD:
                 continue
 
             # Check if args conflict with names in kwargs.

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -283,6 +283,18 @@ class TestPythonOperator(BasePythonTest):
         with pytest.raises(ValueError, match=error_message):
             ti.run()
 
+    def test_unpack_operator_kwargs(self):
+        """Makes sure that keyword arguments are not continually processed after an unpack operator."""
+
+        error_message = "Should be run"
+
+        def func(*unpacked_args, keyword_only_arg):
+            raise RuntimeError(error_message)
+
+        ti = self.create_ti(func, op_args=[1, 2], op_kwargs={"keyword_only_arg": 1})
+        with pytest.raises(RuntimeError, match=error_message):
+            ti.run()
+
     def test_provide_context_does_not_fail(self):
         """Ensures that provide_context doesn't break dags in 2.0."""
 

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -283,18 +283,6 @@ class TestPythonOperator(BasePythonTest):
         with pytest.raises(ValueError, match=error_message):
             ti.run()
 
-    def test_unpack_operator_kwargs(self):
-        """Makes sure that keyword arguments are not continually processed after an unpack operator."""
-
-        error_message = "Should be run"
-
-        def func(*unpacked_args, keyword_only_arg):
-            raise RuntimeError(error_message)
-
-        ti = self.create_ti(func, op_args=[1, 2], op_kwargs={"keyword_only_arg": 1})
-        with pytest.raises(RuntimeError, match=error_message):
-            ti.run()
-
     def test_provide_context_does_not_fail(self):
         """Ensures that provide_context doesn't break dags in 2.0."""
 

--- a/tests/utils/test_operator_helpers.py
+++ b/tests/utils/test_operator_helpers.py
@@ -224,3 +224,7 @@ def test_make_kwargs_callable_conflict():
         kwargs_callable(*args, **kwargs)
 
     assert "ds_nodash" in str(exc_info)
+
+def test_args_and_kwargs_conflicts():
+    kwargs_result = operator_helpers.determine_kwargs(callable10, args=[1, 2], kwargs={"ds_nodash": 1})
+    assert {"ds_nodash": 1} == kwargs_result

--- a/tests/utils/test_operator_helpers.py
+++ b/tests/utils/test_operator_helpers.py
@@ -225,6 +225,7 @@ def test_make_kwargs_callable_conflict():
 
     assert "ds_nodash" in str(exc_info)
 
+
 def test_args_and_kwargs_conflicts():
     kwargs_result = operator_helpers.determine_kwargs(callable10, args=[1, 2], kwargs={"ds_nodash": 1})
     assert {"ds_nodash": 1} == kwargs_result

--- a/tests/utils/test_operator_helpers.py
+++ b/tests/utils/test_operator_helpers.py
@@ -226,6 +226,13 @@ def test_make_kwargs_callable_conflict():
     assert "ds_nodash" in str(exc_info)
 
 
-def test_args_and_kwargs_conflicts():
-    kwargs_result = operator_helpers.determine_kwargs(callable10, args=[1, 2], kwargs={"ds_nodash": 1})
-    assert {"ds_nodash": 1} == kwargs_result
+@pytest.mark.parametrize(
+    "func,args,kwargs,expected",
+    [
+        (callable10, (1, 2), {"ds_nodash": 1}, {"ds_nodash": 1}),
+        (callable11, (1, 2), {"ds_nodash": 1}, {"ds_nodash": 1}),
+    ],
+)
+def test_args_and_kwargs_conflicts(func, args, kwargs, expected):
+    kwargs_result = operator_helpers.determine_kwargs(func, args=args, kwargs=kwargs)
+    assert expected == kwargs_result


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

Support the unpack operator in operator signature.

Closes: #41286

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:



How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
