### PR TITLE
Fix task_instance and dag_run links from list views

### DIFF
--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -403,6 +403,8 @@ def task_instance_link(attr):
     task_id = attr.get("task_id")
     run_id = attr.get("run_id")
     map_index = attr.get("map_index", None)
+    execution_date = attr.get("execution_date") or attr.get("dag_run.execution_date")
+
     if map_index == -1:
         map_index = None
 
@@ -412,6 +414,7 @@ def task_instance_link(attr):
         task_id=task_id,
         dag_run_id=run_id,
         map_index=map_index,
+        execution_date=execution_date,
         tab="graph",
     )
     url_root = url_for(
@@ -421,6 +424,7 @@ def task_instance_link(attr):
         root=task_id,
         dag_run_id=run_id,
         map_index=map_index,
+        execution_date=execution_date,
         tab="graph",
     )
     return Markup(
@@ -500,10 +504,10 @@ def json_f(attr_name):
 def dag_link(attr):
     """Generate a URL to the Graph view for a Dag."""
     dag_id = attr.get("dag_id")
-    execution_date = attr.get("execution_date")
+    execution_date = attr.get("execution_date") or attr.get("dag_run.execution_date")
     if not dag_id:
         return Markup("None")
-    url = url_for("Airflow.graph", dag_id=dag_id, execution_date=execution_date)
+    url = url_for("Airflow.grid", dag_id=dag_id, execution_date=execution_date)
     return Markup('<a href="{}">{}</a>').format(url, dag_id)
 
 
@@ -511,10 +515,15 @@ def dag_run_link(attr):
     """Generate a URL to the Graph view for a DagRun."""
     dag_id = attr.get("dag_id")
     run_id = attr.get("run_id")
+    execution_date = attr.get("execution_date") or attr.get("dag_run.execution_date")
+
+    if not dag_id:
+        return Markup("None")
 
     url = url_for(
         "Airflow.grid",
         dag_id=dag_id,
+        execution_date=execution_date,
         dag_run_id=run_id,
         tab="graph",
     )

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -708,12 +708,16 @@ def show_traceback(error):
             "airflow/traceback.html",
             python_version=sys.version.split(" ")[0] if is_logged_in else "redacted",
             airflow_version=version if is_logged_in else "redacted",
-            hostname=get_hostname()
-            if conf.getboolean("webserver", "EXPOSE_HOSTNAME") and is_logged_in
-            else "redacted",
-            info=traceback.format_exc()
-            if conf.getboolean("webserver", "EXPOSE_STACKTRACE") and is_logged_in
-            else "Error! Please contact server admin.",
+            hostname=(
+                get_hostname()
+                if conf.getboolean("webserver", "EXPOSE_HOSTNAME") and is_logged_in
+                else "redacted"
+            ),
+            info=(
+                traceback.format_exc()
+                if conf.getboolean("webserver", "EXPOSE_STACKTRACE") and is_logged_in
+                else "Error! Please contact server admin."
+            ),
         ),
         500,
     )
@@ -3439,9 +3443,11 @@ class Airflow(AirflowBaseView):
                         DatasetEvent,
                         and_(
                             DatasetEvent.dataset_id == DatasetModel.id,
-                            DatasetEvent.timestamp >= latest_run.execution_date
-                            if latest_run and latest_run.execution_date
-                            else True,
+                            (
+                                DatasetEvent.timestamp >= latest_run.execution_date
+                                if latest_run and latest_run.execution_date
+                                else True
+                            ),
                         ),
                         isouter=True,
                     )


### PR DESCRIPTION
Fix links in dag_runs and task instances view.

When we use the redirection links for tasks or dag_run older that the `25` latest dag run the redirection does not work as expected.



Working on adding a few tests.

Closes: https://github.com/apache/airflow/issues/41406



Now clicking on an old dag run: (both from dag_run or task_instance page)
![Screenshot 2024-09-10 at 17 57 33](https://github.com/user-attachments/assets/119cda0d-0ac5-4b9a-9065-ce6f4b5558e3)

Now clicking on an old task instance:
![Screenshot 2024-09-10 at 17 57 59](https://github.com/user-attachments/assets/752ad8c6-e309-427a-acaa-401b4e5e57bd)


Before clicking on an old dag run:
![Screenshot 2024-09-10 at 17 59 33](https://github.com/user-attachments/assets/0305c75c-28ab-407e-b885-57ab687d7a52)

Before clicking on an old task instance:
![Screenshot 2024-09-10 at 18 00 21](https://github.com/user-attachments/assets/b452f7e3-cda8-452d-b497-2d34998360e8)



