### PR TITLE
Update Dependency Detector to handle DAG dependencies set via partial

### DIFF
--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -1033,10 +1033,36 @@ class DependencyDetector:
                     dependency_id=task.task_id,
                 )
             )
+        elif (
+            isinstance(task, MappedOperator)
+            and issubclass(cast(type[BaseOperator], task.operator_class), TriggerDagRunOperator)
+            and "trigger_dag_id" in task.partial_kwargs
+        ):
+            deps.append(
+                DagDependency(
+                    source=task.dag_id,
+                    target=task.partial_kwargs["trigger_dag_id"],
+                    dependency_type="trigger",
+                    dependency_id=task.task_id,
+                )
+            )
         elif isinstance(task, ExternalTaskSensor):
             deps.append(
                 DagDependency(
                     source=getattr(task, "external_dag_id"),
+                    target=task.dag_id,
+                    dependency_type="sensor",
+                    dependency_id=task.task_id,
+                )
+            )
+        elif (
+            isinstance(task, MappedOperator)
+            and issubclass(cast(type[BaseOperator], task.operator_class), ExternalTaskSensor)
+            and "external_dag_id" in task.partial_kwargs
+        ):
+            deps.append(
+                DagDependency(
+                    source=task.partial_kwargs["external_dag_id"],
                     target=task.dag_id,
                     dependency_type="sensor",
                     dependency_id=task.task_id,

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -1615,7 +1615,8 @@ class TestStringifiedDAGs:
         assert round_tripped.outlets == []
 
     @pytest.mark.db_test
-    def test_derived_dag_deps_sensor(self):
+    @pytest.mark.parametrize("mapped", [False, True])
+    def test_derived_dag_deps_sensor(self, mapped):
         """
         Tests DAG dependency detection for sensors, including derived classes
         """
@@ -1628,11 +1629,19 @@ class TestStringifiedDAGs:
         logical_date = datetime(2020, 1, 1)
         for class_ in [ExternalTaskSensor, DerivedSensor]:
             with DAG(dag_id="test_derived_dag_deps_sensor", schedule=None, start_date=logical_date) as dag:
-                task1 = class_(
-                    task_id="task1",
-                    external_dag_id="external_dag_id",
-                    mode="reschedule",
-                )
+                if mapped:
+                    task1 = class_.partial(
+                        task_id="task1",
+                        external_dag_id="external_dag_id",
+                        mode="reschedule",
+                    ).expand(external_task_id=["some_task", "some_other_task"])
+                else:
+                    task1 = class_(
+                        task_id="task1",
+                        external_dag_id="external_dag_id",
+                        mode="reschedule",
+                    )
+
                 task2 = EmptyOperator(task_id="task2")
                 task1 >> task2
 
@@ -1800,7 +1809,8 @@ class TestStringifiedDAGs:
         )
         assert actual == expected
 
-    def test_derived_dag_deps_operator(self):
+    @pytest.mark.parametrize("mapped", [False, True])
+    def test_derived_dag_deps_operator(self, mapped):
         """
         Tests DAG dependency detection for operators, including derived classes
         """
@@ -1814,10 +1824,16 @@ class TestStringifiedDAGs:
         for class_ in [TriggerDagRunOperator, DerivedOperator]:
             with DAG(dag_id="test_derived_dag_deps_trigger", schedule=None, start_date=logical_date) as dag:
                 task1 = EmptyOperator(task_id="task1")
-                task2 = class_(
-                    task_id="task2",
-                    trigger_dag_id="trigger_dag_id",
-                )
+                if mapped:
+                    task2 = class_.partial(
+                        task_id="task2",
+                        trigger_dag_id="trigger_dag_id",
+                    ).expand(trigger_run_id=["one", "two"])
+                else:
+                    task2 = class_(
+                        task_id="task2",
+                        trigger_dag_id="trigger_dag_id",
+                    )
                 task1 >> task2
 
             dag = SerializedDAG.to_dict(dag)


### PR DESCRIPTION
The DAG dependency view shows dependencies for DAGs that are available at DAG parsing/serialization time.  Dynamically mapped tasks that trigger (via `TriggerDagRunOperator`) or wait for (via `ExternalTaskSensor`) external DAGs are now listed as DAG dependencies provided that those dependencies are set via `partial`, and not dynamically expanded.

Tested with the following:
```
@dag()
def triggering_dag():
    """
    DAG that is doing the triggering.
    """
    t = TriggerDagRunOperator.partial(
        trigger_dag_id="triggered_dag",
        task_id="triggering_task",
        reset_dag_run=True,
    ).expand(trigger_run_id=["trigger_run_id1__{{ ts }}", "trigger_run_id2__{{ ts }}"])

    t


@dag()
def unmapped_triggering_dag():
    """
    DAG that is doing the triggering.
    """
    t = TriggerDagRunOperator(
        trigger_dag_id="triggered_dag",
        task_id="triggering_task",
        reset_dag_run=True,
        trigger_run_id="unmapped_trigger_run_id1__{{ ts }}",
    )

    t


@dag()
def triggered_dag():
    """
    DAG that is getting triggered.
    """

    @task()
    def empty_task() -> int:
        return 0

    empty_task()

triggering_dag()
triggered_dag()
unmapped_triggering_dag()

@dag(
    schedule="*/5 * * * *",
    start_date=pendulum.datetime(2024, 1, 1),
    catchup=False,
)
def mapped_sensor_dag():
    """
    DAG that is doing the waiting/sensing.
    """
    t = ExternalTaskSensor.partial(
        task_id="wait",
        external_dag_id="waited_on_dag",
        deferrable=True,
        check_existence=True,
    ).expand(external_task_id=["empty_task", "another_empty_task"])

    t


@dag(
    schedule="*/5 * * * *",
    start_date=pendulum.datetime(2024, 1, 1),
    catchup=False,
)
def unmapped_sensor_dag():
    """
    DAG that is doing the waiting/sensing.
    """
    t = ExternalTaskSensor(
        task_id="wait",
        external_dag_id="waited_on_dag",
        external_task_id="empty_task",
        deferrable=True,
        check_existence=True,
    )

    t


@dag(
    schedule="*/5 * * * *",
    start_date=pendulum.datetime(2024, 1, 1),
    catchup=False,
)
def waited_on_dag():
    """
    DAG that is getting waited on.
    """

    @task()
    def empty_task() -> int:
        return 0

    @task()
    def another_empty_task() -> int:
        return 1

    @task()
    def yet_another_empty_task() -> int:
        return 2


    empty_task()
    another_empty_task()
    yet_another_empty_task()

waited_on_dag()
unmapped_sensor_dag()
mapped_sensor_dag()
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
