### PR TITLE
Point users at `db migrate` if there are outstanding migrations

### DIFF
--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -882,8 +882,8 @@ def check_and_run_migrations():
         verb = "initialize"
     elif source_heads != db_heads:
         db_command = upgradedb
-        command_name = "upgrade"
-        verb = "upgrade"
+        command_name = "migrate"
+        verb = "migrate"
 
     if sys.stdout.isatty() and verb:
         print()


### PR DESCRIPTION
Before:
```
You still have unapplied migrations. You may need to upgrade the database by running `airflow db upgrade`.  Make sure the 
command is run using Airflow version 3.0.0.dev0.
```

After:
```
You still have unapplied migrations. You may need to migrate the database by running `airflow db migrate`.  Make sure the 
command is run using Airflow version 3.0.0.dev0.
```