### PR TITLE
Fix TestTranslationLegacyModelPredictLink dataset_id error for google provider translation operator

### DIFF
--- a/providers/src/airflow/providers/google/cloud/links/translate.py
+++ b/providers/src/airflow/providers/google/cloud/links/translate.py
@@ -167,13 +167,14 @@ class TranslationLegacyModelPredictLink(BaseGoogleLink):
         task_instance,
         model_id: str,
         project_id: str,
+        dataset_id: str,
     ):
         task_instance.xcom_push(
             context,
             key=TranslationLegacyModelPredictLink.key,
             value={
                 "location": task_instance.location,
-                "dataset_id": task_instance.model.dataset_id,
+                "dataset_id": dataset_id,
                 "model_id": model_id,
                 "project_id": project_id,
             },

--- a/providers/tests/google/cloud/links/test_translate.py
+++ b/providers/tests/google/cloud/links/test_translate.py
@@ -161,6 +161,12 @@ class TestTranslationLegacyModelPredictLink:
         ti.task.model = Model(dataset_id=DATASET, display_name=MODEL)
         session.add(ti)
         session.commit()
-        link.persist(context={"ti": ti}, task_instance=ti.task, model_id=MODEL, project_id=GCP_PROJECT_ID)
+        link.persist(
+            context={"ti": ti},
+            task_instance=ti.task,
+            model_id=MODEL,
+            project_id=GCP_PROJECT_ID,
+            dataset_id=DATASET,
+        )
         actual_url = link.get_link(operator=ti.task, ti_key=ti.key)
         assert actual_url == expected_url

--- a/providers/tests/google/cloud/operators/test_automl.py
+++ b/providers/tests/google/cloud/operators/test_automl.py
@@ -147,6 +147,7 @@ class TestAutoMLBatchPredictOperator:
         mock_hook.return_value.batch_predict.return_value.result.return_value = BatchPredictResult()
         mock_hook.return_value.extract_object_id = extract_object_id
         mock_hook.return_value.wait_for_operation.return_value = BatchPredictResult()
+        mock_hook.return_value.get_model.return_value = mock.MagicMock(**MODEL)
         mock_context = {"ti": mock.MagicMock()}
         with pytest.warns(AirflowProviderDeprecationWarning):
             op = AutoMLBatchPredictOperator(
@@ -175,6 +176,7 @@ class TestAutoMLBatchPredictOperator:
             task_instance=op,
             model_id=MODEL_ID,
             project_id=GCP_PROJECT_ID,
+            dataset_id=DATASET_ID,
         )
 
     @mock.patch("airflow.providers.google.cloud.operators.automl.CloudAutoMLHook")
@@ -243,6 +245,7 @@ class TestAutoMLPredictOperator:
     @mock.patch("airflow.providers.google.cloud.operators.automl.CloudAutoMLHook")
     def test_execute(self, mock_hook, mock_link_persist):
         mock_hook.return_value.predict.return_value = PredictResponse()
+        mock_hook.return_value.get_model.return_value = mock.MagicMock(**MODEL)
         mock_context = {"ti": mock.MagicMock()}
         op = AutoMLPredictOperator(
             model_id=MODEL_ID,
@@ -268,6 +271,7 @@ class TestAutoMLPredictOperator:
             task_instance=op,
             model_id=MODEL_ID,
             project_id=GCP_PROJECT_ID,
+            dataset_id=DATASET_ID,
         )
 
     @pytest.mark.db_test


### PR DESCRIPTION
- Add dataset_id parameter to let TestTranslationLegacyModelPredictLink work with the translation model.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
