### PR TITLE
Add `v2-10-test` to the protected branch after `2.10.0rc1`

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -113,6 +113,11 @@ github:
       required_pull_request_reviews:
         required_approving_review_count: 1
       required_linear_history: true
+    v2-10-test:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+      required_linear_history: true
+      required_conversation_resolution: true
   collaborators:
     # Max 10 collaborators allowed
     # https://github.com/apache/infrastructure-asfyaml/blob/main/README.md#assigning-the-github-triage-role-to-external-collaborators


### PR DESCRIPTION
This would prevent force pushes, and the development of Airflow 2 will continue on this branch. After development, we sync with the v2-10-stable branch for release

