### PR TITLE
Fixing version bump issue when all changes are misc

### DIFF
--- a/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
+++ b/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
@@ -487,6 +487,8 @@ def _update_version_in_provider_yaml(
         maybe_with_new_features = True
     elif type_of_change == TypeOfChange.BUGFIX:
         v = v.bump_patch()
+    elif type_of_change == TypeOfChange.MISC:
+        v = v.bump_patch()
     provider_yaml_path = get_source_package_path(provider_package_id) / "provider.yaml"
     original_provider_yaml_content = provider_yaml_path.read_text()
     new_provider_yaml_content = re.sub(
@@ -772,7 +774,12 @@ def update_release_notes(
                 f"[special]{TYPE_OF_CHANGE_DESCRIPTION[type_of_change]}"
             )
             get_console().print()
-            if type_of_change in [TypeOfChange.BUGFIX, TypeOfChange.FEATURE, TypeOfChange.BREAKING_CHANGE]:
+            if type_of_change in [
+                TypeOfChange.BUGFIX,
+                TypeOfChange.FEATURE,
+                TypeOfChange.BREAKING_CHANGE,
+                TypeOfChange.MISC,
+            ]:
                 with_breaking_changes, maybe_with_new_features, original_provider_yaml_content = (
                     _update_version_in_provider_yaml(
                         provider_package_id=provider_package_id, type_of_change=type_of_change
@@ -816,7 +823,12 @@ def update_release_notes(
         get_console().print()
         if type_of_change == TypeOfChange.DOCUMENTATION:
             _mark_latest_changes_as_documentation_only(provider_package_id, list_of_list_of_changes)
-        elif type_of_change in [TypeOfChange.BUGFIX, TypeOfChange.FEATURE, TypeOfChange.BREAKING_CHANGE]:
+        elif type_of_change in [
+            TypeOfChange.BUGFIX,
+            TypeOfChange.FEATURE,
+            TypeOfChange.BREAKING_CHANGE,
+            TypeOfChange.MISC,
+        ]:
             with_breaking_changes, maybe_with_new_features, _ = _update_version_in_provider_yaml(
                 provider_package_id=provider_package_id,
                 type_of_change=type_of_change,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

A version bump wasnt happening when all changes while preparing documentation for providers were `misc`. This PR fixes that bug.

```
Does the provider: amazon have any changes apart from 'doc-only'?
Press y/N/q: y

Define the type of change for `Fix treatment of "#" in S3Hook.parse_s3_url() (https://github.com/apache/airflow/pull/41796)` by referring to the above table
Type of change (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip, (q)uit ? m


Define the type of change for `airflow.models.taskinstance deprecations removed (https://github.com/apache/airflow/pull/41784)` by referring to the above table
Type of change (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip, (q)uit ? m


Define the type of change for `remove soft_fail part2 (https://github.com/apache/airflow/pull/41727)` by referring to the above table
Type of change (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip, (q)uit ? m


Define the type of change for `remove soft_fail (https://github.com/apache/airflow/pull/41710)` by referring to the above table
Type of change (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip, (q)uit ? m


Define the type of change for `fix: select_query should have precedence over default query in RedshiftToS3Operator (https://github.com/apache/airflow/pull/41634)` by referring to the above table
Type of change (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip, (q)uit ? m


Define the type of change for `fix: remove part of openlineage extraction from S3ToRedshiftOperator (https://github.com/apache/airflow/pull/41631)` by referring to the above table
Type of change (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip, (q)uit ? m


Define the type of change for `filename template arg in providers file task handlers backward compitability support (https://github.com/apache/airflow/pull/41633)` by referring to the above table
Type of change (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip, (q)uit ? m


Define the type of change for `Limit watchtower as depenendcy as 3.3.0 breaks moin. (https://github.com/apache/airflow/pull/41612)` by referring to the above table
Type of change (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip, (q)uit ? m


Define the type of change for `Remove deprecated log handler argument filename_template (https://github.com/apache/airflow/pull/41552)` by referring to the above table
Type of change (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip, (q)uit ? m


Define the type of change for `Openlineage s3 to redshift operator integration (https://github.com/apache/airflow/pull/41575)` by referring to the above table
Type of change (b)ugfix, (f)eature, (x)breaking change, (m)misc, (s)kip, (q)uit ? m

The version will be bumped because of TypeOfChange.MISC kind of change
Provider amazon has been classified as:

Miscellaneous changes - bump in PATCHLEVEL version needed

Bumped version to 8.28.1
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
