### PR TITLE
[DatabricksHook] Respect connection settings

### DIFF
--- a/providers/src/airflow/providers/databricks/hooks/databricks_base.py
+++ b/providers/src/airflow/providers/databricks/hooks/databricks_base.py
@@ -517,6 +517,11 @@ class BaseDatabricksHook(BaseHook):
     def _log_request_error(self, attempt_num: int, error: str) -> None:
         self.log.error("Attempt %s API Request to Databricks failed with reason: %s", attempt_num, error)
 
+    def _endpoint_url(self, endpoint):
+        port = f":{self.databricks_conn.port}" if self.databricks_conn.port else ""
+        schema = self.databricks_conn.schema or "https"
+        return f"{schema}://{self.host}{port}/{endpoint}"
+
     def _do_api_call(
         self,
         endpoint_info: tuple[str, str],
@@ -535,7 +540,7 @@ class BaseDatabricksHook(BaseHook):
         method, endpoint = endpoint_info
 
         # TODO: get rid of explicit 'api/' in the endpoint specification
-        url = f"https://{self.host}/{endpoint}"
+        url = self._endpoint_url(endpoint)
 
         aad_headers = self._get_aad_headers()
         headers = {**self.user_agent_header, **aad_headers}
@@ -601,7 +606,7 @@ class BaseDatabricksHook(BaseHook):
         """
         method, endpoint = endpoint_info
 
-        url = f"https://{self.host}/{endpoint}"
+        url = self._endpoint_url(endpoint)
 
         aad_headers = await self._a_get_aad_headers()
         headers = {**self.user_agent_header, **aad_headers}

--- a/providers/tests/databricks/hooks/test_databricks.py
+++ b/providers/tests/databricks/hooks/test_databricks.py
@@ -1390,7 +1390,7 @@ class TestDatabricksHookAadToken:
     @provide_session
     def setup_method(self, method, session=None):
         conn = session.query(Connection).filter(Connection.conn_id == DEFAULT_CONN_ID).first()
-        conn.host = None # HOST
+        conn.host = None
         conn.schema = None
         conn.port = None
         conn.login = "9ff815a6-4404-4ab8-85cb-cd0e6f879c1d"
@@ -1434,7 +1434,7 @@ class TestDatabricksHookAadTokenOtherClouds:
         self.ad_endpoint = "https://login.microsoftonline.de"
         self.client_id = "9ff815a6-4404-4ab8-85cb-cd0e6f879c1d"
         conn = session.query(Connection).filter(Connection.conn_id == DEFAULT_CONN_ID).first()
-        conn.host = None # HOST
+        conn.host = None
         conn.schema = None
         conn.port = None
         conn.login = self.client_id

--- a/providers/tests/databricks/hooks/test_databricks.py
+++ b/providers/tests/databricks/hooks/test_databricks.py
@@ -1229,7 +1229,7 @@ class TestDatabricksHookTokenInPassword:
     def setup_method(self, method, session=None):
         conn = session.query(Connection).filter(Connection.conn_id == DEFAULT_CONN_ID).first()
         conn.host = HOST
-        conn.schem = None
+        conn.schema = None
         conn.port = None
         conn.login = None
         conn.password = TOKEN

--- a/providers/tests/databricks/hooks/test_databricks.py
+++ b/providers/tests/databricks/hooks/test_databricks.py
@@ -1273,8 +1273,9 @@ class TestDatabricksHookTokenWhenNoHostIsProvidedInExtra(TestDatabricksHookToken
 @pytest.mark.db_test
 class TestDatabricksHookConnSettings(TestDatabricksHookToken):
     """
-    Tests that setting the `schema` and/or `port` does have effect on requested API url.
+    Tests that `schema` and/or `port` get reflected in the requested API URLs.
     """
+
     @provide_session
     def setup_method(self, method, session=None):
         conn = session.query(Connection).filter(Connection.conn_id == DEFAULT_CONN_ID).first()


### PR DESCRIPTION
Avoids hard-coding URL schema and port while allowed to be edited in the Connections dialog. Allows utilizing the hooks against (local) mock servers with less of complications.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
