### PR TITLE
fix: remove part of openlineage extraction from S3ToRedshiftOperator

### DIFF
--- a/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
@@ -26,7 +26,13 @@ from boto3.session import Session
 from airflow.exceptions import AirflowException
 from airflow.models.connection import Connection
 from airflow.providers.amazon.aws.transfers.s3_to_redshift import S3ToRedshiftOperator
-from airflow.providers.common.compat.openlineage.facet import LifecycleStateChange
+from airflow.providers.common.compat.openlineage.facet import (
+    DocumentationDatasetFacet,
+    LifecycleStateChange,
+    LifecycleStateChangeDatasetFacet,
+    SchemaDatasetFacet,
+    SchemaDatasetFacetFields,
+)
 from tests.test_utils.asserts import assert_equal_ignore_multiple_spaces
 
 
@@ -502,8 +508,9 @@ class TestS3ToRedshiftTransfer:
     @mock.patch("airflow.models.connection.Connection.get_connection_from_secrets")
     @mock.patch("boto3.session.Session")
     @mock.patch("airflow.providers.amazon.aws.hooks.redshift_sql.RedshiftSQLHook.run")
+    @mock.patch("airflow.providers.amazon.aws.utils.openlineage.get_facets_from_redshift_table")
     def test_get_openlineage_facets_on_complete_default(
-        self, mock_run, mock_session, mock_connection, mock_hook
+        self, mock_get_facets, mock_run, mock_session, mock_connection, mock_hook
     ):
         access_key = "aws_access_key_id"
         secret_key = "aws_secret_access_key"
@@ -515,6 +522,11 @@ class TestS3ToRedshiftTransfer:
         mock_connection.return_value = mock.MagicMock(
             schema="database", port=5439, host="cluster.id.region.redshift.amazonaws.com", extra_dejson={}
         )
+        mock_facets = {
+            "schema": SchemaDatasetFacet(fields=[SchemaDatasetFacetFields(name="col", type="STRING")]),
+            "documentation": DocumentationDatasetFacet(description="mock_description"),
+        }
+        mock_get_facets.return_value = mock_facets
 
         schema = "schema"
         table = "table"
@@ -531,33 +543,30 @@ class TestS3ToRedshiftTransfer:
             redshift_conn_id="redshift_conn_id",
             aws_conn_id="aws_conn_id",
             task_id="task_id",
-            dag=None,
         )
         op.execute(None)
 
         lineage = op.get_openlineage_facets_on_complete(None)
-        # Hook called two times - on operator execution, and on querying data in redshift to fetch schema
-        assert mock_run.call_count == 2
+        # Hook called only one time - on operator execution - we mocked querying to fetch schema
+        assert mock_run.call_count == 1
 
         assert len(lineage.inputs) == 1
         assert len(lineage.outputs) == 1
         assert lineage.inputs[0].name == s3_key
+        assert lineage.inputs[0].namespace == f"s3://{s3_bucket}"
         assert lineage.outputs[0].name == f"database.{schema}.{table}"
         assert lineage.outputs[0].namespace == "redshift://cluster.region:5439"
 
-        assert lineage.outputs[0].facets.get("schema") is not None
-        assert lineage.outputs[0].facets.get("columnLineage") is not None
-
-        assert lineage.inputs[0].facets.get("schema") is not None
-        # As method was not overwrite, there should be no lifecycleStateChange facet
-        assert "lifecycleStateChange" not in lineage.outputs[0].facets
+        assert lineage.outputs[0].facets == mock_facets
+        assert lineage.inputs[0].facets == {}
 
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
     @mock.patch("airflow.models.connection.Connection.get_connection_from_secrets")
     @mock.patch("boto3.session.Session")
     @mock.patch("airflow.providers.amazon.aws.hooks.redshift_sql.RedshiftSQLHook.run")
+    @mock.patch("airflow.providers.amazon.aws.utils.openlineage.get_facets_from_redshift_table")
     def test_get_openlineage_facets_on_complete_replace(
-        self, mock_run, mock_session, mock_connection, mock_hook
+        self, mock_get_facets, mock_run, mock_session, mock_connection, mock_hook
     ):
         access_key = "aws_access_key_id"
         secret_key = "aws_secret_access_key"
@@ -569,6 +578,11 @@ class TestS3ToRedshiftTransfer:
         mock_connection.return_value = mock.MagicMock(
             schema="database", port=5439, host="cluster.id.region.redshift.amazonaws.com", extra_dejson={}
         )
