### PR TITLE
Fix level of a section in the DAGs documentation

### DIFF
--- a/docs/apache-airflow/core-concepts/dags.rst
+++ b/docs/apache-airflow/core-concepts/dags.rst
@@ -494,7 +494,7 @@ You can also combine this with the :ref:`concepts:depends-on-past` functionality
 
 
 Setup and teardown
-------------------
+~~~~~~~~~~~~~~~~~~
 
 In data workflows it's common to create a resource (such as a compute resource), use it to do some work, and then tear it down. Airflow provides setup and teardown tasks to support this need.
 


### PR DESCRIPTION
Change _"Setup and teardown"_ section's level in the document.
It seems like it should be under _"Control Flow"_ section.
The current state causes confusion, thus I propose to move the section one level above.
