### PR TITLE
Fix gcp_conn_id in PubsubPullTrigger

### DIFF
--- a/airflow/providers/google/cloud/triggers/pubsub.py
+++ b/airflow/providers/google/cloud/triggers/pubsub.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 import asyncio
+from functools import cached_property
 from typing import Any, AsyncIterator, Sequence
 
 from google.cloud.pubsub_v1.types import ReceivedMessage
@@ -67,7 +68,6 @@ class PubsubPullTrigger(BaseTrigger):
         self.poke_interval = poke_interval
         self.gcp_conn_id = gcp_conn_id
         self.impersonation_chain = impersonation_chain
-        self.hook = PubSubAsyncHook()
 
     def serialize(self) -> tuple[str, dict[str, Any]]:
         """Serialize PubsubPullTrigger arguments and classpath."""
@@ -113,3 +113,11 @@ class PubsubPullTrigger(BaseTrigger):
             messages=pulled_messages,
         )
         self.log.info("Acknowledged ack_ids from subscription %s", self.subscription)
+
+    @cached_property
+    def hook(self) -> PubSubAsyncHook:
+        return PubSubAsyncHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+            project_id=self.project_id,
+        )

--- a/tests/providers/google/cloud/triggers/test_pubsub.py
+++ b/tests/providers/google/cloud/triggers/test_pubsub.py
@@ -110,3 +110,23 @@ class TestPubsubPullTrigger:
         response = await trigger.run().asend(None)
 
         assert response == expected_event
+
+    @mock.patch("airflow.providers.google.cloud.triggers.pubsub.PubSubAsyncHook")
+    def test_hook(self, mock_async_hook):
+        trigger = PubsubPullTrigger(
+            project_id=PROJECT_ID,
+            subscription="subscription",
+            max_messages=MAX_MESSAGES,
+            ack_messages=False,
+            poke_interval=TEST_POLL_INTERVAL,
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=None,
+        )
+        async_hook_actual = trigger.hook
+
+        mock_async_hook.assert_called_once_with(
+            gcp_conn_id=trigger.gcp_conn_id,
+            impersonation_chain=trigger.impersonation_chain,
+            project_id=trigger.project_id,
+        )
+        assert async_hook_actual == mock_async_hook.return_value


### PR DESCRIPTION
Currently the values gcp_conn_id, impersonation_chain, project_id not using in PubsubPullTrigger. 
This fix is to use provided values from sensor and create connection hook in PubsubPullTrigger.

closes: #42160 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
