### PR TITLE
Remove deprecated DAG.date_range method

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -947,29 +947,6 @@ class DAG(LoggingMixin):
 
         return updated_access_control
 
-    def date_range(
-        self,
-        start_date: pendulum.DateTime,
-        num: int | None = None,
-        end_date: datetime | None = None,
-    ) -> list[datetime]:
-        message = "`DAG.date_range()` is deprecated."
-        if num is not None:
-            warnings.warn(message, category=RemovedInAirflow3Warning, stacklevel=2)
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", RemovedInAirflow3Warning)
-                return utils_date_range(
-                    start_date=start_date, num=num, delta=self.normalized_schedule_interval
-                )
-        message += " Please use `DAG.iter_dagrun_infos_between(..., align=False)` instead."
-        warnings.warn(message, category=RemovedInAirflow3Warning, stacklevel=2)
-        if end_date is None:
-            coerced_end_date = timezone.utcnow()
-        else:
-            coerced_end_date = end_date
-        it = self.iter_dagrun_infos_between(start_date, pendulum.instance(coerced_end_date), align=False)
-        return [info.logical_date for info in it]
-
     def is_fixed_time_schedule(self):
         """
         Figures out if the schedule has a fixed time (e.g. 3 AM every day).

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -131,7 +131,7 @@ from airflow.timetables.simple import (
 from airflow.timetables.trigger import CronTriggerTimetable
 from airflow.utils import timezone
 from airflow.utils.dag_cycle_tester import check_cycle
-from airflow.utils.dates import cron_presets, date_range as utils_date_range
+from airflow.utils.dates import cron_presets
 from airflow.utils.decorators import fixup_decorator_warning_stack
 from airflow.utils.helpers import at_most_one, exactly_one, validate_instance_args, validate_key
 from airflow.utils.log.logging_mixin import LoggingMixin

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -2864,20 +2864,6 @@ my_postgres_conn:
             data_interval=(TEST_DATE, TEST_DATE),
         )
 
-    def test_return_date_range_with_num_method(self):
-        start_date = TEST_DATE
-        delta = timedelta(days=1)
-
-        dag = DAG("dummy-dag", schedule=delta, start_date=start_date)
-        with pytest.warns(RemovedInAirflow3Warning, match=r"`DAG.date_range\(\)` is deprecated."):
-            dag_dates = dag.date_range(start_date=start_date, num=3)
-
-        assert dag_dates == [
-            start_date,
-            start_date + delta,
-            start_date + 2 * delta,
-        ]
-
     def test_dag_owner_links(self):
         dag = DAG(
             "dag",


### PR DESCRIPTION
This method was already deprecated and is referenced only in a test, which I also remove.