### PR TITLE
Support pre-versions in version handling in Breeze

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/versions.py
+++ b/dev/breeze/src/airflow_breeze/utils/versions.py
@@ -27,7 +27,7 @@ def strip_leading_zeros_from_version(version: str) -> str:
     :param version: version number in CALVER format (potentially with leading 0s in date and month)
     :return: string with leading 0s after dot replaced.
     """
-    return ".".join(str(int(i)) for i in version.split("."))
+    return ".".join(i.lstrip("0") or "0" for i in version.split("."))
 
 
 def get_version_tag(version: str, provider_package_id: str, version_suffix: str = ""):


### PR DESCRIPTION
During the implementation of AIP-69 for which we agreed to make a pre-release as provider only I noticed that breeze fails in non-numeric versions, e.g. I used `0.1.0pre0` as the code attempts to remove leading zeroes.

This bugfix just removed leading zeroes but leaves other parts of the version number unchanged.