### PR TITLE
Flush less in dataset manager

### DIFF
--- a/airflow/api_connexion/endpoints/dataset_endpoint.py
+++ b/airflow/api_connexion/endpoints/dataset_endpoint.py
@@ -352,5 +352,6 @@ def create_dataset_event(session: Session = NEW_SESSION) -> APIResponse:
     )
     if not dataset_event:
         raise NotFound(title="Dataset not found", detail=f"Dataset with uri: '{uri}' not found")
+    session.flush()  # So we can dump the timestamp.
     event = dataset_event_schema.dump(dataset_event)
     return event

--- a/airflow/datasets/manager.py
+++ b/airflow/datasets/manager.py
@@ -150,6 +150,7 @@ class DatasetManager(LoggingMixin):
 
         dataset_event = DatasetEvent(**event_kwargs)
         session.add(dataset_event)
+        session.flush()  # Ensure the event is written earlier than DDRQ entries below.
 
         dags_to_queue_from_dataset = {
             ref.dag for ref in dataset_model.consuming_dags if ref.dag.is_active and not ref.dag.is_paused

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2916,7 +2916,6 @@ class TaskInstance(Base, LoggingMixin):
 
             def __missing__(self, key: str) -> DatasetModel:
                 (dataset_obj,) = dataset_manager.create_datasets([Dataset(uri=key)], session=session)
-                session.flush()
                 self.log.warning("Created a new %r as it did not exist.", dataset_obj)
                 self[key] = dataset_obj
                 return dataset_obj

--- a/tests/datasets/test_manager.py
+++ b/tests/datasets/test_manager.py
@@ -119,9 +119,10 @@ class TestDatasetManager:
         session.add(dsm)
         dsm.consuming_dags = [DagScheduleDatasetReference(dag_id=dag.dag_id) for dag in (dag1, dag2)]
         session.execute(delete(DatasetDagRunQueue))
-        session.commit()
+        session.flush()
 
         dsem.register_dataset_change(task_instance=mock_task_instance, dataset=ds, session=session)
+        session.flush()
 
         # Ensure we've created a dataset
         assert session.query(DatasetEvent).filter_by(dataset_id=dsm.id).count() == 1
@@ -134,9 +135,10 @@ class TestDatasetManager:
         dsm = DatasetModel(uri="never_consumed")
         session.add(dsm)
         session.execute(delete(DatasetDagRunQueue))
-        session.commit()
+        session.flush()
 
         dsem.register_dataset_change(task_instance=mock_task_instance, dataset=ds, session=session)
+        session.flush()
 
         # Ensure we've created a dataset
         assert session.query(DatasetEvent).filter_by(dataset_id=dsm.id).count() == 1
@@ -150,14 +152,15 @@ class TestDatasetManager:
 
         ds = Dataset(uri="test_dataset_uri_2")
         dag1 = DagModel(dag_id="dag3")
-        session.add_all([dag1])
+        session.add(dag1)
 
         dsm = DatasetModel(uri="test_dataset_uri_2")
         session.add(dsm)
         dsm.consuming_dags = [DagScheduleDatasetReference(dag_id=dag1.dag_id)]
-        session.commit()
+        session.flush()
 
         dsem.register_dataset_change(task_instance=mock_task_instance, dataset=ds, session=session)
+        session.flush()
 
         # Ensure the listener was notified
         assert len(dataset_listener.changed) == 1

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -4300,6 +4300,7 @@ class TestSchedulerJob:
             dataset=ds,
             session=session,
         )
+        session.flush()
         assert session.scalars(dse_q).one().source_run_id == dr1.run_id
         assert session.scalars(ddrq_q).one_or_none() is None
 
@@ -4313,6 +4314,7 @@ class TestSchedulerJob:
             dataset=ds,
             session=session,
         )
+        session.flush()
         assert [e.source_run_id for e in session.scalars(dse_q)] == [dr1.run_id, dr2.run_id]
         assert session.scalars(ddrq_q).one().target_dag_id == "consumer"
 

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2327,7 +2327,7 @@ class TestTaskInstance:
         )
         assert all(
             event.timestamp < ddrq_timestamp for (ddrq_timestamp,) in ddrq_timestamps
-        ), f"Some items in {ddrq_timestamps} is earlier than {event.timestamp}"
+        ), f"Some items in {[str(t) for t in ddrq_timestamps]} are earlier than {event.timestamp}"
 
     @pytest.mark.skip_if_database_isolation_mode  # Does not work in db isolation mode
     def test_outlet_datasets_failed(self, create_task_instance):

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2325,7 +2325,9 @@ class TestTaskInstance:
         ddrq_timestamps = (
             session.query(DatasetDagRunQueue.created_at).filter_by(dataset_id=event.dataset.id).all()
         )
-        assert all([event.timestamp < ddrq_timestamp for (ddrq_timestamp,) in ddrq_timestamps])
+        assert all(
+            event.timestamp < ddrq_timestamp for (ddrq_timestamp,) in ddrq_timestamps
+        ), f"Some items in {ddrq_timestamps} is earlier than {event.timestamp}"
 
     @pytest.mark.skip_if_database_isolation_mode  # Does not work in db isolation mode
     def test_outlet_datasets_failed(self, create_task_instance):


### PR DESCRIPTION
As mentioned in https://github.com/apache/airflow/pull/42343#discussion_r1774261268

We don't really *need* those objects in the database after the manager (simply in the memory-managed SQLAlchemy session is good enough), and since the objects are still transaction-held, they can't be accessed by the listener hooks even if they are in the database anyway.

I also took the oppertunity to turn all listener method to class methods instead. This doesn't really make any difference (the manager does not hold instance-level values), and we need at least some of the methods to be class-level (for the internal API), and it's more consistent to have them all be class-level.