### PR TITLE
Exclude partition from BigQuery table name

### DIFF
--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -2415,9 +2415,12 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             table_id = cmpt[1]
         else:
             raise ValueError(
-                f"{var_print(var_name)} Expect format of (<project.|<project:)<dataset>.<table>, "
+                f"{var_print(var_name)}Expect format of (<project.|<project:)<dataset>.<table>, "
                 f"got {table_input}"
             )
+
+        # Exclude partition from the table name
+        table_id = table_id.split("$")[0]
 
         if project_id is None:
             if var_name is not None:
@@ -3282,6 +3285,11 @@ def _escape(s: str) -> str:
     return e
 
 
+@deprecated(
+    planned_removal_date="April 01, 2025",
+    use_instead="airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.split_tablename",
+    category=AirflowProviderDeprecationWarning,
+)
 def split_tablename(
     table_input: str, default_project_id: str, var_name: str | None = None
 ) -> tuple[str, str, str]:
@@ -3329,6 +3337,9 @@ def split_tablename(
         raise ValueError(
             f"{var_print(var_name)}Expect format of (<project.|<project:)<dataset>.<table>, got {table_input}"
         )
+
+    # Exclude partition from the table name
+    table_id = table_id.split("$")[0]
 
     if project_id is None:
         if var_name is not None:

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -1030,12 +1030,11 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
             == result
         )
 
-
-class TestBigQueryTableSplitter:
-    def test_internal_need_default_project(self):
+    def test_split_tablename_internal_need_default_project(self):
         with pytest.raises(ValueError, match="INTERNAL: No default project is specified"):
-            split_tablename("dataset.table", None)
+            self.hook.split_tablename("dataset.table", None)
 
+    @pytest.mark.parametrize("partition", ["$partition", ""])
     @pytest.mark.parametrize(
         "project_expected, dataset_expected, table_expected, table_input",
         [
@@ -1046,9 +1045,11 @@ class TestBigQueryTableSplitter:
             ("alt1:alt", "dataset", "table", "alt1:alt:dataset.table"),
         ],
     )
-    def test_split_tablename(self, project_expected, dataset_expected, table_expected, table_input):
+    def test_split_tablename(
+        self, project_expected, dataset_expected, table_expected, table_input, partition
+    ):
         default_project_id = "project"
-        project, dataset, table = split_tablename(table_input, default_project_id)
+        project, dataset, table = self.hook.split_tablename(table_input + partition, default_project_id)
         assert project_expected == project
         assert dataset_expected == dataset
         assert table_expected == table
@@ -1080,9 +1081,65 @@ class TestBigQueryTableSplitter:
             ),
         ],
     )
-    def test_invalid_syntax(self, table_input, var_name, exception_message):
+    def test_split_tablename_invalid_syntax(self, table_input, var_name, exception_message):
         default_project_id = "project"
         with pytest.raises(ValueError, match=exception_message.format(table_input)):
+            self.hook.split_tablename(table_input, default_project_id, var_name)
+
+
+class TestBigQueryTableSplitter:
+    def test_internal_need_default_project(self):
+        with pytest.raises(AirflowProviderDeprecationWarning):
+            split_tablename("dataset.table", None)
+
+    @pytest.mark.parametrize("partition", ["$partition", ""])
+    @pytest.mark.parametrize(
+        "project_expected, dataset_expected, table_expected, table_input",
+        [
+            ("project", "dataset", "table", "dataset.table"),
+            ("alternative", "dataset", "table", "alternative:dataset.table"),
+            ("alternative", "dataset", "table", "alternative.dataset.table"),
+            ("alt1:alt", "dataset", "table", "alt1:alt.dataset.table"),
+            ("alt1:alt", "dataset", "table", "alt1:alt:dataset.table"),
+        ],
+    )
+    def test_split_tablename(
+        self, project_expected, dataset_expected, table_expected, table_input, partition
+    ):
+        default_project_id = "project"
+        with pytest.raises(AirflowProviderDeprecationWarning):
+            split_tablename(table_input + partition, default_project_id)
+
+    @pytest.mark.parametrize(
+        "table_input, var_name, exception_message",
+        [
+            ("alt1:alt2:alt3:dataset.table", None, "Use either : or . to specify project got {}"),
+            (
+                "alt1.alt.dataset.table",
+                None,
+                r"Expect format of \(<project\.\|<project\:\)<dataset>\.<table>, got {}",
+            ),
+            (
+                "alt1:alt2:alt.dataset.table",
+                "var_x",
+                "Format exception for var_x: Use either : or . to specify project got {}",
+            ),
+            (
+                "alt1:alt2:alt:dataset.table",
+                "var_x",
+                "Format exception for var_x: Use either : or . to specify project got {}",
+            ),
+            (
+                "alt1.alt.dataset.table",
+                "var_x",
+                r"Format exception for var_x: Expect format of "
+                r"\(<project\.\|<project:\)<dataset>.<table>, got {}",
+            ),
+        ],
+    )
+    def test_invalid_syntax(self, table_input, var_name, exception_message):
+        default_project_id = "project"
+        with pytest.raises(AirflowProviderDeprecationWarning):
             split_tablename(table_input, default_project_id, var_name)
 
 


### PR DESCRIPTION
- Bugfixed BigQuery table name splitting by excluding [partition](https://cloud.google.com/bigquery/docs/partitioned-tables#partition_decorators) name following after the "$".
- deprecated the function `split_tablename` which is identical to the method `BigQueryHook.split_tablename`.