### PR TITLE
Removed deprecated parameters from AzureKeyVaultBackend

### DIFF
--- a/airflow/providers/microsoft/azure/secrets/key_vault.py
+++ b/airflow/providers/microsoft/azure/secrets/key_vault.py
@@ -31,9 +31,7 @@ from functools import cached_property
 from azure.core.exceptions import ResourceNotFoundError
 from azure.identity import ClientSecretCredential, DefaultAzureCredential
 from azure.keyvault.secrets import SecretClient
-from deprecated import deprecated
 
-from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.microsoft.azure.utils import get_sync_default_azure_credential
 from airflow.secrets import BaseSecretsBackend
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -153,24 +151,6 @@ class AzureKeyVaultBackend(BaseSecretsBackend, LoggingMixin):
             return None
 
         return self._get_secret(self.connections_prefix, conn_id)
-
-    @deprecated(
-        reason=(
-            "Method `AzureKeyVaultBackend.get_conn_uri` is deprecated and will be removed "
-            "in a future release.  Please use method `get_conn_value` instead."
-        ),
-        category=AirflowProviderDeprecationWarning,
-    )
-    def get_conn_uri(self, conn_id: str) -> str | None:
-        """
-        Return URI representation of Connection conn_id.
-
-        As of Airflow version 2.3.0 this method is deprecated.
-
-        :param conn_id: the connection id
-        :return: deserialized Connection
-        """
-        return self.get_conn_value(conn_id)
 
     def get_variable(self, key: str) -> str | None:
         """

--- a/newsfragments/41536.significant.rst
+++ b/newsfragments/41536.significant.rst
@@ -1,0 +1,15 @@
+**Breaking Change**
+
+The ``get_conn_uri`` method has been removed from the ``AzureKeyVaultBackend`` class.
+This method was previously deprecated in favor of ``get_conn_value``.
+
+If your code still uses ``get_conn_uri``, you should update it to use ``get_conn_value``
+instead to ensure compatibility with future Airflow versions.
+
+Example update:
+
+.. code-block:: python
+
+    connection_by_conn_id = AzureKeyVaultBackend(
+        vault_url="https://example-akv-resource-name.vault.azure.net/"
+    ).get_conn_value(conn_id="conn_id")

--- a/tests/providers/microsoft/azure/secrets/test_key_vault.py
+++ b/tests/providers/microsoft/azure/secrets/test_key_vault.py
@@ -19,10 +19,8 @@ from __future__ import annotations
 
 from unittest import mock
 
-import pytest
 from azure.core.exceptions import ResourceNotFoundError
 
-from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.microsoft.azure.secrets.key_vault import AzureKeyVaultBackend
 
 KEY_VAULT_MODULE = "airflow.providers.microsoft.azure.secrets.key_vault"
@@ -37,7 +35,7 @@ class TestAzureKeyVaultBackend:
 
     @mock.patch(f"{KEY_VAULT_MODULE}.get_sync_default_azure_credential")
     @mock.patch(f"{KEY_VAULT_MODULE}.SecretClient")
-    def test_get_conn_uri(self, mock_secret_client, mock_azure_cred):
+    def test_get_conn_value(self, mock_secret_client, mock_azure_cred):
         mock_cred = mock.Mock()
         mock_sec_client = mock.Mock()
         mock_azure_cred.return_value = mock_cred
@@ -48,15 +46,14 @@ class TestAzureKeyVaultBackend:
         )
 
         backend = AzureKeyVaultBackend(vault_url="https://example-akv-resource-name.vault.azure.net/")
-        with pytest.warns(AirflowProviderDeprecationWarning, match="Method `.*get_conn_uri` is deprecated"):
-            returned_uri = backend.get_conn_uri(conn_id="hi")
+        returned_uri = backend.get_conn_value(conn_id="hi")
         mock_secret_client.assert_called_once_with(
             credential=mock_cred, vault_url="https://example-akv-resource-name.vault.azure.net/"
         )
         assert returned_uri == "postgresql://airflow:airflow@host:5432/airflow"
 
     @mock.patch(f"{KEY_VAULT_MODULE}.AzureKeyVaultBackend.client")
-    def test_get_conn_uri_non_existent_key(self, mock_client):
+    def test_get_conn_value_non_existent_key(self, mock_client):
         """
         Test that if the key with connection ID is not present,
         AzureKeyVaultBackend.get_connection should return None
@@ -65,8 +62,7 @@ class TestAzureKeyVaultBackend:
         mock_client.get_secret.side_effect = ResourceNotFoundError
         backend = AzureKeyVaultBackend(vault_url="https://example-akv-resource-name.vault.azure.net/")
 
-        with pytest.warns(AirflowProviderDeprecationWarning, match="Method `.*get_conn_uri` is deprecated"):
-            assert backend.get_conn_uri(conn_id=conn_id) is None
+        assert backend.get_conn_value(conn_id=conn_id) is None
         assert backend.get_connection(conn_id=conn_id) is None
 
     @mock.patch(f"{KEY_VAULT_MODULE}.AzureKeyVaultBackend.client")
@@ -123,9 +119,9 @@ class TestAzureKeyVaultBackend:
         mock_get_secret.assert_not_called()
 
         mock_get_secret.reset_mock()
-        with pytest.warns(AirflowProviderDeprecationWarning, match="Method `.*get_conn_uri` is deprecated"):
-            assert backend.get_conn_uri("test_mysql") is None
-            mock_get_secret.assert_not_called()
+
+        assert backend.get_conn_value("test_mysql") is None
+        mock_get_secret.assert_not_called()
 
     @mock.patch(f"{KEY_VAULT_MODULE}.AzureKeyVaultBackend._get_secret")
     def test_variable_prefix_none_value(self, mock_get_secret):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
Removed deprecated parameters from AzureKeyVaultBackend
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
