### PR TITLE
Set end_date and duration for triggers completed with end_from_trigger as True

### DIFF
--- a/airflow/triggers/base.py
+++ b/airflow/triggers/base.py
@@ -203,7 +203,7 @@ class BaseTaskEndEvent(TriggerEvent):
         """
         # Mark the task with terminal state and prevent it from resuming on worker
         task_instance.trigger_id = None
-        task_instance.state = self.task_instance_state
+        task_instance.set_state(self.task_instance_state, session=session)
         self._submit_callback_if_necessary(task_instance=task_instance, session=session)
         self._push_xcoms_if_necessary(task_instance=task_instance)
 


### PR DESCRIPTION
closes: #41613
related: #41613

Use `set_state` instead of directly setting the state which will set end_date and duration attribute for the task_instance.

