### PR TITLE
Improve Mongo connection validation and UI

### DIFF
--- a/airflow/providers/mongo/hooks/mongo.py
+++ b/airflow/providers/mongo/hooks/mongo.py
@@ -82,6 +82,28 @@ class MongoHook(BaseHook):
     conn_type = "mongo"
     hook_name = "MongoDB"
 
+    @classmethod
+    def get_connection_form_widgets(cls) -> dict[str, Any]:
+        """Return connection widgets to add to connection form."""
+        from flask_babel import lazy_gettext
+        from wtforms import BooleanField
+
+        return {
+            "srv": BooleanField(label=lazy_gettext("SRV mode"), description="checks srv mode"),
+            "allow_insecure": BooleanField(label=lazy_gettext("SRV mode"), description="checks srv mode"),
+        }
+
+    @classmethod
+    def get_ui_field_behaviour(cls) -> dict[str, Any]:
+        """Return custom field behaviour."""
+        return {
+            "hidden_fields": [],
+            "relabeling": {"login": "Username", "schema": "Default DB"},
+            "placeholders": {
+                "port": "Note: port should not be set when SRV is True",
+            },
+        }
+
     def __init__(self, mongo_conn_id: str = default_conn_name, *args, **kwargs) -> None:
         super().__init__()
         if conn_id := kwargs.pop("conn_id", None):

--- a/airflow/providers/mongo/hooks/mongo.py
+++ b/airflow/providers/mongo/hooks/mongo.py
@@ -126,11 +126,16 @@ class MongoHook(BaseHook):
 
     @staticmethod
     def _validate_connection(conn: Connection):
-        if conn.conn_type == "mongo":
-            return
-        if conn.conn_type == "mongodb+srv":
-            raise AirflowException()
-        raise AirflowException()
+        conn_type = conn.conn_type
+        if conn_type != "mongo":
+            if conn_type == "mongodb+srv":
+                raise AirflowException("use srv=true")
+            raise AirflowException(
+                f"conn_type '{conn_type}' not allowed for MongoHook; conn_type must be 'mongo'"
+            )
+
+        if conn.port and "srv" in conn.extra_dejson and conn.extra_dejson["srv"] is True:
+            raise AirflowException("srv URI should not specify a port")
 
     def __enter__(self):
         """Return the object when a context manager is created."""

--- a/airflow/providers/mongo/hooks/mongo.py
+++ b/airflow/providers/mongo/hooks/mongo.py
@@ -167,7 +167,7 @@ class MongoHook(BaseHook):
                 f"conn_type '{conn_type}' not allowed for MongoHook; conn_type must be 'mongo'"
             )
 
-        if conn.port and "srv" in conn.extra_dejson and conn.extra_dejson["srv"] is True:
+        if conn.port and conn.extra_dejson.get("srv"):
             raise AirflowConfigException("srv URI should not specify a port")
 
     def __enter__(self):

--- a/airflow/providers/mongo/hooks/mongo.py
+++ b/airflow/providers/mongo/hooks/mongo.py
@@ -89,8 +89,17 @@ class MongoHook(BaseHook):
         from wtforms import BooleanField
 
         return {
-            "srv": BooleanField(label=lazy_gettext("SRV mode"), description="checks srv mode"),
-            "allow_insecure": BooleanField(label=lazy_gettext("SRV mode"), description="checks srv mode"),
+            "srv": BooleanField(
+                label=lazy_gettext("SRV Connection"),
+                description="Check if using an SRV/seed list connection, i.e. one that begins with 'mongdb+srv://' (if so, the port field should be left empty)",
+            ),
+            "ssl": BooleanField(
+                label=lazy_gettext("Use SSL"), description="Check to enable SSL/TLS for the connection"
+            ),
+            "allow_insecure": BooleanField(
+                label=lazy_gettext("Allow Invalid Certificates"),
+                description="Check to bypass verification of certificates during SSL/TLS connections (has no effect for non-SSL/TLS connections)",
+            ),
         }
 
     @classmethod
