### PR TITLE
reduce eyestrain in dark mode with reduced contrast and saturation

### DIFF
--- a/airflow/www/static/css/bootstrap-theme.css
+++ b/airflow/www/static/css/bootstrap-theme.css
@@ -37,7 +37,7 @@ html {
   -webkit-text-size-adjust: 100%;
 }
 html[data-color-scheme="dark"] {
-  filter: invert(100%) hue-rotate(180deg);
+  filter: invert(100%) hue-rotate(180deg) saturate(85%) contrast(85%);
 }
 
 /* Default icons to not display until the data-color-scheme has been set */

--- a/airflow/www/static/css/bootstrap-theme.css
+++ b/airflow/www/static/css/bootstrap-theme.css
@@ -37,7 +37,7 @@ html {
   -webkit-text-size-adjust: 100%;
 }
 html[data-color-scheme="dark"] {
-  filter: invert(100%) hue-rotate(180deg) saturate(85%) contrast(85%);
+  filter: invert(100%) hue-rotate(180deg) saturate(90%) contrast(85%);
 }
 
 /* Default icons to not display until the data-color-scheme has been set */


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

While the new dark mode is very appreciated, the inversion and 180 degree hue rotation creates a harsh contrast that some people find a bit extreme and uncomfortable.  This change simply lowers the saturation and contrast to soften the overall appearance, potentially reducing eyestrain for people with eyes that are sensitive to such high contrast.

Adjusting the contrast also emphasizes the styling between alternating rows in the DAG list. 

Open to suggestions to better tweak it for a broader audience.  

Before:
![airflowbefore](https://github.com/user-attachments/assets/72f9646a-c62a-4f46-891d-f06cd8976145)
![airflowbefore](https://github.com/user-attachments/assets/cafda562-15b6-4cd2-bf91-05794b317a61)


After:
![image](https://github.com/user-attachments/assets/a58a7678-39d5-48d2-823e-5a1d3815c419)
![airflowafter](https://github.com/user-attachments/assets/b334609b-8618-4b14-96fb-02793f75f988)



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
