### PR TITLE
AIP-69: Airflow Core adjustments for introduction of Edge Executor

### DIFF
--- a/docs/apache-airflow/core-concepts/executor/index.rst
+++ b/docs/apache-airflow/core-concepts/executor/index.rst
@@ -92,7 +92,7 @@ Airflow tasks are sent to a central queue where remote workers pull tasks to exe
 
 * :doc:`CeleryExecutor <apache-airflow-providers-celery:celery_executor>`
 * :doc:`BatchExecutor <apache-airflow-providers-amazon:executors/batch-executor>`
-
+* :doc:`EdgeExecutor <apache-airflow-providers-edge:edge_executor>` (Experimental Pre-Release)
 
 
 *Containerized Executors*


### PR DESCRIPTION
This PR is a companion to PR #41729 and splits the core adjustments from PoC in PR #40224 and "Mothership" PR #40900.

The PR carries documentation and a small extension to the variables allowing the core to "know" EdgeExecutor. Therefore it is not really a feature but mainly a doc-only change and would propose to add this also to Airflow 2.10 line. Feedback welcome.

Note: Build of docs depends on PR for Provider Package being merged first. (Reference missing)

Note After the discussion the PR is adjusted now from "Remote Executor" to "Edge Executor"