### PR TITLE
Simplify autogenerated API function names in FastAPI + UI

### DIFF
--- a/airflow/api_fastapi/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/openapi/v1-generated.yaml
@@ -12,7 +12,7 @@ paths:
       tags:
       - Asset
       summary: Next Run Assets
-      operationId: next_run_assets_ui_next_run_datasets__dag_id__get
+      operationId: next_run_assets
       parameters:
       - name: dag_id
         in: path
@@ -27,7 +27,7 @@ paths:
             application/json:
               schema:
                 type: object
-                title: Response Next Run Assets Ui Next Run Datasets  Dag Id  Get
+                title: Response Next Run Assets
         '422':
           description: Validation Error
           content:
@@ -40,7 +40,7 @@ paths:
       - DAG
       summary: Get Dags
       description: Get all DAGs.
-      operationId: get_dags_public_dags_get
+      operationId: get_dags
       parameters:
       - name: limit
         in: query
@@ -258,7 +258,7 @@ paths:
       - DAG
       summary: Patch Dag
       description: Patch the specific DAG.
-      operationId: patch_dag_public_dags__dag_id__patch
+      operationId: patch_dag
       parameters:
       - name: dag_id
         in: path

--- a/airflow/api_fastapi/views/public/dags.py
+++ b/airflow/api_fastapi/views/public/dags.py
@@ -47,7 +47,7 @@ from airflow.models import DagModel
 dags_router = APIRouter(tags=["DAG"])
 
 
