### PR TITLE
Avoid joinedload loading with one-to-many relations in dag bulk write…

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -76,6 +76,7 @@ from sqlalchemy import (
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import backref, relationship
+from sqlalchemy.orm import backref, load_only, relationship
 from sqlalchemy.sql import Select, expression
 
 import airflow.templates


### PR DESCRIPTION
Currently we are using joinedload on a lot of relations to dag in the query that locks the dag row.  This could potentially result in join explosion if we were dealing with significant numbers of dags (e.g. dag factory) along with many dag tags or dataset references.

There's not really a good reason to load eagerly in this way.  So let's not do it.

<img width="784" alt="image" src="https://github.com/user-attachments/assets/284c470c-69cb-410a-a3ab-0e4bfd1fca1b">

tagging @Lee-W and @uranusjr  just for vis since dataset alias was a recent addition to this query.

@seanmuth fyi in case curious