### PR TITLE
Make AlreadyExists a subclass of more general Conflict exception

### DIFF
--- a/airflow/api_connexion/exceptions.py
+++ b/airflow/api_connexion/exceptions.py
@@ -153,8 +153,8 @@ class PermissionDenied(ProblemException):
         )
 
 
-class AlreadyExists(ProblemException):
-    """Raise when the object already exists."""
+class Conflict(ProblemException):
+    """Raise when there is some conflict."""
 
     def __init__(
         self,
@@ -171,6 +171,10 @@ class AlreadyExists(ProblemException):
             headers=headers,
             **kwargs,
         )
+
+
+class AlreadyExists(Conflict):
+    """Raise when the object already exists."""
 
 
 class Unknown(ProblemException):


### PR DESCRIPTION
The 409 exception should be a bit more general.  There can be other types of conflicts.
