### PR TITLE
fix test_yandex_lockbox_secret_backend_get_connection_from_json by removing non-json extra

### DIFF
--- a/tests/providers/yandex/secrets/test_lockbox.py
+++ b/tests/providers/yandex/secrets/test_lockbox.py
@@ -27,7 +27,6 @@ import yandex.cloud.lockbox.v1.payload_pb2 as payload_pb
 import yandex.cloud.lockbox.v1.secret_pb2 as secret_pb
 import yandex.cloud.lockbox.v1.secret_service_pb2 as secret_service_pb
 
-from airflow.exceptions import RemovedInAirflow3Warning
 from airflow.providers.yandex.secrets.lockbox import LockboxSecretBackend
 from airflow.providers.yandex.utils.defaults import default_conn_name
 
@@ -60,7 +59,7 @@ class TestLockboxSecretBackend:
     def test_yandex_lockbox_secret_backend_get_connection_from_json(self, mock_get_value):
         conn_id = "airflow_to_yandexcloud"
         conn_type = "yandex_cloud"
-        extra = "some extra values"
+        extra = '{"some": "extra values"}'
         c = {
             "conn_type": conn_type,
             "extra": extra,
@@ -68,18 +67,9 @@ class TestLockboxSecretBackend:
 
         mock_get_value.return_value = json.dumps(c)
 
-        match = "Encountered non-JSON in `extra` field for connection 'airflow_to_yandexcloud'. Support for non-JSON `extra` will be removed in Airflow 3.0"
-        with pytest.warns(
-            RemovedInAirflow3Warning,
-            match=match,
-        ):
-            conn = LockboxSecretBackend().get_connection(conn_id)
+        conn = LockboxSecretBackend().get_connection(conn_id)
 
-        with pytest.warns(
-            RemovedInAirflow3Warning,
-            match=match,
-        ):
-            assert conn.extra == extra
+        assert conn.extra == extra
 
         assert conn.conn_id == conn_id
         assert conn.conn_type == conn_type


### PR DESCRIPTION
## Why
non-json extra is not allowed after https://github.com/apache/airflow/pull/41762 which breaks `test_yandex_lockbox_secret_backend_get_connection_from_json`

## What
Change the extra value to json

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
