### PR TITLE
All executors should inherit from BaseExecutor

### DIFF
--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -122,7 +122,7 @@ class BaseExecutor(LoggingMixin):
     change_sensor_mode_to_reschedule: bool = False
     serve_logs: bool = False
 
-    job_id: None | int | str = None
+    job_id: int | str | None = None
     name: None | ExecutorName = None
     callback_sink: BaseCallbackSink | None = None
 

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -122,7 +122,7 @@ class BaseExecutor(LoggingMixin):
     change_sensor_mode_to_reschedule: bool = False
     serve_logs: bool = False
 
-    job_id: int | str | None = None
+    job_id: None | int | str = None
     name: None | ExecutorName = None
     callback_sink: BaseCallbackSink | None = None
 

--- a/airflow/providers/celery/executors/celery_kubernetes_executor.py
+++ b/airflow/providers/celery/executors/celery_kubernetes_executor.py
@@ -81,6 +81,16 @@ class CeleryKubernetesExecutor(BaseExecutor):
         self.kubernetes_executor.kubernetes_queue = self.kubernetes_queue
 
     @property
+    def _task_event_logs(self):
+        self.celery_executor._task_event_logs += self.kubernetes_executor._task_event_logs
+        self.kubernetes_executor._task_event_logs.clear()
+        return self.celery_executor._task_event_logs
+
+    @_task_event_logs.setter
+    def _task_event_logs(self, value):
+        raise NotImplementedError
+
+    @property
     def queued_tasks(self) -> dict[TaskInstanceKey, QueuedTaskInstanceType]:
         """Return queued tasks from celery and kubernetes executor."""
         queued_tasks = self.celery_executor.queued_tasks.copy()

--- a/airflow/providers/celery/executors/celery_kubernetes_executor.py
+++ b/airflow/providers/celery/executors/celery_kubernetes_executor.py
@@ -88,7 +88,7 @@ class CeleryKubernetesExecutor(BaseExecutor):
 
     @_task_event_logs.setter
     def _task_event_logs(self, value):
-        raise NotImplementedError
+        """Not implemented for hybrid executors."""
 
     @property
     def queued_tasks(self) -> dict[TaskInstanceKey, QueuedTaskInstanceType]:
@@ -100,7 +100,7 @@ class CeleryKubernetesExecutor(BaseExecutor):
 
     @queued_tasks.setter
     def queued_tasks(self, value) -> None:
-        raise NotImplementedError
+        """Not implemented for hybrid executors."""
 
     @property
     def running(self) -> set[TaskInstanceKey]:
@@ -109,7 +109,7 @@ class CeleryKubernetesExecutor(BaseExecutor):
 
     @running.setter
     def running(self, value) -> None:
-        raise NotImplementedError
+        """Not implemented for hybrid executors."""
 
     @property
     def job_id(self) -> int | str | None:

--- a/airflow/providers/cncf/kubernetes/executors/local_kubernetes_executor.py
+++ b/airflow/providers/cncf/kubernetes/executors/local_kubernetes_executor.py
@@ -74,7 +74,7 @@ class LocalKubernetesExecutor(BaseExecutor):
 
     @_task_event_logs.setter
     def _task_event_logs(self, value):
-        raise NotImplementedError
+        """Not implemented for hybrid executors."""
 
     @property
     def queued_tasks(self) -> dict[TaskInstanceKey, QueuedTaskInstanceType]:
@@ -86,7 +86,7 @@ class LocalKubernetesExecutor(BaseExecutor):
 
     @queued_tasks.setter
     def queued_tasks(self, value) -> None:
-        raise NotImplementedError
+        """Not implemented for hybrid executors."""
 
     @property
     def running(self) -> set[TaskInstanceKey]:
@@ -95,7 +95,7 @@ class LocalKubernetesExecutor(BaseExecutor):
 
     @running.setter
     def running(self, value) -> None:
-        raise NotImplementedError
+        """Not implemented for hybrid executors."""
 
     @property
     def job_id(self) -> int | str | None:

--- a/airflow/providers/cncf/kubernetes/executors/local_kubernetes_executor.py
+++ b/airflow/providers/cncf/kubernetes/executors/local_kubernetes_executor.py
@@ -67,6 +67,16 @@ class LocalKubernetesExecutor(BaseExecutor):
         self.kubernetes_executor.kubernetes_queue = self.KUBERNETES_QUEUE
 
     @property
+    def _task_event_logs(self):
+        self.local_executor._task_event_logs += self.kubernetes_executor._task_event_logs
+        self.kubernetes_executor._task_event_logs.clear()
+        return self.local_executor._task_event_logs
+
+    @_task_event_logs.setter
+    def _task_event_logs(self, value):
+        raise NotImplementedError
+
+    @property
     def queued_tasks(self) -> dict[TaskInstanceKey, QueuedTaskInstanceType]:
         """Return queued tasks from local and kubernetes executor."""
         queued_tasks = self.local_executor.queued_tasks.copy()


### PR DESCRIPTION
Here I amend LocalKubernetesExecutor and CeleryKubernetesExecutor to inherit from BaseExecutor.

resolves: https://github.com/apache/airflow/issues/41891