### PR TITLE
Display tryNumber for failed and completed tasks in grid

### DIFF
--- a/airflow/www/static/js/dag/StatusBox.tsx
+++ b/airflow/www/static/js/dag/StatusBox.tsx
@@ -20,6 +20,7 @@
 import React from "react";
 import { isEqual } from "lodash";
 import { Box, useTheme, BoxProps } from "@chakra-ui/react";
+import { MdRefresh } from "react-icons/md";
 
 import { useContainerRef } from "src/context/containerRef";
 import type { Task, TaskInstance, TaskState } from "src/types";
@@ -34,12 +35,14 @@ export const boxSizePx = `${boxSize}px`;
 
 interface StatusWithNotesProps extends BoxProps {
   state: TaskState;
+  tryNumber?: number;
   containsNotes?: boolean;
 }
 
 export const StatusWithNotes = ({
   state,
   containsNotes,
+  tryNumber,
   ...rest
 }: StatusWithNotesProps) => {
   const color = state && stateColors[state] ? stateColors[state] : "white";
@@ -50,8 +53,13 @@ export const StatusWithNotes = ({
       background={getStatusBackgroundColor(color, !!containsNotes)}
       borderRadius="2px"
       borderWidth={state ? 0 : 1}
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
       {...rest}
-    />
+    >
+      {tryNumber !== undefined && tryNumber > 1 && <MdRefresh color="white" />}
+    </Box>
   );
 };
 
@@ -137,6 +145,7 @@ const StatusBox = ({
         <StatusWithNotes
           state={instance.state}
           containsNotes={containsNotes}
+          tryNumber={instance.tryNumber}
           onClick={onClick}
           cursor="pointer"
           data-testid="task-instance"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
This makes a small change to the task instance grid so that it is easy to see at a glance the number of attempts that were made for failed and successful tasks.

Only displayed if attempts > 1. Currently you have to click into each task to check this. 

It will look as follows:

<img width="572" alt="image" src="https://github.com/user-attachments/assets/27e98540-b451-4cbe-81b2-5bc185d62c88">

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
