### PR TITLE
restore python 3.12 support for papermill

### DIFF
--- a/airflow/providers/papermill/provider.yaml
+++ b/airflow/providers/papermill/provider.yaml
@@ -21,11 +21,6 @@ name: Papermill
 description: |
     `Papermill <https://github.com/nteract/papermill>`__
 
-# Papermill is technically compliant with 3.12, but it's 2.5.0 version that is compliant, requires pinned
-# version of aiohttp which conflicts with other providers. The fix for that is implemented extra-links:
-# https://github.com/nteract/papermill/pull/771 and waits for new Papermill release
-excluded-python-versions: ['3.12']
-
 state: ready
 source-date-epoch: 1718605283
 # note that those versions are maintained by release manager - do not update them manually
@@ -56,12 +51,11 @@ versions:
 
 dependencies:
   - apache-airflow>=2.8.0
-  - papermill[all]>=2.4.0
+  - papermill[all]>=2.6.0
   - scrapbook[all]
   - ipykernel
   - pandas>=2.1.2,<2.2;python_version>="3.9"
   - pandas>=1.5.3,<2.2;python_version<"3.9"
-
 
 integrations:
   - integration-name: Papermill

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -1007,15 +1007,13 @@
       "ipykernel",
       "pandas>=1.5.3,<2.2;python_version<\"3.9\"",
       "pandas>=2.1.2,<2.2;python_version>=\"3.9\"",
-      "papermill[all]>=2.4.0",
+      "papermill[all]>=2.6.0",
       "scrapbook[all]"
     ],
     "devel-deps": [],
     "plugins": [],
     "cross-providers-deps": [],
-    "excluded-python-versions": [
-      "3.12"
-    ],
+    "excluded-python-versions": [],
     "state": "ready"
   },
   "pgvector": {


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

The papermill provider was previously excluded from releasing a version compatible with Python 3.12 due to version compatibility issues with the aiohttp dependency. However, papermill version 2.6.0, which includes a fix for this issue, has now been released. By raising the minimum version to 2.6.0, we can ensure compatibility with Python 3.12.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
