### PR TITLE
Update fastapi operation ids

### DIFF
--- a/airflow/api_fastapi/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/openapi/v1-generated.yaml
@@ -12,7 +12,7 @@ paths:
       tags:
       - Asset
       summary: Next Run Assets
-      operationId: next_run_assets_ui_next_run_datasets__dag_id__get
+      operationId: next_run_assets
       parameters:
       - name: dag_id
         in: path
@@ -27,7 +27,7 @@ paths:
             application/json:
               schema:
                 type: object
-                title: Response Next Run Assets Ui Next Run Datasets  Dag Id  Get
+                title: Response Next Run Assets
         '422':
           description: Validation Error
           content:
@@ -40,7 +40,7 @@ paths:
       - DAG
       summary: Get Dags
       description: Get all DAGs.
-      operationId: get_dags_public_dags_get
+      operationId: get_dags
       parameters:
       - name: limit
         in: query
@@ -136,7 +136,7 @@ paths:
       - DAG
       summary: Patch Dags
       description: Patch multiple DAGs.
-      operationId: patch_dags_public_dags_patch
+      operationId: patch_dags
       parameters:
       - name: update_mask
         in: query
@@ -258,7 +258,7 @@ paths:
       - DAG
       summary: Patch Dag
       description: Patch the specific DAG.
-      operationId: patch_dag_public_dags__dag_id__patch
+      operationId: patch_dag
       parameters:
       - name: dag_id
         in: path

--- a/airflow/api_fastapi/views/public/__init__.py
+++ b/airflow/api_fastapi/views/public/__init__.py
@@ -17,11 +17,10 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter
-
 from airflow.api_fastapi.views.public.dags import dags_router
+from airflow.api_fastapi.views.router import AirflowRouter
 
-public_router = APIRouter(prefix="/public")
+public_router = AirflowRouter(prefix="/public")
 
 
 public_router.include_router(dags_router)

--- a/airflow/api_fastapi/views/public/dags.py
+++ b/airflow/api_fastapi/views/public/dags.py
@@ -17,7 +17,7 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import Depends, HTTPException, Query
 from sqlalchemy import update
 from sqlalchemy.orm import Session
 from typing_extensions import Annotated
@@ -42,9 +42,10 @@ from airflow.api_fastapi.parameters import (
     SortParam,
 )
 from airflow.api_fastapi.serializers.dags import DAGCollectionResponse, DAGPatchBody, DAGResponse
+from airflow.api_fastapi.views.router import AirflowRouter
 from airflow.models import DagModel
 
-dags_router = APIRouter(tags=["DAG"])
+dags_router = AirflowRouter(tags=["DAG"])
 
 
 @dags_router.get("/dags")

