### PR TITLE
Fix require_confirmation_dag_change

### DIFF
--- a/airflow/www/static/js/dag.js
+++ b/airflow/www/static/js/dag.js
@@ -55,7 +55,7 @@ $("#pause_resume").on("change", function onChange() {
   const $input = $(this);
   const id = $input.data("dag-id");
   const isPaused = $input.is(":checked");
-  const requireConfirmation = $input.data("require-confirmation");
+  const requireConfirmation = $input.is("[data-require-confirmation]");
   if (requireConfirmation) {
     const confirmation = window.confirm(
       `Are you sure you want to ${isPaused ? "resume" : "pause"} this DAG?`

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -120,7 +120,7 @@
         {% endif %}
         <label class="switch-label{{' disabled' if not can_edit_dag else ''  }} js-tooltip" title="{{ switch_tooltip }}">
           <input class="switch-input" id="pause_resume" data-dag-id="{{ dag.dag_id }}"
-                  data-require-confirmation="{{ appbuilder.require_confirmation_dag_change }}"
+                  data-require-confirmation="{{ appbuilder.require_confirmation_dag_change|lower }}"
                   type="checkbox"{{ " checked" if not dag_is_paused else "" }}
                   {{ " disabled" if not can_edit_dag else "" }}>
           <span class="switch" aria-hidden="true"></span>

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -120,7 +120,7 @@
         {% endif %}
         <label class="switch-label{{' disabled' if not can_edit_dag else ''  }} js-tooltip" title="{{ switch_tooltip }}">
           <input class="switch-input" id="pause_resume" data-dag-id="{{ dag.dag_id }}"
-                  data-require-confirmation="{{ appbuilder.require_confirmation_dag_change|lower }}"
+                  {{ "data-require-confirmation" if appbuilder.require_confirmation_dag_change else "" }}
                   type="checkbox"{{ " checked" if not dag_is_paused else "" }}
                   {{ " disabled" if not can_edit_dag else "" }}>
           <span class="switch" aria-hidden="true"></span>


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Currently `require_confirmation_dag_change` seems to have no effect on pause/resume switch, triggering the switch will cause confirmation window to show up regardless. 

This is caused by JS type conversions. In current version with `data-require-confirmation="{{ appbuilder.require_confirmation_dag_change }}"` resulting value on JS side in [onChange](https://github.com/apache/airflow/blob/main/airflow/www/static/js/dag.js#L58) function has `String` type and does not automatically converts to boolean, which causes incorrect check:
```js
...
const requireConfirmation = $input.data("require-confirmation");  // has String type, non-empty
if (requireConfirmation) { // evaluates to true on non-empty strings
...
```

Adding `lower` on jinja side does the trick and seems like simplest fix, resulting string successfully converts to boolean. After that confirmation window shows up only when passing `True` to `require_confirmation_dag_change`.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
