### PR TITLE
Remove deprecations in airflow.models.skipmixin

### DIFF
--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -32,7 +32,7 @@ from abc import ABCMeta, abstractmethod
 from collections.abc import Container
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING, Any, Callable, Collection, Iterable, Mapping, NamedTuple, Sequence, cast
+from typing import TYPE_CHECKING, Any, Callable, Collection, Iterable, Mapping, NamedTuple, Sequence
 
 import lazy_object_proxy
 
@@ -63,8 +63,6 @@ from airflow.utils.session import create_session
 log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from pendulum.datetime import DateTime
-
     from airflow.serialization.enums import Encoding
     from airflow.utils.context import Context
 
@@ -341,7 +339,6 @@ class ShortCircuitOperator(PythonOperator, SkipMixin):
 
         self.skip(
             dag_run=dag_run,
-            execution_date=cast("DateTime", dag_run.execution_date),
             tasks=to_skip,
             map_index=context["ti"].map_index,
         )

--- a/newsfragments/41780.significant.rst
+++ b/newsfragments/41780.significant.rst
@@ -1,0 +1,1 @@
+Remove deprecated support for passing ``execution_date`` to ``airflow.models.skipmixin.SkipMixin.skip()``.

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -2098,7 +2098,6 @@ class TestShortCircuitWithTeardown:
             # we can't use assert_called_with because it's a set and therefore not ordered
             actual_kwargs = op1.skip.call_args.kwargs
             actual_skipped = set(actual_kwargs["tasks"])
-            assert actual_kwargs["execution_date"] == dagrun.logical_date
             assert actual_skipped == {op3}
 
     @pytest.mark.skip_if_database_isolation_mode  # tests pure logic with run() method, mix of pydantic and mock fails
@@ -2139,7 +2138,6 @@ class TestShortCircuitWithTeardown:
             else:
                 assert isinstance(actual_skipped, Generator)
             assert set(actual_skipped) == {op3}
-            assert actual_kwargs["execution_date"] == dagrun.logical_date
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Code cleanup and removal of deprecations in `airflow.models.skipmixin`