### PR TITLE
Add retrieve output docker swarm operator

### DIFF
--- a/airflow/providers/docker/operators/docker_swarm.py
+++ b/airflow/providers/docker/operators/docker_swarm.py
@@ -180,11 +180,14 @@ class DockerSwarmOperator(DockerOperator):
                 self.log.info("Service status before exiting: %s", self._service_status())
                 break
 
-        self.tasks = self.cli.tasks(filters={"service": self.service["ID"]})
-        for task in self.tasks:
-            container_id = task["Status"]["ContainerStatus"]["ContainerID"]
-            container = self.cli.inspect_container(container_id)
-            self.containers.append(container)
+        if self.service and self._service_status() == "complete":
+            self.tasks = self.cli.tasks(filters={"service": self.service["ID"]})
+            for task in self.tasks:
+                container_id = task["Status"]["ContainerStatus"]["ContainerID"]
+                container = self.cli.inspect_container(container_id)
+                self.containers.append(container)
+        else:
+            raise AirflowException(f"Service did not complete: {self.service!r}")
 
         if self.retrieve_output:
             return self._attempt_to_retrieve_results()

--- a/airflow/providers/docker/operators/docker_swarm.py
+++ b/airflow/providers/docker/operators/docker_swarm.py
@@ -258,7 +258,10 @@ class DockerSwarmOperator(DockerOperator):
             for container in self.containers:
                 file_content = self._copy_from_docker(container["Id"], self.retrieve_output_path)
                 file_contents.append(file_content)
-            return file_contents
+            if len(file_contents) == 1:
+                return file_contents[0]
+            else:
+                return file_contents
         except APIError:
             return None
 

--- a/airflow/providers/docker/operators/docker_swarm.py
+++ b/airflow/providers/docker/operators/docker_swarm.py
@@ -25,6 +25,7 @@ from time import sleep
 from typing import TYPE_CHECKING
 
 from docker import types
+from docker.errors import APIError
 
 from airflow.exceptions import AirflowException
 from airflow.providers.docker.operators.docker import DockerOperator
@@ -87,6 +88,10 @@ class DockerSwarmOperator(DockerOperator):
     :param enable_logging: Show the application's logs in operator's logs.
         Supported only if the Docker engine is using json-file or journald logging drivers.
         The `tty` parameter should be set to use this with Python applications.
