### PR TITLE
Add fastapi migration done marker

### DIFF
--- a/airflow/api_connexion/endpoints/dag_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_endpoint.py
@@ -39,6 +39,7 @@ from airflow.api_connexion.schemas.dag_schema import (
 from airflow.exceptions import AirflowException, DagNotFound
 from airflow.models.dag import DagModel, DagTag
 from airflow.utils.airflow_flask_app import get_airflow_app
+from airflow.utils.api_migration import mark_fastapi_migration_done
 from airflow.utils.db import get_query_count
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.www.decorators import action_logging
@@ -89,6 +90,7 @@ def get_dag_details(
     return dag_detail_schema.dump(dag_model)
 
 
+@mark_fastapi_migration_done
 @security.requires_access_dag("GET")
 @format_parameters({"limit": check_limit})
 @provide_session

--- a/airflow/utils/api_migration.py
+++ b/airflow/utils/api_migration.py
@@ -1,0 +1,40 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Utilities for migration legacy endpoints to FastAPI.
+
+This module can be deleted once the AIP-84 is completed and the legacy API is deleted.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, TypeVar
+
+from airflow.typing_compat import ParamSpec
+
+PS = ParamSpec("PS")
+RT = TypeVar("RT")
+
+
+def mark_fastapi_migration_done(function: Callable[PS, RT]) -> Callable[PS, RT]:
+    """
+    Mark an endpoint as migrated over to the new FastAPI API.
+
+    This will help track what endpoints need to be migrated and the one that can be safely deleted.
+    """
+    return function

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -120,6 +120,7 @@ from airflow.timetables.base import DataInterval, TimeRestriction
 from airflow.timetables.simple import ContinuousTimetable
 from airflow.utils import json as utils_json, timezone, usage_data_collection, yaml
 from airflow.utils.airflow_flask_app import get_airflow_app
+from airflow.utils.api_migration import mark_fastapi_migration_done
 from airflow.utils.dag_edges import dag_edges
 from airflow.utils.db import get_query_count
 from airflow.utils.docs import get_doc_url_for_provider, get_docs_url
@@ -3409,6 +3410,7 @@ class Airflow(AirflowBaseView):
     @expose("/object/next_run_datasets/<string:dag_id>")
     @auth.has_access_dag("GET", DagAccessEntity.RUN)
     @auth.has_access_dataset("GET")
+    @mark_fastapi_migration_done
     def next_run_datasets(self, dag_id):
         """Return datasets necessary, and their status, for the next dag run."""
         dag = get_airflow_app().dag_bag.get_dag(dag_id)

--- a/contributing-docs/17_adding_api_endpoints.rst
+++ b/contributing-docs/17_adding_api_endpoints.rst
@@ -133,3 +133,7 @@ For example, in v1.yaml, you might add:
 Including schemas helps in automatically generating API documentation and ensures consistent data structures across the API.
 
 After adding or modifying schemas, make sure to run the pre-commit hooks again to update any generated files.
+
+Note on the New FastAPI API
+---------------------------
+As part of the AIP-84 you may be adding new endpoints to the FastAPI API by migrating some legacy endpoints. In case you are doing so don't forget to mark the legacy endpoint (Flask one) with the ``@mark_fastapi_migration_done`` decorator. This will help maintainers keep track of the endpoints remaining for the migration and those already migrated.


### PR DESCRIPTION
Follow up of: https://github.com/apache/airflow/pull/42196

You can just review the last commit. This is short one that add a no-op decorator to be able to mark endpoint as migrated over to the new FastAPI API.

The goal with this is to keep track of what is left to migrate and what is already migrated. There are a lot of endpoints and this will prevent maintainers from searching over the code base to get that information. The advantage of a decorator over docstring or comment is that it's code. (searchable by references, consistent in style, etc...).

Kind ask to contributors and reviewers of PR related to `AIP-84` please enforce the usage of this marker on PRs migrating endpoints :).
