### PR TITLE
Check breaking changes have a news fragment

### DIFF
--- a/.github/workflows/news-fragment.yml
+++ b/.github/workflows/news-fragment.yml
@@ -38,15 +38,14 @@ jobs:
 
       - name: Check news fragment
         run: >
-          if ! pipx run towncrier check
+          pipx run towncrier check
           --dir .
           --config newsfragments/config.toml
-          --compare-with origin/${{ github.base_ref }}; then
-
-          echo "Please check
+          --compare-with origin/${{ github.base_ref }}
+          ||
+          printf "\033[1;33mMissing significant newsfragment for PR labeled with
+          'airflow3.0:breaking'.\nCheck
           https://github.com/apache/airflow/blob/main/contributing-docs/16_contribution_workflow.rst
-          for guidance."
-
+          for guidance.\033[m\n"
+          &&
           false
-
-          fi

--- a/.github/workflows/news-fragment.yml
+++ b/.github/workflows/news-fragment.yml
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+name: CI
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    types: [labeled, unlabeled, opened, reopened, synchronize]
+
+jobs:
+  check-news-fragment:
+    name: Check News Fragment
+    runs-on: ubuntu-20.04
+    if: "contains(github.event.pull_request.labels.*.name, 'airflow3.0:breaking')"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          # `towncrier check` runs `git diff --name-only origin/main...`, which
+          # needs a non-shallow clone.
+          fetch-depth: 0
+
+      - name: Check news fragment
+        run: >
+          if ! pipx run towncrier check
+          --dir .
+          --config newsfragments/config.toml
+          --compare-with origin/${{ github.base_ref }}; then
+
+          echo "Please check
+          https://github.com/apache/airflow/blob/main/contributing-docs/16_contribution_workflow.rst
+          for guidance."
+
+          false
+
+          fi

--- a/newsfragments/config.toml
+++ b/newsfragments/config.toml
@@ -18,6 +18,7 @@
 name = "Airflow"
 filename = "RELEASE_NOTES.rst"
 underlines = ["-", '^']
+ignore = ["config.toml"]
 
 [[tool.towncrier.type]]
 directory = "significant"


### PR DESCRIPTION
This adds a CI step for PRs with the label `airflow3.0:breaking` and ensure they include a news fragment.