### PR TITLE
Revert "Provider fab auth manager deprecated methods removed (#41720)"

### DIFF
--- a/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -23,7 +23,8 @@ import logging
 import os
 import random
 import uuid
-from typing import Any, Callable, Collection, Iterable, Sequence
+import warnings
+from typing import TYPE_CHECKING, Any, Callable, Collection, Container, Iterable, Sequence
 
 import jwt
 import packaging.version
@@ -68,12 +69,13 @@ from itsdangerous import want_bytes
 from markupsafe import Markup
 from sqlalchemy import and_, func, inspect, literal, or_, select
 from sqlalchemy.exc import MultipleResultsFound
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import Session, joinedload
 from werkzeug.security import check_password_hash, generate_password_hash
 
 from airflow import __version__ as airflow_version
+from airflow.auth.managers.utils.fab import get_method_from_fab_action_map
 from airflow.configuration import conf
-from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning, RemovedInAirflow3Warning
 from airflow.models import DagBag, DagModel
 from airflow.providers.fab.auth_manager.models import (
     Action,
@@ -106,9 +108,13 @@ from airflow.providers.fab.auth_manager.views.user_edit import (
 )
 from airflow.providers.fab.auth_manager.views.user_stats import CustomUserStatsChartView
 from airflow.security import permissions
+from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.www.extensions.init_auth_manager import get_auth_manager
 from airflow.www.security_manager import AirflowSecurityManagerV2
 from airflow.www.session import AirflowDatabaseSessionInterface
+
+if TYPE_CHECKING:
+    from airflow.auth.managers.base_auth_manager import ResourceMethod
 
 log = logging.getLogger(__name__)
 
@@ -956,6 +962,70 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
             log.exception(const.LOGMSG_ERR_SEC_CREATE_DB)
             exit(1)
 
+    def get_readable_dags(self, user) -> Iterable[DagModel]:
+        """Get the DAGs readable by authenticated user."""
+        warnings.warn(
+            "`get_readable_dags` has been deprecated. Please use `get_auth_manager().get_permitted_dag_ids` "
+            "instead.",
+            RemovedInAirflow3Warning,
+            stacklevel=2,
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RemovedInAirflow3Warning)
+            return self.get_accessible_dags([permissions.ACTION_CAN_READ], user)
+
+    def get_editable_dags(self, user) -> Iterable[DagModel]:
+        """Get the DAGs editable by authenticated user."""
+        warnings.warn(
+            "`get_editable_dags` has been deprecated. Please use `get_auth_manager().get_permitted_dag_ids` "
+            "instead.",
+            RemovedInAirflow3Warning,
+            stacklevel=2,
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RemovedInAirflow3Warning)
+            return self.get_accessible_dags([permissions.ACTION_CAN_EDIT], user)
+
+    @provide_session
+    def get_accessible_dags(
+        self,
+        user_actions: Container[str] | None,
+        user,
+        session: Session = NEW_SESSION,
+    ) -> Iterable[DagModel]:
+        warnings.warn(
+            "`get_accessible_dags` has been deprecated. Please use "
+            "`get_auth_manager().get_permitted_dag_ids` instead.",
+            RemovedInAirflow3Warning,
+            stacklevel=3,
+        )
+
+        dag_ids = self.get_accessible_dag_ids(user, user_actions, session)
+        return session.scalars(select(DagModel).where(DagModel.dag_id.in_(dag_ids)))
+
+    @provide_session
+    def get_accessible_dag_ids(
+        self,
+        user,
+        user_actions: Container[str] | None = None,
+        session: Session = NEW_SESSION,
+    ) -> set[str]:
+        warnings.warn(
+            "`get_accessible_dag_ids` has been deprecated. Please use "
+            "`get_auth_manager().get_permitted_dag_ids` instead.",
+            RemovedInAirflow3Warning,
+            stacklevel=3,
+        )
+        if not user_actions:
+            user_actions = [permissions.ACTION_CAN_EDIT, permissions.ACTION_CAN_READ]
+        method_from_fab_action_map = get_method_from_fab_action_map()
+        user_methods: Container[ResourceMethod] = [
+            method_from_fab_action_map[action]
+            for action in method_from_fab_action_map
+            if action in user_actions
+        ]
+        return get_auth_manager().get_permitted_dag_ids(user=user, methods=user_methods, session=session)
+
     @staticmethod
     def get_readable_dag_ids(user=None) -> set[str]:
         """Get the DAG IDs readable by authenticated user."""
@@ -1012,6 +1082,17 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
 
             if dag.access_control is not None:
                 self.sync_perm_for_dag(root_dag_id, dag.access_control)
+
+    def prefixed_dag_id(self, dag_id: str) -> str:
+        """Return the permission name for a DAG id."""
+        warnings.warn(
+            "`prefixed_dag_id` has been deprecated. "
+            "Please use `airflow.security.permissions.resource_name` instead.",
+            RemovedInAirflow3Warning,
+            stacklevel=2,
+        )
+        root_dag_id = self._get_root_dag_id(dag_id)
+        return self._resource_name(root_dag_id, permissions.RESOURCE_DAG)
 
     def is_dag_resource(self, resource_name: str) -> bool:
         """Determine if a resource belongs to a DAG or all DAGs."""
@@ -1339,6 +1420,20 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
 
     def perms_include_action(self, perms, action_name):
         return any(perm.action and perm.action.name == action_name for perm in perms)
+
+    def init_role(self, role_name, perms) -> None:
+        """
+        Initialize the role with actions and related resources.
+
+        :param role_name:
+        :param perms:
+        """
+        warnings.warn(
+            "`init_role` has been deprecated. Please use `bulk_sync_roles` instead.",
+            RemovedInAirflow3Warning,
+            stacklevel=2,
+        )
+        self.bulk_sync_roles([{"role": role_name, "perms": perms}])
 
     def bulk_sync_roles(self, roles: Iterable[dict[str, Any]]) -> None:
         """Sync the provided roles and permissions."""

--- a/newsfragments/41720.significant.rst
+++ b/newsfragments/41720.significant.rst
@@ -1,5 +1,0 @@
-Removed provider fab auth manager deprecated methods as follows.
-
-Removed methods ``get_readable_dags``, ``get_editable_dags``, ``get_accessible_dags``, ``get_accessible_dag_ids`` and ``get_readable_dag_ids``. Please use ``get_auth_manager().get_permitted_dag_ids`` instead.
-Removed method ``init_role``. Please use ``bulk_sync_roles`` instead.
-Removed method ``prefixed_dag_id``. Please use ``airflow.security.permissions.resource_name`` instead.

--- a/tests/providers/fab/auth_manager/test_security.py
+++ b/tests/providers/fab/auth_manager/test_security.py
@@ -268,6 +268,25 @@ def assert_user_does_not_have_dag_perms(has_dag_perm):
 
 @pytest.mark.parametrize(
     "role",
+    [{"name": "MyRole7", "permissions": [("can_some_other_action", "AnotherBaseView")], "create": False}],
+    indirect=True,
+)
+def test_init_role_baseview(app, security_manager, role):
+    _, params = role
+
+    with pytest.warns(
+        DeprecationWarning,
+        match="`init_role` has been deprecated\\. Please use `bulk_sync_roles` instead\\.",
+    ):
+        security_manager.init_role(params["name"], params["permissions"])
+
+    _role = security_manager.find_role(params["name"])
+    assert _role is not None
+    assert len(_role.permissions) == len(params["permissions"])
+
+
+@pytest.mark.parametrize(
+    "role",
     [{"name": "MyRole3", "permissions": [("can_some_action", "SomeBaseView")]}],
     indirect=True,
 )
@@ -981,6 +1000,17 @@ def test_get_all_roles_with_permissions(security_manager):
         assert isinstance(role, security_manager.role_model)
 
     assert "Admin" in roles
+
+
+def test_prefixed_dag_id_is_deprecated(security_manager):
+    with pytest.warns(
+        DeprecationWarning,
+        match=(
+            "`prefixed_dag_id` has been deprecated. "
+            "Please use `airflow.security.permissions.resource_name` instead."
+        ),
+    ):
+        security_manager.prefixed_dag_id("hello")
 
 
 def test_permissions_work_for_dags_with_dot_in_dagname(


### PR DESCRIPTION
This reverts commit b0391838c142bebdf178ba030c45db16b1f1f33b.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
