### PR TITLE
Fix GlueDataBrewStartJobOperator template fields

### DIFF
--- a/airflow/providers/amazon/aws/operators/glue_databrew.py
+++ b/airflow/providers/amazon/aws/operators/glue_databrew.py
@@ -72,7 +72,8 @@ class GlueDataBrewStartJobOperator(AwsBaseOperator[GlueDataBrewHook]):
         "job_name",
         "wait_for_completion",
         "waiter_delay",
-        "waiter_max_attemptsdeferrable",
+        "waiter_max_attempts",
+        "deferrable",
     )
 
     def __init__(


### PR DESCRIPTION
Typo in the template fields introduced in https://github.com/apache/airflow/pull/41848 broke the operator and caused the example_glue_databrew system test to start failing.

