### PR TITLE
do not camelcase xcom entries

### DIFF
--- a/airflow/www/static/js/api/index.ts
+++ b/airflow/www/static/js/api/index.ts
@@ -65,9 +65,14 @@ axios.interceptors.request.use((config) => {
   return config;
 });
 
-axios.interceptors.response.use((res: AxiosResponse) =>
-  res.data ? camelcaseKeys(res.data, { deep: true }) : res
-);
+// Do not camelCase xCom entry results
+axios.interceptors.response.use((res: AxiosResponse) => {
+  const stopPaths = [];
+  if (res.config.url?.includes("/xcomEntries/")) {
+    stopPaths.push("value");
+  }
+  return res.data ? camelcaseKeys(res.data, { deep: true, stopPaths }) : res;
+});
 
 axios.defaults.headers.common.Accept = "application/json";
 


### PR DESCRIPTION
Skip applying camelCase to `value` when GETting an xcom entry.

Closes #42029

There are probably more places we want to skip camelCasing and in the new UI we are not camelCasing.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
