### PR TITLE
Speed up boring cyborg consistency pre-commit check

### DIFF
--- a/scripts/ci/pre_commit/boring_cyborg.py
+++ b/scripts/ci/pre_commit/boring_cyborg.py
@@ -22,7 +22,6 @@ from pathlib import Path
 
 import yaml
 from termcolor import colored
-from wcmatch import glob
 
 if __name__ not in ("__main__", "__mp_main__"):
     raise SystemExit(
@@ -31,7 +30,6 @@ if __name__ not in ("__main__", "__mp_main__"):
     )
 
 CONFIG_KEY = "labelPRBasedOnFilePath"
-import time
 
 repo_root = Path(__file__).parent.parent.parent.parent
 cyborg_config_path = repo_root / ".github" / "boring-cyborg.yml"
@@ -39,18 +37,17 @@ cyborg_config = yaml.safe_load(cyborg_config_path.read_text())
 if CONFIG_KEY not in cyborg_config:
     raise SystemExit(f"Missing section {CONFIG_KEY}")
 
-start = time.time()
 errors = []
 for label, patterns in cyborg_config[CONFIG_KEY].items():
     for pattern in patterns:
-        if glob.glob(pattern, flags=glob.G | glob.E, root_dir=repo_root):
+        try:
+            next(Path(repo_root).glob(pattern))
             continue
-        yaml_path = f"{CONFIG_KEY}.{label}"
-        errors.append(
-            f"Unused pattern [{colored(pattern, 'cyan')}] in [{colored(yaml_path, 'cyan')}] section."
-        )
-end = time.time()
-print("2: ", end - start)
+        except StopIteration:
+            yaml_path = f"{CONFIG_KEY}.{label}"
+            errors.append(
+                f"Unused pattern [{colored(pattern, 'cyan')}] in [{colored(yaml_path, 'cyan')}] section."
+            )
 
 if errors:
     print(f"Found {colored(str(len(errors)), 'red')} problems:")


### PR DESCRIPTION
This is typically the slowest pre-commit besides mypy, and it runs every time. Previously it loaded all filenames into memory and ran glob filter on that. It seems faster to apply glob against the file system directly. This makes pre-commit much faster.  Previously took around 4 seconds, now about a half a second.
