### PR TITLE
feat: add OpenLineage support for RedshiftToS3Operator

### DIFF
--- a/providers/src/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
+++ b/providers/src/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
@@ -241,7 +241,7 @@ class S3ToRedshiftOperator(BaseOperator):
 
         output_dataset = Dataset(
             namespace=f"redshift://{authority}",
-            name=f"{database}.{self.schema}.{self.table}",
+            name=f"{database}.{self.schema}.{self.table}" if database else f"{self.schema}.{self.table}",
             facets=output_dataset_facets,
         )
 

--- a/providers/tests/amazon/aws/transfers/test_redshift_to_s3.py
+++ b/providers/tests/amazon/aws/transfers/test_redshift_to_s3.py
@@ -27,6 +27,14 @@ from airflow.exceptions import AirflowException
 from airflow.models.connection import Connection
 from airflow.providers.amazon.aws.transfers.redshift_to_s3 import RedshiftToS3Operator
 from airflow.providers.amazon.aws.utils.redshift import build_credentials_block
+from airflow.providers.common.compat.openlineage.facet import (
+    ColumnLineageDatasetFacet,
+    DocumentationDatasetFacet,
+    Fields,
+    InputField,
+    SchemaDatasetFacet,
+    SchemaDatasetFacetFields,
+)
 
 from tests_common.test_utils.asserts import assert_equal_ignore_multiple_spaces
 
@@ -591,3 +599,325 @@ class TestRedshiftToS3Transfer:
         )
         # test sql arg
         assert_equal_ignore_multiple_spaces(mock_rs.execute_statement.call_args.kwargs["Sql"], unload_query)
