### PR TITLE
fix SSH key permissions and ownership in sync container

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -197,7 +197,9 @@ If release name contains chart name it will be used as a full name.
 - name: git-sync-ssh-key
   secret:
     secretName: {{ template "git_sync_ssh_key" . }}
-    defaultMode: 288
+    defaultMode: 438
+- name: git-sync-ssh-key-target
+  emptyDir: {}
 {{- end }}
 
 {{/*  Git sync container */}}
@@ -207,12 +209,27 @@ If release name contains chart name it will be used as a full name.
   imagePullPolicy: {{ .Values.images.gitSync.pullPolicy }}
   securityContext: {{- include "localContainerSecurityContext" .Values.dags.gitSync | nindent 4 }}
   envFrom: {{- include "custom_git_sync_environment_from" . | default "\n  []" | indent 2 }}
+  {{- if eq .is_init "true" }}
+  # https://security.stackexchange.com/a/271780
+  # https://github.com/kubernetes/kubernetes/issues/81089
+  command:
+    - "sh"
+    - "-c"
+    - |-
+      if [ -f /etc/git-secret/ssh ]; then
+        cp -v /etc/git-secret/ssh /git-secret/ssh
+        # make SURE there's a newline at the end of the secret.
+        echo "" >> /git-secret/ssh
+        chown -v $(id -u) /git-secret/ssh
+        chmod -v 600 /git-secret/ssh
+      fi
+  {{- end }}
   env:
     {{- if or .Values.dags.gitSync.sshKeySecret .Values.dags.gitSync.sshKey }}
     - name: GIT_SSH_KEY_FILE
-      value: "/etc/git-secret/ssh"
+      value: "/git-secret/ssh"
     - name: GITSYNC_SSH_KEY_FILE
-      value: "/etc/git-secret/ssh"
+      value: "/git-secret/ssh"
     - name: GIT_SYNC_SSH
       value: "true"
     - name: GITSYNC_SSH
@@ -308,6 +325,8 @@ If release name contains chart name it will be used as a full name.
     mountPath: /etc/git-secret/ssh
     readOnly: true
     subPath: gitSshKey
+  - name: git-sync-ssh-key-target
+    mountPath: /git-secret
   {{- if .Values.dags.gitSync.knownHosts }}
   - name: config
     mountPath: /etc/git-secret/known_hosts


### PR DESCRIPTION
Using the **helm chart** I was unable to get SSH-based git sync to run. Debugging lead to two issues:

- The secret is mounted as `root`, with permissions `0660`, which makes it unreadable for git-sync default user 65533.
- If switching to user `root` (which I did not want to do), the SSH key file is still mounted as `0660`, which makes SSH complain and ignore it.

That fix uses the init-container to fix the SSH key permissions (ownership, and file mode `0400`), which should now work with any user without any k8s-yaml-fu-magic :) .

Also, mounting secrets with non-root _ownership_ (not: group ownership) [seems impossible ATM](https://github.com/kubernetes/kubernetes/issues/81089).

If there in fact _is_ a solution for this, I would be very interested in some example helm values file config :) . I was – as mentioned – unable to create it.

**Update: some reasoning additions below**

* I found [this documentation](https://github.com/kubernetes/git-sync/blob/master/docs/ssh.md#full-example) to be incorrect in that it seems not possible to run as non-root-user, ...
* ... as I tried to replicate in [this little k8s test case](https://gist.github.com/flypenguin/6d6ca3b0757ca0f5e16f081a934b56a8).

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
