### PR TITLE
fix: revert behavior of flattening lists in OpenLineage's InfoJsonEncodable

### DIFF
--- a/airflow/providers/openlineage/utils/utils.py
+++ b/airflow/providers/openlineage/utils/utils.py
@@ -199,7 +199,7 @@ class InfoJsonEncodable(dict):
             return value.isoformat()
         if isinstance(value, datetime.timedelta):
             return f"{value.total_seconds()} seconds"
-        if isinstance(value, (set, tuple)):
+        if isinstance(value, (set, list, tuple)):
             return str(list(value))
         return value
 

--- a/tests/providers/openlineage/plugins/test_utils.py
+++ b/tests/providers/openlineage/plugins/test_utils.py
@@ -164,7 +164,7 @@ def test_info_json_encodable_without_slots():
     }
 
 
-def test_info_json_encodable_list_does_not_flatten():
+def test_info_json_encodable_list_does_flatten():
     class TestInfo(InfoJsonEncodable):
         includes = ["alist"]
 
@@ -174,7 +174,7 @@ def test_info_json_encodable_list_does_not_flatten():
 
     obj = Test(["a", "b", "c"])
 
-    assert json.loads(json.dumps(TestInfo(obj))) == {"alist": ["a", "b", "c"]}
+    assert json.loads(json.dumps(TestInfo(obj))) == {"alist": "['a', 'b', 'c']"}
 
 
 def test_info_json_encodable_list_does_include_nonexisting():

--- a/tests/providers/openlineage/utils/test_utils.py
+++ b/tests/providers/openlineage/utils/test_utils.py
@@ -142,7 +142,7 @@ def test_get_airflow_dag_run_facet():
         "owner": "airflow",
         "timetable": {},
         "start_date": "2024-06-01T00:00:00+00:00",
-        "tags": ["test"],
+        "tags": "['test']",
     }
     if hasattr(dag, "schedule_interval"):  # Airflow 2 compat.
         expected_dag_info["schedule_interval"] = "@once"


### PR DESCRIPTION
This reverts back to the behavior that was mistakenly changed in https://github.com/apache/airflow/pull/40371/files#diff-81a199a7e08fbc41cf7960d2725937b3dcfa2694368196681dfe82e3677fed0eL153

This did not match the jsonschema spec of the facet: https://github.com/apache/airflow/blob/9674af5f88929f5057158241330f4ef4fd08beb2/airflow/providers/openlineage/facets/AirflowDagRunFacet.json.

In the near future, we'd like to autogenerate those facets directly from spec as we're already using in `openlineage-python`. However, in the meantime, let's manually fix the error.