### PR TITLE
Bump minimum Airflow version in providers to Airflow 2.8.0

### DIFF
--- a/PROVIDERS.rst
+++ b/PROVIDERS.rst
@@ -144,8 +144,8 @@ Airflow version to the next MINOR release, when 12 months passed since the first
 MINOR version of Airflow.
 
 For example this means that by default we upgrade the minimum version of Airflow supported by providers
-to 2.8.0 in the first Provider's release after 18th of August 2024. 18th of August 2023 is the date when the
-first ``PATCHLEVEL`` of 2.7 (2.7.0) has been released.
+to 2.8.0 in the first Provider's release after 18th of December 2024. 18th of December 2023 is the date when the
+first ``PATCHLEVEL`` of 2.8 (2.8.0) has been released.
 
 When we increase the minimum Airflow version, this is not a reason to bump ``MAJOR`` version of the providers
 (unless there are other breaking changes in the provider). The reason for that is that people who use

--- a/airflow/providers/airbyte/__init__.py
+++ b/airflow/providers/airbyte/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.8.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-airbyte:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-airbyte:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/airbyte/provider.yaml
+++ b/airflow/providers/airbyte/provider.yaml
@@ -48,7 +48,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-http
 
 integrations:

--- a/airflow/providers/alibaba/__init__.py
+++ b/airflow/providers/alibaba/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "2.8.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-alibaba:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-alibaba:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/alibaba/provider.yaml
+++ b/airflow/providers/alibaba/provider.yaml
@@ -49,7 +49,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - oss2>=2.14.0
   - alibabacloud_adb20211201>=1.0.0
   - alibabacloud_tea_openapi>=0.3.7

--- a/airflow/providers/amazon/__init__.py
+++ b/airflow/providers/amazon/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "8.27.0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-amazon:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-amazon:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -89,7 +89,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-common-compat>=1.1.0
   - apache-airflow-providers-common-sql>=1.3.1
   - apache-airflow-providers-http

--- a/airflow/providers/apache/beam/__init__.py
+++ b/airflow/providers/apache/beam/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "5.7.2"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apache-beam:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-apache-beam:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/apache/beam/provider.yaml
+++ b/airflow/providers/apache/beam/provider.yaml
@@ -59,7 +59,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   # Apache Beam > 2.53.0 and pyarrow > 14.0.1 fix https://nvd.nist.gov/vuln/detail/CVE-2023-47248.
   - apache-beam>=2.53.0
   - pyarrow>=14.0.1

--- a/airflow/providers/apache/cassandra/__init__.py
+++ b/airflow/providers/apache/cassandra/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.5.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apache-cassandra:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-apache-cassandra:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/apache/cassandra/provider.yaml
+++ b/airflow/providers/apache/cassandra/provider.yaml
@@ -46,7 +46,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - cassandra-driver>=3.29.1
 
 integrations:

--- a/airflow/providers/apache/drill/__init__.py
+++ b/airflow/providers/apache/drill/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "2.7.3"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apache-drill:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-apache-drill:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/apache/drill/provider.yaml
+++ b/airflow/providers/apache/drill/provider.yaml
@@ -51,7 +51,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-common-sql>=1.14.1
   - sqlalchemy-drill>=1.1.0
 

--- a/airflow/providers/apache/druid/__init__.py
+++ b/airflow/providers/apache/druid/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.10.2"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apache-druid:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-apache-druid:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/apache/druid/provider.yaml
+++ b/airflow/providers/apache/druid/provider.yaml
@@ -57,7 +57,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-common-sql>=1.14.1
   - pydruid>=0.4.1
 

--- a/airflow/providers/apache/flink/__init__.py
+++ b/airflow/providers/apache/flink/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "1.4.2"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apache-flink:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-apache-flink:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/apache/flink/provider.yaml
+++ b/airflow/providers/apache/flink/provider.yaml
@@ -38,7 +38,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - cryptography>=41.0.0
   - apache-airflow-providers-cncf-kubernetes>=5.1.0
 

--- a/airflow/providers/apache/hdfs/__init__.py
+++ b/airflow/providers/apache/hdfs/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "4.4.2"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apache-hdfs:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-apache-hdfs:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/apache/hdfs/provider.yaml
+++ b/airflow/providers/apache/hdfs/provider.yaml
@@ -53,7 +53,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - hdfs[avro,dataframe,kerberos]>=2.5.4;python_version<"3.12"
   - hdfs[avro,dataframe,kerberos]>=2.7.3;python_version>="3.12"
   - pandas>=2.1.2,<2.2;python_version>="3.9"

--- a/airflow/providers/apache/hive/__init__.py
+++ b/airflow/providers/apache/hive/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "8.1.2"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apache-hive:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-apache-hive:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/apache/hive/provider.yaml
+++ b/airflow/providers/apache/hive/provider.yaml
@@ -71,7 +71,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-common-sql>=1.3.1
   - hmsclient>=0.1.0
   # In pandas 2.2 minimal version of the sqlalchemy is 2.0

--- a/airflow/providers/apache/iceberg/__init__.py
+++ b/airflow/providers/apache/iceberg/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "1.0.0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apache-iceberg:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-apache-iceberg:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/apache/iceberg/provider.yaml
+++ b/airflow/providers/apache/iceberg/provider.yaml
@@ -28,7 +28,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
 
 devel-dependencies:
   - pyiceberg>=0.5.0

--- a/airflow/providers/apache/impala/__init__.py
+++ b/airflow/providers/apache/impala/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "1.4.2"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apache-impala:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-apache-impala:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/apache/impala/provider.yaml
+++ b/airflow/providers/apache/impala/provider.yaml
@@ -40,7 +40,7 @@ versions:
 dependencies:
   - impyla>=0.18.0,<1.0
   - apache-airflow-providers-common-sql>=1.14.1
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
 
 additional-extras:
   - name: kerberos

--- a/airflow/providers/apache/kafka/__init__.py
+++ b/airflow/providers/apache/kafka/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "1.5.0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apache-kafka:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-apache-kafka:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/apache/kafka/provider.yaml
+++ b/airflow/providers/apache/kafka/provider.yaml
@@ -37,7 +37,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - asgiref>=2.3.0
   - confluent-kafka>=2.3.0
 

--- a/airflow/providers/apache/kylin/__init__.py
+++ b/airflow/providers/apache/kylin/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.6.2"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apache-kylin:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-apache-kylin:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/apache/kylin/provider.yaml
+++ b/airflow/providers/apache/kylin/provider.yaml
@@ -44,7 +44,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - kylinpy>=2.7.0
 
 integrations:

--- a/airflow/providers/apache/livy/__init__.py
+++ b/airflow/providers/apache/livy/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.8.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apache-livy:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-apache-livy:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/apache/livy/provider.yaml
+++ b/airflow/providers/apache/livy/provider.yaml
@@ -53,7 +53,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-http
   - aiohttp>=3.9.2
   - asgiref

