### PR TITLE
Add documentation for state mismatch between db and executor

### DIFF
--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -352,7 +352,7 @@ class BaseExecutor(LoggingMixin):
 
                 # Otherwise, we give up and remove the task from the queue.
                 self.log.error(
-                    "could not queue task %s (still running after %d attempts).",
+                    "Could not queue task %s (still running after %d attempts). Learn more: https://airflow.apache.org/docs/apache-airflow/stable/troubleshooting.html#state-mismatch-between-airflow-database-and-executor",
                     key,
                     attempt.total_tries,
                 )

--- a/docs/apache-airflow/troubleshooting.rst
+++ b/docs/apache-airflow/troubleshooting.rst
@@ -20,6 +20,19 @@
 Troubleshooting
 ===============
 
+Obscure scheduling failures
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+State mismatch between Airflow database and executor
+----------------------------------------------------
+
+This indicates that when the scheduler queried the Airflow database, it observed that the task instance had one status according to the Airflow metadata database,
+but a different status according to the executor. A common example is when the query returned to the scheduler, the task instance was in the ``queued`` status,
+but the status according to the executor was ``running``.
+
+This mismatch must have persisted for multiple attempts. When this happens, Airflow will not attempt to queue the task. It's possible that something has gone wrong
+in the executor, and the task may need to be cleared.
+
 Obscure task failures
 ^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
This was discussed at length in [this comment](https://github.com/apache/airflow/pull/40468#discussion_r1670868964) to #40468 