--- a/airflow/api_fastapi/views/router.py
+++ b/airflow/api_fastapi/views/router.py
@@ -1,0 +1,93 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Callable, Sequence
+
+from fastapi import APIRouter, params
+from fastapi.datastructures import Default
+from fastapi.routing import APIRoute
+from fastapi.types import DecoratedCallable, IncEx
+from fastapi.utils import generate_unique_id
+from starlette.responses import JSONResponse, Response
+from starlette.routing import BaseRoute
+
+
+class AirflowRouter(APIRouter):
+    """Extends the FastAPI default router."""
+
+    def api_route(
+        self,
+        path: str,
+        *,
+        response_model: Any = Default(None),
+        status_code: int | None = None,
+        tags: list[str | Enum] | None = None,
+        dependencies: Sequence[params.Depends] | None = None,
+        summary: str | None = None,
+        description: str | None = None,
+        response_description: str = "Successful Response",
+        responses: dict[int | str, dict[str, Any]] | None = None,
+        deprecated: bool | None = None,
+        methods: list[str] | None = None,
+        operation_id: str | None = None,
+        response_model_include: IncEx | None = None,
+        response_model_exclude: IncEx | None = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        include_in_schema: bool = True,
+        response_class: type[Response] = Default(JSONResponse),
+        name: str | None = None,
+        callbacks: list[BaseRoute] | None = None,
+        openapi_extra: dict[str, Any] | None = None,
+        generate_unique_id_function: Callable[[APIRoute], str] = Default(generate_unique_id),
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        def decorator(func: DecoratedCallable) -> DecoratedCallable:
+            self.add_api_route(
+                path,
+                func,
+                response_model=response_model,
+                status_code=status_code,
+                tags=tags,
+                dependencies=dependencies,
+                summary=summary,
+                description=description,
+                response_description=response_description,
+                responses=responses,
+                deprecated=deprecated,
+                methods=methods,
+                operation_id=operation_id or func.__name__,
+                response_model_include=response_model_include,
+                response_model_exclude=response_model_exclude,
+                response_model_by_alias=response_model_by_alias,
+                response_model_exclude_unset=response_model_exclude_unset,
+                response_model_exclude_defaults=response_model_exclude_defaults,
+                response_model_exclude_none=response_model_exclude_none,
+                include_in_schema=include_in_schema,
+                response_class=response_class,
+                name=name,
+                callbacks=callbacks,
+                openapi_extra=openapi_extra,
+                generate_unique_id_function=generate_unique_id_function,
+            )
+            return func
+
+        return decorator

--- a/airflow/api_fastapi/views/ui/__init__.py
+++ b/airflow/api_fastapi/views/ui/__init__.py
@@ -16,10 +16,9 @@
 # under the License.
 from __future__ import annotations
 
-from fastapi import APIRouter
-
+from airflow.api_fastapi.views.router import AirflowRouter
 from airflow.api_fastapi.views.ui.assets import assets_router
 
-ui_router = APIRouter(prefix="/ui")
+ui_router = AirflowRouter(prefix="/ui")
 
 ui_router.include_router(assets_router)

--- a/airflow/api_fastapi/views/ui/assets.py
+++ b/airflow/api_fastapi/views/ui/assets.py
@@ -17,16 +17,17 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import Depends, HTTPException, Request
 from sqlalchemy import and_, func, select
 from sqlalchemy.orm import Session
 from typing_extensions import Annotated
 
 from airflow.api_fastapi.db.common import get_session
+from airflow.api_fastapi.views.router import AirflowRouter
 from airflow.models import DagModel
 from airflow.models.asset import AssetDagRunQueue, AssetEvent, AssetModel, DagScheduleAssetReference
 
-assets_router = APIRouter(tags=["Asset"])
+assets_router = AirflowRouter(tags=["Asset"])
 
 
 @assets_router.get("/next_run_datasets/{dag_id}", include_in_schema=False)

--- a/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow/ui/openapi-gen/queries/common.ts
@@ -4,37 +4,31 @@ import { UseQueryResult } from "@tanstack/react-query";
 import { AssetService, DagService } from "../requests/services.gen";
 import { DagRunState } from "../requests/types.gen";
 
-export type AssetServiceNextRunAssetsUiNextRunDatasetsDagIdGetDefaultResponse =
-  Awaited<
-    ReturnType<typeof AssetService.nextRunAssetsUiNextRunDatasetsDagIdGet>
-  >;
-export type AssetServiceNextRunAssetsUiNextRunDatasetsDagIdGetQueryResult<
-  TData = AssetServiceNextRunAssetsUiNextRunDatasetsDagIdGetDefaultResponse,
+export type AssetServiceNextRunAssetsDefaultResponse = Awaited<
+  ReturnType<typeof AssetService.nextRunAssets>
+>;
+export type AssetServiceNextRunAssetsQueryResult<
+  TData = AssetServiceNextRunAssetsDefaultResponse,
   TError = unknown,
 > = UseQueryResult<TData, TError>;
-export const useAssetServiceNextRunAssetsUiNextRunDatasetsDagIdGetKey =
-  "AssetServiceNextRunAssetsUiNextRunDatasetsDagIdGet";
-export const UseAssetServiceNextRunAssetsUiNextRunDatasetsDagIdGetKeyFn = (
+export const useAssetServiceNextRunAssetsKey = "AssetServiceNextRunAssets";
+export const UseAssetServiceNextRunAssetsKeyFn = (
   {
     dagId,
   }: {
     dagId: string;
   },
   queryKey?: Array<unknown>,
-) => [
-  useAssetServiceNextRunAssetsUiNextRunDatasetsDagIdGetKey,
-  ...(queryKey ?? [{ dagId }]),
-];
-export type DagServiceGetDagsPublicDagsGetDefaultResponse = Awaited<
-  ReturnType<typeof DagService.getDagsPublicDagsGet>
+) => [useAssetServiceNextRunAssetsKey, ...(queryKey ?? [{ dagId }])];
+export type DagServiceGetDagsDefaultResponse = Awaited<
+  ReturnType<typeof DagService.getDags>
 >;
-export type DagServiceGetDagsPublicDagsGetQueryResult<
-  TData = DagServiceGetDagsPublicDagsGetDefaultResponse,
+export type DagServiceGetDagsQueryResult<
+  TData = DagServiceGetDagsDefaultResponse,
   TError = unknown,
 > = UseQueryResult<TData, TError>;
-export const useDagServiceGetDagsPublicDagsGetKey =
-  "DagServiceGetDagsPublicDagsGet";
-export const UseDagServiceGetDagsPublicDagsGetKeyFn = (
+export const useDagServiceGetDagsKey = "DagServiceGetDags";
+export const UseDagServiceGetDagsKeyFn = (
   {
     dagDisplayNamePattern,
     dagIdPattern,
@@ -60,7 +54,7 @@ export const UseDagServiceGetDagsPublicDagsGetKeyFn = (
   } = {},
   queryKey?: Array<unknown>,
 ) => [
-  useDagServiceGetDagsPublicDagsGetKey,
+  useDagServiceGetDagsKey,
   ...(queryKey ?? [
     {
       dagDisplayNamePattern,
@@ -76,9 +70,9 @@ export const UseDagServiceGetDagsPublicDagsGetKeyFn = (
     },
   ]),
 ];
-export type DagServicePatchDagsPublicDagsPatchMutationResult = Awaited<
-  ReturnType<typeof DagService.patchDagsPublicDagsPatch>
+export type DagServicePatchDagsMutationResult = Awaited<
+  ReturnType<typeof DagService.patchDags>
 >;
-export type DagServicePatchDagPublicDagsDagIdPatchMutationResult = Awaited<
-  ReturnType<typeof DagService.patchDagPublicDagsDagIdPatch>
+export type DagServicePatchDagMutationResult = Awaited<
+  ReturnType<typeof DagService.patchDag>
 >;

--- a/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -12,7 +12,7 @@ import * as Common from "./common";
  * @returns unknown Successful Response
  * @throws ApiError
  */
-export const prefetchUseAssetServiceNextRunAssetsUiNextRunDatasetsDagIdGet = (
+export const prefetchUseAssetServiceNextRunAssets = (
   queryClient: QueryClient,
   {
     dagId,
@@ -21,11 +21,8 @@ export const prefetchUseAssetServiceNextRunAssetsUiNextRunDatasetsDagIdGet = (
   },
 ) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseAssetServiceNextRunAssetsUiNextRunDatasetsDagIdGetKeyFn(
-      { dagId },
-    ),
-    queryFn: () =>
-      AssetService.nextRunAssetsUiNextRunDatasetsDagIdGet({ dagId }),
+    queryKey: Common.UseAssetServiceNextRunAssetsKeyFn({ dagId }),
+    queryFn: () => AssetService.nextRunAssets({ dagId }),
   });
 /**
  * Get Dags
@@ -44,7 +41,7 @@ export const prefetchUseAssetServiceNextRunAssetsUiNextRunDatasetsDagIdGet = (
  * @returns DAGCollectionResponse Successful Response
  * @throws ApiError
  */
-export const prefetchUseDagServiceGetDagsPublicDagsGet = (
+export const prefetchUseDagServiceGetDags = (
   queryClient: QueryClient,
   {
     dagDisplayNamePattern,
@@ -71,7 +68,7 @@ export const prefetchUseDagServiceGetDagsPublicDagsGet = (
   } = {},
 ) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseDagServiceGetDagsPublicDagsGetKeyFn({
+    queryKey: Common.UseDagServiceGetDagsKeyFn({
       dagDisplayNamePattern,
       dagIdPattern,
       lastDagRunState,
@@ -84,7 +81,7 @@ export const prefetchUseDagServiceGetDagsPublicDagsGet = (
       tags,
     }),
     queryFn: () =>
-      DagService.getDagsPublicDagsGet({
+      DagService.getDags({
         dagDisplayNamePattern,
         dagIdPattern,
         lastDagRunState,

--- a/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow/ui/openapi-gen/queries/queries.ts
@@ -17,8 +17,8 @@ import * as Common from "./common";
  * @returns unknown Successful Response
  * @throws ApiError
  */
-export const useAssetServiceNextRunAssetsUiNextRunDatasetsDagIdGet = <
-  TData = Common.AssetServiceNextRunAssetsUiNextRunDatasetsDagIdGetDefaultResponse,
+export const useAssetServiceNextRunAssets = <
+  TData = Common.AssetServiceNextRunAssetsDefaultResponse,
   TError = unknown,
   TQueryKey extends Array<unknown> = unknown[],
 >(
@@ -31,12 +31,8 @@ export const useAssetServiceNextRunAssetsUiNextRunDatasetsDagIdGet = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseAssetServiceNextRunAssetsUiNextRunDatasetsDagIdGetKeyFn(
-      { dagId },
-      queryKey,
-    ),
-    queryFn: () =>
-      AssetService.nextRunAssetsUiNextRunDatasetsDagIdGet({ dagId }) as TData,
+    queryKey: Common.UseAssetServiceNextRunAssetsKeyFn({ dagId }, queryKey),
+    queryFn: () => AssetService.nextRunAssets({ dagId }) as TData,
     ...options,
   });
 /**
@@ -56,8 +52,8 @@ export const useAssetServiceNextRunAssetsUiNextRunDatasetsDagIdGet = <
  * @returns DAGCollectionResponse Successful Response
  * @throws ApiError
  */
-export const useDagServiceGetDagsPublicDagsGet = <
-  TData = Common.DagServiceGetDagsPublicDagsGetDefaultResponse,
+export const useDagServiceGetDags = <
+  TData = Common.DagServiceGetDagsDefaultResponse,
   TError = unknown,
   TQueryKey extends Array<unknown> = unknown[],
 >(
@@ -88,7 +84,7 @@ export const useDagServiceGetDagsPublicDagsGet = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseDagServiceGetDagsPublicDagsGetKeyFn(
+    queryKey: Common.UseDagServiceGetDagsKeyFn(
       {
         dagDisplayNamePattern,
         dagIdPattern,
@@ -104,7 +100,7 @@ export const useDagServiceGetDagsPublicDagsGet = <
       queryKey,
     ),
     queryFn: () =>
-      DagService.getDagsPublicDagsGet({
+      DagService.getDags({
         dagDisplayNamePattern,
         dagIdPattern,
         lastDagRunState,
@@ -135,8 +131,8 @@ export const useDagServiceGetDagsPublicDagsGet = <
  * @returns DAGCollectionResponse Successful Response
  * @throws ApiError
  */
-export const useDagServicePatchDagsPublicDagsPatch = <
-  TData = Common.DagServicePatchDagsPublicDagsPatchMutationResult,
+export const useDagServicePatchDags = <
+  TData = Common.DagServicePatchDagsMutationResult,
   TError = unknown,
   TContext = unknown,
 >(
@@ -190,7 +186,7 @@ export const useDagServicePatchDagsPublicDagsPatch = <
       tags,
       updateMask,
     }) =>
-      DagService.patchDagsPublicDagsPatch({
+      DagService.patchDags({
         dagIdPattern,
         lastDagRunState,
         limit,
@@ -214,8 +210,8 @@ export const useDagServicePatchDagsPublicDagsPatch = <
  * @returns DAGResponse Successful Response
  * @throws ApiError
  */
-export const useDagServicePatchDagPublicDagsDagIdPatch = <
-  TData = Common.DagServicePatchDagPublicDagsDagIdPatchMutationResult,
+export const useDagServicePatchDag = <
+  TData = Common.DagServicePatchDagMutationResult,
   TError = unknown,
   TContext = unknown,
 >(
@@ -244,7 +240,7 @@ export const useDagServicePatchDagPublicDagsDagIdPatch = <
     TContext
   >({
     mutationFn: ({ dagId, requestBody, updateMask }) =>
-      DagService.patchDagPublicDagsDagIdPatch({
+      DagService.patchDag({
         dagId,
         requestBody,
         updateMask,

--- a/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow/ui/openapi-gen/queries/suspense.ts
@@ -12,8 +12,8 @@ import * as Common from "./common";
  * @returns unknown Successful Response
  * @throws ApiError
  */
-export const useAssetServiceNextRunAssetsUiNextRunDatasetsDagIdGetSuspense = <
-  TData = Common.AssetServiceNextRunAssetsUiNextRunDatasetsDagIdGetDefaultResponse,
+export const useAssetServiceNextRunAssetsSuspense = <
+  TData = Common.AssetServiceNextRunAssetsDefaultResponse,
   TError = unknown,
   TQueryKey extends Array<unknown> = unknown[],
 >(
@@ -26,12 +26,8 @@ export const useAssetServiceNextRunAssetsUiNextRunDatasetsDagIdGetSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseAssetServiceNextRunAssetsUiNextRunDatasetsDagIdGetKeyFn(
-      { dagId },
-      queryKey,
-    ),
-    queryFn: () =>
-      AssetService.nextRunAssetsUiNextRunDatasetsDagIdGet({ dagId }) as TData,
+    queryKey: Common.UseAssetServiceNextRunAssetsKeyFn({ dagId }, queryKey),
+    queryFn: () => AssetService.nextRunAssets({ dagId }) as TData,
     ...options,
   });
 /**
@@ -51,8 +47,8 @@ export const useAssetServiceNextRunAssetsUiNextRunDatasetsDagIdGetSuspense = <
  * @returns DAGCollectionResponse Successful Response
  * @throws ApiError
  */
-export const useDagServiceGetDagsPublicDagsGetSuspense = <
-  TData = Common.DagServiceGetDagsPublicDagsGetDefaultResponse,
+export const useDagServiceGetDagsSuspense = <
+  TData = Common.DagServiceGetDagsDefaultResponse,
   TError = unknown,
   TQueryKey extends Array<unknown> = unknown[],
 >(
@@ -83,7 +79,7 @@ export const useDagServiceGetDagsPublicDagsGetSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseDagServiceGetDagsPublicDagsGetKeyFn(
+    queryKey: Common.UseDagServiceGetDagsKeyFn(
       {
         dagDisplayNamePattern,
         dagIdPattern,
@@ -99,7 +95,7 @@ export const useDagServiceGetDagsPublicDagsGetSuspense = <
       queryKey,
     ),
     queryFn: () =>
-      DagService.getDagsPublicDagsGet({
+      DagService.getDags({
         dagDisplayNamePattern,
         dagIdPattern,
         lastDagRunState,

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -3,14 +3,14 @@ import type { CancelablePromise } from "./core/CancelablePromise";
 import { OpenAPI } from "./core/OpenAPI";
 import { request as __request } from "./core/request";
 import type {
-  NextRunAssetsUiNextRunDatasetsDagIdGetData,
-  NextRunAssetsUiNextRunDatasetsDagIdGetResponse,
-  GetDagsPublicDagsGetData,
-  GetDagsPublicDagsGetResponse,
-  PatchDagsPublicDagsPatchData,
-  PatchDagsPublicDagsPatchResponse,
-  PatchDagPublicDagsDagIdPatchData,
-  PatchDagPublicDagsDagIdPatchResponse,
+  NextRunAssetsData,
+  NextRunAssetsResponse,
+  GetDagsData,
+  GetDagsResponse,
+  PatchDagsData,
+  PatchDagsResponse,
+  PatchDagData,
+  PatchDagResponse,
 } from "./types.gen";
 
 export class AssetService {
@@ -21,9 +21,9 @@ export class AssetService {
    * @returns unknown Successful Response
    * @throws ApiError
    */
-  public static nextRunAssetsUiNextRunDatasetsDagIdGet(
-    data: NextRunAssetsUiNextRunDatasetsDagIdGetData,
-  ): CancelablePromise<NextRunAssetsUiNextRunDatasetsDagIdGetResponse> {
+  public static nextRunAssets(
+    data: NextRunAssetsData,
+  ): CancelablePromise<NextRunAssetsResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/ui/next_run_datasets/{dag_id}",
@@ -55,9 +55,9 @@ export class DagService {
    * @returns DAGCollectionResponse Successful Response
    * @throws ApiError
    */
-  public static getDagsPublicDagsGet(
-    data: GetDagsPublicDagsGetData = {},
-  ): CancelablePromise<GetDagsPublicDagsGetResponse> {
+  public static getDags(
+    data: GetDagsData = {},
+  ): CancelablePromise<GetDagsResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/dags",
@@ -96,9 +96,9 @@ export class DagService {
    * @returns DAGCollectionResponse Successful Response
    * @throws ApiError
    */
-  public static patchDagsPublicDagsPatch(
-    data: PatchDagsPublicDagsPatchData,
-  ): CancelablePromise<PatchDagsPublicDagsPatchResponse> {
+  public static patchDags(
+    data: PatchDagsData,
+  ): CancelablePromise<PatchDagsResponse> {
     return __request(OpenAPI, {
       method: "PATCH",
       url: "/public/dags",
@@ -135,9 +135,9 @@ export class DagService {
    * @returns DAGResponse Successful Response
    * @throws ApiError
    */
-  public static patchDagPublicDagsDagIdPatch(
-    data: PatchDagPublicDagsDagIdPatchData,
-  ): CancelablePromise<PatchDagPublicDagsDagIdPatchResponse> {
+  public static patchDag(
+    data: PatchDagData,
+  ): CancelablePromise<PatchDagResponse> {
     return __request(OpenAPI, {
       method: "PATCH",
       url: "/public/dags/{dag_id}",

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -88,15 +88,15 @@ export type ValidationError = {
   type: string;
 };
 
-export type NextRunAssetsUiNextRunDatasetsDagIdGetData = {
+export type NextRunAssetsData = {
   dagId: string;
 };
 
-export type NextRunAssetsUiNextRunDatasetsDagIdGetResponse = {
+export type NextRunAssetsResponse = {
   [key: string]: unknown;
 };
 
-export type GetDagsPublicDagsGetData = {
+export type GetDagsData = {
   dagDisplayNamePattern?: string | null;
   dagIdPattern?: string | null;
   lastDagRunState?: DagRunState | null;
@@ -109,9 +109,9 @@ export type GetDagsPublicDagsGetData = {
   tags?: Array<string>;
 };
 
-export type GetDagsPublicDagsGetResponse = DAGCollectionResponse;
+export type GetDagsResponse = DAGCollectionResponse;
 
-export type PatchDagsPublicDagsPatchData = {
+export type PatchDagsData = {
   dagIdPattern?: string | null;
   lastDagRunState?: DagRunState | null;
   limit?: number;
@@ -124,20 +124,20 @@ export type PatchDagsPublicDagsPatchData = {
   updateMask?: Array<string> | null;
 };
 
-export type PatchDagsPublicDagsPatchResponse = DAGCollectionResponse;
+export type PatchDagsResponse = DAGCollectionResponse;
 
-export type PatchDagPublicDagsDagIdPatchData = {
+export type PatchDagData = {
   dagId: string;
   requestBody: DAGPatchBody;
   updateMask?: Array<string> | null;
 };
 
-export type PatchDagPublicDagsDagIdPatchResponse = DAGResponse;
+export type PatchDagResponse = DAGResponse;
 
 export type $OpenApiTs = {
   "/ui/next_run_datasets/{dag_id}": {
     get: {
-      req: NextRunAssetsUiNextRunDatasetsDagIdGetData;
+      req: NextRunAssetsData;
       res: {
         /**
          * Successful Response
@@ -154,7 +154,7 @@ export type $OpenApiTs = {
   };
   "/public/dags": {
     get: {
-      req: GetDagsPublicDagsGetData;
+      req: GetDagsData;
       res: {
         /**
          * Successful Response
@@ -167,7 +167,7 @@ export type $OpenApiTs = {
       };
     };
     patch: {
-      req: PatchDagsPublicDagsPatchData;
+      req: PatchDagsData;
       res: {
         /**
          * Successful Response
@@ -198,7 +198,7 @@ export type $OpenApiTs = {
   };
   "/public/dags/{dag_id}": {
     patch: {
-      req: PatchDagPublicDagsDagIdPatchData;
+      req: PatchDagData;
       res: {
         /**
          * Successful Response

--- a/airflow/ui/package.json
+++ b/airflow/ui/package.json
@@ -11,7 +11,7 @@
     "lint:fix": "eslint --fix && tsc --p tsconfig.app.json",
     "format": "pnpm prettier --write .",
     "preview": "vite preview",
-    "codegen": "openapi-rq -i \"../api_fastapi/openapi/v1-generated.yaml\" -c axios --format prettier -o openapi-gen",
+    "codegen": "openapi-rq -i \"../api_fastapi/openapi/v1-generated.yaml\" -c axios --format prettier -o openapi-gen --operationId",
     "test": "vitest run",
     "coverage": "vitest run --coverage"
   },

--- a/airflow/ui/src/App.test.tsx
+++ b/airflow/ui/src/App.test.tsx
@@ -105,10 +105,9 @@ beforeEach(() => {
     isLoading: false,
   } as QueryObserverSuccessResult<DAGCollectionResponse, unknown>;
 
-  vi.spyOn(
-    openapiQueriesModule,
-    "useDagServiceGetDagsPublicDagsGet",
-  ).mockImplementation(() => returnValue);
+  vi.spyOn(openapiQueriesModule, "useDagServiceGetDags").mockImplementation(
+    () => returnValue,
+  );
 });
 
 afterEach(() => {

--- a/airflow/ui/src/pages/DagsList.tsx
+++ b/airflow/ui/src/pages/DagsList.tsx
@@ -30,7 +30,7 @@ import { Select as ReactSelect } from "chakra-react-select";
 import { type ChangeEventHandler, useCallback } from "react";
 import { useSearchParams } from "react-router-dom";
 
-import { useDagServiceGetDagsPublicDagsGet } from "openapi/queries";
+import { useDagServiceGetDags } from "openapi/queries";
 import type { DAGResponse } from "openapi/requests/types.gen";
 
 import { DataTable } from "../components/DataTable";
@@ -93,7 +93,7 @@ export const DagsList = ({ cardView = false }) => {
   const [sort] = sorting;
   const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : undefined;
 
-  const { data, isLoading } = useDagServiceGetDagsPublicDagsGet({
+  const { data, isLoading } = useDagServiceGetDags({
     limit: pagination.pageSize,
     offset: pagination.pageIndex * pagination.pageSize,
     onlyActive: true,


### PR DESCRIPTION
Based of Brent change in this PR: 
https://github.com/apache/airflow/pull/42585

This automatically fills the `operation_id` of backend routes, this way generated code on the front-end has appropriate shorter names. 