### PR TITLE
Lower log level when no pod template file is supplied

### DIFF
--- a/airflow/kubernetes/pre_7_4_0_compatibility/pod_generator.py
+++ b/airflow/kubernetes/pre_7_4_0_compatibility/pod_generator.py
@@ -566,7 +566,7 @@ class PodGenerator:
                 pod = yaml.safe_load(stream)
         else:
             pod = None
-            log.warning("Model file %s does not exist", path)
+            log.info("Pod template file %s does not exist", path)
 
         return PodGenerator.deserialize_model_dict(pod)
 


### PR DESCRIPTION
I suggest lowering the log message when no pod template file is provided from warning to info level. This is accepted behaviour, many users specify pod settings on task-level. However, logging a warning suggests otherwise, which is confusing.

WARNING log message example:
```
[2024-08-19, 11:09:46 UTC] {pod_generator.py:525} WARNING - Model file /usr/local/airflow/pod_template_file.yaml does not exist
```