### PR TITLE
Change compat tests to use new Airflow 2.10.1

### DIFF
--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -520,7 +520,7 @@ BASE_PROVIDERS_COMPATIBILITY_CHECKS: list[dict[str, str | list[str]]] = [
     },
     {
         "python-version": "3.8",
-        "airflow-version": "2.10.0",
+        "airflow-version": "2.10.1",
         "remove-providers": "cloudant",
         "run-tests": "true",
     },


### PR DESCRIPTION
Adding alongside to #42068 - do we have an automation or checklist where we might need to add the backcompat tests?