### PR TITLE
Fix ElasticSearch SQLClient deprecation warning

### DIFF
--- a/airflow/providers/elasticsearch/hooks/elasticsearch.py
+++ b/airflow/providers/elasticsearch/hooks/elasticsearch.py
@@ -23,7 +23,6 @@ from urllib import parse
 
 from deprecated import deprecated
 from elasticsearch import Elasticsearch
-from elasticsearch.client import SqlClient
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.hooks.base import BaseHook
@@ -70,11 +69,10 @@ class ESConnection:
             self.es = Elasticsearch(self.url, http_auth=(user, password), **self.kwargs)
         else:
             self.es = Elasticsearch(self.url, **self.kwargs)
-        self.es_sql_client = SqlClient(self.es)
 
     def execute_sql(self, query: str) -> ObjectApiResponse:
         sql_query = {"query": query}
-        return self.es_sql_client.query(body=sql_query)
+        return self.es.sql.query(body=sql_query)
 
 
 class ElasticsearchSQLHook(DbApiHook):

--- a/airflow/providers/elasticsearch/hooks/elasticsearch.py
+++ b/airflow/providers/elasticsearch/hooks/elasticsearch.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import sys
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 from urllib import parse
@@ -33,9 +32,6 @@ if TYPE_CHECKING:
     from elastic_transport import ObjectApiResponse
 
     from airflow.models.connection import Connection as AirflowConnection
-
-if "pytest" in sys.modules:
-    import elasticsearch  # noqa: F401
 
 
 def connect(

--- a/airflow/providers/elasticsearch/hooks/elasticsearch.py
+++ b/airflow/providers/elasticsearch/hooks/elasticsearch.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import sys
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 from urllib import parse
@@ -32,6 +33,9 @@ if TYPE_CHECKING:
     from elastic_transport import ObjectApiResponse
 
     from airflow.models.connection import Connection as AirflowConnection
+
+if "pytest" in sys.modules:
+    import elasticsearch  # noqa: F401
 
 
 def connect(

--- a/tests/providers/elasticsearch/hooks/test_elasticsearch.py
+++ b/tests/providers/elasticsearch/hooks/test_elasticsearch.py
@@ -119,7 +119,9 @@ class TestElasticsearchSQLHook:
 
         self.cur.execute.assert_called_once_with(statement)
 
-    @mock.patch("airflow.providers.elasticsearch.hooks.elasticsearch.SqlClient.query")
+    @mock.patch(
+        "airflow.providers.elasticsearch.hooks.elasticsearch.elasticsearch._sync.client.sql.SqlClient.query"
+    )
     def test_execute_sql_query(self, mock_query):
         mock_query.return_value = {
             "columns": [{"name": "id"}, {"name": "first_name"}],

--- a/tests/providers/elasticsearch/hooks/test_elasticsearch.py
+++ b/tests/providers/elasticsearch/hooks/test_elasticsearch.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 from unittest import mock
+from unittest.mock import MagicMock
 
 import pytest
 from elasticsearch import Elasticsearch
@@ -119,18 +120,18 @@ class TestElasticsearchSQLHook:
 
         self.cur.execute.assert_called_once_with(statement)
 
-    @mock.patch(
-        "airflow.providers.elasticsearch.hooks.elasticsearch.elasticsearch._sync.client.sql.SqlClient.query"
-    )
-    def test_execute_sql_query(self, mock_query):
-        mock_query.return_value = {
+    @mock.patch("airflow.providers.elasticsearch.hooks.elasticsearch.Elasticsearch")
+    def test_execute_sql_query(self, mock_es):
+        mock_es_sql_client = MagicMock()
+        mock_es_sql_client.query.return_value = {
             "columns": [{"name": "id"}, {"name": "first_name"}],
             "rows": [[1, "John"], [2, "Jane"]],
         }
+        mock_es.return_value.sql = mock_es_sql_client
 
         es_connection = ESConnection(host="localhost", port=9200)
         response = es_connection.execute_sql("SELECT * FROM index1")
-        mock_query.assert_called_once_with(body={"query": "SELECT * FROM index1"})
+        mock_es_sql_client.query.assert_called_once_with(body={"query": "SELECT * FROM index1"})
 
         assert response["rows"] == [[1, "John"], [2, "Jane"]]
         assert response["columns"] == [{"name": "id"}, {"name": "first_name"}]


### PR DESCRIPTION
After the merge of this [PR](https://github.com/apache/airflow/pull/41537), the import of `SQLClient` has resulted in a deprecation warning (when being used for remote logging) :

https://github.com/elastic/elasticsearch-py/blob/4ee46509e236bf30f540d173b48bb7650159556d/elasticsearch/client.py#L75-L80

So this PR fixes the warning by using the SQL Interface inside a elasaticsearch client (So importing SQLClient is no longer needed)