### PR TITLE
mark dag_run and ti as automatically injected

### DIFF
--- a/dev/mypy/plugin/outputs.py
+++ b/dev/mypy/plugin/outputs.py
@@ -19,8 +19,8 @@ from __future__ import annotations
 
 from typing import Callable
 
-from mypy.plugin import AttributeContext, MethodContext, Plugin
-from mypy.types import AnyType, Type, TypeOfAny
+from mypy.plugin import AttributeContext, MethodContext, MethodSigContext, Plugin
+from mypy.types import AnyType, CallableType, FunctionLike, Type, TypeOfAny
 
 OUTPUT_PROPERTIES = {
     "airflow.models.baseoperator.BaseOperator.output",
@@ -71,6 +71,52 @@ class OperatorOutputPlugin(Plugin):
         if fullname not in TASK_CALL_FUNCTIONS:
             return None
         return self._treat_as_any
+
+    def _treat_as_no_kwargs(self, context: MethodSigContext, /) -> FunctionLike:
+        ats = []
+        aks = []
+        ans = []
+        for arg_type, arg_kind, arg_name in zip(
+            context.default_signature.arg_types,
+            context.default_signature.arg_kinds,
+            context.default_signature.arg_names,
+            strict=True,
+        ):
+            if arg_name not in {"dag_run", "ti"}:
+                ats.append(arg_type)
+                aks.append(arg_kind)
+                ans.append(arg_name)
+
+        return CallableType(
+            ats,
+            aks,
+            ans,
+            context.default_signature.ret_type,
+            context.default_signature.fallback,
+            context.default_signature.name,
+            context.default_signature.definition,
+            context.default_signature.variables,
+            context.default_signature.line,
+            context.default_signature.column,
+            context.default_signature.is_ellipsis_args,
+            context.default_signature.implicit,
+            context.default_signature.special_sig,
+            context.default_signature.from_type_type,
+            context.default_signature.bound_args,
+            context.default_signature.def_extras,
+            context.default_signature.type_guard,
+            context.default_signature.type_is,
+            context.default_signature.from_concatenate,
+            context.default_signature.imprecise_arg_kinds,
+            context.default_signature.unpack_kwargs,
+        )
+
+    def get_method_signature_hook(
+        self, fullname: str
+    ) -> Callable[[MethodSigContext], FunctionLike] | None:
+        if fullname not in TASK_CALL_FUNCTIONS:
+            return None
+        return self._treat_as_no_kwargs
 
 
 def plugin(version: str):

--- a/dev/mypy/plugin/outputs.py
+++ b/dev/mypy/plugin/outputs.py
@@ -111,9 +111,7 @@ class OperatorOutputPlugin(Plugin):
             context.default_signature.unpack_kwargs,
         )
 
-    def get_method_signature_hook(
-        self, fullname: str
-    ) -> Callable[[MethodSigContext], FunctionLike] | None:
+    def get_method_signature_hook(self, fullname: str) -> Callable[[MethodSigContext], FunctionLike] | None:
         if fullname not in TASK_CALL_FUNCTIONS:
             return None
         return self._treat_as_no_kwargs


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Allow the usage of the mypy plugins to typecheck the `@task` annotated tasks. With this change it will be possible to avoid mypy complains when definiing a task like in https://airflow.apache.org/docs/apache-airflow/stable/tutorial/taskflow.html#accessing-context-variables-in-decorated-tasks with `ti` as an automatically injected parameter.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
