### PR TITLE
Add more filters and search to get_dags endpoint

### DIFF
--- a/airflow/api_fastapi/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/openapi/v1-generated.yaml
@@ -64,6 +64,14 @@ paths:
           items:
             type: string
           title: Tags
+      - name: owners
+        in: query
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+          title: Owners
       - name: dag_id_pattern
         in: query
         required: false
@@ -72,6 +80,14 @@ paths:
           - type: string
           - type: 'null'
           title: Dag Id Pattern
+      - name: dag_display_name_pattern
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Dag Display Name Pattern
       - name: only_active
         in: query
         required: false

--- a/airflow/api_fastapi/views/public/dags.py
+++ b/airflow/api_fastapi/views/public/dags.py
@@ -24,10 +24,12 @@ from typing_extensions import Annotated
 
 from airflow.api_fastapi.db import apply_filters_to_select, get_session
 from airflow.api_fastapi.parameters import (
+    QueryDagDisplayNamePatternSearch,
     QueryDagIdPatternSearch,
     QueryLimit,
     QueryOffset,
     QueryOnlyActiveFilter,
+    QueryOwnersFilter,
     QueryPausedFilter,
     QueryTagsFilter,
     SortParam,
@@ -45,16 +47,20 @@ async def get_dags(
     limit: QueryLimit,
     offset: QueryOffset,
     tags: QueryTagsFilter,
+    owners: QueryOwnersFilter,
     dag_id_pattern: QueryDagIdPatternSearch,
+    dag_display_name_pattern: QueryDagDisplayNamePatternSearch,
     only_active: QueryOnlyActiveFilter,
     paused: QueryPausedFilter,
-    order_by: Annotated[SortParam, Depends(SortParam(["dag_id"]))],
+    order_by: Annotated[SortParam, Depends(SortParam(["dag_id", "dag_display_name", "next_dagrun"]))],
     session: Annotated[Session, Depends(get_session)],
 ) -> DAGCollectionResponse:
     """Get all DAGs."""
     dags_query = select(DagModel)
 
-    dags_query = apply_filters_to_select(dags_query, [only_active, paused, dag_id_pattern, tags])
+    dags_query = apply_filters_to_select(
+        dags_query, [only_active, paused, dag_id_pattern, dag_display_name_pattern, tags, owners]
+    )
 
     # TODO: Re-enable when permissions are handled.
     # readable_dags = get_auth_manager().get_permitted_dag_ids(user=g.user)

--- a/airflow/utils/sqlalchemy.py
+++ b/airflow/utils/sqlalchemy.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
     from sqlalchemy.sql.expression import ColumnOperators
     from sqlalchemy.types import TypeEngine
 
+
 log = logging.getLogger(__name__)
 
 

--- a/tests/api_fastapi/views/public/test_dags.py
+++ b/tests/api_fastapi/views/public/test_dags.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -28,11 +28,10 @@ from tests.test_utils.db import clear_db_dags, clear_db_runs, clear_db_serialize
 pytestmark = pytest.mark.db_test
 
 DAG1_ID = "test_dag1"
-DAG1_DISPLAY_NAME = "a"
+DAG1_DISPLAY_NAME = "display1"
 DAG2_ID = "test_dag2"
-DAG2_DISPLAY_NAME = "b"
+DAG2_DISPLAY_NAME = "display2"
 DAG3_ID = "test_dag3"
-DAG3_DISPLAY_NAME = "c"
 TASK_ID = "op1"
 
 
@@ -44,6 +43,8 @@ def _create_deactivated_paused_dag(session=None):
         timetable_summary="2 2 * * *",
         is_active=False,
         is_paused=True,
+        owners="test_owner,another_test_owner",
+        next_dagrun=datetime(2021, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
     )
     session.add(dag_model)
 
@@ -56,6 +57,7 @@ def setup() -> None:
 
     with DAG(
         DAG1_ID,
+        dag_display_name=DAG1_DISPLAY_NAME,
         schedule=None,
         start_date=datetime(2020, 6, 15),
         doc_md="details",
@@ -64,7 +66,16 @@ def setup() -> None:
     ) as dag1:
         EmptyOperator(task_id=TASK_ID)
 
-    with DAG(DAG2_ID, schedule=None, start_date=datetime(2020, 6, 15)) as dag2:
+    with DAG(
+        DAG2_ID,
+        dag_display_name=DAG2_DISPLAY_NAME,
+        schedule=None,
+        start_date=datetime(
+            2020,
+            6,
+            15,
+        ),
+    ) as dag2:
         EmptyOperator(task_id=TASK_ID)
 
     dag1.sync_to_db()
@@ -76,15 +87,24 @@ def setup() -> None:
 @pytest.mark.parametrize(
     "query_params, expected_total_entries, expected_ids",
     [
+        # Filters
         ({}, 2, ["test_dag1", "test_dag2"]),
         ({"limit": 1}, 2, ["test_dag1"]),
         ({"offset": 1}, 2, ["test_dag2"]),
         ({"tags": ["example"]}, 1, ["test_dag1"]),
-        ({"dag_id_pattern": "1"}, 1, ["test_dag1"]),
         ({"only_active": False}, 3, ["test_dag1", "test_dag2", "test_dag3"]),
         ({"paused": True, "only_active": False}, 1, ["test_dag3"]),
         ({"paused": False}, 2, ["test_dag1", "test_dag2"]),
+        ({"owners": ["airflow"]}, 2, ["test_dag1", "test_dag2"]),
+        ({"owners": ["test_owner"], "only_active": False}, 1, ["test_dag3"]),
+        # # Sort
         ({"order_by": "-dag_id"}, 2, ["test_dag2", "test_dag1"]),
+        ({"order_by": "-dag_display_name"}, 2, ["test_dag2", "test_dag1"]),
+        ({"order_by": "dag_display_name"}, 2, ["test_dag1", "test_dag2"]),
+        ({"order_by": "next_dagrun", "only_active": False}, 3, ["test_dag3", "test_dag1", "test_dag2"]),
+        # # Search
+        ({"dag_id_pattern": "1"}, 1, ["test_dag1"]),
+        ({"dag_display_name_pattern": "display2"}, 1, ["test_dag2"]),
     ],
 )
 def test_get_dags(test_client, query_params, expected_total_entries, expected_ids):

--- a/tests/api_fastapi/views/public/test_dags.py
+++ b/tests/api_fastapi/views/public/test_dags.py
@@ -102,7 +102,7 @@ def setup() -> None:
         ({"order_by": "-dag_display_name"}, 2, ["test_dag2", "test_dag1"]),
         ({"order_by": "dag_display_name"}, 2, ["test_dag1", "test_dag2"]),
         ({"order_by": "next_dagrun", "only_active": False}, 3, ["test_dag3", "test_dag1", "test_dag2"]),
-        # # Search
+        # Search
         ({"dag_id_pattern": "1"}, 1, ["test_dag1"]),
         ({"dag_display_name_pattern": "display2"}, 1, ["test_dag2"]),
     ],


### PR DESCRIPTION
Related to: https://github.com/apache/airflow/issues/42159

PR based on https://github.com/apache/airflow/pull/42320 that adds:

filters:
- `owners`

sort:
- `dag_display_name`
- `next_dagrun`

search:
- `dag_display_name_pattern`

Problem encountered:
- Mysql no support for `nullslast`
- Different ordering of `True` / `False` based on database implementation