### PR TITLE
Fixing Object is already attached to session problem for Database Isolation Tests

### DIFF
--- a/tests/providers/cncf/kubernetes/operators/test_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_pod.py
@@ -139,6 +139,7 @@ class TestKubernetesPodOperator:
         dag_id = "TestKubernetesPodOperator"
         ti = create_task_instance_of_operator(
             KubernetesPodOperator,
+            session=session,
             dag_id=dag_id,
             task_id="task-id",
             namespace="{{ dag.dag_id }}",

--- a/tests/providers/cncf/kubernetes/operators/test_spark_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/operators/test_spark_kubernetes.py
@@ -554,6 +554,7 @@ def test_template_body_templating(create_task_instance_of_operator, session):
         kubernetes_conn_id="kubernetes_default_kube_config",
         dag_id="test_template_body_templating_dag",
         task_id="test_template_body_templating_task",
+        session=session,
         execution_date=timezone.datetime(2024, 2, 1, tzinfo=timezone.utc),
     )
     session.add(ti)
@@ -570,7 +571,9 @@ def test_resolve_application_file_template_file(dag_maker, tmp_path, session):
     (tmp_path / filename).write_text("foo: {{ ds }}\nbar: {{ dag_run.dag_id }}\nspam: egg")
 
     with dag_maker(
-        dag_id="test_resolve_application_file_template_file", template_searchpath=tmp_path.as_posix()
+        dag_id="test_resolve_application_file_template_file",
+        template_searchpath=tmp_path.as_posix(),
+        session=session,
     ):
         SparkKubernetesOperator(
             application_file=filename,
@@ -609,7 +612,9 @@ def test_resolve_application_file_template_non_dictionary(dag_maker, tmp_path, b
         yaml.safe_dump(body, fp)
 
     with dag_maker(
-        dag_id="test_resolve_application_file_template_nondictionary", template_searchpath=tmp_path.as_posix()
+        dag_id="test_resolve_application_file_template_nondictionary",
+        template_searchpath=tmp_path.as_posix(),
+        session=session,
     ):
         SparkKubernetesOperator(
             application_file=filename,
@@ -654,6 +659,7 @@ def test_resolve_application_file_real_file(
         kubernetes_conn_id="kubernetes_default_kube_config",
         dag_id="test_resolve_application_file_real_file",
         task_id="test_template_body_templating_task",
+        session=session,
     )
     session.add(ti)
     session.commit()
@@ -677,6 +683,7 @@ def test_resolve_application_file_real_file_not_exists(create_task_instance_of_o
         kubernetes_conn_id="kubernetes_default_kube_config",
         dag_id="test_resolve_application_file_real_file_not_exists",
         task_id="test_template_body_templating_task",
+        session=session,
     )
     session.add(ti)
     session.commit()

--- a/tests/providers/common/io/xcom/test_backend.py
+++ b/tests/providers/common/io/xcom/test_backend.py
@@ -65,12 +65,13 @@ def reset_cache():
 
 
 @pytest.fixture
-def task_instance(create_task_instance_of_operator):
+def task_instance(create_task_instance_of_operator, session):
     return create_task_instance_of_operator(
         EmptyOperator,
         dag_id="test-dag-id",
         task_id="test-task-id",
         execution_date=timezone.datetime(2021, 12, 3, 4, 56),
+        session=session,
     )
 
 

--- a/tests/providers/databricks/operators/test_databricks_copy.py
+++ b/tests/providers/databricks/operators/test_databricks_copy.py
@@ -245,6 +245,7 @@ def test_templating(create_task_instance_of_operator, session):
         dag_id="test_template_body_templating_dag",
         task_id="test_template_body_templating_task",
         execution_date=timezone.datetime(2024, 2, 1, tzinfo=timezone.utc),
+        session=session,
     )
     session.add(ti)
     session.commit()


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Related: https://github.com/apache/airflow/pull/41067
Fixes `already attached to the session` problem with passing session object from the fixture.
I have tested with the same parameters running in the `Special tests/Database isolation` test CI and all seems like passing. 

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
