### PR TITLE
Use FOR KEY SHARE UPDATE instead of FOR UPDATE

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1748,8 +1748,6 @@ def _handle_reschedule(
     if test_mode:
         return
 
-    from airflow.models.dagrun import DagRun
-
     ti = _coalesce_to_orm_ti(ti=ti, session=session)
 
     ti.refresh_from_db(session)
@@ -1760,17 +1758,16 @@ def _handle_reschedule(
     ti.end_date = timezone.utcnow()
     ti.set_duration()
 
-    if session.bind.dialect.name == "mysql":
-        # Lock DAG run to be sure not to get into a deadlock situation when trying to insert
-        # TaskReschedule which apparently also creates lock on corresponding DagRun entity
-        with_row_locks(
-            session.query(DagRun).filter_by(
-                dag_id=ti.dag_id,
-                run_id=ti.run_id,
-            ),
-            session=session,
-        ).one()
-    # Log reschedule request
+    # set state
+    ti.state = TaskInstanceState.UP_FOR_RESCHEDULE
+
+    ti.clear_next_method_args()
+
+    session.merge(ti)
+    session.commit()
+
+    # we add this in separate commit to reduce likelihood of deadlock
+    # see https://github.com/apache/airflow/pull/21362 for more info
     session.add(
         TaskReschedule(
             ti.task_id,
@@ -1783,13 +1780,6 @@ def _handle_reschedule(
             ti.map_index,
         )
     )
-
-    # set state
-    ti.state = TaskInstanceState.UP_FOR_RESCHEDULE
-
-    ti.clear_next_method_args()
-
-    session.merge(ti)
     session.commit()
     return ti
 

--- a/airflow/utils/sqlalchemy.py
+++ b/airflow/utils/sqlalchemy.py
@@ -311,6 +311,7 @@ def with_row_locks(
     *,
     nowait: bool = False,
     skip_locked: bool = False,
+    key_share: bool = True,
     **kwargs,
 ) -> Query:
     """
@@ -328,6 +329,7 @@ def with_row_locks(
     :param session: ORM Session
     :param nowait: If set to True, will pass NOWAIT to supported database backends.
     :param skip_locked: If set to True, will pass SKIP LOCKED to supported database backends.
+    :param key_share: If true, will lock with FOR KEY SHARE UPDATE (at least on postgres).
     :param kwargs: Extra kwargs to pass to with_for_update (of, nowait, skip_locked, etc)
     :return: updated query
     """
@@ -342,7 +344,9 @@ def with_row_locks(
         kwargs["nowait"] = True
     if skip_locked:
         kwargs["skip_locked"] = True
-    return query.with_for_update(**kwargs, key_share=True)
+    if key_share:
+        kwargs["key_share"] = True
+    return query.with_for_update(**kwargs)
 
 
 @contextlib.contextmanager

--- a/airflow/utils/sqlalchemy.py
+++ b/airflow/utils/sqlalchemy.py
@@ -342,7 +342,7 @@ def with_row_locks(
         kwargs["nowait"] = True
     if skip_locked:
         kwargs["skip_locked"] = True
-    return query.with_for_update(**kwargs)
+    return query.with_for_update(**kwargs, key_share=True)
 
 
 @contextlib.contextmanager

--- a/tests/utils/test_sqlalchemy.py
+++ b/tests/utils/test_sqlalchemy.py
@@ -146,7 +146,7 @@ class TestSqlAlchemyUtils:
             returned_value = with_row_locks(query=query, session=session, nowait=True)
 
         if expected_use_row_level_lock:
-            query.with_for_update.assert_called_once_with(nowait=True)
+            query.with_for_update.assert_called_once_with(nowait=True, key_share=True)
         else:
             assert returned_value == query
             query.with_for_update.assert_not_called()


### PR DESCRIPTION
Pretty sure we are taking a stronger lock than we need to.

Why this matters:

Taking the weaker lock FOR KEY SHARE UPDATE allows other tables to do concurrent inserts with fks to the locked row.   This matters e.g. when we insert a task reschedule that keys to dag run.  

Right now we wait (before inserting reschedule) to be able to lock the row on dag run.  But if you have many failures close in time this can be trouble.  And it's unnecessary since we're just inserting a row with a fk to dag run.  But logic was added to fully lock the dag run because there were reported deadlocks.  But if we use the weaker lock in the first place, that would not be an issue.

And since, as far as i know, we're not ever going to change the key of the locked row, it should always be safe to do this.

Here's some relevant docs https://www.postgresql.org/docs/current/explicit-locking.html#LOCKING-ROWS

And this table shows which types of locks conflict with which.

<img width="633" alt="image" src="https://github.com/user-attachments/assets/f428db6f-aa4f-482d-b0f7-69e5c697d032">

Interactive testing notes:
* ran a few dags with 2 schedulers.  seemed to work fine.

cc @seanmuth @nsAstro 