### PR TITLE
Attempt to correct dependency for Slack notification for canary build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -673,6 +673,16 @@ jobs:
 
   notify-slack-failure:
     name: "Notify Slack on Failure"
+    needs:
+      - basic-tests
+      - additional-ci-image-checks
+      - providers
+      - tests-helm
+      - tests-special
+      - tests-with-lowest-direct-resolution
+      - additional-prod-image-tests
+      - tests-kubernetes
+      - finalize-tests
     if: github.event_name == 'schedule' && failure()
     runs-on: ["ubuntu-22.04"]
     steps:


### PR DESCRIPTION
Follow-up of #42394

...as the Slack notifier is not working, attempt to my best knowledge to adjust the dependency of the task to run behind all others.
Picking up all named stated which have no follow-up dependency