### PR TITLE
Fix  tests/decorators/test_python.py for database isolation tests

### DIFF
--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -1000,7 +1000,7 @@ def test_task_decorator_dataset(dag_maker, session):
 
 
 def test_teardown_trigger_rule_selective_application(dag_maker, session):
-    with dag_maker(session=session) as dag:
+    with dag_maker(session=session, serialized=True) as dag:
 
         @dag.task
         def my_work():
@@ -1025,7 +1025,7 @@ def test_teardown_trigger_rule_selective_application(dag_maker, session):
 
 
 def test_teardown_trigger_rule_override_behavior(dag_maker, session):
-    with dag_maker(session=session) as dag:
+    with dag_maker(session=session, serialized=True) as dag:
 
         @dag.task(trigger_rule=TriggerRule.ONE_SUCCESS)
         def my_work():

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -1000,50 +1000,52 @@ def test_task_decorator_dataset(dag_maker, session):
 
 
 def test_teardown_trigger_rule_selective_application(dag_maker, session):
-    with dag_maker(session=session, serialized=True) as dag:
+    with dag_maker(session=session, serialized=True) as created_dag:
+        dag = created_dag
 
-        @dag.task
-        def my_work():
-            return "abc"
+    @dag.task
+    def my_work():
+        return "abc"
 
-        @setup
-        @dag.task
-        def my_setup():
-            return "abc"
+    @setup
+    @dag.task
+    def my_setup():
+        return "abc"
 
-        @teardown
-        @dag.task
-        def my_teardown():
-            return "abc"
+    @teardown
+    @dag.task
+    def my_teardown():
+        return "abc"
 
-        work_task = my_work()
-        setup_task = my_setup()
-        teardown_task = my_teardown()
+    work_task = my_work()
+    setup_task = my_setup()
+    teardown_task = my_teardown()
     assert work_task.operator.trigger_rule == TriggerRule.ALL_SUCCESS
     assert setup_task.operator.trigger_rule == TriggerRule.ALL_SUCCESS
     assert teardown_task.operator.trigger_rule == TriggerRule.ALL_DONE_SETUP_SUCCESS
 
 
 def test_teardown_trigger_rule_override_behavior(dag_maker, session):
-    with dag_maker(session=session, serialized=True) as dag:
+    with dag_maker(session=session, serialized=True) as created_dag:
+        dag = created_dag
 
-        @dag.task(trigger_rule=TriggerRule.ONE_SUCCESS)
-        def my_work():
-            return "abc"
+    @dag.task(trigger_rule=TriggerRule.ONE_SUCCESS)
+    def my_work():
+        return "abc"
 
-        @setup
-        @dag.task(trigger_rule=TriggerRule.ONE_SUCCESS)
-        def my_setup():
-            return "abc"
+    @setup
+    @dag.task(trigger_rule=TriggerRule.ONE_SUCCESS)
+    def my_setup():
+        return "abc"
 
-        @teardown
-        @dag.task(trigger_rule=TriggerRule.ONE_SUCCESS)
-        def my_teardown():
-            return "abc"
+    @teardown
+    @dag.task(trigger_rule=TriggerRule.ONE_SUCCESS)
+    def my_teardown():
+        return "abc"
 
-        work_task = my_work()
-        setup_task = my_setup()
-        with pytest.raises(Exception, match="Trigger rule not configurable for teardown tasks."):
-            my_teardown()
+    work_task = my_work()
+    setup_task = my_setup()
+    with pytest.raises(Exception, match="Trigger rule not configurable for teardown tasks."):
+        my_teardown()
     assert work_task.operator.trigger_rule == TriggerRule.ONE_SUCCESS
     assert setup_task.operator.trigger_rule == TriggerRule.ONE_SUCCESS


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Related: https://github.com/apache/airflow/pull/41067
Fixes `tests/decorators/test_python.py` for database isolation. Passing `serialized` parameter to dag_maker


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
