### PR TITLE
Add CountTokensOperator for Google Generative AI CountTokensAPI

### DIFF
--- a/docs/apache-airflow-providers-google/operators/cloud/vertex_ai.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/vertex_ai.rst
@@ -625,6 +625,17 @@ The operator returns the tuned model's endpoint name in :ref:`XCom <concepts:xco
     :start-after: [START how_to_cloud_vertex_ai_supervised_fine_tuning_train_operator]
     :end-before: [END how_to_cloud_vertex_ai_supervised_fine_tuning_train_operator]
 
+
+To calculates the number of input tokens before sending a request to the Gemini API you can use:
+:class:`~airflow.providers.google.cloud.operators.vertex_ai.generative_model.CountTokensOperator`.
+The operator returns the total tokens in :ref:`XCom <concepts:xcom>` under ``total_tokens`` key.
+
+.. exampleinclude:: /../../tests/system/providers/google/cloud/vertex_ai/example_vertex_ai_generative_model.py
+    :language: python
+    :dedent: 4
+    :start-after: [START how_to_cloud_vertex_ai_count_tokens_operator]
+    :end-before: [END how_to_cloud_vertex_ai_count_tokens_operator]
+
 Reference
 ^^^^^^^^^
 

--- a/tests/providers/google/cloud/hooks/vertex_ai/test_generative_model.py
+++ b/tests/providers/google/cloud/hooks/vertex_ai/test_generative_model.py
@@ -217,3 +217,16 @@ class TestGenerativeModelWithDefaultProjectIdHook:
             learning_rate_multiplier=None,
             tuned_model_display_name=None,
         )
+
+    @mock.patch(GENERATIVE_MODEL_STRING.format("GenerativeModelHook.get_generative_model"))
+    def test_count_tokens(self, mock_model) -> None:
+        self.hook.count_tokens(
+            project_id=GCP_PROJECT,
+            contents=TEST_CONTENTS,
+            location=GCP_LOCATION,
+            pretrained_model=TEST_MULTIMODAL_PRETRAINED_MODEL,
+        )
+        mock_model.assert_called_once_with(TEST_MULTIMODAL_PRETRAINED_MODEL)
+        mock_model.return_value.count_tokens.assert_called_once_with(
+            contents=TEST_CONTENTS,
+        )

--- a/tests/providers/google/cloud/operators/vertex_ai/test_generative_model.py
+++ b/tests/providers/google/cloud/operators/vertex_ai/test_generative_model.py
@@ -26,10 +26,12 @@ from airflow.exceptions import (
 
 # For no Pydantic environment, we need to skip the tests
 pytest.importorskip("google.cloud.aiplatform_v1")
+pytest.importorskip("google.cloud.aiplatform_v1beta1")
 vertexai = pytest.importorskip("vertexai.generative_models")
 from vertexai.generative_models import HarmBlockThreshold, HarmCategory, Tool, grounding
 
 from airflow.providers.google.cloud.operators.vertex_ai.generative_model import (
+    CountTokensOperator,
     GenerateTextEmbeddingsOperator,
     GenerativeModelGenerateContentOperator,
     PromptLanguageModelOperator,
@@ -416,4 +418,33 @@ class TestVertexAISupervisedFineTuningTrainOperator:
             learning_rate_multiplier=None,
             tuned_model_display_name=None,
             validation_dataset=None,
+        )
+
+
+class TestVertexAICountTokensOperator:
+    @mock.patch(VERTEX_AI_PATH.format("generative_model.GenerativeModelHook"))
+    @mock.patch("google.cloud.aiplatform_v1beta1.types.CountTokensResponse.to_dict")
+    def test_execute(self, to_dict_mock, mock_hook):
+        contents = ["In 10 words or less, what is Apache Airflow?"]
+        pretrained_model = "gemini-pro"
+
+        op = CountTokensOperator(
+            task_id=TASK_ID,
+            project_id=GCP_PROJECT,
+            location=GCP_LOCATION,
+            contents=contents,
+            pretrained_model=pretrained_model,
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
+        op.execute(context={"ti": mock.MagicMock()})
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
+        mock_hook.return_value.count_tokens.assert_called_once_with(
+            project_id=GCP_PROJECT,
+            location=GCP_LOCATION,
+            contents=contents,
+            pretrained_model=pretrained_model,
         )

--- a/tests/system/providers/google/cloud/vertex_ai/example_vertex_ai_generative_model.py
+++ b/tests/system/providers/google/cloud/vertex_ai/example_vertex_ai_generative_model.py
@@ -29,6 +29,7 @@ from vertexai.generative_models import HarmBlockThreshold, HarmCategory, Tool, g
 
 from airflow.models.dag import DAG
 from airflow.providers.google.cloud.operators.vertex_ai.generative_model import (
+    CountTokensOperator,
     GenerativeModelGenerateContentOperator,
     TextEmbeddingModelGetEmbeddingsOperator,
     TextGenerationModelPredictOperator,
@@ -83,6 +84,19 @@ with DAG(
         pretrained_model=TEXT_EMBEDDING_MODEL,
     )
     # [END how_to_cloud_vertex_ai_text_embedding_model_get_embeddings_operator]
+
+    # [START how_to_cloud_vertex_ai_count_tokens_operator]
+    count_tokens_task = CountTokensOperator(
+        task_id="count_tokens_task",
+        project_id=PROJECT_ID,
+        contents=CONTENTS,
+        tools=TOOLS,
+        location=REGION,
+        generation_config=GENERATION_CONFIG,
+        safety_settings=SAFETY_SETTINGS,
+        pretrained_model=MULTIMODAL_MODEL,
+    )
+    # [END how_to_cloud_vertex_ai_count_tokens_operator]
 
     # [START how_to_cloud_vertex_ai_generative_model_generate_content_operator]
     generate_content_task = GenerativeModelGenerateContentOperator(

--- a/tests/system/providers/google/cloud/vertex_ai/example_vertex_ai_generative_model.py
+++ b/tests/system/providers/google/cloud/vertex_ai/example_vertex_ai_generative_model.py
@@ -90,10 +90,7 @@ with DAG(
         task_id="count_tokens_task",
         project_id=PROJECT_ID,
         contents=CONTENTS,
-        tools=TOOLS,
         location=REGION,
-        generation_config=GENERATION_CONFIG,
-        safety_settings=SAFETY_SETTINGS,
         pretrained_model=MULTIMODAL_MODEL,
     )
     # [END how_to_cloud_vertex_ai_count_tokens_operator]


### PR DESCRIPTION
The [CountTokens API](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/count-tokens?hl=en) calculates the number of input tokens before sending a request to the Gemini API.
Use the CountTokens API to prevent requests from exceeding the model context window, and estimate potential costs based on billable characters.

Can be used as part of a larger LLM-based DAG:

Training Dataset Lands --> GCSObjectExistenceSensor --> [SupervisedFineTuningTrainOperator](https://github.com/apache/airflow/blob/0f5c25b416f23c6fdc2ab20cba6a147eccaabe2d/airflow/providers/google/cloud/operators/vertex_ai/generative_model.py#L577) --> Use CountTokensOperator as a pre-check to ensure prompts will run successfully and within budget --> [GenerativeModelGenerateContentOperator](https://github.com/apache/airflow/blob/0f5c25b416f23c6fdc2ab20cba6a147eccaabe2d/airflow/providers/google/cloud/operators/vertex_ai/generative_model.py#L502)  --> RapidEvaluation API Operators (to-do)