### PR TITLE
Bugfix task execution from runner in Windows

### DIFF
--- a/airflow/jobs/local_task_job_runner.py
+++ b/airflow/jobs/local_task_job_runner.py
@@ -261,8 +261,8 @@ class LocalTaskJobRunner(BaseJobRunner, LoggingMixin):
             _set_task_deferred_context_var()
         else:
             message = f"Task exited with return code {return_code}"
-            if return_code == -signal.SIGKILL:
-                message += "For more information, see https://airflow.apache.org/docs/apache-airflow/stable/troubleshooting.html#LocalTaskJob-killed"
+            if not IS_WINDOWS and return_code == -signal.SIGKILL:
+                message += ". For more information, see https://airflow.apache.org/docs/apache-airflow/stable/troubleshooting.html#LocalTaskJob-killed"
             self.log.info(message)
 
         if not (self.task_instance.test_mode or is_deferral):


### PR DESCRIPTION
While "playing around" with making the Edge Worker (AIP-69) running on Windows I noticed that the local task runner fails as the `signal` implementation in Windows does not carry `SIGKILL` - but as this is just a cosmetic log message extension (and whitespace was missing) this is just a small bugfix and then... EdgeWorker is running in Windows!

related: #10388

FYI @AutomationDev85 