### PR TITLE
Fix news fragment check conditional

### DIFF
--- a/.github/workflows/news-fragment.yml
+++ b/.github/workflows/news-fragment.yml
@@ -43,9 +43,11 @@ jobs:
           --config newsfragments/config.toml
           --compare-with origin/${{ github.base_ref }}
           ||
+          {
           printf "\033[1;33mMissing significant newsfragment for PR labeled with
           'airflow3.0:breaking'.\nCheck
           https://github.com/apache/airflow/blob/main/contributing-docs/16_contribution_workflow.rst
           for guidance.\033[m\n"
           &&
           false
+          ; }


### PR DESCRIPTION
We only want to fail the script if the 'towncrier check' call fails. The previous code always runs the '&& false' part (because the printf call always succeeds) and failed the job.
