### PR TITLE
chore(docs): add an example for auth with keycloak

### DIFF
--- a/docs/apache-airflow-providers-fab/auth-manager/webserver-authentication.rst
+++ b/docs/apache-airflow-providers-fab/auth-manager/webserver-authentication.rst
@@ -229,3 +229,94 @@ webserver_config.py itself if you wish.
             roles = map_roles(teams)
             log.debug(f"User info from Github: {user_data}\nTeam info from Github: {teams}")
             return {"username": "github_" + user_data.get("login"), "role_keys": roles}
+
+Example using team based Authorization with keyCloak
+''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+Here is an example of what you might have in your webserver_config.py:
+
+.. code-block:: python
+
+  import os
+  import jwt
+  import requests
+  import logging
+  from base64 import b64decode
+  from cryptography.hazmat.primitives import serialization
+  from flask_appbuilder.security.manager import (AUTH_DB, AUTH_OAUTH)
+  from airflow import configuration as conf
+  from airflow.www.security import AirflowSecurityManager
+  
+  log = logging.getLogger(__name__)
+  
+  AUTH_TYPE = AUTH_OAUTH
+  AUTH_USER_REGISTRATION = True
+  AUTH_ROLES_SYNC_AT_LOGIN = True
+  AUTH_USER_REGISTRATION_ROLE = "Viewer"
+  OIDC_ISSUER = "https://sso.keycloak.me/realms/airflow"
+  
+  # Make sure you create these role on Keycloak 
+  AUTH_ROLES_MAPPING = {
+    "Viewer": ["Viewer"],
+    "Admin": ["Admin"],
+    "User": ["User"],
+    "Public": ["Public"],
+    "Op": ["Op"],
+  }
+  
+  OAUTH_PROVIDERS = [
+    {
+      "name": "keycloak",
+      "icon": "fa-key",
+      "token_key": "access_token",
+      "remote_app": {
+        "client_id": "nonprod-airflow",
+        "client_secret": "XydWOAGT84dFjDDuunOjHsod8hIEa5OM",
+        "server_metadata_url": "https://sso.keycloak.me/realms/airflow/.well-known/openid-configuration",
+        "api_base_url": "https://sso.keycloak.me/realms/airflow/protocol/openid-connect",
+        "client_kwargs": {
+            "scope": "email profile"
+        },
+        "access_token_url": "https://sso.keycloak.me/realms/airflow/protocol/openid-connect/token",
+        "authorize_url": "https://sso.keycloak.me/realms/airflow/protocol/openid-connect/auth",
+        "request_token_url": None
+      }
+    }
+  ]
+  
+  # Fetch public key
+  req = requests.get(OIDC_ISSUER)
+  key_der_base64 = req.json()["public_key"]
+  key_der = b64decode(key_der_base64.encode())
+  public_key = serialization.load_der_public_key(key_der)
+  
+  class CustomSecurityManager(AirflowSecurityManager):
+    def oauth_user_info(self, provider, response):
+      if provider == "keycloak":
+        token = response["access_token"]
+        me = jwt.decode(token, public_key, algorithms=['HS256', 'RS256'])
+  
+        # Extract roles from resource access  
+        realm_access = me.get("realm_access", {})
+        groups = realm_access.get("roles", [])
+  
+        log.info("groups: {0}".format(groups))
+  
+        if not groups:
+          groups = ["Viewer"]
+  
+        userinfo = {
+          "username": me.get("preferred_username"),
+          "email": me.get("email"),
+          "first_name": me.get("given_name"),
+          "last_name": me.get("family_name"),
+          "role_keys": groups,
+        }
+  
+        log.info("user info: {0}".format(userinfo))
+  
+        return userinfo
+      else:
+        return {}
+  
+  # Make sure to replace this with your own implementation of AirflowSecurityManager class
+  SECURITY_MANAGER_CLASS = CustomSecurityManager


### PR DESCRIPTION
Added a new section in the authentication documentation that provides a code of configuring Airflow to work with Keycloak.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