--- a/airflow/providers/apache/pig/__init__.py
+++ b/airflow/providers/apache/pig/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "4.4.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apache-pig:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-apache-pig:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/apache/pig/provider.yaml
+++ b/airflow/providers/apache/pig/provider.yaml
@@ -43,7 +43,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
 
 integrations:
   - integration-name: Apache Pig

--- a/airflow/providers/apache/pinot/__init__.py
+++ b/airflow/providers/apache/pinot/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "4.4.2"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apache-pinot:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-apache-pinot:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/apache/pinot/provider.yaml
+++ b/airflow/providers/apache/pinot/provider.yaml
@@ -51,7 +51,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-common-sql>=1.14.1
   - pinotdb>=5.1.0
 

--- a/airflow/providers/apache/spark/__init__.py
+++ b/airflow/providers/apache/spark/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "4.9.0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apache-spark:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-apache-spark:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/apache/spark/provider.yaml
+++ b/airflow/providers/apache/spark/provider.yaml
@@ -60,7 +60,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - pyspark>=3.1.3
   - grpcio-status>=1.59.0
 

--- a/airflow/providers/apprise/__init__.py
+++ b/airflow/providers/apprise/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "1.3.2"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-apprise:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-apprise:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/apprise/provider.yaml
+++ b/airflow/providers/apprise/provider.yaml
@@ -45,7 +45,7 @@ integrations:
     tags: [software]
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apprise>=1.8.0
 
 hooks:

--- a/airflow/providers/arangodb/__init__.py
+++ b/airflow/providers/arangodb/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "2.5.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-arangodb:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-arangodb:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/arangodb/provider.yaml
+++ b/airflow/providers/arangodb/provider.yaml
@@ -22,7 +22,7 @@ description: |
     `ArangoDB <https://www.arangodb.com/>`__
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - python-arango>=7.3.2
 
 state: ready

--- a/airflow/providers/asana/__init__.py
+++ b/airflow/providers/asana/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "2.5.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-asana:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-asana:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/asana/provider.yaml
+++ b/airflow/providers/asana/provider.yaml
@@ -43,7 +43,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   # The Asana provider uses Asana Python API https://github.com/Asana/python-asana/ and version
   # 4.* of it introduced 31.07.2023 is heavily incompatible with previous versions
   # (new way of generating API client from specification has been used). Until we convert to the new API

--- a/airflow/providers/atlassian/jira/__init__.py
+++ b/airflow/providers/atlassian/jira/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "2.6.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-atlassian-jira:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-atlassian-jira:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/atlassian/jira/provider.yaml
+++ b/airflow/providers/atlassian/jira/provider.yaml
@@ -40,7 +40,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - atlassian-python-api>3.41.10
 
 integrations:

--- a/airflow/providers/celery/__init__.py
+++ b/airflow/providers/celery/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.7.3"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-celery:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-celery:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/celery/provider.yaml
+++ b/airflow/providers/celery/provider.yaml
@@ -56,7 +56,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   # The Celery is known to introduce problems when upgraded to a MAJOR version. Airflow Core
   # Uses Celery for CeleryExecutor, and we also know that Kubernetes Python client follows SemVer
   # (https://docs.celeryq.dev/en/stable/contributing.html?highlight=semver#versions).

--- a/airflow/providers/cloudant/__init__.py
+++ b/airflow/providers/cloudant/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.5.2"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-cloudant:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-cloudant:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/cloudant/provider.yaml
+++ b/airflow/providers/cloudant/provider.yaml
@@ -44,7 +44,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - cloudant>=2.13.0
 
 integrations:

--- a/airflow/providers/cncf/kubernetes/__init__.py
+++ b/airflow/providers/cncf/kubernetes/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "8.3.4"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-cncf-kubernetes:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-cncf-kubernetes:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/cncf/kubernetes/provider.yaml
+++ b/airflow/providers/cncf/kubernetes/provider.yaml
@@ -89,7 +89,7 @@ versions:
 
 dependencies:
   - aiofiles>=23.2.0
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - asgiref>=3.5.2
   - cryptography>=41.0.0
   # The Kubernetes API is known to introduce problems when upgraded to a MAJOR version. Airflow Core

--- a/airflow/providers/cohere/__init__.py
+++ b/airflow/providers/cohere/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "1.2.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-cohere:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-cohere:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/cohere/provider.yaml
+++ b/airflow/providers/cohere/provider.yaml
@@ -44,7 +44,7 @@ integrations:
     tags: [software]
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - cohere>=4.37,<5
 
 hooks:

--- a/airflow/providers/common/compat/__init__.py
+++ b/airflow/providers/common/compat/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "1.1.0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-common-compat:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-common-compat:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/common/compat/provider.yaml
+++ b/airflow/providers/common/compat/provider.yaml
@@ -29,7 +29,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
 
 integrations:
   - integration-name: Common Compat

--- a/airflow/providers/common/sql/__init__.py
+++ b/airflow/providers/common/sql/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "1.15.0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-common-sql:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-common-sql:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/common/sql/provider.yaml
+++ b/airflow/providers/common/sql/provider.yaml
@@ -58,7 +58,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - sqlparse>=0.4.2
   - more-itertools>=9.0.0
 

--- a/airflow/providers/databricks/__init__.py
+++ b/airflow/providers/databricks/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "6.8.0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-databricks:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-databricks:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/databricks/provider.yaml
+++ b/airflow/providers/databricks/provider.yaml
@@ -67,7 +67,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-common-sql>=1.10.0
   - requests>=2.27.0,<3
   # The connector 2.9.0 released on Aug 10, 2023 has a bug that it does not properly declare urllib3 and

--- a/airflow/providers/datadog/__init__.py
+++ b/airflow/providers/datadog/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.6.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-datadog:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-datadog:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/datadog/provider.yaml
+++ b/airflow/providers/datadog/provider.yaml
@@ -45,7 +45,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - datadog>=0.14.0
 
 integrations:

--- a/airflow/providers/dbt/cloud/__init__.py
+++ b/airflow/providers/dbt/cloud/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.9.0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-dbt-cloud:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-dbt-cloud:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/dbt/cloud/provider.yaml
+++ b/airflow/providers/dbt/cloud/provider.yaml
@@ -54,7 +54,7 @@ versions:
   - 1.0.1
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-http
   - asgiref
   - aiohttp>=3.9.2

--- a/airflow/providers/dingding/__init__.py
+++ b/airflow/providers/dingding/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.5.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-dingding:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-dingding:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/dingding/provider.yaml
+++ b/airflow/providers/dingding/provider.yaml
@@ -43,7 +43,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-http
 
 integrations:

--- a/airflow/providers/discord/__init__.py
+++ b/airflow/providers/discord/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.7.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-discord:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-discord:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/discord/provider.yaml
+++ b/airflow/providers/discord/provider.yaml
@@ -46,7 +46,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-http
 
 integrations:

--- a/airflow/providers/docker/__init__.py
+++ b/airflow/providers/docker/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.12.3"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-docker:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-docker:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/docker/provider.yaml
+++ b/airflow/providers/docker/provider.yaml
@@ -70,7 +70,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - docker>=7.1.0
   - python-dotenv>=0.21.0
 

