### PR TITLE
Resolve deprecation warnings in Google Kubernetes Engine system tests (#39485)

### DIFF
--- a/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -371,7 +371,7 @@ class GKECreateClusterOperator(GoogleCloudBaseOperator):
             if not self._body_field("node_pools"):
                 error_messages.append(
                     "Field body['node_pools'] is required if none of fields "
-                    "body['initial_node_count'] or body['node_pools'] are specified."
+                    "body['initial_node_count'] or body['node_config'] are specified."
                 )
 
         for message in error_messages:

--- a/tests/always/test_example_dags.py
+++ b/tests/always/test_example_dags.py
@@ -50,11 +50,6 @@ IGNORE_AIRFLOW_PROVIDER_DEPRECATION_WARNING: tuple[str, ...] = (
     "tests/system/providers/google/cloud/dataproc/example_dataproc_gke.py",
     "tests/system/providers/google/cloud/datapipelines/example_datapipeline.py",
     "tests/system/providers/google/cloud/gcs/example_gcs_sensor.py",
-    "tests/system/providers/google/cloud/kubernetes_engine/example_kubernetes_engine.py",
-    "tests/system/providers/google/cloud/kubernetes_engine/example_kubernetes_engine_async.py",
-    "tests/system/providers/google/cloud/kubernetes_engine/example_kubernetes_engine_job.py",
-    "tests/system/providers/google/cloud/kubernetes_engine/example_kubernetes_engine_kueue.py",
-    "tests/system/providers/google/cloud/kubernetes_engine/example_kubernetes_engine_resource.py",
     "tests/system/providers/google/cloud/life_sciences/example_life_sciences.py",
     "tests/system/providers/google/marketing_platform/example_analytics.py",
     # Deprecated Operators/Hooks, which replaced by common.sql Operators/Hooks

--- a/tests/system/providers/google/cloud/kubernetes_engine/example_kubernetes_engine.py
+++ b/tests/system/providers/google/cloud/kubernetes_engine/example_kubernetes_engine.py
@@ -44,7 +44,7 @@ CLUSTER_NAME_FULL = CLUSTER_NAME_BASE + f"-{ENV_ID}".replace("_", "-")
 CLUSTER_NAME = CLUSTER_NAME_BASE if len(CLUSTER_NAME_FULL) >= 33 else CLUSTER_NAME_FULL
 
 # [START howto_operator_gcp_gke_create_cluster_definition]
-CLUSTER = {"name": CLUSTER_NAME, "initial_node_count": 1, "autopilot": {"enabled": True}}
+CLUSTER = {"name": CLUSTER_NAME, "node_pools": [{"initial_node_count": 1}], "autopilot": {"enabled": True}}
 # [END howto_operator_gcp_gke_create_cluster_definition]
 
 
@@ -117,7 +117,6 @@ with DAG(
     # This test needs watcher in order to properly mark success/failure
     # when "teardown" task with trigger rule is part of the DAG
     list(dag.tasks) >> watcher()
-
 
 from tests.system.utils import get_test_run  # noqa: E402
 

--- a/tests/system/providers/google/cloud/kubernetes_engine/example_kubernetes_engine_async.py
+++ b/tests/system/providers/google/cloud/kubernetes_engine/example_kubernetes_engine_async.py
@@ -43,7 +43,7 @@ CLUSTER_NAME_BASE = f"cluster-{DAG_ID}".replace("_", "-")
 CLUSTER_NAME_FULL = CLUSTER_NAME_BASE + f"-{ENV_ID}".replace("_", "-")
 CLUSTER_NAME = CLUSTER_NAME_BASE if len(CLUSTER_NAME_FULL) >= 33 else CLUSTER_NAME_FULL
 
-CLUSTER = {"name": CLUSTER_NAME, "initial_node_count": 1}
+CLUSTER = {"name": CLUSTER_NAME, "node_pools": [{"initial_node_count": 1}]}
 
 with DAG(
     DAG_ID,

--- a/tests/system/providers/google/cloud/kubernetes_engine/example_kubernetes_engine_job.py
+++ b/tests/system/providers/google/cloud/kubernetes_engine/example_kubernetes_engine_job.py
@@ -44,7 +44,7 @@ GCP_PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT", "default")
 
 GCP_LOCATION = "europe-north1-a"
 CLUSTER_NAME = f"gke-job-{ENV_ID}".replace("_", "-")
-CLUSTER = {"name": CLUSTER_NAME, "initial_node_count": 1}
+CLUSTER = {"name": CLUSTER_NAME, "node_pools": [{"initial_node_count": 1}]}
 
 JOB_NAME = "test-pi"
 JOB_NAME_DEF = "test-pi-def"

--- a/tests/system/providers/google/cloud/kubernetes_engine/example_kubernetes_engine_kueue.py
+++ b/tests/system/providers/google/cloud/kubernetes_engine/example_kubernetes_engine_kueue.py
@@ -42,7 +42,7 @@ GCP_PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT", "default")
 
 GCP_LOCATION = "europe-west3"
 CLUSTER_NAME = f"gke-kueue-{ENV_ID}".replace("_", "-")
-CLUSTER = {"name": CLUSTER_NAME, "initial_node_count": 1, "autopilot": {"enabled": True}}
+CLUSTER = {"name": CLUSTER_NAME, "node_pools": [{"initial_node_count": 1}], "autopilot": {"enabled": True}}
 
 flavor_conf = """
 apiVersion: kueue.x-k8s.io/v1beta1

--- a/tests/system/providers/google/cloud/kubernetes_engine/example_kubernetes_engine_resource.py
+++ b/tests/system/providers/google/cloud/kubernetes_engine/example_kubernetes_engine_resource.py
@@ -39,7 +39,7 @@ GCP_PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT", "default")
 
 GCP_LOCATION = "europe-north1-a"
 CLUSTER_NAME = f"gke-resource-{ENV_ID}".replace("_", "-")
-CLUSTER = {"name": CLUSTER_NAME, "initial_node_count": 1}
+CLUSTER = {"name": CLUSTER_NAME, "node_pools": [{"initial_node_count": 1}]}
 
 PVC_NAME = "test-pvc-name"
 PVC_CONF = f"""


### PR DESCRIPTION
Reworks the GKE example DAGs to remove deprecation warnings, also fixes a misprint in the deprecation warning message.

related: #39485

@VladaZakharova requested to be tagged for Google provider changes

@Taragolis as issue owner
