### PR TITLE
Add template fields tests to AWS operators (2)

### DIFF
--- a/tests/providers/amazon/aws/operators/test_eventbridge.py
+++ b/tests/providers/amazon/aws/operators/test_eventbridge.py
@@ -29,6 +29,7 @@ from airflow.providers.amazon.aws.operators.eventbridge import (
     EventBridgePutEventsOperator,
     EventBridgePutRuleOperator,
 )
+from tests.providers.amazon.aws.utils.test_template_fields import validate_template_fields
 
 if TYPE_CHECKING:
     from unittest.mock import MagicMock
@@ -96,6 +97,13 @@ class TestEventBridgePutEventsOperator:
         with pytest.raises(AirflowException):
             operator.execute(context={})
 
+    def test_template_fields(self):
+        operator = EventBridgePutEventsOperator(
+            task_id="failed_put_events_job",
+            entries=ENTRIES,
+        )
+        validate_template_fields(operator)
+
 
 class TestEventBridgePutRuleOperator:
     def test_init(self):
@@ -150,6 +158,12 @@ class TestEventBridgePutRuleOperator:
         with pytest.raises(ValueError):
             operator.execute(None)
 
+    def test_template_fields(self):
+        operator = EventBridgePutRuleOperator(
+            task_id="events_put_rule_job", name=RULE_NAME, event_pattern=EVENT_PATTERN
+        )
+        validate_template_fields(operator)
+
 
 class TestEventBridgeEnableRuleOperator:
     def test_init(self):
@@ -186,6 +200,13 @@ class TestEventBridgeEnableRuleOperator:
         enable_rule.execute(context={})
         mock_conn.enable_rule.assert_called_with(Name=RULE_NAME)
 
+    def test_template_fields(self):
+        operator = EventBridgeEnableRuleOperator(
+            task_id="events_enable_rule_job",
+            name=RULE_NAME,
+        )
+        validate_template_fields(operator)
+
 
 class TestEventBridgeDisableRuleOperator:
     def test_init(self):
@@ -221,3 +242,10 @@ class TestEventBridgeDisableRuleOperator:
 
         disable_rule.execute(context={})
         mock_conn.disable_rule.assert_called_with(Name=RULE_NAME)
+
+    def test_template_fields(self):
+        operator = EventBridgeDisableRuleOperator(
+            task_id="events_disable_rule_job",
+            name=RULE_NAME,
+        )
+        validate_template_fields(operator)

--- a/tests/providers/amazon/aws/operators/test_glacier.py
+++ b/tests/providers/amazon/aws/operators/test_glacier.py
@@ -26,6 +26,7 @@ from airflow.providers.amazon.aws.operators.glacier import (
     GlacierCreateJobOperator,
     GlacierUploadArchiveOperator,
 )
+from tests.providers.amazon.aws.utils.test_template_fields import validate_template_fields
 
 if TYPE_CHECKING:
     from airflow.providers.amazon.aws.operators.base_aws import AwsBaseOperator
@@ -78,6 +79,10 @@ class TestGlacierCreateJobOperator(BaseGlacierOperatorsTests):
         op.execute(mock.MagicMock())
         hook_mock.return_value.retrieve_inventory.assert_called_once_with(vault_name=VAULT_NAME)
 
+    def test_template_fields(self):
+        operator = self.op_class(**self.default_op_kwargs)
+        validate_template_fields(operator)
+
 
 class TestGlacierUploadArchiveOperator(BaseGlacierOperatorsTests):
     op_class = GlacierUploadArchiveOperator
@@ -97,3 +102,7 @@ class TestGlacierUploadArchiveOperator(BaseGlacierOperatorsTests):
                 body=b"Test Data",
                 checksum=None,
             )
+
+    def test_template_fields(self):
+        operator = self.op_class(**self.default_op_kwargs)
+        validate_template_fields(operator)

--- a/tests/providers/amazon/aws/operators/test_glue.py
+++ b/tests/providers/amazon/aws/operators/test_glue.py
@@ -34,6 +34,7 @@ from airflow.providers.amazon.aws.operators.glue import (
     GlueDataQualityRuleSetEvaluationRunOperator,
     GlueJobOperator,
 )
+from tests.providers.amazon.aws.utils.test_template_fields import validate_template_fields
 
 if TYPE_CHECKING:
     from airflow.models import TaskInstance
@@ -307,6 +308,17 @@ class TestGlueJobOperator:
             "folder/file", "artifacts/glue-scripts/file", bucket_name="bucket_name", replace=True
         )
 
+    def test_template_fields(self):
+        operator = GlueJobOperator(
+            task_id=TASK_ID,
+            job_name=JOB_NAME,
+            script_location="folder/file",
+            s3_bucket="bucket_name",
+            iam_role_name="role_arn",
+            replace_script_file=True,
+        )
+        validate_template_fields(operator)
+
 
 class TestGlueDataQualityOperator:
     RULE_SET_NAME = "TestRuleSet"
@@ -435,6 +447,12 @@ class TestGlueDataQualityOperator:
         with pytest.raises(AttributeError, match="RuleSet must starts with Rules = \\[ and ends with \\]"):
             self.operator.validate_inputs()
 
