### PR TITLE
Fix UI pre commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1174,7 +1174,7 @@ repos:
         description: TS types generation / ESLint / Prettier new UI files
         language: node
         types_or: [javascript, ts, tsx, yaml, css, json]
-        files: ^airflow/ui/|^airflow/api_connexion/openapi/v1\.yaml$
+        files: ^airflow/ui/|^airflow/api_fastapi/openapi/v1-generated\.yaml$
         entry: ./scripts/ci/pre_commit/lint_ui.py
         additional_dependencies: ['pnpm@9.7.1']
         pass_filenames: false


### PR DESCRIPTION
File detection for the `ui` pre-commit hook is wrong. Now that the UI is based on the new FastAPI API and that it has its own generated spec, the file detection should happen on that new spec.

Will prevent other failure such as https://github.com/apache/airflow/pull/42422. (Original PR was green but skipped updating the front-end code causing main failure).