### PR TITLE
AIP-84 Migrate the public endpoint DAG Details to FastAPI

### DIFF
--- a/airflow/api_connexion/endpoints/dag_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_endpoint.py
@@ -70,6 +70,7 @@ def get_dag(
     )
 
 
+@mark_fastapi_migration_done
 @security.requires_access_dag("GET")
 @provide_session
 def get_dag_details(

--- a/airflow/api_fastapi/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/openapi/v1-generated.yaml
@@ -370,50 +370,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /public/dags/{dag_id}/details:
-      get:
-        tags:
-        - DAG
-        summary: Get DAG details.
-        description: Get details of a specific DAG.
-        operationId: get_dag_details_public_dags_get_details
-        responses:
-          '200':
-            description: Successful Response
-            content:
-              application/json:
-                schema:
-                  $ref: '#/components/schemas/DAGDetailsResponse'
-          '400':
-            content:
-              application/json:
-                schema:
-                  $ref: '#/components/schemas/HTTPExceptionResponse'
-            description: Bad Request
-          '401':
-            content:
-              application/json:
-                schema:
-                  $ref: '#/components/schemas/HTTPExceptionResponse'
-            description: Unauthorized
-          '403':
-            content:
-              application/json:
-                schema:
-                  $ref: '#/components/schemas/HTTPExceptionResponse'
-            description: Forbidden
-          '404':
-            content:
-              application/json:
-                schema:
-                  $ref: '#/components/schemas/HTTPExceptionResponse'
-            description: Not Found
-          '422':
-            description: Validation Error
-            content:
-              application/json:
-                schema:
-                  $ref: '#/components/schemas/HTTPValidationError'
   /public/connections/{connection_id}:
     delete:
       tags:

--- a/airflow/api_fastapi/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/openapi/v1-generated.yaml
@@ -319,6 +319,50 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /public/dags/{dag_id}/details:
+      get:
+        tags:
+        - DAG
+        summary: Get DAG details.
+        description: Get details of a specific DAG.
+        operationId: get_dag_details_public_dags_get_details
+        responses:
+          '200':
+            description: Successful Response
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/DAGDetailsResponse'
+          '400':
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/HTTPExceptionResponse'
+            description: Bad Request
+          '401':
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/HTTPExceptionResponse'
+            description: Unauthorized
+          '403':
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/HTTPExceptionResponse'
+            description: Forbidden
+          '404':
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/HTTPExceptionResponse'
+            description: Not Found
+          '422':
+            description: Validation Error
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/HTTPValidationError'
   /public/connections/{connection_id}:
     delete:
       tags:

--- a/airflow/api_fastapi/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/openapi/v1-generated.yaml
@@ -252,6 +252,57 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /public/dags/{dag_id}/details:
+    get:
+      tags:
+      - DAG
+      summary: Get Dag Details
+      description: Get details of DAG.
+      operationId: get_dag_details
+      parameters:
+      - name: dag_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Dag Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DAGDetailsResponse'
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Bad Request
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Unauthorized
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Forbidden
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Not Found
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Unprocessable Entity
   /public/dags/{dag_id}:
     patch:
       tags:
@@ -422,6 +473,253 @@ components:
       - total_entries
       title: DAGCollectionResponse
       description: DAG Collection serializer for responses.
+    DAGDetailsResponse:
+      properties:
+        dag_id:
+          type: string
+          title: Dag Id
+        dag_display_name:
+          type: string
+          title: Dag Display Name
+        is_paused:
+          type: boolean
+          title: Is Paused
+        is_active:
+          type: boolean
+          title: Is Active
+        last_parsed_time:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Last Parsed Time
+        last_pickled:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Last Pickled
+        last_expired:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Last Expired
+        scheduler_lock:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Scheduler Lock
+        pickle_id:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Pickle Id
+        default_view:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Default View
+        fileloc:
+          type: string
+          title: Fileloc
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+        timetable_summary:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Timetable Summary
+        timetable_description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Timetable Description
+        tags:
+          items:
+            $ref: '#/components/schemas/DagTagPydantic'
+          type: array
+          title: Tags
+        max_active_tasks:
+          type: integer
+          title: Max Active Tasks
+        max_active_runs:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Max Active Runs
+        max_consecutive_failed_dag_runs:
+          type: integer
+          title: Max Consecutive Failed Dag Runs
+        has_task_concurrency_limits:
+          type: boolean
+          title: Has Task Concurrency Limits
+        has_import_errors:
+          type: boolean
+          title: Has Import Errors
+        next_dagrun:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Next Dagrun
+        next_dagrun_data_interval_start:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Next Dagrun Data Interval Start
+        next_dagrun_data_interval_end:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Next Dagrun Data Interval End
+        next_dagrun_create_after:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Next Dagrun Create After
+        owners:
+          items:
+            type: string
+          type: array
+          title: Owners
+        catchup:
+          type: boolean
+          title: Catchup
+        dagrun_timeout:
+          anyOf:
+          - type: string
+            format: duration
+          - type: 'null'
+          title: Dagrun Timeout
+        dataset_expression:
+          anyOf:
+          - type: object
+          - type: 'null'
+          title: Dataset Expression
+        doc_md:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Doc Md
+        start_date:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Start Date
+        end_date:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: End Date
+        is_paused_upon_creation:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Is Paused Upon Creation
+        orientation:
+          type: string
+          title: Orientation
+        params:
+          anyOf:
+          - {}
+          - type: 'null'
+          title: Params
+        render_template_as_native_obj:
+          type: boolean
+          title: Render Template As Native Obj
+        template_searchpath:
+          anyOf:
+          - type: string
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Template Searchpath
+        timezone:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Timezone
+        last_loaded:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Last Loaded
+        file_token:
+          type: string
+          title: File Token
+          description: Return file token.
+          readOnly: true
+        concurrency:
+          type: integer
+          title: Concurrency
+          description: Return max_active_tasks as concurrency.
+          readOnly: true
+        last_parsed:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Last Parsed
+          description: Return last_loaded as last_parsed.
+          readOnly: true
+      type: object
+      required:
+      - dag_id
+      - dag_display_name
+      - is_paused
+      - is_active
+      - last_parsed_time
+      - last_pickled
+      - last_expired
+      - scheduler_lock
+      - pickle_id
+      - default_view
+      - fileloc
+      - description
+      - timetable_summary
+      - timetable_description
+      - tags
+      - max_active_tasks
+      - max_active_runs
+      - max_consecutive_failed_dag_runs
+      - has_task_concurrency_limits
+      - has_import_errors
+      - next_dagrun
+      - next_dagrun_data_interval_start
+      - next_dagrun_data_interval_end
+      - next_dagrun_create_after
+      - owners
+      - catchup
+      - dagrun_timeout
+      - dataset_expression
+      - doc_md
+      - start_date
+      - end_date
+      - is_paused_upon_creation
+      - orientation
+      - params
+      - render_template_as_native_obj
+      - template_searchpath
+      - timezone
+      - last_loaded
+      - file_token
+      - concurrency
+      - last_parsed
+      title: DAGDetailsResponse
+      description: Specific serializer for DAG Details responses.
     DAGPatchBody:
       properties:
         is_paused:

--- a/airflow/api_fastapi/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/openapi/v1-generated.yaml
@@ -594,12 +594,12 @@ components:
         catchup:
           type: boolean
           title: Catchup
-        dagrun_timeout:
+        dag_run_timeout:
           anyOf:
           - type: string
             format: duration
           - type: 'null'
-          title: Dagrun Timeout
+          title: Dag Run Timeout
         dataset_expression:
           anyOf:
           - type: object
@@ -632,31 +632,30 @@ components:
           title: Orientation
         params:
           anyOf:
-          - {}
+          - type: object
           - type: 'null'
           title: Params
         render_template_as_native_obj:
           type: boolean
           title: Render Template As Native Obj
-        template_searchpath:
+        template_search_path:
           anyOf:
-          - type: string
           - items:
               type: string
             type: array
           - type: 'null'
-          title: Template Searchpath
+          title: Template Search Path
         timezone:
           anyOf:
           - type: string
           - type: 'null'
           title: Timezone
-        last_loaded:
+        last_parsed:
           anyOf:
           - type: string
             format: date-time
           - type: 'null'
-          title: Last Loaded
+          title: Last Parsed
         file_token:
           type: string
           title: File Token
@@ -666,14 +665,6 @@ components:
           type: integer
           title: Concurrency
           description: Return max_active_tasks as concurrency.
-          readOnly: true
-        last_parsed:
-          anyOf:
-          - type: string
-            format: date-time
-          - type: 'null'
-          title: Last Parsed
-          description: Return last_loaded as last_parsed.
           readOnly: true
       type: object
       required:
@@ -703,7 +694,7 @@ components:
       - next_dagrun_create_after
       - owners
       - catchup
-      - dagrun_timeout
+      - dag_run_timeout
       - dataset_expression
       - doc_md
       - start_date
@@ -712,12 +703,11 @@ components:
       - orientation
       - params
       - render_template_as_native_obj
-      - template_searchpath
+      - template_search_path
       - timezone
-      - last_loaded
+      - last_parsed
       - file_token
       - concurrency
-      - last_parsed
       title: DAGDetailsResponse
       description: Specific serializer for DAG Details responses.
     DAGPatchBody:

--- a/airflow/api_fastapi/serializers/dags.py
+++ b/airflow/api_fastapi/serializers/dags.py
@@ -22,7 +22,7 @@ from datetime import datetime, timedelta
 from typing import Any, Iterable
 
 from itsdangerous import URLSafeSerializer
-from pendulum import FixedTimezone, Timezone
+from pendulum.tz.timezone import FixedTimezone, Timezone
 from pydantic import (
     BaseModel,
     computed_field,

--- a/airflow/api_fastapi/serializers/dags.py
+++ b/airflow/api_fastapi/serializers/dags.py
@@ -24,9 +24,9 @@ from typing import Any, Iterable
 from itsdangerous import URLSafeSerializer
 from pendulum.tz.timezone import FixedTimezone, Timezone
 from pydantic import (
-    AliasGenerator,
+    AliasChoices,
     BaseModel,
-    ConfigDict,
+    Field,
     computed_field,
     field_validator,
 )
@@ -103,7 +103,9 @@ class DAGDetailsResponse(DAGResponse):
     """Specific serializer for DAG Details responses."""
 
     catchup: bool
-    dag_run_timeout: timedelta | None
+    dag_run_timeout: timedelta | None = Field(
+        validation_alias=AliasChoices("dag_run_timeout", "dagrun_timeout")
+    )
     dataset_expression: dict | None
     doc_md: str | None
     start_date: datetime | None
@@ -112,19 +114,11 @@ class DAGDetailsResponse(DAGResponse):
     orientation: str
     params: abc.MutableMapping | None
     render_template_as_native_obj: bool
-    template_search_path: Iterable[str] | None
-    timezone: str | None
-    last_parsed: datetime | None
-
-    model_config = ConfigDict(
-        alias_generator=AliasGenerator(
-            validation_alias=lambda field_name: {
-                "dag_run_timeout": "dagrun_timeout",
-                "last_parsed": "last_loaded",
-                "template_search_path": "template_searchpath",
-            }.get(field_name, field_name),
-        )
+    template_search_path: Iterable[str] | None = Field(
+        validation_alias=AliasChoices("template_search_path", "template_searchpath")
     )
+    timezone: str | None
+    last_parsed: datetime | None = Field(validation_alias=AliasChoices("last_parsed", "last_loaded"))
 
     @field_validator("timezone", mode="before")
     @classmethod

--- a/airflow/api_fastapi/serializers/dags.py
+++ b/airflow/api_fastapi/serializers/dags.py
@@ -32,7 +32,6 @@ from pydantic import (
 )
 
 from airflow.configuration import conf
-from airflow.models.param import Param
 from airflow.serialization.pydantic.dag import DagTagPydantic
 
 

--- a/airflow/api_fastapi/serializers/dags.py
+++ b/airflow/api_fastapi/serializers/dags.py
@@ -30,7 +30,6 @@ from pydantic import (
 )
 
 from airflow.configuration import conf
-from airflow.models.param import Param
 from airflow.serialization.pydantic.dag import DagTagPydantic
 
 
@@ -139,13 +138,15 @@ class DAGDetailsResponse(DAGResponse):
             return None
         return {param_name: param_val.serialize() for param_name, param_val in params.items()}
 
-    @computed_field
+    # Mypy issue https://github.com/python/mypy/issues/1362
+    @computed_field  # type: ignore[misc]
     @property
     def concurrency(self) -> int:
         """Return max_active_tasks as concurrency."""
         return self.max_active_tasks
 
-    @computed_field
+    # Mypy issue https://github.com/python/mypy/issues/1362
+    @computed_field  # type: ignore[misc]
     @property
     def last_parsed(self) -> datetime | None:
         """Return last_loaded as last_parsed."""

--- a/airflow/api_fastapi/serializers/dags.py
+++ b/airflow/api_fastapi/serializers/dags.py
@@ -116,17 +116,13 @@ class DAGDetailsResponse(DAGResponse):
     timezone: str | None
     last_parsed: datetime | None
 
-    def _validation_alias_fn(field_name: str):
-        val_dict = {
-            "dag_run_timeout": "dagrun_timeout",
-            "last_parsed": "last_loaded",
-            "template_search_path": "template_searchpath",
-        }
-        return val_dict.get(field_name, field_name)
-
     model_config = ConfigDict(
         alias_generator=AliasGenerator(
-            validation_alias=_validation_alias_fn,
+            validation_alias=lambda field_name: {
+                "dag_run_timeout": "dagrun_timeout",
+                "last_parsed": "last_loaded",
+                "template_search_path": "template_searchpath",
+            }.get(field_name, field_name),
         )
     )
 

--- a/airflow/api_fastapi/views/public/dags.py
+++ b/airflow/api_fastapi/views/public/dags.py
@@ -17,7 +17,8 @@
 
 from __future__ import annotations
 
-from fastapi import Depends, HTTPException, Query
+from fastapi import Depends, HTTPException, Query, Request
+from pydantic import ValidationError
 from sqlalchemy import update
 from sqlalchemy.orm import Session
 from typing_extensions import Annotated
@@ -41,9 +42,14 @@ from airflow.api_fastapi.parameters import (
     QueryTagsFilter,
     SortParam,
 )
-from airflow.api_fastapi.serializers.dags import DAGCollectionResponse, DAGPatchBody, DAGResponse
+from airflow.api_fastapi.serializers.dags import (
+    DAGCollectionResponse,
+    DAGDetailsResponse,
+    DAGPatchBody,
+    DAGResponse,
+)
 from airflow.api_fastapi.views.router import AirflowRouter
-from airflow.models import DagModel
+from airflow.models import DAG, DagModel
 
 dags_router = AirflowRouter(tags=["DAG"])
 
@@ -85,6 +91,34 @@ async def get_dags(
         dags=[DAGResponse.model_validate(dag, from_attributes=True) for dag in dags],
         total_entries=total_entries,
     )
+
+
+@dags_router.get(
+    "/dags/{dag_id}/details", responses=create_openapi_http_exception_doc([400, 401, 403, 404, 422])
+)
+async def get_dag_details(
+    dag_id: str, session: Annotated[Session, Depends(get_session)], request: Request
+) -> DAGDetailsResponse:
+    """Get details of DAG."""
+    if not session:
+        raise HTTPException(401, "Invalid session")
+
+    dag: DAG = request.app.state.dag_bag.get_dag(dag_id)
+    if not dag:
+        raise HTTPException(404, f"Dag with id {dag_id} was not found")
+
+    dag_model: DagModel = session.get(DagModel, dag_id)
+    if not dag_model:
+        raise HTTPException(400, f"Unable to obtain dag with id {dag_id} from session")
+
+    for key, value in dag.__dict__.items():
+        if not key.startswith("_") and not hasattr(dag_model, key):
+            setattr(dag_model, key, value)
+
+    try:
+        return DAGDetailsResponse.model_validate(dag_model, from_attributes=True)
+    except ValidationError as ve:
+        raise HTTPException(422, f"Error while validating dag model with id {dag_id}, details: {str(ve)}")
 
 
 @dags_router.patch("/dags/{dag_id}", responses=create_openapi_http_exception_doc([400, 401, 403, 404]))

--- a/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow/ui/openapi-gen/queries/common.ts
@@ -74,6 +74,22 @@ export const UseDagServiceGetDagsKeyFn = (
     },
   ]),
 ];
