### PR TITLE
Remove DagRun.is_backfill attribute

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -1267,7 +1267,7 @@ class DagRun(Base, LoggingMixin):
 
         def task_filter(task: Operator) -> bool:
             return task.task_id not in task_ids and (
-                self.is_backfill
+                self.run_type == DagRunType.BACKFILL_JOB
                 or (task.start_date is None or task.start_date <= self.execution_date)
                 and (task.end_date is None or self.execution_date <= task.end_date)
             )
@@ -1537,10 +1537,6 @@ class DagRun(Base, LoggingMixin):
             ti.refresh_from_task(task)
             session.flush()
             yield ti
-
-    @property
-    def is_backfill(self) -> bool:
-        return self.run_type == DagRunType.BACKFILL_JOB
 
     @classmethod
     @provide_session

--- a/newsfragments/42548.significant.rst
+++ b/newsfragments/42548.significant.rst
@@ -1,0 +1,1 @@
+Remove is_backfill attribute from DagRun object

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -601,8 +601,7 @@ class TestSchedulerJob:
         ti1.state = State.SCHEDULED
         session.merge(ti1)
         session.flush()
-
-        assert dr1.is_backfill
+        assert dr1.run_type == DagRunType.BACKFILL_JOB
 
         self.job_runner._critical_section_enqueue_task_instances(session)
         session.flush()
@@ -3851,7 +3850,7 @@ class TestSchedulerJob:
         session.merge(dr1)
         session.flush()
 
-        assert dr1.is_backfill
+        assert dr1.run_type == DagRunType.BACKFILL_JOB
         assert 0 == self.job_runner.adopt_or_reset_orphaned_tasks(session=session)
         session.rollback()
 


### PR DESCRIPTION
This attribute is only used in one place and is not very useful.
