### PR TITLE
Fix logout in AWS auth manager

### DIFF
--- a/airflow/providers/amazon/aws/auth_manager/views/auth.py
+++ b/airflow/providers/amazon/aws/auth_manager/views/auth.py
@@ -61,7 +61,7 @@ class AwsAuthManagerAuthenticationViews(AirflowBaseView):
         saml_auth = self._init_saml_auth()
         return redirect(saml_auth.login())
 
-    @expose("/logout")
+    @expose("/logout", methods=("GET", "POST"))
     def logout(self):
         """Start logout process."""
         session.clear()

--- a/tests/providers/amazon/aws/auth_manager/views/test_auth.py
+++ b/tests/providers/amazon/aws/auth_manager/views/test_auth.py
@@ -69,7 +69,7 @@ def aws_app():
         ) as mock_is_policy_store_schema_up_to_date:
             mock_is_policy_store_schema_up_to_date.return_value = True
             mock_parser.parse_remote.return_value = SAML_METADATA_PARSED
-            return application.create_app(testing=True)
+            return application.create_app(testing=True, config={"WTF_CSRF_ENABLED": False})
 
 
 @pytest.mark.db_test
@@ -82,7 +82,7 @@ class TestAwsAuthManagerAuthenticationViews:
 
     def test_logout_redirect_to_identity_center(self, aws_app):
         with aws_app.test_client() as client:
-            response = client.get("/logout")
+            response = client.post("/logout")
             assert response.status_code == 302
             assert response.location.startswith("https://portal.sso.us-east-1.amazonaws.com/saml/logout/")
 


### PR DESCRIPTION
The logout link in Airflow is actually a form which then generate a POST request

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
