### PR TITLE
Add in backport of astunparse where needed in static checks

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -239,6 +239,7 @@ DEVEL_EXTRAS: dict[str, list[str]] = {
         "blinker>=1.7.0",
     ],
     "devel-static-checks": [
+        "astunparse>=1.6.3; python_version < '3.9'",
         "black>=23.12.0",
         "pre-commit>=3.5.0",
         "ruff==0.5.5",

--- a/scripts/ci/pre_commit/check_deferrable_default.py
+++ b/scripts/ci/pre_commit/check_deferrable_default.py
@@ -25,6 +25,12 @@ import os
 import sys
 from typing import Iterator
 
+if hasattr(ast, "unparse"):
+    # Py 3.9+
+    unparse = ast.unparse
+else:
+    from astunparse import unparse  # type: ignore[no-redef]
+
 import libcst as cst
 from libcst.codemod import CodemodContext
 from libcst.codemod.visitors import AddImportsVisitor
@@ -78,7 +84,7 @@ class DefaultDeferrableTransformer(cst.CSTTransformer):
 
 def _is_valid_deferrable_default(default: ast.AST) -> bool:
     """Check whether default is 'conf.getboolean("operators", "default_deferrable", fallback=False)'"""
-    return ast.unparse(default) == "conf.getboolean('operators', 'default_deferrable', fallback=False)"
+    return unparse(default) == "conf.getboolean('operators', 'default_deferrable', fallback=False)"
 
 
 def iter_check_deferrable_default_errors(module_filename: str) -> Iterator[str]:


### PR DESCRIPTION
`ast.unparse` is only avaialble from Python 3.9 and up.

Even though 3.8 is almost unsupported, for now it's simpler to use this backport until we change the min required python version for main.