+    :param retrieve_output: Should this docker image consistently attempt to pull from and output
+        file before manually shutting down the image. Useful for cases where users want a pickle serialized
+        output that is not posted to logs
+    :param retrieve_output_path: path for output file that will be retrieved and passed to xcom
     :param configs: List of docker configs to be exposed to the containers of the swarm service.
         The configs are ConfigReference objects as per the docker api
         [https://docker-py.readthedocs.io/en/stable/services.html#docker.models.services.ServiceCollection.create]_
@@ -122,6 +127,8 @@ class DockerSwarmOperator(DockerOperator):
         self.args = args
         self.enable_logging = enable_logging
         self.service = None
+        self.tasks: list[dict] = []
+        self.containers: list[dict] = []
         self.configs = configs
         self.secrets = secrets
         self.mode = mode
@@ -172,6 +179,15 @@ class DockerSwarmOperator(DockerOperator):
             if self._has_service_terminated():
                 self.log.info("Service status before exiting: %s", self._service_status())
                 break
+
+        self.tasks = self.cli.tasks(filters={"service": self.service["ID"]})
+        for task in self.tasks:
+            container_id = task["Status"]["ContainerStatus"]["ContainerID"]
+            container = self.cli.inspect_container(container_id)
+            self.containers.append(container)
+
+        if self.retrieve_output:
+            return self._attempt_to_retrieve_results()
 
         self.log.info("auto_removeauto_removeauto_removeauto_removeauto_remove : %s", str(self.auto_remove))
         if self.service and self._service_status() != "complete":
@@ -229,6 +245,22 @@ class DockerSwarmOperator(DockerOperator):
         while not self._has_service_terminated():
             sleep(2)
             last_line_logged, last_timestamp = stream_new_logs(last_line_logged, since=last_timestamp)
+
+    def _attempt_to_retrieve_results(self):
+        """
+        Attempt to pull the result from the expected file for each containers.
+
+        This uses Docker's ``get_archive`` function. If the file is not yet
+        ready, *None* is returned.
+        """
+        try:
+            file_contents = []
+            for container in self.containers:
+                file_content = self._copy_from_docker(container["Id"], self.retrieve_output_path)
+                file_contents.append(file_content)
+            return file_contents
+        except APIError:
+            return None
 
     @staticmethod
     def format_args(args: list[str] | str | None) -> list[str] | None:

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -38,7 +38,7 @@ class TestDockerSwarmOperator:
             for _ in range(2):
                 yield [{"Status": {"State": "pending"}}]
             while True:
-                yield [{"Status": {"State": "complete"}}]
+                yield [{"Status": {"State": "complete", "ContainerStatus": {"ContainerID": "some_id"}}}]
 
         def _client_service_logs_effect():
             service_logs = [
@@ -123,7 +123,7 @@ class TestDockerSwarmOperator:
         assert cskwargs["labels"] == {"name": "airflow__adhoc_airflow__unittest"}
         assert cskwargs["name"].startswith("airflow-")
         assert cskwargs["mode"] == types.ServiceMode(mode="replicated", replicas=3)
-        assert client_mock.tasks.call_count == 6
+        assert client_mock.tasks.call_count == 8
         client_mock.remove_service.assert_called_once_with("some_id")
 
     @mock.patch("airflow.providers.docker.operators.docker_swarm.types")
@@ -134,7 +134,9 @@ class TestDockerSwarmOperator:
         client_mock.create_service.return_value = {"ID": "some_id"}
         client_mock.images.return_value = []
         client_mock.pull.return_value = [b'{"status":"pull log"}']
-        client_mock.tasks.return_value = [{"Status": {"State": "complete"}}]
+        client_mock.tasks.return_value = [
+            {"Status": {"State": "complete", "ContainerStatus": {"ContainerID": "some_id"}}}
+        ]
         types_mock.TaskTemplate.return_value = mock_obj
         types_mock.ContainerSpec.return_value = mock_obj
         types_mock.RestartPolicy.return_value = mock_obj
@@ -157,7 +159,9 @@ class TestDockerSwarmOperator:
         client_mock.create_service.return_value = {"ID": "some_id"}
         client_mock.images.return_value = []
         client_mock.pull.return_value = [b'{"status":"pull log"}']
-        client_mock.tasks.return_value = [{"Status": {"State": "complete"}}]
+        client_mock.tasks.return_value = [
+            {"Status": {"State": "complete", "ContainerStatus": {"ContainerID": "some_id"}}}
+        ]
         types_mock.TaskTemplate.return_value = mock_obj
         types_mock.ContainerSpec.return_value = mock_obj
         types_mock.RestartPolicy.return_value = mock_obj
@@ -233,7 +237,9 @@ class TestDockerSwarmOperator:
         client_mock.create_service.return_value = {"ID": "some_id"}
         client_mock.images.return_value = []
         client_mock.pull.return_value = [b'{"status":"pull log"}']
-        client_mock.tasks.return_value = [{"Status": {"State": "complete"}}]
+        client_mock.tasks.return_value = [
+            {"Status": {"State": "complete", "ContainerStatus": {"ContainerID": "some_id"}}}
+        ]
         types_mock.TaskTemplate.return_value = mock_obj
         types_mock.ContainerSpec.return_value = mock_obj
         types_mock.RestartPolicy.return_value = mock_obj
@@ -278,7 +284,9 @@ class TestDockerSwarmOperator:
         client_mock.create_service.return_value = {"ID": "some_id"}
         client_mock.images.return_value = []
         client_mock.pull.return_value = [b'{"status":"pull log"}']
-        client_mock.tasks.return_value = [{"Status": {"State": "complete"}}]
+        client_mock.tasks.return_value = [
+            {"Status": {"State": "complete", "ContainerStatus": {"ContainerID": "some_id"}}}
+        ]
         types_mock.TaskTemplate.return_value = mock_obj
         types_mock.ContainerSpec.return_value = mock_obj
         types_mock.RestartPolicy.return_value = mock_obj
@@ -316,7 +324,9 @@ class TestDockerSwarmOperator:
         client_mock.create_service.return_value = {"ID": "some_id"}
         client_mock.images.return_value = []
         client_mock.pull.return_value = [b'{"status":"pull log"}']
-        client_mock.tasks.return_value = [{"Status": {"State": "complete"}}]
+        client_mock.tasks.return_value = [
+            {"Status": {"State": "complete", "ContainerStatus": {"ContainerID": "some_id"}}}
+        ]
         types_mock.TaskTemplate.return_value = mock_obj
         types_mock.ContainerSpec.return_value = mock_obj
         types_mock.RestartPolicy.return_value = mock_obj


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/41445

Updates the `DockerSwarmOperator` to include the same `retrieve_output` functionality as the `DockerOperator`: get access of the content of a file as XCom at the end of a task, before the container is destroyed. To take account of possible container replication at deployment time, a `Task` and `Container` retrieval step has been added, in addition to the specific `retrieve_output` functionality.

The modifications were tested with the Dag provided below:

```py
from airflow import DAG
from airflow.utils.dates import days_ago
from datetime import timedelta

from docker import types
from airflow.providers.docker.operators.docker import DockerOperator
from airflow.providers.docker.operators.docker_swarm import DockerSwarmOperator

params = {
    'dag_id': 'test_xcom_docker_docker_swarm',
    'catchup': False,
    'max_active_runs': 1,
    'default_args': {
        'owner': 'airflow',
        'start_date': days_ago(1),
        'retries': 1,
        'retry_delay': timedelta(minutes=5)
    }
}

with DAG(**params) as dag:
    write_xcom_docker = DockerOperator(
        task_id='write_xcom_docker',
        image='python:latest',
        api_version='auto',
        command="""python -c '

import os
import pickle

capitals = {
  "Canada": "Ottawa", 
  "England": "London",
  "France": "Paris",
  "Germany": "Berlin", 
}

file_path = "/tmp/variable.pickle"
with open(file_path, "wb+") as file:
    pickle.dump(capitals, file)

    '
    """,
        retrieve_output=True,
        retrieve_output_path='/tmp/variable.pickle')

    write_xcom_docker_swarm = DockerSwarmOperator(
        task_id='write_xcom_docker_swarm',
        image='python:latest',
        api_version='auto',
        command="""python -c '

import os
import pickle

capitals = {
  "Canada": "Ottawa", 
  "England": "London",
  "France": "Paris",
  "Germany": "Berlin", 
}

file_path = "/tmp/variable.pickle"
with open(file_path, "wb+") as file:
    pickle.dump(capitals, file)

    '
    """,
        retrieve_output=True,
        retrieve_output_path='/tmp/variable.pickle')

    write_xcom_docker_swarm_replicas = DockerSwarmOperator(
        task_id='write_xcom_docker_swarm_replicas',
        image='python:latest',
        api_version='auto',
        command="""python -c '

import os
import pickle

capitals = {
  "Canada": "Ottawa", 
  "England": "London",
  "France": "Paris",
  "Germany": "Berlin", 
}

file_path = "/tmp/variable.pickle"
with open(file_path, "wb+") as file:
    pickle.dump(capitals, file)

    '
    """,
        retrieve_output=True,
        retrieve_output_path='/tmp/variable.pickle',
        mode=types.ServiceMode(mode="replicated", replicas=2))

write_xcom_docker >> write_xcom_docker_swarm >> write_xcom_docker_swarm_replicas
```

Here the results:
- `DockerOperator`:
![image](https://github.com/user-attachments/assets/5bb550a3-62ba-4a53-a119-f17bf0211612)
- `DockerSwarmOperator` without replication: 
![image](https://github.com/user-attachments/assets/b4c89d4d-0fdf-4388-ba81-4ae5191e9e60)
- `DockerSwarmOperator` with `replicas=2`: 
![image](https://github.com/user-attachments/assets/9b4c85ba-15a6-478c-ad3b-63b0831f2a6b)
As `replicas=2` in the Service configuration inside the DAG, 2 files were loaded inside the `return_value` XCOM.

If needed, I can create a specific PR for the `v2-10-test` branch !

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
