### PR TITLE
feat(docker): Replace `use_dill` with `serializer`

### DIFF
--- a/airflow/decorators/__init__.pyi
+++ b/airflow/decorators/__init__.pyi
@@ -63,6 +63,8 @@ __all__ = [
 
 _T = TypeVar("_T", bound=Task[..., Any] | _TaskDecorator[..., Any, Any])
 
+Serializer = Literal["pickle", "cloudpickle", "dill"]
+
 class TaskDecoratorCollection:
     @overload
     def python(  # type: ignore[misc]
@@ -114,7 +116,7 @@ class TaskDecoratorCollection:
         # _PythonVirtualenvDecoratedOperator.
         requirements: None | Iterable[str] | str = None,
         python_version: None | str | int | float = None,
-        serializer: Literal["pickle", "cloudpickle", "dill"] | None = None,
+        serializer: Serializer | None = None,
         system_site_packages: bool = True,
         templates_dict: Mapping[str, Any] | None = None,
         pip_install_options: list[str] | None = None,
@@ -188,7 +190,7 @@ class TaskDecoratorCollection:
         multiple_outputs: bool | None = None,
         # 'python_callable', 'op_args' and 'op_kwargs' since they are filled by
         # _PythonVirtualenvDecoratedOperator.
-        serializer: Literal["pickle", "cloudpickle", "dill"] | None = None,
+        serializer: Serializer | None = None,
         templates_dict: Mapping[str, Any] | None = None,
         show_return_value_in_logs: bool = True,
         env_vars: dict[str, str] | None = None,
@@ -253,7 +255,7 @@ class TaskDecoratorCollection:
         # _PythonVirtualenvDecoratedOperator.
         requirements: None | Iterable[str] | str = None,
         python_version: None | str | int | float = None,
-        serializer: Literal["pickle", "cloudpickle", "dill"] | None = None,
+        serializer: Serializer | None = None,
         system_site_packages: bool = True,
         templates_dict: Mapping[str, Any] | None = None,
         pip_install_options: list[str] | None = None,
@@ -316,7 +318,7 @@ class TaskDecoratorCollection:
         multiple_outputs: bool | None = None,
         # 'python_callable', 'op_args' and 'op_kwargs' since they are filled by
         # _PythonVirtualenvDecoratedOperator.
-        serializer: Literal["pickle", "cloudpickle", "dill"] | None = None,
+        serializer: Serializer | None = None,
         templates_dict: Mapping[str, Any] | None = None,
         show_return_value_in_logs: bool = True,
         use_dill: bool = False,
@@ -379,8 +381,9 @@ class TaskDecoratorCollection:
         self,
         *,
         multiple_outputs: bool | None = None,
-        use_dill: bool = False,  # Added by _DockerDecoratedOperator.
         python_command: str = "python3",
+        serializer: Serializer | None = None,
+        use_dill: bool = False,  # Added by _DockerDecoratedOperator.
         # 'command', 'retrieve_output', and 'retrieve_output_path' are filled by
         # _DockerDecoratedOperator.
         image: str,
@@ -432,8 +435,17 @@ class TaskDecoratorCollection:
 
         :param multiple_outputs: If set, function return value will be unrolled to multiple XCom values.
             Dict will unroll to XCom values with keys as XCom keys. Defaults to False.
-        :param use_dill: Whether to use dill or pickle for serialization
         :param python_command: Python command for executing functions, Default: python3
+        :param serializer: Which serializer use to serialize the args and result. It can be one of the following:
+
+            - ``"pickle"``: (default) Use pickle for serialization. Included in the Python Standard Library.
+            - ``"cloudpickle"``: Use cloudpickle for serialize more complex types,
+              this requires to include cloudpickle in your requirements.
+            - ``"dill"``: Use dill for serialize more complex types,
+              this requires to include dill in your requirements.
+        :param use_dill: Deprecated, use ``serializer`` instead. Whether to use dill to serialize
+            the args and result (pickle is default). This allows more complex types
+            but requires you to include dill in your requirements.
         :param image: Docker image from which to create the container.
             If image tag is omitted, "latest" will be used.
         :param api_version: Remote API version. Set to ``auto`` to automatically

--- a/airflow/decorators/__init__.pyi
+++ b/airflow/decorators/__init__.pyi
@@ -63,8 +63,6 @@ __all__ = [
 
 _T = TypeVar("_T", bound=Task[..., Any] | _TaskDecorator[..., Any, Any])
 
-Serializer = Literal["pickle", "cloudpickle", "dill"]
-
 class TaskDecoratorCollection:
     @overload
     def python(  # type: ignore[misc]
@@ -116,7 +114,7 @@ class TaskDecoratorCollection:
         # _PythonVirtualenvDecoratedOperator.
         requirements: None | Iterable[str] | str = None,
         python_version: None | str | int | float = None,
-        serializer: Serializer | None = None,
+        serializer: Literal["pickle", "cloudpickle", "dill"] | None = None,
         system_site_packages: bool = True,
         templates_dict: Mapping[str, Any] | None = None,
         pip_install_options: list[str] | None = None,
@@ -190,7 +188,7 @@ class TaskDecoratorCollection:
         multiple_outputs: bool | None = None,
         # 'python_callable', 'op_args' and 'op_kwargs' since they are filled by
         # _PythonVirtualenvDecoratedOperator.
-        serializer: Serializer | None = None,
+        serializer: Literal["pickle", "cloudpickle", "dill"] | None = None,
         templates_dict: Mapping[str, Any] | None = None,
         show_return_value_in_logs: bool = True,
         env_vars: dict[str, str] | None = None,
@@ -255,7 +253,7 @@ class TaskDecoratorCollection:
         # _PythonVirtualenvDecoratedOperator.
         requirements: None | Iterable[str] | str = None,
         python_version: None | str | int | float = None,
-        serializer: Serializer | None = None,
+        serializer: Literal["pickle", "cloudpickle", "dill"] | None = None,
         system_site_packages: bool = True,
         templates_dict: Mapping[str, Any] | None = None,
         pip_install_options: list[str] | None = None,
@@ -318,7 +316,7 @@ class TaskDecoratorCollection:
         multiple_outputs: bool | None = None,
         # 'python_callable', 'op_args' and 'op_kwargs' since they are filled by
         # _PythonVirtualenvDecoratedOperator.
-        serializer: Serializer | None = None,
+        serializer: Literal["pickle", "cloudpickle", "dill"] | None = None,
         templates_dict: Mapping[str, Any] | None = None,
         show_return_value_in_logs: bool = True,
         use_dill: bool = False,
@@ -382,7 +380,7 @@ class TaskDecoratorCollection:
         *,
         multiple_outputs: bool | None = None,
         python_command: str = "python3",
-        serializer: Serializer | None = None,
+        serializer: Literal["pickle", "cloudpickle", "dill"] | None = None,
         use_dill: bool = False,  # Added by _DockerDecoratedOperator.
         # 'command', 'retrieve_output', and 'retrieve_output_path' are filled by
         # _DockerDecoratedOperator.

--- a/airflow/providers/docker/decorators/docker.py
+++ b/airflow/providers/docker/decorators/docker.py
@@ -18,13 +18,13 @@ from __future__ import annotations
 
 import base64
 import os
-import pickle
+import warnings
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Callable, Sequence
 
-import dill
-
 from airflow.decorators.base import DecoratedOperator, task_decorator_factory
+from airflow.exceptions import AirflowException, RemovedInAirflow3Warning
+from airflow.operators.python import _SERIALIZERS, _SerializerTypeDef
 from airflow.providers.docker.operators.docker import DockerOperator
 from airflow.utils.python_virtualenv import write_python_script
 
@@ -53,7 +53,6 @@ class _DockerDecoratedOperator(DecoratedOperator, DockerOperator):
 
     :param python_callable: A reference to an object that is callable
     :param python: Python binary name to use
-    :param use_dill: Whether dill should be used to serialize the callable
     :param expect_airflow: whether to expect airflow to be installed in the docker environment. if this
           one is specified, the script to run callable will attempt to load Airflow macros.
     :param op_kwargs: a dictionary of keyword arguments that will get unpacked
@@ -63,6 +62,16 @@ class _DockerDecoratedOperator(DecoratedOperator, DockerOperator):
     :param multiple_outputs: if set, function return value will be
         unrolled to multiple XCom values. Dict will unroll to xcom values with keys as keys.
         Defaults to False.
+    :param serializer: Which serializer use to serialize the args and result. It can be one of the following:
+
+        - ``"pickle"``: (default) Use pickle for serialization. Included in the Python Standard Library.
+        - ``"cloudpickle"``: Use cloudpickle for serialize more complex types,
+          this requires to include cloudpickle in your requirements.
+        - ``"dill"``: Use dill for serialize more complex types,
+          this requires to include dill in your requirements.
+    :param use_dill: Deprecated, use ``serializer`` instead. Whether to use dill to serialize
+        the args and result (pickle is default). This allows more complex types
+        but requires you to include dill in your requirements.
     """
 
     custom_operator_name = "@task.docker"
@@ -74,12 +83,35 @@ class _DockerDecoratedOperator(DecoratedOperator, DockerOperator):
         use_dill=False,
         python_command="python3",
         expect_airflow: bool = True,
+        serializer: _SerializerTypeDef | None = None,
         **kwargs,
     ) -> None:
+        if use_dill:
+            warnings.warn(
+                "`use_dill` is deprecated and will be removed in a future version. "
+                "Please provide serializer='dill' instead.",
+                RemovedInAirflow3Warning,
+                stacklevel=3,
+            )
+            if serializer:
+                raise AirflowException(
+                    "Both 'use_dill' and 'serializer' parameters are set. Please set only one of them"
+                )
+            serializer = "dill"
+        serializer = serializer or "pickle"
+        if serializer not in _SERIALIZERS:
+            msg = (
+                f"Unsupported serializer {serializer!r}. "
+                f"Expected one of {', '.join(map(repr, _SERIALIZERS))}"
+            )
+            raise AirflowException(msg)
+
         command = "placeholder command"
         self.python_command = python_command
         self.expect_airflow = expect_airflow
-        self.use_dill = use_dill
+        self.use_dill = serializer == "dill"
+        self.serializer: _SerializerTypeDef = serializer
+
         super().__init__(
             command=command, retrieve_output=True, retrieve_output_path="/tmp/script.out", **kwargs
         )
@@ -128,9 +160,7 @@ class _DockerDecoratedOperator(DecoratedOperator, DockerOperator):
 
     @property
     def pickling_library(self):
-        if self.use_dill:
-            return dill
-        return pickle
+        return _SERIALIZERS[self.serializer]
 
 
 def docker_task(

--- a/airflow/providers/docker/decorators/docker.py
+++ b/airflow/providers/docker/decorators/docker.py
@@ -23,7 +23,7 @@ from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Callable, Sequence
 
 from airflow.decorators.base import DecoratedOperator, task_decorator_factory
-from airflow.exceptions import AirflowException, RemovedInAirflow3Warning
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.operators.python import _SERIALIZERS, _SerializerTypeDef
 from airflow.providers.docker.operators.docker import DockerOperator
 from airflow.utils.python_virtualenv import write_python_script
@@ -90,7 +90,7 @@ class _DockerDecoratedOperator(DecoratedOperator, DockerOperator):
             warnings.warn(
                 "`use_dill` is deprecated and will be removed in a future version. "
                 "Please provide serializer='dill' instead.",
-                RemovedInAirflow3Warning,
+                AirflowProviderDeprecationWarning,
                 stacklevel=3,
             )
             if serializer:

--- a/airflow/providers/docker/decorators/docker.py
+++ b/airflow/providers/docker/decorators/docker.py
@@ -66,7 +66,7 @@ except ImportError:
             raise
         return cloudpickle
 
-    _SERIALIZERS: dict[Serializer, Any] = {
+    _SERIALIZERS: dict[Serializer, Any] = {  # type: ignore[no-redef]
         "pickle": lazy_object_proxy.Proxy(_load_pickle),
         "dill": lazy_object_proxy.Proxy(_load_dill),
         "cloudpickle": lazy_object_proxy.Proxy(_load_cloudpickle),

--- a/tests/providers/docker/decorators/test_docker.py
+++ b/tests/providers/docker/decorators/test_docker.py
@@ -351,3 +351,13 @@ class TestDockerDecorator:
                     AirflowException, match="Both 'use_dill' and 'serializer' parameters are set"
                 ):
                     f()
+
+    def test_invalid_serializer(self, dag_maker):
+        @task.docker(image="python:3.9-slim", auto_remove="force", serializer="airflow")
+        def f():
+            """Ensure dill is correctly installed."""
+            import dill  # noqa: F401
+
+        with dag_maker():
+            with pytest.raises(AirflowException, match="Unsupported serializer 'airflow'"):
+                f()

--- a/tests/providers/docker/decorators/test_docker.py
+++ b/tests/providers/docker/decorators/test_docker.py
@@ -23,7 +23,7 @@ from io import StringIO as StringBuffer
 import pytest
 
 from airflow.decorators import setup, task, teardown
-from airflow.exceptions import AirflowException, RemovedInAirflow3Warning
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.models import TaskInstance
 from airflow.models.dag import DAG
 from airflow.utils import timezone
@@ -346,7 +346,9 @@ class TestDockerDecorator:
             pass
 
         with dag_maker():
-            with pytest.warns(RemovedInAirflow3Warning, match="`use_dill` is deprecated and will be removed"):
+            with pytest.warns(
+                AirflowProviderDeprecationWarning, match="`use_dill` is deprecated and will be removed"
+            ):
                 with pytest.raises(
                     AirflowException, match="Both 'use_dill' and 'serializer' parameters are set"
                 ):
@@ -420,5 +422,7 @@ class TestDockerDecorator:
             import dill  # noqa: F401
 
         with dag_maker():
-            with pytest.warns(RemovedInAirflow3Warning, match="`use_dill` is deprecated and will be removed"):
+            with pytest.warns(
+                AirflowProviderDeprecationWarning, match="`use_dill` is deprecated and will be removed"
+            ):
                 f()


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Made `@task.docker` use `serializer` instead of `use_dill`.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
