### PR TITLE
Do not retry when task is cleared externally (#42093)

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -312,10 +312,9 @@ def _run_raw_task(
         except (AirflowTaskTimeout, AirflowException, AirflowTaskTerminated) as e:
             if not test_mode:
                 ti.refresh_from_db(lock_for_update=True, session=session)
-            # for case when task is marked as success/failed externally
-            # or dagrun timed out and task is marked as skipped
-            # current behavior doesn't hit the callbacks
-            if ti.state in State.finished:
+            # for case when task is marked as success/failed externally (and is cleared shortly afterwards)
+            # or dagrun timed out and task is marked as skipped current behavior doesn't hit the callbacks
+            if ti.state in State.finished or ti.state is None:
                 ti.clear_next_method_args()
                 TaskInstance.save_to_db(ti=ti, session=session)
                 return None

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -551,15 +551,15 @@ class TestTaskInstance:
         assert ti.state == State.UP_FOR_RETRY
 
     @pytest.mark.skip_if_database_isolation_mode  # Does not work in db isolation mode as DB access in code
-    @pytest.mark.parametrize("state", [State.SUCCESS, State.FAILED, State.SKIPPED])
-    def test_task_sigterm_doesnt_change_state_of_finished_tasks(self, state, dag_maker):
+    @pytest.mark.parametrize("state", [State.SUCCESS, State.FAILED, State.SKIPPED, None])
+    def test_task_sigterm_doesnt_change_state_of_finished_and_cleared_tasks(self, state, dag_maker):
         session = settings.Session()
 
         def task_function(ti):
             ti.state = state
             session.merge(ti)
             session.commit()
-            raise AirflowException()
+            raise AirflowTaskTerminated()
 
         with dag_maker("test_mark_failure_2"):
             task = PythonOperator(


### PR DESCRIPTION
When the task is marked as success/failed externally and is cleared before the task instance receives SIGTERM, then we should not retry to ensure scheduling invariants (e.g. max_active_runs).

Closes #42093

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
