### PR TITLE
PoC to make ProvidersManager independent of FAB for connection forms

### DIFF
--- a/airflow/hooks/base.py
+++ b/airflow/hooks/base.py
@@ -29,6 +29,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 
 if TYPE_CHECKING:
     from airflow.models.connection import Connection  # Avoid circular imports.
+    from airflow.models.param import Param
 
 log = logging.getLogger(__name__)
 
@@ -100,7 +101,13 @@ class BaseHook(LoggingMixin):
         raise NotImplementedError()
 
     @classmethod
+    def get_connection_form(cls) -> dict[str, Param]:
+        """Define with the *new* way how form parameters are defined."""
+        return {}
+
+    @classmethod
     def get_connection_form_widgets(cls) -> dict[str, Any]:
+        """Define with the *legacy* way of defining parameter."""
         return {}
 
     @classmethod


### PR DESCRIPTION
PoC to make ProvidersManager independent of FAB

Use a couple of mocks to load pre-existing provider connection forms w/o need to FAB and wtforms.
Convert all form elements to Param objects like trigger form which can be represented as JSON schema.

Test it with, make a `breeze shell` and run `python airflow/providers_manager.py` and see what is working already.