--- a/airflow/providers/elasticsearch/__init__.py
+++ b/airflow/providers/elasticsearch/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "5.4.2"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-elasticsearch:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-elasticsearch:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/elasticsearch/provider.yaml
+++ b/airflow/providers/elasticsearch/provider.yaml
@@ -66,7 +66,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-common-sql>=1.14.1
   - elasticsearch>=8.10,<9
 

--- a/airflow/providers/exasol/__init__.py
+++ b/airflow/providers/exasol/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "4.5.3"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-exasol:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-exasol:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/exasol/provider.yaml
+++ b/airflow/providers/exasol/provider.yaml
@@ -59,7 +59,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-common-sql>=1.14.1
   - pyexasol>=0.5.1
   # In pandas 2.2 minimal version of the sqlalchemy is 2.0

--- a/airflow/providers/facebook/__init__.py
+++ b/airflow/providers/facebook/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.5.2"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-facebook:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-facebook:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/facebook/provider.yaml
+++ b/airflow/providers/facebook/provider.yaml
@@ -48,7 +48,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - facebook-business>=15.0.2
 
 integrations:

--- a/airflow/providers/ftp/__init__.py
+++ b/airflow/providers/ftp/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.10.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-ftp:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-ftp:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/ftp/provider.yaml
+++ b/airflow/providers/ftp/provider.yaml
@@ -53,7 +53,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
 
 integrations:
   - integration-name: File Transfer Protocol (FTP)

--- a/airflow/providers/github/__init__.py
+++ b/airflow/providers/github/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "2.6.2"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-github:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-github:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/github/provider.yaml
+++ b/airflow/providers/github/provider.yaml
@@ -23,7 +23,7 @@ description: |
     `GitHub <https://www.github.com/>`__
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - PyGithub>=2.1.1
 
 state: ready

--- a/airflow/providers/google/__init__.py
+++ b/airflow/providers/google/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "10.21.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-google:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-google:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -93,7 +93,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-common-compat>=1.1.0
   - apache-airflow-providers-common-sql>=1.7.2
   - asgiref>=3.5.2

--- a/airflow/providers/grpc/__init__.py
+++ b/airflow/providers/grpc/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.5.2"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-grpc:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-grpc:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/grpc/provider.yaml
+++ b/airflow/providers/grpc/provider.yaml
@@ -45,7 +45,7 @@ versions:
   - 1.0.1
   - 1.0.0
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   # Google has very clear rules on what dependencies should be used. All the limits below
   # follow strict guidelines of Google Libraries as quoted here:
   # While this issue is open, dependents of google-api-core, google-cloud-core. and google-auth

--- a/airflow/providers/hashicorp/__init__.py
+++ b/airflow/providers/hashicorp/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.7.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-hashicorp:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-hashicorp:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/hashicorp/provider.yaml
+++ b/airflow/providers/hashicorp/provider.yaml
@@ -55,7 +55,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - hvac>=1.1.0
 
 integrations:

--- a/airflow/providers/http/__init__.py
+++ b/airflow/providers/http/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "4.12.0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-http:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-http:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/http/provider.yaml
+++ b/airflow/providers/http/provider.yaml
@@ -59,7 +59,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   # The 2.26.0 release of requests got rid of the chardet LGPL mandatory dependency, allowing us to
   # release it as a requirement for airflow
   - requests>=2.27.0,<3

--- a/airflow/providers/imap/__init__.py
+++ b/airflow/providers/imap/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.6.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-imap:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-imap:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/imap/provider.yaml
+++ b/airflow/providers/imap/provider.yaml
@@ -50,7 +50,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
 
 integrations:
   - integration-name: Internet Message Access Protocol (IMAP)

--- a/airflow/providers/influxdb/__init__.py
+++ b/airflow/providers/influxdb/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "2.6.0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-influxdb:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-influxdb:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/influxdb/provider.yaml
+++ b/airflow/providers/influxdb/provider.yaml
@@ -24,7 +24,7 @@ description: |
     `InfluxDB <https://www.influxdata.com/>`__
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - influxdb-client>=1.19.0
   - requests>=2.27.0,<3
 

--- a/airflow/providers/jdbc/__init__.py
+++ b/airflow/providers/jdbc/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "4.4.0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-jdbc:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-jdbc:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/jdbc/provider.yaml
+++ b/airflow/providers/jdbc/provider.yaml
@@ -51,7 +51,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-common-sql>=1.14.1
   - jaydebeapi>=1.1.1
 

--- a/airflow/providers/jenkins/__init__.py
+++ b/airflow/providers/jenkins/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.6.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-jenkins:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-jenkins:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/jenkins/provider.yaml
+++ b/airflow/providers/jenkins/provider.yaml
@@ -51,7 +51,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - python-jenkins>=1.0.0
 
 integrations:

--- a/airflow/providers/microsoft/azure/__init__.py
+++ b/airflow/providers/microsoft/azure/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "10.3.0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-microsoft-azure:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-microsoft-azure:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/microsoft/azure/provider.yaml
+++ b/airflow/providers/microsoft/azure/provider.yaml
@@ -81,7 +81,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - adlfs>=2023.10.0
   - azure-batch>=8.0.0
   - azure-cosmos>=4.6.0

--- a/airflow/providers/microsoft/mssql/__init__.py
+++ b/airflow/providers/microsoft/mssql/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.8.0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-microsoft-mssql:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-microsoft-mssql:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/microsoft/mssql/provider.yaml
+++ b/airflow/providers/microsoft/mssql/provider.yaml
@@ -53,7 +53,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-common-sql>=1.14.1
   - pymssql>=2.3.0
   - methodtools>=0.4.7

--- a/airflow/providers/microsoft/psrp/__init__.py
+++ b/airflow/providers/microsoft/psrp/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "2.7.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-microsoft-psrp:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-microsoft-psrp:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/microsoft/psrp/provider.yaml
+++ b/airflow/providers/microsoft/psrp/provider.yaml
@@ -48,7 +48,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - pypsrp>=0.8.0
 
 integrations:

--- a/airflow/providers/microsoft/winrm/__init__.py
+++ b/airflow/providers/microsoft/winrm/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.5.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-microsoft-winrm:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-microsoft-winrm:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/microsoft/winrm/provider.yaml
+++ b/airflow/providers/microsoft/winrm/provider.yaml
@@ -47,7 +47,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - pywinrm>=0.4
 
 integrations:

--- a/airflow/providers/mongo/__init__.py
+++ b/airflow/providers/mongo/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "4.1.2"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-mongo:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-mongo:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/mongo/provider.yaml
+++ b/airflow/providers/mongo/provider.yaml
@@ -50,7 +50,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - dnspython>=1.13.0
   - pymongo>=4.0.0
 

--- a/airflow/providers/mysql/__init__.py
+++ b/airflow/providers/mysql/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "5.6.3"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-mysql:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-mysql:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/mysql/provider.yaml
+++ b/airflow/providers/mysql/provider.yaml
@@ -64,7 +64,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-common-sql>=1.14.1
   - mysqlclient>=1.4.0
   - mysql-connector-python>=8.0.29

