### PR TITLE
Add support in MongoHook for `mongodb+srv://` URIs 

### DIFF
--- a/airflow/providers/mongo/hooks/mongo.py
+++ b/airflow/providers/mongo/hooks/mongo.py
@@ -155,7 +155,7 @@ class MongoHook(BaseHook):
         :return: URI string.
         """
         srv = self.extras.pop("srv", False)
-        scheme = "mongodb+srv" if srv else "mongodb"
+        scheme = "mongodb+srv" if srv or self.connection.conn_type == "mongodb+srv" else "mongodb"
         login = self.connection.login
         password = self.connection.password
         netloc = self.connection.host

--- a/tests/providers/mongo/hooks/test_mongo.py
+++ b/tests/providers/mongo/hooks/test_mongo.py
@@ -56,6 +56,10 @@ def mongo_connections():
         ),
         # Mongo establishes connection during initialization, so we need to have this connection
         Connection(conn_id="fake_connection", conn_type="mongo", host="mongo", port=27017),
+        Connection(
+            conn_id="mongo_srv_scheme",
+            uri="mongodb+srv://test_user:test_password@test_host:1234/test_db"
+        ),
     ]
 
     with pytest.MonkeyPatch.context() as mp:
@@ -107,6 +111,10 @@ class TestMongoHook:
 
     def test_srv(self):
         hook = MongoHook(mongo_conn_id="mongo_default_with_srv")
+        assert hook.uri.startswith("mongodb+srv://")
+
+    def test_srv_scheme(self):
+        hook = MongoHook(mongo_conn_id="mongo_srv_scheme")
         assert hook.uri.startswith("mongodb+srv://")
 
     def test_insert_one(self):
@@ -265,6 +273,15 @@ class TestMongoHook:
 
     def test_create_uri_srv_true(self):
         self.hook.extras["srv"] = True
+        self.hook.connection.login = "test_user"
+        self.hook.connection.password = "test_password"
+        self.hook.connection.host = "test_host"
+        self.hook.connection.port = 1234
+        self.hook.connection.schema = "test_db"
+        assert self.hook._create_uri() == "mongodb+srv://test_user:test_password@test_host:1234/test_db"
+
+    def test_create_uri_srv_scheme(self):
+        self.hook.connection.conn_type = "mongodb+srv"
         self.hook.connection.login = "test_user"
         self.hook.connection.password = "test_password"
         self.hook.connection.host = "test_host"


### PR DESCRIPTION
This change adds support for `mongodb+srv://` URIs when the MongoHook interprets the Connection parameters, while maintaining the existing option of an `srv` query parameter.

#### Current Behavior
If you are:
* using the MongoHook AND
* using the [SRV/seed list feature](https://www.mongodb.com/docs/manual/reference/connection-string/#srv-connection-format) in your MongoDB cluster AND
* creating your Connection from a URI string starting with `mongodb+srv://`

you need to manually change your connection URI by adding a query parameter `srv=true` (the URI scheme is in fact ignored completely). 

If you do not add the query param, the hook will munge the scheme to `mongodb://`, attempt to use the SRV locator as a direct service location, and fail to connect properly.

#### New Behavior
After this change:
* Connections created with URIs beginning with `mongodb+srv://`, or with `conn_type=mongodb+srv`, will cause the MongoHook to interpret the connection as an SRV locator
* `srv=true` forces SRV behavior, as before

Tests have been added to verify the new behavior with both `uri` and `conn_type` arguments.

#### Justification
My organization uses the Mongo-supported form of `mongodb+srv://` which we get from the service vendor who hosts our MongoDB instances. (The introduction of SRV to Mongo was blogged [here](https://www.mongodb.com/developer/products/mongodb/srv-connection-strings/)). 

The lack of support for the standard URI scheme means that every time we add or change a MongoDB URL in our Airflow connections, the Ops team can't simply copy the URL from the service vendor to a config file or secret; they have to manually add the query param, or rope in the relevant dev team to do so (or worse, we all have to respond to a production failure and then decide under pressure who's going to modify the URL).

Merging this change will make coordinating Mongo clients in our Airflow stack simpler and more robust.
