### PR TITLE
FastAPI API Add test query params standardization an reusability

### DIFF
--- a/airflow/api_fastapi/db.py
+++ b/airflow/api_fastapi/db.py
@@ -19,13 +19,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from sqlalchemy.sql import Select
-
-from airflow.api_fastapi.parameters import BaseParam
 from airflow.utils.session import create_session
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
+    from sqlalchemy.sql import Select
+
+    from airflow.api_fastapi.parameters import BaseParam
 
 
 async def get_session() -> Session:

--- a/airflow/api_fastapi/db.py
+++ b/airflow/api_fastapi/db.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from sqlalchemy.orm import Query
+from sqlalchemy.sql import Select
 
 from airflow.api_fastapi.parameters import BaseParam
 from airflow.utils.session import create_session
@@ -46,9 +46,9 @@ async def get_session() -> Session:
         yield session
 
 
-def apply_filters_to_query(base_query: Query, filters: list[BaseParam]) -> Query:
-    query = base_query
+def apply_filters_to_select(base_select: Select, filters: list[BaseParam]) -> Select:
+    select = base_select
     for filter in filters:
-        query = filter.to_orm(query)
+        select = filter.to_orm(select)
 
-    return query
+    return select

--- a/airflow/api_fastapi/db.py
+++ b/airflow/api_fastapi/db.py
@@ -19,6 +19,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from sqlalchemy.orm import Query
+
+from airflow.api_fastapi.parameters import BaseParam
 from airflow.utils.session import create_session
 
 if TYPE_CHECKING:
@@ -41,3 +44,11 @@ async def get_session() -> Session:
     """
     with create_session() as session:
         yield session
+
+
+def apply_filters_to_query(base_query: Query, filters: list[BaseParam]) -> Query:
+    query = base_query
+    for filter in filters:
+        query = filter.to_orm(query)
+
+    return query

--- a/airflow/api_fastapi/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/openapi/v1-generated.yaml
@@ -60,11 +60,9 @@ paths:
         in: query
         required: false
         schema:
-          anyOf:
-          - type: array
-            items:
-              type: string
-          - type: 'null'
+          type: array
+          items:
+            type: string
           title: Tags
       - name: dag_id_pattern
         in: query

--- a/airflow/api_fastapi/parameters.py
+++ b/airflow/api_fastapi/parameters.py
@@ -1,0 +1,166 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Generic, List, TypeVar, Union
+
+from fastapi import Depends, HTTPException, Query as FastAPIQuery
+from sqlalchemy import or_
+from sqlalchemy.orm import Query
+from sqlalchemy.sql import ColumnElement
+from typing_extensions import Annotated, Self
+
+from airflow.models.dag import DagModel, DagTag
+
+T = TypeVar("T")
+
+
+class BaseParam(Generic[T], ABC):
+    """Base class for filters."""
+
+    def __init__(self) -> None:
+        self.value: T | None = None
+        self.attribute: ColumnElement | None = None
+
+    @abstractmethod
+    def to_orm(self, query: Query) -> Query:
+        pass
+
+    @abstractmethod
+    def __call__(self, *args: Any, **kwarg: Any) -> BaseParam:
+        pass
+
+    def set_value(self, value: T) -> Self:
+        self.value = value
+        return self
+
+
+class _LimitFilter(BaseParam[int]):
+    """Filter on the limit."""
+
+    def to_orm(self, query: Query) -> Query:
+        if self.value is None:
+            return query
+
+        return query.limit(self.value)
+
+    def __call__(self, limit: int = 100) -> _LimitFilter:
+        self.value = limit
+
+        return self
+
+
+class _OffsetFilter(BaseParam[int]):
+    """Filter on offset."""
+
+    def to_orm(self, query: Query) -> Query:
+        if self.value is None:
+            return query
+        return query.offset(self.value)
+
+    def __call__(self, offset: int = 0) -> _OffsetFilter:
+        self.value = offset
+
+        return self
+
+
+class _PausedFilter(BaseParam[Union[bool, None]]):
+    """Filter on is_paused."""
+
+    def to_orm(self, query: Query) -> Query:
+        if self.value is None:
+            return query
+        return query.where(DagModel.is_paused == self.value)
+
+    def __call__(self, paused: bool | None = FastAPIQuery(default=None)) -> _PausedFilter:
+        return self.set_value(paused)
+
+
+class _OnlyActiveFilter(BaseParam[bool]):
+    """Filter on is_active."""
+
+    def to_orm(self, query: Query) -> Query:
+        if self.value:
+            return query.where(DagModel.is_active == self.value)
+        return query
+
+    def __call__(self, only_active: bool = FastAPIQuery(default=True)) -> _OnlyActiveFilter:
+        return self.set_value(only_active)
+
+
+class _DagIdPatternSearch(BaseParam[Union[str, None]]):
+    """Search on dag_id."""
+
+    def to_orm(self, query: Query) -> Query:
+        if self.value is None:
+            return query
+        return query.where(DagModel.dag_id.ilike(f"%{self.value}"))
+
+    def __call__(self, dag_id_pattern: str | None = FastAPIQuery(default=None)) -> _DagIdPatternSearch:
+        return self.set_value(dag_id_pattern)
+
+
+class SortParam(BaseParam[Union[str]]):
+    """Order result by the attribute."""
+
+    def __init__(self, allowed_attrs: list[str]) -> None:
+        super().__init__()
+        self.allowed_attrs = allowed_attrs
+
+    def to_orm(self, query: Query) -> Query:
+        if self.value is None:
+            return query
+
+        lstriped_orderby = self.value.lstrip("-")
+        if self.allowed_attrs and lstriped_orderby not in self.allowed_attrs:
+            raise HTTPException(
+                400,
+                f"Ordering with '{lstriped_orderby}' is disallowed or "
+                f"the attribute does not exist on the model",
+            )
+        if self.value[0] == "-":
+            return query.order_by(getattr(DagModel, lstriped_orderby).desc())
+        else:
+            return query.order_by(getattr(DagModel, lstriped_orderby).asc())
+        return query
+
+    def __call__(self, order_by: str = FastAPIQuery(default="dag_id")) -> SortParam:
+        return self.set_value(order_by)
+
+
+class _TagsFilter(BaseParam[List[str]]):
+    """Filter on tags."""
+
+    def to_orm(self, query: Query) -> Query:
+        if self.value:
+            conditions = [DagModel.tags.any(DagTag.name == tag) for tag in self.value]
+            return query.where(or_(*conditions))
+
+        return query
+
+    def __call__(self, tags: list[str] = FastAPIQuery(default_factory=list)) -> _TagsFilter:
+        return self.set_value(tags)
+
+
+QueryLimit = Annotated[_LimitFilter, Depends(_LimitFilter())]
+QueryOffset = Annotated[_OffsetFilter, Depends(_OffsetFilter())]
+QueryPausedFilter = Annotated[_PausedFilter, Depends(_PausedFilter())]
+QueryOnlyActiveFilter = Annotated[_OnlyActiveFilter, Depends(_OnlyActiveFilter())]
+QueryDagIdPatternSearch = Annotated[_DagIdPatternSearch, Depends(_DagIdPatternSearch())]
+QueryTagsFilter = Annotated[_TagsFilter, Depends(_TagsFilter())]

--- a/airflow/api_fastapi/views/public/dags.py
+++ b/airflow/api_fastapi/views/public/dags.py
@@ -22,7 +22,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 from typing_extensions import Annotated
 
-from airflow.api_fastapi.db import apply_filters_to_query, get_session
+from airflow.api_fastapi.db import apply_filters_to_select, get_session
 from airflow.api_fastapi.parameters import (
     QueryDagIdPatternSearch,
     QueryLimit,
@@ -54,7 +54,7 @@ async def get_dags(
     """Get all DAGs."""
     dags_query = select(DagModel)
 
-    dags_query = apply_filters_to_query(dags_query, [only_active, paused, dag_id_pattern, tags])
+    dags_query = apply_filters_to_select(dags_query, [only_active, paused, dag_id_pattern, tags])
 
     # TODO: Re-enable when permissions are handled.
     # readable_dags = get_auth_manager().get_permitted_dag_ids(user=g.user)
@@ -62,7 +62,7 @@ async def get_dags(
 
     total_entries = get_query_count(dags_query, session=session)
 
-    dags_query = apply_filters_to_query(dags_query, [order_by, offset, limit])
+    dags_query = apply_filters_to_select(dags_query, [order_by, offset, limit])
 
     dags = session.scalars(dags_query).all()
 

--- a/tests/api_fastapi/views/public/test_dags.py
+++ b/tests/api_fastapi/views/public/test_dags.py
@@ -27,9 +27,12 @@ from tests.test_utils.db import clear_db_dags, clear_db_runs, clear_db_serialize
 
 pytestmark = pytest.mark.db_test
 
-DAG_ID = "test_dag1"
+DAG1_ID = "test_dag1"
+DAG1_DISPLAY_NAME = "a"
 DAG2_ID = "test_dag2"
+DAG2_DISPLAY_NAME = "b"
 DAG3_ID = "test_dag3"
+DAG3_DISPLAY_NAME = "c"
 TASK_ID = "op1"
 
 
@@ -52,7 +55,7 @@ def setup() -> None:
     clear_db_serialized_dags()
 
     with DAG(
-        DAG_ID,
+        DAG1_ID,
         schedule=None,
         start_date=datetime(2020, 6, 15),
         doc_md="details",


### PR DESCRIPTION
Related to: https://github.com/apache/airflow/issues/42159

This will abstract the handling of common FIlters, Search and Sort query param so we do not have to copy and past the same `query.where(...)`  on all endpoints that are using this same logic.

This allows:
- To remove some logic from the views, and only keep http related thing. (serialization/deserialization, query param validation, etc...). Aim for a more layed and decouple AIP code. (hexagonal / onion architecture is an inspiration, but that's too early and not a priority). Cf the custom code removed from the `get_dags` view.
- Initialize some reusable logic for the db layer
- Will allow to add more complex filters that cannot be done today, especially on the `order_by` because we were using a sqlalchemy `text` clause that do not work with hybrid properties. (cf follow up PR to add ordering by `dag_display_name`)

The goal is to have that extended and have a library of `query params` that can be re-used accross all the RestAPI.