--- a/airflow/providers/neo4j/__init__.py
+++ b/airflow/providers/neo4j/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.6.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-neo4j:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-neo4j:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/neo4j/provider.yaml
+++ b/airflow/providers/neo4j/provider.yaml
@@ -48,7 +48,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - neo4j>=4.2.1
 
 integrations:

--- a/airflow/providers/odbc/__init__.py
+++ b/airflow/providers/odbc/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "4.6.3"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-odbc:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-odbc:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/odbc/provider.yaml
+++ b/airflow/providers/odbc/provider.yaml
@@ -52,7 +52,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-common-sql>=1.14.1
   - pyodbc>=5.0.0
 

--- a/airflow/providers/openai/__init__.py
+++ b/airflow/providers/openai/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "1.2.2"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-openai:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-openai:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/openai/provider.yaml
+++ b/airflow/providers/openai/provider.yaml
@@ -43,7 +43,7 @@ integrations:
     tags: [software]
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - openai[datalib]>=1.32.0
 
 hooks:

--- a/airflow/providers/openfaas/__init__.py
+++ b/airflow/providers/openfaas/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.5.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-openfaas:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-openfaas:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/openfaas/provider.yaml
+++ b/airflow/providers/openfaas/provider.yaml
@@ -42,7 +42,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
 
 integrations:
   - integration-name: OpenFaaS

--- a/airflow/providers/openlineage/__init__.py
+++ b/airflow/providers/openlineage/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "1.10.0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-openlineage:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-openlineage:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/openlineage/provider.yaml
+++ b/airflow/providers/openlineage/provider.yaml
@@ -45,7 +45,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-common-sql>=1.6.0
   - attrs>=22.2
   - openlineage-integration-common>=1.16.0

--- a/airflow/providers/opensearch/__init__.py
+++ b/airflow/providers/opensearch/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "1.3.0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-opensearch:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-opensearch:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/opensearch/provider.yaml
+++ b/airflow/providers/opensearch/provider.yaml
@@ -34,7 +34,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - opensearch-py>=2.2.0
 
 integrations:

--- a/airflow/providers/opsgenie/__init__.py
+++ b/airflow/providers/opsgenie/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "5.6.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-opsgenie:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-opsgenie:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/opsgenie/provider.yaml
+++ b/airflow/providers/opsgenie/provider.yaml
@@ -47,7 +47,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - opsgenie-sdk>=2.1.5
 
 integrations:

--- a/airflow/providers/oracle/__init__.py
+++ b/airflow/providers/oracle/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.10.3"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-oracle:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-oracle:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/oracle/provider.yaml
+++ b/airflow/providers/oracle/provider.yaml
@@ -58,7 +58,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-common-sql>=1.3.1
   - oracledb>=2.0.0
 

--- a/airflow/providers/pagerduty/__init__.py
+++ b/airflow/providers/pagerduty/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.7.2"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-pagerduty:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-pagerduty:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/pagerduty/provider.yaml
+++ b/airflow/providers/pagerduty/provider.yaml
@@ -49,7 +49,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - pdpyras>=4.2.0
 
 integrations:

--- a/airflow/providers/papermill/__init__.py
+++ b/airflow/providers/papermill/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.7.2"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-papermill:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-papermill:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/papermill/provider.yaml
+++ b/airflow/providers/papermill/provider.yaml
@@ -55,7 +55,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - papermill[all]>=2.4.0
   - scrapbook[all]
   - ipykernel

--- a/airflow/providers/pgvector/__init__.py
+++ b/airflow/providers/pgvector/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "1.2.2"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-pgvector:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-pgvector:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/pgvector/provider.yaml
+++ b/airflow/providers/pgvector/provider.yaml
@@ -42,7 +42,7 @@ integrations:
     tags: [software]
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-postgres>=5.7.1
   # setting !=0.3.0 version due to https://github.com/pgvector/pgvector-python/issues/79
   # observed in 0.3.0.

--- a/airflow/providers/pinecone/__init__.py
+++ b/airflow/providers/pinecone/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "2.0.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-pinecone:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-pinecone:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/pinecone/provider.yaml
+++ b/airflow/providers/pinecone/provider.yaml
@@ -43,7 +43,7 @@ integrations:
     tags: [software]
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - pinecone-client>=3.1.0
 
 hooks:

--- a/airflow/providers/postgres/__init__.py
+++ b/airflow/providers/postgres/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "5.11.3"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-postgres:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-postgres:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/postgres/provider.yaml
+++ b/airflow/providers/postgres/provider.yaml
@@ -63,7 +63,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-common-sql>=1.14.1
   - psycopg2-binary>=2.9.4
 

--- a/airflow/providers/presto/__init__.py
+++ b/airflow/providers/presto/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "5.5.2"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-presto:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-presto:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/presto/provider.yaml
+++ b/airflow/providers/presto/provider.yaml
@@ -60,7 +60,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-common-sql>=1.3.1
   - presto-python-client>=0.8.4
   # In pandas 2.2 minimal version of the sqlalchemy is 2.0

--- a/airflow/providers/qdrant/__init__.py
+++ b/airflow/providers/qdrant/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "1.1.2"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-qdrant:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-qdrant:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/qdrant/provider.yaml
+++ b/airflow/providers/qdrant/provider.yaml
@@ -42,7 +42,7 @@ integrations:
 
 dependencies:
   - qdrant_client>=1.10.1
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
 
 hooks:
   - integration-name: Qdrant

--- a/airflow/providers/redis/__init__.py
+++ b/airflow/providers/redis/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.7.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-redis:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-redis:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/redis/provider.yaml
+++ b/airflow/providers/redis/provider.yaml
@@ -48,7 +48,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   # 5.0.2 excluded due to breaking changes which fixed in https://github.com/redis/redis-py/pull/3176
   - redis>=4.5.2,!=4.5.5,!=5.0.2
 

--- a/airflow/providers/salesforce/__init__.py
+++ b/airflow/providers/salesforce/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "5.7.2"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-salesforce:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-salesforce:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/salesforce/provider.yaml
+++ b/airflow/providers/salesforce/provider.yaml
@@ -57,7 +57,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - simple-salesforce>=1.0.0
   # In pandas 2.2 minimal version of the sqlalchemy is 2.0
   # https://pandas.pydata.org/docs/whatsnew/v2.2.0.html#increased-minimum-versions-for-dependencies

--- a/airflow/providers/samba/__init__.py
+++ b/airflow/providers/samba/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "4.7.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-samba:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-samba:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/samba/provider.yaml
+++ b/airflow/providers/samba/provider.yaml
@@ -46,7 +46,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - smbprotocol>=1.5.0
 
 integrations:

--- a/airflow/providers/segment/__init__.py
+++ b/airflow/providers/segment/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.5.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-segment:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-segment:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/segment/provider.yaml
+++ b/airflow/providers/segment/provider.yaml
@@ -42,7 +42,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - analytics-python>=1.2.9
 
 integrations:

