### PR TITLE
[Backport] logout link in no roles error page fix (#41813)

### DIFF
--- a/airflow/www/templates/airflow/no_roles_permissions.html
+++ b/airflow/www/templates/airflow/no_roles_permissions.html
@@ -30,7 +30,12 @@
     <p>Unfortunately your user has no roles, and therefore you cannot use Airflow.</p>
     <p>Please contact your Airflow administrator
       (<a href="https://airflow.apache.org/docs/apache-airflow/stable/security/webserver.html#web-authentication">authentication</a>
-      may be misconfigured) or <a href="{{ logout_url }}">log out</a> to try again.</p>
+      may be misconfigured) or
+      <form method="POST" action="{{logout_url}}" id="logout-form">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        <a href="javascript:{}" onclick="document.getElementById('logout-form').submit();">log out</a> to try again.
+      </form>
+    </p>
     <p>{{ hostname }}</p>
   </div>
 </body>


### PR DESCRIPTION
backports: #41813

(cherry picked from commit 032ac87b1d93abc53d3281313c957708017e21d4)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
