### PR TITLE
Fix mocking in cncf.kubernetes tests after get_connections removal

### DIFF
--- a/tests/providers/google/cloud/operators/test_kubernetes_engine.py
+++ b/tests/providers/google/cloud/operators/test_kubernetes_engine.py
@@ -342,7 +342,7 @@ class TestGKEPodOperator:
 
     @mock.patch.dict(os.environ, {})
     @mock.patch(
-        "airflow.hooks.base.BaseHook.get_connections",
+        "airflow.hooks.base.BaseHook.get_connection",
         return_value=[Connection(extra=json.dumps({"keyfile_dict": '{"private_key": "r4nd0m_k3y"}'}))],
     )
     @mock.patch(KUB_OPERATOR_EXEC)
@@ -357,7 +357,7 @@ class TestGKEPodOperator:
 
     @mock.patch.dict(os.environ, {})
     @mock.patch(
-        "airflow.hooks.base.BaseHook.get_connections",
+        "airflow.hooks.base.BaseHook.get_connection",
         return_value=[Connection(extra=json.dumps({"keyfile_dict": '{"private_key": "r4nd0m_k3y"}'}))],
     )
     @mock.patch(KUB_OPERATOR_EXEC)
@@ -615,7 +615,7 @@ class TestGKEStartKueueInsideClusterOperator:
 
     @mock.patch.dict(os.environ, {})
     @mock.patch(
-        "airflow.hooks.base.BaseHook.get_connections",
+        "airflow.hooks.base.BaseHook.get_connection",
         return_value=[Connection(extra=json.dumps({"keyfile_dict": '{"private_key": "r4nd0m_k3y"}'}))],
     )
     @mock.patch(TEMP_FILE)
@@ -634,7 +634,7 @@ class TestGKEStartKueueInsideClusterOperator:
 
     @mock.patch.dict(os.environ, {})
     @mock.patch(
-        "airflow.hooks.base.BaseHook.get_connections",
+        "airflow.hooks.base.BaseHook.get_connection",
         return_value=[Connection(extra=json.dumps({"keyfile_dict": '{"private_key": "r4nd0m_k3y"}'}))],
     )
     @mock.patch(TEMP_FILE)
@@ -942,7 +942,7 @@ class TestGKEStartJobOperator:
 
     @mock.patch.dict(os.environ, {})
     @mock.patch(
-        "airflow.hooks.base.BaseHook.get_connections",
+        "airflow.hooks.base.BaseHook.get_connection",
         return_value=[Connection(extra=json.dumps({"keyfile_dict": '{"private_key": "r4nd0m_k3y"}'}))],
     )
     @mock.patch(KUB_JOB_OPERATOR_EXEC)
@@ -959,7 +959,7 @@ class TestGKEStartJobOperator:
 
     @mock.patch.dict(os.environ, {})
     @mock.patch(
-        "airflow.hooks.base.BaseHook.get_connections",
+        "airflow.hooks.base.BaseHook.get_connection",
         return_value=[Connection(extra=json.dumps({"keyfile_dict": '{"private_key": "r4nd0m_k3y"}'}))],
     )
     @mock.patch(KUB_JOB_OPERATOR_EXEC)
@@ -1042,7 +1042,7 @@ class TestGKEDescribeJobOperator:
 
     @mock.patch.dict(os.environ, {})
     @mock.patch(
-        "airflow.hooks.base.BaseHook.get_connections",
+        "airflow.hooks.base.BaseHook.get_connection",
         return_value=[Connection(extra=json.dumps({"keyfile_dict": '{"private_key": "r4nd0m_k3y"}'}))],
     )
     @mock.patch(TEMP_FILE)
@@ -1060,7 +1060,7 @@ class TestGKEDescribeJobOperator:
 
     @mock.patch.dict(os.environ, {})
     @mock.patch(
-        "airflow.hooks.base.BaseHook.get_connections",
+        "airflow.hooks.base.BaseHook.get_connection",
         return_value=[Connection(extra=json.dumps({"keyfile_dict": '{"private_key": "r4nd0m_k3y"}'}))],
     )
     @mock.patch(TEMP_FILE)
@@ -1141,7 +1141,7 @@ class TestGKECreateCustomResourceOperator:
 
     @mock.patch.dict(os.environ, {})
     @mock.patch(
-        "airflow.hooks.base.BaseHook.get_connections",
+        "airflow.hooks.base.BaseHook.get_connection",
         return_value=[Connection(extra=json.dumps({"keyfile_dict": '{"private_key": "r4nd0m_k3y"}'}))],
     )
     @mock.patch(KUB_CREATE_RES_OPERATOR_EXEC)
@@ -1158,7 +1158,7 @@ class TestGKECreateCustomResourceOperator:
 
     @mock.patch.dict(os.environ, {})
     @mock.patch(
-        "airflow.hooks.base.BaseHook.get_connections",
+        "airflow.hooks.base.BaseHook.get_connection",
         return_value=[Connection(extra=json.dumps({"keyfile_dict": '{"private_key": "r4nd0m_k3y"}'}))],
     )
     @mock.patch(KUB_CREATE_RES_OPERATOR_EXEC)