--- a/airflow/providers/sendgrid/__init__.py
+++ b/airflow/providers/sendgrid/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.5.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-sendgrid:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-sendgrid:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/sendgrid/provider.yaml
+++ b/airflow/providers/sendgrid/provider.yaml
@@ -22,7 +22,7 @@ description: |
     `Sendgrid <https://sendgrid.com/>`__
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - sendgrid>=6.0.0
 
 state: ready

--- a/airflow/providers/sftp/__init__.py
+++ b/airflow/providers/sftp/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "4.10.3"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-sftp:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-sftp:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/sftp/provider.yaml
+++ b/airflow/providers/sftp/provider.yaml
@@ -65,7 +65,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-ssh>=2.1.0
   - paramiko>=2.9.0
   - asyncssh>=2.12.0

--- a/airflow/providers/singularity/__init__.py
+++ b/airflow/providers/singularity/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.5.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-singularity:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-singularity:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/singularity/provider.yaml
+++ b/airflow/providers/singularity/provider.yaml
@@ -44,7 +44,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - spython>=0.0.56
 
 integrations:

--- a/airflow/providers/slack/__init__.py
+++ b/airflow/providers/slack/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "8.8.0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-slack:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-slack:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/slack/provider.yaml
+++ b/airflow/providers/slack/provider.yaml
@@ -63,7 +63,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-common-sql>=1.3.1
   - slack_sdk>=3.19.0
 

--- a/airflow/providers/smtp/__init__.py
+++ b/airflow/providers/smtp/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "1.7.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-smtp:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-smtp:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/smtp/provider.yaml
+++ b/airflow/providers/smtp/provider.yaml
@@ -42,7 +42,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
 
 integrations:
   - integration-name: Simple Mail Transfer Protocol (SMTP)

--- a/airflow/providers/snowflake/__init__.py
+++ b/airflow/providers/snowflake/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "5.6.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-snowflake:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-snowflake:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/snowflake/provider.yaml
+++ b/airflow/providers/snowflake/provider.yaml
@@ -76,7 +76,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-common-compat>=1.1.0
   - apache-airflow-providers-common-sql>=1.14.1
   # In pandas 2.2 minimal version of the sqlalchemy is 2.0

--- a/airflow/providers/sqlite/__init__.py
+++ b/airflow/providers/sqlite/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.8.2"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-sqlite:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-sqlite:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/sqlite/provider.yaml
+++ b/airflow/providers/sqlite/provider.yaml
@@ -54,7 +54,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-common-sql>=1.14.1
 
 integrations:

--- a/airflow/providers/ssh/__init__.py
+++ b/airflow/providers/ssh/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.12.0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-ssh:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-ssh:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/ssh/provider.yaml
+++ b/airflow/providers/ssh/provider.yaml
@@ -61,7 +61,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - paramiko>=2.9.0
   - sshtunnel>=0.3.2
 

--- a/airflow/providers/tableau/__init__.py
+++ b/airflow/providers/tableau/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "4.5.2"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-tableau:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-tableau:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/tableau/provider.yaml
+++ b/airflow/providers/tableau/provider.yaml
@@ -52,7 +52,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - tableauserverclient>=0.25
 
 integrations:

--- a/airflow/providers/tabular/__init__.py
+++ b/airflow/providers/tabular/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "1.5.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-tabular:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-tabular:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/tabular/provider.yaml
+++ b/airflow/providers/tabular/provider.yaml
@@ -37,7 +37,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-apache-iceberg
 
 devel-dependencies:

--- a/airflow/providers/telegram/__init__.py
+++ b/airflow/providers/telegram/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "4.5.2"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-telegram:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-telegram:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/telegram/provider.yaml
+++ b/airflow/providers/telegram/provider.yaml
@@ -48,7 +48,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - python-telegram-bot>=20.2
 
 integrations:

--- a/airflow/providers/teradata/__init__.py
+++ b/airflow/providers/teradata/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "2.5.0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-teradata:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-teradata:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/teradata/provider.yaml
+++ b/airflow/providers/teradata/provider.yaml
@@ -34,7 +34,7 @@ versions:
   - 2.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-common-sql>=1.14.1
   - teradatasqlalchemy>=17.20.0.0
   - teradatasql>=17.20.0.28

--- a/airflow/providers/trino/__init__.py
+++ b/airflow/providers/trino/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "5.7.2"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-trino:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-trino:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/trino/provider.yaml
+++ b/airflow/providers/trino/provider.yaml
@@ -62,7 +62,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-common-sql>=1.3.1
   # In pandas 2.2 minimal version of the sqlalchemy is 2.0
   # https://pandas.pydata.org/docs/whatsnew/v2.2.0.html#increased-minimum-versions-for-dependencies

--- a/airflow/providers/vertica/__init__.py
+++ b/airflow/providers/vertica/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.8.2"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-vertica:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-vertica:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/vertica/provider.yaml
+++ b/airflow/providers/vertica/provider.yaml
@@ -52,7 +52,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-common-sql>=1.3.1
   - vertica-python>=0.6.0
 

--- a/airflow/providers/weaviate/__init__.py
+++ b/airflow/providers/weaviate/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "2.0.0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-weaviate:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-weaviate:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/weaviate/provider.yaml
+++ b/airflow/providers/weaviate/provider.yaml
@@ -48,7 +48,7 @@ integrations:
     tags: [software]
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - httpx>=0.25.0
   - weaviate-client>=4.4.0
   # In pandas 2.2 minimal version of the sqlalchemy is 2.0

--- a/airflow/providers/yandex/__init__.py
+++ b/airflow/providers/yandex/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "3.11.2"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-yandex:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-yandex:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/yandex/provider.yaml
+++ b/airflow/providers/yandex/provider.yaml
@@ -51,7 +51,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - yandexcloud>=0.308.0
   - yandex-query-client>=0.1.4
 

--- a/airflow/providers/ydb/__init__.py
+++ b/airflow/providers/ydb/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "1.2.0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-ydb:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-ydb:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/ydb/provider.yaml
+++ b/airflow/providers/ydb/provider.yaml
@@ -30,7 +30,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - apache-airflow-providers-common-sql>=1.14.1
   - ydb>=3.12.1
 

--- a/airflow/providers/zendesk/__init__.py
+++ b/airflow/providers/zendesk/__init__.py
@@ -32,8 +32,8 @@ __all__ = ["__version__"]
 __version__ = "4.7.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
-    "2.7.0"
+    "2.8.0"
 ):
     raise RuntimeError(
-        f"The package `apache-airflow-providers-zendesk:{__version__}` needs Apache Airflow 2.7.0+"
+        f"The package `apache-airflow-providers-zendesk:{__version__}` needs Apache Airflow 2.8.0+"
     )

--- a/airflow/providers/zendesk/provider.yaml
+++ b/airflow/providers/zendesk/provider.yaml
@@ -46,7 +46,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.7.0
+  - apache-airflow>=2.8.0
   - zenpy>=2.0.40
 
 integrations:

