### PR TITLE
Recommend reserializing DAGs after downgrade

### DIFF
--- a/docs/apache-airflow/howto/usage-cli.rst
+++ b/docs/apache-airflow/howto/usage-cli.rst
@@ -287,6 +287,10 @@ Options ``--from-revision`` and ``--from-version`` may only be used in conjuncti
 
 For a mapping between Airflow version and Alembic revision see :doc:`/migrations-ref`.
 
+.. note::
+
+    It's highly recommended that you reserialize your DAGs with ``dags reserialize`` after you finish downgrading your Airflow environment (meaning, after you've downgraded the Airflow version installed in your Python environment, not immediately after you've downgraded the database).
+    This is to ensure that the serialized DAGs are compatible with the downgraded version of Airflow.
 
 .. _cli-export-connections:
 


### PR DESCRIPTION
We should recommend that users reserialize DAGs after finishing their downgrades - the older version may have a different representation and can cause odd failures.

<img width="1096" alt="Screenshot 2024-08-08 at 11 29 55 PM" src="https://github.com/user-attachments/assets/fb124c58-ff9f-4d91-9090-012729bcd992">
