### PR TITLE
feat: allow customizing podManagementPolicy

### DIFF
--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -74,6 +74,9 @@ spec:
       tier: airflow
       component: worker
       release: {{ .Release.Name }}
+  {{- if and $persistence .Values.workers.podManagementPolicy }}
+  podManagementPolicy: {{ .Values.workers.podManagementPolicy }}
+  {{- end }}
   {{- if and $persistence .Values.workers.updateStrategy }}
   updateStrategy: {{- toYaml .Values.workers.updateStrategy | nindent 4 }}
   {{- end }}
@@ -107,9 +110,6 @@ spec:
       {{- end }}
       {{- if .Values.workers.priorityClassName }}
       priorityClassName: {{ .Values.workers.priorityClassName }}
-      {{- end }}
-      {{- if .Values.workers.podManagementPolicy }}
-      podManagementPolicy: {{ .Values.workers.podManagementPolicy }}
       {{- end }}
       {{- if .Values.schedulerName }}
       schedulerName: {{ .Values.schedulerName }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -108,6 +108,9 @@ spec:
       {{- if .Values.workers.priorityClassName }}
       priorityClassName: {{ .Values.workers.priorityClassName }}
       {{- end }}
+      {{- if .Values.workers.podManagementPolicy }}
+      podManagementPolicy: {{ .Values.workers.podManagementPolicy }}
+      {{- end }}
       {{- if .Values.schedulerName }}
       schedulerName: {{ .Values.schedulerName }}
       {{- end }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1598,6 +1598,15 @@
                     ],
                     "default": null
                 },
+                "podManagementPolicy": {
+                    "description": "Specifies the policy for managing pods within the worker. Only applicable to StatefulSet.",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "default": null,
+                    "enum": ["OrderedReady", "Parallel"]
+                },
                 "strategy": {
                     "description": "Specifies the strategy used to replace old Pods by new ones when deployed as a Deployment.",
                     "type": [

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1605,7 +1605,10 @@
                         "string"
                     ],
                     "default": null,
-                    "enum": ["OrderedReady", "Parallel"]
+                    "enum": [
+                        "OrderedReady",
+                        "Parallel"
+                    ]
                 },
                 "strategy": {
                     "description": "Specifies the strategy used to replace old Pods by new ones when deployed as a Deployment.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -590,6 +590,9 @@ workers:
       maxSurge: "100%"
       maxUnavailable: "50%"
 
+  # Allow relaxing ordering guarantees while preserving its uniqueness and identity
+  # podManagementPolicy: Parallel
+
   # When not set, the values defined in the global securityContext will be used
   securityContext: {}
   #  runAsUser: 50000


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
I as a user of StatefulSets in Airflow, would like to preserving workload uniqueness and identity guarantees, but allow scalling up and down without waiting for termination grace period.

This is useful when termination grace period is very high. In such cases, scaling up and down gets fully stuck while waiting for long running tasks. 
