### PR TITLE
Add plugin data to scarf usage data collection

### DIFF
--- a/airflow/utils/usage_data_collection.py
+++ b/airflow/utils/usage_data_collection.py
@@ -33,6 +33,7 @@ from packaging.version import parse
 
 from airflow import __version__ as airflow_version, settings
 from airflow.configuration import conf
+from airflow.plugins_manager import get_plugin_info
 
 
 def usage_data_collection():
@@ -95,3 +96,15 @@ def get_executor() -> str:
 
 def get_python_version() -> str:
     return platform.python_version()
+
+
+def get_plugin_counts() -> dict[str, int]:
+    plugin_info = get_plugin_info()
+
+    return {
+        "plugins": len(plugin_info),
+        "flask_blueprints": sum(len(x["flask_blueprints"]) for x in plugin_info),
+        "appbuilder_views": sum(len(x["appbuilder_views"]) for x in plugin_info),
+        "appbuilder_menu_items": sum(len(x["appbuilder_menu_items"]) for x in plugin_info),
+        "timetables": sum(len(x["timetables"]) for x in plugin_info),
+    }

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -234,15 +234,22 @@ def build_scarf_url(dags_count: int) -> str:
     db_name = usage_data_collection.get_database_name()
     executor = usage_data_collection.get_executor()
     python_version = usage_data_collection.get_python_version()
+    plugin_counts = usage_data_collection.get_plugin_counts()
+    plugins_count = plugin_counts["plugins"]
+    flask_blueprints_count = plugin_counts["flask_blueprints"]
+    appbuilder_views_count = plugin_counts["appbuilder_views"]
+    appbuilder_menu_items_count = plugin_counts["appbuilder_menu_items"]
+    timetables_count = plugin_counts["timetables"]
 
     # Path Format:
-    # /{version}/{python_version}/{platform}/{arch}/{database}/{db_version}/{executor}/{num_dags}
+    # /{version}/{python_version}/{platform}/{arch}/{database}/{db_version}/{executor}/{num_dags}/{plugin_count}/{flask_blueprint_count}/{appbuilder_view_count}/{appbuilder_menu_item_count}/{timetables}
     #
     # This path redirects to a Pixel tracking URL
     scarf_url = (
         f"{scarf_domain}/webserver"
         f"/{version}/{python_version}"
         f"/{platform_sys}/{platform_arch}/{db_name}/{db_version}/{executor}/{dags_count}"
+        f"/{plugins_count}/{flask_blueprints_count}/{appbuilder_views_count}/{appbuilder_menu_items_count}/{timetables_count}"
     )
 
     return scarf_url

--- a/docs/apache-airflow/faq.rst
+++ b/docs/apache-airflow/faq.rst
@@ -546,3 +546,5 @@ The telemetry data collected is limited to the following:
 - Executor
 - Metadata DB type & its version
 - Number of DAGs
+- Number of Airflow plugins
+- Number of timetables, Flask blueprints, Flask AppBuilder views, and Flask Appbuilder menu items from Airflow plugins


### PR DESCRIPTION
This will give us counts for the following:

- plugins in use
- flask blueprints
- FAB specific usage
  - custom appbuilder views
  - custom appbuilder menu items
- timetables