### PR TITLE
Make SAML a required dependency of Amazon provider

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -257,8 +257,8 @@ Those extras are available as regular core airflow extras - they install optiona
 # START CORE EXTRAS HERE
 
 aiobotocore, apache-atlas, apache-webhdfs, async, cgroups, cloudpickle, github-enterprise, google-
-auth, graphviz, kerberos, ldap, leveldb, otel, pandas, password, rabbitmq, s3fs, saml, sentry,
-statsd, uv, virtualenv
+auth, graphviz, kerberos, ldap, leveldb, otel, pandas, password, rabbitmq, s3fs, sentry, statsd, uv,
+virtualenv
 
 # END CORE EXTRAS HERE
 

--- a/airflow/providers/papermill/provider.yaml
+++ b/airflow/providers/papermill/provider.yaml
@@ -57,6 +57,7 @@ dependencies:
   - ipykernel
   - pandas>=2.1.2,<2.2;python_version>="3.9"
   - pandas>=1.5.3,<2.2;python_version<"3.9"
+  - python3-saml>=1.16.0
 
 integrations:
   - integration-name: Papermill

--- a/contributing-docs/12_airflow_dependencies_and_extras.rst
+++ b/contributing-docs/12_airflow_dependencies_and_extras.rst
@@ -165,8 +165,8 @@ Those extras are available as regular core airflow extras - they install optiona
   .. START CORE EXTRAS HERE
 
 aiobotocore, apache-atlas, apache-webhdfs, async, cgroups, cloudpickle, github-enterprise, google-
-auth, graphviz, kerberos, ldap, leveldb, otel, pandas, password, rabbitmq, s3fs, saml, sentry,
-statsd, uv, virtualenv
+auth, graphviz, kerberos, ldap, leveldb, otel, pandas, password, rabbitmq, s3fs, sentry, statsd, uv,
+virtualenv
 
   .. END CORE EXTRAS HERE
 

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -1014,6 +1014,7 @@
       "pandas>=1.5.3,<2.2;python_version<\"3.9\"",
       "pandas>=2.1.2,<2.2;python_version>=\"3.9\"",
       "papermill[all]>=2.6.0",
+      "python3-saml>=1.16.0",
       "scrapbook[all]"
     ],
     "devel-deps": [],

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -124,10 +124,6 @@ CORE_EXTRAS: dict[str, list[str]] = {
         # which can have a conflict with boto3 as mentioned in aiobotocore extra
         "s3fs>=2023.10.0",
     ],
-    "saml": [
-        # This is required for support of SAML which might be used by some providers (e.g. Amazon)
-        "python3-saml>=1.16.0",
-    ],
     "sentry": [
         "blinker>=1.1",
         # Sentry SDK 1.33 is broken when greenlets are installed and fails to import

--- a/newsfragments/42137.significant.rst
+++ b/newsfragments/42137.significant.rst
@@ -1,0 +1,1 @@
+Optional ``[saml]`` extra has been removed from Airflow core - instead Amazon Provider gets saml as required dependency.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,8 +79,8 @@ dynamic = ["version", "optional-dependencies", "dependencies"]
 # START CORE EXTRAS HERE
 #
 # aiobotocore, apache-atlas, apache-webhdfs, async, cgroups, cloudpickle, github-enterprise, google-
-# auth, graphviz, kerberos, ldap, leveldb, otel, pandas, password, rabbitmq, s3fs, saml, sentry,
-# statsd, uv, virtualenv
+# auth, graphviz, kerberos, ldap, leveldb, otel, pandas, password, rabbitmq, s3fs, sentry, statsd, uv,
+# virtualenv
 #
 # END CORE EXTRAS HERE
 #
@@ -387,7 +387,6 @@ combine-as-imports = true
 "airflow/security/kerberos.py" = ["E402"]
 "airflow/security/utils.py" = ["E402"]
 "tests/providers/amazon/aws/auth_manager/security_manager/test_aws_security_manager_override.py" = ["E402"]
-"tests/system/providers/amazon/aws/tests/test_aws_auth_manager.py" = ["E402"]
 "tests/providers/common/io/xcom/test_backend.py" = ["E402"]
 "tests/providers/elasticsearch/log/elasticmock/__init__.py" = ["E402"]
 "tests/providers/elasticsearch/log/elasticmock/utilities/__init__.py" = ["E402"]

--- a/tests/providers/amazon/aws/auth_manager/security_manager/test_aws_security_manager_override.py
+++ b/tests/providers/amazon/aws/auth_manager/security_manager/test_aws_security_manager_override.py
@@ -51,7 +51,6 @@ class TestAwsSecurityManagerOverride:
         "airflow.providers.amazon.aws.auth_manager.views.auth.conf.get_mandatory_value", return_value="test"
     )
     def test_register_views(self, mock_get_mandatory_value, override, appbuilder):
-        pytest.importorskip("onelogin")
         from airflow.providers.amazon.aws.auth_manager.views.auth import AwsAuthManagerAuthenticationViews
 
         with patch.object(AwsAuthManagerAuthenticationViews, "idp_data"):

--- a/tests/providers/amazon/aws/auth_manager/test_aws_auth_manager.py
+++ b/tests/providers/amazon/aws/auth_manager/test_aws_auth_manager.py
@@ -790,7 +790,6 @@ class TestAwsAuthManager:
         "airflow.providers.amazon.aws.auth_manager.views.auth.conf.get_mandatory_value", return_value="test"
     )
     def test_register_views(self, mock_get_mandatory_value, auth_manager_with_appbuilder):
-        pytest.importorskip("onelogin")
         from airflow.providers.amazon.aws.auth_manager.views.auth import AwsAuthManagerAuthenticationViews
 
         with patch.object(AwsAuthManagerAuthenticationViews, "idp_data"):

--- a/tests/providers/amazon/aws/auth_manager/views/test_auth.py
+++ b/tests/providers/amazon/aws/auth_manager/views/test_auth.py
@@ -26,8 +26,6 @@ from airflow.www import app as application
 from tests.test_utils.compat import AIRFLOW_V_2_9_PLUS
 from tests.test_utils.config import conf_vars
 
-pytest.importorskip("onelogin")
-
 pytestmark = [
     pytest.mark.skipif(not AIRFLOW_V_2_9_PLUS, reason="Test requires Airflow 2.9+"),
     pytest.mark.skip_if_database_isolation_mode,

--- a/tests/system/providers/amazon/aws/tests/test_aws_auth_manager.py
+++ b/tests/system/providers/amazon/aws/tests/test_aws_auth_manager.py
@@ -22,8 +22,6 @@ from unittest.mock import Mock, patch
 import boto3
 import pytest
 
-pytest.importorskip("onelogin")
-
 from airflow.www import app as application
 from tests.system.providers.amazon.aws.utils import set_env_id
 from tests.test_utils.config import conf_vars


### PR DESCRIPTION
Amazon provider with auth manager requires SAML onelogin import and it starts to be more and more problematic to skip the related tests for compatibility.

It seems appropriate to move saml to be a required dependency of Amazon provider in this case.

Since saml is only used by Amazon provider, we can also safely remove optional extra for it.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
