### PR TITLE
Ensure consistent Seriailized DAG hashing 

### DIFF
--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -29,7 +29,7 @@ import sys
 from typing import TYPE_CHECKING
 
 import re2
-from sqlalchemy import select
+from sqlalchemy import delete, select
 
 from airflow import settings
 from airflow.api.client import get_current_api_client
@@ -638,7 +638,7 @@ def dag_test(args, dag: DAG | None = None, session: Session = NEW_SESSION) -> No
 @provide_session
 def dag_reserialize(args, session: Session = NEW_SESSION) -> None:
     """Serialize a DAG instance."""
-    # session.execute(delete(SerializedDagModel).execution_options(synchronize_session=False))
+    session.execute(delete(SerializedDagModel).execution_options(synchronize_session=False))
 
     if not args.clear_only:
         dagbag = DagBag(process_subdir(args.subdir))

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -29,7 +29,7 @@ import sys
 from typing import TYPE_CHECKING
 
 import re2
-from sqlalchemy import delete, select
+from sqlalchemy import select
 
 from airflow import settings
 from airflow.api.client import get_current_api_client
@@ -638,7 +638,7 @@ def dag_test(args, dag: DAG | None = None, session: Session = NEW_SESSION) -> No
 @provide_session
 def dag_reserialize(args, session: Session = NEW_SESSION) -> None:
     """Serialize a DAG instance."""
-    session.execute(delete(SerializedDagModel).execution_options(synchronize_session=False))
+    # session.execute(delete(SerializedDagModel).execution_options(synchronize_session=False))
 
     if not args.clear_only:
         dagbag = DagBag(process_subdir(args.subdir))

--- a/airflow/models/serialized_dag.py
+++ b/airflow/models/serialized_dag.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import logging
 import zlib
 from datetime import timedelta
-from typing import TYPE_CHECKING, Collection
+from typing import TYPE_CHECKING, Any, Collection
 
 import sqlalchemy_jsonfield
 from sqlalchemy import BigInteger, Column, Index, LargeBinary, String, and_, exc, or_, select
@@ -114,6 +114,7 @@ class SerializedDagModel(Base):
         self.processor_subdir = processor_subdir
 
         dag_data = SerializedDAG.to_dict(dag)
+        dag_data = SerializedDagModel._sort_serialized_dag_dict(dag_data)
         dag_data_json = json.dumps(dag_data, sort_keys=True).encode("utf-8")
 
         self.dag_hash = md5(dag_data_json).hexdigest()
@@ -131,6 +132,23 @@ class SerializedDagModel(Base):
 
     def __repr__(self) -> str:
         return f"<SerializedDag: {self.dag_id}>"
+
+    @classmethod
+    def _sort_serialized_dag_dict(cls, serialized_dag: Any):
+        """Recursively sort json_dict and its nested dictionaries and lists."""
+        if isinstance(serialized_dag, dict):
+            return {k: cls._sort_serialized_dag_dict(v) for k, v in sorted(serialized_dag.items())}
+        elif isinstance(serialized_dag, list):
+            if all(isinstance(i, dict) for i in serialized_dag):
+                if all("task_id" in i.get("__var", {}) for i in serialized_dag):
+                    return sorted(
+                        [cls._sort_serialized_dag_dict(i) for i in serialized_dag],
+                        key=lambda x: x["__var"]["task_id"],
+                    )
+            elif all(isinstance(item, str) for item in serialized_dag):
+                return sorted(serialized_dag)
+            return [cls._sort_serialized_dag_dict(i) for i in serialized_dag]
+        return serialized_dag
 
     @classmethod
     @provide_session

--- a/airflow/models/serialized_dag.py
+++ b/airflow/models/serialized_dag.py
@@ -114,10 +114,10 @@ class SerializedDagModel(Base):
         self.processor_subdir = processor_subdir
 
         dag_data = SerializedDAG.to_dict(dag)