+export type DagServiceGetDagDetailsDefaultResponse = Awaited<
+  ReturnType<typeof DagService.getDagDetails>
+>;
+export type DagServiceGetDagDetailsQueryResult<
+  TData = DagServiceGetDagDetailsDefaultResponse,
+  TError = unknown,
+> = UseQueryResult<TData, TError>;
+export const useDagServiceGetDagDetailsKey = "DagServiceGetDagDetails";
+export const UseDagServiceGetDagDetailsKeyFn = (
+  {
+    dagId,
+  }: {
+    dagId: string;
+  },
+  queryKey?: Array<unknown>,
+) => [useDagServiceGetDagDetailsKey, ...(queryKey ?? [{ dagId }])];
 export type DagServicePatchDagsMutationResult = Awaited<
   ReturnType<typeof DagService.patchDags>
 >;

--- a/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -94,3 +94,23 @@ export const prefetchUseDagServiceGetDags = (
         tags,
       }),
   });
+/**
+ * Get Dag Details
+ * Get details of DAG.
+ * @param data The data for the request.
+ * @param data.dagId
+ * @returns DAGDetailsResponse Successful Response
+ * @throws ApiError
+ */
+export const prefetchUseDagServiceGetDagDetails = (
+  queryClient: QueryClient,
+  {
+    dagId,
+  }: {
+    dagId: string;
+  },
+) =>
+  queryClient.prefetchQuery({
+    queryKey: Common.UseDagServiceGetDagDetailsKeyFn({ dagId }),
+    queryFn: () => DagService.getDagDetails({ dagId }),
+  });

