### PR TITLE
Skip test_scan_stale_dags_when_dag_folder_change in DB isolation mode

### DIFF
--- a/tests/dag_processing/test_job_runner.py
+++ b/tests/dag_processing/test_job_runner.py
@@ -763,6 +763,7 @@ class TestDagProcessorJobRunner:
             active_dag_count = session.query(func.count(DagModel.dag_id)).filter(DagModel.is_active).scalar()
             assert active_dag_count == 1
 
+    @pytest.mark.skip_if_database_isolation_mode  # Test is broken in db isolation mode
     def test_scan_stale_dags_when_dag_folder_change(self):
         """
         Ensure dags from old dag_folder is marked as stale when dag processor


### PR DESCRIPTION
Since the similar test(test_scan_stale_dags_standalone_mode) is skipped in DB isolation mode and it's [breaking CI](https://github.com/apache/airflow/actions/runs/10633117503/job/29478029666 ) which is a blocker for 2.10.1 release.