### PR TITLE
Remove deprecated CloudSQL HA functionality from the system test

### DIFF
--- a/docs/apache-airflow-providers-google/operators/cloud/cloud_sql.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/cloud_sql.rst
@@ -180,15 +180,6 @@ it will be retrieved from the Google Cloud connection used. Both variants are sh
     :start-after: [START howto_operator_cloudsql_delete]
     :end-before: [END howto_operator_cloudsql_delete]
 
-Note: If the instance has read or failover replicas you need to delete them before you delete the primary instance.
-Replicas are deleted the same way as primary instances:
-
-.. exampleinclude:: /../../tests/system/providers/google/cloud/cloud_sql/example_cloud_sql.py
-    :language: python
-    :dedent: 4
-    :start-after: [START howto_operator_cloudsql_replicas_delete]
-    :end-before: [END howto_operator_cloudsql_replicas_delete]
-
 Templating
 """"""""""
 
@@ -392,16 +383,6 @@ Example body defining the instance with failover replica:
     :language: python
     :start-after: [START howto_operator_cloudsql_create_body]
     :end-before: [END howto_operator_cloudsql_create_body]
-
-Example body defining read replica for the instance above:
-
-.. exampleinclude:: /../../tests/system/providers/google/cloud/cloud_sql/example_cloud_sql.py
-    :language: python
-    :start-after: [START howto_operator_cloudsql_create_replica]
-    :end-before: [END howto_operator_cloudsql_create_replica]
-
-Note: Failover replicas are created together with the instance in a single task.
-Read replicas need to be created in separate tasks.
 
 Using the operator
 """"""""""""""""""

--- a/tests/system/providers/google/cloud/cloud_sql/example_cloud_sql.py
+++ b/tests/system/providers/google/cloud/cloud_sql/example_cloud_sql.py
@@ -62,8 +62,6 @@ FILE_NAME_DEFERRABLE = f"{DAG_ID}_{ENV_ID}_def_exportImportTestFile".replace("-"
 FILE_URI = f"gs://{BUCKET_NAME}/{FILE_NAME}"
 FILE_URI_DEFERRABLE = f"gs://{BUCKET_NAME}/{FILE_NAME_DEFERRABLE}"
 
-FAILOVER_REPLICA_NAME = f"{INSTANCE_NAME}-failover-replica"
-READ_REPLICA_NAME = f"{INSTANCE_NAME}-read-replica"
 CLONED_INSTANCE_NAME = f"{INSTANCE_NAME}-clone"
 
 # Bodies below represent Cloud SQL instance resources:
@@ -86,29 +84,14 @@ body = {
         "locationPreference": {"zone": "europe-west4-a"},
         "maintenanceWindow": {"hour": 5, "day": 7, "updateTrack": "canary"},
         "pricingPlan": "PER_USE",
-        "replicationType": "ASYNCHRONOUS",
         "storageAutoResize": True,
         "storageAutoResizeLimit": 0,
         "userLabels": {"my-key": "my-value"},
     },
-    "failoverReplica": {"name": FAILOVER_REPLICA_NAME},
     "databaseVersion": "MYSQL_5_7",
     "region": "europe-west4",
 }
 # [END howto_operator_cloudsql_create_body]
-
-# [START howto_operator_cloudsql_create_replica]
-read_replica_body = {
-    "name": READ_REPLICA_NAME,
-    "settings": {
-        "tier": "db-n1-standard-1",
-    },
-    "databaseVersion": "MYSQL_5_7",
-    "region": "europe-west4",
-    "masterInstanceName": INSTANCE_NAME,
-}
-# [END howto_operator_cloudsql_create_replica]
-
 
 # [START howto_operator_cloudsql_patch_body]
 patch_body = {
@@ -168,12 +151,6 @@ with DAG(
         body=body, instance=INSTANCE_NAME, task_id="sql_instance_create_task"
     )
     # [END howto_operator_cloudsql_create]
-
-    sql_instance_read_replica_create = CloudSQLCreateInstanceOperator(
-        body=read_replica_body,
-        instance=READ_REPLICA_NAME,
-        task_id="sql_instance_read_replica_create",
-    )
 
     # ############################################## #
     # ### MODIFYING INSTANCE AND ITS DATABASE ###### #
@@ -277,20 +254,6 @@ with DAG(
     # ### INSTANCES TEAR DOWN ###################### #
     # ############################################## #
 
-    # [START howto_operator_cloudsql_replicas_delete]
-    sql_instance_failover_replica_delete_task = CloudSQLDeleteInstanceOperator(
-        instance=FAILOVER_REPLICA_NAME,
-        task_id="sql_instance_failover_replica_delete_task",
-        trigger_rule=TriggerRule.ALL_DONE,
-    )
-
-    sql_instance_read_replica_delete_task = CloudSQLDeleteInstanceOperator(
-        instance=READ_REPLICA_NAME,
-        task_id="sql_instance_read_replica_delete_task",
-        trigger_rule=TriggerRule.ALL_DONE,
-    )
-    # [END howto_operator_cloudsql_replicas_delete]
-
     sql_instance_clone_delete_task = CloudSQLDeleteInstanceOperator(
         instance=CLONED_INSTANCE_NAME,
         task_id="sql_instance_clone_delete_task",
@@ -312,7 +275,6 @@ with DAG(
         create_bucket
         # TEST BODY
         >> sql_instance_create_task
-        >> sql_instance_read_replica_create
         >> sql_instance_patch_task
         >> sql_db_create_task
         >> sql_db_patch_task
@@ -323,8 +285,6 @@ with DAG(
         >> sql_import_task
         >> sql_instance_clone
         >> sql_db_delete_task
-        >> sql_instance_failover_replica_delete_task
-        >> sql_instance_read_replica_delete_task
         >> sql_instance_clone_delete_task
         >> sql_instance_delete_task
         # TEST TEARDOWN


### PR DESCRIPTION
Removed deprecate CloudSQL HA functionality from the system test

https://cloud.google.com/sql/docs/mysql/configure-legacy-ha#curl