### PR TITLE
Fix typo in error stack trace formatting for clearer output

### DIFF
--- a/airflow/providers/openlineage/plugins/adapter.py
+++ b/airflow/providers/openlineage/plugins/adapter.py
@@ -311,7 +311,7 @@ class OpenLineageAdapter(LoggingMixin):
             if isinstance(error, BaseException) and error.__traceback__:
                 import traceback
 
-                stack_trace = "\\n".join(traceback.format_exception(type(error), error, error.__traceback__))
+                stack_trace = traceback.format_exc()
             run_facets["errorMessage"] = error_message_run.ErrorMessageRunFacet(
                 message=str(error), programmingLanguage="python", stackTrace=stack_trace
             )

--- a/airflow/providers/openlineage/plugins/adapter.py
+++ b/airflow/providers/openlineage/plugins/adapter.py
@@ -311,7 +311,7 @@ class OpenLineageAdapter(LoggingMixin):
             if isinstance(error, BaseException) and error.__traceback__:
                 import traceback
 
-                stack_trace = traceback.format_exc()
+                stack_trace = "".join(traceback.format_exception(type(error), error, error.__traceback__))
             run_facets["errorMessage"] = error_message_run.ErrorMessageRunFacet(
                 message=str(error), programmingLanguage="python", stackTrace=stack_trace
             )


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Fix a typo in error stack trace formatting by replacing "\\\n" joins with [`traceback.format_exc()`](https://docs.python.org/3/library/traceback.html#traceback.format_exc). The previous implementation used "\\\n" to join lines, resulting in "\n" printed at the beginning of the lines. Fixing it by joining on "\n" would just  add unnecessary line breaks and extra spacing in the stack trace. Since traceback functions already handle line breaks, this fix ensures proper formatting without redundant joins.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
