### PR TITLE
Improving validation of task retries to handle None values

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -127,7 +127,9 @@ logger = logging.getLogger("airflow.models.baseoperator.BaseOperator")
 
 
 def parse_retries(retries: Any) -> int | None:
-    if retries is None or type(retries) == int:  # noqa: E721
+    if retries is None:
+        return 0
+    elif type(retries) == int:  # noqa: E721
         return retries
     try:
         parsed_retries = int(retries)

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -473,6 +473,7 @@ def clear_task_instances(
                 ti.refresh_from_task(task)
                 if TYPE_CHECKING:
                     assert ti.task
+                #Calculate max_tries by gracefully handling non-numeric values for task.retries to be considered as 0    
                 ti.max_tries = ti.try_number + (task.retries or 0)
             else:
                 # Ignore errors when updating max_tries if the DAG or

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -473,7 +473,7 @@ def clear_task_instances(
                 ti.refresh_from_task(task)
                 if TYPE_CHECKING:
                     assert ti.task
-                ti.max_tries = ti.try_number + (task.retries if task.retries is not None else 0)
+                ti.max_tries = ti.try_number + (task.retries or 0)
             else:
                 # Ignore errors when updating max_tries if the DAG or
                 # task are not found since database records could be

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -473,7 +473,7 @@ def clear_task_instances(
                 ti.refresh_from_task(task)
                 if TYPE_CHECKING:
                     assert ti.task
-                ti.max_tries = ti.try_number + task.retries
+                ti.max_tries = ti.try_number + (task.retries if task.retries is not None else 0)
             else:
                 # Ignore errors when updating max_tries if the DAG or
                 # task are not found since database records could be

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -473,8 +473,7 @@ def clear_task_instances(
                 ti.refresh_from_task(task)
                 if TYPE_CHECKING:
                     assert ti.task
-                #Calculate max_tries by gracefully handling non-numeric values for task.retries to be considered as 0    
-                ti.max_tries = ti.try_number + (task.retries or 0)
+                ti.max_tries = ti.try_number + task.retries
             else:
                 # Ignore errors when updating max_tries if the DAG or
                 # task are not found since database records could be


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

This PR fixes issue #42273 which causes an error when retries is set to None at task level

The issue has been fixed by improving the validation of task retries to handle None values.


**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
