### PR TITLE
Fix the system test: `dataflow_native_java`

### DIFF
--- a/tests/system/providers/google/cloud/dataflow/example_dataflow_native_java.py
+++ b/tests/system/providers/google/cloud/dataflow/example_dataflow_native_java.py
@@ -52,9 +52,15 @@ BUCKET_NAME = f"bucket_{DAG_ID}_{ENV_ID}"
 PUBLIC_BUCKET = "airflow-system-tests-resources"
 
 JAR_FILE_NAME = "word-count-beam-bundled-0.1.jar"
+# For the distributed system, we need to store the JAR file in a folder that can be accessed by multiple
+# worker.
+# For example in Composer the correct path is gcs/data/word-count-beam-bundled-0.1.jar.
+# Because gcs/data/ is shared folder for Airflow's workers.
+IS_COMPOSER = bool(os.environ.get("COMPOSER_ENVIRONMENT", ""))
+LOCAL_JAR = f"gcs/data/{JAR_FILE_NAME}" if IS_COMPOSER else JAR_FILE_NAME
 REMOTE_JAR_FILE_PATH = f"dataflow/java/{JAR_FILE_NAME}"
-GCS_OUTPUT = f"gs://{BUCKET_NAME}"
 GCS_JAR = f"gs://{PUBLIC_BUCKET}/dataflow/java/{JAR_FILE_NAME}"
+GCS_OUTPUT = f"gs://{BUCKET_NAME}"
 LOCATION = "europe-west3"
 
 with DAG(
@@ -70,13 +76,13 @@ with DAG(
         task_id="download_file",
         object_name=REMOTE_JAR_FILE_PATH,
         bucket=PUBLIC_BUCKET,
-        filename=JAR_FILE_NAME,
+        filename=LOCAL_JAR,
     )
 
     # [START howto_operator_start_java_job_local_jar]
     start_java_job_local = BeamRunJavaPipelineOperator(
         task_id="start_java_job_local",
-        jar=JAR_FILE_NAME,
+        jar=LOCAL_JAR,
         pipeline_options={
             "output": GCS_OUTPUT,
         },
@@ -92,24 +98,7 @@ with DAG(
     # [START howto_operator_start_java_job_jar_on_gcs]
     start_java_job = BeamRunJavaPipelineOperator(
         runner=BeamRunnerType.DataflowRunner,
-        task_id="start-java-job",
-        jar=GCS_JAR,
-        pipeline_options={
-            "output": GCS_OUTPUT,
-        },
-        job_class="org.apache.beam.examples.WordCount",
-        dataflow_config={
-            "check_if_running": CheckJobRunning.IgnoreJob,
-            "location": LOCATION,
-            "poll_sleep": 10,
-        },
-    )
-    # [END howto_operator_start_java_job_jar_on_gcs]
-
-    # [START howto_operator_start_java_job_jar_on_gcs_deferrable]
-    start_java_deferrable = BeamRunJavaPipelineOperator(
-        runner=BeamRunnerType.DataflowRunner,
-        task_id="start-java-job-deferrable",
+        task_id="start_java_job",
         jar=GCS_JAR,
         pipeline_options={
             "output": GCS_OUTPUT,
@@ -117,6 +106,25 @@ with DAG(
         job_class="org.apache.beam.examples.WordCount",
         dataflow_config={
             "job_name": "test-java-pipeline-job",
+            "check_if_running": CheckJobRunning.IgnoreJob,
+            "location": LOCATION,
+            "poll_sleep": 10,
+            "append_job_name": False,
+        },
+    )
+    # [END howto_operator_start_java_job_jar_on_gcs]
+
+    # [START howto_operator_start_java_job_jar_on_gcs_deferrable]
+    start_java_deferrable = BeamRunJavaPipelineOperator(
+        runner=BeamRunnerType.DataflowRunner,
+        task_id="start_java_job_deferrable",
+        jar=GCS_JAR,
+        pipeline_options={
+            "output": GCS_OUTPUT,
+        },
+        job_class="org.apache.beam.examples.WordCount",
+        dataflow_config={
+            "job_name": "test-deferrable-java-pipeline-job",
             "check_if_running": CheckJobRunning.WaitForRun,
             "location": LOCATION,
             "poll_sleep": 10,


### PR DESCRIPTION
This PR is adding a logic to use a shared folder for the `example_dataflow_native_java` system test.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
