### PR TITLE
Undo partition exclusion from the table name when splitting a full BigQuery table name

### DIFF
--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -2418,10 +2418,6 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
                 f"{var_print(var_name)}Expect format of (<project.|<project:)<dataset>.<table>, "
                 f"got {table_input}"
             )
-
-        # Exclude partition from the table name
-        table_id = table_id.split("$")[0]
-
         if project_id is None:
             if var_name is not None:
                 self.log.info(

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -1034,7 +1034,6 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
         with pytest.raises(ValueError, match="INTERNAL: No default project is specified"):
             self.hook.split_tablename("dataset.table", None)
 
-    @pytest.mark.parametrize("partition", ["$partition", ""])
     @pytest.mark.parametrize(
         "project_expected, dataset_expected, table_expected, table_input",
         [
@@ -1045,11 +1044,9 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
             ("alt1:alt", "dataset", "table", "alt1:alt:dataset.table"),
         ],
     )
-    def test_split_tablename(
-        self, project_expected, dataset_expected, table_expected, table_input, partition
-    ):
+    def test_split_tablename(self, project_expected, dataset_expected, table_expected, table_input):
         default_project_id = "project"
-        project, dataset, table = self.hook.split_tablename(table_input + partition, default_project_id)
+        project, dataset, table = self.hook.split_tablename(table_input, default_project_id)
         assert project_expected == project
         assert dataset_expected == dataset
         assert table_expected == table


### PR DESCRIPTION
Undo partition exclusion from the table name when splitting a full BigQuery table name. 

Relates to https://github.com/apache/airflow/pull/42130