+
+    @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
+    @mock.patch("airflow.models.connection.Connection.get_connection_from_secrets")
+    @mock.patch("boto3.session.Session")
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_sql.RedshiftSQLHook.run")
+    @mock.patch("airflow.providers.amazon.aws.utils.openlineage.get_facets_from_redshift_table")
+    def test_get_openlineage_facets_on_complete_default(
+        self, mock_get_facets, mock_run, mock_session, mock_connection, mock_hook
+    ):
+        access_key = "aws_access_key_id"
+        secret_key = "aws_secret_access_key"
+        mock_session.return_value = Session(access_key, secret_key)
+        mock_session.return_value.access_key = access_key
+        mock_session.return_value.secret_key = secret_key
+        mock_session.return_value.token = None
+
+        mock_connection.return_value = mock.MagicMock(
+            schema="database", port=5439, host="cluster.id.region.redshift.amazonaws.com", extra_dejson={}
+        )
+        mock_facets = {
+            "schema": SchemaDatasetFacet(fields=[SchemaDatasetFacetFields(name="col", type="STRING")]),
+            "documentation": DocumentationDatasetFacet(description="mock_description"),
+        }
+        mock_get_facets.return_value = mock_facets
+
+        schema = "schema"
+        table = "table"
+        s3_bucket = "bucket"
+        s3_key = "key"
+
+        op = RedshiftToS3Operator(
+            schema=schema,
+            table=table,
+            s3_bucket=s3_bucket,
+            s3_key=s3_key,
+            redshift_conn_id="redshift_conn_id",
+            aws_conn_id="aws_conn_id",
+            task_id="task_id",
+        )
+        op.execute(None)
+
+        lineage = op.get_openlineage_facets_on_complete(None)
+        # Hook called only one time - on operator execution - we mocked querying to fetch schema
+        assert mock_run.call_count == 1
+
+        assert len(lineage.inputs) == 1
+        assert len(lineage.outputs) == 1
+        assert lineage.outputs[0].name == f"{s3_key}/{table}_"
+        assert lineage.outputs[0].namespace == f"s3://{s3_bucket}"
+        assert lineage.inputs[0].name == f"database.{schema}.{table}"
+        assert lineage.inputs[0].namespace == "redshift://cluster.region:5439"
+
+        assert lineage.inputs[0].facets == mock_facets
+        assert lineage.outputs[0].facets == {
+            "columnLineage": ColumnLineageDatasetFacet(
+                fields={
+                    "col": Fields(
+                        inputFields=[
+                            InputField(
+                                namespace="redshift://cluster.region:5439",
+                                name=f"database.{schema}.{table}",
+                                field="col",
+                            )
+                        ],
+                        transformationType="IDENTITY",
+                        transformationDescription="identical",
+                    )
+                }
+            ),
+            "schema": SchemaDatasetFacet(fields=[SchemaDatasetFacetFields(name="col", type="STRING")]),
+        }
+
+    @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
+    @mock.patch("airflow.models.connection.Connection.get_connection_from_secrets")
+    @mock.patch("boto3.session.Session")
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_sql.RedshiftSQLHook.run")
+    @mock.patch("airflow.providers.amazon.aws.utils.openlineage.get_facets_from_redshift_table")
+    def test_get_openlineage_facets_on_complete_with_select_query(
+        self, mock_get_facets, mock_run, mock_session, mock_connection, mock_hook
+    ):
+        access_key = "aws_access_key_id"
+        secret_key = "aws_secret_access_key"
+        mock_session.return_value = Session(access_key, secret_key)
+        mock_session.return_value.access_key = access_key
+        mock_session.return_value.secret_key = secret_key
+        mock_session.return_value.token = None
+
+        mock_connection.return_value = mock.MagicMock(
+            schema="database", port=5439, host="cluster.id.region.redshift.amazonaws.com", extra_dejson={}
+        )
+        mock_facets = {
+            "schema": SchemaDatasetFacet(fields=[SchemaDatasetFacetFields(name="col", type="STRING")]),
+            "documentation": DocumentationDatasetFacet(description="mock_description"),
+        }
+        mock_get_facets.return_value = mock_facets
+
+        schema = "schema"
+        table = "table"
+        s3_bucket = "bucket"
+        s3_key = "key"
+        query = """
+        SELECT
+            c.customer_id,
+            c.first_name,
+            c.last_name,
+            o.order_id,
+            o.order_date,
+            o.total_amount
+        FROM
+            schema1.customers c
+        INNER JOIN
+            schema2.orders o
+        ON
+            c.customer_id = o.customer_id
+        ORDER BY
+            o.order_date DESC;
+        """
+        op = RedshiftToS3Operator(
+            schema=schema,  # should be ignored
+            table=table,  # should be ignored
+            s3_bucket=s3_bucket,
+            s3_key=s3_key,
+            table_as_file_name=False,
+            select_query=query,
+            redshift_conn_id="redshift_conn_id",
+            aws_conn_id="aws_conn_id",
+            task_id="task_id",
+        )
+        op.execute(None)
+
+        lineage = op.get_openlineage_facets_on_complete(None)
+
+        assert len(lineage.inputs) == 2
+        assert len(lineage.outputs) == 1
+        assert lineage.outputs[0].name == s3_key
+        assert lineage.outputs[0].namespace == f"s3://{s3_bucket}"
+        assert lineage.inputs[0].name == "database.schema1.customers"
+        assert lineage.inputs[0].namespace == "redshift://cluster.region:5439"
+        assert lineage.inputs[1].name == "database.schema2.orders"
+        assert lineage.inputs[1].namespace == "redshift://cluster.region:5439"
+
+        assert lineage.inputs[0].facets == mock_facets
+        assert lineage.outputs[0].facets == {}
+
+    @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
+    @mock.patch("airflow.models.connection.Connection.get_connection_from_secrets")
+    @mock.patch("boto3.session.Session")
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_data.RedshiftDataHook.conn")
+    @mock.patch(
+        "airflow.providers.amazon.aws.hooks.redshift_data.RedshiftDataHook.region_name",
+        new_callable=mock.PropertyMock,
+    )
+    @mock.patch("airflow.providers.amazon.aws.utils.openlineage.get_facets_from_redshift_table")
+    def test_get_openlineage_facets_on_complete_using_redshift_data_api(
+        self, mock_get_facets, mock_rs_region, mock_rs, mock_session, mock_connection, mock_hook
+    ):
+        """
+        Using the Redshift Data API instead of the SQL-based connection
+        """
+        access_key = "aws_access_key_id"
+        secret_key = "aws_secret_access_key"
+        mock_session.return_value = Session(access_key, secret_key)
+        mock_session.return_value.access_key = access_key
+        mock_session.return_value.secret_key = secret_key
+        mock_session.return_value.token = None
+
+        mock_hook.return_value = Connection()
+        mock_rs.execute_statement.return_value = {"Id": "STATEMENT_ID"}
+        mock_rs.describe_statement.return_value = {"Status": "FINISHED"}
+
+        mock_rs_region.return_value = "region"
+        mock_facets = {
+            "schema": SchemaDatasetFacet(fields=[SchemaDatasetFacetFields(name="col", type="STRING")]),
+            "documentation": DocumentationDatasetFacet(description="mock_description"),
+        }
+        mock_get_facets.return_value = mock_facets
+
+        schema = "schema"
+        table = "table"
+        s3_bucket = "bucket"
+        s3_key = "key"
+
+        # RS Data API params
+        database = "database"
+        cluster_identifier = "cluster"
+        db_user = "db_user"
+        secret_arn = "secret_arn"
+        statement_name = "statement_name"
+
+        op = RedshiftToS3Operator(
+            schema=schema,
+            table=table,
+            s3_bucket=s3_bucket,
+            s3_key=s3_key,
+            redshift_conn_id="redshift_conn_id",
+            aws_conn_id="aws_conn_id",
+            task_id="task_id",
+            redshift_data_api_kwargs=dict(
+                database=database,
+                cluster_identifier=cluster_identifier,
+                db_user=db_user,
+                secret_arn=secret_arn,
+                statement_name=statement_name,
+            ),
+        )
+        op.execute(None)
+
+        lineage = op.get_openlineage_facets_on_complete(None)
+
+        assert len(lineage.inputs) == 1
+        assert len(lineage.outputs) == 1
+        assert lineage.outputs[0].name == f"{s3_key}/{table}_"
+        assert lineage.outputs[0].namespace == f"s3://{s3_bucket}"
+        assert lineage.inputs[0].name == f"database.{schema}.{table}"
+        assert lineage.inputs[0].namespace == "redshift://cluster.region:5439"
+
+        assert lineage.inputs[0].facets == mock_facets
+        assert lineage.outputs[0].facets == {
+            "columnLineage": ColumnLineageDatasetFacet(
+                fields={
+                    "col": Fields(
+                        inputFields=[
+                            InputField(
+                                namespace="redshift://cluster.region:5439",
+                                name=f"database.{schema}.{table}",
+                                field="col",
+                            )
+                        ],
+                        transformationType="IDENTITY",
+                        transformationDescription="identical",
+                    )
+                }
+            ),
+            "schema": SchemaDatasetFacet(fields=[SchemaDatasetFacetFields(name="col", type="STRING")]),
+        }
+
+    @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
+    @mock.patch("airflow.models.connection.Connection.get_connection_from_secrets")
+    @mock.patch("boto3.session.Session")
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_sql.RedshiftSQLHook.run")
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_data.RedshiftDataHook.conn")
+    @mock.patch(
+        "airflow.providers.amazon.aws.hooks.redshift_data.RedshiftDataHook.region_name",
+        new_callable=mock.PropertyMock,
+    )
+    @mock.patch("airflow.providers.amazon.aws.utils.openlineage.get_facets_from_redshift_table")
+    def test_get_openlineage_facets_on_complete_data_and_sql_hooks_aligned(
+        self, mock_get_facets, mock_rs_region, mock_rs, mock_run, mock_session, mock_connection, mock_hook
+    ):
+        """
+        Ensuring both supported hooks - RedshiftDataHook and RedshiftSQLHook return same lineage.
+        """
+        access_key = "aws_access_key_id"
+        secret_key = "aws_secret_access_key"
+        mock_session.return_value = Session(access_key, secret_key)
+        mock_session.return_value.access_key = access_key
+        mock_session.return_value.secret_key = secret_key
+        mock_session.return_value.token = None
+
+        mock_connection.return_value = mock.MagicMock(
+            schema="database", port=5439, host="cluster.id.region.redshift.amazonaws.com", extra_dejson={}
+        )
+        mock_hook.return_value = Connection()
+        mock_rs.execute_statement.return_value = {"Id": "STATEMENT_ID"}
+        mock_rs.describe_statement.return_value = {"Status": "FINISHED"}
+
+        mock_rs_region.return_value = "region"
+        mock_facets = {
+            "schema": SchemaDatasetFacet(fields=[SchemaDatasetFacetFields(name="col", type="STRING")]),
+            "documentation": DocumentationDatasetFacet(description="mock_description"),
+        }
+        mock_get_facets.return_value = mock_facets
+
+        schema = "schema"
+        table = "table"
+        s3_bucket = "bucket"
+        s3_key = "key"
+
+        # RS Data API params
+        database = "database"
+        cluster_identifier = "cluster"
+        db_user = "db_user"
+        secret_arn = "secret_arn"
+        statement_name = "statement_name"
+
+        op_rs_data = RedshiftToS3Operator(
+            schema=schema,
+            table=table,
+            s3_bucket=s3_bucket,
+            s3_key=s3_key,
+            redshift_conn_id="redshift_conn_id",
+            aws_conn_id="aws_conn_id",
+            task_id="task_id",
+            redshift_data_api_kwargs=dict(
+                database=database,
+                cluster_identifier=cluster_identifier,
+                db_user=db_user,
+                secret_arn=secret_arn,
+                statement_name=statement_name,
+            ),
+        )
+        op_rs_data.execute(None)
+        rs_data_lineage = op_rs_data.get_openlineage_facets_on_complete(None)
+
+        op_rs_sql = RedshiftToS3Operator(
+            schema=schema,
+            table=table,
+            s3_bucket=s3_bucket,
+            s3_key=s3_key,
+            redshift_conn_id="redshift_conn_id",
+            aws_conn_id="aws_conn_id",
+            task_id="task_id",
+        )
+        op_rs_sql.execute(None)
+        rs_sql_lineage = op_rs_sql.get_openlineage_facets_on_complete(None)
+
+        assert len(rs_sql_lineage.inputs) == 1
+        assert len(rs_sql_lineage.outputs) == 1
+        assert rs_sql_lineage.inputs == rs_data_lineage.inputs
+        assert rs_sql_lineage.outputs == rs_data_lineage.outputs
+        assert rs_sql_lineage.job_facets == rs_data_lineage.job_facets
+        assert rs_sql_lineage.run_facets == rs_data_lineage.run_facets


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Similar to #41575 , I'm adding OpenLineage support for operator in reverse direction - RedshiftToS3Operator.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
