### PR TITLE
Removed deprecated method reference airflow.www.auth.has_access when min airflow version >= 2.8.0

### DIFF
--- a/airflow/providers/databricks/plugins/databricks_workflow.py
+++ b/airflow/providers/databricks/plugins/databricks_workflow.py
@@ -24,7 +24,6 @@ from urllib.parse import unquote
 
 from flask import current_app, flash, redirect, request, url_for
 from flask_appbuilder.api import expose
-from packaging.version import Version
 
 from airflow.exceptions import AirflowException, TaskInstanceNotFound
 from airflow.models import BaseOperator, BaseOperatorLink
@@ -34,13 +33,11 @@ from airflow.models.taskinstance import TaskInstance, TaskInstanceKey
 from airflow.models.xcom import XCom
 from airflow.plugins_manager import AirflowPlugin
 from airflow.providers.databricks.hooks.databricks import DatabricksHook
-from airflow.security import permissions
 from airflow.utils.airflow_flask_app import AirflowApp
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import TaskInstanceState
 from airflow.utils.task_group import TaskGroup
-from airflow.version import version
 from airflow.www import auth
 from airflow.www.views import AirflowBaseView
 
@@ -55,15 +52,6 @@ airflow_app = cast(AirflowApp, current_app)
 
 
 def get_auth_decorator():
-    # TODO: remove this if block when min_airflow_version is set to higher than 2.8.0
-    if Version(version) < Version("2.8"):
-        return auth.has_access(
-            [
-                (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG),
-                (permissions.ACTION_CAN_CREATE, permissions.RESOURCE_DAG_RUN),
-            ]
-        )
-
     from airflow.auth.managers.models.resource_details import DagAccessEntity
 
     return auth.has_access_dag("POST", DagAccessEntity.RUN)


### PR DESCRIPTION
Removed deprecated method reference airflow.www.auth.has_access when min airflow version >= 2.8.0

This should be merged before #41738