### PR TITLE
Move ECS executor to stable

### DIFF
--- a/docs/apache-airflow-providers-amazon/executors/ecs-executor.rst
+++ b/docs/apache-airflow-providers-amazon/executors/ecs-executor.rst
@@ -16,9 +16,6 @@
     under the License.
 
 
-.. warning::
-   The ECS Executor is alpha/experimental at the moment and may be subject to change without warning.
-
 .. |executorName| replace:: ECS
 .. |dockerfileLink| replace:: `here <https://github.com/apache/airflow/blob/main/airflow/providers/amazon/aws/executors/Dockerfile>`__
 .. |configKwargs| replace:: SUBMIT_JOB_KWARGS

--- a/docs/apache-airflow-providers-amazon/executors/index.rst
+++ b/docs/apache-airflow-providers-amazon/executors/index.rst
@@ -24,5 +24,5 @@ Amazon Executors
 .. toctree::
     :maxdepth: 1
 
-    ECS Executor (experimental) <ecs-executor>
+    ECS Executor <ecs-executor>
     Batch Executor (experimental) <batch-executor>


### PR DESCRIPTION
The AWS ECS executor has been released for just under one year. We have made changes as users have found issues but it has remained stable for quite a while now.

This PR proposes to remove the experimental warning for the executor and move it to respecting semver (so no more breaking changes in minor releases).

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
