### PR TITLE
Remove deprecated param in `DayOfWeekSensor`

### DIFF
--- a/airflow/sensors/weekday.py
+++ b/airflow/sensors/weekday.py
@@ -17,10 +17,8 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Iterable
 
-from airflow.exceptions import RemovedInAirflow3Warning
 from airflow.sensors.base import BaseSensorOperator
 from airflow.utils import timezone
 from airflow.utils.weekday import WeekDay
@@ -75,7 +73,6 @@ class DayOfWeekSensor(BaseSensorOperator):
         with week_day. Execution Date is Useful for backfilling.
         If ``False``, uses system's day of the week. Useful when you
         don't want to run anything on weekdays on the system.
-    :param use_task_execution_day: deprecated parameter, same effect as `use_task_logical_date`
 
     .. seealso::
         For more information on how to use this sensor, take a look at the guide:
@@ -88,19 +85,11 @@ class DayOfWeekSensor(BaseSensorOperator):
         *,
         week_day: str | Iterable[str] | WeekDay | Iterable[WeekDay],
         use_task_logical_date: bool = False,
-        use_task_execution_day: bool = False,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.week_day = week_day
         self.use_task_logical_date = use_task_logical_date
-        if use_task_execution_day:
-            self.use_task_logical_date = use_task_execution_day
-            warnings.warn(
-                "Parameter ``use_task_execution_day`` is deprecated. Use ``use_task_logical_date``.",
-                RemovedInAirflow3Warning,
-                stacklevel=2,
-            )
         self._week_day_num = WeekDay.validate_week_day(week_day)
 
     def poke(self, context: Context) -> bool:

--- a/newsfragments/newsfragments/41393.significant.rst
+++ b/newsfragments/newsfragments/41393.significant.rst
@@ -1,0 +1,18 @@
+**Breaking Change**
+
+The ``use_task_execution_day`` parameter has been removed from the ``DayOfWeekSensor`` class.
+This parameter was previously deprecated in favor of ``use_task_logical_date``.
+
+If your code still uses ``use_task_execution_day``, you should update it to use ``use_task_logical_date``
+instead to ensure compatibility with future Airflow versions.
+
+Example update:
+
+.. code-block:: python
+
+    sensor = DayOfWeekSensor(
+        task_id="example",
+        week_day="Tuesday",
+        use_task_logical_date=True,
+        dag=dag,
+    )

--- a/tests/sensors/test_weekday_sensor.py
+++ b/tests/sensors/test_weekday_sensor.py
@@ -129,18 +129,3 @@ class TestDayOfWeekSensor:
         )
         with pytest.raises(AirflowSensorTimeout):
             op.run(start_date=WEEKDAY_DATE, end_date=WEEKDAY_DATE, ignore_ti_state=True)
-
-    def test_deprecation_warning(self):
-        warning_message = (
-            """Parameter ``use_task_execution_day`` is deprecated. Use ``use_task_logical_date``."""
-        )
-        with pytest.warns(DeprecationWarning) as warnings:
-            DayOfWeekSensor(
-                task_id="week_day_warn",
-                poke_interval=1,
-                timeout=2,
-                week_day="Tuesday",
-                use_task_execution_day=True,
-                dag=self.dag,
-            )
-        assert warning_message == str(warnings[0].message)


### PR DESCRIPTION
The `use_task_execution_day` param is deprecated

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