--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -505,12 +505,6 @@ CHICKEN_EGG_PROVIDERS = " ".join([])
 BASE_PROVIDERS_COMPATIBILITY_CHECKS: list[dict[str, str | list[str]]] = [
     {
         "python-version": "3.8",
-        "airflow-version": "2.7.3",
-        "remove-providers": "common.io fab",
-        "run-tests": "true",
-    },
-    {
-        "python-version": "3.8",
         "airflow-version": "2.8.4",
         "remove-providers": "fab",
         "run-tests": "true",

--- a/dev/breeze/src/airflow_breeze/utils/packages.py
+++ b/dev/breeze/src/airflow_breeze/utils/packages.py
@@ -48,7 +48,7 @@ from airflow_breeze.utils.publish_docs_helpers import (
 from airflow_breeze.utils.run_utils import run_command
 from airflow_breeze.utils.versions import get_version_tag, strip_leading_zeros_from_version
 
-MIN_AIRFLOW_VERSION = "2.7.0"
+MIN_AIRFLOW_VERSION = "2.8.0"
 HTTPS_REMOTE = "apache-https-for-providers"
 
 LONG_PROVIDERS_PREFIX = "apache-airflow-providers-"

--- a/dev/breeze/tests/test_packages.py
+++ b/dev/breeze/tests/test_packages.py
@@ -104,7 +104,7 @@ def test_get_long_package_name():
 
 def test_get_provider_requirements():
     # update me when asana dependencies change
-    assert get_provider_requirements("asana") == ["apache-airflow>=2.7.0", "asana>=0.10,<4.0.0"]
+    assert get_provider_requirements("asana") == ["apache-airflow>=2.8.0", "asana>=0.10,<4.0.0"]
 
 
 def test_get_removed_providers():
@@ -205,7 +205,7 @@ def test_get_documentation_package_path():
             "beta0",
             """
     "apache-airflow-providers-common-sql>=1.14.1b0",
-    "apache-airflow>=2.7.0b0",
+    "apache-airflow>=2.8.0b0",
     "psycopg2-binary>=2.9.4",
     """,
             id="beta0 suffix postgres",
@@ -215,7 +215,7 @@ def test_get_documentation_package_path():
             "",
             """
     "apache-airflow-providers-common-sql>=1.14.1",
-    "apache-airflow>=2.7.0",
+    "apache-airflow>=2.8.0",
     "psycopg2-binary>=2.9.4",
     """,
             id="No suffix postgres",
@@ -431,8 +431,8 @@ def test_validate_provider_info_with_schema():
 @pytest.mark.parametrize(
     "provider_id, min_version",
     [
-        ("amazon", "2.7.0"),
-        ("common.io", "2.8.0"),
+        ("amazon", "2.8.0"),
+        ("fab", "2.9.0"),
     ],
 )
 def test_get_min_airflow_version(provider_id: str, min_version: str):
@@ -496,7 +496,7 @@ def test_provider_jinja_context():
         "CHANGELOG_RELATIVE_PATH": "../../airflow/providers/amazon",
         "SUPPORTED_PYTHON_VERSIONS": ["3.8", "3.9", "3.10", "3.11", "3.12"],
         "PLUGINS": [],
-        "MIN_AIRFLOW_VERSION": "2.7.0",
+        "MIN_AIRFLOW_VERSION": "2.8.0",
         "PROVIDER_REMOVED": False,
         "PROVIDER_INFO": provider_info,
     }

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -2,7 +2,7 @@
   "airbyte": {
     "deps": [
       "apache-airflow-providers-http",
-      "apache-airflow>=2.7.0"
+      "apache-airflow>=2.8.0"
     ],
     "devel-deps": [],
     "plugins": [],
@@ -16,7 +16,7 @@
     "deps": [
       "alibabacloud_adb20211201>=1.0.0",
       "alibabacloud_tea_openapi>=0.3.7",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "oss2>=2.14.0"
     ],
     "devel-deps": [],
@@ -32,7 +32,7 @@
       "apache-airflow-providers-common-compat>=1.1.0",
       "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow-providers-http",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "asgiref>=2.3.0",
       "boto3>=1.34.90",
       "botocore>=1.34.90",
@@ -77,7 +77,7 @@
   },
   "apache.beam": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "apache-beam>=2.53.0",
       "pyarrow>=14.0.1"
     ],
@@ -93,7 +93,7 @@
   },
   "apache.cassandra": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "cassandra-driver>=3.29.1"
     ],
     "devel-deps": [],
@@ -105,7 +105,7 @@
   "apache.drill": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.14.1",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "sqlalchemy-drill>=1.1.0"
     ],
     "devel-deps": [],
@@ -119,7 +119,7 @@
   "apache.druid": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.14.1",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "pydruid>=0.4.1"
     ],
     "devel-deps": [],
@@ -134,7 +134,7 @@
   "apache.flink": {
     "deps": [
       "apache-airflow-providers-cncf-kubernetes>=5.1.0",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "cryptography>=41.0.0"
     ],
     "devel-deps": [],
@@ -147,7 +147,7 @@
   },
   "apache.hdfs": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "hdfs[avro,dataframe,kerberos]>=2.5.4;python_version<\"3.12\"",
       "hdfs[avro,dataframe,kerberos]>=2.7.3;python_version>=\"3.12\"",
       "pandas>=1.5.3,<2.2;python_version<\"3.9\"",
@@ -162,7 +162,7 @@
   "apache.hive": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "hmsclient>=0.1.0",
       "jmespath>=0.7.0",
       "pandas>=1.5.3,<2.2;python_version<\"3.9\"",
@@ -191,7 +191,7 @@
   },
   "apache.iceberg": {
     "deps": [
-      "apache-airflow>=2.7.0"
+      "apache-airflow>=2.8.0"
     ],
     "devel-deps": [
       "pyiceberg>=0.5.0"
@@ -204,7 +204,7 @@
   "apache.impala": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.14.1",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "impyla>=0.18.0,<1.0"
     ],
     "devel-deps": [],
@@ -217,7 +217,7 @@
   },
   "apache.kafka": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "asgiref>=2.3.0",
       "confluent-kafka>=2.3.0"
     ],
@@ -229,7 +229,7 @@
   },
   "apache.kylin": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "kylinpy>=2.7.0"
     ],
     "devel-deps": [],
@@ -242,7 +242,7 @@
     "deps": [
       "aiohttp>=3.9.2",
       "apache-airflow-providers-http",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "asgiref"
     ],
     "devel-deps": [],
@@ -255,7 +255,7 @@
   },
   "apache.pig": {
     "deps": [
-      "apache-airflow>=2.7.0"
+      "apache-airflow>=2.8.0"
     ],
     "devel-deps": [],
     "plugins": [],
@@ -266,7 +266,7 @@
   "apache.pinot": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.14.1",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "pinotdb>=5.1.0"
     ],
     "devel-deps": [],
@@ -279,7 +279,7 @@
   },
   "apache.spark": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "grpcio-status>=1.59.0",
       "pyspark>=3.1.3"
     ],
