### PR TITLE
Add slack notification for canary build failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -686,4 +686,4 @@ jobs:
                     Commit: ${{ github.sha }}\n
                     Check the details at:
                     ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          }' $SLACK_WEBHOOK_URL
+          }' ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -672,7 +672,7 @@ jobs:
 
   notify-slack-failure:
     name: "Notify Slack on Failure"
-    if: failure()
+    # if: failure()
     runs-on: ["ubuntu-22.04"]
     steps:
       - name: Notify Slack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -669,3 +669,21 @@ jobs:
       include-success-outputs: ${{ needs.build-info.outputs.include-success-outputs }}
       docker-cache: ${{ needs.build-info.outputs.docker-cache }}
       canary-run: ${{ needs.build-info.outputs.canary-run }}
+
+  notify-slack-failure:
+    name: "Notify Slack on Failure"
+    if: failure()
+    runs-on: ["ubuntu-22.04"]
+    steps:
+      - name: Notify Slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' --data '{
+            "text": "The GitLab CI workflow *Tests* has failed.\n
+                    Repository: ${{ github.repository }}\n
+                    Branch: ${{ github.ref_name }}\n
+                    Commit: ${{ github.sha }}\n
+                    Check the details at:
+                    ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          }' $SLACK_WEBHOOK_URL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ env:
   GITHUB_USERNAME: ${{ github.actor }}
   IMAGE_TAG: "${{ github.event.pull_request.head.sha || github.sha }}"
   VERBOSE: "true"
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}
@@ -676,8 +677,6 @@ jobs:
     runs-on: ["ubuntu-22.04"]
     steps:
       - name: Notify Slack
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
           curl -X POST -H 'Content-type: application/json' --data '{
             "text": "The GitLab CI workflow *Tests* has failed.\n
@@ -686,4 +685,4 @@ jobs:
                     Commit: ${{ github.sha }}\n
                     Check the details at:
                     ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          }' ${{ secrets.SLACK_WEBHOOK_URL }}
+          }' ${{ env.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
closes: [#42203](https://github.com/apache/airflow/issues/42203)

this PR should send message to this slack channel https://apache-airflow.slack.com/archives/C07MWFASWJ1 if the CI is failed.
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
