### PR TITLE
Remove deprecated ``TaskMixin`` class

### DIFF
--- a/airflow/models/taskmixin.py
+++ b/airflow/models/taskmixin.py
@@ -16,11 +16,10 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
 from abc import ABCMeta, abstractmethod
 from typing import TYPE_CHECKING, Any, Iterable, Sequence
 
-from airflow.exceptions import AirflowException, RemovedInAirflow3Warning
+from airflow.exceptions import AirflowException
 from airflow.utils.types import NOTSET
 
 if TYPE_CHECKING:
@@ -89,7 +88,7 @@ class DependencyMixin:
         self, other: DependencyMixin, upstream: bool = True, edge_modifier: EdgeModifier | None = None
     ) -> None:
         """
-        Update relationship information about another TaskMixin. Default is no-op.
+        Update relationship information about another DependencyMixin. Default is no-op.
 
         Override if necessary.
         """
@@ -126,22 +125,6 @@ class DependencyMixin:
         elif isinstance(obj, Sequence):
             for o in obj:
                 yield from cls._iter_references(o)
-
-
-class TaskMixin(DependencyMixin):
-    """
-    Mixin to provide task-related things.
-
-    :meta private:
-    """
-
-    def __init_subclass__(cls) -> None:
-        warnings.warn(
-            f"TaskMixin has been renamed to DependencyMixin, please update {cls.__name__}",
-            category=RemovedInAirflow3Warning,
-            stacklevel=2,
-        )
-        return super().__init_subclass__()
 
 
 class DAGNode(DependencyMixin, metaclass=ABCMeta):

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -135,12 +135,12 @@ class XComArg(ResolveMixin, DependencyMixin):
 
     @property
     def roots(self) -> list[DAGNode]:
-        """Required by TaskMixin."""
+        """Required by DependencyMixin."""
         return [op for op, _ in self.iter_references()]
 
     @property
     def leaves(self) -> list[DAGNode]:
-        """Required by TaskMixin."""
+        """Required by DependencyMixin."""
         return [op for op, _ in self.iter_references()]
 
     def set_upstream(
@@ -148,7 +148,7 @@ class XComArg(ResolveMixin, DependencyMixin):
         task_or_task_list: DependencyMixin | Sequence[DependencyMixin],
         edge_modifier: EdgeModifier | None = None,
     ):
-        """Proxy to underlying operator set_upstream method. Required by TaskMixin."""
+        """Proxy to underlying operator set_upstream method. Required by DependencyMixin."""
         for operator, _ in self.iter_references():
             operator.set_upstream(task_or_task_list, edge_modifier)
 
@@ -157,7 +157,7 @@ class XComArg(ResolveMixin, DependencyMixin):
         task_or_task_list: DependencyMixin | Sequence[DependencyMixin],
         edge_modifier: EdgeModifier | None = None,
     ):
-        """Proxy to underlying operator set_downstream method. Required by TaskMixin."""
+        """Proxy to underlying operator set_downstream method. Required by DependencyMixin."""
         for operator, _ in self.iter_references():
             operator.set_downstream(task_or_task_list, edge_modifier)
 

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -369,12 +369,12 @@ class TaskGroup(DAGNode):
 
     @property
     def roots(self) -> list[BaseOperator]:
-        """Required by TaskMixin."""
+        """Required by DependencyMixin."""
         return list(self.get_roots())
 
     @property
     def leaves(self) -> list[BaseOperator]:
-        """Required by TaskMixin."""
+        """Required by DependencyMixin."""
         return list(self.get_leaves())
 
     def get_roots(self) -> Generator[BaseOperator, None, None]:

--- a/newsfragments/41394.significant.rst
+++ b/newsfragments/41394.significant.rst
@@ -1,0 +1,6 @@
+**Breaking Change**
+
+The ``airflow.models.taskMixin.TaskMixin`` class has been removed. It was previously
+deprecated in favor of the ``airflow.models.taskMixin.DependencyMixin`` class.
+If your code relies on ``TaskMixin``, please update it to use ``DependencyMixin`` instead
+to ensure compatibility with Airflow 3.0 and beyond.


### PR DESCRIPTION
The ``airflow.models.taskMixin.TaskMixin`` class has been removed. It was previously deprecated in favor of the ``airflow.models.taskMixin.DependencyMixin`` class.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
