### PR TITLE
Fix pinecone PINECONE_DEBUG_CURL unit test

### DIFF
--- a/tests/providers/pinecone/hooks/test_pinecone.py
+++ b/tests/providers/pinecone/hooks/test_pinecone.py
@@ -52,11 +52,9 @@ class TestPineconeHook:
         self.pinecone_hook.list_indexes()
         mock_list_indexes.assert_called_once()
 
-    @patch("airflow.providers.pinecone.hooks.pinecone.PineconeHook.list_indexes")
-    def test_debug_curl_setting(self, mock_list_indexes):
+    def test_debug_curl_setting(self):
         """Test that the PINECONE_DEBUG_CURL environment variable is set when initializing Pinecone Object."""
-        self.pinecone_hook.list_indexes()
-        mock_list_indexes.assert_called_once()
+        self.pinecone_hook.pinecone_client
         assert os.environ.get("PINECONE_DEBUG_CURL") == "true"
 
     @patch("airflow.providers.pinecone.hooks.pinecone.PineconeHook.create_index")


### PR DESCRIPTION
Previously the unit test was mocking too early and [the code](https://github.com/apache/airflow/blob/2ac4e4dfe324638824a0edd16c6ff6857b053d9b/airflow/providers/pinecone/hooks/pinecone.py#L119) which sets the env variable was not even running. This PR removes the mocking and creates the client only to ensure the env variable is being set.

I'm not entirely sure how this test was ever passing since this code has not changed recently, but our tests on main (within aws and also locally confirmed running the test in Breeze on my laptop) detected this recently and have been consistently failing for a day.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
