### PR TITLE
fix: only treat null/undefined as falsy when rendering XComEntry (#42…

### DIFF
--- a/airflow/www/static/js/dag/details/taskInstance/Xcom/XcomEntry.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Xcom/XcomEntry.tsx
@@ -67,7 +67,7 @@ const XcomEntry = ({
         No value found for XCom key
       </Alert>
     );
-  } else if (!xcom.value) {
+  } else if (xcom.value === undefined || xcom.value === null) {
     content = (
       <Alert status="info">
         <AlertIcon />


### PR DESCRIPTION
(cherry picked from commit https://github.com/apache/airflow/commit/ade9de12defdd2727d3308c7e34b28ba4f68d18f)