### PR TITLE
 Add callback to process Azure Service Bus message contents

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/asb.py
+++ b/airflow/providers/microsoft/azure/hooks/asb.py
@@ -365,8 +365,9 @@ class MessageHook(BaseAzureServiceBusHook):
         else:
             try:
                 message_callback(msg)
-                receiver.complete_message(msg)
             except Exception as e:
                 self.log.error("Error processing message: %s", e)
                 receiver.abandon_message(msg)
                 raise e
+            else:
+                receiver.complete_message(msg)

--- a/airflow/providers/microsoft/azure/hooks/asb.py
+++ b/airflow/providers/microsoft/azure/hooks/asb.py
@@ -18,7 +18,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Callable
 
-from azure.servicebus import ServiceBusClient, ServiceBusMessage, ServiceBusSender
+from azure.servicebus import (
+    ServiceBusClient,
+    ServiceBusMessage,
+    ServiceBusReceivedMessage,
+    ServiceBusReceiver,
+    ServiceBusSender,
+)
 from azure.servicebus.management import QueueProperties, ServiceBusAdministrationClient
 
 from airflow.hooks.base import BaseHook
@@ -274,7 +280,7 @@ class MessageHook(BaseAzureServiceBusHook):
 
     def receive_message(
         self,
-        queue_name,
+        queue_name: str,
         max_message_count: int | None = 1,
         max_wait_time: float | None = None,
         message_callback: MessageCallback | None = None,
@@ -338,7 +344,12 @@ class MessageHook(BaseAzureServiceBusHook):
             for msg in received_msgs:
                 self._process_message(msg, message_callback, subscription_receiver)
 
-    def _process_message(self, msg, message_callback, receiver):
+    def _process_message(
+        self,
+        msg: ServiceBusReceivedMessage,
+        message_callback: MessageCallback | None,
+        receiver: ServiceBusReceiver,
+    ):
         """
         Process the message by calling the message_callback or logging the message.
 

--- a/airflow/providers/microsoft/azure/hooks/asb.py
+++ b/airflow/providers/microsoft/azure/hooks/asb.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 from azure.servicebus import ServiceBusClient, ServiceBusMessage, ServiceBusSender
 from azure.servicebus.management import QueueProperties, ServiceBusAdministrationClient
@@ -27,6 +27,9 @@ from airflow.providers.microsoft.azure.utils import (
     get_field,
     get_sync_default_azure_credential,
 )
+
+MessageCallback = Callable[[ServiceBusMessage], None]
+
 
 if TYPE_CHECKING:
     from azure.identity import DefaultAzureCredential
@@ -270,7 +273,11 @@ class MessageHook(BaseAzureServiceBusHook):
         sender.send_messages(batch_message)
 
     def receive_message(
-        self, queue_name, max_message_count: int | None = 1, max_wait_time: float | None = None
+        self,
+        queue_name,
+        max_message_count: int | None = 1,
+        max_wait_time: float | None = None,
+        message_callback: MessageCallback | None = None,
     ):
         """
         Receive a batch of messages at once in a specified Queue name.
@@ -278,6 +285,9 @@ class MessageHook(BaseAzureServiceBusHook):
         :param queue_name: The name of the queue name or a QueueProperties with name.
         :param max_message_count: Maximum number of messages in the batch.
         :param max_wait_time: Maximum time to wait in seconds for the first message to arrive.
+        :param message_callback: Optional callback to process each message. If not provided, then
+            the message will be logged and completed. If provided, and throws an exception, the
+            message will be abandoned for future redelivery.
         """
         if queue_name is None:
             raise TypeError("Queue name cannot be None.")
@@ -289,8 +299,7 @@ class MessageHook(BaseAzureServiceBusHook):
                 max_message_count=max_message_count, max_wait_time=max_wait_time
             )
             for msg in received_msgs:
-                self.log.info(msg)
-                receiver.complete_message(msg)
+                self._process_message(msg, message_callback, receiver)
 
     def receive_subscription_message(
         self,
@@ -298,6 +307,7 @@ class MessageHook(BaseAzureServiceBusHook):
         subscription_name: str,
         max_message_count: int | None,
         max_wait_time: float | None,
+        message_callback: MessageCallback | None = None,
     ):
         """
         Receive a batch of subscription message at once.
@@ -326,5 +336,27 @@ class MessageHook(BaseAzureServiceBusHook):
                 max_message_count=max_message_count, max_wait_time=max_wait_time
             )
             for msg in received_msgs:
-                self.log.info(msg)
-                subscription_receiver.complete_message(msg)
+                self._process_message(msg, message_callback, subscription_receiver)
+
+    def _process_message(self, msg, message_callback, receiver):
+        """
+        Process the message by calling the message_callback or logging the message.
+
+        :param msg: The message to process.
+        :param message_callback: Optional callback to process each message. If not provided, then
+            the message will be logged and completed. If provided, and throws an exception, the
+            message will be abandoned for future redelivery.
+        :param receiver: The receiver that received the message.
+        """
+        print("message_callback:", message_callback)
+        if message_callback is None:
+            self.log.info(msg)
+            receiver.complete_message(msg)
+        else:
+            try:
+                message_callback(msg)
+                receiver.complete_message(msg)
+            except Exception as e:
+                self.log.error("Error processing message: %s", e)
+                receiver.abandon_message(msg)
+                raise e

--- a/airflow/providers/microsoft/azure/hooks/asb.py
+++ b/airflow/providers/microsoft/azure/hooks/asb.py
@@ -348,7 +348,6 @@ class MessageHook(BaseAzureServiceBusHook):
             message will be abandoned for future redelivery.
         :param receiver: The receiver that received the message.
         """
-        print("message_callback:", message_callback)
         if message_callback is None:
             self.log.info(msg)
             receiver.complete_message(msg)


### PR DESCRIPTION
This PR adds a callback to process messages from an Azure Service Bus. 

Right now, on main, the Azure Service Bus message receiver simply logs the messages received and returns. This PR preserves that default, but adds the ability to pass in a callback function with the signature ServiceBusMessage -> None which is applied to each message received.

This change is made to both the general receiver and the subscription receiver.

I'd like someone from the Airflow community to weigh in on if this is a good solution. To me, it seemed like the least intrusive way to add a hook to obtain the message contents. However, I'm not sure if it plays well with the Airflow Operator standards as I've barely been using Airflow for a month.

Please let me know if you see any errors, omissions, or if I'm headed in the wrong direction.

Thank you,
Tim