### PR TITLE
Fix oracle bulk insert issue when leftover chunk is empty

### DIFF
--- a/airflow/providers/oracle/hooks/oracle.py
+++ b/airflow/providers/oracle/hooks/oracle.py
@@ -369,10 +369,11 @@ class OracleHook(DbApiHook):
                 # Empty chunk
                 row_chunk = []
         # Commit the leftover chunk
-        cursor.prepare(prepared_stm)
-        cursor.executemany(None, row_chunk)
-        conn.commit()  # type: ignore[attr-defined]
-        self.log.info("[%s] inserted %s rows", table, row_count)
+        if row_chunk:
+            cursor.prepare(prepared_stm)
+            cursor.executemany(None, row_chunk)
+            conn.commit()  # type: ignore[attr-defined]
+            self.log.info("[%s] inserted %s rows", table, row_count)
         cursor.close()
         conn.close()  # type: ignore[attr-defined]
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

---
In bulk_insert_rows method of oracle hook, if number of rows is equal to chunk size, then leftover of chunk is 0, and code will fail, I've just checked the size of leftover before executing query.


