### PR TITLE
Setup ui rest api

### DIFF
--- a/airflow/api_ui/__init__.py
+++ b/airflow/api_ui/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/api_ui/app.py
+++ b/airflow/api_ui/app.py
@@ -16,12 +16,9 @@
 # under the License.
 from __future__ import annotations
 
-import os
-
 from fastapi import FastAPI
 
-from airflow.models.dagbag import DagBag
-from airflow.settings import DAGS_FOLDER
+from airflow.www.extensions.init_dagbag import get_dag_bag
 
 
 def init_dag_bag(app: FastAPI) -> None:
@@ -30,10 +27,7 @@ def init_dag_bag(app: FastAPI) -> None:
 
     To access it use ``request.app.state.dag_bag``.
     """
-    if os.environ.get("SKIP_DAGS_PARSING") == "True":
-        app.state.dag_bag = DagBag(os.devnull, include_examples=False)
-    else:
-        app.state.dag_bag = DagBag(DAGS_FOLDER, read_dags_from_db=True)
+    app.state.dag_bag = get_dag_bag()
 
 
 def create_app() -> FastAPI:

--- a/airflow/api_ui/main.py
+++ b/airflow/api_ui/main.py
@@ -1,0 +1,116 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import os
+
+from fastapi import APIRouter, FastAPI, HTTPException, Request
+from sqlalchemy import and_, func, select
+
+from airflow.models import DagModel
+from airflow.models.dagbag import DagBag
+from airflow.models.dataset import DagScheduleDatasetReference, DatasetDagRunQueue, DatasetEvent, DatasetModel
+from airflow.settings import DAGS_FOLDER
+from airflow.utils.session import create_session
+
+
+def init_dag_bag(app: FastAPI) -> None:
+    """
+    Create global DagBag for the FastAPI application.
+
+    To access it use ``request.app.state.dag_bag``.
+    """
+    if os.environ.get("SKIP_DAGS_PARSING") == "True":
+        app.state.dag_bag = DagBag(os.devnull, include_examples=False)
+    else:
+        app.state.dag_bag = DagBag(DAGS_FOLDER, read_dags_from_db=True)
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(
+        description="Internal Rest API for the UI frontend. It shouldn't be used and is subject to breaking "
+        "change if needed by the front-end. Users should use the public API instead."
+    )
+
+    init_dag_bag(app)
+
+    return app
+
+
+app = create_app()
+
+
+router = APIRouter(prefix="/ui", tags=["UI"])
+
+
+# Ultimately we want an async route, with async sqlalchemy session / context manager.
+# Additional effort, not handled for now and most likely part of the AIP-70
+@router.get("/next_run_datasets/{dag_id}")
+def next_run_datasets(dag_id: str, request: Request) -> dict:
+    dag = request.app.state.dag_bag.get_dag(dag_id)
+
+    if not dag:
+        raise HTTPException(404, f"can't find dag {dag_id}")
+
+    with create_session() as session:
+        dag_model = DagModel.get_dagmodel(dag_id, session=session)
+
+        if dag_model is None:
+            raise HTTPException(404, f"can't find associated dag_model {dag_id}")
+
+        latest_run = dag_model.get_last_dagrun(session=session)
+
+        events = [
+            dict(info._mapping)
+            for info in session.execute(
+                select(
+                    DatasetModel.id,
+                    DatasetModel.uri,
+                    func.max(DatasetEvent.timestamp).label("lastUpdate"),
+                )
+                .join(DagScheduleDatasetReference, DagScheduleDatasetReference.dataset_id == DatasetModel.id)
+                .join(
+                    DatasetDagRunQueue,
+                    and_(
+                        DatasetDagRunQueue.dataset_id == DatasetModel.id,
+                        DatasetDagRunQueue.target_dag_id == DagScheduleDatasetReference.dag_id,
+                    ),
+                    isouter=True,
+                )
+                .join(
+                    DatasetEvent,
+                    and_(
+                        DatasetEvent.dataset_id == DatasetModel.id,
+                        (
+                            DatasetEvent.timestamp >= latest_run.execution_date
+                            if latest_run and latest_run.execution_date
+                            else True
+                        ),
+                    ),
+                    isouter=True,
+                )
+                .where(DagScheduleDatasetReference.dag_id == dag_id, ~DatasetModel.is_orphaned)
+                .group_by(DatasetModel.id, DatasetModel.uri)
+                .order_by(DatasetModel.uri)
+            )
+        ]
+        data = {"dataset_expression": dag_model.dataset_expression, "events": events}
+        return data
+
+
+app.include_router(router)

--- a/airflow/api_ui/views/__init__.py
+++ b/airflow/api_ui/views/__init__.py
@@ -14,19 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-from __future__ import annotations
-
-from fastapi import APIRouter
-
-from airflow.api_ui.app import create_app
-from airflow.api_ui.views.datasets import dataset_router
-
-app = create_app()
-
-root_router = APIRouter(prefix="/ui")
-
-root_router.include_router(dataset_router)
-
-
-app.include_router(root_router)

--- a/airflow/api_ui/views/datasets.py
+++ b/airflow/api_ui/views/datasets.py
@@ -1,0 +1,82 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+from sqlalchemy import and_, func, select
+
+from airflow.models import DagModel
+from airflow.models.dataset import DagScheduleDatasetReference, DatasetDagRunQueue, DatasetEvent, DatasetModel
+from airflow.utils.session import create_session
+
+dataset_router = APIRouter(tags=["Dataset"])
+
+
+# Ultimately we want async routes, with async sqlalchemy session / context manager.
+# Additional effort to make airflow utility code async, not handled for now and most likely part of the AIP-70
+@dataset_router.get("/next_run_datasets/{dag_id}")
+def next_run_datasets(dag_id: str, request: Request) -> dict:
+    dag = request.app.state.dag_bag.get_dag(dag_id)
+
+    if not dag:
+        raise HTTPException(404, f"can't find dag {dag_id}")
+
+    with create_session() as session:
+        dag_model = DagModel.get_dagmodel(dag_id, session=session)
+
+        if dag_model is None:
+            raise HTTPException(404, f"can't find associated dag_model {dag_id}")
+
+        latest_run = dag_model.get_last_dagrun(session=session)
+
+        events = [
+            dict(info._mapping)
+            for info in session.execute(
+                select(
+                    DatasetModel.id,
+                    DatasetModel.uri,
+                    func.max(DatasetEvent.timestamp).label("lastUpdate"),
+                )
+                .join(DagScheduleDatasetReference, DagScheduleDatasetReference.dataset_id == DatasetModel.id)
+                .join(
+                    DatasetDagRunQueue,
+                    and_(
+                        DatasetDagRunQueue.dataset_id == DatasetModel.id,
+                        DatasetDagRunQueue.target_dag_id == DagScheduleDatasetReference.dag_id,
+                    ),
+                    isouter=True,
+                )
+                .join(
+                    DatasetEvent,
+                    and_(
+                        DatasetEvent.dataset_id == DatasetModel.id,
+                        (
+                            DatasetEvent.timestamp >= latest_run.execution_date
+                            if latest_run and latest_run.execution_date
+                            else True
+                        ),
+                    ),
+                    isouter=True,
+                )
+                .where(DagScheduleDatasetReference.dag_id == dag_id, ~DatasetModel.is_orphaned)
+                .group_by(DatasetModel.id, DatasetModel.uri)
+                .order_by(DatasetModel.uri)
+            )
+        ]
+        data = {"dataset_expression": dag_model.dataset_expression, "events": events}
+        return data

--- a/airflow/www/extensions/init_dagbag.py
+++ b/airflow/www/extensions/init_dagbag.py
@@ -22,13 +22,17 @@ from airflow.models import DagBag
 from airflow.settings import DAGS_FOLDER
 
 
+def get_dag_bag() -> DagBag:
+    """Instantiate the appropriate DagBag based on the ``SKIP_DAGS_PARSING`` environment variable."""
+    if os.environ.get("SKIP_DAGS_PARSING") == "True":
+        return DagBag(os.devnull, include_examples=False)
+    return DagBag(DAGS_FOLDER, read_dags_from_db=True)
+
+
 def init_dagbag(app):
     """
     Create global DagBag for webserver and API.
 
     To access it use ``flask.current_app.dag_bag``.
     """
-    if os.environ.get("SKIP_DAGS_PARSING") == "True":
-        app.dag_bag = DagBag(os.devnull, include_examples=False)
-    else:
-        app.dag_bag = DagBag(DAGS_FOLDER, read_dags_from_db=True)
+    app.dag_bag = get_dag_bag()


### PR DESCRIPTION
This is the initial PR for AIP-84, setting up a very basic separate FastAPI API for UI purposes. I wanted to take that incrementally instead of opening a big PR latter. Some steps will require discussions on the implementation (I see different ways of handling things), and I don't want a gigantic PR getting blocked for days/weeks.

The goal at the end of that is to have 1 `object` custom endpoint duplicated to the new `UI REST API` showing how such endpoint are developed and tested as part of the new API.

At the time of airflow 3 release, old endpoint `/object` will simply be deleted, so we do not care at that time about duplication. (old endpoint contribution will be limited / filtered anyway).

To test this very basic endpoint you can for now simply run airflow with breeze. Stop the webserver and start the new UI Rest API manually with `fastapi dev airflow/api_ui/main.py`. Then in another breeze terminal run `curl localhost:8000/ui/next_run_datasets/<your_dag_id_with_datasets>` 

Follow up PRs in the next few days to:
- Integrate the new UI API to the CLI (most likely under a new command `airflow ui-api` or directly under `airflow webserver` ?)
- Integrate the new UI API to Breeze (for developer experience)
- Tests + CI integration (new test type, CI jobs etc.)
- Add permissions and access control
- Contributor documentation for this new API
- dev tools to automatically generate front-end code (typescript types + react queries) based on the API spec
- Clean and modularize code.


![Screenshot 2024-08-27 at 17 50 18](https://github.com/user-attachments/assets/e21503f7-e058-4aff-8e92-30783e36be1b)

