### PR TITLE
Feature/add pgbouncer and statsd ingress

### DIFF
--- a/chart/templates/pgbouncer/pgbouncer-ingress.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-ingress.yaml
@@ -1,0 +1,87 @@
+{{/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/}}
+
+################################
+## Airflow Pgbouncer Ingress
+#################################
+{{- if and .Values.pgbouncer.enabled .Values.ingress.pgbouncer.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "airflow.fullname" . }}-pgbouncer-ingress
+  labels:
+    tier: airflow
+    component: pgbouncer-ingress
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    {{- with .Values.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.ingress.pgbouncer.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.pgbouncer.hosts (.Values.ingress.pgbouncer.hosts | first | kindIs "string" | not) }}
+  {{- $anyTlsHosts := false -}}
+  {{- range .Values.ingress.pgbouncer.hosts }}
+  {{- if .tls }}
+  {{- if .tls.enabled }}
+  {{- $anyTlsHosts = true -}}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- if $anyTlsHosts }}
+  tls:
+  {{- range .Values.ingress.pgbouncer.hosts }}
+  {{- if .tls }}
+  {{- if .tls.enabled }}
+    - hosts:
+        - {{ .name | quote }}
+      secretName: {{ .tls.secretName }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.pgbouncer.hosts | default (list .Values.ingress.pgbouncer.host) }}
+    - http:
+        paths:
+          - backend:
+              service:
+                name: {{ $.Release.Name }}-pgbouncer
+                port:
+                  name: pgbouncer-metrics
+            {{- if $.Values.ingress.pgbouncer.path }}
+            path: {{ $.Values.ingress.pgbouncer.path }}
+            pathType: {{ $.Values.ingress.pgbouncer.pathType }}
+            {{- end }}
+      {{- $hostname := . -}}
+      {{- if . | kindIs "string" | not }}
+      {{- $hostname = .name -}}
+      {{- end }}
+      {{- if $hostname }}
+      host: {{ tpl $hostname $ | quote }}
+      {{- end }}
+    {{- end }}
+  {{- if .Values.ingress.pgbouncer.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.pgbouncer.ingressClassName }}
+  {{- end }}
+{{- end }}

--- a/chart/templates/pgbouncer/pgbouncer-ingress.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-ingress.yaml
@@ -68,7 +68,7 @@ spec:
               service:
                 name: {{ $.Release.Name }}-pgbouncer
                 port:
-                  name: pgbouncer-metrics
+                  name: pgb-metrics
             {{- if $.Values.ingress.pgbouncer.path }}
             path: {{ $.Values.ingress.pgbouncer.path }}
             pathType: {{ $.Values.ingress.pgbouncer.pathType }}

--- a/chart/templates/pgbouncer/pgbouncer-service.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-service.yaml
@@ -53,7 +53,7 @@ spec:
     - name: pgbouncer
       protocol: TCP
       port: {{ .Values.ports.pgbouncer }}
-    - name: pgbouncer-metrics
+    - name: pgb-metrics
       protocol: TCP
       port: {{ .Values.ports.pgbouncerScrape }}
 {{- end }}

--- a/chart/templates/statsd/statsd-ingress.yaml
+++ b/chart/templates/statsd/statsd-ingress.yaml
@@ -68,7 +68,7 @@ spec:
               service:
                 name: {{ $.Release.Name }}-statsd
                 port:
-                  name: statsd-metrics
+                  name: statsd-scrape
             {{- if $.Values.ingress.statsd.path }}
             path: {{ $.Values.ingress.statsd.path }}
             pathType: {{ $.Values.ingress.statsd.pathType }}

--- a/chart/templates/statsd/statsd-ingress.yaml
+++ b/chart/templates/statsd/statsd-ingress.yaml
@@ -1,0 +1,87 @@
+{{/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/}}
+
+################################
+## Airflow Statsd Ingress
+#################################
+{{- if and .Values.statsd.enabled .Values.ingress.statsd.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "airflow.fullname" . }}-statsd-ingress
+  labels:
+    tier: airflow
+    component: statsd-ingress
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    {{- with .Values.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.ingress.statsd.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.statsd.hosts (.Values.ingress.statsd.hosts | first | kindIs "string" | not) }}
+  {{- $anyTlsHosts := false -}}
+  {{- range .Values.ingress.statsd.hosts }}
+  {{- if .tls }}
+  {{- if .tls.enabled }}
+  {{- $anyTlsHosts = true -}}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- if $anyTlsHosts }}
+  tls:
+  {{- range .Values.ingress.statsd.hosts }}
+  {{- if .tls }}
+  {{- if .tls.enabled }}
+    - hosts:
+        - {{ .name | quote }}
+      secretName: {{ .tls.secretName }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.statsd.hosts | default (list .Values.ingress.statsd.host) }}
+    - http:
+        paths:
+          - backend:
+              service:
+                name: {{ $.Release.Name }}-statsd
+                port:
+                  name: statsd-metrics
+            {{- if $.Values.ingress.statsd.path }}
+            path: {{ $.Values.ingress.statsd.path }}
+            pathType: {{ $.Values.ingress.statsd.pathType }}
+            {{- end }}
+      {{- $hostname := . -}}
+      {{- if . | kindIs "string" | not }}
+      {{- $hostname = .name -}}
+      {{- end }}
+      {{- if $hostname }}
+      host: {{ tpl $hostname $ | quote }}
+      {{- end }}
+    {{- end }}
+  {{- if .Values.ingress.statsd.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.statsd.ingressClassName }}
+  {{- end }}
+{{- end }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -452,6 +452,176 @@
                             }
                         }
                     }
