### PR TITLE
Add config to default schedule to None

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2639,6 +2639,21 @@ scheduler:
       example: ~
       default: "True"
       see_also: ":ref:`Differences between the two cron timetables`"
+    default_none_schedule:
+      description: |
+        When a DAG is created without an explicit ``schedule`` argument, whether to default to *None* or a
+        runnable schedule.
+
+        The default is *False*, which sets the default schedule to ``timedelta(days=1)``. If set to *True*,
+        the default schedule will be *None*.
+
+        This configuration exists only for backward compatibility. The default of this configuration will be
+        changed to *True* in a future release.
+      version_added: 2.10.0
+      type: boolean
+      example: ~
+      default: "False"
+      see_also: :ref:`Core Concepts — DAGs <concepts-dags>`
 triggerer:
   description: ~
   options:

--- a/docs/apache-airflow/core-concepts/dags.rst
+++ b/docs/apache-airflow/core-concepts/dags.rst
@@ -92,6 +92,16 @@ Or, you can use the ``@dag`` decorator to :ref:`turn a function into a DAG gener
 
 DAGs are nothing without :doc:`tasks` to run, and those will usually come in the form of either :doc:`operators`, :doc:`sensors` or :doc:`taskflow`.
 
+.. note::
+
+    Due to historical reasons, the default ``schedule`` value defaults to ``timedelta(days=1)``, i.e. the DAG
+    is run every day starting from ``start_date``.
+
+    To avoid confusion, it is recommended to always set an explicit ``schedule`` for your DAGs instead.
+
+    This default can be changed by setting the ``[scheduler] default_none_schedule`` configuration to *True*
+    (default is *False*).
+
 
 Task Dependencies
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Alternative to #41321. This is easier for 2.10 since all tests would behave the same for now.

We still need to fix those DAGs when we change the default for Airflow 3, but we will have a bit more time (hopefully…) for that.