### PR TITLE
Fix DB utils for Airflow Backwards compatability tests - import not existing

### DIFF
--- a/tests/test_utils/db.py
+++ b/tests/test_utils/db.py
@@ -35,7 +35,6 @@ from airflow.models import (
     Variable,
     XCom,
 )
-from airflow.models.backfill import Backfill, BackfillDagRun
 from airflow.models.dag import DagOwnerAttributes
 from airflow.models.dagcode import DagCode
 from airflow.models.dagwarning import DagWarning
@@ -68,6 +67,8 @@ def clear_db_runs():
 
 
 def clear_db_backfills():
+    from airflow.models.backfill import Backfill, BackfillDagRun
+
     with create_session() as session:
         session.query(BackfillDagRun).delete()
         session.query(Backfill).delete()


### PR DESCRIPTION
Fix broken main/canary in https://github.com/apache/airflow/actions/runs/11058948895/job/30726378646
...as of merge #42455

Moving import into function preventing non existing import from utils

```
ImportError while importing test module '/opt/airflow/tests/providers/google/cloud/log/test_gcs_task_handler.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/local/lib/python3.8/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/providers/google/cloud/log/test_gcs_task_handler.py:31: in <module>
    from tests.test_utils.db import clear_db_dags, clear_db_runs
tests/test_utils/db.py:38: in <module>
    from airflow.models.backfill import Backfill, BackfillDagRun
E   ModuleNotFoundError: No module named 'airflow.models.backfill'
```