### PR TITLE
Support for Kubernetes Executor side task attempt logging for failed tasks in case of task pods doesn't reach running state

### DIFF
--- a/providers/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -398,7 +398,7 @@ class KubernetesExecutor(BaseExecutor):
                     self.kube_scheduler.run_next(task)
                     self.task_publish_retries.pop(key, None)
                 except PodReconciliationError as e:
-                    self.task_logger.exception(
+                    self.task_logger.error(
                         "Pod reconciliation failed, likely due to kubernetes library upgrade. "
                         "Try clearing the task to re-run. Details: %s",
                         e.__cause__,

--- a/providers/tests/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/providers/tests/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -1657,6 +1657,7 @@ class TestKubernetesJobWatcher:
             )
         )
 
+    @pytest.mark.db_test
     @pytest.mark.parametrize(
         "raw_object, is_watcher_queue_called",
         [
@@ -1838,6 +1839,7 @@ class TestKubernetesJobWatcher:
         else:
             self.watcher.watcher_queue.put.assert_not_called()
 
+    @pytest.mark.db_test
     def test_process_status_pending_deleted(self, task_instance):
         self.events.append({"type": "DELETED", "object": self.pod})
         self.pod.metadata.deletion_timestamp = timezone.utcnow()
@@ -1845,6 +1847,7 @@ class TestKubernetesJobWatcher:
         self._run()
         self.assert_watcher_queue_called_once_with_state(State.FAILED)
 
+    @pytest.mark.db_test
     def test_process_status_failed(self, task_instance):
         self.pod.status.phase = "Failed"
         self.events.append({"type": "MODIFIED", "object": self.pod})
@@ -1852,6 +1855,7 @@ class TestKubernetesJobWatcher:
         self._run()
         self.assert_watcher_queue_called_once_with_state(State.FAILED)
 
+    @pytest.mark.db_test
     def test_process_status_provider_failed(self, task_instance):
         self.pod.status.reason = "ProviderFailed"
         self.events.append({"type": "MODIFIED", "object": self.pod})
@@ -1901,6 +1905,7 @@ class TestKubernetesJobWatcher:
             )
         )
 
+    @pytest.mark.db_test
     def test_process_status_running_deleted(self, task_instance):
         self.pod.status.phase = "Running"
         self.pod.metadata.deletion_timestamp = timezone.utcnow()


### PR DESCRIPTION
Right now, when the tasks fail due to pod launch failures or the pod is stuck in the pending phase, then the task logs from the UI are empty. It is very inconvenient for airflow consumers to debug it. They might not have access to the scheduler logs. We can push these failure reasons from the Kubernetes executor to task logs. So, that airflow consumers can able to see task failure reasons from the UI.

closes: #37435