### PR TITLE
Fix dev_mode check in init_react_ui

### DIFF
--- a/airflow/www/extensions/init_react_ui.py
+++ b/airflow/www/extensions/init_react_ui.py
@@ -22,7 +22,7 @@ from flask import Blueprint
 
 
 def init_react_ui(app):
-    dev_mode = bool(os.environ.get("DEV_MODE", ""))
+    dev_mode = os.environ.get("DEV_MODE", False) == "true"
 
     bp = Blueprint(
         "ui",


### PR DESCRIPTION
We had a bug when checking the dev_mode environment variable when figuring out which html file to load the UI from. It was always true, so the index html would try to read from a dev server which wasn't running.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
