### PR TITLE
Fix `AwsTaskLogFetcher` missing logs

### DIFF
--- a/airflow/providers/amazon/aws/utils/task_log_fetcher.py
+++ b/airflow/providers/amazon/aws/utils/task_log_fetcher.py
@@ -59,8 +59,20 @@ class AwsTaskLogFetcher(Thread):
         while not self.is_stopped():
             time.sleep(self.fetch_interval.total_seconds())
             log_events = self._get_log_events(continuation_token)
+            prev_timestamp_event = None
             for log_event in log_events:
+                current_timestamp_event = datetime.fromtimestamp(
+                    log_event["timestamp"] / 1000.0, tz=timezone.utc
+                )
+                if current_timestamp_event == prev_timestamp_event:
+                    # When multiple events have the same timestamp, somehow, only one event is logged
+                    # As a consequence, some logs are missed in the log group (in case they have the same
+                    # timestamp)
+                    # When a slight delay is added before logging the event, that solves the issue
+                    # See https://github.com/apache/airflow/issues/40875
+                    time.sleep(0.1)
                 self.logger.info(self.event_to_str(log_event))
+                prev_timestamp_event = current_timestamp_event
 
     def _get_log_events(self, skip_token: AwsLogsHook.ContinuationToken | None = None) -> Generator:
         if skip_token is None:


### PR DESCRIPTION
Resolves #40875.

As mentioned in #40875, in some cases `EcsRunTaskOperator` have missing logs in the log group specified through `awslogs_group`. When `awslogs_group` is provided, the operator pull logs from `awslogs_group` (where the ECS task logs are) and log them so that the user can see them in the UI. The issue is, somehow (and I really cannot explain why), when multiple logs from `awslogs_group` have the same timestamp, only one of them (the first one) is logged. An example to better understand:

```
log_events = self._get_log_events(continuation_token)
for log_event in log_events:
    self.logger.info(self.event_to_str(log_event))
```

If `log_events` has 2 events with the same timestamp, `self.logger.info(self.event_to_str(log_event))` will run twice but will log once.

Adding a delay between the logging operators "fix" the issue.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
