### PR TITLE
Add trace tags to task instances and also support OTEL_RESOURCE_ATTRIBUTES for spans

### DIFF
--- a/airflow/traces/otel_tracer.py
+++ b/airflow/traces/otel_tracer.py
@@ -67,7 +67,7 @@ class OtelTrace:
         self, component: str, trace_id: int | None = None, span_id: int | None = None
     ) -> OpenTelemetryTracer | Tracer:
         """Tracer that will use special AirflowOtelIdGenerator to control producing certain span and trace id."""
-        resource = Resource(attributes={HOST_NAME: get_hostname(), SERVICE_NAME: self.otel_service})
+        resource = Resource.create(attributes={HOST_NAME: get_hostname(), SERVICE_NAME: self.otel_service})
         if trace_id or span_id:
             # in case where trace_id or span_id was given
             tracer_provider = TracerProvider(
@@ -183,6 +183,7 @@ class OtelTrace:
         Essentially the span represents the ti itself if child == True, it will create a 'child' span under the given span.
         """
         dagrun = ti.dag_run
+        conf = dagrun.conf
         trace_id = int(gen_trace_id(dag_run=dagrun, as_int=True))
         span_id = int(gen_span_id(ti=ti, as_int=True))
         if span_name is None:
@@ -208,9 +209,16 @@ class OtelTrace:
         else:
             tracer = self.get_tracer(component=component)
 
+        tag_string = self.tag_string if self.tag_string else ""
+        tag_string = tag_string + ("," + conf.get(TRACESTATE) if (conf and conf.get(TRACESTATE)) else "")
+
         ctx = trace.set_span_in_context(NonRecordingSpan(span_ctx))
         span = tracer.start_as_current_span(
-            name=span_name, context=ctx, start_time=datetime_to_nano(ti.queued_dttm), links=_links
+            name=span_name,
+            context=ctx,
+            links=_links,
+            start_time=datetime_to_nano(ti.queued_dttm),
+            attributes=parse_tracestate(tag_string),
         )
         return span
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

closes: #41840 

This PR addresses features mentioned in above issue, that OTEL traces will now be able to collect user-defined resources via OTEL_RESOURCE_ATTRIBUTES.

Also, in addition to this, the PR also addresses more complete instrumentation that task instance span will also now contain the tags specified via airflow config's `airflow.traces.tags`, providing more ways to instrument spans with less user coding involved.

For more information about the OTEL_RESOURCE_ATTRIBUTES, please visit [here](https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_resource_attributes)