+                },
+                "statsd": {
+                    "description": "Configuration for the Ingress of the statsd Service.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": {
+                            "description": "Enable statsd ingress resource.",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "annotations": {
+                            "description": "Annotations for the statsd Ingress.",
+                            "type": "object",
+                            "default": {},
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        },
+                        "path": {
+                            "description": "The path for the statsd Ingress.",
+                            "type": "string",
+                            "default": "/metrics"
+                        },
+                        "pathType": {
+                            "description": "The pathType for the statsd Ingress (required for Kubernetes 1.19 and above).",
+                            "type": "string",
+                            "default": "ImplementationSpecific"
+                        },
+                        "host": {
+                            "description": "The hostname for the statsd Ingress. (Deprecated - renamed to `ingress.statsd.hosts`)",
+                            "type": "string",
+                            "default": ""
+                        },
+                        "hosts": {
+                            "description": "The hostnames or hosts configuration for the statsd Ingress.",
+                            "type": "array",
+                            "default": [],
+                            "items": {
+                                "oneOf": [
+                                    {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "name": {
+                                                "description": "The hostname for the web Ingress.",
+                                                "type": "string",
+                                                "default": ""
+                                            },
+                                            "tls": {
+                                                "description": "Configuration for web Ingress TLS.",
+                                                "type": "object",
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "enabled": {
+                                                        "description": "Enable TLS termination for the web Ingress.",
+                                                        "type": "boolean",
+                                                        "default": false
+                                                    },
+                                                    "secretName": {
+                                                        "description": "The name of a pre-created Secret containing a TLS private key and certificate.",
+                                                        "type": "string",
+                                                        "default": ""
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ]
+                                    },
+                                    {
+                                        "type": "string",
+                                        "default": "",
+                                        "$comment": "Deprecated by object above"
+                                    }
+                                ]
+                            }
+                        },
+                        "ingressClassName": {
+                            "description": "The Ingress Class for the statsd Ingress.",
+                            "type": "string",
+                            "default": ""
+                        }
+                    }
+                },
+                "pgbouncer": {
+                    "description": "Configuration for the Ingress of the pgbouncer Service.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": {
+                            "description": "Enable pgbouncer ingress resource.",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "annotations": {
+                            "description": "Annotations for the pgbouncer Ingress.",
+                            "type": "object",
+                            "default": {},
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        },
+                        "path": {
+                            "description": "The path for the pgbouncer Ingress.",
+                            "type": "string",
+                            "default": "/metrics"
+                        },
+                        "pathType": {
+                            "description": "The pathType for the pgbouncer Ingress (required for Kubernetes 1.19 and above).",
+                            "type": "string",
+                            "default": "ImplementationSpecific"
+                        },
+                        "host": {
+                            "description": "The hostname for the pgbouncer Ingress. (Deprecated - renamed to `ingress.pgbouncer.hosts`)",
+                            "type": "string",
+                            "default": ""
+                        },
+                        "hosts": {
+                            "description": "The hostnames or hosts configuration for the pgbouncer Ingress.",
+                            "type": "array",
+                            "default": [],
+                            "items": {
+                                "oneOf": [
+                                    {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "name": {
+                                                "description": "The hostname for the web Ingress.",
+                                                "type": "string",
+                                                "default": ""
+                                            },
+                                            "tls": {
+                                                "description": "Configuration for web Ingress TLS.",
+                                                "type": "object",
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "enabled": {
+                                                        "description": "Enable TLS termination for the web Ingress.",
+                                                        "type": "boolean",
+                                                        "default": false
+                                                    },
+                                                    "secretName": {
+                                                        "description": "The name of a pre-created Secret containing a TLS private key and certificate.",
+                                                        "type": "string",
+                                                        "default": ""
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ]
+                                    },
+                                    {
+                                        "type": "string",
+                                        "default": "",
+                                        "$comment": "Deprecated by object above"
+                                    }
+                                ]
+                            }
+                        },
+                        "ingressClassName": {
+                            "description": "The Ingress Class for the pgbouncer Ingress.",
+                            "type": "string",
+                            "default": ""
+                        }
+                    }
                 }
             }
         },

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -539,17 +539,17 @@
                     }
                 },
                 "pgbouncer": {
-                    "description": "Configuration for the Ingress of the pgbouncer Service.",
+                    "description": "Configuration for the Ingress of the PgBouncer Service.",
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
                         "enabled": {
-                            "description": "Enable pgbouncer ingress resource.",
+                            "description": "Enable PgBouncer ingress resource.",
                             "type": "boolean",
                             "default": false
                         },
                         "annotations": {
-                            "description": "Annotations for the pgbouncer Ingress.",
+                            "description": "Annotations for the PgBouncer Ingress.",
                             "type": "object",
                             "default": {},
                             "additionalProperties": {
@@ -557,22 +557,22 @@
                             }
                         },
                         "path": {
-                            "description": "The path for the pgbouncer Ingress.",
+                            "description": "The path for the PgBouncer Ingress.",
                             "type": "string",
                             "default": "/metrics"
                         },
                         "pathType": {
-                            "description": "The pathType for the pgbouncer Ingress (required for Kubernetes 1.19 and above).",
+                            "description": "The pathType for the PgBouncer Ingress (required for Kubernetes 1.19 and above).",
                             "type": "string",
                             "default": "ImplementationSpecific"
                         },
                         "host": {
-                            "description": "The hostname for the pgbouncer Ingress. (Deprecated - renamed to `ingress.pgbouncer.hosts`)",
+                            "description": "The hostname for the PgBouncer Ingress. (Deprecated - renamed to `ingress.pgbouncer.hosts`)",
                             "type": "string",
                             "default": ""
                         },
                         "hosts": {
-                            "description": "The hostnames or hosts configuration for the pgbouncer Ingress.",
+                            "description": "The hostnames or hosts configuration for the PgBouncer Ingress.",
                             "type": "array",
                             "default": [],
                             "items": {
@@ -617,7 +617,7 @@
                             }
                         },
                         "ingressClassName": {
-                            "description": "The Ingress Class for the pgbouncer Ingress.",
+                            "description": "The Ingress Class for the PgBouncer Ingress.",
                             "type": "string",
                             "default": ""
                         }

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -222,7 +222,7 @@ ingress:
       # the name of a pre-created Secret containing a TLS private key and certificate
       secretName: ""
 
-  # Configs for the Ingress of the flower Service
+  # Configs for the Ingress of the statsd Service
   statsd:
     # Enable web ingress resource
     enabled: false
@@ -252,7 +252,7 @@ ingress:
     # The Ingress Class for the statsd Ingress (used only with Kubernetes v1.19 and above)
     ingressClassName: ""
 
-  # Configs for the Ingress of the flower Service
+  # Configs for the Ingress of the pgbouncer Service
   pgbouncer:
     # Enable web ingress resource
     enabled: false

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -222,6 +222,66 @@ ingress:
       # the name of a pre-created Secret containing a TLS private key and certificate
       secretName: ""
 
+  # Configs for the Ingress of the flower Service
+  statsd:
+    # Enable web ingress resource
+    enabled: false
+
+    # Annotations for the statsd Ingress
+    annotations: {}
+
+    # The path for the statsd Ingress
+    path: "/metrics"
+
+    # The pathType for the above path (used only with Kubernetes v1.19 and above)
+    pathType: "ImplementationSpecific"
+
+    # The hostname for the statsd Ingress (Deprecated - renamed to `ingress.statsd.hosts`)
+    host: ""
+
+    # The hostnames or hosts configuration for the statsd Ingress
+    hosts: []
+    #   # The hostname for the statsd Ingress (can be templated)
+    # - name: ""
+    #   tls:
+    #     # Enable TLS termination for the statsd Ingress
+    #     enabled: false
+    #     # the name of a pre-created Secret containing a TLS private key and certificate
+    #     secretName: ""
+
+    # The Ingress Class for the statsd Ingress (used only with Kubernetes v1.19 and above)
+    ingressClassName: ""
+
+  # Configs for the Ingress of the flower Service
+  pgbouncer:
+    # Enable web ingress resource
+    enabled: false
+
+    # Annotations for the pgbouncer Ingress
+    annotations: {}
+
+    # The path for the pgbouncer Ingress
+    path: "/metrics"
+
+    # The pathType for the above path (used only with Kubernetes v1.19 and above)
+    pathType: "ImplementationSpecific"
+
+    # The hostname for the pgbouncer Ingress (Deprecated - renamed to `ingress.pgbouncer.hosts`)
+    host: ""
+
+    # The hostnames or hosts configuration for the pgbouncer Ingress
+    hosts: []
+    #   # The hostname for the statsd Ingress (can be templated)
+    # - name: ""
+    #   tls:
+    #     # Enable TLS termination for the pgbouncer Ingress
+    #     enabled: false
+    #     # the name of a pre-created Secret containing a TLS private key and certificate
+    #     secretName: ""
+
+    # The Ingress Class for the pgbouncer Ingress (used only with Kubernetes v1.19 and above)
+    ingressClassName: ""
+
 # Network policy configuration
 networkPolicies:
   # Enabled network policies

--- a/helm_tests/other/test_pgbouncer.py
+++ b/helm_tests/other/test_pgbouncer.py
@@ -852,6 +852,7 @@ class TestPgbouncerIngress:
                         "hosts": [
                             {"name": "some-host", "tls": {"enabled": True, "secretName": "some-secret"}}
                         ],
+                        "ingressClassName": "ingress-class",
                     }
                 },
             },
