### PR TITLE
Make CronTriggerTimetable startup behavior intuitive

### DIFF
--- a/airflow/timetables/trigger.py
+++ b/airflow/timetables/trigger.py
@@ -137,7 +137,8 @@ class CronTriggerTimetable(CronMixin, Timetable):
             start_time_candidates = [self._align_to_prev(coerce_datetime(utcnow()))]
             if last_automated_data_interval is not None:
                 start_time_candidates.append(self._get_next(last_automated_data_interval.end))
-            else:
+            elif restriction.earliest is None:
+                # Run immediately has no effect if there is restriction on earliest
                 start_time_candidates.append(self._calc_first_run())
             if restriction.earliest is not None:
                 start_time_candidates.append(self._align_to_next(restriction.earliest))

--- a/airflow/timetables/trigger.py
+++ b/airflow/timetables/trigger.py
@@ -163,18 +163,14 @@ class CronTriggerTimetable(CronMixin, Timetable):
         next_run_time = self._align_to_next(now)
         if self.run_immediately is True:  # not truthy, actually set to True
             return past_run_time
-        elif self.run_immediately is False:
-            return next_run_time
+
         gap_between_runs = next_run_time - past_run_time
         gap_to_past = now - past_run_time
-        if self.run_immediately is False:
-            buffer_between_runs = max(gap_to_past * 10, datetime.timedelta(minutes=5))
-            if gap_between_runs > buffer_between_runs:
-                return past_run_time
-            else:
-                return next_run_time
+        if isinstance(self.run_immediately, datetime.timedelta):
+            buffer_between_runs = self.run_immediately
         else:
-            if gap_to_past < self.run_immediately:
-                return past_run_time
-            else:
-                return next_run_time
+            buffer_between_runs = max(gap_between_runs / 10, datetime.timedelta(minutes=5))
+        if gap_to_past <= buffer_between_runs:
+            return past_run_time
+        else:
+            return next_run_time

--- a/airflow/timetables/trigger.py
+++ b/airflow/timetables/trigger.py
@@ -47,11 +47,20 @@ class CronTriggerTimetable(CronMixin, Timetable):
     :param cron: cron string that defines when to run
     :param timezone: Which timezone to use to interpret the cron string
     :param interval: timedelta that defines the data interval start. Default 0.
-    :param run_immediately: If no start_time is given, use this to determine when to schedule the first run of the DAG. Has no effect if there already exist runs for this DAG.
-                            If True, always run immediately the most recent possible DAG Run.
-                            If False, wait to run until the next scheduled time in the future. If this is passed a timedelta, will run the most recent possible DAG Run if that Run's data_interval_end is within timedelta of now.
-                            If None, the timedelta is calculated as 10% of the time between the most recent past scheduled time and the next scheduled time. E.g. if running every hour, this would run the previous time if less than 6 minutes had past since the previous run time, otherwise it would wait until the next hour.
 
+    *run_immediately* controls, if no *start_time* is given to the DAG, when
+    the first run of the DAG should be scheduled. It has no effect if there
+    already exist runs for this DAG.
+
+    * If *True*, always run immediately the most recent possible DAG run.
+    * If *False*, wait to run until the next scheduled time in the future.
+    * If passed a ``timedelta``, will run the most recent possible DAG run
+      if that run's ``data_interval_end`` is within timedelta of now.
+    * If *None*, the timedelta is calculated as 10% of the time between the
+      most recent past scheduled time and the next scheduled time. E.g. if
+      running every hour, this would run the previous time if less than 6
+      minutes had past since the previous run time, otherwise it would wait
+      until the next hour.
     """
 
     def __init__(

--- a/airflow/timetables/trigger.py
+++ b/airflow/timetables/trigger.py
@@ -75,11 +75,15 @@ class CronTriggerTimetable(CronMixin, Timetable):
             interval = decode_relativedelta(data["interval"])
         else:
             interval = datetime.timedelta(seconds=data["interval"])
+
         immediate: bool | datetime.timedelta
-        if isinstance(data["immediate"], float):
+        if "immediate" not in data:
+            immediate = False
+        elif isinstance(data["immediate"], float):
             immediate = datetime.timedelta(seconds=data["interval"])
         else:
             immediate = data["immediate"]
+
         return cls(
             data["expression"],
             timezone=decode_timezone(data["timezone"]),

--- a/tests/timetables/test_trigger_timetable.py
+++ b/tests/timetables/test_trigger_timetable.py
@@ -155,12 +155,6 @@ def test_hourly_cron_trigger_no_catchup_next_info(
             DagRunInfo.exact(pendulum.DateTime(2022, 7, 27, 1, 0, 0, tzinfo=utc)),
             id="no_last_automated_with_earliest_not_on_boundary",
         ),
-        pytest.param(
-            None,
-            None,
-            None,
-            id="no_last_automated_no_earliest",
-        ),
     ],
 )
 def test_hourly_cron_trigger_catchup_next_info(

--- a/tests/timetables/test_trigger_timetable.py
+++ b/tests/timetables/test_trigger_timetable.py
@@ -266,3 +266,18 @@ def test_run_immediately(catchup, run_immediately, current_time, correct_interva
             restriction=TimeRestriction(earliest=None, latest=None, catchup=catchup),
         )
         assert next_info == correct_interval
+
+
+@pytest.mark.parametrize("catchup", [True, False])
+def test_run_immediately_fast_dag(catchup):
+    timetable = CronTriggerTimetable(
+        "*/10 3 * * *",  # Runs every 10 minutes, so falls back to 5 min hardcoded limit on buffer time
+        timezone=utc,
+        run_immediately=False,
+    )
+    with time_machine.travel(JUST_AFTER):
+        next_info = timetable.next_dagrun_info(
+            last_automated_data_interval=None,
+            restriction=TimeRestriction(earliest=None, latest=None, catchup=catchup),
+        )
+        assert next_info == PREVIOUS


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

The first run behavior for cron based DAGs (and most DAGs really) is quite unintuitive. It is very common for users to want to run a DAG for the first time either immediately, with a logical date of the past run that would have occurred most recently, or to wait until the next run time and then begin. The former is only possible if you set catchup to False and the latter is not possible without knowing ahead of time when that next run would be and hardcoding the start time for the DAG (which is not feasible when doing dev/text/prod environment promotion of the same DAG file). 

It is also very common to set the start_date to a dynamic function that calculates a date in the recent past, such as days_ago(1), which can bite you if you're used to doing that (or have coded it into a DAG factory pattern) and then you set up your first monthly DAG. The existing timetables behavior is to silently miss the run, which makes it even worse.

This PR adds the ability to set start_date to `None` and get the intuitive behavior of running the last run if that run would have happened in the very recent past (10% of the distance between DAG runs) or to wait for the next run otherwise. It also allows using the `run_immediately` parameter to specify always running the last run, always waiting for the next run, or passing a timedelta to exactly control what "recent past" means for this particular DAG. Setting start_date to `None` is a much more accurate and clear indication of author intent that `days_ago(x)`.

I hope that if this is widely adopted, we can stop seeing users miss DAG runs or using dynamic start dates.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
