### PR TITLE
KubernetesHook kube_config extra can take dict

### DIFF
--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -250,6 +250,8 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
         if kubeconfig is not None:
             with tempfile.NamedTemporaryFile() as temp_config:
                 self.log.debug("loading kube_config from: connection kube_config")
+                if isinstance(kubeconfig, dict):
+                    kubeconfig = json.dumps(kubeconfig)
                 temp_config.write(kubeconfig.encode())
                 temp_config.flush()
                 self._is_in_cluster = False

--- a/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
@@ -53,8 +53,7 @@ CONTAINER_NAME = "test-container"
 POLL_INTERVAL = 100
 
 
-class DeprecationRemovalRequired(AirflowException):
-    ...
+class DeprecationRemovalRequired(AirflowException): ...
 
 
 DEFAULT_CONN_ID = "kubernetes_default"

--- a/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
@@ -53,7 +53,8 @@ CONTAINER_NAME = "test-container"
 POLL_INTERVAL = 100
 
 
-class DeprecationRemovalRequired(AirflowException): ...
+class DeprecationRemovalRequired(AirflowException):
+    ...
 
 
 DEFAULT_CONN_ID = "kubernetes_default"
@@ -79,6 +80,7 @@ class TestKubernetesHook:
             ("in_cluster", {"in_cluster": True}),
             ("in_cluster_empty", {"in_cluster": ""}),
             ("kube_config", {"kube_config": '{"test": "kube"}'}),
+            ("kube_config_dict", {"kube_config": {"test": "kube"}}),
             ("kube_config_path", {"kube_config_path": "path/to/file"}),
             ("kube_config_empty", {"kube_config": ""}),
             ("kube_config_path_empty", {"kube_config_path": ""}),
@@ -285,6 +287,7 @@ class TestKubernetesHook:
         (
             (None, False),
             ("kube_config", True),
+            ("kube_config_dict", True),
             ("kube_config_empty", False),
         ),
     )


### PR DESCRIPTION
Previously had to be json-encoded string which is less convenient when defining the conn in json.

E.g. before only this works
```
AIRFLOW_CONN_KUBERNETES_DEFAULT='{"extra":{"cluster_context":"orbstack","kube_config":"{\"kind\":\"Config\",...
```

But after, now this also works:
```
AIRFLOW_CONN_KUBERNETES_DEFAULT='{"extra":{"cluster_context":"orbstack","kube_config":{"kind":"Config",...
```