### PR TITLE
Add extra and renderedTemplates as keys to skip camelCasing

### DIFF
--- a/airflow/www/static/js/api/index.ts
+++ b/airflow/www/static/js/api/index.ts
@@ -65,9 +65,10 @@ axios.interceptors.request.use((config) => {
   return config;
 });
 
-// Do not camelCase xCom entry results
 axios.interceptors.response.use((res: AxiosResponse) => {
-  const stopPaths = [];
+  // Do not camelCase rendered_fields, extra or conf
+  const stopPaths = ["rendered_fields", "extra", "conf"];
+  // Do not camelCase xCom entry results
   if (res.config.url?.includes("/xcomEntries/")) {
     stopPaths.push("value");
   }

--- a/airflow/www/static/js/api/index.ts
+++ b/airflow/www/static/js/api/index.ts
@@ -66,8 +66,8 @@ axios.interceptors.request.use((config) => {
 });
 
 axios.interceptors.response.use((res: AxiosResponse) => {
-  // Do not camelCase rendered_fields, extra or conf
-  const stopPaths = ["rendered_fields", "extra", "conf"];
+  // Do not camelCase rendered_fields or extra
+  const stopPaths = ["rendered_fields", "extra", "dataset_events.extra"];
   // Do not camelCase xCom entry results
   if (res.config.url?.includes("/xcomEntries/")) {
     stopPaths.push("value");

--- a/airflow/www/static/js/components/DatasetEventCard.tsx
+++ b/airflow/www/static/js/components/DatasetEventCard.tsx
@@ -60,10 +60,8 @@ const DatasetEventCard = ({
   const selectedUri = decodeURIComponent(searchParams.get("uri") || "");
   const containerRef = useContainerRef();
 
-  const { fromRestApi, ...extra } = datasetEvent?.extra as Record<
-    string,
-    string
-  >;
+  const { from_rest_api: fromRestApi, ...extra } =
+    datasetEvent?.extra as Record<string, string>;
 
   return (
     <Box>

--- a/airflow/www/static/js/dag/details/graph/DatasetNode.tsx
+++ b/airflow/www/static/js/dag/details/graph/DatasetNode.tsx
@@ -51,7 +51,10 @@ const DatasetNode = ({
 }: NodeProps<CustomNodeProps>) => {
   const containerRef = useContainerRef();
 
-  const { fromRestApi } = (datasetEvent?.extra || {}) as Record<string, string>;
+  const { from_rest_api: fromRestApi } = (datasetEvent?.extra || {}) as Record<
+    string,
+    string
+  >;
 
   return (
     <Popover>


### PR DESCRIPTION
After we stopped camelCasing xcomEntry.value, I realized we had a few other spots we may want to also skip.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