@@ -866,3 +867,4 @@ class TestPgbouncerIngress:
         assert {"hosts": ["some-host"], "secretName": "some-secret"} == jmespath.search(
             "spec.tls[0]", docs[0]
         )
+        assert "ingress-class" == jmespath.search("spec.ingressClassName", docs[0])

--- a/helm_tests/other/test_pgbouncer.py
+++ b/helm_tests/other/test_pgbouncer.py
@@ -62,7 +62,7 @@ class TestPgbouncer:
         assert {"name": "pgbouncer", "protocol": "TCP", "port": 6543} in jmespath.search(
             "spec.ports", docs[0]
         )
-        assert {"name": "pgbouncer-metrics", "protocol": "TCP", "port": 9127} in jmespath.search(
+        assert {"name": "pgb-metrics", "protocol": "TCP", "port": 9127} in jmespath.search(
             "spec.ports", docs[0]
         )
 
@@ -80,7 +80,7 @@ class TestPgbouncer:
         assert {"name": "pgbouncer", "protocol": "TCP", "port": 1111} in jmespath.search(
             "spec.ports", docs[0]
         )
-        assert {"name": "pgbouncer-metrics", "protocol": "TCP", "port": 2222} in jmespath.search(
+        assert {"name": "pgb-metrics", "protocol": "TCP", "port": 2222} in jmespath.search(
             "spec.ports", docs[0]
         )
 
@@ -859,7 +859,7 @@ class TestPgbouncerIngress:
             show_only=["templates/pgbouncer/pgbouncer-ingress.yaml"],
         )
 
-        assert {"name": "release-name-pgbouncer", "port": {"name": "pgbouncer-metrics"}} == jmespath.search(
+        assert {"name": "release-name-pgbouncer", "port": {"name": "pgb-metrics"}} == jmespath.search(
             "spec.rules[0].http.paths[0].backend.service", docs[0]
         )
         assert "/metrics" == jmespath.search("spec.rules[0].http.paths[0].path", docs[0])

--- a/helm_tests/other/test_statsd.py
+++ b/helm_tests/other/test_statsd.py
@@ -398,7 +398,7 @@ class TestStatsdIngress:
             show_only=["templates/statsd/statsd-ingress.yaml"],
         )
 
-        assert {"name": "release-name-statsd", "port": {"name": "statsd-metrics"}} == jmespath.search(
+        assert {"name": "release-name-statsd", "port": {"name": "statsd-scrape"}} == jmespath.search(
             "spec.rules[0].http.paths[0].backend.service", docs[0]
         )
         assert "/metrics" == jmespath.search("spec.rules[0].http.paths[0].path", docs[0])

--- a/helm_tests/other/test_statsd.py
+++ b/helm_tests/other/test_statsd.py
@@ -391,6 +391,7 @@ class TestStatsdIngress:
                         "hosts": [
                             {"name": "some-host", "tls": {"enabled": True, "secretName": "some-secret"}}
                         ],
+                        "ingressClassName": "ingress-class",
                     }
                 },
             },
@@ -405,3 +406,4 @@ class TestStatsdIngress:
         assert {"hosts": ["some-host"], "secretName": "some-secret"} == jmespath.search(
             "spec.tls[0]", docs[0]
         )
+        assert "ingress-class" == jmespath.search("spec.ingressClassName", docs[0])


### PR DESCRIPTION
Today pgbouncer and statsd expose /metrics route but we cannot access it outside the cluster.
This PR adds an ingress to pgbouncer and statsd (same as webUI and flower)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
