### PR TITLE
Remove deprecated `ExternalTaskSensorLink`

### DIFF
--- a/airflow/sensors/external_task.py
+++ b/airflow/sensors/external_task.py
@@ -22,10 +22,8 @@ import os
 import warnings
 from typing import TYPE_CHECKING, Any, Callable, Collection, Iterable
 
-import attr
-
 from airflow.configuration import conf
-from airflow.exceptions import AirflowException, AirflowSkipException, RemovedInAirflow3Warning
+from airflow.exceptions import AirflowException, AirflowSkipException
 from airflow.models.baseoperatorlink import BaseOperatorLink
 from airflow.models.dag import DagModel
 from airflow.models.dagbag import DagBag
@@ -511,20 +509,3 @@ class ExternalTaskMarker(EmptyOperator):
         if not cls.__serialized_fields:
             cls.__serialized_fields = frozenset(super().get_serialized_fields() | {"recursion_depth"})
         return cls.__serialized_fields
-
-
-@attr.s(auto_attribs=True)
-class ExternalTaskSensorLink(ExternalDagLink):
-    """
-    This external link is deprecated.
-
-    Please use :class:`airflow.sensors.external_task.ExternalDagLink`.
-    """
-
-    def __attrs_post_init__(self):
-        warnings.warn(
-            "This external link is deprecated. "
-            "Please use :class:`airflow.sensors.external_task.ExternalDagLink`.",
-            RemovedInAirflow3Warning,
-            stacklevel=2,
-        )

--- a/newsfragments/41391.significant.rst
+++ b/newsfragments/41391.significant.rst
@@ -1,0 +1,5 @@
+**Breaking Change**
+
+The ``airflow.sensors.external_task.ExternalTaskSensorLink`` class has been removed.
+This class was deprecated and is no longer available. Users should now use
+the ``airflow.sensors.external_task.ExternalDagLink`` class directly.

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -41,7 +41,6 @@ from airflow.operators.python import PythonOperator
 from airflow.sensors.external_task import (
     ExternalTaskMarker,
     ExternalTaskSensor,
-    ExternalTaskSensorLink,
 )
 from airflow.sensors.time_sensor import TimeSensor
 from airflow.serialization.serialized_objects import SerializedBaseOperator
@@ -1737,11 +1736,3 @@ def test_clear_overlapping_external_task_marker_mapped_tasks(dag_bag_head_tail_m
         )
         == 70
     )
-
-
-class TestExternalTaskSensorLink:
-    def test_deprecation_warning(self):
-        with pytest.warns(DeprecationWarning) as warnings:
-            ExternalTaskSensorLink()
-            assert len(warnings) == 1
-            assert warnings[0].filename == __file__


### PR DESCRIPTION
It is replaced by `airflow.sensors.external_task.ExternalDagLink`

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
