### PR TITLE
Add Jens Scheffler for UI as contributor

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,10 +27,10 @@
 /airflow/api_connexion/ @ephraimbuddy @pierrejeambrun
 
 # WWW
-/airflow/www/ @ryanahamilton @ashb @bbovenzi @pierrejeambrun
+/airflow/www/ @ryanahamilton @ashb @bbovenzi @pierrejeambrun @jscheffl
 
 # UI
-/airflow/ui/ @bbovenzi @pierrejeambrun @ryanahamilton
+/airflow/ui/ @bbovenzi @pierrejeambrun @ryanahamilton @jscheffl
 
 # Security/Permissions
 /airflow/api_connexion/security.py @jhtimmins
@@ -65,6 +65,7 @@
 /airflow/providers/cncf/kubernetes @jedcunningham @hussein-awala
 /airflow/providers/common/sql/ @eladkal
 /airflow/providers/dbt/cloud/ @josh-fell
+/airflow/providers/edge @jscheffl
 /airflow/providers/hashicorp/ @hussein-awala
 /airflow/providers/openlineage/ @mobuchowski
 /airflow/providers/slack/ @eladkal


### PR DESCRIPTION
I'd like to volunteer (more) to UI work if possible and to be "up-to-date" I'd like to see the PRs currently made for Airflow 3. Therefore I'd like to "join forces".

Also adding myself as maintainer for the (new) edge provider