### PR TITLE
Revert "Adding url sanitisation for extra links"

### DIFF
--- a/airflow/www/static/js/dag/details/taskInstance/ExtraLinks.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/ExtraLinks.tsx
@@ -53,14 +53,6 @@ const ExtraLinks = ({
   const isExternal = (url: string | null) =>
     url && /^(?:[a-z]+:)?\/\//.test(url);
 
-  const isSanitised = (url: string | null) => {
-    if (!url) {
-      return true;
-    }
-    const urlRegex = /^(https?:)/i;
-    return urlRegex.test(url);
-  };
-
   return (
     <Box my={3}>
       <Text as="strong">Extra Links</Text>
@@ -71,7 +63,7 @@ const ExtraLinks = ({
             as={Link}
             colorScheme="blue"
             href={url}
-            isDisabled={!isSanitised(url)}
+            isDisabled={!url}
             target={isExternal(url) ? "_blank" : undefined}
             mr={2}
           >


### PR DESCRIPTION
Reverts apache/airflow#41665

In the original PR, we considered absolute paths, but we also need to account for relative paths, as this is leading to [issue](https://github.com/apache/airflow/issues/41977). I tried to explore the possible option to extend the check to relative paths but couldn't find any good options as they can vary a lot(especially strings like `page.html`) 

### Possible relative paths
Relative to Current Directory:

    page.html – Points to a file page.html in the current directory.
    images/logo.png – Points to an images folder and the logo.png file within the current directory.

Relative to Parent Directory:

    ../about.html – Points to about.html in the parent directory.
    ../assets/styles.css – Points to styles.css in the assets folder in the parent directory.

Relative to the Root Directory:

    /index.html – Points to index.html in the root directory of the site.
    /css/styles.css – Points to the styles.css file in the css folder within the root directory.

Relative to the Current Path:

    ./file.html – Points to file.html in the current directory (same as file.html).
    ./folder/page.html – Points to page.html in the folder within the current directory.

Relative URL with Anchor (Fragment Identifier):

    #section1 – Points to the element with the id="section1" within the current page.
    page.html#header – Points to the #header within the page.html.

Relative URL with Query String:

    search.html?q=term – Points to search.html with a query parameter q=term.
    ./view.php?id=123 – Points to view.php in the current directory with a query parameter id=123.

cc: @amoghrajesh @potiuk 