@@ -293,7 +293,7 @@
   },
   "apprise": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "apprise>=1.8.0"
     ],
     "devel-deps": [],
@@ -304,7 +304,7 @@
   },
   "arangodb": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "python-arango>=7.3.2"
     ],
     "devel-deps": [],
@@ -315,7 +315,7 @@
   },
   "asana": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "asana>=0.10,<4.0.0"
     ],
     "devel-deps": [],
@@ -326,7 +326,7 @@
   },
   "atlassian.jira": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "atlassian-python-api>3.41.10"
     ],
     "devel-deps": [],
@@ -337,7 +337,7 @@
   },
   "celery": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "celery[redis]>=5.3.0,<6,!=5.3.3,!=5.3.2",
       "flower>=1.0.0",
       "google-re2>=1.0"
@@ -352,7 +352,7 @@
   },
   "cloudant": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "cloudant>=2.13.0"
     ],
     "devel-deps": [],
@@ -364,7 +364,7 @@
   "cncf.kubernetes": {
     "deps": [
       "aiofiles>=23.2.0",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "asgiref>=3.5.2",
       "cryptography>=41.0.0",
       "google-re2>=1.0",
@@ -379,7 +379,7 @@
   },
   "cohere": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "cohere>=4.37,<5"
     ],
     "devel-deps": [],
@@ -390,7 +390,7 @@
   },
   "common.compat": {
     "deps": [
-      "apache-airflow>=2.7.0"
+      "apache-airflow>=2.8.0"
     ],
     "devel-deps": [],
     "plugins": [],
@@ -413,7 +413,7 @@
   },
   "common.sql": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "more-itertools>=9.0.0",
       "sqlparse>=0.4.2"
     ],
@@ -429,7 +429,7 @@
     "deps": [
       "aiohttp>=3.9.2, <4",
       "apache-airflow-providers-common-sql>=1.10.0",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "databricks-sql-connector>=2.0.0, <3.0.0, !=2.9.0",
       "mergedeep>=1.3.4",
       "pandas>=1.5.3,<2.2;python_version<\"3.9\"",
@@ -454,7 +454,7 @@
   },
   "datadog": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "datadog>=0.14.0"
     ],
     "devel-deps": [],
@@ -467,7 +467,7 @@
     "deps": [
       "aiohttp>=3.9.2",
       "apache-airflow-providers-http",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "asgiref"
     ],
     "devel-deps": [],
@@ -482,7 +482,7 @@
   "dingding": {
     "deps": [
       "apache-airflow-providers-http",
-      "apache-airflow>=2.7.0"
+      "apache-airflow>=2.8.0"
     ],
     "devel-deps": [],
     "plugins": [],
@@ -495,7 +495,7 @@
   "discord": {
     "deps": [
       "apache-airflow-providers-http",
-      "apache-airflow>=2.7.0"
+      "apache-airflow>=2.8.0"
     ],
     "devel-deps": [],
     "plugins": [],
@@ -507,7 +507,7 @@
   },
   "docker": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "docker>=7.1.0",
       "python-dotenv>=0.21.0"
     ],
@@ -520,7 +520,7 @@
   "elasticsearch": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.14.1",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "elasticsearch>=8.10,<9"
     ],
     "devel-deps": [],
@@ -534,7 +534,7 @@
   "exasol": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.14.1",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "pandas>=1.5.3,<2.2;python_version<\"3.9\"",
       "pandas>=2.1.2,<2.2;python_version>=\"3.9\"",
       "pyexasol>=0.5.1"
@@ -564,7 +564,7 @@
   },
   "facebook": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "facebook-business>=15.0.2"
     ],
     "devel-deps": [],
@@ -575,7 +575,7 @@
   },
   "ftp": {
     "deps": [
-      "apache-airflow>=2.7.0"
+      "apache-airflow>=2.8.0"
     ],
     "devel-deps": [],
     "plugins": [],
@@ -589,7 +589,7 @@
   "github": {
     "deps": [
       "PyGithub>=2.1.1",
-      "apache-airflow>=2.7.0"
+      "apache-airflow>=2.8.0"
     ],
     "devel-deps": [],
     "plugins": [],
@@ -602,7 +602,7 @@
       "PyOpenSSL>=23.0.0",
       "apache-airflow-providers-common-compat>=1.1.0",
       "apache-airflow-providers-common-sql>=1.7.2",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "asgiref>=3.5.2",
       "dill>=0.2.3",
       "gcloud-aio-auth>=5.2.0",
@@ -692,7 +692,7 @@
   },
   "grpc": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "google-auth-httplib2>=0.0.1",
       "google-auth>=1.0.0, <3.0.0",
       "grpcio>=1.59.0"
@@ -705,7 +705,7 @@
   },
   "hashicorp": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "hvac>=1.1.0"
     ],
     "devel-deps": [],
@@ -719,7 +719,7 @@
   "http": {
     "deps": [
       "aiohttp>=3.9.2",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "asgiref",
       "requests>=2.27.0,<3",
       "requests_toolbelt"
@@ -732,7 +732,7 @@
   },
   "imap": {
     "deps": [
-      "apache-airflow>=2.7.0"
+      "apache-airflow>=2.8.0"
     ],
     "devel-deps": [],
     "plugins": [],
@@ -742,7 +742,7 @@
   },
   "influxdb": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "influxdb-client>=1.19.0",
       "requests>=2.27.0,<3"
     ],
@@ -755,7 +755,7 @@
   "jdbc": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.14.1",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "jaydebeapi>=1.1.1"
     ],
     "devel-deps": [],
@@ -768,7 +768,7 @@
   },
   "jenkins": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "python-jenkins>=1.0.0"
     ],
     "devel-deps": [],
@@ -781,7 +781,7 @@
     "deps": [
       "adal>=1.2.7",
       "adlfs>=2023.10.0",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "azure-batch>=8.0.0",
       "azure-cosmos>=4.6.0",
       "azure-datalake-store>=0.0.45",
@@ -819,7 +819,7 @@
   "microsoft.mssql": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.14.1",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "methodtools>=0.4.7",
       "pymssql>=2.3.0"
     ],
@@ -833,7 +833,7 @@
   },
   "microsoft.psrp": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "pypsrp>=0.8.0"
     ],
     "devel-deps": [],
@@ -844,7 +844,7 @@
   },
   "microsoft.winrm": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "pywinrm>=0.4"
     ],
     "devel-deps": [],
@@ -855,7 +855,7 @@
   },
   "mongo": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "dnspython>=1.13.0",
       "pymongo>=4.0.0"
     ],
@@ -870,7 +870,7 @@
   "mysql": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.14.1",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "mysql-connector-python>=8.0.29",
       "mysqlclient>=1.4.0"
     ],
@@ -889,7 +889,7 @@
   },
   "neo4j": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "neo4j>=4.2.1"
     ],
     "devel-deps": [],
@@ -901,7 +901,7 @@
   "odbc": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.14.1",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "pyodbc>=5.0.0"
     ],
     "devel-deps": [],
