### PR TITLE
Remove Python 3.12 exclusion for Apache Beam

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -76,7 +76,7 @@
   "apache.beam": {
     "deps": [
       "apache-airflow>=2.8.0",
-      "apache-beam>=2.53.0",
+      "apache-beam>=2.59.0",
       "pyarrow>=14.0.1"
     ],
     "devel-deps": [],
@@ -84,9 +84,7 @@
     "cross-providers-deps": [
       "google"
     ],
-    "excluded-python-versions": [
-      "3.12"
-    ],
+    "excluded-python-versions": [],
     "state": "ready"
   },
   "apache.cassandra": {

--- a/providers/src/airflow/providers/apache/beam/provider.yaml
+++ b/providers/src/airflow/providers/apache/beam/provider.yaml
@@ -62,8 +62,9 @@ versions:
 
 dependencies:
   - apache-airflow>=2.8.0
-  # Apache Beam > 2.53.0 and pyarrow > 14.0.1 fix https://nvd.nist.gov/vuln/detail/CVE-2023-47248.
-  - apache-beam>=2.53.0
+  # Apache Beam 2.59.0 removes some problematic requests exclusions that were present in 2.58.*
+  # Limiting it to >= 2.59.0 will allow to speed up resolution of dependencies.
+  - apache-beam>=2.59.0
   - pyarrow>=14.0.1
 
 additional-extras:


### PR DESCRIPTION
After https://github.com/apache/beam/issues/29149 has been fixed and Apache Beam 2.59.0 released we can finally unblock Apache Beam provider for Python 3.12 - mainly because requests is no longer limited so that Apache Beam does not conflict with few other dependencies.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
