### PR TITLE
Enable workload identity authentication for the Databricks provider

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -817,7 +817,6 @@ IS_EXECUTOR_CONTAINER = bool(os.environ.get("AIRFLOW_IS_EXECUTOR_CONTAINER", "")
 IS_K8S_EXECUTOR_POD = bool(os.environ.get("AIRFLOW_IS_K8S_EXECUTOR_POD", ""))
 """Will be True if running in kubernetes executor pod."""
 
-
 HIDE_SENSITIVE_VAR_CONN_FIELDS = conf.getboolean("core", "hide_sensitive_var_conn_fields")
 
 # By default this is off, but is automatically configured on when running task

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -817,6 +817,7 @@ IS_EXECUTOR_CONTAINER = bool(os.environ.get("AIRFLOW_IS_EXECUTOR_CONTAINER", "")
 IS_K8S_EXECUTOR_POD = bool(os.environ.get("AIRFLOW_IS_K8S_EXECUTOR_POD", ""))
 """Will be True if running in kubernetes executor pod."""
 
+
 HIDE_SENSITIVE_VAR_CONN_FIELDS = conf.getboolean("core", "hide_sensitive_var_conn_fields")
 
 # By default this is off, but is automatically configured on when running task

--- a/docs/apache-airflow-providers-databricks/connections/databricks.rst
+++ b/docs/apache-airflow-providers-databricks/connections/databricks.rst
@@ -87,7 +87,7 @@ Extra (optional)
 
     * ``use_azure_managed_identity``: required boolean flag to specify if managed identity needs to be used instead of
       service principal
-    * ``use_default_azure_credential``: required boolean flag to specify if the `DefaultAzureCredential` class should be used to retrieve a AAD token. For example, this can be used when authenticating with workload identity within an AKS cluster. Note that this option can't be set together with the `use_azure_managed_identity` parameter.
+    * ``use_default_azure_credential``: required boolean flag to specify if the `DefaultAzureCredential` class should be used to retrieve a AAD token. For example, this can be used when authenticating with workload identity within an Azure Kubernetes Service cluster. Note that this option can't be set together with the `use_azure_managed_identity` parameter.
     * ``azure_resource_id``: optional Resource ID of the Azure Databricks workspace (required if managed identity isn't
       a user inside workspace)
 

--- a/docs/apache-airflow-providers-databricks/connections/databricks.rst
+++ b/docs/apache-airflow-providers-databricks/connections/databricks.rst
@@ -87,6 +87,7 @@ Extra (optional)
 
     * ``use_azure_managed_identity``: required boolean flag to specify if managed identity needs to be used instead of
       service principal
+    * ``use_azure_workload_identity``: required boolean flag to specify if workload identity needs to be used to used within an AKS cluster. Note that this option can't be set together with the `use_azure_managed_identity` parameter.
     * ``azure_resource_id``: optional Resource ID of the Azure Databricks workspace (required if managed identity isn't
       a user inside workspace)
 

--- a/docs/apache-airflow-providers-databricks/connections/databricks.rst
+++ b/docs/apache-airflow-providers-databricks/connections/databricks.rst
@@ -87,7 +87,7 @@ Extra (optional)
 
     * ``use_azure_managed_identity``: required boolean flag to specify if managed identity needs to be used instead of
       service principal
-    * ``use_azure_workload_identity``: required boolean flag to specify if workload identity needs to be used to used within an AKS cluster. Note that this option can't be set together with the `use_azure_managed_identity` parameter.
+    * ``use_default_azure_credential``: required boolean flag to specify if the `DefaultAzureCredential` class should be used to retrieve a AAD token. For example, this can be used when authenticating with workload identity within an AKS cluster. Note that this option can't be set together with the `use_azure_managed_identity` parameter.
     * ``azure_resource_id``: optional Resource ID of the Azure Databricks workspace (required if managed identity isn't
       a user inside workspace)
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -32,6 +32,7 @@ airbyte
 AirflowException
 airflowignore
 ajax
+aks
 AlertApi
 alertPolicies
 Alibaba
@@ -60,7 +61,6 @@ ans
 Ansible
 apache
 api
-aks
 apikey
 apis
 AppBuilder

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -60,6 +60,7 @@ ans
 Ansible
 apache
 api
+aks
 apikey
 apis
 AppBuilder

--- a/providers/src/airflow/providers/databricks/hooks/databricks_base.py
+++ b/providers/src/airflow/providers/databricks/hooks/databricks_base.py
@@ -35,26 +35,7 @@ from urllib.parse import urlsplit
 
 import aiohttp
 import requests
-<<<<<<< HEAD:providers/src/airflow/providers/databricks/hooks/databricks_base.py
-<<<<<<< HEAD:providers/src/airflow/providers/databricks/hooks/databricks_base.py
-<<<<<<< HEAD:providers/src/airflow/providers/databricks/hooks/databricks_base.py
-<<<<<<< HEAD:providers/src/airflow/providers/databricks/hooks/databricks_base.py
 from aiohttp.client_exceptions import ClientConnectorError
-=======
-from azure.core.credentials import AccessToken
-from azure.identity import DefaultAzureCredential, WorkloadIdentityCredential
->>>>>>> 29de4a2773 (add kubernetes check):airflow/providers/databricks/hooks/databricks_base.py
-=======
->>>>>>> d0bac3f2a8 (Cleanup imports):airflow/providers/databricks/hooks/databricks_base.py
-=======
-from azure.core.credentials import AccessToken
-from azure.identity import DefaultAzureCredential
-from azure.identity.aio import (
-    DefaultAzureCredential as AsyncDefaultAzureCredential,
-)
->>>>>>> a927365ae2 (Ruff format):airflow/providers/databricks/hooks/databricks_base.py
-=======
->>>>>>> ee82bb116a (Revert "Work with callables"):airflow/providers/databricks/hooks/databricks_base.py
 from requests import PreparedRequest, exceptions as requests_exceptions
 from requests.auth import AuthBase, HTTPBasicAuth
 from requests.exceptions import JSONDecodeError

--- a/providers/src/airflow/providers/databricks/hooks/databricks_base.py
+++ b/providers/src/airflow/providers/databricks/hooks/databricks_base.py
@@ -456,7 +456,6 @@ class BaseDatabricksHook(BaseHook):
 
         self.log.info("Existing AAD token is expired, or going to expire soon. Refreshing...")
         try:
-            # from azure.identity import DefaultAzureCredential
             from azure.identity.aio import (
                 DefaultAzureCredential as AsyncDefaultAzureCredential,
             )

--- a/providers/src/airflow/providers/databricks/hooks/databricks_base.py
+++ b/providers/src/airflow/providers/databricks/hooks/databricks_base.py
@@ -111,6 +111,7 @@ class BaseDatabricksHook(BaseHook):
         "token",
         "host",
         "use_azure_managed_identity",
+        DEFAULT_AZURE_CREDENTIAL_SETTING_KEY,
         "azure_ad_endpoint",
         "azure_resource_id",
         "azure_tenant_id",

--- a/providers/src/airflow/providers/databricks/hooks/databricks_base.py
+++ b/providers/src/airflow/providers/databricks/hooks/databricks_base.py
@@ -465,8 +465,8 @@ class BaseDatabricksHook(BaseHook):
                     # This only works in an AKS Cluster given the following environment variables:
                     # AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_FEDERATED_TOKEN_FILE
                     #
-                    # While there is a WorkloadIdentityCredential class, the below class is advised by microsoft examples
-                    # https://learn.microsoft.com/nl-nl/azure/aks/workload-identity-overview
+                    # While there is a WorkloadIdentityCredential class, the below class is advised by Microsoft
+                    # https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview
                     token = await AsyncDefaultAzureCredential().get_token(f"{resource}/.default")
 
                     jsn = {

--- a/providers/src/airflow/providers/databricks/hooks/databricks_base.py
+++ b/providers/src/airflow/providers/databricks/hooks/databricks_base.py
@@ -34,11 +34,9 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 from urllib.parse import urlsplit
 
-from azure.core.credentials import AccessToken
-from azure.identity import DefaultAzureCredential
-
 import aiohttp
 import requests
+<<<<<<< HEAD:providers/src/airflow/providers/databricks/hooks/databricks_base.py
 <<<<<<< HEAD:providers/src/airflow/providers/databricks/hooks/databricks_base.py
 <<<<<<< HEAD:providers/src/airflow/providers/databricks/hooks/databricks_base.py
 from aiohttp.client_exceptions import ClientConnectorError
@@ -48,6 +46,13 @@ from azure.identity import DefaultAzureCredential, WorkloadIdentityCredential
 >>>>>>> 29de4a2773 (add kubernetes check):airflow/providers/databricks/hooks/databricks_base.py
 =======
 >>>>>>> d0bac3f2a8 (Cleanup imports):airflow/providers/databricks/hooks/databricks_base.py
+=======
+from azure.core.credentials import AccessToken
+from azure.identity import DefaultAzureCredential
+from azure.identity.aio import (
+    DefaultAzureCredential as AsyncDefaultAzureCredential,
+)
+>>>>>>> a927365ae2 (Ruff format):airflow/providers/databricks/hooks/databricks_base.py
 from requests import PreparedRequest, exceptions as requests_exceptions
 from requests.auth import AuthBase, HTTPBasicAuth
 from requests.exceptions import JSONDecodeError
@@ -58,9 +63,6 @@ from tenacity import (
     retry_if_exception,
     stop_after_attempt,
     wait_exponential,
-)
-from azure.identity.aio import (
-    DefaultAzureCredential as AsyncDefaultAzureCredential,
 )
 
 from airflow import __version__
@@ -301,7 +303,7 @@ class BaseDatabricksHook(BaseHook):
             raise AirflowException(msg)
 
         return jsn["access_token"]
-    
+
     def _call_aad_token_executor(self, resource: str, get_token_callable: Callable[[str], AccessToken]):
         """
         Get AAD token for given resource.
@@ -319,7 +321,7 @@ class BaseDatabricksHook(BaseHook):
             for attempt in self._get_retry_object():
                 with attempt:
                     token = get_token_callable(f"{resource}/.default")
-                       
+
                     jsn = {
                         "access_token": token.token,
                         "token_type": "Bearer",
@@ -337,8 +339,10 @@ class BaseDatabricksHook(BaseHook):
             raise AirflowException(msg)
 
         return jsn["access_token"]
-    
-    async def _a_call_aad_token_executor(self, resource: str, get_token_callable: Callable[[str], Awaitable[AccessToken]]):
+
+    async def _a_call_aad_token_executor(
+        self, resource: str, get_token_callable: Callable[[str], Awaitable[AccessToken]]
+    ):
         """
         Get AAD token for given resource.
 
@@ -418,8 +422,6 @@ class BaseDatabricksHook(BaseHook):
             raise AirflowException(msg)
 
         return jsn["access_token"]
-    
-    
 
     async def _a_get_aad_token(self, resource: str) -> str:
         """
@@ -579,7 +581,9 @@ class BaseDatabricksHook(BaseHook):
             return self._get_aad_token(DEFAULT_DATABRICKS_SCOPE)
         elif self.databricks_conn.extra_dejson.get(DEFAULT_AZURE_CREDENTIAL_SETTING_KEY, False):
             self.log.debug("Using default Azure Credential authentication.")
-            return self._call_aad_token_executor(DEFAULT_DATABRICKS_SCOPE, self._get_aad_token_for_default_az_credential)
+            return self._call_aad_token_executor(
+                DEFAULT_DATABRICKS_SCOPE, self._get_aad_token_for_default_az_credential
+            )
         elif self.databricks_conn.extra_dejson.get("service_principal_oauth", False):
             if self.databricks_conn.login == "" or self.databricks_conn.password == "":
                 raise AirflowException("Service Principal credentials aren't provided")
@@ -614,7 +618,9 @@ class BaseDatabricksHook(BaseHook):
                     "Workload identity authentication is only supporting when running in an Kubernetes cluster"
                 )
             self.log.debug("Using Azure Workload Identity authentication.")
-            return await self._a_call_aad_token_executor(DEFAULT_DATABRICKS_SCOPE, self._a_get_aad_token_for_default_az_credential)
+            return await self._a_call_aad_token_executor(
+                DEFAULT_DATABRICKS_SCOPE, self._a_get_aad_token_for_default_az_credential
+            )
         elif self.databricks_conn.extra_dejson.get("service_principal_oauth", False):
             if self.databricks_conn.login == "" or self.databricks_conn.password == "":
                 raise AirflowException("Service Principal credentials aren't provided")

--- a/providers/src/airflow/providers/databricks/hooks/databricks_base.py
+++ b/providers/src/airflow/providers/databricks/hooks/databricks_base.py
@@ -1,4 +1,4 @@
-
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/providers/src/airflow/providers/databricks/hooks/databricks_base.py
+++ b/providers/src/airflow/providers/databricks/hooks/databricks_base.py
@@ -31,11 +31,12 @@ import platform
 import time
 from asyncio.exceptions import TimeoutError
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Awaitable, Callable
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit
 
 import aiohttp
 import requests
+<<<<<<< HEAD:providers/src/airflow/providers/databricks/hooks/databricks_base.py
 <<<<<<< HEAD:providers/src/airflow/providers/databricks/hooks/databricks_base.py
 <<<<<<< HEAD:providers/src/airflow/providers/databricks/hooks/databricks_base.py
 <<<<<<< HEAD:providers/src/airflow/providers/databricks/hooks/databricks_base.py
@@ -53,6 +54,8 @@ from azure.identity.aio import (
     DefaultAzureCredential as AsyncDefaultAzureCredential,
 )
 >>>>>>> a927365ae2 (Ruff format):airflow/providers/databricks/hooks/databricks_base.py
+=======
+>>>>>>> ee82bb116a (Revert "Work with callables"):airflow/providers/databricks/hooks/databricks_base.py
 from requests import PreparedRequest, exceptions as requests_exceptions
 from requests.auth import AuthBase, HTTPBasicAuth
 from requests.exceptions import JSONDecodeError
@@ -304,80 +307,6 @@ class BaseDatabricksHook(BaseHook):
 
         return jsn["access_token"]
 
-    def _call_aad_token_executor(self, resource: str, get_token_callable: Callable[[str], AccessToken]):
-        """
-        Get AAD token for given resource.
-
-        Supports managed identity or service principal auth.
-        :param resource: resource to issue token to
-        :return: AAD token, or raise an exception
-        """
-        aad_token = self.oauth_tokens.get(resource)
-        if aad_token and self._is_oauth_token_valid(aad_token):
-            return aad_token["access_token"]
-
-        self.log.info("Existing AAD token is expired, or going to expire soon. Refreshing...")
-        try:
-            for attempt in self._get_retry_object():
-                with attempt:
-                    token = get_token_callable(f"{resource}/.default")
-
-                    jsn = {
-                        "access_token": token.token,
-                        "token_type": "Bearer",
-                        "expires_on": token.expires_on,
-                    }
-                    self._is_oauth_token_valid(jsn)
-                    self.oauth_tokens[resource] = jsn
-                    break
-        except ImportError as e:
-            raise AirflowOptionalProviderFeatureException(e)
-        except RetryError:
-            raise AirflowException(f"API requests to Azure failed {self.retry_limit} times. Giving up.")
-        except requests_exceptions.HTTPError as e:
-            msg = f"Response: {e.response.content.decode()}, Status Code: {e.response.status_code}"
-            raise AirflowException(msg)
-
-        return jsn["access_token"]
-
-    async def _a_call_aad_token_executor(
-        self, resource: str, get_token_callable: Callable[[str], Awaitable[AccessToken]]
-    ):
-        """
-        Get AAD token for given resource.
-
-        Supports managed identity or service principal auth.
-        :param resource: resource to issue token to
-        :return: AAD token, or raise an exception
-        """
-        aad_token = self.oauth_tokens.get(resource)
-        if aad_token and self._is_oauth_token_valid(aad_token):
-            return aad_token["access_token"]
-
-        self.log.info("Existing AAD token is expired, or going to expire soon. Refreshing...")
-        try:
-            for attempt in self._get_retry_object():
-                with attempt:
-                    token = await get_token_callable(f"{resource}/.default")
-
-                    jsn = {
-                        "access_token": token.token,
-                        "token_type": "Bearer",
-                        "expires_on": token.expires_on,
-                    }
-                    self._is_oauth_token_valid(jsn)
-                    self.oauth_tokens[resource] = jsn
-                    break
-        except ImportError as e:
-            raise AirflowOptionalProviderFeatureException(e)
-        except RetryError:
-            raise AirflowException(f"API requests to Azure failed {self.retry_limit} times. Giving up.")
-        except requests_exceptions.HTTPError as e:
-            msg = f"Response: {e.response.content.decode()}, Status Code: {e.response.status_code}"
-            raise AirflowException(msg)
-
-        return jsn["access_token"]
-
     def _get_aad_token(self, resource: str) -> str:
         """
         Get AAD token for given resource.
@@ -469,11 +398,94 @@ class BaseDatabricksHook(BaseHook):
 
         return jsn["access_token"]
 
-    def _get_aad_token_for_default_az_credential(self, resource: str):
-        return DefaultAzureCredential().get_token(resource)
+    def _get_aad_token_for_default_az_credential(self, resource: str) -> str:
+        """
+        Get AAD token for given resource for workload identity.
 
-    async def _a_get_aad_token_for_default_az_credential(self, resource: str):
-        return await AsyncDefaultAzureCredential().get_token(resource)
+        Supports managed identity or service principal auth.
+        :param resource: resource to issue token to
+        :return: AAD token, or raise an exception
+        """
+        aad_token = self.oauth_tokens.get(resource)
+        if aad_token and self._is_oauth_token_valid(aad_token):
+            return aad_token["access_token"]
+
+        self.log.info("Existing AAD token is expired, or going to expire soon. Refreshing...")
+        try:
+            from azure.identity import DefaultAzureCredential
+
+            for attempt in self._get_retry_object():
+                with attempt:
+                    # This only works in an AKS Cluster given the following environment variables:
+                    # AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_FEDERATED_TOKEN_FILE
+                    #
+                    # While there is a WorkloadIdentityCredential class, the below class is advised by microsoft examples
+                    # https://learn.microsoft.com/nl-nl/azure/aks/workload-identity-overview
+                    token = DefaultAzureCredential().get_token(f"{resource}/.default")
+
+                    jsn = {
+                        "access_token": token.token,
+                        "token_type": "Bearer",
+                        "expires_on": token.expires_on,
+                    }
+                    self._is_oauth_token_valid(jsn)
+                    self.oauth_tokens[resource] = jsn
+                    break
+        except ImportError as e:
+            raise AirflowOptionalProviderFeatureException(e)
+        except RetryError:
+            raise AirflowException(f"API requests to Azure failed {self.retry_limit} times. Giving up.")
+        except requests_exceptions.HTTPError as e:
+            msg = f"Response: {e.response.content.decode()}, Status Code: {e.response.status_code}"
+            raise AirflowException(msg)
+
+        return token.token
+
+    async def _a_get_aad_token_for_default_az_credential(self, resource: str) -> str:
+        """
+        Get AAD token for given resource for workload identity.
+
+        Supports managed identity or service principal auth.
+        :param resource: resource to issue token to
+        :return: AAD token, or raise an exception
+        """
+        aad_token = self.oauth_tokens.get(resource)
+        if aad_token and self._is_oauth_token_valid(aad_token):
+            return aad_token["access_token"]
+
+        self.log.info("Existing AAD token is expired, or going to expire soon. Refreshing...")
+        try:
+            # from azure.identity import DefaultAzureCredential
+            from azure.identity.aio import (
+                DefaultAzureCredential as AsyncDefaultAzureCredential,
+            )
+
+            for attempt in self._get_retry_object():
+                with attempt:
+                    # This only works in an AKS Cluster given the following environment variables:
+                    # AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_FEDERATED_TOKEN_FILE
+                    #
+                    # While there is a WorkloadIdentityCredential class, the below class is advised by microsoft examples
+                    # https://learn.microsoft.com/nl-nl/azure/aks/workload-identity-overview
+                    token = await AsyncDefaultAzureCredential().get_token(f"{resource}/.default")
+
+                    jsn = {
+                        "access_token": token.token,
+                        "token_type": "Bearer",
+                        "expires_on": token.expires_on,
+                    }
+                    self._is_oauth_token_valid(jsn)
+                    self.oauth_tokens[resource] = jsn
+                    break
+        except ImportError as e:
+            raise AirflowOptionalProviderFeatureException(e)
+        except RetryError:
+            raise AirflowException(f"API requests to Azure failed {self.retry_limit} times. Giving up.")
+        except requests_exceptions.HTTPError as e:
+            msg = f"Response: {e.response.content.decode()}, Status Code: {e.response.status_code}"
+            raise AirflowException(msg)
+
+        return token.token
 
     def _get_aad_headers(self) -> dict:
         """
@@ -557,10 +569,6 @@ class BaseDatabricksHook(BaseHook):
         except (requests_exceptions.RequestException, ValueError) as e:
             raise AirflowException(f"Can't reach Azure Metadata Service: {e}")
 
-    def _running_in_kubernetes(self):
-        """https://kubernetes.io/docs/tutorials/services/connect-applications-service/#environment-variables."""
-        return bool(os.environ.get("KUBERNETES_SERVICE_HOST", ""))
-
     def _get_token(self, raise_error: bool = False) -> str | None:
         if "token" in self.databricks_conn.extra_dejson:
             self.log.info(
@@ -581,9 +589,7 @@ class BaseDatabricksHook(BaseHook):
             return self._get_aad_token(DEFAULT_DATABRICKS_SCOPE)
         elif self.databricks_conn.extra_dejson.get(DEFAULT_AZURE_CREDENTIAL_SETTING_KEY, False):
             self.log.debug("Using default Azure Credential authentication.")
-            return self._call_aad_token_executor(
-                DEFAULT_DATABRICKS_SCOPE, self._get_aad_token_for_default_az_credential
-            )
+            return self._get_aad_token_for_default_az_credential(DEFAULT_DATABRICKS_SCOPE)
         elif self.databricks_conn.extra_dejson.get("service_principal_oauth", False):
             if self.databricks_conn.login == "" or self.databricks_conn.password == "":
                 raise AirflowException("Service Principal credentials aren't provided")
@@ -613,14 +619,9 @@ class BaseDatabricksHook(BaseHook):
             await self._a_check_azure_metadata_service()
             return await self._a_get_aad_token(DEFAULT_DATABRICKS_SCOPE)
         elif self.databricks_conn.extra_dejson.get(DEFAULT_AZURE_CREDENTIAL_SETTING_KEY, False):
-            if not self._running_in_kubernetes():
-                raise AirflowException(
-                    "Workload identity authentication is only supporting when running in an Kubernetes cluster"
-                )
-            self.log.debug("Using Azure Workload Identity authentication.")
-            return await self._a_call_aad_token_executor(
-                DEFAULT_DATABRICKS_SCOPE, self._a_get_aad_token_for_default_az_credential
-            )
+            self.log.debug("Using AzureDefaultCredentialy for authentication.")
+
+            return await self._a_get_aad_token_for_default_az_credential(DEFAULT_DATABRICKS_SCOPE)
         elif self.databricks_conn.extra_dejson.get("service_principal_oauth", False):
             if self.databricks_conn.login == "" or self.databricks_conn.password == "":
                 raise AirflowException("Service Principal credentials aren't provided")

--- a/providers/src/airflow/providers/databricks/hooks/databricks_base.py
+++ b/providers/src/airflow/providers/databricks/hooks/databricks_base.py
@@ -619,7 +619,7 @@ class BaseDatabricksHook(BaseHook):
             await self._a_check_azure_metadata_service()
             return await self._a_get_aad_token(DEFAULT_DATABRICKS_SCOPE)
         elif self.databricks_conn.extra_dejson.get(DEFAULT_AZURE_CREDENTIAL_SETTING_KEY, False):
-            self.log.debug("Using AzureDefaultCredentialy for authentication.")
+            self.log.debug("Using AzureDefaultCredential for authentication.")
 
             return await self._a_get_aad_token_for_default_az_credential(DEFAULT_DATABRICKS_SCOPE)
         elif self.databricks_conn.extra_dejson.get("service_principal_oauth", False):

--- a/providers/src/airflow/providers/databricks/hooks/databricks_base.py
+++ b/providers/src/airflow/providers/databricks/hooks/databricks_base.py
@@ -26,7 +26,6 @@ operators talk to the ``api/2.0/jobs/runs/submit``
 from __future__ import annotations
 
 import copy
-import os
 import platform
 import time
 from asyncio.exceptions import TimeoutError

--- a/providers/src/airflow/providers/databricks/hooks/databricks_base.py
+++ b/providers/src/airflow/providers/databricks/hooks/databricks_base.py
@@ -1,4 +1,4 @@
-#
+
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -58,7 +58,6 @@ from airflow import __version__
 from airflow.exceptions import AirflowException, AirflowOptionalProviderFeatureException
 from airflow.hooks.base import BaseHook
 from airflow.providers_manager import ProvidersManager
-from airflow.settings import RUNNING_IN_KUBERNETES
 
 if TYPE_CHECKING:
     from airflow.models import Connection
@@ -385,6 +384,50 @@ class BaseDatabricksHook(BaseHook):
 
         return jsn["access_token"]
 
+    def _get_aad_token_for_workload_identity(self, resource: str) -> str:
+        """
+        Get AAD token for given resource for workload identity.
+
+        Supports managed identity or service principal auth.
+        :param resource: resource to issue token to
+        :return: AAD token, or raise an exception
+        """
+        aad_token = self.oauth_tokens.get(resource)
+        if aad_token and self._is_oauth_token_valid(aad_token):
+            return aad_token["access_token"]
+
+        self.log.info("Existing AAD token is expired, or going to expire soon. Refreshing...")
+        try:
+            from azure.identity import DefaultAzureCredential
+
+            for attempt in self._get_retry_object():
+                with attempt:
+                    # This only works in an AKS Cluster given the following environment variables:
+                    # AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_FEDERATED_TOKEN_FILE
+                    #
+                    # While there is a WorkloadIdentityCredential class, the below class is advised by microsoft examples
+                    # https://learn.microsoft.com/nl-nl/azure/aks/workload-identity-overview
+                    token = DefaultAzureCredential().get_token(f"{resource}/.default")
+
+                    jsn = {
+                        "access_token": token.token,
+                        "token_type": "Bearer",
+                        "expires_on": token.expires_on,
+                    }
+                    self._is_oauth_token_valid(jsn)
+                    self.oauth_tokens[resource] = jsn
+                    break
+        except ImportError as e:
+            raise AirflowOptionalProviderFeatureException(e)
+        except RetryError:
+            raise AirflowException(f"API requests to Azure failed {self.retry_limit} times. Giving up.")
+        except requests_exceptions.HTTPError as e:
+            msg = f"Response: {e.response.content.decode()}, Status Code: {e.response.status_code}"
+            raise AirflowException(msg)
+
+        return token.token
+
+
     def _get_aad_headers(self) -> dict:
         """
         Fill AAD headers if necessary (SPN is outside of the workspace).
@@ -494,19 +537,9 @@ class BaseDatabricksHook(BaseHook):
                 raise AirflowException(
                     "Workload identity authentication is only supporting when running in an Kubernetes cluster"
                 )
-
             self.log.debug("Using Azure Workload Identity authentication.")
 
-            # This only works in an AKS Cluster given the following environment variables:
-            # AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_FEDERATED_TOKEN_FILE
-            #
-            # While there is a WorkloadIdentityCredential class, the below class is advised by microsoft examples
-            # https://learn.microsoft.com/nl-nl/azure/aks/workload-identity-overview
-            credential = DefaultAzureCredential()
-
-            token_obj: AccessToken = credential.get_token(DEFAULT_DATABRICKS_SCOPE)
-
-            return token_obj.token
+            return self._get_aad_token_for_workload_identity(DEFAULT_DATABRICKS_SCOPE)
         elif self.databricks_conn.extra_dejson.get("service_principal_oauth", False):
             if self.databricks_conn.login == "" or self.databricks_conn.password == "":
                 raise AirflowException("Service Principal credentials aren't provided")

--- a/providers/src/airflow/providers/databricks/hooks/databricks_base.py
+++ b/providers/src/airflow/providers/databricks/hooks/databricks_base.py
@@ -37,11 +37,14 @@ from urllib.parse import urlsplit
 import aiohttp
 import requests
 <<<<<<< HEAD:providers/src/airflow/providers/databricks/hooks/databricks_base.py
+<<<<<<< HEAD:providers/src/airflow/providers/databricks/hooks/databricks_base.py
 from aiohttp.client_exceptions import ClientConnectorError
 =======
 from azure.core.credentials import AccessToken
 from azure.identity import DefaultAzureCredential, WorkloadIdentityCredential
 >>>>>>> 29de4a2773 (add kubernetes check):airflow/providers/databricks/hooks/databricks_base.py
+=======
+>>>>>>> d0bac3f2a8 (Cleanup imports):airflow/providers/databricks/hooks/databricks_base.py
 from requests import PreparedRequest, exceptions as requests_exceptions
 from requests.auth import AuthBase, HTTPBasicAuth
 from requests.exceptions import JSONDecodeError

--- a/providers/src/airflow/providers/databricks/hooks/databricks_base.py
+++ b/providers/src/airflow/providers/databricks/hooks/databricks_base.py
@@ -420,8 +420,8 @@ class BaseDatabricksHook(BaseHook):
                     # This only works in an AKS Cluster given the following environment variables:
                     # AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_FEDERATED_TOKEN_FILE
                     #
-                    # While there is a WorkloadIdentityCredential class, the below class is advised by microsoft examples
-                    # https://learn.microsoft.com/nl-nl/azure/aks/workload-identity-overview
+                    # While there is a WorkloadIdentityCredential class, the below class is advised by Microsoft
+                    # https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview
                     token = DefaultAzureCredential().get_token(f"{resource}/.default")
 
                     jsn = {

--- a/providers/src/airflow/providers/databricks/hooks/databricks_base.py
+++ b/providers/src/airflow/providers/databricks/hooks/databricks_base.py
@@ -416,7 +416,7 @@ class BaseDatabricksHook(BaseHook):
 
             for attempt in self._get_retry_object():
                 with attempt:
-                    # This only works in an AKS Cluster given the following environment variables:
+                    # This only works in an Azure Kubernetes Service Cluster given the following environment variables:
                     # AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_FEDERATED_TOKEN_FILE
                     #
                     # While there is a WorkloadIdentityCredential class, the below class is advised by Microsoft
@@ -461,7 +461,7 @@ class BaseDatabricksHook(BaseHook):
 
             for attempt in self._get_retry_object():
                 with attempt:
-                    # This only works in an AKS Cluster given the following environment variables:
+                    # This only works in an Azure Kubernetes Service Cluster given the following environment variables:
                     # AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_FEDERATED_TOKEN_FILE
                     #
                     # While there is a WorkloadIdentityCredential class, the below class is advised by Microsoft

--- a/providers/tests/databricks/hooks/test_databricks_azure_workload_identity.py
+++ b/providers/tests/databricks/hooks/test_databricks_azure_workload_identity.py
@@ -78,7 +78,6 @@ class TestDatabricksHookAadTokenManagedIdentity:
     )
     @mock.patch("airflow.providers.databricks.hooks.databricks_base.requests.get")
     def test_one(self, requests_mock, get_token_mock: mock.MagicMock):
-        # get_token_mock.return_value = create_aad_token_for_resource()
         requests_mock.return_value = create_successful_response_mock({"jobs": []})
 
         result = self._hook.list_jobs()

--- a/providers/tests/databricks/hooks/test_databricks_azure_workload_identity.py
+++ b/providers/tests/databricks/hooks/test_databricks_azure_workload_identity.py
@@ -8,6 +8,7 @@ import pytest
 import tenacity
 from azure.core.credentials import AccessToken
 
+from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.providers.databricks.hooks.databricks import DatabricksHook
 from airflow.providers.databricks.hooks.databricks_base import WORKLOAD_IDENTITY_SETTING_KEY
@@ -20,8 +21,9 @@ def create_successful_response_mock(content):
     response.status_code = 200
     return response
 
+
 def create_aad_token_for_resource() -> AccessToken:
-    return AccessToken(expires_on=1575500666, token='sample-token')
+    return AccessToken(expires_on=1575500666, token="sample-token")
 
 
 HOST = "xx.cloud.databricks.com"
@@ -31,6 +33,7 @@ DEFAULT_RETRY_ARGS = dict(
     wait=tenacity.wait_none(),
     stop=tenacity.stop_after_attempt(DEFAULT_RETRY_NUMBER),
 )
+
 
 @pytest.mark.db_test
 class TestDatabricksHookAadTokenManagedIdentity:
@@ -54,8 +57,25 @@ class TestDatabricksHookAadTokenManagedIdentity:
         # This will use the default connection id (databricks_default)
         self._hook = DatabricksHook(retry_args=DEFAULT_RETRY_ARGS)
 
-    @mock.patch.dict(os.environ, {"AZURE_CLIENT_ID": "fake-client-id", "AZURE_TENANT_ID": "fake-tenant-id", "AZURE_FEDERATED_TOKEN_FILE": '/badpath'})
-    @mock.patch('azure.identity.WorkloadIdentityCredential.get_token', return_value=create_aad_token_for_resource())
+
+    def test_not_running_in_kubernetes(self):
+        with pytest.raises(AirflowException) as e:
+            self._hook.list_jobs()
+
+        assert str(e.value) == "Workload identity authentication is only supporting when running in an Kubernetes cluster"
+
+    @mock.patch.dict(
+        os.environ,
+        {
+            "AZURE_CLIENT_ID": "fake-client-id",
+            "AZURE_TENANT_ID": "fake-tenant-id",
+            "AZURE_FEDERATED_TOKEN_FILE": "/badpath",
+            "KUBERNETES_SERVICE_HOST": "fakeip"
+        },
+    )
+    @mock.patch(
+        "azure.identity.WorkloadIdentityCredential.get_token", return_value=create_aad_token_for_resource()
+    )
     @mock.patch("airflow.providers.databricks.hooks.databricks_base.requests.get")
     def test_one(self, requests_mock, get_token_mock: mock.MagicMock):
         # get_token_mock.return_value = create_aad_token_for_resource()

--- a/providers/tests/databricks/hooks/test_databricks_azure_workload_identity.py
+++ b/providers/tests/databricks/hooks/test_databricks_azure_workload_identity.py
@@ -37,10 +37,6 @@ DEFAULT_RETRY_ARGS = dict(
 
 @pytest.mark.db_test
 class TestDatabricksHookAadTokenWorkloadIdentity:
-    """
-    Tests for DatabricksHook when auth is done with AAD leveraging Managed Identity authentication
-    """
-
     _hook: DatabricksHook
 
     @provide_session

--- a/providers/tests/databricks/hooks/test_databricks_azure_workload_identity.py
+++ b/providers/tests/databricks/hooks/test_databricks_azure_workload_identity.py
@@ -1,0 +1,12 @@
+from airflow.providers.databricks.hooks.databricks_base import BaseDatabricksHook
+
+
+class WorkloadIdentitySupportDatabricksHook(BaseDatabricksHook):
+    ...
+
+def test_x():
+    hook = WorkloadIdentitySupportDatabricksHook(databricks_conn_id='databricks_default')
+    
+    
+    hook._do_api_call(('GET', '/api/2.1/jobs/list'))
+    print(x)

--- a/providers/tests/databricks/hooks/test_databricks_azure_workload_identity.py
+++ b/providers/tests/databricks/hooks/test_databricks_azure_workload_identity.py
@@ -1,14 +1,18 @@
+from __future__ import annotations
+
 import json
 import os
 from unittest import mock
+
 import pytest
-from airflow.providers.databricks.hooks.databricks import DatabricksHook
-from airflow.providers.databricks.hooks.databricks_base import DEFAULT_DATABRICKS_SCOPE, BaseDatabricksHook
-from airflow.utils.session import provide_session
-from airflow.models import Connection
-from azure.core.credentials import AccessToken
-from azure.identity import WorkloadIdentityCredential
 import tenacity
+from azure.core.credentials import AccessToken
+
+from airflow.models import Connection
+from airflow.providers.databricks.hooks.databricks import DatabricksHook
+from airflow.providers.databricks.hooks.databricks_base import WORKLOAD_IDENTITY_SETTING_KEY
+from airflow.utils.session import provide_session
+
 
 def create_successful_response_mock(content):
     response = mock.MagicMock()
@@ -27,25 +31,6 @@ DEFAULT_RETRY_ARGS = dict(
     wait=tenacity.wait_none(),
     stop=tenacity.stop_after_attempt(DEFAULT_RETRY_NUMBER),
 )
-
-WORKLOAD_IDENTITY_SETTING_KEY = "use_azure_workload_identity"
-
-
-class WorkloadIdentitySupportDatabricksHook(DatabricksHook):
-    def _get_token(self, raise_error: bool = False) -> str | None:
-        if self.databricks_conn.extra_dejson.get(WORKLOAD_IDENTITY_SETTING_KEY, False):
-            self.log.debug("Using Azure Workload Identity authentication.")
-            
-            # This only works in an AKS Cluster given the following environment variables:
-            # AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_FEDERATED_TOKEN_FILE
-            credential = WorkloadIdentityCredential()
-            
-            token_obj: AccessToken = credential.get_token(DEFAULT_DATABRICKS_SCOPE)
-            token: str = token_obj.token
-            
-            return token
-
-        return None
 
 @pytest.mark.db_test
 class TestDatabricksHookAadTokenManagedIdentity:
@@ -67,16 +52,15 @@ class TestDatabricksHookAadTokenManagedIdentity:
         session.commit()
 
         # This will use the default connection id (databricks_default)
-        self._hook = WorkloadIdentitySupportDatabricksHook(retry_args=DEFAULT_RETRY_ARGS)
-        
-    @mock.patch.dict(os.environ, {"AZURE_CLIENT_ID": "fake-client-id", "AZURE_TENANT_ID": "fake-tenant-id", "AZURE_FEDERATED_TOKEN_FILE": '/badpath'})
-    @mock.patch('azure.identity.WorkloadIdentityCredential.get_token')
-    @mock.patch("airflow.providers.databricks.hooks.databricks_base.requests.get")
+        self._hook = DatabricksHook(retry_args=DEFAULT_RETRY_ARGS)
 
+    @mock.patch.dict(os.environ, {"AZURE_CLIENT_ID": "fake-client-id", "AZURE_TENANT_ID": "fake-tenant-id", "AZURE_FEDERATED_TOKEN_FILE": '/badpath'})
+    @mock.patch('azure.identity.WorkloadIdentityCredential.get_token', return_value=create_aad_token_for_resource())
+    @mock.patch("airflow.providers.databricks.hooks.databricks_base.requests.get")
     def test_one(self, requests_mock, get_token_mock: mock.MagicMock):
-        get_token_mock.return_value = create_aad_token_for_resource()
+        # get_token_mock.return_value = create_aad_token_for_resource()
         requests_mock.return_value = create_successful_response_mock({"jobs": []})
 
         result = self._hook.list_jobs()
-        
+
         assert result == []

--- a/providers/tests/databricks/hooks/test_databricks_azure_workload_identity.py
+++ b/providers/tests/databricks/hooks/test_databricks_azure_workload_identity.py
@@ -36,7 +36,7 @@ DEFAULT_RETRY_ARGS = dict(
 
 
 @pytest.mark.db_test
-class TestDatabricksHookAadTokenManagedIdentity:
+class TestDatabricksHookAadTokenWorkloadIdentity:
     """
     Tests for DatabricksHook when auth is done with AAD leveraging Managed Identity authentication
     """

--- a/providers/tests/databricks/hooks/test_databricks_azure_workload_identity.py
+++ b/providers/tests/databricks/hooks/test_databricks_azure_workload_identity.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 from __future__ import annotations
 
 import json
@@ -8,7 +25,6 @@ import pytest
 import tenacity
 from azure.core.credentials import AccessToken
 
-from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.providers.databricks.hooks.databricks import DatabricksHook
 from airflow.providers.databricks.hooks.databricks_base import DEFAULT_AZURE_CREDENTIAL_SETTING_KEY
@@ -59,7 +75,7 @@ class TestDatabricksHookAadTokenWorkloadIdentity:
             "AZURE_CLIENT_ID": "fake-client-id",
             "AZURE_TENANT_ID": "fake-tenant-id",
             "AZURE_FEDERATED_TOKEN_FILE": "/badpath",
-            "KUBERNETES_SERVICE_HOST": "fakeip"
+            "KUBERNETES_SERVICE_HOST": "fakeip",
         },
     )
     @mock.patch(

--- a/providers/tests/databricks/hooks/test_databricks_azure_workload_identity.py
+++ b/providers/tests/databricks/hooks/test_databricks_azure_workload_identity.py
@@ -1,12 +1,82 @@
-from airflow.providers.databricks.hooks.databricks_base import BaseDatabricksHook
+import json
+import os
+from unittest import mock
+import pytest
+from airflow.providers.databricks.hooks.databricks import DatabricksHook
+from airflow.providers.databricks.hooks.databricks_base import DEFAULT_DATABRICKS_SCOPE, BaseDatabricksHook
+from airflow.utils.session import provide_session
+from airflow.models import Connection
+from azure.core.credentials import AccessToken
+from azure.identity import WorkloadIdentityCredential
+import tenacity
+
+def create_successful_response_mock(content):
+    response = mock.MagicMock()
+    response.json.return_value = content
+    response.status_code = 200
+    return response
+
+def create_aad_token_for_resource() -> AccessToken:
+    return AccessToken(expires_on=1575500666, token='sample-token')
 
 
-class WorkloadIdentitySupportDatabricksHook(BaseDatabricksHook):
-    ...
+HOST = "xx.cloud.databricks.com"
+DEFAULT_CONN_ID = "databricks_default"
+DEFAULT_RETRY_NUMBER = 3
+DEFAULT_RETRY_ARGS = dict(
+    wait=tenacity.wait_none(),
+    stop=tenacity.stop_after_attempt(DEFAULT_RETRY_NUMBER),
+)
 
-def test_x():
-    hook = WorkloadIdentitySupportDatabricksHook(databricks_conn_id='databricks_default')
-    
-    
-    hook._do_api_call(('GET', '/api/2.1/jobs/list'))
-    print(x)
+WORKLOAD_IDENTITY_SETTING_KEY = "use_azure_workload_identity"
+
+
+class WorkloadIdentitySupportDatabricksHook(DatabricksHook):
+    def _get_token(self, raise_error: bool = False) -> str | None:
+        if self.databricks_conn.extra_dejson.get(WORKLOAD_IDENTITY_SETTING_KEY, False):
+            self.log.debug("Using Azure Workload Identity authentication.")
+            
+            # This only works in an AKS Cluster given the following environment variables:
+            # AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_FEDERATED_TOKEN_FILE
+            credential = WorkloadIdentityCredential()
+            
+            token_obj: AccessToken = credential.get_token(DEFAULT_DATABRICKS_SCOPE)
+            token: str = token_obj.token
+            
+            return token
+
+        return None
+
+@pytest.mark.db_test
+class TestDatabricksHookAadTokenManagedIdentity:
+    """
+    Tests for DatabricksHook when auth is done with AAD leveraging Managed Identity authentication
+    """
+
+    _hook: DatabricksHook
+
+    @provide_session
+    def setup_method(self, method, session=None):
+        conn = session.query(Connection).filter(Connection.conn_id == DEFAULT_CONN_ID).first()
+        conn.host = HOST
+        conn.extra = json.dumps(
+            {
+                WORKLOAD_IDENTITY_SETTING_KEY: True,
+            }
+        )
+        session.commit()
+
+        # This will use the default connection id (databricks_default)
+        self._hook = WorkloadIdentitySupportDatabricksHook(retry_args=DEFAULT_RETRY_ARGS)
+        
+    @mock.patch.dict(os.environ, {"AZURE_CLIENT_ID": "fake-client-id", "AZURE_TENANT_ID": "fake-tenant-id", "AZURE_FEDERATED_TOKEN_FILE": '/badpath'})
+    @mock.patch('azure.identity.WorkloadIdentityCredential.get_token')
+    @mock.patch("airflow.providers.databricks.hooks.databricks_base.requests.get")
+
+    def test_one(self, requests_mock, get_token_mock: mock.MagicMock):
+        get_token_mock.return_value = create_aad_token_for_resource()
+        requests_mock.return_value = create_successful_response_mock({"jobs": []})
+
+        result = self._hook.list_jobs()
+        
+        assert result == []

--- a/providers/tests/databricks/hooks/test_databricks_azure_workload_identity.py
+++ b/providers/tests/databricks/hooks/test_databricks_azure_workload_identity.py
@@ -11,7 +11,7 @@ from azure.core.credentials import AccessToken
 from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.providers.databricks.hooks.databricks import DatabricksHook
-from airflow.providers.databricks.hooks.databricks_base import WORKLOAD_IDENTITY_SETTING_KEY
+from airflow.providers.databricks.hooks.databricks_base import DEFAULT_AZURE_CREDENTIAL_SETTING_KEY
 from airflow.utils.session import provide_session
 
 
@@ -45,20 +45,13 @@ class TestDatabricksHookAadTokenWorkloadIdentity:
         conn.host = HOST
         conn.extra = json.dumps(
             {
-                WORKLOAD_IDENTITY_SETTING_KEY: True,
+                DEFAULT_AZURE_CREDENTIAL_SETTING_KEY: True,
             }
         )
         session.commit()
 
         # This will use the default connection id (databricks_default)
         self._hook = DatabricksHook(retry_args=DEFAULT_RETRY_ARGS)
-
-
-    def test_not_running_in_kubernetes(self):
-        with pytest.raises(AirflowException) as e:
-            self._hook.list_jobs()
-
-        assert str(e.value) == "Workload identity authentication is only supporting when running in an Kubernetes cluster"
 
     @mock.patch.dict(
         os.environ,
@@ -70,7 +63,7 @@ class TestDatabricksHookAadTokenWorkloadIdentity:
         },
     )
     @mock.patch(
-        "azure.identity.WorkloadIdentityCredential.get_token", return_value=create_aad_token_for_resource()
+        "azure.identity.DefaultAzureCredential.get_token", return_value=create_aad_token_for_resource()
     )
     @mock.patch("airflow.providers.databricks.hooks.databricks_base.requests.get")
     def test_one(self, requests_mock, get_token_mock: mock.MagicMock):

--- a/providers/tests/databricks/hooks/test_databricks_azure_workload_identity_async.py
+++ b/providers/tests/databricks/hooks/test_databricks_azure_workload_identity_async.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 from __future__ import annotations
 
 import json
@@ -8,7 +25,6 @@ import pytest
 import tenacity
 from azure.core.credentials import AccessToken
 
-from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.providers.databricks.hooks.databricks import DatabricksHook
 from airflow.providers.databricks.hooks.databricks_base import DEFAULT_AZURE_CREDENTIAL_SETTING_KEY
@@ -60,7 +76,7 @@ class TestDatabricksHookAadTokenWorkloadIdentityAsync:
             "AZURE_CLIENT_ID": "fake-client-id",
             "AZURE_TENANT_ID": "fake-tenant-id",
             "AZURE_FEDERATED_TOKEN_FILE": "/badpath",
-            "KUBERNETES_SERVICE_HOST": "fakeip"
+            "KUBERNETES_SERVICE_HOST": "fakeip",
         },
     )
     @mock.patch(
@@ -69,9 +85,7 @@ class TestDatabricksHookAadTokenWorkloadIdentityAsync:
     @mock.patch("airflow.providers.databricks.hooks.databricks_base.aiohttp.ClientSession.get")
     async def test_one(self, requests_mock, get_token_mock: mock.MagicMock):
         requests_mock.return_value.__aenter__.return_value.json.side_effect = mock.AsyncMock(
-            side_effect=[
-                {"data": 1}
-            ]
+            side_effect=[{"data": 1}]
         )
 
         async with self._hook:

--- a/providers/tests/databricks/hooks/test_databricks_azure_workload_identity_async.py
+++ b/providers/tests/databricks/hooks/test_databricks_azure_workload_identity_async.py
@@ -37,10 +37,6 @@ DEFAULT_RETRY_ARGS = dict(
 
 @pytest.mark.db_test
 class TestDatabricksHookAadTokenWorkloadIdentityAsync:
-    """
-    Tests for DatabricksHook when auth is done with AAD leveraging Managed Identity authentication
-    """
-
     _hook: DatabricksHook
 
     @provide_session

--- a/providers/tests/databricks/hooks/test_databricks_azure_workload_identity_async.py
+++ b/providers/tests/databricks/hooks/test_databricks_azure_workload_identity_async.py
@@ -53,8 +53,6 @@ DEFAULT_RETRY_ARGS = dict(
 
 @pytest.mark.db_test
 class TestDatabricksHookAadTokenWorkloadIdentityAsync:
-    _hook: DatabricksHook
-
     @provide_session
     def setup_method(self, method, session=None):
         conn = session.query(Connection).filter(Connection.conn_id == DEFAULT_CONN_ID).first()
@@ -65,9 +63,6 @@ class TestDatabricksHookAadTokenWorkloadIdentityAsync:
             }
         )
         session.commit()
-
-        # This will use the default connection id (databricks_default)
-        self._hook = DatabricksHook(retry_args=DEFAULT_RETRY_ARGS)
 
     @pytest.mark.asyncio
     @mock.patch(
@@ -88,7 +83,7 @@ class TestDatabricksHookAadTokenWorkloadIdentityAsync:
                 side_effect=[{"data": 1}]
             )
 
-            async with self._hook:
-                result = await self._hook.a_get_run_output(0)
+            async with DatabricksHook(retry_args=DEFAULT_RETRY_ARGS) as hook:
+                result = await hook.a_get_run_output(0)
 
             assert result == {"data": 1}

--- a/providers/tests/databricks/hooks/test_databricks_azure_workload_identity_async.py
+++ b/providers/tests/databricks/hooks/test_databricks_azure_workload_identity_async.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+import os
+from unittest import mock
+
+import pytest
+import tenacity
+from azure.core.credentials import AccessToken
+
+from airflow.exceptions import AirflowException
+from airflow.models import Connection
+from airflow.providers.databricks.hooks.databricks import DatabricksHook
+from airflow.providers.databricks.hooks.databricks_base import WORKLOAD_IDENTITY_SETTING_KEY
+from airflow.utils.session import provide_session
+
+
+def create_successful_response_mock(content):
+    response = mock.MagicMock()
+    response.json.return_value = content
+    response.status_code = 200
+    return response
+
+
+def create_aad_token_for_resource() -> AccessToken:
+    return AccessToken(expires_on=1575500666, token="sample-token")
+
+
+HOST = "xx.cloud.databricks.com"
+DEFAULT_CONN_ID = "databricks_default"
+DEFAULT_RETRY_NUMBER = 3
+DEFAULT_RETRY_ARGS = dict(
+    wait=tenacity.wait_none(),
+    stop=tenacity.stop_after_attempt(DEFAULT_RETRY_NUMBER),
+)
+
+
+@pytest.mark.db_test
+class TestDatabricksHookAadTokenWorkloadIdentityAsync:
+    """
+    Tests for DatabricksHook when auth is done with AAD leveraging Managed Identity authentication
+    """
+
+    _hook: DatabricksHook
+
+    @provide_session
+    def setup_method(self, method, session=None):
+        conn = session.query(Connection).filter(Connection.conn_id == DEFAULT_CONN_ID).first()
+        conn.host = HOST
+        conn.extra = json.dumps(
+            {
+                WORKLOAD_IDENTITY_SETTING_KEY: True,
+            }
+        )
+        session.commit()
+
+        # This will use the default connection id (databricks_default)
+        self._hook = DatabricksHook(retry_args=DEFAULT_RETRY_ARGS)
+
+
+    @pytest.mark.asyncio
+    async def test_not_running_in_kubernetes(self):
+        with pytest.raises(AirflowException) as e:
+            await self._hook.a_get_run_output(0)
+
+        assert str(e.value) == "Workload identity authentication is only supporting when running in an Kubernetes cluster"
+
+    @pytest.mark.asyncio
+    @mock.patch.dict(
+        os.environ,
+        {
+            "AZURE_CLIENT_ID": "fake-client-id",
+            "AZURE_TENANT_ID": "fake-tenant-id",
+            "AZURE_FEDERATED_TOKEN_FILE": "/badpath",
+            "KUBERNETES_SERVICE_HOST": "fakeip"
+        },
+    )
+    @mock.patch(
+        "azure.identity.aio.WorkloadIdentityCredential.get_token", return_value=create_aad_token_for_resource()
+    )
+    @mock.patch("airflow.providers.databricks.hooks.databricks_base.aiohttp.ClientSession.get")
+    async def test_one(self, requests_mock, get_token_mock: mock.MagicMock):
+        requests_mock.return_value.__aenter__.return_value.json.side_effect = mock.AsyncMock(
+            side_effect=[
+                {"data": 1}
+            ]
+        )
+
+        async with self._hook:
+            result = await self._hook.a_get_run_output(0)
+
+        assert result == {"data": 1}


### PR DESCRIPTION
This pull request adds support for [authenticating using Workload Identity ](https://learn.microsoft.com/nl-nl/azure/aks/workload-identity-overview?tabs=dotnet)for the Databricks provider. In the provided unit tests, this has been tested using mocking the token generation. However, the `DefaultAzureCredential().get_token(...)` part has been tested on an actual AKS cluster. This closes #41586.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #41586

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
