### PR TITLE
Make kerberos an optional and devel dependency for impala and fab

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -154,8 +154,8 @@ jobs:
         env:
           HATCH_ENV: "test"
         working-directory: ./clients/python
-      - name: "Install Airflow in editable mode with fab for webserver tests"
-        run: pip install -e ".[fab]"
+      - name: "Install Airflow with fab for webserver tests"
+        run: pip install ".[fab]"
       - name: "Install Python client"
         run: pip install ./dist/apache_airflow_client-*.whl
       - name: "Initialize Airflow DB and start webserver"

--- a/airflow/providers/apache/impala/provider.yaml
+++ b/airflow/providers/apache/impala/provider.yaml
@@ -48,6 +48,8 @@ additional-extras:
     dependencies:
       - kerberos>=1.3.0
 
+devel-dependencies:
+  - kerberos>=1.3.0
 
 integrations:
   - integration-name: Apache Impala

--- a/airflow/providers/fab/provider.yaml
+++ b/airflow/providers/fab/provider.yaml
@@ -57,6 +57,14 @@ dependencies:
   - google-re2>=1.0
   - jmespath>=0.7.0
 
+additional-extras:
+  - name: kerberos
+    dependencies:
+      - kerberos>=1.3.0
+
+devel-dependencies:
+  - kerberos>=1.3.0
+
 config:
   fab:
     description: This section contains configs specific to FAB provider.

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -207,7 +207,9 @@
       "apache-airflow>=2.8.0",
       "impyla>=0.18.0,<1.0"
     ],
-    "devel-deps": [],
+    "devel-deps": [
+      "kerberos>=1.3.0"
+    ],
     "plugins": [],
     "cross-providers-deps": [
       "common.sql"
@@ -556,7 +558,9 @@
       "google-re2>=1.0",
       "jmespath>=0.7.0"
     ],
-    "devel-deps": [],
+    "devel-deps": [
+      "kerberos>=1.3.0"
+    ],
     "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [],


### PR DESCRIPTION
The improved compatibility tests detected that FAB provider tests have implicit dependency on kerberos - similar as impala. This change make kerberos an optional dependency of FAB as well as it as development dependency for both impala and FAB.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
