### PR TITLE
Fix the span link of task instance to point to the correct span in the scheduler_job_loop (issue #42429)

### DIFF
--- a/airflow/traces/otel_tracer.py
+++ b/airflow/traces/otel_tracer.py
@@ -199,7 +199,12 @@ class OtelTrace:
 
         _links.append(
             Link(
-                context=trace.get_current_span().get_span_context(),
+                context=SpanContext(
+                    trace_id=trace.get_current_span().get_span_context().trace_id,
+                    span_id=span_id,
+                    is_remote=True,
+                    trace_flags=TraceFlags(0x01),
+                ),
                 attributes={"meta.annotation_type": "link", "from": "parenttrace"},
             )
         )


### PR DESCRIPTION
# Overview

This PR contains the fix for the following issue:

closes: #42429 

The fix covers creating span link of the task instance having the correct span of which to point to.
currently, the span link points to the root span of the scheduler job loop, but the fix will have the link
pointing to the actual location of where the task instance was triggered to run, providing better clarity.