### PR TITLE
Pin airbyte-api to 0.51.0 (#42154)

### DIFF
--- a/airflow/providers/airbyte/provider.yaml
+++ b/airflow/providers/airbyte/provider.yaml
@@ -51,7 +51,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.8.0
-  - airbyte-api>=0.51.0
+  - airbyte-api==0.51.0  # v0.52.0 breaks hooks, see https://github.com/apache/airflow/issues/42154
 
 integrations:
   - integration-name: Airbyte

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -1,7 +1,7 @@
 {
   "airbyte": {
     "deps": [
-      "airbyte-api>=0.51.0",
+      "airbyte-api==0.51.0",
       "apache-airflow>=2.8.0"
     ],
     "devel-deps": [],


### PR DESCRIPTION
Temporarily pin the apibyte-api version until provider is fixed

related: #42154 