### PR TITLE
fix: unwrap Param objects when used as DagParam defaults

### DIFF
--- a/airflow/models/param.py
+++ b/airflow/models/param.py
@@ -324,6 +324,9 @@ class DagParam(ResolveMixin):
         if default is not NOTSET:
             current_dag.params[name] = default
         self._name = name
+        if isinstance(default, Param):
+            # If default is a Param, we need to "unwrap" the actual default value
+            default = default.value
         self._default = default
 
     def iter_references(self) -> Iterable[tuple[Operator, str]]:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
Using a Param as a default in a DagParam _almost_ works; the "Trigger DAG" UI form is correctly generated taking into account the "metadata" in the Param (like `description`), and when triggering the DAG manually everything works as expected.

However when the DAG is triggered on a schedule (so that the default values are used) the DagParam resolves to the Param object at runtime (rather than the default _inside_ the Param object) which obviously breaks the DAG.

This is especially a problem when using the `@dag` decorator to define DagParams implicitly through the decorated functions default parameters. Without this fix, the utility of the `@dag` decorator is significantly diminished because only "plain" defaults (without any attached metadata to drive UI generation) can be used in the decorated function.