### PR TITLE
Don't Fail LocalTaskJob on heartbeat

### DIFF
--- a/airflow/jobs/local_task_job_runner.py
+++ b/airflow/jobs/local_task_job_runner.py
@@ -208,9 +208,14 @@ class LocalTaskJobRunner(BaseJobRunner, LoggingMixin):
 
                     if span.is_recording():
                         span.add_event(name="perform_heartbeat")
-                    perform_heartbeat(
-                        job=self.job, heartbeat_callback=self.heartbeat_callback, only_if_necessary=False
-                    )
+                    try:
+                        perform_heartbeat(
+                            job=self.job, heartbeat_callback=self.heartbeat_callback, only_if_necessary=False
+                        )
+                    except Exception:
+                        # Failing the heartbeat should never kill the localtaskjob
+                        # If it repeatedly can't heartbeat, it will be marked as a zombie anyhow
+                        pass
 
                     # If it's been too long since we've heartbeat, then it's possible that
                     # the scheduler rescheduled this task, so kill launched processes.

--- a/airflow/jobs/local_task_job_runner.py
+++ b/airflow/jobs/local_task_job_runner.py
@@ -212,9 +212,11 @@ class LocalTaskJobRunner(BaseJobRunner, LoggingMixin):
                         perform_heartbeat(
                             job=self.job, heartbeat_callback=self.heartbeat_callback, only_if_necessary=False
                         )
-                    except Exception:
+                    except Exception as e:
                         # Failing the heartbeat should never kill the localtaskjob
                         # If it repeatedly can't heartbeat, it will be marked as a zombie anyhow
+                        warn_string = f"Heartbeat failed with Exception: {e}"
+                        self.log.warning(warn_string)
                         pass
 
                     # If it's been too long since we've heartbeat, then it's possible that

--- a/airflow/jobs/local_task_job_runner.py
+++ b/airflow/jobs/local_task_job_runner.py
@@ -215,8 +215,7 @@ class LocalTaskJobRunner(BaseJobRunner, LoggingMixin):
                     except Exception as e:
                         # Failing the heartbeat should never kill the localtaskjob
                         # If it repeatedly can't heartbeat, it will be marked as a zombie anyhow
-                        warn_string = f"Heartbeat failed with Exception: {e}"
-                        self.log.warning(warn_string)
+                        self.log.warning("Heartbeat failed with Exception: %s", e)
                         pass
 
                     # If it's been too long since we've heartbeat, then it's possible that

--- a/airflow/jobs/local_task_job_runner.py
+++ b/airflow/jobs/local_task_job_runner.py
@@ -216,7 +216,6 @@ class LocalTaskJobRunner(BaseJobRunner, LoggingMixin):
                         # Failing the heartbeat should never kill the localtaskjob
                         # If it repeatedly can't heartbeat, it will be marked as a zombie anyhow
                         self.log.warning("Heartbeat failed with Exception: %s", e)
-                        pass
 
                     # If it's been too long since we've heartbeat, then it's possible that
                     # the scheduler rescheduled this task, so kill launched processes.


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

The local task job heartbeat will crash the task if it fails. This is counter to the goal of the heartbeat, which is that it's ok if the task temporarily loses connection to the DB as long as it re-establishes it within the zombie timeout.

I've used an extremely broad exception here. I'm open to something more narrow if we have a smaller error type that will still cover the problems not controllable by the Airflow code, but I think it's reasonable to use a very broad exception.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
