### PR TITLE
Fix main. Disable sync role in FAB auth manager tests

### DIFF
--- a/tests/providers/fab/auth_manager/cli_commands/test_role_command.py
+++ b/tests/providers/fab/auth_manager/cli_commands/test_role_command.py
@@ -26,6 +26,7 @@ import pytest
 
 from airflow.cli import cli_parser
 from tests.test_utils.compat import ignore_provider_compatibility_error
+from tests.test_utils.config import conf_vars
 
 with ignore_provider_compatibility_error("2.9.0+", __file__):
     from airflow.providers.fab.auth_manager.cli_commands import role_command
@@ -47,11 +48,12 @@ class TestCliRoles:
     @pytest.fixture(autouse=True)
     def _set_attrs(self):
         self.parser = cli_parser.get_parser()
-        with get_application_builder() as appbuilder:
-            self.appbuilder = appbuilder
-            self.clear_users_and_roles()
-            yield
-            self.clear_users_and_roles()
+        with conf_vars({("fab", "UPDATE_FAB_PERMS"): "False"}):
+            with get_application_builder() as appbuilder:
+                self.appbuilder = appbuilder
+                self.clear_users_and_roles()
+                yield
+                self.clear_users_and_roles()
 
     def clear_users_and_roles(self):
         session = self.appbuilder.get_session


### PR DESCRIPTION
Fix main.

In #42004, auth managers are init before using them (rightfully so). In FAB auth manager, the `init` method add some permissions on the fly to roles. We need to  disable this mechanism in tests so that it does not conflict with them.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
