### PR TITLE
Do not attempt to provide not stringified objects to UI via xcom if pickling is active

### DIFF
--- a/airflow/api_connexion/endpoints/xcom_endpoint.py
+++ b/airflow/api_connexion/endpoints/xcom_endpoint.py
@@ -125,7 +125,7 @@ def get_xcom_entry(
         stub.value = XCom.deserialize_value(stub)
         item = stub
 
-    if stringify:
+    if stringify or conf.getboolean("core", "enable_xcom_pickling"):
         return xcom_schema_string.dump(item)
 
     return xcom_schema_native.dump(item)

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -2040,6 +2040,8 @@ paths:
             If set to true (default) the Any value will be returned as string, e.g. a Python representation
             of a dict. If set to false it will return the raw data as dict, list, string or whatever was stored.
 
+            This parameter is not meaningful when using XCom pickling, then it is always returned as string.
+
             *New in version 2.10.0*
       responses:
         "200":


### PR DESCRIPTION
With this PR the xcom will always be returned as string if XCom pickling is active. Like it was in Airflow 2.9.

closes: #42117
