### PR TITLE
Exclude google-cloud-spanner 3.49.0

### DIFF
--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -138,7 +138,9 @@ dependencies:
   - google-cloud-pubsub>=2.19.0
   - google-cloud-redis>=2.12.0
   - google-cloud-secret-manager>=2.16.0
-  - google-cloud-spanner>=3.11.1
+  # Google Cloud spanner 3.49.0 is excluded due to a bug in the library (missing grpc_interceptor)
+  # See https://github.com/googleapis/python-spanner/issues/1193
+  - google-cloud-spanner>=3.11.1,!=3.49.0
   - google-cloud-speech>=2.18.0
   - google-cloud-storage>=2.7.0
   - google-cloud-storage-transfer>=1.4.1

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -643,7 +643,7 @@
       "google-cloud-redis>=2.12.0",
       "google-cloud-run>=0.10.0",
       "google-cloud-secret-manager>=2.16.0",
-      "google-cloud-spanner>=3.11.1",
+      "google-cloud-spanner>=3.11.1,!=3.49.0",
       "google-cloud-speech>=2.18.0",
       "google-cloud-storage-transfer>=1.4.1",
       "google-cloud-storage>=2.7.0",


### PR DESCRIPTION
Google Cloud Spanner library released today has a missing grpc_intercept module.

See: https://github.com/googleapis/python-spanner/issues/1193

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
