### PR TITLE
Fix: render non-null falsy XCom entries correctly in UI

### DIFF
--- a/airflow/www/static/js/dag/details/taskInstance/Xcom/XcomEntry.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Xcom/XcomEntry.tsx
@@ -67,7 +67,7 @@ const XcomEntry = ({
         No value found for XCom key
       </Alert>
     );
-  } else if (!xcom.value) {
+  } else if (xcom.value === undefined || xcom.value === null) {
     content = (
       <Alert status="info">
         <AlertIcon />


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

Fixed issues described in https://github.com/apache/airflow/issues/42096, which were introduced in https://github.com/apache/airflow/commit/563bc494ab5c610c46a60b2fe6beed742e3d588e

