### PR TITLE
Set better logging level for path wrapper

### DIFF
--- a/airflow/io/path.py
+++ b/airflow/io/path.py
@@ -54,7 +54,7 @@ class TrackingFileWrapper(LoggingMixin):
         if callable(attr):
             # If the attribute is a method, wrap it in another method to intercept the call
             def wrapper(*args, **kwargs):
-                self.log.error("Calling method: %s", name)
+                self.log.debug("Calling method: %s", name)
                 if name == "read":
                     get_hook_lineage_collector().add_input_dataset(context=self._path, uri=str(self._path))
                 elif name == "write":


### PR DESCRIPTION
This PR improves the log level of the `ObjectStoragePath` wrapper (`TrackingFileWrapper`). Currently it logs regular operations as errors which does not make sense to us. We can also remove the entire log line if desired.