### PR TITLE
Update hook-weight to -1 for proper ArgoCD sync

### DIFF
--- a/chart/templates/configmaps/extra-configmaps.yaml
+++ b/chart/templates/configmaps/extra-configmaps.yaml
@@ -40,7 +40,7 @@ metadata:
   {{- $annotations := dict }}
   {{- if or $configMapContent.useHelmHooks (not (hasKey $configMapContent "useHelmHooks")) }}
     {{- $_ := set $annotations "helm.sh/hook" "pre-install,pre-upgrade" }}
-    {{- $_ := set $annotations "helm.sh/hook-weight" "0" }}
+    {{- $_ := set $annotations "helm.sh/hook-weight" "-1" }}
     {{- $_ := set $annotations "helm.sh/hook-delete-policy" "before-hook-creation" }}
   {{- end }}
   {{- with $annotations := merge $annotations ($configMapContent.annotations | default dict) }}

--- a/chart/templates/secrets/extra-secrets.yaml
+++ b/chart/templates/secrets/extra-secrets.yaml
@@ -40,7 +40,7 @@ metadata:
   {{- $annotations := dict }}
   {{- if or $secretContent.useHelmHooks (not (hasKey $secretContent "useHelmHooks")) }}
     {{- $_ := set $annotations "helm.sh/hook" "pre-install,pre-upgrade" }}
-    {{- $_ := set $annotations "helm.sh/hook-weight" "0" }}
+    {{- $_ := set $annotations "helm.sh/hook-weight" "-1" }}
     {{- $_ := set $annotations "helm.sh/hook-delete-policy" "before-hook-creation" }}
   {{- end }}
   {{- with $annotations := merge $annotations ($secretContent.annotations | default dict) }}

--- a/chart/templates/secrets/fernetkey-secret.yaml
+++ b/chart/templates/secrets/fernetkey-secret.yaml
@@ -37,7 +37,7 @@ metadata:
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-delete-policy": "before-hook-creation"
-    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-weight": "-1"
 type: Opaque
 data:
   fernet-key: {{ (default $generated_fernet_key .Values.fernetKey) | b64enc | quote }}

--- a/chart/templates/secrets/redis-secrets.yaml
+++ b/chart/templates/secrets/redis-secrets.yaml
@@ -46,7 +46,7 @@ metadata:
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-delete-policy": "before-hook-creation"
-    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-weight": "-1"
 type: Opaque
 data:
   password: {{ (default $random_redis_password .Values.redis.password) | b64enc | quote }}
@@ -72,7 +72,7 @@ metadata:
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-delete-policy": "before-hook-creation"
-    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-weight": "-1"
 type: Opaque
 data:
   {{- if .Values.redis.enabled }}

--- a/helm_tests/airflow_aux/test_airflow_common.py
+++ b/helm_tests/airflow_aux/test_airflow_common.py
@@ -309,7 +309,7 @@ class TestAirflowCommon:
             show_only=["templates/secrets/fernetkey-secret.yaml"],
         )
         annotations = jmespath.search("metadata.annotations", docs[0])
-        assert annotations["helm.sh/hook-weight"] == "0"
+        assert annotations["helm.sh/hook-weight"] == "-1"
 
     def test_should_disable_some_variables(self):
         docs = render_chart(

--- a/helm_tests/other/test_redis.py
+++ b/helm_tests/other/test_redis.py
@@ -357,7 +357,7 @@ class TestRedis:
             show_only=["templates/secrets/redis-secrets.yaml"],
         )
         annotations = jmespath.search("metadata.annotations", docs[0])
-        assert annotations["helm.sh/hook-weight"] == "0"
+        assert annotations["helm.sh/hook-weight"] == "-1"
 
     def test_persistence_volume_annotations(self):
         docs = render_chart(

--- a/helm_tests/security/test_extra_configmaps_secrets.py
+++ b/helm_tests/security/test_extra_configmaps_secrets.py
@@ -211,7 +211,7 @@ class TestExtraConfigMapsSecrets:
         expected_annotations = {
             "helm.sh/hook": "pre-install,pre-upgrade",
             "helm.sh/hook-delete-policy": "before-hook-creation",
-            "helm.sh/hook-weight": "0",
+            "helm.sh/hook-weight": "-1",
             "test_annotation": "test_annotation_value",
         }
 


### PR DESCRIPTION
According to ArgoCD, the pre-install hook-weight should be -1 in order to execute the hook before running the upgrade.
https://argo-cd.readthedocs.io/en/stable/user-guide/helm/#hook-tips