### PR TITLE
Fix details tab log url detection

### DIFF
--- a/airflow/www/static/js/dag/details/taskInstance/Logs/utils.test.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/utils.test.tsx
@@ -38,7 +38,7 @@ const mockTaskLog = `
 [2022-06-04 00:00:01,921] {dagbag.py:507} INFO - Filling up the DagBag from /files/dags/test_ui_grid.py
 [2022-06-04 00:00:01,964] {task_command.py:377} INFO - Running <TaskInstance: test_ui_grid.section_1.get_entry_group scheduled__2022-06-03T00:00:00+00:00 [running]> on host 5d28cfda3219
 [2022-06-04 00:00:02,010] {taskinstance.py:1548} WARNING - Exporting env vars: AIRFLOW_CTX_DAG_OWNER=*** AIRFLOW_CTX_DAG_ID=test_ui_grid
-[2024-07-01 00:00:02,010] {taskinstance.py:1548} INFO - Url parsing test => "https://apple.com", "https://google.com"
+[2024-07-01 00:00:02,010] {taskinstance.py:1548} INFO - Url parsing test => "https://apple.com", "https://google.com", https://something.logs/_dashboard/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-1d,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState))))
 `;
 
 describe("Test Logs Utils.", () => {
@@ -136,7 +136,7 @@ describe("Test Logs Utils.", () => {
     lines.forEach((line) => expect(line).toMatch(/INFO|WARNING/));
   });
 
-  test("parseLogs function with quoted urls", () => {
+  test("parseLogs function with urls", () => {
     const { parsedLogs } = parseLogs(
       mockTaskLog,
       null,
@@ -151,6 +151,9 @@ describe("Test Logs Utils.", () => {
     );
     expect(lines[lines.length - 1]).toContain(
       '<a href="https://google.com" target="_blank" rel="noopener noreferrer" style="color: blue; text-decoration: underline;">https://google.com</a>'
+    );
+    expect(lines[lines.length - 1]).toContain(
+      '<a href="https://something.logs/_dashboard/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-1d,to:now))&amp;_a=(columns:!(_source),filters:!((&#x27;$state&#x27;:(store:appState))))" target="_blank" rel="noopener noreferrer" style="color: blue; text-decoration: underline;">https://something.logs/_dashboard/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-1d,to:now))&amp;_a=(columns:!(_source),filters:!((&#x27;$state&#x27;:(store:appState))))</a>'
     );
   });
 });

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/utils.ts
@@ -82,7 +82,8 @@ export const parseLogs = (
   const ansiUp = new AnsiUp();
   ansiUp.url_allowlist = {};
 
-  const urlRegex = /((https?:\/\/|http:\/\/)(?:(?!&#x27;|&quot;)[^\s])+)/g;
+  const urlRegex =
+    /http(s)?:\/\/[\w.-]+(\.?:[\w.-]+)*([/?#][\w\-._~:/?#[\]@!$&'()*+,;=.%]+)?/g;
   // Coloring (blue-60 as chakra style, is #0060df) and style such that log group appears like a link
   const logGroupStyle = "color:#0060df;cursor:pointer;font-weight:bold;";
 
@@ -137,7 +138,8 @@ export const parseLogs = (
       const lineWithHyperlinks = coloredLine
         .replace(
           urlRegex,
-          '<a href="$1" target="_blank" rel="noopener noreferrer" style="color: blue; text-decoration: underline;">$1</a>'
+          (url) =>
+            `<a href="${url}" target="_blank" rel="noopener noreferrer" style="color: blue; text-decoration: underline;">${url}</a>`
         )
         .replace(logGroupStart, (textLine) => {
           const unfoldIdSuffix = "_unfold";


### PR DESCRIPTION
Use the same regexp that we have for the legacy log page which is more complex and robust. This will also enforce consistancy between the two pages. Cf screenshot the url was not properly matched, `!((` was causing trouble.

### Before
![Screenshot 2024-09-09 at 15 33 19](https://github.com/user-attachments/assets/cb5cdb19-2b18-4d09-a66f-8e50f45ab41b)


### After
![Screenshot 2024-09-09 at 15 32 37](https://github.com/user-attachments/assets/a90eff14-1fa5-4c3c-babe-42727b25296c)
