### PR TITLE
Protect against None components of universal pathlib xcom backend (#4…

### DIFF
--- a/airflow/io/path.py
+++ b/airflow/io/path.py
@@ -198,7 +198,7 @@ class ObjectStoragePath(CloudPath):
 
         Returns the new Path instance pointing to the target path.
         """
-        return self.rename(target, overwrite=True)
+        return self.rename(target)
 
     @classmethod
     def cwd(cls):

--- a/airflow/providers/common/io/xcom/backend.py
+++ b/airflow/providers/common/io/xcom/backend.py
@@ -142,7 +142,12 @@ class XComObjectStorageBackend(BaseXCom):
 
         base_path = _get_base_path()
         while True:  # Safeguard against collisions.
-            p = base_path.joinpath(dag_id, run_id, task_id, f"{uuid.uuid4()}{suffix}")
+            p = base_path.joinpath(
+                dag_id or "NO_DAG_ID",
+                run_id or "NO_RUN_ID",
+                task_id or "NO_TASK_ID",
+                f"{uuid.uuid4()}{suffix}",
+            )
             if not p.exists():
                 break
         p.parent.mkdir(parents=True, exist_ok=True)

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -497,8 +497,7 @@ DEPENDENCIES = [
     # See https://github.com/apache/airflow/pull/31693
     # We should also remove "3rd-party-licenses/LICENSE-unicodecsv.txt" file when we remove this dependency
     "unicodecsv>=0.14.1",
-    # The Universal Pathlib provides  Pathlib-like interface for FSSPEC
-    "universal-pathlib==0.2.2",  # Temporarily pin to 0.2.2 as 0.2.3 generates mypy errors
+    "universal-pathlib>=0.2.3",
     # Werkzug 3 breaks Flask-Login 0.6.2, also connexion needs to be updated to >= 3.0
     # we should remove this limitation when FAB supports Flask 2.3 and we migrate connexion to 3+
     "werkzeug>=2.0,<3",


### PR DESCRIPTION
…1921)

fixes: #41723
(cherry picked from commit 7a75f0a2bc6f964a943db98946ce652c43942180)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
