### PR TITLE
Try to make dataset objects totally unhashable, redux

### DIFF
--- a/airflow/datasets/__init__.py
+++ b/airflow/datasets/__init__.py
@@ -206,19 +206,11 @@ class BaseDataset:
         raise NotImplementedError
 
 
-@attr.define()
+@attr.define(unsafe_hash=False)
 class DatasetAlias(BaseDataset):
     """A represeation of dataset alias which is used to create dataset during the runtime."""
 
     name: str
-
-    def __eq__(self, other: Any) -> bool:
-        if isinstance(other, DatasetAlias):
-            return self.name == other.name
-        return NotImplemented
-
-    def __hash__(self) -> int:
-        return hash(self.name)
 
     def iter_dag_dependencies(self, *, source: str, target: str) -> Iterator[DagDependency]:
         """
@@ -241,7 +233,7 @@ class DatasetAliasEvent(TypedDict):
     dest_dataset_uri: str
 
 
-@attr.define()
+@attr.define(unsafe_hash=False)
 class Dataset(os.PathLike, BaseDataset):
     """A representation of data dependencies between workflows."""
 
@@ -249,20 +241,12 @@ class Dataset(os.PathLike, BaseDataset):
         converter=_sanitize_uri,
         validator=[attr.validators.min_len(1), attr.validators.max_len(3000)],
     )
-    extra: dict[str, Any] | None = None
+    extra: dict[str, Any] = attr.field(factory=dict)
 
     __version__: ClassVar[int] = 1
 
     def __fspath__(self) -> str:
         return self.uri
-
-    def __eq__(self, other: Any) -> bool:
-        if isinstance(other, self.__class__):
-            return self.uri == other.uri
-        return NotImplemented
-
-    def __hash__(self) -> int:
-        return hash(self.uri)
 
     @property
     def normalized_uri(self) -> str | None:

--- a/airflow/datasets/__init__.py
+++ b/airflow/datasets/__init__.py
@@ -233,6 +233,18 @@ class DatasetAliasEvent(TypedDict):
     dest_dataset_uri: str
 
 
+def _set_extra_default(extra: dict | None) -> dict:
+    """
+    Automatically convert None to an empty dict.
+
+    This allows the caller site to continue doing ``Dataset(uri, extra=None)``,
+    but still allow the ``extra`` attribute to always be a dict.
+    """
+    if extra is None:
+        return {}
+    return extra
+
+
 @attr.define(unsafe_hash=False)
 class Dataset(os.PathLike, BaseDataset):
     """A representation of data dependencies between workflows."""
@@ -241,7 +253,7 @@ class Dataset(os.PathLike, BaseDataset):
         converter=_sanitize_uri,
         validator=[attr.validators.min_len(1), attr.validators.max_len(3000)],
     )
-    extra: dict[str, Any] = attr.field(factory=dict)
+    extra: dict[str, Any] = attr.field(factory=dict, converter=_set_extra_default)
 
     __version__: ClassVar[int] = 1
 

--- a/airflow/lineage/hook.py
+++ b/airflow/lineage/hook.py
@@ -126,6 +126,7 @@ class HookLineageCollector(LoggingMixin):
             return None
 
         dataset_kwargs = dataset_kwargs or {}
+        dataset_extra = dataset_extra or {}
         try:
             return dataset_factory(**dataset_kwargs, extra=dataset_extra)
         except Exception as e:

--- a/airflow/lineage/hook.py
+++ b/airflow/lineage/hook.py
@@ -112,7 +112,7 @@ class HookLineageCollector(LoggingMixin):
         """
         if uri:
             # Fallback to default factory using the provided URI
