### PR TITLE
Add codeowners for new UI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,6 +29,9 @@
 # WWW
 /airflow/www/ @ryanahamilton @ashb @bbovenzi @pierrejeambrun
 
+# UI
+/airflow/ui/ @bbovenzi @pierrejeambrun
+
 # Security/Permissions
 /airflow/api_connexion/security.py @jhtimmins
 /airflow/security/permissions.py @jhtimmins


### PR DESCRIPTION
Add myself and @pierrejeambrun as codeowners for the `airflow/ui` directory


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
