### PR TITLE
Add warning that listeners can be dangerous

### DIFF
--- a/docs/apache-airflow/administration-and-deployment/listeners.rst
+++ b/docs/apache-airflow/administration-and-deployment/listeners.rst
@@ -21,6 +21,11 @@ Listeners
 You can write listeners to enable Airflow to notify you when events happen.
 `Pluggy <https://pluggy.readthedocs.io/en/stable/>`__ powers these listeners.
 
+.. warning::
+
+    Listeners are an advanced feature of Airflow. They are not isolated from the Airflow components they run in, and
+    can slow down or in come cases take down your Airflow instance. As such, extra care should be taken when writing listeners.
+
 Airflow supports notifications for the following events:
 
 Lifecycle Events


### PR DESCRIPTION
They are necessarily dangerous, but simply due to the way they are integrated into Airflow, their side effects can be pretty impactful.

![Screenshot 2024-09-02 at 4 25 22 PM](https://github.com/user-attachments/assets/704cbbb7-7d6c-4f8e-82a7-96f020d072b1)
