### PR TITLE
Remove deprecated parameters from airflow (core) Operators

### DIFF
--- a/airflow/operators/datetime.py
+++ b/airflow/operators/datetime.py
@@ -17,10 +17,9 @@
 from __future__ import annotations
 
 import datetime
-import warnings
 from typing import TYPE_CHECKING, Iterable
 
-from airflow.exceptions import AirflowException, RemovedInAirflow3Warning
+from airflow.exceptions import AirflowException
 from airflow.operators.branch import BaseBranchOperator
 from airflow.utils import timezone
 
@@ -56,7 +55,6 @@ class BranchDateTimeOperator(BaseBranchOperator):
         target_lower: datetime.datetime | datetime.time | None,
         target_upper: datetime.datetime | datetime.time | None,
         use_task_logical_date: bool = False,
-        use_task_execution_date: bool = False,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -71,13 +69,6 @@ class BranchDateTimeOperator(BaseBranchOperator):
         self.follow_task_ids_if_true = follow_task_ids_if_true
         self.follow_task_ids_if_false = follow_task_ids_if_false
         self.use_task_logical_date = use_task_logical_date
-        if use_task_execution_date:
-            self.use_task_logical_date = use_task_execution_date
-            warnings.warn(
-                "Parameter ``use_task_execution_date`` is deprecated. Use ``use_task_logical_date``.",
-                RemovedInAirflow3Warning,
-                stacklevel=2,
-            )
 
     def choose_branch(self, context: Context) -> str | Iterable[str]:
         if self.use_task_logical_date:

--- a/airflow/operators/trigger_dagrun.py
+++ b/airflow/operators/trigger_dagrun.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import datetime
 import json
 import time
-import warnings
 from typing import TYPE_CHECKING, Any, Sequence, cast
 
 from sqlalchemy import select
@@ -34,7 +33,6 @@ from airflow.exceptions import (
     AirflowSkipException,
     DagNotFound,
     DagRunAlreadyExists,
-    RemovedInAirflow3Warning,
 )
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.baseoperatorlink import BaseOperatorLink
@@ -110,7 +108,6 @@ class TriggerDagRunOperator(BaseOperator):
         DAG for the same logical date already exists.
     :param deferrable: If waiting for completion, whether or not to defer the task until done,
         default is ``False``.
-    :param execution_date: Deprecated parameter; same as ``logical_date``.
     """
 
     template_fields: Sequence[str] = (
@@ -139,7 +136,6 @@ class TriggerDagRunOperator(BaseOperator):
         failed_states: list[str | DagRunState] | None = None,
         skip_when_already_exists: bool = False,
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
-        execution_date: str | datetime.datetime | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -159,14 +155,6 @@ class TriggerDagRunOperator(BaseOperator):
             self.failed_states = [DagRunState.FAILED]
         self.skip_when_already_exists = skip_when_already_exists
         self._defer = deferrable
-
-        if execution_date is not None:
-            warnings.warn(
-                "Parameter 'execution_date' is deprecated. Use 'logical_date' instead.",
-                RemovedInAirflow3Warning,
-                stacklevel=2,
-            )
-            logical_date = execution_date
 
         if logical_date is not None and not isinstance(logical_date, (str, datetime.datetime)):
             type_name = type(logical_date).__name__

--- a/airflow/operators/weekday.py
+++ b/airflow/operators/weekday.py
@@ -17,10 +17,8 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Iterable
 
-from airflow.exceptions import RemovedInAirflow3Warning
 from airflow.operators.branch import BaseBranchOperator
 from airflow.utils import timezone
 from airflow.utils.weekday import WeekDay
@@ -91,7 +89,6 @@ class BranchDayOfWeekOperator(BaseBranchOperator):
     :param use_task_logical_date: If ``True``, uses task's logical date to compare
         with is_today. Execution Date is Useful for backfilling.
         If ``False``, uses system's day of the week.
-    :param use_task_execution_day: deprecated parameter, same effect as `use_task_logical_date`
     """
 
     def __init__(
@@ -101,7 +98,6 @@ class BranchDayOfWeekOperator(BaseBranchOperator):
         follow_task_ids_if_false: str | Iterable[str],
         week_day: str | Iterable[str] | WeekDay | Iterable[WeekDay],
         use_task_logical_date: bool = False,
-        use_task_execution_day: bool = False,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -109,13 +105,6 @@ class BranchDayOfWeekOperator(BaseBranchOperator):
         self.follow_task_ids_if_false = follow_task_ids_if_false
         self.week_day = week_day
         self.use_task_logical_date = use_task_logical_date
-        if use_task_execution_day:
-            self.use_task_logical_date = use_task_execution_day
-            warnings.warn(
-                "Parameter ``use_task_execution_day`` is deprecated. Use ``use_task_logical_date``.",
-                RemovedInAirflow3Warning,
-                stacklevel=2,
-            )
         self._week_day_num = WeekDay.validate_week_day(week_day)
 
     def choose_branch(self, context: Context) -> str | Iterable[str]:

--- a/newsfragments/41736.significant.rst
+++ b/newsfragments/41736.significant.rst
@@ -1,0 +1,7 @@
+Removed deprecated parameters from core-operators.
+
+Parameters removed:
+
+- airflow.operators.datetime.BranchDateTimeOperator: use_task_execution_date
+- airflow.operators.trigger_dagrun.TriggerDagRunOperator: execution_date
+- airflow.operators.weekday.BranchDayOfWeekOperator: use_task_execution_day

--- a/tests/operators/test_datetime.py
+++ b/tests/operators/test_datetime.py
@@ -253,19 +253,3 @@ class TestBranchDateTimeOperator:
                 "branch_2": State.SKIPPED,
             }
         )
-
-    def test_deprecation_warning(self):
-        warning_message = (
-            """Parameter ``use_task_execution_date`` is deprecated. Use ``use_task_logical_date``."""
-        )
-        with pytest.warns(DeprecationWarning) as warnings:
-            BranchDateTimeOperator(
-                task_id="warning",
-                follow_task_ids_if_true="branch_1",
-                follow_task_ids_if_false="branch_2",
-                target_upper=timezone.datetime(2020, 7, 7, 10, 30, 0),
-                target_lower=timezone.datetime(2020, 7, 7, 10, 30, 0),
-                use_task_execution_date=True,
-                dag=self.dag,
-            )
-        assert warning_message == str(warnings[0].message)

--- a/tests/operators/test_weekday.py
+++ b/tests/operators/test_weekday.py
@@ -285,23 +285,3 @@ class TestBranchDayOfWeekOperator:
         for ti in tis:
             if ti.task_id == "make_choice":
                 assert ti.xcom_pull(task_ids="make_choice") == "branch_1"
-
-    def test_deprecation_warning(self, dag_maker):
-        warning_message = (
-            """Parameter ``use_task_execution_day`` is deprecated. Use ``use_task_logical_date``."""
-        )
-        with pytest.warns(DeprecationWarning) as warnings:
-            with dag_maker(
-                "branch_day_of_week_operator_test",
-                start_date=DEFAULT_DATE,
-                schedule=INTERVAL,
-                serialized=True,
-            ):
-                BranchDayOfWeekOperator(
-                    task_id="week_day_warn",
-                    follow_task_ids_if_true="branch_1",
-                    follow_task_ids_if_false="branch_2",
-                    week_day="Monday",
-                    use_task_execution_day=True,
-                )
-        assert warning_message == str(warnings[0].message)


### PR DESCRIPTION
Cleanup as deprecation promised for Airflow 3

Note: Python Operators are already in PR https://github.com/apache/airflow/pull/41493