### PR TITLE
Bump dompurify from 2.2.9 to 2.5.6 in /airflow/www (#42263)

### DIFF
--- a/airflow/www/yarn.lock
+++ b/airflow/www/yarn.lock
@@ -5786,9 +5786,9 @@ domhandler@^4.3.1:
     domelementtype "^2.2.0"
 
 dompurify@^2.2.8:
-  version "2.2.9"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.2.9.tgz#4b42e244238032d9286a0d2c87b51313581d9624"
-  integrity sha512-+9MqacuigMIZ+1+EwoEltogyWGFTJZWU3258Rupxs+2CGs4H914G9er6pZbsme/bvb5L67o2rade9n21e4RW/w==
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.5.6.tgz#8402b501611eaa7fb3786072297fcbe2787f8592"
+  integrity sha512-zUTaUBO8pY4+iJMPE1B9XlO2tXVYIcEA4SNGtvDELzTSCQO7RzH+j7S180BmhmJId78lqGU2z19vgVx2Sxs/PQ==
 
 domutils@1.5:
   version "1.5.1"


### PR DESCRIPTION
(cherry picked from commit https://github.com/apache/airflow/commit/fc5f686e3a238b7e11034057e62524ce9f598b80)