### PR TITLE
Allow 3.x Docker images

### DIFF
--- a/docker_tests/test_prod_image.py
+++ b/docker_tests/test_prod_image.py
@@ -68,7 +68,7 @@ class TestCommands:
     def test_airflow_version(self, default_docker_image):
         """Checking 'airflow version' command. It should return zero exit code."""
         output = run_airflow_cmd_in_docker(["version"], image=default_docker_image)
-        assert "2." in output
+        assert "2." in output or "3." in output
 
     def test_python_version(self, default_docker_image):
         """Checking 'python --version' command. It should return zero exit code."""

--- a/docker_tests/test_prod_image.py
+++ b/docker_tests/test_prod_image.py
@@ -68,7 +68,7 @@ class TestCommands:
     def test_airflow_version(self, default_docker_image):
         """Checking 'airflow version' command. It should return zero exit code."""
         output = run_airflow_cmd_in_docker(["version"], image=default_docker_image)
-        assert "2." in output or "3." in output
+        assert "3." in output
 
     def test_python_version(self, default_docker_image):
         """Checking 'python --version' command. It should return zero exit code."""


### PR DESCRIPTION
This is starting to fail since we’ve bumped the Airflow version…

I _think_ we can’t get rid of the `2.` case just yet? Not sure about that.