### PR TITLE
fix DagPriorityParsingRequest unique constraint error when dataset aliases are resolved into new datasets

### DIFF
--- a/airflow/datasets/manager.py
+++ b/airflow/datasets/manager.py
@@ -222,7 +222,7 @@ class DatasetManager(LoggingMixin):
                 with session.begin_nested():
                     session.merge(req)
             except exc.IntegrityError:
-                cls.logger().debug("Skipping request %s", req, exc_info=True)
+                cls.logger().debug("Skipping request %s, already present", req, exc_info=True)
                 return None
             return req.fileloc
 

--- a/airflow/datasets/manager.py
+++ b/airflow/datasets/manager.py
@@ -226,9 +226,7 @@ class DatasetManager(LoggingMixin):
                 return None
             return req.fileloc
 
-        results = (_send_dag_priority_parsing_request_if_needed(fileloc) for fileloc in file_locs)
-        if filelocs_to_parse := [result for result in results if result is not None]:
-            cls.logger().debug("parse DAGs in %s", filelocs_to_parse)
+        (_send_dag_priority_parsing_request_if_needed(fileloc) for fileloc in file_locs)
 
     @classmethod
     def _postgres_send_dag_priority_parsing_request(cls, file_locs: Iterable[str], session: Session) -> None:

--- a/airflow/datasets/manager.py
+++ b/airflow/datasets/manager.py
@@ -140,10 +140,8 @@ class DatasetManager(LoggingMixin):
 
         dags_to_reparse = dags_to_queue_from_dataset_alias - dags_to_queue_from_dataset
         if dags_to_reparse:
-            session.add_all(
-                DagPriorityParsingRequest(fileloc=fileloc)
-                for fileloc in {dag.fileloc for dag in dags_to_reparse}
-            )
+            file_locs = {dag.fileloc for dag in dags_to_reparse}
+            cls._send_dag_priority_parsing_request(file_locs, session)
         session.flush()
 
         cls.notify_dataset_changed(dataset=dataset)
@@ -207,6 +205,37 @@ class DatasetManager(LoggingMixin):
         values = [{"target_dag_id": dag.dag_id} for dag in dags_to_queue]
         stmt = insert(DatasetDagRunQueue).values(dataset_id=dataset_id).on_conflict_do_nothing()
         session.execute(stmt, values)
+
+    @classmethod
+    def _send_dag_priority_parsing_request(cls, file_locs: Iterable[str], session: Session) -> None:
+        if session.bind.dialect.name == "postgresql":
+            return cls._postgres_send_dag_priority_parsing_request(file_locs, session)
+        return cls._slow_path_send_dag_priority_parsing_request(file_locs, session)
+
+    @classmethod
+    def _slow_path_send_dag_priority_parsing_request(cls, file_locs: Iterable[str], session: Session) -> None:
+        def _send_dag_priority_parsing_request_if_needed(fileloc: str) -> str | None:
+            # Don't error whole transaction when a single DagPriorityParsingRequest item conflicts.
+            # https://docs.sqlalchemy.org/en/14/orm/session_transaction.html#using-savepoint
+            req = DagPriorityParsingRequest(fileloc=fileloc)
+            try:
+                with session.begin_nested():
+                    session.merge(req)
+            except exc.IntegrityError:
+                cls.logger().debug("Skipping request %s", req, exc_info=True)
+                return None
+            return req.fileloc
+
+        results = (_send_dag_priority_parsing_request_if_needed(fileloc) for fileloc in file_locs)
+        if filelocs_to_parse := [result for result in results if result is not None]:
+            cls.logger().debug("parse DAGs in %s", filelocs_to_parse)
+
+    @classmethod
+    def _postgres_send_dag_priority_parsing_request(cls, file_locs: Iterable[str], session: Session) -> None:
+        from sqlalchemy.dialects.postgresql import insert
+
+        stmt = insert(DagPriorityParsingRequest).on_conflict_do_nothing()
+        session.execute(stmt, {"fileloc": fileloc for fileloc in file_locs})
 
 
 def resolve_dataset_manager() -> DatasetManager:


### PR DESCRIPTION
## Why
This happens when dynamic task mapping is used as each task create the exact same `DagPriorityParsingRequest`s.

## What
Follow how dataset queue a DagRun. ignore the conflict trasctions

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
