### PR TITLE
docs: fix Executor alias syntax

### DIFF
--- a/docs/apache-airflow/core-concepts/executor/index.rst
+++ b/docs/apache-airflow/core-concepts/executor/index.rst
@@ -154,7 +154,7 @@ To make it easier to specify executors on tasks and DAGs, executor configuration
 .. code-block:: ini
 
     [core]
-    executor = 'LocalExecutor,my.custom.module.ExecutorClass:ShortName'
+    executor = 'LocalExecutor,ShortName:my.custom.module.ExecutorClass'
 
 .. note::
     If a DAG specifies a task to use an executor that is not configured, the DAG will fail to parse and a warning dialog will be shown in the Airflow UI. Please ensure that all executors you wish to use are specified in Airflow configuration on *any* host/container that is running an Airflow component (scheduler, workers, etc).


### PR DESCRIPTION
Hi! 
It looks like a wrong example of an Executor's short name in Docs due to https://github.com/apache/airflow/blob/193defd2898772e7e989cbee85815d49e9f0d8f0/airflow/executors/executor_loader.py#L116
