### PR TITLE
Add `__doc__` property to `@task`

### DIFF
--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -334,6 +334,10 @@ class _TaskDecorator(ExpandableFactory, Generic[FParams, FReturn, OperatorSubcla
     is_teardown: bool = False
     on_failure_fail_dagrun: bool = False
 
+    @property
+    def __doc__(self):
+        return self.function.__doc__
+
     @multiple_outputs.default
     def _infer_multiple_outputs(self):
         if "return" not in self.function.__annotations__:

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -872,8 +872,8 @@ def test_task_decorator_has_wrapped_attr():
 
 def test_task_decorator_has_doc_attr():
     """
-    Test  @task original underlying function is accessible
-    through the __wrapped__ attribute.
+    Test  @task original underlying function docstring
+    through the __doc__ attribute.
     """
 
     def org_test_func():
@@ -885,7 +885,7 @@ def test_task_decorator_has_doc_attr():
     assert hasattr(
         decorated_test_func, "__doc__"
     ), "decorated function does not have __doc__ attribute"
-    assert decorated_test_func.__doc__ is org_test_func.__doc__, "__doc__ attr is not the original docstring"
+    assert decorated_test_func.__doc__ == org_test_func.__doc__, "__doc__ attr is not the original docstring"
 
 
 @pytest.mark.skip_if_database_isolation_mode  # Test is broken in db isolation mode

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -881,7 +881,9 @@ def test_task_decorator_has_doc_attr():
 
     decorated_test_func = task_decorator(org_test_func)
     assert hasattr(decorated_test_func, "__doc__"), "decorated function should have __doc__ attribute"
-    assert decorated_test_func.__doc__ == org_test_func.__doc__, "__doc__ attr should be the original docstring"
+    assert (
+        decorated_test_func.__doc__ == org_test_func.__doc__
+    ), "__doc__ attr should be the original docstring"
 
 
 @pytest.mark.skip_if_database_isolation_mode  # Test is broken in db isolation mode

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -870,6 +870,23 @@ def test_task_decorator_has_wrapped_attr():
     ), "decorated function does not have __wrapped__ attribute"
     assert decorated_test_func.__wrapped__ is org_test_func, "__wrapped__ attr is not the original function"
 
+def test_task_decorator_has_doc_attr():
+    """
+    Test  @task original underlying function is accessible
+    through the __wrapped__ attribute.
+    """
+
+    def org_test_func():
+        """Docstring"""
+        pass
+
+    decorated_test_func = task_decorator(org_test_func)
+
+    assert hasattr(
+        decorated_test_func, "__doc__"
+    ), "decorated function does not have __doc__ attribute"
+    assert decorated_test_func.__doc__ is org_test_func.__doc__, "__doc__ attr is not the original docstring"
+
 
 @pytest.mark.skip_if_database_isolation_mode  # Test is broken in db isolation mode
 def test_upstream_exception_produces_none_xcom(dag_maker, session):

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -878,13 +878,9 @@ def test_task_decorator_has_doc_attr():
 
     def org_test_func():
         """Docstring"""
-        pass
 
     decorated_test_func = task_decorator(org_test_func)
-
-    assert hasattr(
-        decorated_test_func, "__doc__"
-    ), "decorated function does not have __doc__ attribute"
+    assert hasattr(decorated_test_func, "__doc__"), "decorated function does not have __doc__ attribute"
     assert decorated_test_func.__doc__ == org_test_func.__doc__, "__doc__ attr is not the original docstring"
 
 

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -880,8 +880,8 @@ def test_task_decorator_has_doc_attr():
         """Docstring"""
 
     decorated_test_func = task_decorator(org_test_func)
-    assert hasattr(decorated_test_func, "__doc__"), "decorated function does not have __doc__ attribute"
-    assert decorated_test_func.__doc__ == org_test_func.__doc__, "__doc__ attr is not the original docstring"
+    assert hasattr(decorated_test_func, "__doc__"), "decorated function should have __doc__ attribute"
+    assert decorated_test_func.__doc__ == org_test_func.__doc__, "__doc__ attr should be the original docstring"
 
 
 @pytest.mark.skip_if_database_isolation_mode  # Test is broken in db isolation mode

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -872,7 +872,7 @@ def test_task_decorator_has_wrapped_attr():
 
 def test_task_decorator_has_doc_attr():
     """
-    Test  @task original underlying function docstring
+    Test @task original underlying function docstring
     through the __doc__ attribute.
     """
 

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -870,6 +870,7 @@ def test_task_decorator_has_wrapped_attr():
     ), "decorated function does not have __wrapped__ attribute"
     assert decorated_test_func.__wrapped__ is org_test_func, "__wrapped__ attr is not the original function"
 
+
 def test_task_decorator_has_doc_attr():
     """
     Test @task original underlying function docstring


### PR DESCRIPTION
Adds `__doc__` property to `@task` decorators via `_TaskDecorator`
This is helpful to use things like [doctests](https://docs.python.org/3/library/doctest.html)

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
