### PR TITLE
Chart: Allow hybrid executors

### DIFF
--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -53,7 +53,6 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    executor: {{ .Values.executor }}
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -516,16 +516,7 @@
             "description": "Airflow executor.",
             "type": "string",
             "x-docsSection": "Common",
-            "default": "CeleryExecutor",
-            "enum": [
-                "LocalExecutor",
-                "LocalKubernetesExecutor",
-                "CeleryExecutor",
-                "KubernetesExecutor",
-                "CeleryKubernetesExecutor",
-                "airflow.providers.amazon.aws.executors.batch.AwsBatchExecutor",
-                "airflow.providers.amazon.aws.executors.ecs.AwsEcsExecutor"
-            ]
+            "default": "CeleryExecutor"
         },
         "allowPodLaunching": {
             "description": "Whether various Airflow components launch pods.",

--- a/helm_tests/airflow_aux/test_basic_helm_chart.py
+++ b/helm_tests/airflow_aux/test_basic_helm_chart.py
@@ -421,8 +421,6 @@ class TestBaseChartTest:
             }
             if component:
                 expected_labels["component"] = component
-            if k8s_object_name == f"{release_name}-scheduler":
-                expected_labels["executor"] = "CeleryExecutor"
             actual_labels = kind_k8s_obj_labels_tuples.pop((k8s_object_name, kind))
             assert actual_labels == expected_labels
 
@@ -538,6 +536,8 @@ class TestBaseChartTest:
             "CeleryKubernetesExecutor",
             "airflow.providers.amazon.aws.executors.batch.AwsBatchExecutor",
             "airflow.providers.amazon.aws.executors.ecs.AwsEcsExecutor",
+            # Hybrid executors
+            "CeleryExecutor,airflow.providers.amazon.aws.executors.ecs.AwsEcsExecutor:AwsEcsExecutor",
         ],
     )
     def test_supported_executor(self, executor):
@@ -546,22 +546,6 @@ class TestBaseChartTest:
             {
                 "executor": executor,
             },
-        )
-
-    def test_unsupported_executor(self):
-        with pytest.raises(CalledProcessError) as ex_ctx:
-            render_chart(
-                "test-basic",
-                {
-                    "executor": "SequentialExecutor",
-                },
-            )
-        assert (
-            'executor must be one of the following: "LocalExecutor", '
-            '"LocalKubernetesExecutor", "CeleryExecutor", '
-            '"KubernetesExecutor", "CeleryKubernetesExecutor", '
-            '"airflow.providers.amazon.aws.executors.batch.AwsBatchExecutor", '
-            '"airflow.providers.amazon.aws.executors.ecs.AwsEcsExecutor"' in ex_ctx.value.stderr.decode()
         )
 
     @pytest.mark.parametrize(

--- a/helm_tests/airflow_core/test_scheduler.py
+++ b/helm_tests/airflow_core/test_scheduler.py
@@ -777,25 +777,6 @@ class TestScheduler:
         )
         assert {"foo": "bar"} == jmespath.search("spec.volumeClaimTemplates[0].metadata.annotations", docs[0])
 
-    @pytest.mark.parametrize(
-        "executor",
-        [
-            "LocalExecutor",
-            "LocalKubernetesExecutor",
-            "CeleryExecutor",
-            "KubernetesExecutor",
-            "CeleryKubernetesExecutor",
-        ],
-    )
-    def test_scheduler_deployment_has_executor_label(self, executor):
-        docs = render_chart(
-            values={"executor": executor},
-            show_only=["templates/scheduler/scheduler-deployment.yaml"],
-        )
-
-        assert 1 == len(docs)
-        assert executor == docs[0]["metadata"]["labels"].get("executor")
-
     def test_should_add_component_specific_annotations(self):
         docs = render_chart(
             values={


### PR DESCRIPTION
Airflow 2.10.0 has the new feature to use multiple executors. The value schema check in the current Helm chart doesn't allow this because it has a strict list of allowed values. I removed this enum check list to enable custom and combinations of executors.

Another change is the `executor` label in the scheduler Deployment. I removed this label because it has no functional use. Reasons are:

1. Characters such as `:` are not allowed in label values. This prevents me from using short names such as `airflow.providers.amazon.aws.executors.ecs.AwsEcsExecutor:AwsEcsExecutor`
2. The label value can have max 63 characters. Even if (1) is okay, we still need to do some string truncating.

~Another change is the `executor` label in the scheduler Deployment. Because Kubernetes allows max 63 characters for label values, and hybrid executor values can easily exceed this limit, therefore I added a `trunc -63` to prevent this. This value has no functional use AFAIK, so doing a truncate here will not cause any functional problems.~


