### PR TITLE
Enabling TLS arguments for FastAPI

### DIFF
--- a/tests/cli/commands/test_fastapi_api_command.py
+++ b/tests/cli/commands/test_fastapi_api_command.py
@@ -124,7 +124,9 @@ class TestCliFastAPI(_CommonCLIGunicornTestClass):
                 close_fds=True,
             )
 
-    def test_cli_fastapi_api_args(self):
+    def test_cli_fastapi_api_args(self, ssl_cert_and_key):
+        cert_path, key_path = ssl_cert_and_key
+
         with mock.patch("subprocess.Popen") as Popen, mock.patch.object(
             fastapi_api_command, "GunicornMonitor"
         ):
@@ -135,6 +137,10 @@ class TestCliFastAPI(_CommonCLIGunicornTestClass):
                     "custom_log_format",
                     "--pid",
                     "/tmp/x.pid",
+                    "--ssl-cert",
+                    str(cert_path),
+                    "--ssl-key",
+                    str(key_path),
                 ]
             )
             fastapi_api_command.fastapi_api(args)
@@ -162,6 +168,10 @@ class TestCliFastAPI(_CommonCLIGunicornTestClass):
                     "-",
                     "--config",
                     "python:airflow.api_fastapi.gunicorn_config",
+                    "--certfile",
+                    str(cert_path),
+                    "--keyfile",
+                    str(key_path),
                     "--access-logformat",
                     "custom_log_format",
                     "airflow.api_fastapi.app:cached_app()",
@@ -171,20 +181,29 @@ class TestCliFastAPI(_CommonCLIGunicornTestClass):
             )
 
     @pytest.mark.parametrize(
-        "ssl_arguments",
-        [["--ssl-cert", "_.crt", "--ssl-key", "_.key"], ["--ssl-cert", "_.crt"], ["--ssl-key", "_.key"]],
+        "ssl_arguments, error_pattern",
+        [
+            (["--ssl-cert", "_.crt", "--ssl-key", "_.key"], "does not exist _.crt"),
+            (["--ssl-cert", "_.crt"], "Need both.*certificate.*key"),
+            (["--ssl-key", "_.key"], "Need both.*key.*certificate"),
+        ],
     )
-    def test_get_ssl_cert_and_key_filepaths_with_incorrect_usage(self, ssl_arguments):
+    def test_get_ssl_cert_and_key_filepaths_with_incorrect_usage(self, ssl_arguments, error_pattern):
         args = self.parser.parse_args(["fastapi-api"] + ssl_arguments)
-        with pytest.raises(AirflowConfigException):
+        with pytest.raises(AirflowConfigException, match=error_pattern):
             fastapi_api_command._get_ssl_cert_and_key_filepaths(args)
 
-    def test_get_ssl_cert_and_key_filepaths_with_correct_usage(self, tmp_path):
-        cert_path, key_path = tmp_path / "_.crt", tmp_path / "_.key"
-        cert_path.touch()
-        key_path.touch()
+    def test_get_ssl_cert_and_key_filepaths_with_correct_usage(self, ssl_cert_and_key):
+        cert_path, key_path = ssl_cert_and_key
 
         args = self.parser.parse_args(
             ["fastapi-api"] + ["--ssl-cert", str(cert_path), "--ssl-key", str(key_path)]
         )
-        fastapi_api_command._get_ssl_cert_and_key_filepaths(args)
+        assert fastapi_api_command._get_ssl_cert_and_key_filepaths(args) == (str(cert_path), str(key_path))
+
+    @pytest.fixture
+    def ssl_cert_and_key(self, tmp_path):
+        cert_path, key_path = tmp_path / "_.crt", tmp_path / "_.key"
+        cert_path.touch()
+        key_path.touch()
+        return cert_path, key_path


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Passing SSL arguments down to process invocation for `fastapi-api`.

Have erred to leave a couple things untouched (for the moment at least). 
- The debug branch as invoking via `gunicorn` has some odd logs (https://github.com/apache/airflow/pull/41896). Have assumed the intent for now is to keep debug using `fastapi`. `fastapi` cli does not seem to have flags for SSL/TLS.
- `airflow/airflow/cli/commands/internal_api_command.py`, have inferred from https://github.com/apache/airflow/pull/41896 that they're kinda separate

related: [42359](https://github.com/apache/airflow/issues/42359)

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
