### PR TITLE
Revert "Fix the order of tasks during serialization (#42219)"

### DIFF
--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -1604,9 +1604,7 @@ class SerializedDAG(DAG, BaseSerialization):
         try:
             serialized_dag = cls.serialize_to_json(dag, cls._decorated_fields)
             serialized_dag["_processor_dags_folder"] = DAGS_FOLDER
-            serialized_dag["tasks"] = [
-                cls.serialize(dag.task_dict[task_id]) for task_id in sorted(dag.task_dict)
-            ]
+            serialized_dag["tasks"] = [cls.serialize(task) for _, task in dag.task_dict.items()]
 
             dag_deps = [
                 dep


### PR DESCRIPTION
This reverts commit adb9466bd7ce1c92e51f11a90d39fd557c99dc5b a.k.a. PR #42219, which was causing tests to fail.
