### PR TITLE
Remove deprecations in airflow.models.taskreschedule

### DIFF
--- a/newsfragments/41808.significant.rst
+++ b/newsfragments/41808.significant.rst
@@ -1,0 +1,3 @@
+Removed deprecations in ``airflow.models.taskreschedule``.
+
+Note: there are no replacements, if data is needed, you need to query via sqlalchemy.

--- a/newsfragments/41808.significant.rst
+++ b/newsfragments/41808.significant.rst
@@ -1,3 +1,8 @@
 Removed deprecations in ``airflow.models.taskreschedule``.
 
+Removed methods:
+
+- ``query_for_task_instance()``
+- ``find_for_task_instance()``
+
 Note: there are no replacements, if data is needed, you need to query via sqlalchemy.


### PR DESCRIPTION
Code cleanup and removal of deprecations in `airflow.models.taskreschedule`.