### PR TITLE
Make migrations path relative to ini

### DIFF
--- a/airflow/alembic.ini
+++ b/airflow/alembic.ini
@@ -20,7 +20,7 @@
 
 [alembic]
 # path to migration scripts
-script_location = migrations
+script_location = %(here)s/migrations
 
 # template used to generate migration files
 # file_template = %%(rev)s_%%(slug)s


### PR DESCRIPTION
This makes it so that we can alembic commands from the root repo dir.

E.g.

```
alembic -c airflow/alembic.ini revision --autogenerate -m "Do something"
```

Sometimes when running from airflow subfolder we get errors.