@@ -914,7 +914,7 @@
   },
   "openai": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "openai[datalib]>=1.32.0"
     ],
     "devel-deps": [],
@@ -925,7 +925,7 @@
   },
   "openfaas": {
     "deps": [
-      "apache-airflow>=2.7.0"
+      "apache-airflow>=2.8.0"
     ],
     "devel-deps": [],
     "plugins": [],
@@ -936,7 +936,7 @@
   "openlineage": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.6.0",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "attrs>=22.2",
       "openlineage-integration-common>=1.16.0",
       "openlineage-python>=1.16.0"
@@ -956,7 +956,7 @@
   },
   "opensearch": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "opensearch-py>=2.2.0"
     ],
     "devel-deps": [],
@@ -967,7 +967,7 @@
   },
   "opsgenie": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "opsgenie-sdk>=2.1.5"
     ],
     "devel-deps": [],
@@ -979,7 +979,7 @@
   "oracle": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "oracledb>=2.0.0"
     ],
     "devel-deps": [],
@@ -992,7 +992,7 @@
   },
   "pagerduty": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "pdpyras>=4.2.0"
     ],
     "devel-deps": [],
@@ -1003,7 +1003,7 @@
   },
   "papermill": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "ipykernel",
       "pandas>=1.5.3,<2.2;python_version<\"3.9\"",
       "pandas>=2.1.2,<2.2;python_version>=\"3.9\"",
@@ -1021,7 +1021,7 @@
   "pgvector": {
     "deps": [
       "apache-airflow-providers-postgres>=5.7.1",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "pgvector!=0.3.0"
     ],
     "devel-deps": [],
@@ -1035,7 +1035,7 @@
   },
   "pinecone": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "pinecone-client>=3.1.0"
     ],
     "devel-deps": [],
@@ -1047,7 +1047,7 @@
   "postgres": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.14.1",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "psycopg2-binary>=2.9.4"
     ],
     "devel-deps": [],
@@ -1063,7 +1063,7 @@
   "presto": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "pandas>=1.5.3,<2.2;python_version<\"3.9\"",
       "pandas>=2.1.2,<2.2;python_version>=\"3.9\"",
       "presto-python-client>=0.8.4"
@@ -1079,7 +1079,7 @@
   },
   "qdrant": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "qdrant_client>=1.10.1"
     ],
     "devel-deps": [],
@@ -1090,7 +1090,7 @@
   },
   "redis": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "redis>=4.5.2,!=4.5.5,!=5.0.2"
     ],
     "devel-deps": [],
@@ -1101,7 +1101,7 @@
   },
   "salesforce": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "pandas>=1.5.3,<2.2;python_version<\"3.9\"",
       "pandas>=2.1.2,<2.2;python_version>=\"3.9\"",
       "simple-salesforce>=1.0.0"
@@ -1114,7 +1114,7 @@
   },
   "samba": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "smbprotocol>=1.5.0"
     ],
     "devel-deps": [],
@@ -1128,7 +1128,7 @@
   "segment": {
     "deps": [
       "analytics-python>=1.2.9",
-      "apache-airflow>=2.7.0"
+      "apache-airflow>=2.8.0"
     ],
     "devel-deps": [],
     "plugins": [],
@@ -1138,7 +1138,7 @@
   },
   "sendgrid": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "sendgrid>=6.0.0"
     ],
     "devel-deps": [],
@@ -1150,7 +1150,7 @@
   "sftp": {
     "deps": [
       "apache-airflow-providers-ssh>=2.1.0",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "asyncssh>=2.12.0",
       "paramiko>=2.9.0"
     ],
@@ -1166,7 +1166,7 @@
   },
   "singularity": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "spython>=0.0.56"
     ],
     "devel-deps": [],
@@ -1178,7 +1178,7 @@
   "slack": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "slack_sdk>=3.19.0"
     ],
     "devel-deps": [],
@@ -1191,7 +1191,7 @@
   },
   "smtp": {
     "deps": [
-      "apache-airflow>=2.7.0"
+      "apache-airflow>=2.8.0"
     ],
     "devel-deps": [],
     "plugins": [],
@@ -1203,7 +1203,7 @@
     "deps": [
       "apache-airflow-providers-common-compat>=1.1.0",
       "apache-airflow-providers-common-sql>=1.14.1",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "pandas>=1.5.3,<2.2;python_version<\"3.9\"",
       "pandas>=2.1.2,<2.2;python_version>=\"3.9\"",
       "pyarrow>=14.0.1",
@@ -1223,7 +1223,7 @@
   "sqlite": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.14.1",
-      "apache-airflow>=2.7.0"
+      "apache-airflow>=2.8.0"
     ],
     "devel-deps": [],
     "plugins": [],
@@ -1235,7 +1235,7 @@
   },
   "ssh": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "paramiko>=2.9.0",
       "sshtunnel>=0.3.2"
     ],
@@ -1247,7 +1247,7 @@
   },
   "tableau": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "tableauserverclient>=0.25"
     ],
     "devel-deps": [],
@@ -1259,7 +1259,7 @@
   "tabular": {
     "deps": [
       "apache-airflow-providers-apache-iceberg",
-      "apache-airflow>=2.7.0"
+      "apache-airflow>=2.8.0"
     ],
     "devel-deps": [
       "pyiceberg>=0.5.0"
@@ -1273,7 +1273,7 @@
   },
   "telegram": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "python-telegram-bot>=20.2"
     ],
     "devel-deps": [],
@@ -1285,7 +1285,7 @@
   "teradata": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.14.1",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "teradatasql>=17.20.0.28",
       "teradatasqlalchemy>=17.20.0.0"
     ],
@@ -1302,7 +1302,7 @@
   "trino": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "pandas>=1.5.3,<2.2;python_version<\"3.9\"",
       "pandas>=2.1.2,<2.2;python_version>=\"3.9\"",
       "trino>=0.318.0"
@@ -1320,7 +1320,7 @@
   "vertica": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "vertica-python>=0.6.0"
     ],
     "devel-deps": [],
@@ -1333,7 +1333,7 @@
   },
   "weaviate": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "httpx>=0.25.0",
       "pandas>=1.5.3,<2.2;python_version<\"3.9\"",
       "pandas>=2.1.2,<2.2;python_version>=\"3.9\"",
@@ -1347,7 +1347,7 @@
   },
   "yandex": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "yandex-query-client>=0.1.4",
       "yandexcloud>=0.308.0"
     ],
@@ -1360,7 +1360,7 @@
   "ydb": {
     "deps": [
       "apache-airflow-providers-common-sql>=1.14.1",
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "ydb>=3.12.1"
     ],
     "devel-deps": [],
@@ -1373,7 +1373,7 @@
   },
   "zendesk": {
     "deps": [
-      "apache-airflow>=2.7.0",
+      "apache-airflow>=2.8.0",
       "zenpy>=2.0.40"
     ],
     "devel-deps": [],


### PR DESCRIPTION
Note: the changelog entry about version bump will be updated during release time