### PR TITLE
[Backport] Skip test_scan_stale_dags_when_dag_folder_change in DB isolation mode

### DIFF
--- a/tests/dag_processing/test_job_runner.py
+++ b/tests/dag_processing/test_job_runner.py
@@ -763,6 +763,7 @@ class TestDagProcessorJobRunner:
             active_dag_count = session.query(func.count(DagModel.dag_id)).filter(DagModel.is_active).scalar()
             assert active_dag_count == 1
 
+    @pytest.mark.skip_if_database_isolation_mode  # Test is broken in db isolation mode
     def test_scan_stale_dags_when_dag_folder_change(self):
         """
         Ensure dags from old dag_folder is marked as stale when dag processor


### PR DESCRIPTION
Since the similar test(test_scan_stale_dags_standalone_mode) are skipped in DB isolation mode

(cherry picked from commit 07af14ae75820a98b60ecffa2949ef7ad70bacab)