+        mock_facets = {
+            "schema": SchemaDatasetFacet(fields=[SchemaDatasetFacetFields(name="col", type="STRING")]),
+            "documentation": DocumentationDatasetFacet(description="mock_description"),
+        }
+        mock_get_facets.return_value = mock_facets
 
         schema = "schema"
         table = "table"
@@ -586,59 +600,25 @@ class TestS3ToRedshiftTransfer:
             redshift_conn_id="redshift_conn_id",
             aws_conn_id="aws_conn_id",
             task_id="task_id",
-            dag=None,
         )
         op.execute(None)
 
         lineage = op.get_openlineage_facets_on_complete(None)
 
-        assert (
-            lineage.outputs[0].facets["lifecycleStateChange"].lifecycleStateChange
-            == LifecycleStateChange.OVERWRITE
-        )
+        assert len(lineage.inputs) == 1
+        assert len(lineage.outputs) == 1
+        assert lineage.inputs[0].name == s3_key
+        assert lineage.inputs[0].namespace == f"s3://{s3_bucket}"
+        assert lineage.outputs[0].name == f"database.{schema}.{table}"
+        assert lineage.outputs[0].namespace == "redshift://cluster.region:5439"
 
-    @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
-    @mock.patch("airflow.models.connection.Connection.get_connection_from_secrets")
-    @mock.patch("boto3.session.Session")
-    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_sql.RedshiftSQLHook.run")
-    def test_get_openlineage_facets_on_complete_column_list(
-        self, mock_run, mock_session, mock_connection, mock_hook
-    ):
-        access_key = "aws_access_key_id"
-        secret_key = "aws_secret_access_key"
-        mock_session.return_value = Session(access_key, secret_key)
-        mock_session.return_value.access_key = access_key
-        mock_session.return_value.secret_key = secret_key
-        mock_session.return_value.token = None
-
-        mock_connection.return_value = mock.MagicMock(
-            schema="database", port=5439, host="cluster.id.region.redshift.amazonaws.com", extra_dejson={}
-        )
-
-        schema = "schema"
-        table = "table"
-        s3_bucket = "bucket"
-        s3_key = "key"
-        copy_options = ""
-
-        op = S3ToRedshiftOperator(
-            schema=schema,
-            table=table,
-            s3_bucket=s3_bucket,
-            s3_key=s3_key,
-            copy_options=copy_options,
-            column_list=["column1", "column2"],
-            redshift_conn_id="redshift_conn_id",
-            aws_conn_id="aws_conn_id",
-            task_id="task_id",
-            dag=None,
-        )
-        op.execute(None)
-
-        lineage = op.get_openlineage_facets_on_complete(None)
-
-        assert lineage.outputs[0].facets.get("schema") is not None
-        assert lineage.inputs[0].facets.get("schema") is None
+        assert lineage.outputs[0].facets == {
+            **mock_facets,
+            "lifecycleStateChange": LifecycleStateChangeDatasetFacet(
+                lifecycleStateChange=LifecycleStateChange.OVERWRITE
+            ),
+        }
+        assert lineage.inputs[0].facets == {}
 
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
     @mock.patch("airflow.models.connection.Connection.get_connection_from_secrets")
@@ -648,8 +628,9 @@ class TestS3ToRedshiftTransfer:
         "airflow.providers.amazon.aws.hooks.redshift_data.RedshiftDataHook.region_name",
         new_callable=mock.PropertyMock,
     )