-        dag_data = SerializedDagModel._sort_serialized_dag_dict(dag_data)
-        dag_data_json = json.dumps(dag_data, sort_keys=True).encode("utf-8")
+        self.dag_hash = SerializedDagModel.hash(dag_data)
 
-        self.dag_hash = md5(dag_data_json).hexdigest()
+        # partially ordered json data
+        dag_data_json = json.dumps(dag_data, sort_keys=True).encode("utf-8")
 
         if COMPRESS_SERIALIZED_DAGS:
             self._data = None
@@ -132,6 +132,13 @@ class SerializedDagModel(Base):
 
     def __repr__(self) -> str:
         return f"<SerializedDag: {self.dag_id}>"
+
+    @classmethod
+    def hash(cls, dag_data):
+        """Hash the data to get the dag_hash."""
+        dag_data = cls._sort_serialized_dag_dict(dag_data)
+        data_json = json.dumps(dag_data, sort_keys=True).encode("utf-8")
+        return md5(data_json).hexdigest()
 
     @classmethod
     def _sort_serialized_dag_dict(cls, serialized_dag: Any):

--- a/airflow/models/serialized_dag.py
+++ b/airflow/models/serialized_dag.py
@@ -174,6 +174,7 @@ class SerializedDagModel(Base):
 
         :param dag: a DAG to be written into database
         :param min_update_interval: minimal interval in seconds to update serialized DAG
+        :param processor_subdir: The dag directory of the processor
         :param session: ORM Session
 
         :returns: Boolean indicating if the DAG was written to the DB

--- a/airflow/serialization/helpers.py
+++ b/airflow/serialization/helpers.py
@@ -44,14 +44,17 @@ def serialize_template_field(template_field: Any, name: str) -> str | dict | lis
     max_length = conf.getint("core", "max_templated_field_length")
 
     if not is_jsonable(template_field):
-        serialized = str(template_field)
+        try:
+            serialized = template_field.serialize()
+        except AttributeError:
+            serialized = str(template_field)
         if len(serialized) > max_length:
             rendered = redact(serialized, name)
             return (
                 "Truncated. You can change this behaviour in [core]max_templated_field_length. "
                 f"{rendered[:max_length - 79]!r}... "
             )
-        return str(template_field)
+        return serialized
     else:
         if not template_field:
             return template_field
@@ -62,4 +65,4 @@ def serialize_template_field(template_field: Any, name: str) -> str | dict | lis
                 "Truncated. You can change this behaviour in [core]max_templated_field_length. "
                 f"{rendered[:max_length - 79]!r}... "
             )
-        return template_field
+        return serialized

--- a/airflow/serialization/helpers.py
+++ b/airflow/serialization/helpers.py
@@ -65,4 +65,4 @@ def serialize_template_field(template_field: Any, name: str) -> str | dict | lis
                 "Truncated. You can change this behaviour in [core]max_templated_field_length. "
                 f"{rendered[:max_length - 79]!r}... "
             )
-        return serialized
+        return template_field

--- a/airflow/utils/types.py
+++ b/airflow/utils/types.py
@@ -41,6 +41,14 @@ class ArgNotSet:
         is_arg_passed(None)  # True.
     """
 
+    @staticmethod
+    def serialize():
+        return "NOTSET"
+
+    @classmethod
+    def deserialize(cls):
+        return cls
+
 
 NOTSET = ArgNotSet()
 """Sentinel value for argument default. See ``ArgNotSet``."""


### PR DESCRIPTION
The serialized DAG dictionary is not ordered correctly when creating hashes, and that causes inconsistent hashes, leading to
frequent update of the serialized DAG table.

Changes:

Implemented sorting for serialized DAG dictionaries and nested structures to ensure consistent and predictable serialization order for hashing. Using `sort_keys` in `json.dumps` is not enough to sort the nested structures in the serialized DAG.

Added serialize and deserialize methods for DagParam and ArgNotSet to allow for more structured serialization.

Updated serialize_template_field to handle objects that implement the serialize method. This was done because of DagParam and ArgNotSet in the template fields. Previously, it produced an object, but with this change, it now serialises to a consistent object.