@@ -100,7 +109,7 @@ class MongoHook(BaseHook):
             "hidden_fields": [],
             "relabeling": {"login": "Username", "schema": "Default DB"},
             "placeholders": {
-                "port": "Note: port should not be set when SRV is True",
+                "port": "Note: port should not be set for SRV connections",
             },
         }
 
@@ -151,7 +160,9 @@ class MongoHook(BaseHook):
         conn_type = conn.conn_type
         if conn_type != "mongo":
             if conn_type == "mongodb+srv":
-                raise AirflowException("use srv=true")
+                raise AirflowException(
+                    "Mongo SRV connections should have the conn_type 'mongo' and set 'use_srv=true' in extras"
+                )
             raise AirflowException(
                 f"conn_type '{conn_type}' not allowed for MongoHook; conn_type must be 'mongo'"
             )

--- a/airflow/providers/mongo/hooks/mongo.py
+++ b/airflow/providers/mongo/hooks/mongo.py
@@ -26,7 +26,7 @@ from urllib.parse import quote_plus, urlunsplit
 import pymongo
 from pymongo import MongoClient, ReplaceOne
 
-from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowConfigException, AirflowProviderDeprecationWarning
 from airflow.hooks.base import BaseHook
 
 if TYPE_CHECKING:
@@ -160,15 +160,15 @@ class MongoHook(BaseHook):
         conn_type = conn.conn_type
         if conn_type != "mongo":
             if conn_type == "mongodb+srv":
