### PR TITLE
fix: OL dag start event not being emitted

### DIFF
--- a/airflow/providers/openlineage/plugins/listener.py
+++ b/airflow/providers/openlineage/plugins/listener.py
@@ -439,7 +439,6 @@ class OpenLineageListener:
             self.submit_callable(
                 self.adapter.dag_started,
                 dag_id=dag_run.dag_id,
-                run_id=dag_run.run_id,
                 logical_date=dag_run.logical_date,
                 start_date=dag_run.start_date,
                 nominal_start_time=data_interval_start,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
In [apache-airflow-providers-openlineage==1.12.0](https://pypi.org/project/apache-airflow-providers-openlineage/1.12.0/) after changes from #41690 the DAG start events are not being emitted properly.

I think the main cause is trying to pass run_id to adapter's dag_started method https://github.com/apache/airflow/blob/dcb184687dcc0894bea384ddab1ed282304afb30/airflow/providers/openlineage/plugins/listener.py#L439-L453

when the adapter's method do not accept this argument https://github.com/apache/airflow/blob/dcb184687dcc0894bea384ddab1ed282304afb30/airflow/providers/openlineage/plugins/adapter.py#L336-L347

Error in scheduler logs:
```
[2024-09-24T15:14:49.910+0000] {listener.py:529} WARNING - Failed to submit method to executor
concurrent.futures.process._RemoteTraceback:
"""
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/concurrent/futures/process.py", line 239, in _process_worker
    r = call_item.fn(*call_item.args, **call_item.kwargs)
TypeError: dag_started() got an unexpected keyword argument 'run_id'
"""

The above exception was the direct cause of the following exception:

TypeError: dag_started() got an unexpected keyword argument 'run_id'
```
<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