+    def test_template_fields(self):
+        operator = GlueDataQualityOperator(
+            task_id="create_data_quality_ruleset", name=self.RULE_SET_NAME, ruleset=self.RULE_SET
+        )
+        validate_template_fields(operator)
+
 
 class TestGlueDataQualityRuleSetEvaluationRunOperator:
     RUN_ID = "1234567890"
@@ -537,6 +555,9 @@ class TestGlueDataQualityRuleSetEvaluationRunOperator:
         assert response == self.RUN_ID
         assert glue_data_quality_hook.get_waiter.call_count == wait_for_completion
         assert self.operator.defer.call_count == deferrable
+
+    def test_template_fields(self):
+        validate_template_fields(self.operator)
 
 
 class TestGlueDataQualityRuleRecommendationRunOperator:
@@ -643,3 +664,6 @@ class TestGlueDataQualityRuleRecommendationRunOperator:
         assert response == self.RUN_ID
         assert glue_data_quality_hook.get_waiter.call_count == wait_for_completion
         assert self.operator.defer.call_count == deferrable
+
+    def test_template_fields(self):
+        validate_template_fields(self.operator)

--- a/tests/providers/amazon/aws/operators/test_glue_crawler.py
+++ b/tests/providers/amazon/aws/operators/test_glue_crawler.py
@@ -25,6 +25,7 @@ from moto import mock_aws
 from airflow.providers.amazon.aws.hooks.glue_crawler import GlueCrawlerHook
 from airflow.providers.amazon.aws.hooks.sts import StsHook
 from airflow.providers.amazon.aws.operators.glue_crawler import GlueCrawlerOperator
+from tests.providers.amazon.aws.utils.test_template_fields import validate_template_fields
 
 if TYPE_CHECKING:
     from airflow.providers.amazon.aws.hooks.base_aws import BaseAwsConnection
@@ -173,3 +174,6 @@ class TestGlueCrawlerOperator:
         assert response == mock_crawler_name
         assert crawler_hook.get_waiter.call_count == wait_for_completion
         assert self.op.defer.call_count == deferrable
+
+    def test_template_fields(self):
+        validate_template_fields(self.op)

--- a/tests/providers/amazon/aws/operators/test_glue_databrew.py
+++ b/tests/providers/amazon/aws/operators/test_glue_databrew.py
@@ -26,6 +26,7 @@ from moto import mock_aws
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.amazon.aws.hooks.glue_databrew import GlueDataBrewHook
 from airflow.providers.amazon.aws.operators.glue_databrew import GlueDataBrewStartJobOperator
+from tests.providers.amazon.aws.utils.test_template_fields import validate_template_fields
 
 JOB_NAME = "test_job"
 
@@ -101,3 +102,7 @@ class TestGlueDataBrewOperator:
         assert operator.waiter_delay == 15
         operator.execute(None)
         mock_hook_get_waiter.assert_not_called()
+
+    def test_template_fields(self):
+        operator = GlueDataBrewStartJobOperator(task_id="fake_task_id", job_name=JOB_NAME)
+        validate_template_fields(operator)

--- a/tests/providers/amazon/aws/operators/test_kinesis_analytics.py
+++ b/tests/providers/amazon/aws/operators/test_kinesis_analytics.py
@@ -30,6 +30,7 @@ from airflow.providers.amazon.aws.operators.kinesis_analytics import (
     KinesisAnalyticsV2StartApplicationOperator,
     KinesisAnalyticsV2StopApplicationOperator,
 )
+from tests.providers.amazon.aws.utils.test_template_fields import validate_template_fields
 
 if TYPE_CHECKING:
     from airflow.providers.amazon.aws.hooks.base_aws import BaseAwsConnection
@@ -158,6 +159,15 @@ class TestKinesisAnalyticsV2CreateApplicationOperator:
 
         with pytest.raises(AirflowException, match=error_message):
             operator.execute({})
+
+    def test_template_fields(self):
+        operator = KinesisAnalyticsV2CreateApplicationOperator(
+            task_id="create_application_operator",
+            application_name="demo",
+            runtime_environment="FLINK_18_9",
+            service_execution_role="arn",
+        )
+        validate_template_fields(operator)
 
 
 class TestKinesisAnalyticsV2StartApplicationOperator:
@@ -327,6 +337,9 @@ class TestKinesisAnalyticsV2StartApplicationOperator:
         ):
             self.operator.execute_complete(context=None, event=event)
 
+    def test_template_fields(self):
+        validate_template_fields(self.operator)
+
 
 class TestKinesisAnalyticsV2StopApplicationOperator:
     APPLICATION_ARN = "arn:aws:kinesisanalytics:us-east-1:123456789012:application/demo"
@@ -483,3 +496,6 @@ class TestKinesisAnalyticsV2StopApplicationOperator:
             AirflowException, match="Error while stopping AWS Managed Service for Apache Flink application"
         ):
             self.operator.execute_complete(context=None, event=event)
+
+    def test_template_fields(self):
+        validate_template_fields(self.operator)

