### PR TITLE
Add is_paused toggle

### DIFF
--- a/airflow/ui/package.json
+++ b/airflow/ui/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@7nohe/openapi-react-query-codegen": "^1.6.0",
+    "@eslint/compat": "^1.1.1",
     "@eslint/js": "^9.10.0",
     "@stylistic/eslint-plugin": "^2.8.0",
     "@tanstack/eslint-plugin-query": "^5.52.0",

--- a/airflow/ui/pnpm-lock.yaml
+++ b/airflow/ui/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@7nohe/openapi-react-query-codegen':
         specifier: ^1.6.0
         version: 1.6.0(commander@12.1.0)(glob@11.0.0)(magicast@0.3.5)(ts-morph@23.0.0)(typescript@5.5.4)
+      '@eslint/compat':
+        specifier: ^1.1.1
+        version: 1.1.1
       '@eslint/js':
         specifier: ^9.10.0
         version: 9.10.0
@@ -919,6 +922,10 @@ packages:
   '@eslint-community/regexpp@4.11.0':
     resolution: {integrity: sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/compat@1.1.1':
+    resolution: {integrity: sha512-lpHyRyplhGPL5mGEh6M9O5nnKk0Gz4bFI+Zu6tKlPpDUN7XshWvH9C/px4UVm87IAANE0W81CEsNGbS1KlzXpA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/config-array@0.18.0':
     resolution: {integrity: sha512-fTxvnS1sRMu3+JjXwJG0j/i4RT9u4qJ+lqS/yCGap4lH4zZGzQ7tu+xZqQmcMZq5OBZDL4QRxQzRjkWcGt8IVw==}
@@ -4367,6 +4374,8 @@ snapshots:
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.11.0': {}
+
+  '@eslint/compat@1.1.1': {}
 
   '@eslint/config-array@0.18.0':
     dependencies:

--- a/airflow/ui/rules/react.js
+++ b/airflow/ui/rules/react.js
@@ -20,6 +20,7 @@
 /**
  * @import { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
  */
+import { fixupPluginRules } from "@eslint/compat";
 import jsxA11y from "eslint-plugin-jsx-a11y";
 import react from "eslint-plugin-react";
 import reactHooks from "eslint-plugin-react-hooks";
@@ -57,7 +58,7 @@ export const reactRefreshNamespace = "react-refresh";
 export const reactRules = /** @type {const} @satisfies {FlatConfig.Config} */ ({
   plugins: {
     [jsxA11yNamespace]: jsxA11y,
-    [reactHooksNamespace]: reactHooks,
+    [reactHooksNamespace]: fixupPluginRules(reactHooks),
     [reactNamespace]: react,
     [reactRefreshNamespace]: reactRefresh,
   },

--- a/airflow/ui/src/components/DataTable/DataTable.tsx
+++ b/airflow/ui/src/components/DataTable/DataTable.tsx
@@ -115,7 +115,7 @@ export const DataTable = <TData,>({
   return (
     <TableContainer maxH="calc(100vh - 10rem)" overflowY="auto">
       <ChakraTable colorScheme="blue">
-        <Thead bg={theadBg} position="sticky" top={0}>
+        <Thead bg={theadBg} position="sticky" top={0} zIndex={1}>
           {table.getHeaderGroups().map((headerGroup) => (
             <Tr key={headerGroup.id}>
               {headerGroup.headers.map(

--- a/airflow/ui/src/components/TogglePause.tsx
+++ b/airflow/ui/src/components/TogglePause.tsx
@@ -1,0 +1,85 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Switch } from "@chakra-ui/react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useSearchParams } from "react-router-dom";
+
+import { useTableURLState } from "./DataTable/useTableUrlState";
+import {
+  type DagServiceGetDagsPublicDagsGetDefaultResponse,
+  type DagServicePatchDagPublicDagsDagIdPatchMutationResult,
+  UseDagServiceGetDagsPublicDagsGetKeyFn,
+  useDagServicePatchDagPublicDagsDagIdPatch,
+} from "openapi/queries";
+import { useCallback } from "react";
+
+type Props = {
+  readonly dagId: string;
+  readonly isPaused: boolean;
+};
+
+export const TogglePause = ({ dagId, isPaused }: Props) => {
+  const [searchParams] = useSearchParams();
+  const { tableURLState } = useTableURLState();
+  // const { pagination, sorting } = tableURLState;
+  // const showPaused = searchParams.get("paused") === "true";
+  // const sort = sorting[0];
+  // const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : undefined;
+  // const queryClient = useQueryClient();
+
+  // const onSuccess = (data: DagServicePatchDagPublicDagsDagIdPatchMutationResult) => {
+  //   // Update Dags list query on result instead of refetching it
+  //   queryClient.setQueryData(
+  //     UseDagServiceGetDagsPublicDagsGetKeyFn({
+  //       limit: pagination.pageSize,
+  //       offset: pagination.pageIndex * pagination.pageSize,
+  //       onlyActive: true,
+  //       orderBy,
+  //       paused: showPaused ? undefined : false, // undefined returns all dags
+  //     }),
+  //     (oldData: DagServiceGetDagsPublicDagsGetDefaultResponse) => {
+  //       // if (!showPaused && data.is_paused)
+  //       //   return {
+  //       //     ...oldData,
+  //       //     total_entries: oldData.total_entries
+  //       //       ? oldData.total_entries - 1
+  //       //       : oldData.total_entries,
+  //       //     dags: oldData.dags?.filter((dag) => dag.dag_id !== data.dag_id),
+  //       //   };
+  //       // return {
+  //       //   ...oldData,
+  //       //   dags: oldData.dags?.map((dag) => (dag.dag_id === dagId ? data : dag)),
+  //       // };
+  //     }
+  //   );
+  // };
+  const { mutate } = useDagServicePatchDagPublicDagsDagIdPatch();
+
+  const onChange = useCallback(() => {
+    mutate({
+      dagId,
+      requestBody: {
+        is_paused: !isPaused,
+      },
+    });
+  }, [dagId, isPaused]);
+  
+  return <Switch isChecked={!isPaused} onChange={onChange} size="sm" />;
+};

--- a/airflow/ui/src/components/TogglePause.tsx
+++ b/airflow/ui/src/components/TogglePause.tsx
@@ -21,8 +21,8 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 
 import {
-  useDagServiceGetDagsPublicDagsGetKey,
-  useDagServicePatchDagPublicDagsDagIdPatch,
+  useDagServiceGetDagsKey,
+  useDagServicePatchDag,
 } from "openapi/queries";
 
 type Props = {
@@ -35,11 +35,11 @@ export const TogglePause = ({ dagId, isPaused }: Props) => {
 
   const onSuccess = async () => {
     await queryClient.invalidateQueries({
-      queryKey: [useDagServiceGetDagsPublicDagsGetKey],
+      queryKey: [useDagServiceGetDagsKey],
     });
   };
 
-  const { mutate } = useDagServicePatchDagPublicDagsDagIdPatch({
+  const { mutate } = useDagServicePatchDag({
     onSuccess,
   });
 

--- a/airflow/ui/src/pages/DagsList.tsx
+++ b/airflow/ui/src/pages/DagsList.tsx
@@ -38,17 +38,24 @@ import { useTableURLState } from "../components/DataTable/useTableUrlState";
 import { QuickFilterButton } from "../components/QuickFilterButton";
 import { SearchBar } from "../components/SearchBar";
 import { pluralize } from "../utils/pluralize";
+import { TogglePause } from "src/components/TogglePause";
 
 const columns: Array<ColumnDef<DAGResponse>> = [
+  {
+    accessorKey: "is_paused",
+    cell: ({ row }) => (
+      <TogglePause
+        dagId={row.original.dag_id}
+        isPaused={row.original.is_paused}
+      />
+    ),
+    enableSorting: false,
+    header: "",
+  },
   {
     accessorKey: "dag_id",
     cell: ({ row }) => row.original.dag_display_name,
     header: "DAG",
-  },
-  {
-    accessorKey: "is_paused",
-    enableSorting: false,
-    header: () => "Is Paused",
   },
   {
     accessorKey: "timetable_description",

--- a/airflow/ui/src/pages/DagsList/DagsFilters.tsx
+++ b/airflow/ui/src/pages/DagsList/DagsFilters.tsx
@@ -1,0 +1,86 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { HStack, Select, Text, Box } from "@chakra-ui/react";
+import { Select as ReactSelect } from "chakra-react-select";
+import { useCallback } from "react";
+import { useSearchParams } from "react-router-dom";
+
+import { useTableURLState } from "src/components/DataTable/useTableUrlState";
+import { QuickFilterButton } from "src/components/QuickFilterButton";
+
+const PAUSED_PARAM = "paused";
+
+export const DagsFilters = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const showPaused = searchParams.get(PAUSED_PARAM);
+
+  const { setTableURLState, tableURLState } = useTableURLState();
+  const { pagination, sorting } = tableURLState;
+
+  const handlePausedChange: React.ChangeEventHandler<HTMLSelectElement> =
+    useCallback(
+      ({ target: { value } }) => {
+        if (value === "All") {
+          searchParams.delete(PAUSED_PARAM);
+        } else {
+          searchParams.set(PAUSED_PARAM, value);
+        }
+        setSearchParams(searchParams);
+        setTableURLState({
+          pagination: { ...pagination, pageIndex: 0 },
+          sorting,
+        });
+      },
+      [pagination, searchParams, setSearchParams, setTableURLState, sorting],
+    );
+
+  return (
+    <HStack justifyContent="space-between">
+      <HStack spacing={4}>
+        <Box>
+          <Text fontSize="sm" fontWeight={200} mb={1}>
+            State:
+          </Text>
+          <HStack>
+            <QuickFilterButton isActive>All</QuickFilterButton>
+            <QuickFilterButton isDisabled>Failed</QuickFilterButton>
+            <QuickFilterButton isDisabled>Running</QuickFilterButton>
+            <QuickFilterButton isDisabled>Successful</QuickFilterButton>
+          </HStack>
+        </Box>
+        <Box>
+          <Text fontSize="sm" fontWeight={200} mb={1}>
+            Active:
+          </Text>
+          <Select
+            onChange={handlePausedChange}
+            value={showPaused ?? undefined}
+            variant="flushed"
+          >
+            <option>All</option>
+            <option value="false">Enabled DAGs</option>
+            <option value="true">Disabled DAGs</option>
+          </Select>
+        </Box>
+      </HStack>
+      <ReactSelect isDisabled placeholder="Filter by tag" />
+    </HStack>
+  );
+};

--- a/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -18,7 +18,6 @@
  */
 import {
   Badge,
-  Checkbox,
   Heading,
   HStack,
   Select,
@@ -26,19 +25,18 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
-import { Select as ReactSelect } from "chakra-react-select";
 import { type ChangeEventHandler, useCallback } from "react";
 import { useSearchParams } from "react-router-dom";
 
 import { useDagServiceGetDags } from "openapi/queries";
 import type { DAGResponse } from "openapi/requests/types.gen";
-
-import { DataTable } from "../components/DataTable";
-import { useTableURLState } from "../components/DataTable/useTableUrlState";
-import { QuickFilterButton } from "../components/QuickFilterButton";
-import { SearchBar } from "../components/SearchBar";
-import { pluralize } from "../utils/pluralize";
+import { DataTable } from "src/components/DataTable";
+import { useTableURLState } from "src/components/DataTable/useTableUrlState";
+import { SearchBar } from "src/components/SearchBar";
 import { TogglePause } from "src/components/TogglePause";
+import { pluralize } from "src/utils/pluralize";
+
+import { DagsFilters } from "./DagsFilters";
 
 const columns: Array<ColumnDef<DAGResponse>> = [
   {
@@ -89,9 +87,9 @@ const PAUSED_PARAM = "paused";
 
 // eslint-disable-next-line complexity
 export const DagsList = ({ cardView = false }) => {
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
 
-  const showPaused = searchParams.get(PAUSED_PARAM) === "true";
+  const showPaused = searchParams.get(PAUSED_PARAM);
 
   const { setTableURLState, tableURLState } = useTableURLState();
   const { pagination, sorting } = tableURLState;
@@ -105,21 +103,8 @@ export const DagsList = ({ cardView = false }) => {
     offset: pagination.pageIndex * pagination.pageSize,
     onlyActive: true,
     orderBy,
-    paused: showPaused,
+    paused: showPaused === null ? undefined : showPaused === "true",
   });
-
-  const handlePausedChange = useCallback(() => {
-    searchParams[showPaused ? "delete" : "set"](PAUSED_PARAM, "true");
-    setSearchParams(searchParams);
-    setTableURLState({ pagination: { ...pagination, pageIndex: 0 }, sorting });
-  }, [
-    pagination,
-    searchParams,
-    setSearchParams,
-    setTableURLState,
-    showPaused,
-    sorting,
-  ]);
 
   const handleSortChange = useCallback<ChangeEventHandler<HTMLSelectElement>>(
     ({ currentTarget: { value } }) => {
@@ -143,20 +128,7 @@ export const DagsList = ({ cardView = false }) => {
               buttonProps={{ isDisabled: true }}
               inputProps={{ isDisabled: true }}
             />
-            <HStack justifyContent="space-between">
-              <HStack>
-                <HStack>
-                  <QuickFilterButton isActive>All</QuickFilterButton>
-                  <QuickFilterButton isDisabled>Failed</QuickFilterButton>
-                  <QuickFilterButton isDisabled>Running</QuickFilterButton>
-                  <QuickFilterButton isDisabled>Successful</QuickFilterButton>
-                </HStack>
-                <Checkbox isChecked={showPaused} onChange={handlePausedChange}>
-                  Show Paused DAGs
-                </Checkbox>
-              </HStack>
-              <ReactSelect isDisabled placeholder="Filter by tag" />
-            </HStack>
+            <DagsFilters />
             <HStack justifyContent="space-between">
               <Heading size="md">
                 {pluralize("DAG", data?.total_entries)}

--- a/airflow/ui/src/pages/DagsList/index.tsx
+++ b/airflow/ui/src/pages/DagsList/index.tsx
@@ -1,0 +1,20 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export { DagsList } from "./DagsList";


### PR DESCRIPTION
Add switch to toggle DAGs paused and unpaused. I decided to use "enabled" and "disabled" nomenclature as discussed in https://github.com/apache/airflow/issues/41519, but happy to adjust this.

Also had to add a fix to an outdated eslint rule.

<img width="654" alt="Screenshot 2024-10-01 at 3 24 08 PM" src="https://github.com/user-attachments/assets/8670f9dc-720a-4604-8a03-3aa87c18fae6">

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
