### PR TITLE
logout link in no roles error page fix

### DIFF
--- a/airflow/www/templates/airflow/no_roles_permissions.html
+++ b/airflow/www/templates/airflow/no_roles_permissions.html
@@ -30,11 +30,12 @@
     <p>Unfortunately your user has no roles, and therefore you cannot use Airflow.</p>
     <p>Please contact your Airflow administrator
       (<a href="https://airflow.apache.org/docs/apache-airflow/stable/security/webserver.html#web-authentication">authentication</a>
-      may be misconfigured) or 
+      may be misconfigured) or
       <form method="POST" action="{{logout_url}}" id="logout-form">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         <a href="javascript:{}" onclick="document.getElementById('logout-form').submit();">log out</a> to try again.
       </form>
+    </p>
     <p>{{ hostname }}</p>
   </div>
 </body>

--- a/airflow/www/templates/airflow/no_roles_permissions.html
+++ b/airflow/www/templates/airflow/no_roles_permissions.html
@@ -30,7 +30,11 @@
     <p>Unfortunately your user has no roles, and therefore you cannot use Airflow.</p>
     <p>Please contact your Airflow administrator
       (<a href="https://airflow.apache.org/docs/apache-airflow/stable/security/webserver.html#web-authentication">authentication</a>
-      may be misconfigured) or <a href="{{ logout_url }}">log out</a> to try again.</p>
+      may be misconfigured) or 
+      <form method="POST" action="{{logout_url}}" id="logout-form">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        <a href="javascript:{}" onclick="document.getElementById('logout-form').submit();">log out</a> to try again.
+      </form>
     <p>{{ hostname }}</p>
   </div>
 </body>


### PR DESCRIPTION
closes: #41580

This PR fixes log out link in no roles and permissions error page

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