+    @mock.patch("airflow.providers.amazon.aws.utils.openlineage.get_facets_from_redshift_table")
     def test_get_openlineage_facets_on_complete_using_redshift_data_api(
-        self, mock_rs_region, mock_rs, mock_session, mock_connection, mock_hook
+        self, mock_get_facets, mock_rs_region, mock_rs, mock_session, mock_connection, mock_hook
     ):
         """
         Using the Redshift Data API instead of the SQL-based connection
@@ -666,6 +647,11 @@ class TestS3ToRedshiftTransfer:
         mock_rs.describe_statement.return_value = {"Status": "FINISHED"}
 
         mock_rs_region.return_value = "region"
+        mock_facets = {
+            "schema": SchemaDatasetFacet(fields=[SchemaDatasetFacetFields(name="col", type="STRING")]),
+            "documentation": DocumentationDatasetFacet(description="mock_description"),
+        }
+        mock_get_facets.return_value = mock_facets
 
         schema = "schema"
         table = "table"
@@ -689,7 +675,7 @@ class TestS3ToRedshiftTransfer:
             redshift_conn_id="redshift_conn_id",
             aws_conn_id="aws_conn_id",
             task_id="task_id",
-            dag=None,
+            method="REPLACE",
             redshift_data_api_kwargs=dict(
                 database=database,
                 cluster_identifier=cluster_identifier,
@@ -705,15 +691,17 @@ class TestS3ToRedshiftTransfer:
         assert len(lineage.inputs) == 1
         assert len(lineage.outputs) == 1
         assert lineage.inputs[0].name == s3_key
+        assert lineage.inputs[0].namespace == f"s3://{s3_bucket}"
         assert lineage.outputs[0].name == f"database.{schema}.{table}"
         assert lineage.outputs[0].namespace == "redshift://cluster.region:5439"
 
-        assert lineage.outputs[0].facets.get("schema") is not None
-        assert lineage.outputs[0].facets.get("columnLineage") is not None
-
-        assert lineage.inputs[0].facets.get("schema") is not None
-        # As method was not overwrite, there should be no lifecycleStateChange facet
-        assert "lifecycleStateChange" not in lineage.outputs[0].facets
+        assert lineage.outputs[0].facets == {
+            **mock_facets,
+            "lifecycleStateChange": LifecycleStateChangeDatasetFacet(
+                lifecycleStateChange=LifecycleStateChange.OVERWRITE
+            ),
+        }
+        assert lineage.inputs[0].facets == {}
 
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
     @mock.patch("airflow.models.connection.Connection.get_connection_from_secrets")
@@ -724,8 +712,9 @@ class TestS3ToRedshiftTransfer:
         "airflow.providers.amazon.aws.hooks.redshift_data.RedshiftDataHook.region_name",
         new_callable=mock.PropertyMock,
     )
+    @mock.patch("airflow.providers.amazon.aws.utils.openlineage.get_facets_from_redshift_table")
     def test_get_openlineage_facets_on_complete_data_and_sql_hooks_aligned(
-        self, mock_rs_region, mock_rs, mock_run, mock_session, mock_connection, mock_hook
+        self, mock_get_facets, mock_rs_region, mock_rs, mock_run, mock_session, mock_connection, mock_hook
     ):
         """
         Ensuring both supported hooks - RedshiftDataHook and RedshiftSQLHook return same lineage.
@@ -745,6 +734,11 @@ class TestS3ToRedshiftTransfer:
         mock_rs.describe_statement.return_value = {"Status": "FINISHED"}
 
         mock_rs_region.return_value = "region"
+        mock_facets = {
+            "schema": SchemaDatasetFacet(fields=[SchemaDatasetFacetFields(name="col", type="STRING")]),
+            "documentation": DocumentationDatasetFacet(description="mock_description"),
+        }
+        mock_get_facets.return_value = mock_facets
 
         schema = "schema"
         table = "table"
@@ -794,13 +788,9 @@ class TestS3ToRedshiftTransfer:
         op_rs_sql.execute(None)
         rs_sql_lineage = op_rs_sql.get_openlineage_facets_on_complete(None)
 
-        assert rs_sql_lineage.inputs == rs_data_lineage.inputs
+        assert len(rs_sql_lineage.inputs) == 1
         assert len(rs_sql_lineage.outputs) == 1
-        assert len(rs_data_lineage.outputs) == 1
-        assert rs_sql_lineage.outputs[0].facets["schema"] == rs_data_lineage.outputs[0].facets["schema"]
-        assert (
-            rs_sql_lineage.outputs[0].facets["columnLineage"]
-            == rs_data_lineage.outputs[0].facets["columnLineage"]
-        )
-        assert rs_sql_lineage.outputs[0].name == rs_data_lineage.outputs[0].name
-        assert rs_sql_lineage.outputs[0].namespace == rs_data_lineage.outputs[0].namespace
+        assert rs_sql_lineage.inputs == rs_data_lineage.inputs
+        assert rs_sql_lineage.outputs == rs_data_lineage.outputs
+        assert rs_sql_lineage.job_facets == rs_data_lineage.job_facets
+        assert rs_sql_lineage.run_facets == rs_data_lineage.run_facets


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Recently the OpenLineage support for S3ToRedshiftOperator has been added. Upon closer inspection together with @Artuz37 we found out that some edge cases do not allow us to deduce the schema and column level lineage on s3 file, and the wildcard char in S3 does not work like some may expect, so we adjusted the OpenLineage extraction to provide only reliable lineage. Tests were adjusted to reflect that changes.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