--- a/tests/providers/amazon/aws/operators/test_lambda_function.py
+++ b/tests/providers/amazon/aws/operators/test_lambda_function.py
@@ -29,6 +29,7 @@ from airflow.providers.amazon.aws.operators.lambda_function import (
     LambdaCreateFunctionOperator,
     LambdaInvokeFunctionOperator,
 )
+from tests.providers.amazon.aws.utils.test_template_fields import validate_template_fields
 
 FUNCTION_NAME = "function_name"
 PAYLOADS = [
@@ -160,6 +161,17 @@ class TestLambdaCreateFunctionOperator:
         assert operator.config.get("snap_start") == config.get("snap_start")
         assert operator.config.get("ephemeral_storage") == config.get("ephemeral_storage")
 
+    def test_template_fields(self):
+        operator = LambdaCreateFunctionOperator(
+            task_id="task_test",
+            function_name=FUNCTION_NAME,
+            role=ROLE_ARN,
+            code={
+                "ImageUri": IMAGE_URI,
+            },
+        )
+        validate_template_fields(operator)
+
 
 class TestLambdaInvokeFunctionOperator:
     @pytest.mark.parametrize("payload", PAYLOADS)
@@ -280,3 +292,10 @@ class TestLambdaInvokeFunctionOperator:
 
         with pytest.raises(ValueError):
             operator.execute(None)
+
+    def test_template_fields(self):
+        operator = LambdaInvokeFunctionOperator(
+            task_id="task_test",
+            function_name="a",
+        )
+        validate_template_fields(operator)

--- a/tests/providers/amazon/aws/operators/test_neptune.py
+++ b/tests/providers/amazon/aws/operators/test_neptune.py
@@ -30,6 +30,7 @@ from airflow.providers.amazon.aws.operators.neptune import (
     NeptuneStartDbClusterOperator,
     NeptuneStopDbClusterOperator,
 )
+from tests.providers.amazon.aws.utils.test_template_fields import validate_template_fields
 
 CLUSTER_ID = "test_cluster"
 
@@ -201,6 +202,16 @@ class TestNeptuneStartClusterOperator:
         # mock_defer.assert_has_calls(calls)
         assert mock_defer.call_count == 2
 
+    def test_template_fields(self):
+        operator = NeptuneStartDbClusterOperator(
+            task_id="task_test",
+            db_cluster_id=CLUSTER_ID,
+            deferrable=True,
+            wait_for_completion=False,
+            aws_conn_id="aws_default",
+        )
+        validate_template_fields(operator)
+
 
 class TestNeptuneStopClusterOperator:
     @mock.patch.object(NeptuneHook, "conn")
@@ -368,3 +379,13 @@ class TestNeptuneStopClusterOperator:
 
         with pytest.raises(TaskDeferred):
             operator.execute(None)
+
+    def test_template_fields(self):
+        operator = NeptuneStopDbClusterOperator(
+            task_id="task_test",
+            db_cluster_id=CLUSTER_ID,
+            deferrable=True,
+            wait_for_completion=False,
+            aws_conn_id="aws_default",
+        )
+        validate_template_fields(operator)

--- a/tests/providers/amazon/aws/operators/test_quicksight.py
+++ b/tests/providers/amazon/aws/operators/test_quicksight.py
@@ -21,6 +21,7 @@ from unittest import mock
 
 from airflow.providers.amazon.aws.hooks.quicksight import QuickSightHook
 from airflow.providers.amazon.aws.operators.quicksight import QuickSightCreateIngestionOperator
+from tests.providers.amazon.aws.utils.test_template_fields import validate_template_fields
 
 DATA_SET_ID = "DemoDataSet"
 INGESTION_ID = "DemoDataSet_Ingestion"
@@ -80,3 +81,7 @@ class TestQuickSightCreateIngestionOperator:
             wait_for_completion=True,
             check_interval=30,
         )
+
+    def test_template_fields(self):
+        operator = QuickSightCreateIngestionOperator(**self.default_op_kwargs)
+        validate_template_fields(operator)

--- a/tests/providers/amazon/aws/operators/test_redshift_cluster.py
+++ b/tests/providers/amazon/aws/operators/test_redshift_cluster.py
@@ -38,6 +38,7 @@ from airflow.providers.amazon.aws.triggers.redshift_cluster import (
     RedshiftPauseClusterTrigger,
     RedshiftResumeClusterTrigger,
 )
+from tests.providers.amazon.aws.utils.test_template_fields import validate_template_fields
 
 
 class TestRedshiftCreateClusterOperator:
@@ -137,6 +138,18 @@ class TestRedshiftCreateClusterOperator:
         with pytest.raises(TaskDeferred):
             redshift_operator.execute(None)
 
+    def test_template_fields(self):
+        operator = RedshiftCreateClusterOperator(
+            task_id="task_test",
+            cluster_identifier="test-cluster",
+            node_type="dc2.large",
+            master_username="adminuser",
+            master_user_password="Test123$",
+            cluster_type="single-node",
+            deferrable=True,
+        )
+        validate_template_fields(operator)
+
 
 class TestRedshiftCreateClusterSnapshotOperator:
     @mock.patch.object(RedshiftHook, "cluster_status")
