### PR TITLE
Pin universal-pathlib to 0.2.2 as 0.2.3 generates static code check errors

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -496,7 +496,7 @@ DEPENDENCIES = [
     # We should also remove "3rd-party-licenses/LICENSE-unicodecsv.txt" file when we remove this dependency
     "unicodecsv>=0.14.1",
     # The Universal Pathlib provides  Pathlib-like interface for FSSPEC
-    "universal-pathlib>=0.2.2",
+    "universal-pathlib==0.2.2",  # Temporarily pin to 0.2.2 as 0.2.3 generates mypy errors
     # Werkzug 3 breaks Flask-Login 0.6.2, also connexion needs to be updated to >= 3.0
     # we should remove this limitation when FAB supports Flask 2.3 and we migrate connexion to 3+
     "werkzeug>=2.0,<3",


### PR DESCRIPTION
This PR fixes the Mypy Errors I see on my PR since universal-pathlib 0.2.3 has been released:

Manual MyPy Airflow:
```
 airflow/io/path.py:201: error: Unexpected keyword argument "overwrite" for
"rename" of "UPath"  [call-arg]
            return self.rename(target, overwrite=True)
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Manual MyPy Providers:
```
airflow/providers/common/io/xcom/backend.py:145: error: Argument 1 to
"joinpath" of "UPath" has incompatible type "Optional[str]"; expected
"Union[str, PathLike[str]]"  [arg-type]
                p = base_path.joinpath(dag_id, run_id, task_id, f"{uuid.uu...
                                       ^~~~~~
airflow/providers/common/io/xcom/backend.py:145: error: Argument 2 to
"joinpath" of "UPath" has incompatible type "Optional[str]"; expected
"Union[str, PathLike[str]]"  [arg-type]
                p = base_path.joinpath(dag_id, run_id, task_id, f"{uuid.uu...
                                               ^~~~~~
airflow/providers/common/io/xcom/backend.py:145: error: Argument 3 to
"joinpath" of "UPath" has incompatible type "Optional[str]"; expected
"Union[str, PathLike[str]]"  [arg-type]
    ...          p = base_path.joinpath(dag_id, run_id, task_id, f"{uuid.uuid...
                                                        ^~~~~~~
```

Where the interface for XCom only allows a pre-raising if params are missing, the error in core with `overwrite` is something where logic might need to be adjusted for a permanent fix. But as this turns all PRs red, proposing to just pin version to 0.2.2 for the moment.

@bolkedebruin Do you have a better idea?