### PR TITLE
Temporarily disable branch protection for older v2-* branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -81,43 +81,43 @@ github:
       required_pull_request_reviews:
         required_approving_review_count: 1
       required_linear_history: true
-    v2-3-stable:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-      required_linear_history: true
-    v2-4-stable:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-      required_linear_history: true
-    v2-5-stable:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-      required_linear_history: true
-    v2-6-stable:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-      required_linear_history: true
-    v2-7-stable:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-      required_linear_history: true
-    v2-8-stable:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-      required_linear_history: true
-    v2-9-stable:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-      required_linear_history: true
-    v2-10-stable:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-      required_linear_history: true
-    v2-10-test:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-      required_linear_history: true
-      required_conversation_resolution: true
+      #    v2-3-stable:
+      #      required_pull_request_reviews:
+      #        required_approving_review_count: 1
+      #      required_linear_history: true
+      #    v2-4-stable:
+      #      required_pull_request_reviews:
+      #        required_approving_review_count: 1
+      #      required_linear_history: true
+      #    v2-5-stable:
+      #      required_pull_request_reviews:
+      #        required_approving_review_count: 1
+      #      required_linear_history: true
+      #    v2-6-stable:
+      #      required_pull_request_reviews:
+      #        required_approving_review_count: 1
+      #      required_linear_history: true
+      #    v2-7-stable:
+      #      required_pull_request_reviews:
+      #        required_approving_review_count: 1
+      #      required_linear_history: true
+      #    v2-8-stable:
+      #      required_pull_request_reviews:
+      #        required_approving_review_count: 1
+      #      required_linear_history: true
+      #    v2-9-stable:
+      #      required_pull_request_reviews:
+      #        required_approving_review_count: 1
+      #      required_linear_history: true
+      #    v2-10-stable:
+      #      required_pull_request_reviews:
+      #        required_approving_review_count: 1
+      #      required_linear_history: true
+      #    v2-10-test:
+      #      required_pull_request_reviews:
+      #        required_approving_review_count: 1
+      #      required_linear_history: true
+      #      required_conversation_resolution: true
   collaborators:
     # Max 10 collaborators allowed
     # https://github.com/apache/infrastructure-asfyaml/blob/main/README.md#assigning-the-github-triage-role-to-external-collaborators


### PR DESCRIPTION
We have to do some maintenance and temporarily disabling branch protection is the easiest way to do it.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
