### PR TITLE
Fix broken main: generated JS types

### DIFF
--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -76,7 +76,7 @@ export type GetDagsPublicDagsGetData = {
   onlyActive?: boolean;
   orderBy?: string;
   paused?: boolean | null;
-  tags?: Array<string> | null;
+  tags?: Array<string>;
 };
 
 export type GetDagsPublicDagsGetResponse = DAGCollectionResponse;


### PR DESCRIPTION
Fix for static checks in https://github.com/apache/airflow/actions/runs/10995403123/job/30526485436

@pierrejeambrun was the API change intended that causes the generated DIFF? Or is this an unwanted side-effect?