### PR TITLE
Skip `fastapi-cli` Indirection and SSL/TLS on Debug

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -497,6 +497,7 @@ DEPENDENCIES = [
     # Universal Pathlib 0.2.4 adds extra validation for Paths and our integration with local file paths
     # Does not work with it Tracked in https://github.com/fsspec/universal_pathlib/issues/276
     "universal-pathlib>=0.2.2,!=0.2.4",
+    "uvicorn[standard]>=0.15.0",
     # Werkzug 3 breaks Flask-Login 0.6.2, also connexion needs to be updated to >= 3.0
     # we should remove this limitation when FAB supports Flask 2.3 and we migrate connexion to 3+
     "werkzeug>=2.0,<3",

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -497,7 +497,7 @@ DEPENDENCIES = [
     # Universal Pathlib 0.2.4 adds extra validation for Paths and our integration with local file paths
     # Does not work with it Tracked in https://github.com/fsspec/universal_pathlib/issues/276
     "universal-pathlib>=0.2.2,!=0.2.4",
-    "uvicorn[standard]>=0.15.0",
+    "uvicorn[standard]>=0.24.0",
     # Werkzug 3 breaks Flask-Login 0.6.2, also connexion needs to be updated to >= 3.0
     # we should remove this limitation when FAB supports Flask 2.3 and we migrate connexion to 3+
     "werkzeug>=2.0,<3",

--- a/tests/test_utils/test_appendable.py
+++ b/tests/test_utils/test_appendable.py
@@ -1,0 +1,110 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import os
+from copy import copy
+from pathlib import Path
+from typing import TypeVar, Union
+
+import pytest
+
+T = TypeVar("T", bound=Union[list, tuple, dict])
+
+
+class Appendable:
+    """
+    To be used in flat lists, tuples and dictionaries. Intended to
+    be used with pytest.mark.parametrize. For example, when values
+    want to be relative to `tmp_path`.
+    """
+
+    def __init__(self, path: str, *, should_touch: bool = True):
+        self.path = path
+        self.should_touch = should_touch
+
+    @classmethod
+    def onto(cls, appendables: T, base_path: Path) -> T:
+        """
+        Returns `appendables` where `Appendable` elements are appended
+        onto `base_path`. The return is not a full copy, and it is not
+        recursive.
+        """
+        if isinstance(appendables, list):
+            return cls._onto_list(appendables, base_path)
+        elif isinstance(appendables, tuple):
+            return cls._onto_tuple(appendables, base_path)
+        elif isinstance(appendables, dict):
+            return cls._onto_dict(appendables, base_path)
+
+    def _onto_single(self, base_path: Path) -> str:
+        new_path = base_path / self.path
+        if self.should_touch:
+            new_path.touch()
+        return str(new_path)
+
+    @classmethod
+    def _onto_list(cls, appendables: list, base_path: Path) -> list:
+        appendables = copy(appendables)
+        for index, potentially_appendable in enumerate(appendables):
+            if isinstance(potentially_appendable, cls):
+                new_path = potentially_appendable._onto_single(base_path)
+                appendables[index] = str(new_path)
+        return appendables
+
+    @classmethod
+    def _onto_tuple(cls, appendables: tuple, base_path: Path) -> tuple:
+        return tuple(cls._onto_list(list(appendables), base_path))
+
+    @classmethod
+    def _onto_dict(cls, appendables: dict, base_path: Path) -> dict:
+        appended = {}
+        for key, value in appendables.items():
+            if isinstance(key, cls):
+                key = key._onto_single(base_path)
+            if isinstance(value, cls):
+                value = value._onto_single(base_path)
+            appended[key] = value
+        return appended
+
+
+def test_onto(tmp_path):
+    A = Appendable
+    onto = A.onto
+
+    def t(filename):
+        return str(tmp_path / filename)
+
+    assert onto([A("a")], tmp_path) == [t("a")]
+    assert onto(["--path", A("a")], tmp_path) == ["--path", t("a")]
+
+    assert onto((A("a"), A("b")), tmp_path) == (t("a"), t("b"))
+
+    assert onto({"path": A("a")}, tmp_path) == {"path": t("a")}
+    assert onto({"something": "else", "path": A("a")}, tmp_path) == {"something": "else", "path": t("a")}
+
+
+@pytest.mark.parametrize(
+    "appendables, should_exist",
+    [
+        ([Appendable("a")], True),
+        ([Appendable("a", should_touch=False)], False),
+    ],
+)
+def test_onto_should_touch(appendables, should_exist, tmp_path):
+    [path] = Appendable.onto(appendables, tmp_path)
+    assert os.path.isfile(path) == should_exist

--- a/tests/test_utils/test_appendable.py
+++ b/tests/test_utils/test_appendable.py
@@ -29,7 +29,7 @@ T = TypeVar("T", bound=Union[list, tuple, dict])
 class Appendable:
     """
     To be used in flat lists, tuples and dictionaries. Intended to
-    be used with pytest.mark.parametrize. For example, when values
+    be used with `pytest.mark.parametrize`. For example, when values
     want to be relative to `tmp_path`.
     """
 
@@ -45,11 +45,13 @@ class Appendable:
         recursive.
         """
         if isinstance(appendables, list):
-            return cls._onto_list(appendables, base_path)
+            return cls._onto_list(appendables, base_path)  # type: ignore
         elif isinstance(appendables, tuple):
-            return cls._onto_tuple(appendables, base_path)
-        elif isinstance(appendables, dict):
-            return cls._onto_dict(appendables, base_path)
+            return cls._onto_tuple(appendables, base_path)  # type: ignore
+        else:
+            assert isinstance(appendables, dict), "should only supply list, "
+            "tuple or dict to this function."
+            return cls._onto_dict(appendables, base_path)  # type: ignore
 
     def _onto_single(self, base_path: Path) -> str:
         new_path = base_path / self.path


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Following up on, https://github.com/apache/airflow/pull/42395. Have just added the SSL/TLS flags to the debug control flow. `fastapi` cli does not have SSL flags, but it is a thin wrapper around `uvicorn.run` (https://github.com/fastapi/fastapi-cli/blob/main/src/fastapi_cli/cli.py#L92)

Have created the `Appendable` test utility to declare files/filepaths in `pytest.mark.parametrize` that are to be relative `tmp_path`. Lmk if it is a bit weird / not good. Or whether it should be separated out into a different PR.

~~There are some CI failures, not too sure atm if it is because of `uvicorn[standard]>=0.15.0` or flakiness. Between [fa4239a](https://github.com/apache/airflow/pull/42443/commits/fa4239ae2f05eb3f8174f53b978e86e1a5536094) and [ba2fec5](https://github.com/apache/airflow/pull/42443/commits/ba2fec52381296abec57d00537cce8f50d5fd08d) same checks did not fail (barring mypy). Other PRs that trigger the same checks seem to sometimes error too (though error message is a bit different).~~ Atm, the only failing CI check looks to be resolved as a part of #42500.
~~`fastapi[standard]>=0.112.2` itself requires `uvicorn[standard]>=0.15.0`, wondering though whether since `uvicorn` is no longer a transitive dependency the tests fail.~~

related: https://github.com/apache/airflow/issues/42359

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