-                raise AirflowException(
+                raise AirflowConfigException(
                     "Mongo SRV connections should have the conn_type 'mongo' and set 'use_srv=true' in extras"
                 )
-            raise AirflowException(
+            raise AirflowConfigException(
                 f"conn_type '{conn_type}' not allowed for MongoHook; conn_type must be 'mongo'"
             )
 
         if conn.port and "srv" in conn.extra_dejson and conn.extra_dejson["srv"] is True:
-            raise AirflowException("srv URI should not specify a port")
+            raise AirflowConfigException("srv URI should not specify a port")
 
     def __enter__(self):
         """Return the object when a context manager is created."""

--- a/tests/providers/mongo/hooks/test_mongo.py
+++ b/tests/providers/mongo/hooks/test_mongo.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING
 import pymongo
 import pytest
 
-from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowConfigException, AirflowProviderDeprecationWarning
 from airflow.models import Connection
 from airflow.providers.mongo.hooks.mongo import MongoHook
 from tests.test_utils.compat import connection_as_json
@@ -119,19 +119,20 @@ class TestMongoHook:
 
     def test_invalid_conn_type(self):
         with pytest.raises(
-            AirflowException, match="conn_type 'mongodb' not allowed for MongoHook; conn_type must be 'mongo'"
+            AirflowConfigException,
+            match="conn_type 'mongodb' not allowed for MongoHook; conn_type must be 'mongo'",
         ):
             MongoHook(mongo_conn_id="mongo_invalid_conn_type")
 
     def test_invalid_conn_type_srv(self):
         with pytest.raises(
-            AirflowException,
+            AirflowConfigException,
             match="Mongo SRV connections should have the conn_type 'mongo' and set 'use_srv=true' in extras",
         ):
             MongoHook(mongo_conn_id="mongo_invalid_conn_type_srv")
 
     def test_invalid_srv_with_port(self):
-        with pytest.raises(AirflowException, match="srv URI should not specify a port"):
+        with pytest.raises(AirflowConfigException, match="srv URI should not specify a port"):
             MongoHook(mongo_conn_id="mongo_invalid_srv_with_port")
 
     def test_insert_one(self):

--- a/tests/providers/mongo/hooks/test_mongo.py
+++ b/tests/providers/mongo/hooks/test_mongo.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING
 import pymongo
 import pytest
 
-from airflow.exceptions import AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.models import Connection
 from airflow.providers.mongo.hooks.mongo import MongoHook
 from tests.test_utils.compat import connection_as_json
@@ -49,6 +49,15 @@ def mongo_connections():
         Connection(conn_id="mongo_default", conn_type="mongo", host="mongo", port=27017),
         Connection(
             conn_id="mongo_default_with_srv",
+            conn_type="mongo",
+            host="mongo",
+            port=27017,
+            extra='{"srv": true}',
+        ),
+        Connection(conn_id="mongo_invalid_conn_type", conn_type="mongodb", host="mongo", port=27017),
+        Connection(conn_id="mongo_invalid_conn_type_srv", conn_type="mongodb+srv", host="mongo", port=27017),
+        Connection(
+            conn_id="mongo_invalid_srv_with_port",
             conn_type="mongo",
             host="mongo",
             port=27017,
@@ -108,6 +117,20 @@ class TestMongoHook:
     def test_srv(self):
         hook = MongoHook(mongo_conn_id="mongo_default_with_srv")
         assert hook.uri.startswith("mongodb+srv://")
+
+    def test_invalid_conn_type(self):
+        with pytest.raises(
+            AirflowException, match="conn_type 'mongodb' not allowed for MongoHook; conn_type must be 'mongo'"
+        ):
+            MongoHook(mongo_conn_id="mongo_invalid_conn_type")
+
+    def test_invalid_conn_type_srv(self):
+        with pytest.raises(AirflowException, match="use srv=true"):
+            MongoHook(mongo_conn_id="mongo_invalid_conn_type_srv")
+
+    def test_invalid_srv_with_port(self):
+        with pytest.raises(AirflowException, match="srv URI should not specify a port"):
+            MongoHook(mongo_conn_id="mongo_invalid_srv_with_port")
 
     def test_insert_one(self):
         collection = mongomock.MongoClient().db.collection

--- a/tests/providers/mongo/hooks/test_mongo.py
+++ b/tests/providers/mongo/hooks/test_mongo.py
@@ -51,7 +51,6 @@ def mongo_connections():
             conn_id="mongo_default_with_srv",
             conn_type="mongo",
             host="mongo",
-            port=27017,
             extra='{"srv": true}',
         ),
         Connection(conn_id="mongo_invalid_conn_type", conn_type="mongodb", host="mongo", port=27017),
@@ -125,7 +124,10 @@ class TestMongoHook:
             MongoHook(mongo_conn_id="mongo_invalid_conn_type")
 
     def test_invalid_conn_type_srv(self):
-        with pytest.raises(AirflowException, match="use srv=true"):
+        with pytest.raises(
+            AirflowException,
+            match="Mongo SRV connections should have the conn_type 'mongo' and set 'use_srv=true' in extras",
+        ):
             MongoHook(mongo_conn_id="mongo_invalid_conn_type_srv")
 
     def test_invalid_srv_with_port(self):

--- a/tests/providers/mongo/sensors/test_mongo.py
+++ b/tests/providers/mongo/sensors/test_mongo.py
@@ -42,6 +42,7 @@ class TestMongoSensor:
     def test_execute_operator(self, mock_mongo_conn, mock_mongo_find, mock_create_uri):
         mock_mongo_find.return_value = {"test_key": "test"}
         mock_connection = MagicMock(spec=Connection)
+        mock_connection.conn_type = "mongo"
 
         mock_extra_dejson = {"ssl": "false", "srv": "false"}
         mock_connection.extra_dejson = MagicMock(spec=dict)


### PR DESCRIPTION
This change tightens up the Mongo connection UX:

* The `MongoHook` constructor validates the connection object to ensure it is of the correct `conn_type` (`mongo`), raising an exception otherwise
* If the user have set the scheme/conn_type to `mongodb+srv`, the constructor exception provides an informative message telling the user to use the `mongo` conn_type and set `srv=true` in the `extras`
* The UI has been expanded with special boolean widgets for the supported `srv`, `ssl` and `allow_insecure` extra parameters

This is a replacement for #41371 which aimed to improve the Mongo connection parameters in a different and less-functional way.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
