### PR TITLE
Implement pagination for the new home page.

### DIFF
--- a/airflow/ui/src/app.tsx
+++ b/airflow/ui/src/app.tsx
@@ -27,7 +27,7 @@ import { Nav } from "src/nav";
 
 export const App = () => {
   // TODO: Change this to be taken from airflow.cfg
-  const pageSize = 10;
+  const pageSize = 50;
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
     pageSize: pageSize,

--- a/airflow/ui/src/app.tsx
+++ b/airflow/ui/src/app.tsx
@@ -17,21 +17,38 @@
  * under the License.
  */
 
+import { useState } from "react";
 import { Box, Spinner } from "@chakra-ui/react";
 
 import { useDagServiceGetDags } from "openapi/queries";
-import { DagsList } from "src/dagsList";
+import { DagsList, IPagination } from "src/dagsList";
 import { Nav } from "src/nav";
 
 export const App = () => {
-  const { data, isLoading } = useDagServiceGetDags();
+  const pageSize = 10;
+  const [pagination, setPagination] = useState<IPagination>({
+    pageIndex: 0,
+    pageSize: pageSize,
+  });
+
+  const { data, isLoading } = useDagServiceGetDags({
+    limit: pagination.pageSize,
+    offset: pagination.pageIndex * pagination.pageSize,
+  });
 
   return (
     <Box maxWidth="100vw">
       <Nav />
       <Box p={3}>
         {isLoading && <Spinner />}
-        {!isLoading && !!data?.dags && <DagsList data={data.dags} />}
+        {!isLoading && !!data?.dags && (
+          <DagsList
+            data={data.dags}
+            total={data.total_entries}
+            pagination={pagination}
+            setPagination={setPagination}
+          />
+        )}
       </Box>
     </Box>
   );

--- a/airflow/ui/src/app.tsx
+++ b/airflow/ui/src/app.tsx
@@ -19,14 +19,16 @@
 
 import { useState } from "react";
 import { Box, Spinner } from "@chakra-ui/react";
+import { PaginationState } from "@tanstack/react-table";
 
 import { useDagServiceGetDags } from "openapi/queries";
-import { DagsList, IPagination } from "src/dagsList";
+import { DagsList } from "src/dagsList";
 import { Nav } from "src/nav";
 
 export const App = () => {
+  // TODO: Change this to be taken from airflow.cfg
   const pageSize = 10;
-  const [pagination, setPagination] = useState<IPagination>({
+  const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
     pageSize: pageSize,
   });

--- a/airflow/ui/src/dagsList.tsx
+++ b/airflow/ui/src/dagsList.tsx
@@ -101,7 +101,7 @@ type PaginatorProps<TData> = {
   table: TanStackTable<TData>;
 };
 
-function TablePaginator({ table }: PaginatorProps<DAG>) {
+const TablePaginator = ({ table }: PaginatorProps<DAG>) => {
   const pageInterval = 3;
   const currentPageNumber = table.getState().pagination.pageIndex + 1;
   const startPageNumber = Math.max(1, currentPageNumber - pageInterval);
@@ -119,8 +119,7 @@ function TablePaginator({ table }: PaginatorProps<DAG>) {
         isDisabled={index === currentPageNumber}
         onClick={() => table.setPageIndex(index - 1)}
       >
-        {" "}
-        {index}{" "}
+        {index}
       </Button>
     );
   }
@@ -159,7 +158,7 @@ function TablePaginator({ table }: PaginatorProps<DAG>) {
       </Button>
     </Box>
   );
-}
+};
 
 const Table = ({
   data,

--- a/airflow/ui/src/dagsList.tsx
+++ b/airflow/ui/src/dagsList.tsx
@@ -20,12 +20,6 @@
 import React, { Fragment } from "react";
 
 import {
-  OnChangeFn,
-  PaginationState,
-  Table as TanStackTable,
-} from "@tanstack/table-core";
-
-import {
   useReactTable,
   getCoreRowModel,
   getExpandedRowModel,
@@ -33,6 +27,9 @@ import {
   ColumnDef,
   flexRender,
   Row,
+  OnChangeFn,
+  PaginationState,
+  Table as TanStackTable,
 } from "@tanstack/react-table";
 import { MdExpandMore } from "react-icons/md";
 import {


### PR DESCRIPTION
Thanks @bbovenzi for the new UI page and contribution docs. Looks really nice with built in dark mode from ground up. New build system using Vite and HMR is really nice. I don't need to reload for changes and enables a faster feedback loop with state intact. I tried implementing basic pagination for the new UI page. I opened this PR for initial feedback and some questions on trying out the implementation in new UI. I guess it serves as a good point to discuss and improve upon.

Questions 

1. In the previous API the case of the keys of the response used to be changed using interceptor. In this case will this be applicable to new API/UI? like total_entries will become totalEntries?
2. Default dags per page is configurable in airflow.cfg . Earlier the values used to be passed along meta tag for rendering. In this case page title and page size are some of the attributes that might be needed. I don't see any endpoint in airflow/www/views.py so I was wondering how to get those values here like the other react implementation. Currently, I just used 10 hard coded as a constant.
3. The new UI generates API stubs from openapi I guess similar to the other react project. Will this be merged eventually as I see useQuery for other parts with somewhat different conventions compared to the current one where useDagServiceGetDags is used.

Pagination Ref : 

https://tanstack.com/table/latest/docs/guide/pagination#manual-server-side-pagination
https://medium.com/@aylo.srd/server-side-pagination-and-sorting-with-tanstack-table-and-react-bd493170125e

Screenshot : (first page, previous page, next page, last page)

![image](https://github.com/user-attachments/assets/c4d9f45c-f7cd-4503-85a0-516da675a5b6)