-            return Dataset(uri=uri, extra=dataset_extra)
+            return Dataset(uri=uri, extra=dataset_extra or {})
 
         if not scheme:
             self.log.debug(

--- a/airflow/lineage/hook.py
+++ b/airflow/lineage/hook.py
@@ -112,7 +112,7 @@ class HookLineageCollector(LoggingMixin):
         """
         if uri:
             # Fallback to default factory using the provided URI
-            return Dataset(uri=uri, extra=dataset_extra or {})
+            return Dataset(uri=uri, extra=dataset_extra)
 
         if not scheme:
             self.log.debug(
@@ -126,7 +126,6 @@ class HookLineageCollector(LoggingMixin):
             return None
 
         dataset_kwargs = dataset_kwargs or {}
-        dataset_extra = dataset_extra or {}
         try:
             return dataset_factory(**dataset_kwargs, extra=dataset_extra)
         except Exception as e:

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2786,12 +2786,12 @@ class DAG(LoggingMixin):
             curr_outlet_references = curr_orm_dag and curr_orm_dag.task_outlet_dataset_references
             for task in dag.tasks:
                 dataset_outlets: list[Dataset] = []
-                dataset_alias_outlets: set[DatasetAlias] = set()
+                dataset_alias_outlets: list[DatasetAlias] = []
                 for outlet in task.outlets:
                     if isinstance(outlet, Dataset):
                         dataset_outlets.append(outlet)
                     elif isinstance(outlet, DatasetAlias):
-                        dataset_alias_outlets.add(outlet)
+                        dataset_alias_outlets.append(outlet)
 
                 if not dataset_outlets:
                     if curr_outlet_references:

--- a/newsfragments/42054.significant.rst
+++ b/newsfragments/42054.significant.rst
@@ -1,0 +1,4 @@
+Dataset and DatasetAlias are no longer hashable
+
+This means they can no longer be used as dict keys or put into a set. Dataset's
+equality logic is also tweaked slightly to consider the extra dict.

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -120,12 +120,6 @@ def test_not_equal_when_different_uri():
     assert dataset1 != dataset2
 
 
-def test_hash():
-    uri = "s3://example/dataset"
-    dataset = Dataset(uri=uri)
-    hash(dataset)
-
-
 def test_dataset_logic_operations():
     result_or = dataset1 | dataset2
     assert isinstance(result_or, DatasetAny)
@@ -187,10 +181,10 @@ def test_datasetbooleancondition_evaluate_iter():
     assert all_condition.evaluate({"s3://bucket1/data1": True, "s3://bucket2/data2": False}) is False
 
     # Testing iter_datasets indirectly through the subclasses
-    datasets_any = set(any_condition.iter_datasets())
-    datasets_all = set(all_condition.iter_datasets())
-    assert datasets_any == {("s3://bucket1/data1", dataset1), ("s3://bucket2/data2", dataset2)}
-    assert datasets_all == {("s3://bucket1/data1", dataset1), ("s3://bucket2/data2", dataset2)}
+    datasets_any = dict(any_condition.iter_datasets())
+    datasets_all = dict(all_condition.iter_datasets())
+    assert datasets_any == {"s3://bucket1/data1": dataset1, "s3://bucket2/data2": dataset2}
+    assert datasets_all == {"s3://bucket1/data1": dataset1, "s3://bucket2/data2": dataset2}
 
 
 @pytest.mark.parametrize(

--- a/tests/lineage/test_hook.py
+++ b/tests/lineage/test_hook.py
@@ -96,18 +96,79 @@ class TestHookLineageCollector:
     @patch("airflow.lineage.hook.ProvidersManager")
     def test_create_dataset(self, mock_providers_manager):
         def create_dataset(arg1, arg2="default", extra=None):
-            return Dataset(uri=f"myscheme://{arg1}/{arg2}", extra=extra or {})
+            return Dataset(uri=f"myscheme://{arg1}/{arg2}", extra=extra)
 
-        mock_providers_manager.return_value.dataset_factories = {"myscheme": create_dataset}
+        test_scheme = "myscheme"
+        mock_providers_manager.return_value.dataset_factories = {test_scheme: create_dataset}
+
+        test_uri = "urischeme://value_a/value_b"
+        test_kwargs = {"arg1": "value_1"}
+        test_kwargs_uri = "myscheme://value_1/default"
+        test_extra = {"key": "value"}
+
+        # test uri arg - should take precedence over the keyword args + scheme
         assert self.collector.create_dataset(
-            scheme="myscheme", uri=None, dataset_kwargs={"arg1": "value_1"}, dataset_extra=None
-        ) == Dataset("myscheme://value_1/default")
+            scheme=test_scheme, uri=test_uri, dataset_kwargs=test_kwargs, dataset_extra=None
+        ) == Dataset(test_uri)
         assert self.collector.create_dataset(
-            scheme="myscheme",
+            scheme=test_scheme, uri=test_uri, dataset_kwargs=test_kwargs, dataset_extra={}
+        ) == Dataset(test_uri)
+        assert self.collector.create_dataset(
+            scheme=test_scheme, uri=test_uri, dataset_kwargs=test_kwargs, dataset_extra=test_extra
+        ) == Dataset(test_uri, extra=test_extra)
+
+        # test keyword args
+        assert self.collector.create_dataset(
+            scheme=test_scheme, uri=None, dataset_kwargs=test_kwargs, dataset_extra=None
+        ) == Dataset(test_kwargs_uri)
+        assert self.collector.create_dataset(
+            scheme=test_scheme, uri=None, dataset_kwargs=test_kwargs, dataset_extra={}
+        ) == Dataset(test_kwargs_uri)
+        assert self.collector.create_dataset(
+            scheme=test_scheme,
             uri=None,
-            dataset_kwargs={"arg1": "value_1", "arg2": "value_2"},
-            dataset_extra={"key": "value"},
-        ) == Dataset("myscheme://value_1/value_2", extra={"key": "value"})
+            dataset_kwargs={**test_kwargs, "arg2": "value_2"},
+            dataset_extra=test_extra,
+        ) == Dataset("myscheme://value_1/value_2", extra=test_extra)
+
+        # missing both uri and scheme
+        assert (
+            self.collector.create_dataset(
+                scheme=None, uri=None, dataset_kwargs=test_kwargs, dataset_extra=None
+            )
+            is None
+        )
+
+    @patch("airflow.lineage.hook.ProvidersManager")
+    def test_create_dataset_no_factory(self, mock_providers_manager):
+        test_scheme = "myscheme"
+        mock_providers_manager.return_value.dataset_factories = {}
+
+        test_kwargs = {"arg1": "value_1"}
+
+        assert (
+            self.collector.create_dataset(
+                scheme=test_scheme, uri=None, dataset_kwargs=test_kwargs, dataset_extra=None
+            )
+            is None
+        )
+
+    @patch("airflow.lineage.hook.ProvidersManager")
+    def test_create_dataset_factory_exception(self, mock_providers_manager):
+        def create_dataset(extra=None, **kwargs):
+            raise RuntimeError("Factory error")
+
+        test_scheme = "myscheme"
+        mock_providers_manager.return_value.dataset_factories = {test_scheme: create_dataset}
+
+        test_kwargs = {"arg1": "value_1"}
+
+        assert (
+            self.collector.create_dataset(
+                scheme=test_scheme, uri=None, dataset_kwargs=test_kwargs, dataset_extra=None
+            )
+            is None
+        )
 
     def test_collected_datasets(self):
         context_input = MagicMock()

--- a/tests/lineage/test_hook.py
+++ b/tests/lineage/test_hook.py
@@ -69,7 +69,7 @@ class TestHookLineageCollector:
         self.collector.add_input_dataset(hook, uri="test_uri")
 
         assert next(iter(self.collector._inputs.values())) == (dataset, hook)
-        mock_dataset.assert_called_once_with(uri="test_uri", extra={})
+        mock_dataset.assert_called_once_with(uri="test_uri", extra=None)
 
     def test_grouping_datasets(self):
         hook_1 = MagicMock()

--- a/tests/lineage/test_hook.py
+++ b/tests/lineage/test_hook.py
@@ -69,7 +69,7 @@ class TestHookLineageCollector:
         self.collector.add_input_dataset(hook, uri="test_uri")
 
         assert next(iter(self.collector._inputs.values())) == (dataset, hook)
-        mock_dataset.assert_called_once_with(uri="test_uri", extra=None)
+        mock_dataset.assert_called_once_with(uri="test_uri", extra={})
 
     def test_grouping_datasets(self):
         hook_1 = MagicMock()
@@ -96,7 +96,7 @@ class TestHookLineageCollector:
     @patch("airflow.lineage.hook.ProvidersManager")
     def test_create_dataset(self, mock_providers_manager):
         def create_dataset(arg1, arg2="default", extra=None):
-            return Dataset(uri=f"myscheme://{arg1}/{arg2}", extra=extra)
+            return Dataset(uri=f"myscheme://{arg1}/{arg2}", extra=extra or {})
 
         mock_providers_manager.return_value.dataset_factories = {"myscheme": create_dataset}
         assert self.collector.create_dataset(

--- a/tests/timetables/test_datasets_timetable.py
+++ b/tests/timetables/test_datasets_timetable.py
@@ -134,7 +134,7 @@ def test_serialization(dataset_timetable: DatasetOrTimeSchedule, monkeypatch: An
         "timetable": "mock_serialized_timetable",
         "dataset_condition": {
             "__type": "dataset_all",
-            "objects": [{"__type": "dataset", "uri": "test_dataset", "extra": None}],
+            "objects": [{"__type": "dataset", "uri": "test_dataset", "extra": {}}],
         },
     }
 


### PR DESCRIPTION
Re-post of @uranusjr 's change in #42054, with a bug fixed and tests added.

Original PR description:

> Using the hash property on Dataset (and DatasetAlias) is problematic since subclassing is a possibility, and user code may not correctly implement hashing for Airflow’s purposes.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
