### PR TITLE
Deprecate ``--tree`` flag for ``tasks list`` cli command

### DIFF
--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -432,7 +432,11 @@ ARG_MARK_SUCCESS_PATTERN = Arg(
 )
 
 # list_tasks
-ARG_TREE = Arg(("-t", "--tree"), help="Tree view", action="store_true")
+ARG_TREE = Arg(
+    ("-t", "--tree"),
+    help="Deprecated - use `dags show` instead. Display tasks in a tree. Note that generating the tree can be slow and the output very large for some DAGs.",
+    action="store_true",
+)
 
 # tasks_run
 # This is a hidden option -- not meant for users to set or know about

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2772,6 +2772,12 @@ class DAG(LoggingMixin):
 
     def tree_view(self) -> None:
         """Print an ASCII tree representation of the DAG."""
+        warnings.warn(
+            "`tree_view` is deprecated and will be removed in Airflow 3.0.",
+            category=RemovedInAirflow3Warning,
+            stacklevel=2,
+        )
+
         for tmp in self._generate_tree_view():
             print(tmp)
 
@@ -2787,6 +2793,12 @@ class DAG(LoggingMixin):
 
     def get_tree_view(self) -> str:
         """Return an ASCII tree representation of the DAG."""
+        warnings.warn(
+            "`get_tree_view` is deprecated and will be removed in Airflow 3.0.",
+            category=RemovedInAirflow3Warning,
+            stacklevel=2,
+        )
+
         rst = ""
         for tmp in self._generate_tree_view():
             rst += tmp + "\n"

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -1653,7 +1653,11 @@ class TestDag:
             op1_a >> op2 >> op3
 
             with redirect_stdout(StringIO()) as stdout:
-                dag.tree_view()
+                with pytest.warns(
+                    RemovedInAirflow3Warning,
+                    match="`tree_view` is deprecated and will be removed in Airflow 3.0",
+                ):
+                    dag.tree_view()
                 stdout = stdout.getvalue()
 
             stdout_lines = stdout.splitlines()
@@ -1661,7 +1665,13 @@ class TestDag:
             assert "t2" in stdout_lines[1]
             assert "t3" in stdout_lines[2]
             assert "t1_b" in stdout_lines[3]
-            assert dag.get_tree_view() == (
+
+            with pytest.warns(
+                RemovedInAirflow3Warning,
+                match="`get_tree_view` is deprecated and will be removed in Airflow 3.0",
+            ):
+                get_tree_view = dag.get_tree_view()
+            assert get_tree_view == (
                 "<Task(EmptyOperator): t1_a>\n"
                 "    <Task(EmptyOperator): t2>\n"
                 "        <Task(EmptyOperator): t3>\n"


### PR DESCRIPTION
This also deprecates the public helper functions that powered it. These will all be removed in Airflow 3 in favor of `dags show`.

Note that I didn't force a warning when `--tree` is used - that cli command is marked to suppress warnings and logging, and forcing it felt more like a breaking change to me.

Related to #41505.  Airflow 3 removal is in #41964.