### PR TITLE
New UI allow dag pause

### DIFF
--- a/airflow/ui/src/components/DataTable/DataTable.tsx
+++ b/airflow/ui/src/components/DataTable/DataTable.tsx
@@ -176,7 +176,7 @@ export const DataTable = <TData,>({
   return (
     <TableContainer overflowY="auto" maxH="calc(100vh - 10rem)">
       <ChakraTable colorScheme="blue">
-        <Thead position="sticky" top={0} bg={theadBg}>
+        <Thead position="sticky" top={0} bg={theadBg} zIndex={1}>
           {table.getHeaderGroups().map((headerGroup) => (
             <Tr key={headerGroup.id}>
               {headerGroup.headers.map(

--- a/airflow/ui/src/components/PauseToggle.tsx
+++ b/airflow/ui/src/components/PauseToggle.tsx
@@ -1,0 +1,82 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Switch } from "@chakra-ui/react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useSearchParams } from "react-router-dom";
+
+import {
+  DagServiceGetDagsDefaultResponse,
+  DagServicePatchDagMutationResult,
+  UseDagServiceGetDagsKeyFn,
+  useDagServicePatchDag,
+} from "openapi/queries";
+import { useTableURLState } from "./DataTable/useTableUrlState";
+
+type Props = {
+  dagId: string;
+  isPaused: boolean;
+};
+
+export const PauseToggle = ({ dagId, isPaused }: Props) => {
+  const [searchParams] = useSearchParams();
+  const { tableURLState } = useTableURLState();
+  const { sorting, pagination } = tableURLState;
+  const showPaused = searchParams.get("paused") === "true";
+  const sort = sorting[0];
+  const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : undefined;
+
+  const onSuccess = (data: DagServicePatchDagMutationResult) => {
+    // Update Dags list query on result instead of refetching it
+    queryClient.setQueryData(
+      UseDagServiceGetDagsKeyFn({
+        limit: pagination.pageSize,
+        offset: pagination.pageIndex * pagination.pageSize,
+        onlyActive: true,
+        paused: showPaused === true ? undefined : false, // undefined returns all dags
+        orderBy,
+      }),
+      (oldData: DagServiceGetDagsDefaultResponse) => {
+        if (!showPaused && data.is_paused)
+          return {
+            ...oldData,
+            total_entries: oldData.total_entries
+              ? oldData.total_entries - 1
+              : oldData.total_entries,
+            dags: oldData.dags?.filter((dag) => dag.dag_id !== data.dag_id),
+          };
+        return {
+          ...oldData,
+          dags: oldData.dags?.map((dag) => (dag.dag_id === dagId ? data : dag)),
+        };
+      }
+    );
+  };
+  const { mutate } = useDagServicePatchDag({ onSuccess });
+  const queryClient = useQueryClient();
+  const onChange = () => {
+    mutate({
+      dagId,
+      requestBody: {
+        is_paused: !isPaused,
+      },
+    });
+  };
+  return <Switch size="sm" isChecked={!isPaused} onChange={onChange} />;
+};

--- a/airflow/ui/src/nav.tsx
+++ b/airflow/ui/src/nav.tsx
@@ -56,9 +56,11 @@ const NavButton = ({ icon, title, ...rest }: NavButtonProps) => (
     variant="ghost"
     borderRadius="none"
     height={16}
+    width={24}
     alignItems="center"
     flexDir="column"
     whiteSpace="wrap"
+    transition="background-color 0.2s ease-in-out"
     {...rest}
   >
     <Box alignSelf="center">{icon}</Box>
@@ -96,7 +98,7 @@ export const Nav = () => {
         <NavButton title="Home" icon={<FiHome size="1.75rem" />} isDisabled />
         <NavButton title="DAGs" icon={<DagIcon height={7} width={7} />} />
         <NavButton
-          title="Datasets"
+          title="Assets"
           icon={<FiDatabase size="1.75rem" />}
           isDisabled
         />

--- a/airflow/ui/src/theme.ts
+++ b/airflow/ui/src/theme.ts
@@ -61,6 +61,13 @@ const theme = extendTheme({
   config: {
     useSystemColorMode: true,
   },
+  styles: {
+    global: {
+      "*, *::before, &::after": {
+        borderColor: "gray.200",
+      },
+    },
+  },
   components: {
     Tooltip: {
       baseStyle: {

--- a/airflow/ui/src/theme.ts
+++ b/airflow/ui/src/theme.ts
@@ -61,13 +61,6 @@ const theme = extendTheme({
   config: {
     useSystemColorMode: true,
   },
-  styles: {
-    global: {
-      "*, *::before, &::after": {
-        borderColor: "gray.200",
-      },
-    },
-  },
   components: {
     Tooltip: {
       baseStyle: {


### PR DESCRIPTION
Add Switch to pause and unpause DAGs from the new UI DAGs List. Use react query cache to update the existing dags list result vs refetching the entire list on every change.

<img width="821" alt="Screenshot 2024-09-10 at 10 30 09 AM" src="https://github.com/user-attachments/assets/4b75bf29-a609-4bc9-b486-4c09c268526a">

Also:
- move the loading state to just the table and not its search/filter buttons.
- fix some nav button hover area and transition
- Datasets -> Assets
- Use timetable summary instead of the more verbose description

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
