### PR TITLE
fix: update path handling in `get_dag_directory()` to return the absolute path of the symlink

### DIFF
--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -1090,7 +1090,7 @@ class DagFileProcessorManager(LoggingMixin):
     def get_dag_directory(self) -> str:
         """Return the dag_director as a string."""
         if isinstance(self._dag_directory, Path):
-            return str(self._dag_directory.resolve())
+            return str(self._dag_directory.absolute())
         else:
             return str(self._dag_directory)
 


### PR DESCRIPTION
Somtimes, I use symlinks in my local environment, like this:

```bash
❯ ls -rtlh /opt/airflow/
total 0
lrwxrwxrwx 1 oboki oboki 39 Sep 19 21:24 dags -> /home/oboki/projects/oboki-airflow/dags
lrwxrwxrwx 1 oboki oboki 42 Sep 19 21:24 plugins -> /home/oboki/projects/oboki-airflow/plugins
```

In this case, the `get_dag_directory()` function follows the symlink and returns the original path, which causes issues.

To resolve this, it should return the absolute path of the symlink itself.

Even though `airflow.cfg` is set with `dags_folder = /opt/airflow/dags`, if that path is a symlink, it returns `/home/oboki/projects/oboki-airflow/dags`, leading to `dag_not_in_current_folder = True` and causing issues. (a valid DAG is periodically deactivated.)

I changed `manager.py` to use the absolute path of symlink itself instead of resolved one.