@@ -214,6 +227,15 @@ class TestRedshiftCreateClusterSnapshotOperator:
             exc.value.trigger, RedshiftCreateClusterSnapshotTrigger
         ), "Trigger is not a RedshiftCreateClusterSnapshotTrigger"
 
+    def test_template_fields(self):
+        operator = RedshiftCreateClusterSnapshotOperator(
+            task_id="test_snapshot",
+            cluster_identifier="test_cluster",
+            snapshot_identifier="test_snapshot",
+            wait_for_completion=True,
+        )
+        validate_template_fields(operator)
+
 
 class TestRedshiftDeleteClusterSnapshotOperator:
     @mock.patch(
@@ -255,6 +277,15 @@ class TestRedshiftDeleteClusterSnapshotOperator:
         )
 
         mock_get_cluster_snapshot_status.assert_not_called()
+
+    def test_template_fields(self):
+        operator = RedshiftDeleteClusterSnapshotOperator(
+            task_id="test_snapshot",
+            cluster_identifier="test_cluster",
+            snapshot_identifier="test_snapshot",
+            wait_for_completion=False,
+        )
+        validate_template_fields(operator)
 
 
 class TestResumeClusterOperator:
@@ -386,6 +417,14 @@ class TestResumeClusterOperator:
                 context=None, event={"status": "error", "message": "test failure message"}
             )
 
+    def test_template_fields(self):
+        operator = RedshiftResumeClusterOperator(
+            task_id="task_test",
+            cluster_identifier="test_cluster",
+            aws_conn_id="aws_conn_test",
+        )
+        validate_template_fields(operator)
+
 
 class TestPauseClusterOperator:
     def test_init(self):
@@ -510,6 +549,13 @@ class TestPauseClusterOperator:
             redshift_operator.execute_complete(
                 context=None, event={"status": "error", "message": "test failure message"}
             )
+
+    def test_template_fields(self):
+        operator = RedshiftPauseClusterOperator(
+            task_id="task_test",
+            cluster_identifier="test_cluster",
+        )
+        validate_template_fields(operator)
 
 
 class TestDeleteClusterOperator:
@@ -648,3 +694,10 @@ class TestDeleteClusterOperator:
             redshift_operator.execute_complete(
                 context=None, event={"status": "error", "message": "test failure message"}
             )
+
+    def test_template_fields(self):
+        operator = RedshiftDeleteClusterOperator(
+            task_id="task_test",
+            cluster_identifier="test_cluster",
+        )
+        validate_template_fields(operator)

--- a/tests/providers/amazon/aws/operators/test_redshift_data.py
+++ b/tests/providers/amazon/aws/operators/test_redshift_data.py
@@ -24,6 +24,7 @@ import pytest
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning, TaskDeferred
 from airflow.providers.amazon.aws.operators.redshift_data import RedshiftDataOperator
 from airflow.providers.amazon.aws.triggers.redshift_data import RedshiftDataTrigger
+from tests.providers.amazon.aws.utils.test_template_fields import validate_template_fields
 
 CONN_ID = "aws_conn_test"
 TASK_ID = "task_id"
@@ -349,3 +350,14 @@ class TestRedshiftDataOperator:
 
             assert not mock_check_query_is_finished.called
             assert not mock_defer.called
+
+    def test_template_fields(self):
+        operator = RedshiftDataOperator(
+            aws_conn_id=CONN_ID,
+            task_id=TASK_ID,
+            cluster_identifier="cluster_identifier",
+            sql=SQL,
+            database=DATABASE,
+            wait_for_completion=False,
+        )
+        validate_template_fields(operator)

--- a/tests/providers/amazon/aws/operators/test_s3.py
+++ b/tests/providers/amazon/aws/operators/test_s3.py
@@ -52,6 +52,7 @@ from airflow.providers.common.compat.openlineage.facet import (
 )
 from airflow.providers.openlineage.extractors import OperatorLineage
 from airflow.utils.timezone import datetime, utcnow
+from tests.providers.amazon.aws.utils.test_template_fields import validate_template_fields
 
 BUCKET_NAME = os.environ.get("BUCKET_NAME", "test-airflow-bucket")
 S3_KEY = "test-airflow-key"
@@ -85,6 +86,9 @@ class TestS3CreateBucketOperator:
         mock_check_for_bucket.assert_called_once_with(BUCKET_NAME)
         mock_create_bucket.assert_called_once_with(bucket_name=BUCKET_NAME, region_name=None)
 
+    def test_template_fields(self):
+        validate_template_fields(self.create_bucket_operator)
+
 
 class TestS3DeleteBucketOperator:
     def setup_method(self):
@@ -113,6 +117,9 @@ class TestS3DeleteBucketOperator:
         mock_check_for_bucket.assert_called_once_with(BUCKET_NAME)
         mock_delete_bucket.assert_not_called()
 
+    def test_template_fields(self):
+        validate_template_fields(self.delete_bucket_operator)
+
 
 class TestS3GetBucketTaggingOperator:
     def setup_method(self):
@@ -140,6 +147,9 @@ class TestS3GetBucketTaggingOperator:
         self.get_bucket_tagging_operator.execute({})
         mock_check_for_bucket.assert_called_once_with(BUCKET_NAME)
         get_bucket_tagging.assert_not_called()