--- a/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow/ui/openapi-gen/queries/queries.ts
@@ -119,6 +119,32 @@ export const useDagServiceGetDags = <
     ...options,
   });
 /**
+ * Get Dag Details
+ * Get details of DAG.
+ * @param data The data for the request.
+ * @param data.dagId
+ * @returns DAGDetailsResponse Successful Response
+ * @throws ApiError
+ */
+export const useDagServiceGetDagDetails = <
+  TData = Common.DagServiceGetDagDetailsDefaultResponse,
+  TError = unknown,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  {
+    dagId,
+  }: {
+    dagId: string;
+  },
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
+) =>
+  useQuery<TData, TError>({
+    queryKey: Common.UseDagServiceGetDagDetailsKeyFn({ dagId }, queryKey),
+    queryFn: () => DagService.getDagDetails({ dagId }) as TData,
+    ...options,
+  });
+/**
  * Patch Dags
  * Patch multiple DAGs.
  * @param data The data for the request.

--- a/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow/ui/openapi-gen/queries/suspense.ts
@@ -109,3 +109,29 @@ export const useDagServiceGetDagsSuspense = <
       }) as TData,
     ...options,
   });
+/**
+ * Get Dag Details
+ * Get details of DAG.
+ * @param data The data for the request.
+ * @param data.dagId
+ * @returns DAGDetailsResponse Successful Response
+ * @throws ApiError
+ */
+export const useDagServiceGetDagDetailsSuspense = <
+  TData = Common.DagServiceGetDagDetailsDefaultResponse,
+  TError = unknown,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  {
+    dagId,
+  }: {
+    dagId: string;
+  },
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
+) =>
+  useSuspenseQuery<TData, TError>({
+    queryKey: Common.UseDagServiceGetDagDetailsKeyFn({ dagId }, queryKey),
+    queryFn: () => DagService.getDagDetails({ dagId }) as TData,
+    ...options,
+  });

