### PR TITLE
Remove reference to 'scheduler_loop.jpg' in _run_scheduler_loop docstring

### DIFF
--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1021,11 +1021,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             #. Heartbeat executor
                 #. Execute queued tasks in executor asynchronously
                 #. Sync on the states of running tasks
-
-        Following is a graphic representation of these steps.
-
-        .. image:: ../docs/apache-airflow/img/scheduler_loop.jpg
-
         """
         if not self.processor_agent and not self._standalone_dag_processor:
             raise ValueError("Processor agent is not started.")


### PR DESCRIPTION
The image 'scheduler_loop.jpg' was removed in PR #38438, but its reference remained in the docstring of '_run_scheduler_loop'. This commit removes the outdated image reference.

Confirmed that no other docstrings reference images removed in PR #38438.