### PR TITLE
Add 'retry_if_resource_not_ready' logic for DataprocCreateClusterOperator and DataprocCreateBatchOperator

### DIFF
--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_batch.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_batch.py
@@ -70,6 +70,7 @@ with DAG(
         batch=BATCH_CONFIG,
         batch_id=BATCH_ID,
         result_retry=Retry(maximum=100.0, initial=10.0, multiplier=1.0),
+        num_retries_if_resource_is_not_ready=3,
     )
 
     create_batch_2 = DataprocCreateBatchOperator(
@@ -79,6 +80,7 @@ with DAG(
         batch=BATCH_CONFIG,
         batch_id=BATCH_ID_2,
         result_retry=Retry(maximum=100.0, initial=10.0, multiplier=1.0),
+        num_retries_if_resource_is_not_ready=3,
     )
 
     create_batch_3 = DataprocCreateBatchOperator(
@@ -89,6 +91,7 @@ with DAG(
         batch_id=BATCH_ID_3,
         asynchronous=True,
         result_retry=Retry(maximum=100.0, initial=10.0, multiplier=1.0),
+        num_retries_if_resource_is_not_ready=3,
     )
     # [END how_to_cloud_dataproc_create_batch_operator]
 
@@ -123,6 +126,7 @@ with DAG(
         batch=BATCH_CONFIG,
         batch_id=BATCH_ID_4,
         asynchronous=True,
+        num_retries_if_resource_is_not_ready=3,
     )
 
     # [START how_to_cloud_dataproc_cancel_operation_operator]

--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_batch_deferrable.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_batch_deferrable.py
@@ -65,6 +65,7 @@ with DAG(
         batch_id=BATCH_ID,
         deferrable=True,
         result_retry=Retry(maximum=100.0, initial=10.0, multiplier=1.0),
+        num_retries_if_resource_is_not_ready=3,
     )
     # [END how_to_cloud_dataproc_create_batch_operator_async]
 

--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_batch_persistent.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_batch_persistent.py
@@ -92,6 +92,7 @@ with DAG(
         region=REGION,
         cluster_name=CLUSTER_NAME,
         retry=Retry(maximum=100.0, initial=10.0, multiplier=1.0),
+        num_retries_if_resource_is_not_ready=3,
     )
     # [END how_to_cloud_dataproc_create_cluster_for_persistent_history_server]
 
@@ -103,6 +104,7 @@ with DAG(
         batch=BATCH_CONFIG_WITH_PHS,
         batch_id=BATCH_ID,
         result_retry=Retry(maximum=100.0, initial=10.0, multiplier=1.0),
+        num_retries_if_resource_is_not_ready=3,
     )
     # [END how_to_cloud_dataproc_create_batch_operator_with_persistent_history_server]
 

--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_cluster_create_existing_stopped_cluster.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_cluster_create_existing_stopped_cluster.py
@@ -72,6 +72,7 @@ with DAG(
         cluster_name=CLUSTER_NAME,
         use_if_exists=True,
         retry=Retry(maximum=100.0, initial=10.0, multiplier=1.0),
+        num_retries_if_resource_is_not_ready=3,
     )
 
     start_cluster = DataprocStartClusterOperator(
@@ -97,6 +98,7 @@ with DAG(
         cluster_name=CLUSTER_NAME,
         use_if_exists=True,
         retry=Retry(maximum=100.0, initial=10.0, multiplier=1.0),
+        num_retries_if_resource_is_not_ready=3,
     )
 
     delete_cluster = DataprocDeleteClusterOperator(

--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_cluster_deferrable.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_cluster_deferrable.py
@@ -98,6 +98,7 @@ with DAG(
         cluster_name=CLUSTER_NAME,
         deferrable=True,
         retry=Retry(maximum=100.0, initial=10.0, multiplier=1.0),
+        num_retries_if_resource_is_not_ready=3,
     )
     # [END how_to_cloud_dataproc_create_cluster_operator_async]
 

--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_cluster_diagnose.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_cluster_diagnose.py
@@ -75,6 +75,7 @@ with DAG(
         region=REGION,
         cluster_name=CLUSTER_NAME,
         retry=Retry(maximum=100.0, initial=10.0, multiplier=1.0),
+        num_retries_if_resource_is_not_ready=3,
     )
 
     # [START how_to_cloud_dataproc_diagnose_cluster]

--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_cluster_generator.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_cluster_generator.py
@@ -72,6 +72,7 @@ CLUSTER_GENERATOR_CONFIG = ClusterGenerator(
     metadata={"PIP_PACKAGES": "pyyaml requests pandas openpyxl"},
     num_preemptible_workers=1,
     preemptibility="PREEMPTIBLE",
+    internal_ip_only=False,
 ).make()
 
 # [END how_to_cloud_dataproc_create_cluster_generate_cluster_config]
@@ -106,6 +107,7 @@ with DAG(
         region=REGION,
         cluster_config=CLUSTER_GENERATOR_CONFIG,
         retry=Retry(maximum=100.0, initial=10.0, multiplier=1.0),
+        num_retries_if_resource_is_not_ready=3,
     )
 
     # [END how_to_cloud_dataproc_create_cluster_generate_cluster_config_operator]

--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_cluster_start_stop.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_cluster_start_stop.py
@@ -71,6 +71,7 @@ with DAG(
         cluster_name=CLUSTER_NAME,
         use_if_exists=True,
         retry=Retry(maximum=100.0, initial=10.0, multiplier=1.0),
+        num_retries_if_resource_is_not_ready=3,
     )
 
     # [START how_to_cloud_dataproc_start_cluster_operator]

--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_cluster_update.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_cluster_update.py
@@ -86,6 +86,7 @@ with DAG(
         region=REGION,
         cluster_name=CLUSTER_NAME,
         retry=Retry(maximum=100.0, initial=10.0, multiplier=1.0),
+        num_retries_if_resource_is_not_ready=3,
     )
 
     # [START how_to_cloud_dataproc_update_cluster_operator]

--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_flink.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_flink.py
@@ -95,6 +95,7 @@ with DAG(
         region=REGION,
         cluster_name=CLUSTER_NAME,
         retry=Retry(maximum=100.0, initial=10.0, multiplier=1.0),
+        num_retries_if_resource_is_not_ready=3,
     )
 
     flink_task = DataprocSubmitJobOperator(

--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_gke.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_gke.py
@@ -113,6 +113,7 @@ with DAG(
         cluster_name=CLUSTER_NAME,
         virtual_cluster_config=VIRTUAL_CLUSTER_CONFIG,
         retry=Retry(maximum=100.0, initial=10.0, multiplier=1.0),
+        num_retries_if_resource_is_not_ready=3,
     )
     # [END how_to_cloud_dataproc_create_cluster_operator_in_gke]
 

--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_hadoop.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_hadoop.py
@@ -94,6 +94,7 @@ with DAG(
         region=REGION,
         cluster_name=CLUSTER_NAME,
         retry=Retry(maximum=100.0, initial=10.0, multiplier=1.0),
+        num_retries_if_resource_is_not_ready=3,
     )
 
     hadoop_task = DataprocSubmitJobOperator(

--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_hive.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_hive.py
@@ -96,6 +96,7 @@ with DAG(
         region=REGION,
         cluster_name=CLUSTER_NAME,
         retry=Retry(maximum=100.0, initial=10.0, multiplier=1.0),
+        num_retries_if_resource_is_not_ready=3,
     )
     # [END how_to_cloud_dataproc_create_cluster_operator]
 

--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_pig.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_pig.py
@@ -83,6 +83,7 @@ with DAG(
         region=REGION,
         cluster_name=CLUSTER_NAME,
         retry=Retry(maximum=100.0, initial=10.0, multiplier=1.0),
+        num_retries_if_resource_is_not_ready=3,
     )
 
     pig_task = DataprocSubmitJobOperator(

--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_presto.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_presto.py
@@ -90,6 +90,7 @@ with DAG(
         region=REGION,
         cluster_name=CLUSTER_NAME,
         retry=Retry(maximum=100.0, initial=10.0, multiplier=1.0),
+        num_retries_if_resource_is_not_ready=3,
     )
 
     presto_task = DataprocSubmitJobOperator(

--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_pyspark.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_pyspark.py
@@ -106,6 +106,7 @@ with DAG(
         region=REGION,
         cluster_name=CLUSTER_NAME,
         retry=Retry(maximum=100.0, initial=10.0, multiplier=1.0),
+        num_retries_if_resource_is_not_ready=3,
     )
 
     # [START how_to_cloud_dataproc_submit_job_to_cluster_operator]

--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_spark.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_spark.py
@@ -86,6 +86,7 @@ with DAG(
         region=REGION,
         cluster_name=CLUSTER_NAME,
         retry=Retry(maximum=100.0, initial=10.0, multiplier=1.0),
+        num_retries_if_resource_is_not_ready=3,
     )
 
     spark_task = DataprocSubmitJobOperator(

--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_spark_async.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_spark_async.py
@@ -85,6 +85,7 @@ with DAG(
         region=REGION,
         cluster_name=CLUSTER_NAME,
         retry=Retry(maximum=100.0, initial=10.0, multiplier=1.0),
+        num_retries_if_resource_is_not_ready=3,
     )
 
     # [START cloud_dataproc_async_submit_sensor]

--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_spark_deferrable.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_spark_deferrable.py
@@ -87,6 +87,7 @@ with DAG(
         region=REGION,
         cluster_name=CLUSTER_NAME,
         retry=Retry(maximum=100.0, initial=10.0, multiplier=1.0),
+        num_retries_if_resource_is_not_ready=3,
     )
 
     spark_task = DataprocSubmitJobOperator(

--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_spark_sql.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_spark_sql.py
@@ -83,6 +83,7 @@ with DAG(
         region=REGION,
         cluster_name=CLUSTER_NAME,
         retry=Retry(maximum=100.0, initial=10.0, multiplier=1.0),
+        num_retries_if_resource_is_not_ready=3,
     )
 
     spark_sql_task = DataprocSubmitJobOperator(

--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_sparkr.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_sparkr.py
@@ -104,6 +104,7 @@ with DAG(
         region=REGION,
         cluster_name=CLUSTER_NAME,
         retry=Retry(maximum=100.0, initial=10.0, multiplier=1.0),
+        num_retries_if_resource_is_not_ready=3,
     )
 
     sparkr_task = DataprocSubmitJobOperator(

--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_trino.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_trino.py
@@ -92,6 +92,7 @@ with DAG(
         region=REGION,
         cluster_name=CLUSTER_NAME,
         retry=Retry(maximum=100.0, initial=10.0, multiplier=1.0),
+        num_retries_if_resource_is_not_ready=3,
     )
 
     trino_task = DataprocSubmitJobOperator(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

In this PR I have added a logic for retrying a cluster creation request in case when Dataproc returns an error with `The resource 'projects/PROJECT/regions/REGION/subnetworks/default' is not ready` message.

More information about this error here: https://cloud.google.com/compute/docs/troubleshooting/troubleshooting-vm-creation#simultaneous_resource_mutation_or_creation_operations

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
