### PR TITLE
Use FAB auth manager in `test_google_openid`

### DIFF
--- a/tests/providers/google/common/auth_backend/test_google_openid.py
+++ b/tests/providers/google/common/auth_backend/test_google_openid.py
@@ -41,7 +41,13 @@ def google_openid_app():
     )
     def factory():
         with conf_vars(
-            {("api", "auth_backends"): "airflow.providers.google.common.auth_backend.google_openid"}
+            {
+                ("api", "auth_backends"): "airflow.providers.google.common.auth_backend.google_openid",
+                (
+                    "core",
+                    "auth_manager",
+                ): "airflow.providers.fab.auth_manager.fab_auth_manager.FabAuthManager",
+            }
         ):
             _app = create_app(testing=True, config={"WTF_CSRF_ENABLED": False})  # type:ignore
             _app.config["AUTH_ROLE_PUBLIC"] = None

--- a/tests/providers/google/common/auth_backend/test_google_openid.py
+++ b/tests/providers/google/common/auth_backend/test_google_openid.py
@@ -22,6 +22,7 @@ import pytest
 from google.auth.exceptions import GoogleAuthError
 
 from airflow.www.app import create_app
+from tests.test_utils.compat import AIRFLOW_V_2_9_PLUS
 from tests.test_utils.config import conf_vars
 from tests.test_utils.db import clear_db_pools
 from tests.test_utils.decorators import dont_initialize_flask_app_submodules
@@ -73,6 +74,7 @@ def admin_user(google_openid_app):
     return role_admin
 
 
+@pytest.mark.skipif(not AIRFLOW_V_2_9_PLUS, reason="The tests should be skipped for Airflow < 2.9")
 @pytest.mark.skip_if_database_isolation_mode
 @pytest.mark.db_test
 class TestGoogleOpenID:


### PR DESCRIPTION
The auth backend Google OpenID relies on FAB auth manager. As such, explicitly set in `test_google_openid` to use the FAB auth manager. This is part of the effort of not assuming FAB auth manager is the default one.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
