### PR TITLE
Re-Add 'executor=None' argument in run() method

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2301,6 +2301,7 @@ class DAG(LoggingMixin):
         end_date=None,
         mark_success=False,
         local=False,
+        executor=None,
         donot_pickle=airflow_conf.getboolean("core", "donot_pickle"),
         ignore_task_deps=False,
         ignore_first_depends_on_past=True,


### PR DESCRIPTION
Upon checking the blame history, I found that there were no specific changes that removed the executor=None keyword argument from this method. This argument was present in version 2.9, but for reasons that are unclear (or that I may have missed in my search), it seems to have been removed in the current version.

Interestingly, the docstring for the method still references the executor argument, which suggests a discrepancy between the code and its documentation. Given this inconsistency, I am submitting this PR to restore the executor=None argument, ensuring that the method signature aligns with its intended functionality and the existing documentation.