### PR TITLE
Fix Non-DB test calculation for main builds (#41499)

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/run_tests.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_tests.py
@@ -374,7 +374,7 @@ def generate_args_for_pytest(
     args.extend(get_excluded_provider_args(python_version))
     if use_xdist:
         args.extend(["-n", str(parallelism) if parallelism else "auto"])
-    # We have to disabke coverage for Python 3.12 because of the issue with coverage that takes too long, despite
+    # We have to disable coverage for Python 3.12 because of the issue with coverage that takes too long, despite
     # Using experimental support for Python 3.12 PEP 669. The coverage.py is not yet fully compatible with the
     # full scope of PEP-669. That will be fully done when https://github.com/nedbat/coveragepy/issues/1746 is
     # resolve for now we are disabling coverage for Python 3.12, and it causes slower execution and occasional
@@ -417,5 +417,13 @@ def convert_parallel_types_to_folders(
                 python_version=python_version,
             )
         )
-    # leave only folders, strip --pytest-args
-    return [arg for arg in args if arg.startswith("test")]
+    # leave only folders, strip --pytest-args that exclude some folders with `-' prefix
+    folders = [arg for arg in args if arg.startswith("test")]
+    # remove specific provider sub-folders if "tests/providers" is already in the list
+    # This workarounds pytest issues where it will only run tests from specific subfolders
+    # if both parent and child folders are in the list
+    # The issue in Pytest (changed behaviour in Pytest 8.2 is tracked here
+    # https://github.com/pytest-dev/pytest/issues/12605
+    if "tests/providers" in folders:
+        folders = [folder for folder in folders if not folder.startswith("tests/providers/")]
+    return folders

--- a/dev/breeze/tests/test_pytest_args_for_test_types.py
+++ b/dev/breeze/tests/test_pytest_args_for_test_types.py
@@ -329,6 +329,19 @@ def test_pytest_args_for_helm_test_types(helm_test_package: str, pytest_args: li
             ],
             True,
         ),
+        (
+            "Core Providers[-amazon,google] Providers[amazon] Providers[google]",
+            [
+                "tests/core",
+                "tests/executors",
+                "tests/jobs",
+                "tests/models",
+                "tests/ti_deps",
+                "tests/utils",
+                "tests/providers",
+            ],
+            False,
+        ),
     ],
 )
 def test_folders_for_parallel_test_types(


### PR DESCRIPTION
Pytest has a weird behaviour that it will not collect tests from parent folder when subfolder of it is specified after the parent folder. This caused some non-db tests from providers folder have been skipped during main build.

The issue in Pytest 8.2 (used to work before) is tracked at https://github.com/pytest-dev/pytest/issues/12605

(cherry picked from commit d48982692c54d024d7c05e1efb7cd2adeb7d896c)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
