### PR TITLE
Fix mock assertion in Livy test

### DIFF
--- a/tests/providers/apache/livy/hooks/test_livy.py
+++ b/tests/providers/apache/livy/hooks/test_livy.py
@@ -306,7 +306,7 @@ class TestLivyDbHook:
         # base_url is set
         hook.base_url = "//livy:8998"
         hook.post_batch(file="sparkapp")
-        mock_get_conn.not_called()
+        mock_get_conn.assert_not_called()
 
     def test_invalid_uri(self):
         with pytest.raises(RequestException):


### PR DESCRIPTION
Looks like #41658 introduced a typo in mock assertion code, `not_called()` instead of `assert_not_called()`.

This passed in Python 3.8-3.11, but Mock in 3.12 threw an error which killed 3.12 tests e.g. in #41555:

```
FAILED tests/providers/apache/livy/hooks/test_livy.py::TestLivyDbHook::test_post_batch_calls_get_conn_if_no_batch_id - AttributeError: 'not_called' is not a valid assertion. Use a spec for the mock if 'not_called' is meant to be an attribute.
```

(I guess unittest.mock in 3.12 auto-detects when you intended to assert.)

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
