### PR TITLE
fix broken main on news fragment

### DIFF
--- a/newsfragments/41395.significant.rst
+++ b/newsfragments/41395.significant.rst
@@ -8,4 +8,3 @@ The following deprecated functions, constants, and classes have been removed as 
 - ``airflow.utils.file.mkdirs`` function: Use ``pathlib.Path.mkdir`` instead.
 - ``airflow.utils.state.SHUTDOWN`` state: No action needed; this state is no longer used.
 - ``airflow.utils.state.terminating_states`` constant: No action needed; this constant is no longer used.
-


### PR DESCRIPTION
Fixes:

```
pre-commit hook(s) made changes.
If you are seeing this message in CI, reproduce locally with: `pre-commit run --all-files`.
To run `pre-commit` as part of git workflow, use `pre-commit install`.
All changes made by hooks:
diff --git a/newsfragments/41395.significant.rst b/newsfragments/41395.significant.rst
index 844fc91..77be51a 100644
--- a/newsfragments/41395.significant.rst
+++ b/newsfragments/41395.significant.rst
@@ -8,4 +8,3 @@ The following deprecated functions, constants, and classes have been removed as
 - ``airflow.utils.file.mkdirs`` function: Use ``pathlib.Path.mkdir`` instead.
 - ``airflow.utils.state.SHUTDOWN`` state: No action needed; this state is no longer used.
 - ``airflow.utils.state.terminating_states`` constant: No action needed; this constant is no longer used.
-

This error means that you have to fix the issues listed above:
```


Example failure
https://github.com/apache/airflow/actions/runs/10350376109/job/28646831125?pr=41402#step:8:189