+
+    def test_template_fields(self):
+        validate_template_fields(self.get_bucket_tagging_operator)
 
 
 class TestS3PutBucketTaggingOperator:
@@ -172,6 +182,9 @@ class TestS3PutBucketTaggingOperator:
         mock_check_for_bucket.assert_called_once_with(BUCKET_NAME)
         put_bucket_tagging.assert_not_called()
 
+    def test_template_fields(self):
+        validate_template_fields(self.put_bucket_tagging_operator)
+
 
 class TestS3DeleteBucketTaggingOperator:
     def setup_method(self):
@@ -199,6 +212,9 @@ class TestS3DeleteBucketTaggingOperator:
         self.delete_bucket_tagging_operator.execute({})
         mock_check_for_bucket.assert_called_once_with(BUCKET_NAME)
         delete_bucket_tagging.assert_not_called()
+
+    def test_template_fields(self):
+        validate_template_fields(self.delete_bucket_tagging_operator)
 
 
 class TestS3FileTransformOperator:
@@ -381,6 +397,16 @@ class TestS3FileTransformOperator:
 
         return input_path, output_path
 
+    def test_template_fields(self):
+        operator = S3FileTransformOperator(
+            source_s3_key="test/key",
+            dest_s3_key="test/key",
+            transform_script=self.transform_script,
+            replace=True,
+            task_id="task_id",
+        )
+        validate_template_fields(operator)
+
 
 class TestS3ListOperator:
     @mock.patch("airflow.providers.amazon.aws.operators.s3.S3Hook")
@@ -404,6 +430,15 @@ class TestS3ListOperator:
         )
         assert sorted(files) == sorted(["TEST1.csv", "TEST2.csv", "TEST3.csv"])
 
+    def test_template_fields(self):
+        operator = S3ListOperator(
+            task_id="test-s3-list-operator",
+            bucket=BUCKET_NAME,
+            prefix="TEST",
+            delimiter=".csv",
+        )
+        validate_template_fields(operator)
+
 
 class TestS3ListPrefixesOperator:
     @mock.patch("airflow.providers.amazon.aws.operators.s3.S3Hook")
@@ -420,6 +455,12 @@ class TestS3ListPrefixesOperator:
             bucket_name=BUCKET_NAME, prefix="test/", delimiter="/"
         )
         assert subfolders == ["test/"]
+
+    def test_template_fields(self):
+        operator = S3ListPrefixesOperator(
+            task_id="test-s3-list-prefixes-operator", bucket=BUCKET_NAME, prefix="test/", delimiter="/"
+        )
+        validate_template_fields(operator)
 
 
 class TestS3CopyObjectOperator:
@@ -527,6 +568,16 @@ class TestS3CopyObjectOperator:
         assert len(lineage.outputs) == 1
         assert lineage.inputs[0] == expected_input
         assert lineage.outputs[0] == expected_output
+
+    def test_template_fields(self):
+        operator = S3CopyObjectOperator(
+            task_id="test_task_s3_copy_object",
+            source_bucket_key=self.source_key,
+            source_bucket_name=self.source_bucket,
+            dest_bucket_key=self.dest_key,
+            dest_bucket_name=self.dest_bucket,
+        )
+        validate_template_fields(operator)
 
 
 @mock_aws
@@ -839,6 +890,12 @@ class TestS3DeleteObjectsOperator:
         lineage = op.get_openlineage_facets_on_complete(None)
         assert lineage == OperatorLineage()
 
+    def test_template_fields(self):
+        operator = S3DeleteObjectsOperator(
+            task_id="test_task_s3_delete_single_object", bucket="test-bucket", keys="test/file.csv"
+        )
+        validate_template_fields(operator)
+
 
 class TestS3CreateObjectOperator:
     @mock.patch.object(S3Hook, "load_string")
@@ -892,3 +949,7 @@ class TestS3CreateObjectOperator:
         assert len(lineage.inputs) == 0
         assert len(lineage.outputs) == 1
         assert lineage.outputs[0] == expected_output
+
+    def test_template_fields(self):
+        operator = S3CreateObjectOperator(task_id="test", s3_bucket="bucket", s3_key="key", data="test")
+        validate_template_fields(operator)

--- a/tests/providers/amazon/aws/operators/test_sagemaker_base.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_base.py
@@ -32,6 +32,7 @@ from airflow.providers.amazon.aws.operators.sagemaker import (
 )
 from airflow.utils import timezone
 from airflow.utils.types import DagRunType
+from tests.providers.amazon.aws.utils.test_template_fields import validate_template_fields
 
 CONFIG: dict = {
     "key1": "1",
@@ -195,3 +196,11 @@ class TestSageMakerExperimentOperator:
             Description="the desc",
             Tags=[{"Key": "jinja", "Value": "tid"}],
         )
+
+    def test_template_fields(self):
+        operator = SageMakerCreateExperimentOperator(
+            name="the name",
+            description="the desc",
+            task_id="tid",
+        )
+        validate_template_fields(operator)

