### PR TITLE
Change confirmation text

### DIFF
--- a/airflow/www/templates/airflow/confirm.html
+++ b/airflow/www/templates/airflow/confirm.html
@@ -21,7 +21,7 @@
 
 {% block content %}
   {{ super() }}
-  <h2>Wait a minute</h2>
+  <h2>Please confirm</h2>
   <div class="panel">
     <p>{{ message }}</p>
     {% if details %}

--- a/tests/www/views/test_views_acl.py
+++ b/tests/www/views/test_views_acl.py
@@ -788,7 +788,7 @@ def test_success_fail_for_read_only_task_instance_access(client_only_dags_tis):
         past="false",
     )
     resp = client_only_dags_tis.post("success", data=form)
-    check_content_not_in_response("Wait a minute", resp, resp_code=302)
+    check_content_not_in_response("Please confirm", resp, resp_code=302)
 
 
 GET_LOGS_WITH_METADATA_URL = (

--- a/tests/www/views/test_views_decorators.py
+++ b/tests/www/views/test_views_decorators.py
@@ -116,7 +116,7 @@ def test_action_logging_post(session, admin_client):
         only_failed="false",
     )
     resp = admin_client.post("clear", data=form)
-    check_content_in_response(["example_bash_operator", "Wait a minute"], resp)
+    check_content_in_response(["example_bash_operator", "Please confirm"], resp)
     # In mysql backend, this commit() is needed to write down the logs
     session.commit()
     _check_last_log(

--- a/tests/www/views/test_views_tasks.py
+++ b/tests/www/views/test_views_tasks.py
@@ -320,12 +320,12 @@ def client_ti_without_dag_edit(app):
         pytest.param(
             f"confirm?task_id=runme_0&dag_id=example_bash_operator&state=success"
             f"&dag_run_id={DEFAULT_DAGRUN}",
-            ["Wait a minute"],
+            ["Please confirm"],
             id="confirm-success",
         ),
         pytest.param(
             f"confirm?task_id=runme_0&dag_id=example_bash_operator&state=failed&dag_run_id={DEFAULT_DAGRUN}",
-            ["Wait a minute"],
+            ["Please confirm"],
             id="confirm-failed",
         ),
         pytest.param(


### PR DESCRIPTION
**Cherry-pick of #41650 / a11656cc6be3b3381997734ced65f586d57b05ae from main to v2-10-test**

Change confirmation text page to say "Please confirm" instead of "Wait a minute" and update associated UI-level tests. As a new user to airflow, the text "Wait a minute" implied that the user should wait for some background process, whereas the intention is for the user to review the action and confirm it. This is a trivial text change, so extensive testing was not performed, as the UI tests cover the change.

closes: #41649
