### PR TITLE
[Fix #41763]: Redundant forward slash in SFTPToGCSOperator when destination_path is not specified or have default value

### DIFF
--- a/airflow/providers/google/cloud/transfers/sftp_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/sftp_to_gcs.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import os
 from tempfile import NamedTemporaryFile
-from typing import Sequence, TYPE_CHECKING
+from typing import TYPE_CHECKING, Sequence
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
@@ -30,6 +30,7 @@ from airflow.providers.sftp.hooks.sftp import SFTPHook
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
+
 
 WILDCARD = "*"
 

--- a/airflow/providers/google/cloud/transfers/sftp_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/sftp_to_gcs.py
@@ -134,8 +134,8 @@ class SFTPToGCSOperator(BaseOperator):
             for file in files:
                 destination_path = file.replace(base_path, self.destination_path, 1)
                 # See issue: https://github.com/apache/airflow/issues/41763
-                # If the destination path is not specified, it defaults to an empty string. As a result,
-                # replacing base_path with an empty string is ineffective, causing the destination to
+                # If the destination_path is not specified, it defaults to an empty string. As a result,
+                # replacing base_path with an empty string is ineffective, causing the destination_path to
                 # retain the "/" prefix, if it has.
                 if not self.destination_path:
                     destination_path = destination_path.lstrip("/")


### PR DESCRIPTION
If the destination path is not specified, it defaults to an empty string. As a result, replacing base_path with an empty string is ineffective, causing the destination to retain the "/" prefix, if it has.

closes: #41763
related: #41763 
