### PR TITLE
Permanent fix for Running db.resetdb() (e.g. in test suite) modifies logging.root.level

### DIFF
--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -1200,6 +1200,7 @@ def upgradedb(
 @provide_session
 def resetdb(session: Session = NEW_SESSION, skip_init: bool = False):
     """Clear out the database."""
+    original_logging_level = logging.root.level
     if not settings.engine:
         raise RuntimeError("The settings.engine must be set. This is a critical assertion")
     log.info("Dropping tables that exist")
@@ -1216,6 +1217,7 @@ def resetdb(session: Session = NEW_SESSION, skip_init: bool = False):
 
     if not skip_init:
         initdb(session=session)
+    logging.root.setLevel(original_logging_level)
 
 
 @provide_session

--- a/tests/utils/test_db.py
+++ b/tests/utils/test_db.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import inspect
+import logging
 import os
 import re
 from contextlib import redirect_stdout
@@ -228,6 +229,14 @@ class TestDb:
             mock_init.assert_not_called()
         else:
             mock_init.assert_called_once_with(session=session_mock)
+
+    def test_resetdb_logging_level(self):
+        unset_logging_level = logging.root.level
+        logging.root.setLevel(logging.DEBUG)
+        set_logging_level = logging.root.level
+        resetdb()
+        assert logging.root.level == set_logging_level
+        assert logging.root.level != unset_logging_level
 
     def test_alembic_configuration(self):
         with mock.patch.dict(


### PR DESCRIPTION
- Fixes #42432
- Added a unit test

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
