### PR TITLE
Add Airflow 2.10.0 to Provider Compatibility Checks

### DIFF
--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -513,7 +513,13 @@ BASE_PROVIDERS_COMPATIBILITY_CHECKS: list[dict[str, str | list[str]]] = [
     },
     {
         "python-version": "3.8",
-        "airflow-version": "2.9.1",
+        "airflow-version": "2.9.3",
+        "remove-providers": "",
+        "run-tests": "true",
+    },
+    {
+        "python-version": "3.8",
+        "airflow-version": "2.10.0",
         "remove-providers": "",
         "run-tests": "true",
     },


### PR DESCRIPTION
I realized that after we released Airflow 2.10 and made main to be the target development for Airflow 3 line... we did not add a Provider Compatibility Check for Airflow 2.10 line. Also the version 2.9 line was never updated to recent patch releases.

This PR Upgrades the compatibility checks from 2.9.1 to 2.9.3 and adds 2.10.0.