### PR TITLE
Add missing `role_id` parameter back to `auth_args` for hashicorp provider, remove bad deprecation message

### DIFF
--- a/airflow/providers/hashicorp/_internal_client/vault_client.py
+++ b/airflow/providers/hashicorp/_internal_client/vault_client.py
@@ -341,6 +341,7 @@ class _VaultClient(LoggingMixin):
                     "access_key": credentials["Credentials"]["AccessKeyId"],
                     "secret_key": credentials["Credentials"]["SecretAccessKey"],
                     "session_token": credentials["Credentials"]["SessionToken"],
+                    "role": self.role_id,
                 }
             else:
                 session = boto3.Session()

--- a/airflow/providers/hashicorp/_internal_client/vault_client.py
+++ b/airflow/providers/hashicorp/_internal_client/vault_client.py
@@ -350,6 +350,7 @@ class _VaultClient(LoggingMixin):
                     "access_key": credentials.access_key,
                     "secret_key": credentials.secret_key,
                     "session_token": credentials.token,
+                    "role": self.role_id,
                 }
 
         if self.auth_mount_point:

--- a/airflow/providers/hashicorp/hooks/vault.py
+++ b/airflow/providers/hashicorp/hooks/vault.py
@@ -385,7 +385,7 @@ class VaultHook(BaseHook):
                 description="Must be 1 or 2.",
                 default=DEFAULT_KV_ENGINE_VERSION,
             ),
-            "role_id": StringField(lazy_gettext("Role ID (deprecated)"), widget=BS3TextFieldWidget()),
+            "role_id": StringField(lazy_gettext("Role ID"), widget=BS3TextFieldWidget()),
             "kubernetes_role": StringField(lazy_gettext("Kubernetes role"), widget=BS3TextFieldWidget()),
             "kubernetes_jwt_path": StringField(
                 lazy_gettext("Kubernetes jwt path"), widget=BS3TextFieldWidget()


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
closes: #42125

Adds missing `role_id` parameter back to `auth_args` dict when hitting the `else` portion of the logic, i.e., when using an IAM role to get dynamic credentials instead of using a static access key and secret access key. This was broken when that `if-else` was modified by the following PR when support for this sort of dynamic credential usage was implemented (though probably never actually tested w/o a static key + access key): https://github.com/apache/airflow/pull/38536/files

Lastly, the `(deprecated)` message is removed from the UI when creating and editing a Vault connection. That parameter is only deprecated for the `approle` auth type and is REQUIRED for `aws_iam` auth, hence why we removed that here. Users adding that parameter when using the `approle` auth method will see a deprecation message/warning still in the logs so no need to confuse users utilizing `aws_iam` in the UI.

*this is a contribution to an open issue with the hashicorp provider, no core airflow files modified*

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
