### PR TITLE
Fix failing compatibility test: importing missing saml for old airflows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -387,6 +387,7 @@ combine-as-imports = true
 "airflow/security/kerberos.py" = ["E402"]
 "airflow/security/utils.py" = ["E402"]
 "tests/providers/amazon/aws/auth_manager/security_manager/test_aws_security_manager_override.py" = ["E402"]
+"tests/system/providers/amazon/aws/tests/test_aws_auth_manager.py" = ["E402"]
 "tests/providers/common/io/xcom/test_backend.py" = ["E402"]
 "tests/providers/elasticsearch/log/elasticmock/__init__.py" = ["E402"]
 "tests/providers/elasticsearch/log/elasticmock/utilities/__init__.py" = ["E402"]

--- a/tests/system/providers/amazon/aws/tests/test_aws_auth_manager.py
+++ b/tests/system/providers/amazon/aws/tests/test_aws_auth_manager.py
@@ -22,12 +22,12 @@ from unittest.mock import Mock, patch
 import boto3
 import pytest
 
+pytest.importorskip("onelogin")
+
 from airflow.www import app as application
 from tests.system.providers.amazon.aws.utils import set_env_id
 from tests.test_utils.config import conf_vars
 from tests.test_utils.www import check_content_in_response
-
-pytest.importorskip("onelogin")
 
 SAML_METADATA_URL = "/saml/metadata"
 SAML_METADATA_PARSED = {


### PR DESCRIPTION
The Compatibility tests for AWS are failing after recent changes as they attempt to import saml library before skipping the tests when the import is missing.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
