### PR TITLE
fix schedule_downstream_tasks bug

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -3673,21 +3673,12 @@ class TaskInstance(Base, LoggingMixin):
                 assert task
                 assert task.dag
 
-            # Get a partial DAG with just the specific tasks we want to examine.
-            # In order for dep checks to work correctly, we include ourself (so
-            # TriggerRuleDep can check the state of the task we just executed).
-            partial_dag = task.dag.partial_subset(
-                task.downstream_task_ids,
-                include_downstream=True,
-                include_upstream=True,
-                include_direct_upstream=True,
-            )
-
-            dag_run.dag = partial_dag
+            # In many scenarios, get a partial DAG is an unsafe operation and will lead to many bad cases.
+            dag_run.dag = task.dag
             info = dag_run.task_instance_scheduling_decisions(session)
 
             skippable_task_ids = {
-                task_id for task_id in partial_dag.task_ids if task_id not in task.downstream_task_ids
+                task_id for task_id in task.dag.task_ids if task_id not in task.downstream_task_ids
             }
 
             schedulable_tis = [

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -3673,7 +3673,10 @@ class TaskInstance(Base, LoggingMixin):
                 assert task
                 assert task.dag
 
-            # In many scenarios, get a partial DAG is an unsafe operation and will lead to many bad cases.
+            # Previously, this section used task.dag.partial_subset to retrieve a partial DAG.
+            # However, this approach is unsafe as it can result in incomplete or incorrect task execution,
+            # leading to potential bad cases. As a result, the operation has been removed.
+            # For more details, refer to the discussion in PR #[https://github.com/apache/airflow/pull/42582].
             dag_run.dag = task.dag
             info = dag_run.task_instance_scheduling_decisions(session)
 

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -3679,7 +3679,7 @@ class TaskInstance(Base, LoggingMixin):
             partial_dag = task.dag.partial_subset(
                 task.downstream_task_ids,
                 include_downstream=True,
-                include_upstream=False,
+                include_upstream=True,
                 include_direct_upstream=True,
             )
 

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -77,7 +77,7 @@ from airflow.models.variable import Variable
 from airflow.models.xcom import LazyXComSelectSequence, XCom
 from airflow.notifications.basenotifier import BaseNotifier
 from airflow.operators.empty import EmptyOperator
-from airflow.operators.python import PythonOperator
+from airflow.operators.python import BranchPythonOperator, PythonOperator
 from airflow.providers.standard.operators.bash import BashOperator
 from airflow.sensors.base import BaseSensorOperator
 from airflow.sensors.python import PythonSensor
@@ -5258,6 +5258,80 @@ def test_mapped_task_expands_in_mini_scheduler_if_upstreams_are_done(dag_maker, 
         middle_ti = dr.get_task_instance(task_id="middle_task", map_index=i)
         assert middle_ti.state == State.SCHEDULED
     assert "3 downstream tasks scheduled from follow-on schedule" in caplog.text
+
+
+@pytest.mark.skip_if_database_isolation_mode
+def test_one_success_task_in_mini_scheduler_if_upstreams_are_done(dag_maker, caplog, session):
+    """Test that mini scheduler with one_success task"""
+    with dag_maker() as dag:
+        branch = BranchPythonOperator(task_id="branch", python_callable=lambda: "task_run")
+        task_run = BashOperator(task_id="task_run", bash_command="echo 0")
+        task_skip = BashOperator(task_id="task_skip", bash_command="echo 0")
+        task_1 = BashOperator(task_id="task_1", bash_command="echo 0")
+        task_one_success = BashOperator(
+            task_id="task_one_success", bash_command="echo 0", trigger_rule="one_success"
+        )
+        task_2 = BashOperator(task_id="task_2", bash_command="echo 0")
+
+        task_1 >> task_2
+        branch >> task_skip
+        branch >> task_run
+        task_run >> task_one_success
+        task_skip >> task_one_success
+        task_one_success >> task_2
+        task_skip >> task_2
+
+    dr = dag_maker.create_dagrun()
+
+    branch = dr.get_task_instance(task_id="branch")
+    task_1 = dr.get_task_instance(task_id="task_1")
+    task_skip = dr.get_task_instance(task_id="task_skip")
+    branch.state = State.SUCCESS
+    task_1.state = State.SUCCESS
+    task_skip.state = State.SKIPPED
+    session.merge(branch)
+    session.merge(task_1)
+    session.merge(task_skip)
+    session.commit()
+    task_1.refresh_from_task(dag.get_task("task_1"))
+    task_1.schedule_downstream_tasks(session=session)
+
+    branch = dr.get_task_instance(task_id="branch")
+    task_run = dr.get_task_instance(task_id="task_run")
+    task_skip = dr.get_task_instance(task_id="task_skip")
+    task_1 = dr.get_task_instance(task_id="task_1")
+    task_one_success = dr.get_task_instance(task_id="task_one_success")
+    task_2 = dr.get_task_instance(task_id="task_2")
+    assert branch.state == State.SUCCESS
+    assert task_run.state == State.NONE
+    assert task_skip.state == State.SKIPPED
+    assert task_1.state == State.SUCCESS
+    # task_one_success should not be scheduled
+    assert task_one_success.state == State.NONE
+    assert task_2.state == State.SKIPPED
+    assert "0 downstream tasks scheduled from follow-on schedule" in caplog.text
+
+    task_run = dr.get_task_instance(task_id="task_run")
+    task_run.state = State.SUCCESS
+    session.merge(task_run)
+    session.commit()
+    task_run.refresh_from_task(dag.get_task("task_run"))
+    task_run.schedule_downstream_tasks(session=session)
+
+    branch = dr.get_task_instance(task_id="branch")
+    task_run = dr.get_task_instance(task_id="task_run")
+    task_skip = dr.get_task_instance(task_id="task_skip")
+    task_1 = dr.get_task_instance(task_id="task_1")
+    task_one_success = dr.get_task_instance(task_id="task_one_success")
+    task_2 = dr.get_task_instance(task_id="task_2")
+    assert branch.state == State.SUCCESS
+    assert task_run.state == State.SUCCESS
+    assert task_skip.state == State.SKIPPED
+    assert task_1.state == State.SUCCESS
+    # task_one_success should not be scheduled
+    assert task_one_success.state == State.SCHEDULED
+    assert task_2.state == State.SKIPPED
+    assert "1 downstream tasks scheduled from follow-on schedule" in caplog.text
 
 
 @pytest.mark.skip_if_database_isolation_mode  # Does not work in db isolation mode


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/42581
### Problem Description
![image](https://github.com/user-attachments/assets/acd6da8b-c1d8-4ac1-b1e2-4899195f1c78)
The trigger_rule of `task_one_success` is `one_success`. When the upstream node of `task_one_success` has not yet run, `task_one_success` is skipped. According to the semantics of `one_success`, `task_one_success` should be able to run.

In this scenario, Airflow turns on the `schedule_after_task_execution` parameter, which means that after the upstream node finishes running, it will try to schedule the downstream node in the current worker.

This problem may occur when `task_1` runs faster than `task_run`. More specifically, it occurs when `task_1` finishes running and successfully schedules downstream tasks in the current worker.

### Related Code
Below is the code in question
![image](https://github.com/user-attachments/assets/07adfa4f-ce38-4e37-ac02-42a000fb107c)
![image](https://github.com/user-attachments/assets/2a9bc36c-f431-4650-821e-044a471c713a)
When `task_1` is finished, it will try to schedule downstream tasks. First, a partial dag will be generated.
```python
partial_dag = task.dag.partial_subset(
                task.downstream_task_ids,
                include_downstream=True,
                include_upstream=False,
                include_direct_upstream=True,
            )
```
`task => "task_1"`
`task.downstream_task_ids => "task_2"`

`include_downstream=True => ["task_2"]`
`include_upstream=False => ["task_2"]`
`include_direct_upstream=True => ["task_2", "task_skip", "task_one_success", "task_1"]`

So the final `partial_dag` is `["task_2", "task_skip", "task_one_success", "task_1"]`
![image](https://github.com/user-attachments/assets/73f2bc6a-d790-4a29-9256-a70c8968f30b)
![image](https://github.com/user-attachments/assets/789cedfb-8d62-420d-b74b-3deedaf4ea30)


This partial_dag is incomplete because `task_one_success`'s other upstream node `task_run` is not in it.Specifically, the `include_upstream` parameter should not be false

### Solution
The correct subgraph division should be as follows, `include_upstream=True`:
```python
partial_dag = task.dag.partial_subset(
                task.downstream_task_ids,
                include_downstream=True,
                include_upstream=True,
                include_direct_upstream=True,
            )
```
`task => "task_1"`
`task.downstream_task_ids => "task_2"`

`include_downstream=True => ["task_2"]`
`include_upstream=True =>["task_2", "task_skip", "task_one_success", "task_1", "task_run", "branch"]`
`include_direct_upstream=True => ["task_2", "task_skip", "task_one_success", "task_1", "task_run", "branch"]`

So the final partial_dag is `["task_2", "task_skip", "task_one_success", "task_1", "task_run", "branch"]`

The final partial_dag should be as follows:
![image](https://github.com/user-attachments/assets/7832ea16-2eeb-4e0c-bcb2-9b1b84a7ac7b)
![image](https://github.com/user-attachments/assets/5092f9f4-9093-43de-98d8-c6980fef2757)


Subgraph pruning will only be performed when the `schedule_after_task_execution` parameter is turned on. Normal scheduler scheduling will not have this problem.