### PR TITLE
Fetch history dataset events based on DDRQ instead of the previous Dag Run

### DIFF
--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1405,12 +1405,10 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                         and_(
                             DatasetDagRunQueue.dataset_id == DatasetEvent.dataset_id,
                             DatasetDagRunQueue.created_at <= DatasetEvent.timestamp,
+                            DatasetDagRunQueue.target_dag_id == dag.dag_id,
                         ),
                     )
-                    .where(
-                        DatasetDagRunQueue.target_dag_id == dag.dag_id,
-                        DatasetEvent.timestamp <= exec_date,
-                    )
+                    .where(DatasetEvent.timestamp <= exec_date)
                 ).all()
 
                 data_interval = dag.timetable.data_interval_for_events(exec_date, dataset_events)

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -148,7 +148,7 @@ class TestSchedulerJob:
     @pytest.fixture(autouse=True)
     def per_test(self) -> Generator:
         self.clean_db()
-        self.job_runner = None
+        self.job_runner: SchedulerJobRunner | None = None
 
         yield
 
@@ -5577,7 +5577,7 @@ class TestSchedulerJob:
         def watch_set_state(dr: DagRun, state, **kwargs):
             if state in (DagRunState.SUCCESS, DagRunState.FAILED):
                 # Stop the scheduler
-                self.job_runner.num_runs = 1  # type: ignore[attr-defined]
+                self.job_runner.num_runs = 1  # type: ignore[attr-defined, union-attr]
             orig_set_state(dr, state, **kwargs)  # type: ignore[call-arg]
 
         def watch_heartbeat(*args, **kwargs):

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2325,7 +2325,7 @@ class TestTaskInstance:
         ddrq_timestamps = (
             session.query(DatasetDagRunQueue.created_at).filter_by(dataset_id=event.dataset.id).all()
         )
-        assert all([event.timestamp < ddrq_timestamp for (ddrq_timestamp,) in ddrq_timestamps])
+        assert all([event.timestamp == ddrq_timestamp for (ddrq_timestamp,) in ddrq_timestamps])
 
     @pytest.mark.skip_if_database_isolation_mode  # Does not work in db isolation mode
     def test_outlet_datasets_failed(self, create_task_instance):


### PR DESCRIPTION
## Why
Before this change, we used the previous DagRun to decide which dataset events should be append to a DagRun as its `consumed_dataset_events.` However, if we delete the previous run, these DatasetEvent will be added to the next DagRun, which is confusing.

## What
Instead of using the timestamp of the previous run as the start time to filter dataset events, it now fetches the dataset event created after the `create_at` timestamp of `DatasetDagRunQueue`s (a.k.a DDRQ). To achieve this, we also need to ensure the first created DDRQ is no later than the creation time of a dataset event. Thus, it also passes the timestamp of the dataset event that calls `_queue_dag_run` as the `created_at` timestamp of DDRQs

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