@@ -1202,7 +1202,7 @@ class TestGKEDeleteCustomResourceOperator:
 
     @mock.patch.dict(os.environ, {})
     @mock.patch(
-        "airflow.hooks.base.BaseHook.get_connections",
+        "airflow.hooks.base.BaseHook.get_connection",
         return_value=[Connection(extra=json.dumps({"keyfile_dict": '{"private_key": "r4nd0m_k3y"}'}))],
     )
     @mock.patch(KUB_DELETE_RES_OPERATOR_EXEC)
@@ -1219,7 +1219,7 @@ class TestGKEDeleteCustomResourceOperator:
 
     @mock.patch.dict(os.environ, {})
     @mock.patch(
-        "airflow.hooks.base.BaseHook.get_connections",
+        "airflow.hooks.base.BaseHook.get_connection",
         return_value=[Connection(extra=json.dumps({"keyfile_dict": '{"private_key": "r4nd0m_k3y"}'}))],
     )
     @mock.patch(KUB_DELETE_RES_OPERATOR_EXEC)
@@ -1281,7 +1281,7 @@ class TestGKEStartKueueJobOperator:
 
     @mock.patch.dict(os.environ, {})
     @mock.patch(
-        "airflow.hooks.base.BaseHook.get_connections",
+        "airflow.hooks.base.BaseHook.get_connection",
         return_value=[Connection(extra=json.dumps({"keyfile_dict": '{"private_key": "r4nd0m_k3y"}'}))],
     )
     @mock.patch(KUB_JOB_OPERATOR_EXEC)
@@ -1298,7 +1298,7 @@ class TestGKEStartKueueJobOperator:
 
     @mock.patch.dict(os.environ, {})
     @mock.patch(
-        "airflow.hooks.base.BaseHook.get_connections",
+        "airflow.hooks.base.BaseHook.get_connection",
         return_value=[Connection(extra=json.dumps({"keyfile_dict": '{"private_key": "r4nd0m_k3y"}'}))],
     )
     @mock.patch(KUB_JOB_OPERATOR_EXEC)
@@ -1393,7 +1393,7 @@ class TestGKEDeleteJobOperator:
 
     @mock.patch.dict(os.environ, {})
     @mock.patch(
-        "airflow.hooks.base.BaseHook.get_connections",
+        "airflow.hooks.base.BaseHook.get_connection",
         return_value=[Connection(extra=json.dumps({"keyfile_dict": '{"private_key": "r4nd0m_k3y"}'}))],
     )
     @mock.patch(DEL_KUB_JOB_OPERATOR_EXEC)
@@ -1410,7 +1410,7 @@ class TestGKEDeleteJobOperator:
 
     @mock.patch.dict(os.environ, {})
     @mock.patch(
-        "airflow.hooks.base.BaseHook.get_connections",
+        "airflow.hooks.base.BaseHook.get_connection",
         return_value=[Connection(extra=json.dumps({"keyfile_dict": '{"private_key": "r4nd0m_k3y"}'}))],
     )
     @mock.patch(DEL_KUB_JOB_OPERATOR_EXEC)
@@ -1499,7 +1499,7 @@ class TestGKESuspendJobOperator:
 
     @mock.patch.dict(os.environ, {})
     @mock.patch(
-        "airflow.hooks.base.BaseHook.get_connections",
+        "airflow.hooks.base.BaseHook.get_connection",
         return_value=[Connection(extra=json.dumps({"keyfile_dict": '{"private_key": "r4nd0m_k3y"}'}))],
     )
     @mock.patch(TEMP_FILE)
@@ -1517,7 +1517,7 @@ class TestGKESuspendJobOperator:
 
     @mock.patch.dict(os.environ, {})
     @mock.patch(
-        "airflow.hooks.base.BaseHook.get_connections",
+        "airflow.hooks.base.BaseHook.get_connection",
         return_value=[Connection(extra=json.dumps({"keyfile_dict": '{"private_key": "r4nd0m_k3y"}'}))],
     )
     @mock.patch(TEMP_FILE)
@@ -1607,7 +1607,7 @@ class TestGKEResumeJobOperator:
 
     @mock.patch.dict(os.environ, {})
     @mock.patch(
-        "airflow.hooks.base.BaseHook.get_connections",
+        "airflow.hooks.base.BaseHook.get_connection",
         return_value=[Connection(extra=json.dumps({"keyfile_dict": '{"private_key": "r4nd0m_k3y"}'}))],
     )
     @mock.patch(TEMP_FILE)
@@ -1625,7 +1625,7 @@ class TestGKEResumeJobOperator:
 
     @mock.patch.dict(os.environ, {})
     @mock.patch(
-        "airflow.hooks.base.BaseHook.get_connections",
+        "airflow.hooks.base.BaseHook.get_connection",
         return_value=[Connection(extra=json.dumps({"keyfile_dict": '{"private_key": "r4nd0m_k3y"}'}))],
     )
     @mock.patch(TEMP_FILE)


### PR DESCRIPTION
The #41733 removed deprecated get_connections but it was still used in cncf.kubernetes tests.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
