### PR TITLE
Fix problem, skip tests if only not compatible providers are tested a…

### DIFF
--- a/dev/breeze/tests/test_run_test_args.py
+++ b/dev/breeze/tests/test_run_test_args.py
@@ -111,7 +111,7 @@ def test_primary_test_arg_is_excluded_by_extra_pytest_arg(mock_run_command):
         skip_docker_compose_down=True,
     )
 
-    assert mock_run_command.call_count == 2
+    assert mock_run_command.call_count > 1
     run_cmd_call = mock_run_command.call_args_list[1]
     arg_str = " ".join(run_cmd_call.args[0])
 

--- a/dev/breeze/tests/test_run_test_args.py
+++ b/dev/breeze/tests/test_run_test_args.py
@@ -100,17 +100,10 @@ def test_irregular_provider_with_extra_ignore_should_be_valid_cmd(mock_run_comma
 
 
 def test_primary_test_arg_is_excluded_by_extra_pytest_arg(mock_run_command):
-    """This code scenario currently has a bug - if a test type resolves to a single test directory,
-     but the same directory is also set to be ignored (either by extra_pytest_args or because a provider is
-     suspended or excluded), the _run_test function removes the test directory from the argument list,
-     which has the effect of running all of the tests pytest can find. Not good!
-
-     NB: this test accurately describes the buggy behavior; IOW when fixing the bug the test must be changed.
-
-    TODO: fix this bug that runs unintended tests; probably the correct behavior is to skip the run."""
     test_provider = "http"  # "Providers[<id>]" scans the source tree so we need to use a real provider id
+    test_provider_not_skipped = "ftp"
     _run_test(
-        shell_params=ShellParams(test_type=f"Providers[{test_provider}]"),
+        shell_params=ShellParams(test_type=f"Providers[{test_provider},{test_provider_not_skipped}]"),
         extra_pytest_args=(f"--ignore=tests/providers/{test_provider}",),
         python_version="3.8",
         output=None,
@@ -118,6 +111,7 @@ def test_primary_test_arg_is_excluded_by_extra_pytest_arg(mock_run_command):
         skip_docker_compose_down=True,
     )
 
+    assert mock_run_command.call_count == 2
     run_cmd_call = mock_run_command.call_args_list[1]
     arg_str = " ".join(run_cmd_call.args[0])
 
@@ -127,6 +121,25 @@ def test_primary_test_arg_is_excluded_by_extra_pytest_arg(mock_run_command):
     # bc without a directory or module arg, pytest tests everything (which we don't want!)
     # We check "--verbosity=0" to ensure nothing is between the airflow container id and the verbosity arg,
     # IOW that the primary test arg is removed
-    match_pattern = re.compile(f"airflow --verbosity=0 .+ --ignore=tests/providers/{test_provider}")
+    match_pattern = re.compile(
+        f"airflow tests/providers/{test_provider_not_skipped} --verbosity=0 .+ --ignore=tests/providers/{test_provider}"
+    )
 
     assert match_pattern.search(arg_str)
+
+
+def test_test_is_skipped_if_all_are_ignored(mock_run_command):
+    test_providers = [
+        "http",
+        "ftp",
+    ]  # "Providers[<id>]" scans the source tree so we need to use a real provider id
+    _run_test(
+        shell_params=ShellParams(test_type=f"Providers[{','.join(test_providers)}]"),
+        extra_pytest_args=[f"--ignore=tests/providers/{provider}" for provider in test_providers],
+        python_version="3.8",
+        output=None,
+        test_timeout=60,
+        skip_docker_compose_down=True,
+    )
+
+    mock_run_command.assert_called_once()  # called only to compose down


### PR DESCRIPTION
Following the advise from @potiuk I was splitting my contributions with the new edge provider.

Unfortunately tests with back-compat provider tests fail because:
- Edge provider is not compatible for old airflow versions lower than 2.10
- Therefore the Edge provider is excluded
- The test list is filtered for all skipped packages
- In case a PR is made _only_ for edge provider, no positivle list to test is left-over
- Pytest in this cases attempts to test _ALL_ tests - which obviously fail as not being compliant to old airflow versions

With this PR Breeze skips backcompat tests if after filtering of skipped no provider is left to test