### PR TITLE
Backcompat for non inheriting executors

### DIFF
--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1144,6 +1144,9 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
                 for executor in self.job.executors:
                     try:
+                        # this is backcompat check if executor does not inherit from BaseExecutor
+                        if not hasattr(executor, "_task_event_logs"):
+                            continue
                         with create_session() as session:
                             self._process_task_event_logs(executor._task_event_logs, session)
                     except Exception:


### PR DESCRIPTION
Some executors don't inherit from BaseExecutor.  2.10 change assumes they do.

This fixes that.

Resolves https://github.com/apache/airflow/issues/41891