### PR TITLE
Spot clean try_number references to use ti.try_number

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -927,7 +927,7 @@ logging:
       is_template: true
       default: "dag_id={{ ti.dag_id }}/run_id={{ ti.run_id }}/task_id={{ ti.task_id }}/\
                {%% if ti.map_index >= 0 %%}map_index={{ ti.map_index }}/{%% endif %%}\
-               attempt={{ try_number }}.log"
+               attempt={{ ti.try_number }}.log"
     log_processor_filename_template:
       description: |
         Formatting for how airflow generates file names for log


### PR DESCRIPTION
Some tasks in airflow 2.10.2 are being launched with try number 0. However, the webserver is looking for logs starting with try number 1. Upon further investigation, I suspect that `{try_number}` and `{ti.try_number}` are diverging leading to this. 

This is an attempt to cleanup references to `{try_number}`

related: #42549, #39336