--- a/tests/providers/amazon/aws/operators/test_sagemaker_endpoint.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_endpoint.py
@@ -27,6 +27,7 @@ from airflow.providers.amazon.aws.hooks.sagemaker import SageMakerHook
 from airflow.providers.amazon.aws.operators import sagemaker
 from airflow.providers.amazon.aws.operators.sagemaker import SageMakerEndpointOperator
 from airflow.providers.amazon.aws.triggers.sagemaker import SageMakerTrigger
+from tests.providers.amazon.aws.utils.test_template_fields import validate_template_fields
 
 CREATE_MODEL_PARAMS: dict = {
     "ModelName": "model_name",
@@ -173,3 +174,6 @@ class TestSageMakerEndpointOperator:
         assert isinstance(defer.value.trigger, SageMakerTrigger)
         assert defer.value.trigger.job_name == "endpoint_name"
         assert defer.value.trigger.job_type == "endpoint"
+
+    def test_template_fields(self):
+        validate_template_fields(self.sagemaker)

--- a/tests/providers/amazon/aws/operators/test_sagemaker_endpoint_config.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_endpoint_config.py
@@ -25,6 +25,7 @@ from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.sagemaker import SageMakerHook
 from airflow.providers.amazon.aws.operators import sagemaker
 from airflow.providers.amazon.aws.operators.sagemaker import SageMakerEndpointConfigOperator
+from tests.providers.amazon.aws.utils.test_template_fields import validate_template_fields
 
 CREATE_ENDPOINT_CONFIG_PARAMS: dict = {
     "EndpointConfigName": "config_name",
@@ -81,3 +82,6 @@ class TestSageMakerEndpointConfigOperator:
         }
         with pytest.raises(AirflowException):
             self.sagemaker.execute(None)
+
+    def test_template_fields(self):
+        validate_template_fields(self.sagemaker)

--- a/tests/providers/amazon/aws/operators/test_sagemaker_model.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_model.py
@@ -31,6 +31,7 @@ from airflow.providers.amazon.aws.operators.sagemaker import (
     SageMakerModelOperator,
     SageMakerRegisterModelVersionOperator,
 )
+from tests.providers.amazon.aws.utils.test_template_fields import validate_template_fields
 
 CREATE_MODEL_PARAMS: dict = {
     "ModelName": "model_name",
@@ -73,6 +74,12 @@ class TestSageMakerDeleteModelOperator:
         )
         op.execute(None)
         delete_model.assert_called_once_with(model_name="model_name")
+
+    def test_template_fields(self):
+        op = SageMakerDeleteModelOperator(
+            task_id="test_sagemaker_operator", config={"ModelName": "model_name"}
+        )
+        validate_template_fields(op)
 
 
 class TestSageMakerRegisterModelVersionOperator:
@@ -144,3 +151,14 @@ class TestSageMakerRegisterModelVersionOperator:
         conn_mock().create_model_package.assert_called_once()
         args_dict = conn_mock().create_model_package.call_args.kwargs
         assert args_dict["InferenceSpecification"]["SupportedResponseMIMETypes"] == response_type
+
+    def test_template_fields(self):
+        response_type = ["test/test"]
+        op = SageMakerRegisterModelVersionOperator(
+            task_id="test",
+            image_uri="257758044811.dkr.ecr.us-east-2.amazonaws.com/sagemaker-xgboost:1.2-1",
+            model_url="s3://your-bucket-name/model.tar.gz",
+            package_group_name="group-name",
+            extras={"InferenceSpecification": {"SupportedResponseMIMETypes": response_type}},
+        )
+        validate_template_fields(op)

--- a/tests/providers/amazon/aws/operators/test_sagemaker_notebook.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_notebook.py
@@ -30,6 +30,7 @@ from airflow.providers.amazon.aws.operators.sagemaker import (
     SageMakerStartNoteBookOperator,
     SageMakerStopNotebookOperator,
 )
+from tests.providers.amazon.aws.utils.test_template_fields import validate_template_fields
 
 INSTANCE_NAME = "notebook"
 INSTANCE_TYPE = "ml.t3.medium"
@@ -105,6 +106,15 @@ class TestSagemakerCreateNotebookOperator:
         mock_hook_conn.create_notebook_instance.assert_called_once()
         mock_hook_conn.get_waiter.assert_called_once_with("notebook_instance_in_service")
 
+    def test_template_fields(self):
+        operator = SageMakerCreateNotebookOperator(
+            task_id="task_test",
+            instance_name=INSTANCE_NAME,
+            instance_type=INSTANCE_TYPE,
+            role_arn=ROLE_ARN,
+        )
+        validate_template_fields(operator)
+
 
 class TestSageMakerStopNotebookOperator:
     @mock.patch.object(SageMakerHook, "conn")
@@ -124,6 +134,12 @@ class TestSageMakerStopNotebookOperator:
         operator.execute(None)
         hook.conn.stop_notebook_instance.assert_called_once()
         mock_hook_conn.get_waiter.assert_called_once_with("notebook_instance_stopped")
+
+    def test_template_fields(self):
+        operator = SageMakerStopNotebookOperator(
+            task_id="stop_test", instance_name=INSTANCE_NAME, wait_for_completion=False
+        )
+        validate_template_fields(operator)
 
 
 class TestSageMakerDeleteNotebookOperator:
@@ -145,6 +161,12 @@ class TestSageMakerDeleteNotebookOperator:
         hook.conn.delete_notebook_instance.assert_called_once()
         mock_hook_conn.get_waiter.assert_called_once_with("notebook_instance_deleted")
 
+    def test_template_fields(self):
+        operator = SageMakerDeleteNotebookOperator(
+            task_id="delete_test", instance_name=INSTANCE_NAME, wait_for_completion=True
+        )
+        validate_template_fields(operator)
+
 
 class TestSageMakerStartNotebookOperator:
     @mock.patch.object(SageMakerHook, "conn")
@@ -164,3 +186,9 @@ class TestSageMakerStartNotebookOperator:
         operator.execute(None)
         hook.conn.start_notebook_instance.assert_called_once()
         mock_hook_conn.get_waiter.assert_called_once_with("notebook_instance_in_service")
+
+    def test_template_fields(self):
+        operator = SageMakerStartNoteBookOperator(
+            task_id="start_test", instance_name=INSTANCE_NAME, wait_for_completion=True
+        )
+        validate_template_fields(operator)

--- a/tests/providers/amazon/aws/operators/test_sagemaker_pipeline.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_pipeline.py
@@ -29,6 +29,7 @@ from airflow.providers.amazon.aws.operators.sagemaker import (
     SageMakerStopPipelineOperator,
 )
 from airflow.providers.amazon.aws.triggers.sagemaker import SageMakerPipelineTrigger
+from tests.providers.amazon.aws.utils.test_template_fields import validate_template_fields
 
 if TYPE_CHECKING:
     from unittest.mock import MagicMock
@@ -71,6 +72,13 @@ class TestSageMakerStartPipelineOperator:
         assert isinstance(defer.value.trigger, SageMakerPipelineTrigger)
         assert defer.value.trigger.waiter_type == SageMakerPipelineTrigger.Type.COMPLETE
 
+    def test_template_fields(self):
+        operator = SageMakerStartPipelineOperator(
+            task_id="test_sagemaker_operator",
+            pipeline_name="my_pipeline",
+        )
+        validate_template_fields(operator)
+
 
 class TestSageMakerStopPipelineOperator:
     @mock.patch.object(SageMakerHook, "stop_pipeline")
@@ -100,3 +108,11 @@ class TestSageMakerStopPipelineOperator:
 
         assert isinstance(defer.value.trigger, SageMakerPipelineTrigger)
         assert defer.value.trigger.waiter_type == SageMakerPipelineTrigger.Type.STOPPED
+
+    def test_template_fields(self):
+        operator = SageMakerStopPipelineOperator(
+            task_id="test_sagemaker_operator",
+            pipeline_exec_arn="my_pipeline_arn",
+            deferrable=True,
+        )
+        validate_template_fields(operator)

--- a/tests/providers/amazon/aws/operators/test_sagemaker_processing.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_processing.py
@@ -31,6 +31,7 @@ from airflow.providers.amazon.aws.operators.sagemaker import (
 from airflow.providers.amazon.aws.triggers.sagemaker import SageMakerTrigger
 from airflow.providers.common.compat.openlineage.facet import Dataset
 from airflow.providers.openlineage.extractors import OperatorLineage
+from tests.providers.amazon.aws.utils.test_template_fields import validate_template_fields
 
 CREATE_PROCESSING_PARAMS: dict = {
     "AppSpecification": {
@@ -345,3 +346,10 @@ class TestSageMakerProcessingOperator:
             inputs=[Dataset(namespace="s3://input-bucket", name="input-path")],
             outputs=[Dataset(namespace="s3://output-bucket", name="output-path")],
         )
+
+    def test_template_fields(self):
+        operator = SageMakerProcessingOperator(
+            **self.processing_config_kwargs,
+            config=CREATE_PROCESSING_PARAMS,
+        )
+        validate_template_fields(operator)

--- a/tests/providers/amazon/aws/operators/test_sagemaker_training.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_training.py
@@ -31,6 +31,7 @@ from airflow.providers.amazon.aws.triggers.sagemaker import (
 )
 from airflow.providers.common.compat.openlineage.facet import Dataset
 from airflow.providers.openlineage.extractors import OperatorLineage
+from tests.providers.amazon.aws.utils.test_template_fields import validate_template_fields
 
 EXPECTED_INTEGER_FIELDS: list[list[str]] = [
     ["ResourceConfig", "InstanceCount"],
@@ -235,3 +236,6 @@ class TestSageMakerTrainingOperator:
             inputs=[Dataset(namespace="s3://input-bucket", name="input-path")],
             outputs=[Dataset(namespace="s3://model-bucket", name="model-path")],
         )
+
+    def test_template_fields(self):
+        validate_template_fields(self.sagemaker)

--- a/tests/providers/amazon/aws/operators/test_sagemaker_transform.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_transform.py
@@ -30,6 +30,7 @@ from airflow.providers.amazon.aws.operators.sagemaker import SageMakerTransformO
 from airflow.providers.amazon.aws.triggers.sagemaker import SageMakerTrigger
 from airflow.providers.common.compat.openlineage.facet import Dataset
 from airflow.providers.openlineage.extractors import OperatorLineage
+from tests.providers.amazon.aws.utils.test_template_fields import validate_template_fields
 
 EXPECTED_INTEGER_FIELDS: list[list[str]] = [
     ["Transform", "TransformResources", "InstanceCount"],
@@ -377,3 +378,6 @@ class TestSageMakerTransformOperator:
             ],
             outputs=[Dataset(namespace="s3://output-bucket", name="output-path")],
         )
+
+    def test_template_fields(self):
+        validate_template_fields(self.sagemaker)

--- a/tests/providers/amazon/aws/operators/test_sagemaker_tuning.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_tuning.py
@@ -26,6 +26,7 @@ from airflow.providers.amazon.aws.hooks.sagemaker import SageMakerHook
 from airflow.providers.amazon.aws.operators import sagemaker
 from airflow.providers.amazon.aws.operators.sagemaker import SageMakerTuningOperator
 from airflow.providers.amazon.aws.triggers.sagemaker import SageMakerTrigger
+from tests.providers.amazon.aws.utils.test_template_fields import validate_template_fields
 
 EXPECTED_INTEGER_FIELDS: list[list[str]] = [
     ["HyperParameterTuningJobConfig", "ResourceLimits", "MaxNumberOfTrainingJobs"],
@@ -120,3 +121,6 @@ class TestSageMakerTuningOperator:
         assert isinstance(defer.value.trigger, SageMakerTrigger)
         assert defer.value.trigger.job_name == "job_name"
         assert defer.value.trigger.job_type == "tuning"
+
+    def test_template_fields(self):
+        validate_template_fields(self.sagemaker)

--- a/tests/providers/amazon/aws/operators/test_sns.py
+++ b/tests/providers/amazon/aws/operators/test_sns.py
@@ -22,6 +22,7 @@ from unittest import mock
 import pytest
 
 from airflow.providers.amazon.aws.operators.sns import SnsPublishOperator
+from tests.providers.amazon.aws.utils.test_template_fields import validate_template_fields
 
 TASK_ID = "sns_publish_job"
 AWS_CONN_ID = "custom_aws_conn"
@@ -76,3 +77,7 @@ class TestSnsPublishOperator:
             subject=SUBJECT,
             target_arn=TARGET_ARN,
         )
+
+    def test_template_fields(self):
+        operator = SnsPublishOperator(**self.default_op_kwargs)
+        validate_template_fields(operator)

--- a/tests/providers/amazon/aws/operators/test_sqs.py
+++ b/tests/providers/amazon/aws/operators/test_sqs.py
@@ -25,6 +25,7 @@ from moto import mock_aws
 
 from airflow.providers.amazon.aws.hooks.sqs import SqsHook
 from airflow.providers.amazon.aws.operators.sqs import SqsPublishOperator
+from tests.providers.amazon.aws.utils.test_template_fields import validate_template_fields
 
 REGION_NAME = "eu-west-1"
 QUEUE_NAME = "test-queue"
@@ -119,3 +120,9 @@ class TestSqsPublishOperator:
         assert message["Messages"][0]["MessageId"] == result["MessageId"]
         assert message["Messages"][0]["Body"] == "hello"
         assert message["Messages"][0]["Attributes"]["MessageGroupId"] == "abc"
+
+    def test_template_fields(self):
+        operator = SqsPublishOperator(
+            **self.default_op_kwargs, sqs_queue=FIFO_QUEUE_NAME, message_group_id="abc"
+        )
+        validate_template_fields(operator)

--- a/tests/providers/amazon/aws/operators/test_step_function.py
+++ b/tests/providers/amazon/aws/operators/test_step_function.py
@@ -26,6 +26,7 @@ from airflow.providers.amazon.aws.operators.step_function import (
     StepFunctionGetExecutionOutputOperator,
     StepFunctionStartExecutionOperator,
 )
+from tests.providers.amazon.aws.utils.test_template_fields import validate_template_fields
 
 EXECUTION_ARN = (
     "arn:aws:states:us-east-1:123456789012:execution:"
@@ -101,6 +102,14 @@ class TestStepFunctionGetExecutionOutputOperator:
             region_name=mock.ANY,
             execution_arn=EXECUTION_ARN,
         )
+
+    def test_template_fields(self):
+        operator = StepFunctionGetExecutionOutputOperator(
+            task_id=self.TASK_ID,
+            execution_arn=EXECUTION_ARN,
+            aws_conn_id=None,
+        )
+        validate_template_fields(operator)
 
 
 class TestStepFunctionStartExecutionOperator:
@@ -232,3 +241,14 @@ class TestStepFunctionStartExecutionOperator:
             region_name=mock.ANY,
             execution_arn=EXECUTION_ARN,
         )
+
+    def test_template_fields(self):
+        operator = StepFunctionStartExecutionOperator(
+            task_id=self.TASK_ID,
+            state_machine_arn=STATE_MACHINE_ARN,
+            name=NAME,
+            is_redrive_execution=True,
+            state_machine_input=None,
+            aws_conn_id=None,
+        )
+        validate_template_fields(operator)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
Adding template field tests to remaining AWS operators.

Part1: #42183
 
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
