### PR TITLE
Correct scheduled slots documentation and missing open telemetry span (#41899)

### DIFF
--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1835,6 +1835,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 span.set_attribute(f"pool.queued_slots.{pool_name}", slot_stats["queued"])
                 span.set_attribute(f"pool.running_slots.{pool_name}", slot_stats["running"])
                 span.set_attribute(f"pool.deferred_slots.{pool_name}", slot_stats["deferred"])
+                span.set_attribute(f"pool.scheduled_slots.{pool_name}", slot_stats["scheduled"])
 
     @provide_session
     def adopt_or_reset_orphaned_tasks(self, session: Session = NEW_SESSION) -> int:

--- a/docs/apache-airflow/administration-and-deployment/logging-monitoring/metrics.rst
+++ b/docs/apache-airflow/administration-and-deployment/logging-monitoring/metrics.rst
@@ -242,8 +242,8 @@ Name                                                 Description
 ``pool.running_slots``                               Number of running slots in the pool. Metric with pool_name tagging.
 ``pool.deferred_slots.<pool_name>``                  Number of deferred slots in the pool
 ``pool.deferred_slots``                              Number of deferred slots in the pool. Metric with pool_name tagging.
-``pool.scheduled_tasks.<pool_name>``                 Number of scheduled tasks in the pool
-``pool.scheduled_tasks``                             Number of scheduled tasks in the pool. Metric with pool_name tagging.
+``pool.scheduled_slots.<pool_name>``                 Number of scheduled slots in the pool
+``pool.scheduled_slots``                             Number of scheduled slots in the pool. Metric with pool_name tagging.
 ``pool.starving_tasks.<pool_name>``                  Number of starving tasks in the pool
 ``pool.starving_tasks``                              Number of starving tasks in the pool. Metric with pool_name tagging.
 ``task.cpu_usage_percent.<dag_id>.<task_id>``        Percentage of CPU used by a task


### PR DESCRIPTION
* Correct documentation for pool.scheduled_slots metrics

* Add missing pool.scheduled_slots telemetry span

(cherry picked from commit 0a816c6f0b500e1b0515452e38e3446412f3e8e3)

This cherry-picks #41899.