### PR TITLE
Remove deprecation warning for cgitb in Plugins Manager

### DIFF
--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -27,7 +27,6 @@ import logging
 import os
 import sys
 import types
-from cgitb import Hook
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable
 
@@ -78,7 +77,7 @@ operator_extra_links: list[Any] | None = None
 registered_operator_link_classes: dict[str, type] | None = None
 registered_ti_dep_classes: dict[str, type] | None = None
 timetable_classes: dict[str, type[Timetable]] | None = None
-hook_lineage_reader_classes: list[type[Hook]] | None = None
+hook_lineage_reader_classes: list[type[HookLineageReader]] | None = None
 priority_weight_strategy_classes: dict[str, type[PriorityWeightStrategy]] | None = None
 """
 Mapping of class names to class of OperatorLinks registered by plugins.


### PR DESCRIPTION
Recently when running Airflow (locally but probably also when deployed) a lot of warnings are emitted by Plugins Manager like:
```
/opt/airflow/airflow/plugins_manager.py:30 DeprecationWarning: 'cgitb' is deprecated and slated for removal in Python 3.13
```

This is caused by a import in plugins_manager.py - and surprisingly besides this import all other types of the specified list actually use `HookLineageReader` - unable to trace this down, this PR removes the import and traces. Less noise in logs.

As this also will bother all users in Airfow 2.10, I propose to fix this also in the 2.10 code-line