### PR TITLE
Fix changelog template for new providers w/o relevant commits

### DIFF
--- a/dev/breeze/src/airflow_breeze/templates/CHANGELOG_TEMPLATE.rst.jinja2
+++ b/dev/breeze/src/airflow_breeze/templates/CHANGELOG_TEMPLATE.rst.jinja2
@@ -40,7 +40,7 @@ Features
 {%- endif %}
 
 
-{%- if classified_changes.fixes %}
+{%- if classified_changes and classified_changes.fixes %}
 
 Bug Fixes
 ~~~~~~~~~
@@ -50,7 +50,7 @@ Bug Fixes
 {%- endif %}
 
 
-{%- if classified_changes.misc %}
+{%- if classified_changes and classified_changes.misc %}
 
 Misc
 ~~~~
@@ -62,7 +62,7 @@ Misc
 
 .. Below changes are excluded from the changelog. Move them to
    appropriate section above if needed. Do not delete the lines(!):
-{%- if classified_changes.other %}
+{%- if classified_changes and classified_changes.other %}
    {%- for other in classified_changes.other %}
    * ``{{ other.message_without_backticks | safe }}``
    {%- endfor %}


### PR DESCRIPTION
During the implementation of AIP-69 I realized that the CI fails during the check of preparation of changelog. Reason is that the `classified_changes` prepared is None and the Jinja templating fails. See `dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py:960`.

This PR fixes/adjusts the jinja template if no commits can be found.