### PR TITLE
Add support for executing multiple sequential sql statements in AthenaOperator [defer support]

### DIFF
--- a/tests/providers/amazon/aws/operators/test_athena.py
+++ b/tests/providers/amazon/aws/operators/test_athena.py
@@ -286,9 +286,10 @@ class TestAthenaOperator:
         assert operator.query_execution_id is None
 
         query_execution_id = "123456"
-        operator.execute_complete(
+        operator.execute_next_query(
             context=None,
             event={"status": "success", "value": query_execution_id},
+            query_list=["SELECT * FROM TEST_TABLE"],
         )
         assert operator.query_execution_id == query_execution_id
 


### PR DESCRIPTION
This PR introduces support for multiple queries in the `AthenaOperator` in the AWS provider for Apache Airflow
   - The `query` parameter now accepts a list of SQL strings in addition to a single string. This allows the execution of multiple queries in sequence within a single task.
   - A new optional parameter `split_statements` has been added.
   - The query execution logic has been refactored into a loop that processes each query individually, ensuring that all queries are executed or appropriately deferred.
   - The `execute_next_query` method has been introduced to handle the deferred execution of queries. This method replaces the `execute_complete` method.

**Note: I haven’t worked on tests or docs yet, I’ll proceed with those once we’re happy with the implementation.**