### PR TITLE
KubernetesPodOperator never stops if credentials are refreshed

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -652,7 +652,6 @@ class KubernetesPodOperator(BaseOperator):
             return result
 
     @tenacity.retry(
-        stop=tenacity.stop_after_attempt(3),
         wait=tenacity.wait_exponential(max=15),
         retry=tenacity.retry_if_exception(lambda exc: check_exception_is_kubernetes_api_unauthorized(exc)),
         reraise=True,

--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -677,8 +677,9 @@ class KubernetesPodOperator(BaseOperator):
                     "Failed to check container status due to permission error. Refreshing credentials and retrying."
                 )
                 self._refresh_cached_properties()
-                self.pod_manager.read_pod(pod)
-            raise PodCredentialsExpiredFailure
+                self.pod_manager.read_pod(pod=pod) # attempt using refreshed credentials, raises if still invalid
+                raise PodCredentialsExpiredFailure("Kubernetes credentials expired, retrying after refresh.")
+            raise exc
 
     def _refresh_cached_properties(self):
         del self.hook

--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -112,6 +112,9 @@ class PodEventType(Enum):
 class PodReattachFailure(AirflowException):
     """When we expect to be able to find a pod but cannot."""
 
+class PodCredentialsExpiredFailure(AirflowException):
+    """When pod fails to refresh credentials."""
+
 
 class KubernetesPodOperator(BaseOperator):
     """
@@ -650,10 +653,10 @@ class KubernetesPodOperator(BaseOperator):
 
         if self.do_xcom_push:
             return result
-
+        
     @tenacity.retry(
         wait=tenacity.wait_exponential(max=15),
-        retry=tenacity.retry_if_exception(lambda exc: check_exception_is_kubernetes_api_unauthorized(exc)),
+        retry=tenacity.retry_if_exception_type(PodCredentialsExpiredFailure),
         reraise=True,
     )
     def await_pod_completion(self, pod: k8s.V1Pod):
@@ -674,7 +677,8 @@ class KubernetesPodOperator(BaseOperator):
                     "Failed to check container status due to permission error. Refreshing credentials and retrying."
                 )
                 self._refresh_cached_properties()
-            raise exc
+                self.pod_manager.read_pod(pod)
+            raise PodCredentialsExpiredFailure
 
     def _refresh_cached_properties(self):
         del self.hook

--- a/tests/providers/cncf/kubernetes/operators/test_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_pod.py
@@ -1672,10 +1672,10 @@ class TestKubernetesPodOperator:
 
         mock_await_container_completion.side_effect = [ApiException(status=401)]
         mock_read_pod.side_effect = [ApiException(status=401)]
-        
+
         with pytest.raises(ApiException):
             k.await_pod_completion(pod)
-        
+
         mock_read_pod.assert_called()
         # assert cache was refreshed
         assert client != k.client

--- a/tests/providers/cncf/kubernetes/operators/test_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_pod.py
@@ -1663,7 +1663,7 @@ class TestKubernetesPodOperator:
         "side_effect, exception_type, expect_exc",
         [
             ([ApiException(401), mock.DEFAULT], ApiException, True),  # works after one 401
-            ([ApiException(401)] * 10, ApiException, False),  # exc after 3 retries on 401
+            ([ApiException(401)] * 1000 + [mock.DEFAULT], ApiException, True),  # works after 1000 retries
             ([ApiException(402)], ApiException, False),  # exc on non-401
             ([ApiException(500)], ApiException, False),  # exc on non-401
             ([Exception], Exception, False),  # exc on different exception
@@ -1684,7 +1684,7 @@ class TestKubernetesPodOperator:
         else:
             with pytest.raises(exception_type):
                 k.await_pod_completion(pod)
-        expected_call_count = min(len(side_effect), 3)  # retry max 3 times
+        expected_call_count = len(side_effect)
         mock_await_container_completion.assert_has_calls(
             [mock.call(pod=pod, container_name=k.base_container_name)] * expected_call_count
         )

--- a/tests/providers/cncf/kubernetes/operators/test_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_pod.py
@@ -1629,8 +1629,9 @@ class TestKubernetesPodOperator:
     @pytest.mark.parametrize("get_logs", [True, False])
     @patch(f"{POD_MANAGER_CLASS}.fetch_requested_container_logs")
     @patch(f"{POD_MANAGER_CLASS}.await_container_completion")
+    @patch(f"{POD_MANAGER_CLASS}.read_pod")
     def test_await_container_completion_refreshes_properties_on_exception(
-        self, mock_await_container_completion, fetch_requested_container_logs, get_logs
+        self, mock_read_pod, mock_await_container_completion, fetch_requested_container_logs, get_logs
     ):
         k = KubernetesPodOperator(task_id="task", get_logs=get_logs)
         pod = self.run_pod(k)
@@ -1655,6 +1656,28 @@ class TestKubernetesPodOperator:
             mock_await_container_completion.assert_has_calls(
                 [mock.call(pod=pod, container_name=k.base_container_name)] * 3
             )
+        mock_read_pod.assert_called()
+        assert client != k.client
+        assert hook != k.hook
+        assert pod_manager != k.pod_manager
+
+    @patch(f"{POD_MANAGER_CLASS}.await_container_completion")
+    @patch(f"{POD_MANAGER_CLASS}.read_pod")
+    def test_await_container_completion_raises_unauthorized_if_credentials_still_invalid_after_refresh(
+        self, mock_read_pod, mock_await_container_completion
+    ):
+        k = KubernetesPodOperator(task_id="task", get_logs=False)
+        pod = self.run_pod(k)
+        client, hook, pod_manager = k.client, k.hook, k.pod_manager
+
+        mock_await_container_completion.side_effect = [ApiException(status=401)]
+        mock_read_pod.side_effect = [ApiException(status=401)]
+        
+        with pytest.raises(ApiException):
+            k.await_pod_completion(pod)
+        
+        mock_read_pod.assert_called()
+        # assert cache was refreshed
         assert client != k.client
         assert hook != k.hook
         assert pod_manager != k.pod_manager
@@ -1663,7 +1686,7 @@ class TestKubernetesPodOperator:
         "side_effect, exception_type, expect_exc",
         [
             ([ApiException(401), mock.DEFAULT], ApiException, True),  # works after one 401
-            ([ApiException(401)] * 1000 + [mock.DEFAULT], ApiException, True),  # works after 1000 retries
+            ([ApiException(401)] * 3 + [mock.DEFAULT], ApiException, True),  # works after 3 retries
             ([ApiException(402)], ApiException, False),  # exc on non-401
             ([ApiException(500)], ApiException, False),  # exc on non-401
             ([Exception], Exception, False),  # exc on different exception


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This is a follow-up of this PR: https://github.com/apache/airflow/pull/39325

With the above change, the tenacity retry mechanism was introduced while waiting pod completion. For long running tasks, in fact, k8s credentials could expire while the task is still running, we are therefore refreshing credentials and retrying. However this did not completely solve the issue due to the `stop_after_attempt(3)`: the job is still failing when credentials were expiring more than twice.

This PR attempts at fixing this issue by:
1) removing the `stop_after_attempt` logic
2) still failing the job in case credentials are invalid after refresh. we in fact still want to make sure the job doesn't run forever if it is producing 401s after refresh

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
