### PR TITLE
Remove special handling of backfills in scheduler

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -405,7 +405,7 @@ class DagRun(Base, LoggingMixin):
         query = (
             select(cls)
             .with_hint(cls, "USE INDEX (idx_dag_run_running_dags)", dialect_name="mysql")
-            .where(cls.state == DagRunState.RUNNING, cls.run_type != DagRunType.BACKFILL_JOB)
+            .where(cls.state == DagRunState.RUNNING)
             .join(DagModel, DagModel.dag_id == cls.dag_id)
             .where(DagModel.is_paused == false(), DagModel.is_active == true())
             .order_by(
@@ -450,7 +450,7 @@ class DagRun(Base, LoggingMixin):
         )
         query = (
             select(cls)
-            .where(cls.state == DagRunState.QUEUED, cls.run_type != DagRunType.BACKFILL_JOB)
+            .where(cls.state == DagRunState.QUEUED)
             .join(DagModel, DagModel.dag_id == cls.dag_id)
             .where(DagModel.is_paused == false(), DagModel.is_active == true())
             .outerjoin(running_drs, running_drs.c.dag_id == DagRun.dag_id)


### PR DESCRIPTION
Before airflow 3.0, scheduler would completely ignore all backfill runs.  This PR gets rid of that logic so that backfill runs are treated the same as non-backfill.  This is a baby step on the way to adding scheduling of backfill dag runs into the scheduler.