-@dags_router.get("/dags")
+@dags_router.get("/dags", operation_id="get_dags")
 async def get_dags(
     limit: QueryLimit,
     offset: QueryOffset,
@@ -86,7 +86,11 @@ async def get_dags(
     )
 
 
-@dags_router.patch("/dags/{dag_id}", responses=create_openapi_http_exception_doc([400, 401, 403, 404]))
+@dags_router.patch(
+    "/dags/{dag_id}",
+    responses=create_openapi_http_exception_doc([400, 401, 403, 404]),
+    operation_id="patch_dag",
+)
 async def patch_dag(
     dag_id: str,
     patch_body: DAGPatchBody,

--- a/airflow/api_fastapi/views/ui/assets.py
+++ b/airflow/api_fastapi/views/ui/assets.py
@@ -29,7 +29,7 @@ from airflow.models.asset import AssetDagRunQueue, AssetEvent, AssetModel, DagSc
 assets_router = APIRouter(tags=["Asset"])
 
 
-@assets_router.get("/next_run_datasets/{dag_id}", include_in_schema=False)
+@assets_router.get("/next_run_datasets/{dag_id}", include_in_schema=False, operation_id="next_run_assets")
 async def next_run_assets(
     dag_id: str,
     request: Request,

--- a/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow/ui/openapi-gen/queries/common.ts
@@ -4,37 +4,31 @@ import { UseQueryResult } from "@tanstack/react-query";
 import { AssetService, DagService } from "../requests/services.gen";
 import { DagRunState } from "../requests/types.gen";
 
-export type AssetServiceNextRunAssetsUiNextRunDatasetsDagIdGetDefaultResponse =
-  Awaited<
-    ReturnType<typeof AssetService.nextRunAssetsUiNextRunDatasetsDagIdGet>
-  >;
-export type AssetServiceNextRunAssetsUiNextRunDatasetsDagIdGetQueryResult<
-  TData = AssetServiceNextRunAssetsUiNextRunDatasetsDagIdGetDefaultResponse,
+export type AssetServiceNextRunAssetsDefaultResponse = Awaited<
+  ReturnType<typeof AssetService.nextRunAssets>
+>;
+export type AssetServiceNextRunAssetsQueryResult<
+  TData = AssetServiceNextRunAssetsDefaultResponse,
   TError = unknown,
 > = UseQueryResult<TData, TError>;
-export const useAssetServiceNextRunAssetsUiNextRunDatasetsDagIdGetKey =
-  "AssetServiceNextRunAssetsUiNextRunDatasetsDagIdGet";
-export const UseAssetServiceNextRunAssetsUiNextRunDatasetsDagIdGetKeyFn = (
+export const useAssetServiceNextRunAssetsKey = "AssetServiceNextRunAssets";
+export const UseAssetServiceNextRunAssetsKeyFn = (
   {
     dagId,
   }: {
     dagId: string;
   },
   queryKey?: Array<unknown>,
-) => [
-  useAssetServiceNextRunAssetsUiNextRunDatasetsDagIdGetKey,
-  ...(queryKey ?? [{ dagId }]),
-];
-export type DagServiceGetDagsPublicDagsGetDefaultResponse = Awaited<
-  ReturnType<typeof DagService.getDagsPublicDagsGet>
+) => [useAssetServiceNextRunAssetsKey, ...(queryKey ?? [{ dagId }])];
+export type DagServiceGetDagsDefaultResponse = Awaited<
+  ReturnType<typeof DagService.getDags>
 >;
-export type DagServiceGetDagsPublicDagsGetQueryResult<
-  TData = DagServiceGetDagsPublicDagsGetDefaultResponse,
+export type DagServiceGetDagsQueryResult<
+  TData = DagServiceGetDagsDefaultResponse,
   TError = unknown,
 > = UseQueryResult<TData, TError>;
-export const useDagServiceGetDagsPublicDagsGetKey =
-  "DagServiceGetDagsPublicDagsGet";
-export const UseDagServiceGetDagsPublicDagsGetKeyFn = (
+export const useDagServiceGetDagsKey = "DagServiceGetDags";
+export const UseDagServiceGetDagsKeyFn = (
   {
     dagDisplayNamePattern,
     dagIdPattern,
@@ -60,7 +54,7 @@ export const UseDagServiceGetDagsPublicDagsGetKeyFn = (
   } = {},
   queryKey?: Array<unknown>,
 ) => [
-  useDagServiceGetDagsPublicDagsGetKey,
+  useDagServiceGetDagsKey,
   ...(queryKey ?? [
     {
       dagDisplayNamePattern,
@@ -79,6 +73,6 @@ export const UseDagServiceGetDagsPublicDagsGetKeyFn = (
 export type DagServicePatchDagsPublicDagsPatchMutationResult = Awaited<
   ReturnType<typeof DagService.patchDagsPublicDagsPatch>
 >;
-export type DagServicePatchDagPublicDagsDagIdPatchMutationResult = Awaited<
-  ReturnType<typeof DagService.patchDagPublicDagsDagIdPatch>
+export type DagServicePatchDagMutationResult = Awaited<
+  ReturnType<typeof DagService.patchDag>
 >;

--- a/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -12,7 +12,7 @@ import * as Common from "./common";
  * @returns unknown Successful Response
  * @throws ApiError
  */
-export const prefetchUseAssetServiceNextRunAssetsUiNextRunDatasetsDagIdGet = (
+export const prefetchUseAssetServiceNextRunAssets = (
   queryClient: QueryClient,
   {
     dagId,
@@ -21,11 +21,8 @@ export const prefetchUseAssetServiceNextRunAssetsUiNextRunDatasetsDagIdGet = (
   },
 ) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseAssetServiceNextRunAssetsUiNextRunDatasetsDagIdGetKeyFn(
-      { dagId },
-    ),
-    queryFn: () =>
-      AssetService.nextRunAssetsUiNextRunDatasetsDagIdGet({ dagId }),
+    queryKey: Common.UseAssetServiceNextRunAssetsKeyFn({ dagId }),
+    queryFn: () => AssetService.nextRunAssets({ dagId }),
   });
 /**
  * Get Dags
@@ -44,7 +41,7 @@ export const prefetchUseAssetServiceNextRunAssetsUiNextRunDatasetsDagIdGet = (
  * @returns DAGCollectionResponse Successful Response
  * @throws ApiError
  */
-export const prefetchUseDagServiceGetDagsPublicDagsGet = (
+export const prefetchUseDagServiceGetDags = (
   queryClient: QueryClient,
   {
     dagDisplayNamePattern,
@@ -71,7 +68,7 @@ export const prefetchUseDagServiceGetDagsPublicDagsGet = (
   } = {},
 ) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseDagServiceGetDagsPublicDagsGetKeyFn({
+    queryKey: Common.UseDagServiceGetDagsKeyFn({
       dagDisplayNamePattern,
       dagIdPattern,
       lastDagRunState,
@@ -84,7 +81,7 @@ export const prefetchUseDagServiceGetDagsPublicDagsGet = (
       tags,
     }),
     queryFn: () =>
-      DagService.getDagsPublicDagsGet({
+      DagService.getDags({
         dagDisplayNamePattern,
         dagIdPattern,
         lastDagRunState,

--- a/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow/ui/openapi-gen/queries/queries.ts
@@ -17,8 +17,8 @@ import * as Common from "./common";
  * @returns unknown Successful Response
  * @throws ApiError
  */
-export const useAssetServiceNextRunAssetsUiNextRunDatasetsDagIdGet = <
-  TData = Common.AssetServiceNextRunAssetsUiNextRunDatasetsDagIdGetDefaultResponse,
+export const useAssetServiceNextRunAssets = <
+  TData = Common.AssetServiceNextRunAssetsDefaultResponse,
   TError = unknown,
   TQueryKey extends Array<unknown> = unknown[],
 >(
@@ -31,12 +31,8 @@ export const useAssetServiceNextRunAssetsUiNextRunDatasetsDagIdGet = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseAssetServiceNextRunAssetsUiNextRunDatasetsDagIdGetKeyFn(
-      { dagId },
-      queryKey,
-    ),
-    queryFn: () =>
-      AssetService.nextRunAssetsUiNextRunDatasetsDagIdGet({ dagId }) as TData,
+    queryKey: Common.UseAssetServiceNextRunAssetsKeyFn({ dagId }, queryKey),
+    queryFn: () => AssetService.nextRunAssets({ dagId }) as TData,
     ...options,
   });
 /**
@@ -56,8 +52,8 @@ export const useAssetServiceNextRunAssetsUiNextRunDatasetsDagIdGet = <
  * @returns DAGCollectionResponse Successful Response
  * @throws ApiError
  */
-export const useDagServiceGetDagsPublicDagsGet = <
-  TData = Common.DagServiceGetDagsPublicDagsGetDefaultResponse,
+export const useDagServiceGetDags = <
+  TData = Common.DagServiceGetDagsDefaultResponse,
   TError = unknown,
   TQueryKey extends Array<unknown> = unknown[],
 >(
@@ -88,7 +84,7 @@ export const useDagServiceGetDagsPublicDagsGet = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseDagServiceGetDagsPublicDagsGetKeyFn(
+    queryKey: Common.UseDagServiceGetDagsKeyFn(
       {
         dagDisplayNamePattern,
         dagIdPattern,
@@ -104,7 +100,7 @@ export const useDagServiceGetDagsPublicDagsGet = <
       queryKey,
     ),
     queryFn: () =>
-      DagService.getDagsPublicDagsGet({
+      DagService.getDags({
         dagDisplayNamePattern,
         dagIdPattern,
         lastDagRunState,
@@ -214,8 +210,8 @@ export const useDagServicePatchDagsPublicDagsPatch = <
  * @returns DAGResponse Successful Response
  * @throws ApiError
  */
-export const useDagServicePatchDagPublicDagsDagIdPatch = <
-  TData = Common.DagServicePatchDagPublicDagsDagIdPatchMutationResult,
+export const useDagServicePatchDag = <
+  TData = Common.DagServicePatchDagMutationResult,
   TError = unknown,
   TContext = unknown,
 >(
@@ -244,7 +240,7 @@ export const useDagServicePatchDagPublicDagsDagIdPatch = <
     TContext
   >({
     mutationFn: ({ dagId, requestBody, updateMask }) =>
-      DagService.patchDagPublicDagsDagIdPatch({
+      DagService.patchDag({
         dagId,
         requestBody,
         updateMask,

--- a/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow/ui/openapi-gen/queries/suspense.ts
@@ -12,8 +12,8 @@ import * as Common from "./common";
  * @returns unknown Successful Response
  * @throws ApiError
  */
-export const useAssetServiceNextRunAssetsUiNextRunDatasetsDagIdGetSuspense = <
-  TData = Common.AssetServiceNextRunAssetsUiNextRunDatasetsDagIdGetDefaultResponse,
+export const useAssetServiceNextRunAssetsSuspense = <
+  TData = Common.AssetServiceNextRunAssetsDefaultResponse,
   TError = unknown,
   TQueryKey extends Array<unknown> = unknown[],
 >(
@@ -26,12 +26,8 @@ export const useAssetServiceNextRunAssetsUiNextRunDatasetsDagIdGetSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseAssetServiceNextRunAssetsUiNextRunDatasetsDagIdGetKeyFn(
-      { dagId },
-      queryKey,
-    ),
-    queryFn: () =>
-      AssetService.nextRunAssetsUiNextRunDatasetsDagIdGet({ dagId }) as TData,
+    queryKey: Common.UseAssetServiceNextRunAssetsKeyFn({ dagId }, queryKey),
+    queryFn: () => AssetService.nextRunAssets({ dagId }) as TData,
     ...options,
   });
 /**
@@ -51,8 +47,8 @@ export const useAssetServiceNextRunAssetsUiNextRunDatasetsDagIdGetSuspense = <
  * @returns DAGCollectionResponse Successful Response
  * @throws ApiError
  */
-export const useDagServiceGetDagsPublicDagsGetSuspense = <
-  TData = Common.DagServiceGetDagsPublicDagsGetDefaultResponse,
+export const useDagServiceGetDagsSuspense = <
+  TData = Common.DagServiceGetDagsDefaultResponse,
   TError = unknown,
   TQueryKey extends Array<unknown> = unknown[],
 >(
@@ -83,7 +79,7 @@ export const useDagServiceGetDagsPublicDagsGetSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseDagServiceGetDagsPublicDagsGetKeyFn(
+    queryKey: Common.UseDagServiceGetDagsKeyFn(
       {
         dagDisplayNamePattern,
         dagIdPattern,
@@ -99,7 +95,7 @@ export const useDagServiceGetDagsPublicDagsGetSuspense = <
       queryKey,
     ),
     queryFn: () =>
-      DagService.getDagsPublicDagsGet({
+      DagService.getDags({
         dagDisplayNamePattern,
         dagIdPattern,
         lastDagRunState,

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -3,14 +3,14 @@ import type { CancelablePromise } from "./core/CancelablePromise";
 import { OpenAPI } from "./core/OpenAPI";
 import { request as __request } from "./core/request";
 import type {
-  NextRunAssetsUiNextRunDatasetsDagIdGetData,
-  NextRunAssetsUiNextRunDatasetsDagIdGetResponse,
-  GetDagsPublicDagsGetData,
-  GetDagsPublicDagsGetResponse,
+  NextRunAssetsData,
+  NextRunAssetsResponse,
+  GetDagsData,
+  GetDagsResponse,
   PatchDagsPublicDagsPatchData,
   PatchDagsPublicDagsPatchResponse,
-  PatchDagPublicDagsDagIdPatchData,
-  PatchDagPublicDagsDagIdPatchResponse,
+  PatchDagData,
+  PatchDagResponse,
 } from "./types.gen";
 
 export class AssetService {
@@ -21,9 +21,9 @@ export class AssetService {
    * @returns unknown Successful Response
    * @throws ApiError
    */
-  public static nextRunAssetsUiNextRunDatasetsDagIdGet(
-    data: NextRunAssetsUiNextRunDatasetsDagIdGetData,
-  ): CancelablePromise<NextRunAssetsUiNextRunDatasetsDagIdGetResponse> {
+  public static nextRunAssets(
+    data: NextRunAssetsData,
+  ): CancelablePromise<NextRunAssetsResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/ui/next_run_datasets/{dag_id}",
@@ -55,9 +55,9 @@ export class DagService {
    * @returns DAGCollectionResponse Successful Response
    * @throws ApiError
    */
-  public static getDagsPublicDagsGet(
-    data: GetDagsPublicDagsGetData = {},
-  ): CancelablePromise<GetDagsPublicDagsGetResponse> {
+  public static getDags(
+    data: GetDagsData = {},
+  ): CancelablePromise<GetDagsResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/dags",
@@ -135,9 +135,9 @@ export class DagService {
    * @returns DAGResponse Successful Response
    * @throws ApiError
    */
-  public static patchDagPublicDagsDagIdPatch(
-    data: PatchDagPublicDagsDagIdPatchData,
-  ): CancelablePromise<PatchDagPublicDagsDagIdPatchResponse> {
+  public static patchDag(
+    data: PatchDagData,
+  ): CancelablePromise<PatchDagResponse> {
     return __request(OpenAPI, {
       method: "PATCH",
       url: "/public/dags/{dag_id}",

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -88,15 +88,15 @@ export type ValidationError = {
   type: string;
 };
 
-export type NextRunAssetsUiNextRunDatasetsDagIdGetData = {
+export type NextRunAssetsData = {
   dagId: string;
 };
 
-export type NextRunAssetsUiNextRunDatasetsDagIdGetResponse = {
+export type NextRunAssetsResponse = {
   [key: string]: unknown;
 };
 
-export type GetDagsPublicDagsGetData = {
+export type GetDagsData = {
   dagDisplayNamePattern?: string | null;
   dagIdPattern?: string | null;
   lastDagRunState?: DagRunState | null;
@@ -109,7 +109,7 @@ export type GetDagsPublicDagsGetData = {
   tags?: Array<string>;
 };
 
-export type GetDagsPublicDagsGetResponse = DAGCollectionResponse;
+export type GetDagsResponse = DAGCollectionResponse;
 
 export type PatchDagsPublicDagsPatchData = {
   dagIdPattern?: string | null;
@@ -126,18 +126,18 @@ export type PatchDagsPublicDagsPatchData = {
 
 export type PatchDagsPublicDagsPatchResponse = DAGCollectionResponse;
 
-export type PatchDagPublicDagsDagIdPatchData = {
+export type PatchDagData = {
   dagId: string;
   requestBody: DAGPatchBody;
   updateMask?: Array<string> | null;
 };
 
-export type PatchDagPublicDagsDagIdPatchResponse = DAGResponse;
+export type PatchDagResponse = DAGResponse;
 
 export type $OpenApiTs = {
   "/ui/next_run_datasets/{dag_id}": {
     get: {
-      req: NextRunAssetsUiNextRunDatasetsDagIdGetData;
+      req: NextRunAssetsData;
       res: {
         /**
          * Successful Response
@@ -154,7 +154,7 @@ export type $OpenApiTs = {
   };
   "/public/dags": {
     get: {
-      req: GetDagsPublicDagsGetData;
+      req: GetDagsData;
       res: {
         /**
          * Successful Response
@@ -198,7 +198,7 @@ export type $OpenApiTs = {
   };
   "/public/dags/{dag_id}": {
     patch: {
-      req: PatchDagPublicDagsDagIdPatchData;
+      req: PatchDagData;
       res: {
         /**
          * Successful Response

--- a/airflow/ui/package.json
+++ b/airflow/ui/package.json
@@ -11,7 +11,7 @@
     "lint:fix": "eslint --fix && tsc --p tsconfig.app.json",
     "format": "pnpm prettier --write .",
     "preview": "vite preview",
-    "codegen": "openapi-rq -i \"../api_fastapi/openapi/v1-generated.yaml\" -c axios --format prettier -o openapi-gen",
+    "codegen": "openapi-rq -i \"../api_fastapi/openapi/v1-generated.yaml\" -c axios --format prettier -o openapi-gen --operationId",
     "test": "vitest run",
     "coverage": "vitest run --coverage"
   },

--- a/airflow/ui/src/App.test.tsx
+++ b/airflow/ui/src/App.test.tsx
@@ -105,10 +105,9 @@ beforeEach(() => {
     isLoading: false,
   } as QueryObserverSuccessResult<DAGCollectionResponse, unknown>;
 
-  vi.spyOn(
-    openapiQueriesModule,
-    "useDagServiceGetDagsPublicDagsGet",
-  ).mockImplementation(() => returnValue);
+  vi.spyOn(openapiQueriesModule, "useDagServiceGetDags").mockImplementation(
+    () => returnValue,
+  );
 });
 
 afterEach(() => {

--- a/airflow/ui/src/pages/DagsList.tsx
+++ b/airflow/ui/src/pages/DagsList.tsx
@@ -30,7 +30,7 @@ import { Select as ReactSelect } from "chakra-react-select";
 import { type ChangeEventHandler, useCallback } from "react";
 import { useSearchParams } from "react-router-dom";
 
-import { useDagServiceGetDagsPublicDagsGet } from "openapi/queries";
+import { useDagServiceGetDags } from "openapi/queries";
 import type { DAGResponse } from "openapi/requests/types.gen";
 
 import { DataTable } from "../components/DataTable";
@@ -93,7 +93,7 @@ export const DagsList = ({ cardView = false }) => {
   const [sort] = sorting;
   const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : undefined;
 
-  const { data, isLoading } = useDagServiceGetDagsPublicDagsGet({
+  const { data, isLoading } = useDagServiceGetDags({
     limit: pagination.pageSize,
     offset: pagination.pageIndex * pagination.pageSize,
     onlyActive: true,


### PR DESCRIPTION
Use `operation_id` to reduce the autogenerated query and mutation function names used in the UI

Before: `useDagServiceGetDagsPublicDagsGet()`
After: `useDagServiceGetDags()`


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