--- a/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -239,7 +239,7 @@ export const $DAGDetailsResponse = {
       type: "boolean",
       title: "Catchup",
     },
-    dagrun_timeout: {
+    dag_run_timeout: {
       anyOf: [
         {
           type: "string",
@@ -249,7 +249,7 @@ export const $DAGDetailsResponse = {
           type: "null",
         },
       ],
-      title: "Dagrun Timeout",
+      title: "Dag Run Timeout",
     },
     dataset_expression: {
       anyOf: [
@@ -314,7 +314,9 @@ export const $DAGDetailsResponse = {
     },
     params: {
       anyOf: [
-        {},
+        {
+          type: "object",
+        },
         {
           type: "null",
         },
@@ -325,11 +327,8 @@ export const $DAGDetailsResponse = {
       type: "boolean",
       title: "Render Template As Native Obj",
     },
-    template_searchpath: {
+    template_search_path: {
       anyOf: [
-        {
-          type: "string",
-        },
         {
           items: {
             type: "string",
@@ -340,7 +339,7 @@ export const $DAGDetailsResponse = {
           type: "null",
         },
       ],
-      title: "Template Searchpath",
+      title: "Template Search Path",
     },
     timezone: {
       anyOf: [
@@ -353,30 +352,6 @@ export const $DAGDetailsResponse = {
       ],
       title: "Timezone",
     },
-    last_loaded: {
-      anyOf: [
-        {
-          type: "string",
-          format: "date-time",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Last Loaded",
-    },
-    file_token: {
-      type: "string",
-      title: "File Token",
-      description: "Return file token.",
-      readOnly: true,
-    },
-    concurrency: {
-      type: "integer",
-      title: "Concurrency",
-      description: "Return max_active_tasks as concurrency.",
-      readOnly: true,
-    },
     last_parsed: {
       anyOf: [
         {
@@ -388,7 +363,17 @@ export const $DAGDetailsResponse = {
         },
       ],
       title: "Last Parsed",
-      description: "Return last_loaded as last_parsed.",
+    },
+    file_token: {
+      type: "string",
+      title: "File Token",
+      description: "Return file token.",
+      readOnly: true,
+    },
+    concurrency: {
+      type: "integer",
+      title: "Concurrency",
+      description: "Return max_active_tasks as concurrency.",
       readOnly: true,
     },
   },
@@ -420,7 +405,7 @@ export const $DAGDetailsResponse = {
     "next_dagrun_create_after",
     "owners",
     "catchup",
-    "dagrun_timeout",
+    "dag_run_timeout",
     "dataset_expression",
     "doc_md",
     "start_date",
@@ -429,12 +414,11 @@ export const $DAGDetailsResponse = {
     "orientation",
     "params",
     "render_template_as_native_obj",
-    "template_searchpath",
+    "template_search_path",
     "timezone",
-    "last_loaded",
+    "last_parsed",
     "file_token",
     "concurrency",
-    "last_parsed",
   ],
   title: "DAGDetailsResponse",
   description: "Specific serializer for DAG Details responses.",

--- a/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -20,6 +20,426 @@ export const $DAGCollectionResponse = {
   description: "DAG Collection serializer for responses.",
 } as const;
 
+export const $DAGDetailsResponse = {
+  properties: {
+    dag_id: {
+      type: "string",
+      title: "Dag Id",
+    },
+    dag_display_name: {
+      type: "string",
+      title: "Dag Display Name",
+    },
+    is_paused: {
+      type: "boolean",
+      title: "Is Paused",
+    },
+    is_active: {
+      type: "boolean",
+      title: "Is Active",
+    },
+    last_parsed_time: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Last Parsed Time",
+    },
+    last_pickled: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Last Pickled",
+    },
+    last_expired: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Last Expired",
+    },
+    scheduler_lock: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Scheduler Lock",
+    },
+    pickle_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Pickle Id",
+    },
+    default_view: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Default View",
+    },
+    fileloc: {
+      type: "string",
+      title: "Fileloc",
+    },
+    description: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Description",
+    },
+    timetable_summary: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Timetable Summary",
+    },
+    timetable_description: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Timetable Description",
+    },
+    tags: {
+      items: {
+        $ref: "#/components/schemas/DagTagPydantic",
+      },
+      type: "array",
+      title: "Tags",
+    },
+    max_active_tasks: {
+      type: "integer",
+      title: "Max Active Tasks",
+    },
+    max_active_runs: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Max Active Runs",
+    },
+    max_consecutive_failed_dag_runs: {
+      type: "integer",
+      title: "Max Consecutive Failed Dag Runs",
+    },
+    has_task_concurrency_limits: {
+      type: "boolean",
+      title: "Has Task Concurrency Limits",
+    },
+    has_import_errors: {
+      type: "boolean",
+      title: "Has Import Errors",
+    },
+    next_dagrun: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Next Dagrun",
+    },
+    next_dagrun_data_interval_start: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Next Dagrun Data Interval Start",
+    },
+    next_dagrun_data_interval_end: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Next Dagrun Data Interval End",
+    },
+    next_dagrun_create_after: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Next Dagrun Create After",
+    },
+    owners: {
+      items: {
+        type: "string",
+      },
+      type: "array",
+      title: "Owners",
+    },
+    catchup: {
+      type: "boolean",
+      title: "Catchup",
+    },
+    dagrun_timeout: {
+      anyOf: [
+        {
+          type: "string",
+          format: "duration",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Dagrun Timeout",
+    },
+    dataset_expression: {
+      anyOf: [
+        {
+          type: "object",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Dataset Expression",
+    },
+    doc_md: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Doc Md",
+    },
+    start_date: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Start Date",
+    },
+    end_date: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "End Date",
+    },
+    is_paused_upon_creation: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Is Paused Upon Creation",
+    },
+    orientation: {
+      type: "string",
+      title: "Orientation",
+    },
+    params: {
+      anyOf: [
+        {},
+        {
+          type: "null",
+        },
+      ],
+      title: "Params",
+    },
+    render_template_as_native_obj: {
+      type: "boolean",
+      title: "Render Template As Native Obj",
+    },
+    template_searchpath: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          items: {
+            type: "string",
+          },
+          type: "array",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Template Searchpath",
+    },
+    timezone: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Timezone",
+    },
+    last_loaded: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Last Loaded",
+    },
+    file_token: {
+      type: "string",
+      title: "File Token",
+      description: "Return file token.",
+      readOnly: true,
+    },
+    concurrency: {
+      type: "integer",
+      title: "Concurrency",
+      description: "Return max_active_tasks as concurrency.",
+      readOnly: true,
+    },
+    last_parsed: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Last Parsed",
+      description: "Return last_loaded as last_parsed.",
+      readOnly: true,
+    },
+  },
+  type: "object",
+  required: [
+    "dag_id",
+    "dag_display_name",
+    "is_paused",
+    "is_active",
+    "last_parsed_time",
+    "last_pickled",
+    "last_expired",
+    "scheduler_lock",
+    "pickle_id",
+    "default_view",
+    "fileloc",
+    "description",
+    "timetable_summary",
+    "timetable_description",
+    "tags",
+    "max_active_tasks",
+    "max_active_runs",
+    "max_consecutive_failed_dag_runs",
+    "has_task_concurrency_limits",
+    "has_import_errors",
+    "next_dagrun",
+    "next_dagrun_data_interval_start",
+    "next_dagrun_data_interval_end",
+    "next_dagrun_create_after",
+    "owners",
+    "catchup",
+    "dagrun_timeout",
+    "dataset_expression",
+    "doc_md",
+    "start_date",
+    "end_date",
+    "is_paused_upon_creation",
+    "orientation",
+    "params",
+    "render_template_as_native_obj",
+    "template_searchpath",
+    "timezone",
+    "last_loaded",
+    "file_token",
+    "concurrency",
+    "last_parsed",
+  ],
+  title: "DAGDetailsResponse",
+  description: "Specific serializer for DAG Details responses.",
+} as const;
+
 export const $DAGPatchBody = {
   properties: {
     is_paused: {

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -9,6 +9,8 @@ import type {
   GetDagsResponse,
   PatchDagsData,
   PatchDagsResponse,
+  GetDagDetailsData,
+  GetDagDetailsResponse,
   PatchDagData,
   PatchDagResponse,
   DeleteConnectionData,
@@ -123,6 +125,33 @@ export class DagService {
         403: "Forbidden",
         404: "Not Found",
         422: "Validation Error",
+      },
+    });
+  }
+
+  /**
+   * Get Dag Details
+   * Get details of DAG.
+   * @param data The data for the request.
+   * @param data.dagId
+   * @returns DAGDetailsResponse Successful Response
+   * @throws ApiError
+   */
+  public static getDagDetails(
+    data: GetDagDetailsData,
+  ): CancelablePromise<GetDagDetailsResponse> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/public/dags/{dag_id}/details",
+      path: {
+        dag_id: data.dagId,
+      },
+      errors: {
+        400: "Bad Request",
+        401: "Unauthorized",
+        403: "Forbidden",
+        404: "Not Found",
+        422: "Unprocessable Entity",
       },
     });
   }

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -9,6 +9,64 @@ export type DAGCollectionResponse = {
 };
 
 /**
+ * Specific serializer for DAG Details responses.
+ */
+export type DAGDetailsResponse = {
+  dag_id: string;
+  dag_display_name: string;
+  is_paused: boolean;
+  is_active: boolean;
+  last_parsed_time: string | null;
+  last_pickled: string | null;
+  last_expired: string | null;
+  scheduler_lock: string | null;
+  pickle_id: string | null;
+  default_view: string | null;
+  fileloc: string;
+  description: string | null;
+  timetable_summary: string | null;
+  timetable_description: string | null;
+  tags: Array<DagTagPydantic>;
+  max_active_tasks: number;
+  max_active_runs: number | null;
+  max_consecutive_failed_dag_runs: number;
+  has_task_concurrency_limits: boolean;
+  has_import_errors: boolean;
+  next_dagrun: string | null;
+  next_dagrun_data_interval_start: string | null;
+  next_dagrun_data_interval_end: string | null;
+  next_dagrun_create_after: string | null;
+  owners: Array<string>;
+  catchup: boolean;
+  dagrun_timeout: string | null;
+  dataset_expression: {
+    [key: string]: unknown;
+  } | null;
+  doc_md: string | null;
+  start_date: string | null;
+  end_date: string | null;
+  is_paused_upon_creation: boolean | null;
+  orientation: string;
+  params: unknown | null;
+  render_template_as_native_obj: boolean;
+  template_searchpath: string | Array<string> | null;
+  timezone: string | null;
+  last_loaded: string | null;
+  /**
+   * Return file token.
+   */
+  readonly file_token: string;
+  /**
+   * Return max_active_tasks as concurrency.
+   */
+  readonly concurrency: number;
+  /**
+   * Return last_loaded as last_parsed.
+   */
+  readonly last_parsed: string | null;
+};
+
+/**
  * Dag Serializer for updatable body.
  */
 export type DAGPatchBody = {
@@ -126,6 +184,12 @@ export type PatchDagsData = {
 
 export type PatchDagsResponse = DAGCollectionResponse;
 
+export type GetDagDetailsData = {
+  dagId: string;
+};
+
+export type GetDagDetailsResponse = DAGDetailsResponse;
+
 export type PatchDagData = {
   dagId: string;
   requestBody: DAGPatchBody;
@@ -199,6 +263,37 @@ export type $OpenApiTs = {
          * Validation Error
          */
         422: HTTPValidationError;
+      };
+    };
+  };
+  "/public/dags/{dag_id}/details": {
+    get: {
+      req: GetDagDetailsData;
+      res: {
+        /**
+         * Successful Response
+         */
+        200: DAGDetailsResponse;
+        /**
+         * Bad Request
+         */
+        400: HTTPExceptionResponse;
+        /**
+         * Unauthorized
+         */
+        401: HTTPExceptionResponse;
+        /**
+         * Forbidden
+         */
+        403: HTTPExceptionResponse;
+        /**
+         * Not Found
+         */
+        404: HTTPExceptionResponse;
+        /**
+         * Unprocessable Entity
+         */
+        422: HTTPExceptionResponse;
       };
     };
   };

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -38,7 +38,7 @@ export type DAGDetailsResponse = {
   next_dagrun_create_after: string | null;
   owners: Array<string>;
   catchup: boolean;
-  dagrun_timeout: string | null;
+  dag_run_timeout: string | null;
   dataset_expression: {
     [key: string]: unknown;
   } | null;
@@ -47,11 +47,13 @@ export type DAGDetailsResponse = {
   end_date: string | null;
   is_paused_upon_creation: boolean | null;
   orientation: string;
-  params: unknown | null;
+  params: {
+    [key: string]: unknown;
+  } | null;
   render_template_as_native_obj: boolean;
-  template_searchpath: string | Array<string> | null;
+  template_search_path: Array<string> | null;
   timezone: string | null;
-  last_loaded: string | null;
+  last_parsed: string | null;
   /**
    * Return file token.
    */
@@ -60,10 +62,6 @@ export type DAGDetailsResponse = {
    * Return max_active_tasks as concurrency.
    */
   readonly concurrency: number;
-  /**
-   * Return last_loaded as last_parsed.
-   */
-  readonly last_parsed: string | null;
 };
 
 /**

--- a/tests/api_fastapi/views/public/test_dags.py
+++ b/tests/api_fastapi/views/public/test_dags.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+import pendulum
 import pytest
 
 from airflow.models.dag import DagModel
@@ -34,8 +35,10 @@ DAG1_ID = "test_dag1"
 DAG1_DISPLAY_NAME = "display1"
 DAG2_ID = "test_dag2"
 DAG2_DISPLAY_NAME = "display2"
+DAG2_START_DATE = datetime(2021, 6, 15, tzinfo=timezone.utc)
 DAG3_ID = "test_dag3"
 TASK_ID = "op1"
+UTC_JSON_REPR = "UTC" if pendulum.__version__.startswith("3") else "Timezone('UTC')"
 
 
 @provide_session
@@ -96,11 +99,11 @@ def setup(dag_maker) -> None:
         DAG2_ID,
         dag_display_name=DAG2_DISPLAY_NAME,
         schedule=None,
-        start_date=datetime(
-            2021,
-            6,
-            15,
-        ),
+        start_date=DAG2_START_DATE,
+        doc_md="details",
+        params={"foo": 1},
+        max_active_tasks=16,
+        max_active_runs=16,
     ):
         EmptyOperator(task_id=TASK_ID)
 
@@ -225,3 +228,73 @@ def test_patch_dags(test_client, query_params, body, expected_status_code, expec
         assert [dag["dag_id"] for dag in body["dags"]] == expected_ids
         paused_dag_ids = [dag["dag_id"] for dag in body["dags"] if dag["is_paused"]]
         assert paused_dag_ids == expected_paused_ids
+
+
+@pytest.mark.parametrize(
+    "query_params, dag_id, expected_status_code, dag_display_name, start_date",
+    [
+        ({}, "fake_dag_id", 404, "fake_dag", datetime(2023, 12, 31, tzinfo=timezone.utc)),
+        ({}, DAG2_ID, 200, DAG2_DISPLAY_NAME, DAG2_START_DATE),
+    ],
+)
+def test_dag_details(test_client, query_params, dag_id, expected_status_code, dag_display_name, start_date):
+    response = test_client.get(f"/public/dags/{dag_id}/details", params=query_params)
+    assert response.status_code == expected_status_code
+    if expected_status_code != 200:
+        return
+
+    # Match expected and actual responses below.
+    res_json = response.json()
+    last_loaded = res_json["last_loaded"]
+    last_parsed_time = res_json["last_parsed_time"]
+    file_token = res_json["file_token"]
+    expected = {
+        "catchup": True,
+        "concurrency": 16,
+        "dag_id": dag_id,
+        "dag_display_name": dag_display_name,
+        "dagrun_timeout": None,
+        "dataset_expression": None,
+        "default_view": "grid",
+        "description": None,
+        "doc_md": "details",
+        "end_date": None,
+        "fileloc": "/opt/airflow/tests/api_fastapi/views/public/test_dags.py",
+        "file_token": file_token,
+        "has_import_errors": False,
+        "has_task_concurrency_limits": False,
+        "is_active": True,
+        "is_paused": False,
+        "is_paused_upon_creation": None,
+        "last_expired": None,
+        "last_parsed": last_loaded,
+        "last_loaded": last_loaded, # TODO: remove last_loaded as it is the same as last_parsed
+        "last_parsed_time": last_parsed_time,
+        "last_pickled": None,
+        "max_active_runs": 16,
+        "max_active_tasks": 16,
+        "max_consecutive_failed_dag_runs": 0,
+        "next_dagrun": None,
+        "next_dagrun_create_after": None,
+        "next_dagrun_data_interval_end": None,
+        "next_dagrun_data_interval_start": None,
+        "orientation": "LR",
+        "owners": ["airflow"],
+        "params": {
+            "foo": {
+                "description": None,
+                "schema": {},
+                "value": 1,
+            }
+        },
+        "pickle_id": None,
+        "render_template_as_native_obj": False,
+        "timetable_summary": None,
+        "scheduler_lock": None,
+        "start_date": start_date.replace(tzinfo=None).isoformat() + "Z",  # pydantic datetime format
+        "tags": [],
+        "template_searchpath": None,
+        "timetable_description": "Never, external triggers only",
+        "timezone": UTC_JSON_REPR,
+    }
+    assert res_json == expected

--- a/tests/api_fastapi/views/public/test_dags.py
+++ b/tests/api_fastapi/views/public/test_dags.py
@@ -268,7 +268,7 @@ def test_dag_details(test_client, query_params, dag_id, expected_status_code, da
         "is_paused_upon_creation": None,
         "last_expired": None,
         "last_parsed": last_loaded,
-        "last_loaded": last_loaded, # TODO: remove last_loaded as it is the same as last_parsed
+        "last_loaded": last_loaded,  # TODO: remove last_loaded as it is the same as last_parsed
         "last_parsed_time": last_parsed_time,
         "last_pickled": None,
         "max_active_runs": 16,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

Closes: #42453 
Related: #42370 

This migrates the Get DAG Details API from `api_connexion` to `api_fastapi`.