### PR TITLE
Add ability to switch between table and card views for listing items

### DIFF
--- a/airflow/ui/src/App.test.tsx
+++ b/airflow/ui/src/App.test.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable unicorn/no-null */
-
 /*!
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/airflow/ui/src/App.test.tsx
+++ b/airflow/ui/src/App.test.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable unicorn/no-null */
+
 /*!
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/airflow/ui/src/components/DataTable/CardList.tsx
+++ b/airflow/ui/src/components/DataTable/CardList.tsx
@@ -48,7 +48,6 @@ export const CardList = <TData,>({
           <Box
             _hover={onRowClick ? { cursor: "pointer" } : undefined}
             key={row.id}
-            // eslint-disable-next-line react/jsx-no-bind
             onClick={onRowClick ? (event) => onRowClick(event, row) : undefined}
             title={onRowClick ? "View details" : undefined}
           >

--- a/airflow/ui/src/components/DataTable/CardList.tsx
+++ b/airflow/ui/src/components/DataTable/CardList.tsx
@@ -1,0 +1,71 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box, SimpleGrid, Skeleton } from "@chakra-ui/react";
+import {
+  type CoreRow,
+  flexRender,
+  type Table as TanStackTable,
+} from "@tanstack/react-table";
+import type { SyntheticEvent } from "react";
+
+import type { CardDef } from "./types";
+
+type DataTableProps<TData> = {
+  readonly cardDef: CardDef<TData>;
+  readonly isLoading?: boolean;
+  readonly onRowClick?: (e: SyntheticEvent, row: CoreRow<TData>) => void;
+  readonly table: TanStackTable<TData>;
+};
+
+export const CardList = <TData,>({
+  cardDef,
+  isLoading,
+  onRowClick,
+  table,
+}: DataTableProps<TData>) => {
+  const defaultGridProps = { column: { base: 1 }, spacing: 2 };
+
+  return (
+    <Box overflow="auto" width="100%">
+      <SimpleGrid {...{ ...defaultGridProps, ...cardDef.gridProps }}>
+        {table.getRowModel().rows.map((row) => (
+          <Box
+            _hover={onRowClick ? { cursor: "pointer" } : undefined}
+            key={row.id}
+            // eslint-disable-next-line react/jsx-no-bind
+            onClick={onRowClick ? (event) => onRowClick(event, row) : undefined}
+            title={onRowClick ? "View details" : undefined}
+          >
+            {Boolean(isLoading) &&
+              (cardDef.meta?.customSkeleton ?? (
+                <Skeleton
+                  data-testid="skeleton"
+                  display="inline-block"
+                  height={80}
+                  width="100%"
+                />
+              ))}
+            {!Boolean(isLoading) &&
+              flexRender(cardDef.card, { row: row.original })}
+          </Box>
+        ))}
+      </SimpleGrid>
+    </Box>
+  );
+};

--- a/airflow/ui/src/components/DataTable/DataTable.test.tsx
+++ b/airflow/ui/src/components/DataTable/DataTable.test.tsx
@@ -16,12 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { Text } from "@chakra-ui/react";
 import type { ColumnDef, PaginationState } from "@tanstack/react-table";
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { DataTable } from "./DataTable.tsx";
+import type { CardDef } from "./types.ts";
 
 const columns: Array<ColumnDef<{ name: string }>> = [
   {
@@ -35,6 +37,10 @@ const data = [{ name: "John Doe" }, { name: "Jane Doe" }];
 
 const pagination: PaginationState = { pageIndex: 0, pageSize: 1 };
 const onStateChange = vi.fn();
+
+const cardDef: CardDef<{ name: string }> = {
+  card: ({ row }) => <Text>My name is {row.name}.</Text>,
+};
 
 describe("DataTable", () => {
   it("renders table with data", () => {
@@ -83,5 +89,45 @@ describe("DataTable", () => {
 
     expect(screen.getByText(">>")).toBeDisabled();
     expect(screen.getByText(">")).toBeDisabled();
+  });
+
+  it("when isLoading renders skeleton columns", () => {
+    render(<DataTable columns={columns} data={data} isLoading />);
+
+    expect(screen.getAllByTestId("skeleton")).toHaveLength(10);
+  });
+
+  it("still displays table if mode is card but there is no cardDef", () => {
+    render(<DataTable columns={columns} data={data} displayMode="card" />);
+
+    expect(screen.getByText("Name")).toBeInTheDocument();
+  });
+
+  it("displays cards if mode is card and there is cardDef", () => {
+    render(
+      <DataTable
+        cardDef={cardDef}
+        columns={columns}
+        data={data}
+        displayMode="card"
+      />,
+    );
+
+    expect(screen.getByText("My name is John Doe.")).toBeInTheDocument();
+  });
+
+  it("displays skeleton for loading card list", () => {
+    render(
+      <DataTable
+        cardDef={cardDef}
+        columns={columns}
+        data={data}
+        displayMode="card"
+        isLoading
+        skeletonCount={5}
+      />,
+    );
+
+    expect(screen.getAllByTestId("skeleton")).toHaveLength(5);
   });
 });

--- a/airflow/ui/src/components/DataTable/DataTable.tsx
+++ b/airflow/ui/src/components/DataTable/DataTable.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Progress, Text } from "@chakra-ui/react";
+import { Progress, Text } from "@chakra-ui/react";
 import {
   getCoreRowModel,
   getExpandedRowModel,
@@ -93,7 +93,7 @@ export const DataTable = <TData,>({
     [onStateChange],
   );
 
-  const extra = Boolean(isLoading)
+  const rest = Boolean(isLoading)
     ? createSkeletonMock(displayMode, skeletonCount, columns)
     : {};
 
@@ -109,7 +109,7 @@ export const DataTable = <TData,>({
     onStateChange: handleStateChange,
     rowCount: total,
     state: initialState,
-    ...extra,
+    ...rest,
   });
 
   ref.current.tableRef = table;
@@ -119,7 +119,7 @@ export const DataTable = <TData,>({
   const display = displayMode === "card" && Boolean(cardDef) ? "card" : "table";
 
   return (
-    <Box>
+    <>
       <Progress
         isIndeterminate
         size="xs"
@@ -137,6 +137,6 @@ export const DataTable = <TData,>({
         <CardList cardDef={cardDef} isLoading={isLoading} table={table} />
       )}
       <TablePaginator table={table} />
-    </Box>
+    </>
   );
 };

--- a/airflow/ui/src/components/DataTable/DataTable.tsx
+++ b/airflow/ui/src/components/DataTable/DataTable.tsx
@@ -22,7 +22,6 @@ import {
   getExpandedRowModel,
   getPaginationRowModel,
   useReactTable,
-  type ColumnDef,
   type OnChangeFn,
   type TableState as ReactTableState,
   type Row,
@@ -34,11 +33,12 @@ import React, { type ReactNode, useCallback, useRef } from "react";
 import { CardList } from "./CardList";
 import { TableList } from "./TableList";
 import { TablePaginator } from "./TablePaginator";
-import type { CardDef, TableState } from "./types";
+import { createSkeletonMock } from "./skeleton";
+import type { CardDef, MetaColumn, TableState } from "./types";
 
 type DataTableProps<TData> = {
   readonly cardDef?: CardDef<TData>;
-  readonly columns: Array<ColumnDef<TData>>;
+  readonly columns: Array<MetaColumn<TData>>;
   readonly data: Array<TData>;
   readonly displayMode?: "card" | "table";
   readonly getRowCanExpand?: (row: Row<TData>) => boolean;
@@ -51,6 +51,7 @@ type DataTableProps<TData> = {
   readonly renderSubComponent?: (props: {
     row: Row<TData>;
   }) => React.ReactElement;
+  readonly skeletonCount?: number;
   readonly total?: number;
 };
 
@@ -68,6 +69,7 @@ export const DataTable = <TData,>({
   modelName,
   noRowsMessage,
   onStateChange,
+  skeletonCount = 10,
   total = 0,
 }: DataTableProps<TData>) => {
   const ref = useRef<{ tableRef: TanStackTable<TData> | undefined }>({
@@ -91,6 +93,10 @@ export const DataTable = <TData,>({
     [onStateChange],
   );
 
+  const extra = Boolean(isLoading)
+    ? createSkeletonMock(displayMode, skeletonCount, columns)
+    : {};
+
   const table = useReactTable({
     columns,
     data,
@@ -103,6 +109,7 @@ export const DataTable = <TData,>({
     onStateChange: handleStateChange,
     rowCount: total,
     state: initialState,
+    ...extra,
   });
 
   ref.current.tableRef = table;

--- a/airflow/ui/src/components/DataTable/DataTable.tsx
+++ b/airflow/ui/src/components/DataTable/DataTable.tsx
@@ -16,18 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { Box, Progress, Text } from "@chakra-ui/react";
 import {
-  Table as ChakraTable,
-  TableContainer,
-  Tbody,
-  Td,
-  Th,
-  Thead,
-  Tr,
-  useColorModeValue,
-} from "@chakra-ui/react";
-import {
-  flexRender,
   getCoreRowModel,
   getExpandedRowModel,
   getPaginationRowModel,
@@ -39,21 +29,24 @@ import {
   type Table as TanStackTable,
   type Updater,
 } from "@tanstack/react-table";
-import React, { Fragment, useCallback, useRef } from "react";
-import {
-  TiArrowSortedDown,
-  TiArrowSortedUp,
-  TiArrowUnsorted,
-} from "react-icons/ti";
+import React, { type ReactNode, useCallback, useRef } from "react";
 
+import { CardList } from "./CardList";
+import { TableList } from "./TableList";
 import { TablePaginator } from "./TablePaginator";
-import type { TableState } from "./types";
+import type { CardDef, TableState } from "./types";
 
 type DataTableProps<TData> = {
+  readonly cardDef?: CardDef<TData>;
   readonly columns: Array<ColumnDef<TData>>;
   readonly data: Array<TData>;
+  readonly displayMode?: "card" | "table";
   readonly getRowCanExpand?: (row: Row<TData>) => boolean;
   readonly initialState?: TableState;
+  readonly isFetching?: boolean;
+  readonly isLoading?: boolean;
+  readonly modelName?: string;
+  readonly noRowsMessage?: ReactNode;
   readonly onStateChange?: (state: TableState) => void;
   readonly renderSubComponent?: (props: {
     row: Row<TData>;
@@ -64,12 +57,17 @@ type DataTableProps<TData> = {
 const defaultGetRowCanExpand = () => false;
 
 export const DataTable = <TData,>({
+  cardDef,
   columns,
   data,
+  displayMode = "table",
   getRowCanExpand = defaultGetRowCanExpand,
   initialState,
+  isFetching,
+  isLoading,
+  modelName,
+  noRowsMessage,
   onStateChange,
-  renderSubComponent,
   total = 0,
 }: DataTableProps<TData>) => {
   const ref = useRef<{ tableRef: TanStackTable<TData> | undefined }>({
@@ -109,83 +107,29 @@ export const DataTable = <TData,>({
 
   ref.current.tableRef = table;
 
-  const theadBg = useColorModeValue("white", "gray.800");
+  const { rows } = table.getRowModel();
+
+  const display = displayMode === "card" && Boolean(cardDef) ? "card" : "table";
 
   return (
-    <TableContainer maxH="calc(100vh - 10rem)" overflowY="auto">
-      <ChakraTable colorScheme="blue">
-        <Thead bg={theadBg} position="sticky" top={0} zIndex={1}>
-          {table.getHeaderGroups().map((headerGroup) => (
-            <Tr key={headerGroup.id}>
-              {headerGroup.headers.map(
-                ({ colSpan, column, getContext, id, isPlaceholder }) => {
-                  const sort = column.getIsSorted();
-                  const canSort = column.getCanSort();
-
-                  return (
-                    <Th
-                      colSpan={colSpan}
-                      cursor={column.getCanSort() ? "pointer" : undefined}
-                      key={id}
-                      onClick={column.getToggleSortingHandler()}
-                      whiteSpace="nowrap"
-                    >
-                      {isPlaceholder ? undefined : (
-                        <>{flexRender(column.columnDef.header, getContext())}</>
-                      )}
-                      {canSort && sort === false ? (
-                        <TiArrowUnsorted
-                          aria-label="unsorted"
-                          size="1em"
-                          style={{ display: "inline" }}
-                        />
-                      ) : undefined}
-                      {canSort && sort !== false ? (
-                        sort === "desc" ? (
-                          <TiArrowSortedDown
-                            aria-label="sorted descending"
-                            size="1em"
-                            style={{ display: "inline" }}
-                          />
-                        ) : (
-                          <TiArrowSortedUp
-                            aria-label="sorted ascending"
-                            size="1em"
-                            style={{ display: "inline" }}
-                          />
-                        )
-                      ) : undefined}
-                    </Th>
-                  );
-                },
-              )}
-            </Tr>
-          ))}
-        </Thead>
-        <Tbody>
-          {table.getRowModel().rows.map((row) => (
-            <Fragment key={row.id}>
-              <Tr>
-                {/* first row is a normal row */}
-                {row.getVisibleCells().map((cell) => (
-                  <Td key={cell.id}>
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </Td>
-                ))}
-              </Tr>
-              {row.getIsExpanded() && (
-                <Tr>
-                  {/* 2nd row is a custom 1 cell row */}
-                  <Td colSpan={row.getVisibleCells().length}>
-                    {renderSubComponent?.({ row })}
-                  </Td>
-                </Tr>
-              )}
-            </Fragment>
-          ))}
-        </Tbody>
-      </ChakraTable>
+    <Box>
+      <Progress
+        isIndeterminate
+        size="xs"
+        visibility={
+          Boolean(isFetching) && !Boolean(isLoading) ? "visible" : "hidden"
+        }
+      />
+      {!Boolean(isLoading) && !rows.length && (
+        <Text fontSize="small">
+          {noRowsMessage ?? `No ${modelName}s found.`}
+        </Text>
+      )}
+      {display === "table" && <TableList table={table} />}
+      {display === "card" && cardDef !== undefined && (
+        <CardList cardDef={cardDef} isLoading={isLoading} table={table} />
+      )}
       <TablePaginator table={table} />
-    </TableContainer>
+    </Box>
   );
 };

--- a/airflow/ui/src/components/DataTable/TableList.tsx
+++ b/airflow/ui/src/components/DataTable/TableList.tsx
@@ -24,7 +24,6 @@ import {
   Th,
   Thead,
   Tr,
-  useColorModeValue,
 } from "@chakra-ui/react";
 import {
   flexRender,
@@ -48,83 +47,79 @@ type DataTableProps<TData> = {
 export const TableList = <TData,>({
   renderSubComponent,
   table,
-}: DataTableProps<TData>) => {
-  const theadBg = useColorModeValue("white", "gray.800");
+}: DataTableProps<TData>) => (
+  <TableContainer maxH="calc(100vh - 10rem)" overflowY="auto">
+    <ChakraTable colorScheme="blue">
+      <Thead bg="chakra-body-bg" position="sticky" top={0} zIndex={1}>
+        {table.getHeaderGroups().map((headerGroup) => (
+          <Tr key={headerGroup.id}>
+            {headerGroup.headers.map(
+              ({ colSpan, column, getContext, id, isPlaceholder }) => {
+                const sort = column.getIsSorted();
+                const canSort = column.getCanSort();
 
-  return (
-    <TableContainer maxH="calc(100vh - 10rem)" overflowY="auto">
-      <ChakraTable colorScheme="blue">
-        <Thead bg={theadBg} position="sticky" top={0} zIndex={1}>
-          {table.getHeaderGroups().map((headerGroup) => (
-            <Tr key={headerGroup.id}>
-              {headerGroup.headers.map(
-                ({ colSpan, column, getContext, id, isPlaceholder }) => {
-                  const sort = column.getIsSorted();
-                  const canSort = column.getCanSort();
-
-                  return (
-                    <Th
-                      colSpan={colSpan}
-                      cursor={column.getCanSort() ? "pointer" : undefined}
-                      key={id}
-                      onClick={column.getToggleSortingHandler()}
-                      whiteSpace="nowrap"
-                    >
-                      {isPlaceholder ? undefined : (
-                        <>{flexRender(column.columnDef.header, getContext())}</>
-                      )}
-                      {canSort && sort === false ? (
-                        <TiArrowUnsorted
-                          aria-label="unsorted"
+                return (
+                  <Th
+                    colSpan={colSpan}
+                    cursor={column.getCanSort() ? "pointer" : undefined}
+                    key={id}
+                    onClick={column.getToggleSortingHandler()}
+                    whiteSpace="nowrap"
+                  >
+                    {isPlaceholder ? undefined : (
+                      <>{flexRender(column.columnDef.header, getContext())}</>
+                    )}
+                    {canSort && sort === false ? (
+                      <TiArrowUnsorted
+                        aria-label="unsorted"
+                        size="1em"
+                        style={{ display: "inline" }}
+                      />
+                    ) : undefined}
+                    {canSort && sort !== false ? (
+                      sort === "desc" ? (
+                        <TiArrowSortedDown
+                          aria-label="sorted descending"
                           size="1em"
                           style={{ display: "inline" }}
                         />
-                      ) : undefined}
-                      {canSort && sort !== false ? (
-                        sort === "desc" ? (
-                          <TiArrowSortedDown
-                            aria-label="sorted descending"
-                            size="1em"
-                            style={{ display: "inline" }}
-                          />
-                        ) : (
-                          <TiArrowSortedUp
-                            aria-label="sorted ascending"
-                            size="1em"
-                            style={{ display: "inline" }}
-                          />
-                        )
-                      ) : undefined}
-                    </Th>
-                  );
-                },
-              )}
+                      ) : (
+                        <TiArrowSortedUp
+                          aria-label="sorted ascending"
+                          size="1em"
+                          style={{ display: "inline" }}
+                        />
+                      )
+                    ) : undefined}
+                  </Th>
+                );
+              },
+            )}
+          </Tr>
+        ))}
+      </Thead>
+      <Tbody>
+        {table.getRowModel().rows.map((row) => (
+          <Fragment key={row.id}>
+            <Tr>
+              {/* first row is a normal row */}
+              {row.getVisibleCells().map((cell) => (
+                <Td key={cell.id}>
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </Td>
+              ))}
             </Tr>
-          ))}
-        </Thead>
-        <Tbody>
-          {table.getRowModel().rows.map((row) => (
-            <Fragment key={row.id}>
+            {row.getIsExpanded() && (
               <Tr>
-                {/* first row is a normal row */}
-                {row.getVisibleCells().map((cell) => (
-                  <Td key={cell.id}>
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </Td>
-                ))}
+                {/* 2nd row is a custom 1 cell row */}
+                <Td colSpan={row.getVisibleCells().length}>
+                  {renderSubComponent?.({ row })}
+                </Td>
               </Tr>
-              {row.getIsExpanded() && (
-                <Tr>
-                  {/* 2nd row is a custom 1 cell row */}
-                  <Td colSpan={row.getVisibleCells().length}>
-                    {renderSubComponent?.({ row })}
-                  </Td>
-                </Tr>
-              )}
-            </Fragment>
-          ))}
-        </Tbody>
-      </ChakraTable>
-    </TableContainer>
-  );
-};
+            )}
+          </Fragment>
+        ))}
+      </Tbody>
+    </ChakraTable>
+  </TableContainer>
+);

--- a/airflow/ui/src/components/DataTable/TableList.tsx
+++ b/airflow/ui/src/components/DataTable/TableList.tsx
@@ -1,0 +1,130 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {
+  Table as ChakraTable,
+  TableContainer,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+  useColorModeValue,
+} from "@chakra-ui/react";
+import {
+  flexRender,
+  type Row,
+  type Table as TanStackTable,
+} from "@tanstack/react-table";
+import React, { Fragment } from "react";
+import {
+  TiArrowSortedDown,
+  TiArrowSortedUp,
+  TiArrowUnsorted,
+} from "react-icons/ti";
+
+type DataTableProps<TData> = {
+  readonly renderSubComponent?: (props: {
+    row: Row<TData>;
+  }) => React.ReactElement;
+  readonly table: TanStackTable<TData>;
+};
+
+export const TableList = <TData,>({
+  renderSubComponent,
+  table,
+}: DataTableProps<TData>) => {
+  const theadBg = useColorModeValue("white", "gray.800");
+
+  return (
+    <TableContainer maxH="calc(100vh - 10rem)" overflowY="auto">
+      <ChakraTable colorScheme="blue">
+        <Thead bg={theadBg} position="sticky" top={0} zIndex={1}>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <Tr key={headerGroup.id}>
+              {headerGroup.headers.map(
+                ({ colSpan, column, getContext, id, isPlaceholder }) => {
+                  const sort = column.getIsSorted();
+                  const canSort = column.getCanSort();
+
+                  return (
+                    <Th
+                      colSpan={colSpan}
+                      cursor={column.getCanSort() ? "pointer" : undefined}
+                      key={id}
+                      onClick={column.getToggleSortingHandler()}
+                      whiteSpace="nowrap"
+                    >
+                      {isPlaceholder ? undefined : (
+                        <>{flexRender(column.columnDef.header, getContext())}</>
+                      )}
+                      {canSort && sort === false ? (
+                        <TiArrowUnsorted
+                          aria-label="unsorted"
+                          size="1em"
+                          style={{ display: "inline" }}
+                        />
+                      ) : undefined}
+                      {canSort && sort !== false ? (
+                        sort === "desc" ? (
+                          <TiArrowSortedDown
+                            aria-label="sorted descending"
+                            size="1em"
+                            style={{ display: "inline" }}
+                          />
+                        ) : (
+                          <TiArrowSortedUp
+                            aria-label="sorted ascending"
+                            size="1em"
+                            style={{ display: "inline" }}
+                          />
+                        )
+                      ) : undefined}
+                    </Th>
+                  );
+                },
+              )}
+            </Tr>
+          ))}
+        </Thead>
+        <Tbody>
+          {table.getRowModel().rows.map((row) => (
+            <Fragment key={row.id}>
+              <Tr>
+                {/* first row is a normal row */}
+                {row.getVisibleCells().map((cell) => (
+                  <Td key={cell.id}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </Td>
+                ))}
+              </Tr>
+              {row.getIsExpanded() && (
+                <Tr>
+                  {/* 2nd row is a custom 1 cell row */}
+                  <Td colSpan={row.getVisibleCells().length}>
+                    {renderSubComponent?.({ row })}
+                  </Td>
+                </Tr>
+              )}
+            </Fragment>
+          ))}
+        </Tbody>
+      </ChakraTable>
+    </TableContainer>
+  );
+};

--- a/airflow/ui/src/components/DataTable/ToggleTableDisplay.tsx
+++ b/airflow/ui/src/components/DataTable/ToggleTableDisplay.tsx
@@ -26,36 +26,29 @@ type Props = {
   readonly setDisplay: (display: Display) => void;
 };
 
-export const ToggleTableDisplay = ({ display, setDisplay }: Props) => {
-  const setCardView = () => setDisplay("card");
-  const setTableView = () => setDisplay("table");
-
-  return (
-    <HStack pb={2} spacing={1}>
-      <IconButton
-        aria-label="Show card view"
-        colorScheme="blue"
-        height={8}
-        icon={<FiGrid />}
-        isActive={display === "card"}
-        minWidth={8}
-        // eslint-disable-next-line react/jsx-no-bind
-        onClick={setCardView}
-        variant="outline"
-        width={8}
-      />
-      <IconButton
-        aria-label="Show table view"
-        colorScheme="blue"
-        height={8}
-        icon={<FiAlignJustify />}
-        isActive={display === "table"}
-        minWidth={8}
-        // eslint-disable-next-line react/jsx-no-bind
-        onClick={setTableView}
-        variant="outline"
-        width={8}
-      />
-    </HStack>
-  );
-};
+export const ToggleTableDisplay = ({ display, setDisplay }: Props) => (
+  <HStack pb={2} spacing={1}>
+    <IconButton
+      aria-label="Show card view"
+      colorScheme="blue"
+      height={8}
+      icon={<FiGrid />}
+      isActive={display === "card"}
+      minWidth={8}
+      onClick={() => setDisplay("card")}
+      variant="outline"
+      width={8}
+    />
+    <IconButton
+      aria-label="Show table view"
+      colorScheme="blue"
+      height={8}
+      icon={<FiAlignJustify />}
+      isActive={display === "table"}
+      minWidth={8}
+      onClick={() => setDisplay("table")}
+      variant="outline"
+      width={8}
+    />
+  </HStack>
+);

--- a/airflow/ui/src/components/DataTable/ToggleTableDisplay.tsx
+++ b/airflow/ui/src/components/DataTable/ToggleTableDisplay.tsx
@@ -1,0 +1,61 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { HStack, IconButton } from "@chakra-ui/react";
+import { FiAlignJustify, FiGrid } from "react-icons/fi";
+
+type Display = "card" | "table";
+
+type Props = {
+  readonly display: Display;
+  readonly setDisplay: (display: Display) => void;
+};
+
+export const ToggleTableDisplay = ({ display, setDisplay }: Props) => {
+  const setCardView = () => setDisplay("card");
+  const setTableView = () => setDisplay("table");
+
+  return (
+    <HStack pb={2} spacing={1}>
+      <IconButton
+        aria-label="Show card view"
+        colorScheme="blue"
+        height={8}
+        icon={<FiGrid />}
+        isActive={display === "card"}
+        minWidth={8}
+        // eslint-disable-next-line react/jsx-no-bind
+        onClick={setCardView}
+        variant="outline"
+        width={8}
+      />
+      <IconButton
+        aria-label="Show table view"
+        colorScheme="blue"
+        height={8}
+        icon={<FiAlignJustify />}
+        isActive={display === "table"}
+        minWidth={8}
+        // eslint-disable-next-line react/jsx-no-bind
+        onClick={setTableView}
+        variant="outline"
+        width={8}
+      />
+    </HStack>
+  );
+};

--- a/airflow/ui/src/components/DataTable/skeleton.tsx
+++ b/airflow/ui/src/components/DataTable/skeleton.tsx
@@ -16,30 +16,36 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import type { SimpleGridProps } from "@chakra-ui/react";
-import type {
-  ColumnDef,
-  PaginationState,
-  SortingState,
-} from "@tanstack/react-table";
-import type { ReactNode } from "react";
+import { Skeleton } from "@chakra-ui/react";
 
-export type TableState = {
-  pagination: PaginationState;
-  sorting: SortingState;
+import type { MetaColumn } from "./types";
+
+export const createSkeletonMock = <TData,>(
+  mode: "card" | "table",
+  skeletonCount: number,
+  columnDefs: Array<MetaColumn<TData>>,
+) => {
+  const colDefs = columnDefs.map((colDef) => ({
+    ...colDef,
+    cell: () => {
+      if (mode === "table") {
+        return (
+          colDef.meta?.customSkeleton ?? (
+            <Skeleton
+              data-testid="skeleton"
+              display="inline-block"
+              height="16px"
+              width={colDef.meta?.skeletonWidth ?? 200}
+            />
+          )
+        );
+      }
+
+      return undefined;
+    },
+  }));
+
+  const data = [...Array<TData>(skeletonCount)].map(() => ({}));
+
+  return { columns: colDefs, data };
 };
-
-export type CardDef<TData> = {
-  card: (props: { row: TData }) => ReactNode;
-  gridProps?: SimpleGridProps;
-  meta?: {
-    customSkeleton?: JSX.Element;
-  };
-};
-
-export type MetaColumn<TData> = {
-  meta?: {
-    customSkeleton?: ReactNode;
-    skeletonWidth?: number;
-  } & ColumnDef<TData>["meta"];
-} & ColumnDef<TData>;

--- a/airflow/ui/src/components/DataTable/types.ts
+++ b/airflow/ui/src/components/DataTable/types.ts
@@ -16,9 +16,19 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import type { SimpleGridProps } from "@chakra-ui/react";
 import type { PaginationState, SortingState } from "@tanstack/react-table";
+import type { ReactNode } from "react";
 
 export type TableState = {
   pagination: PaginationState;
   sorting: SortingState;
+};
+
+export type CardDef<TData> = {
+  card: (props: { row: TData }) => ReactNode;
+  gridProps?: SimpleGridProps;
+  meta?: {
+    customSkeleton?: JSX.Element;
+  };
 };

--- a/airflow/ui/src/pages/DagsList/DagCard.test.tsx
+++ b/airflow/ui/src/pages/DagsList/DagCard.test.tsx
@@ -1,0 +1,87 @@
+/* eslint-disable unicorn/no-null */
+
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render, screen } from "@testing-library/react";
+import type {
+  DAGResponse,
+  DagTagPydantic,
+} from "openapi-gen/requests/types.gen";
+import { afterEach, describe, it, vi, expect } from "vitest";
+
+import { Wrapper } from "src/utils/Wrapper";
+
+import { DagCard } from "./DagCard";
+
+const mockDag = {
+  dag_display_name: "nested_groups",
+  dag_id: "nested_groups",
+  default_view: "grid",
+  description: null,
+  file_token:
+    "Ii9maWxlcy9kYWdzL25lc3RlZF90YXNrX2dyb3Vwcy5weSI.G3EkdxmDUDQsVb7AIZww1TSGlFE",
+  fileloc: "/files/dags/nested_task_groups.py",
+  has_import_errors: false,
+  has_task_concurrency_limits: false,
+  is_active: true,
+  is_paused: false,
+  last_expired: null,
+  last_parsed_time: "2024-08-22T13:50:10.372238+00:00",
+  last_pickled: null,
+  max_active_runs: 16,
+  max_active_tasks: 16,
+  max_consecutive_failed_dag_runs: 0,
+  next_dagrun: "2024-08-22T00:00:00+00:00",
+  next_dagrun_create_after: "2024-08-23T00:00:00+00:00",
+  next_dagrun_data_interval_end: "2024-08-23T00:00:00+00:00",
+  next_dagrun_data_interval_start: "2024-08-22T00:00:00+00:00",
+  owners: ["airflow"],
+  pickle_id: null,
+  scheduler_lock: null,
+  tags: [],
+  timetable_description: "",
+  timetable_summary: "",
+} satisfies DAGResponse;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("DagCard", () => {
+  it("DagCard should render without tags", () => {
+    render(<DagCard dag={mockDag} />, { wrapper: Wrapper });
+    expect(screen.getByText(mockDag.dag_display_name)).toBeInTheDocument();
+    expect(screen.queryByTestId("dag-tag")).toBeNull();
+  });
+
+  it("DagCard should show +X more text if there are more than 3 tags", () => {
+    const tags = [
+      { dag_id: "id", name: "tag1" },
+      { dag_id: "id", name: "tag2" },
+      { dag_id: "id", name: "tag3" },
+      { dag_id: "id", name: "tag4" },
+    ] satisfies Array<DagTagPydantic>;
+
+    const expandedMockDag = { ...mockDag, tags } satisfies DAGResponse;
+
+    render(<DagCard dag={expandedMockDag} />, { wrapper: Wrapper });
+    expect(screen.getByTestId("dag-tag")).toBeInTheDocument();
+    expect(screen.getByText("+1 more")).toBeInTheDocument();
+  });
+});

--- a/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -16,7 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Flex, HStack, SimpleGrid, Text, VStack } from "@chakra-ui/react";
+import {
+  Badge,
+  Box,
+  Flex,
+  HStack,
+  SimpleGrid,
+  Text,
+  Tooltip,
+  useColorModeValue,
+  VStack,
+} from "@chakra-ui/react";
 import { FiCalendar, FiTag } from "react-icons/fi";
 
 import type { DAGResponse } from "openapi/requests/types.gen";
@@ -26,55 +36,84 @@ type Props = {
   readonly dag: DAGResponse;
 };
 
-export const DagCard = ({ dag }: Props) => (
-  <Box
-    borderColor="gray.100"
-    borderRadius={8}
-    borderWidth={1}
-    overflow="hidden"
-  >
-    <Flex
-      alignItems="center"
-      bg="blue.50"
-      justifyContent="space-between"
-      px={3}
-      py={2}
+const MAX_TAGS = 3;
+
+export const DagCard = ({ dag }: Props) => {
+  const cardHeadBg = useColorModeValue("blue.50", "gray.900");
+  const cardBorder = useColorModeValue("gray.100", "gray.700");
+  const dagIdColor = useColorModeValue("blue.600", "blue.400");
+  const tooltipBg = useColorModeValue("blue.100", "gray.700");
+
+  return (
+    <Box
+      borderColor={cardBorder}
+      borderRadius={8}
+      borderWidth={1}
+      overflow="hidden"
     >
-      <HStack>
-        <Text color="blue.600" fontWeight="bold">
-          {dag.dag_display_name}
-        </Text>
-        {dag.tags.length ? (
-          <HStack spacing={1}>
-            <FiTag />
-            {dag.tags.map((tag, index) => (
-              <Text fontSize="sm" key={tag.name}>
-                {tag.name}
-                {index === dag.tags.length - 1 ? undefined : ","}
-              </Text>
-            ))}
-          </HStack>
-        ) : undefined}
-      </HStack>
-      <HStack>
-        <TogglePause dagId={dag.dag_id} isPaused={dag.is_paused} />
-      </HStack>
-    </Flex>
-    <SimpleGrid columns={4} height={20} px={3} py={2} spacing={4}>
-      <Box />
-      {Boolean(dag.next_dagrun) ? (
+      <Flex
+        alignItems="center"
+        bg={cardHeadBg}
+        justifyContent="space-between"
+        px={3}
+        py={2}
+      >
+        <HStack>
+          <Tooltip hasArrow label={dag.description}>
+            <Text color={dagIdColor} fontWeight="bold">
+              {dag.dag_display_name}
+            </Text>
+          </Tooltip>
+          {dag.tags.length ? (
+            <HStack spacing={1}>
+              <FiTag data-testid="dag-tag" />
+              {dag.tags.slice(0, MAX_TAGS).map((tag) => (
+                <Badge key={tag.name}>{tag.name}</Badge>
+              ))}
+              {dag.tags.length > MAX_TAGS && (
+                <Tooltip
+                  bg={tooltipBg}
+                  hasArrow
+                  label={
+                    <VStack p={1} spacing={1}>
+                      {dag.tags.slice(MAX_TAGS).map((tag) => (
+                        <Badge key={tag.name}>{tag.name}</Badge>
+                      ))}
+                    </VStack>
+                  }
+                >
+                  <Badge>+{dag.tags.length - MAX_TAGS} more</Badge>
+                </Tooltip>
+              )}
+            </HStack>
+          ) : undefined}
+        </HStack>
+        <HStack>
+          <TogglePause dagId={dag.dag_id} isPaused={dag.is_paused} />
+        </HStack>
+      </Flex>
+      <SimpleGrid columns={4} height={20} px={3} py={2} spacing={4}>
+        <Box />
         <VStack align="flex-start" spacing={1}>
           <Text color="gray.500" fontSize="sm">
             Next Run
           </Text>
-          <Text fontSize="sm">
-            {dag.next_dagrun} <FiCalendar style={{ display: "inline" }} />{" "}
-            {dag.timetable_description}
-          </Text>
+          {Boolean(dag.next_dagrun) ? (
+            <Text fontSize="sm">{dag.next_dagrun}</Text>
+          ) : undefined}
+          {Boolean(dag.timetable_summary) ? (
+            <Tooltip hasArrow label={dag.timetable_description}>
+              <Text fontSize="sm">
+                {" "}
+                <FiCalendar style={{ display: "inline" }} />{" "}
+                {dag.timetable_summary}
+              </Text>
+            </Tooltip>
+          ) : undefined}
         </VStack>
-      ) : undefined}
-      <Box />
-      <Box />
-    </SimpleGrid>
-  </Box>
-);
+        <Box />
+        <Box />
+      </SimpleGrid>
+    </Box>
+  );
+};

--- a/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -40,10 +40,8 @@ type Props = {
 const MAX_TAGS = 3;
 
 export const DagCard = ({ dag }: Props) => {
-  const cardHeadBg = useColorModeValue("blue.50", "gray.900");
   const cardBorder = useColorModeValue("gray.100", "gray.700");
-  const dagIdColor = useColorModeValue("blue.600", "blue.400");
-  const tooltipBg = useColorModeValue("blue.100", "gray.700");
+  const tooltipBg = useColorModeValue("gray.200", "gray.700");
 
   return (
     <Box
@@ -54,14 +52,14 @@ export const DagCard = ({ dag }: Props) => {
     >
       <Flex
         alignItems="center"
-        bg={cardHeadBg}
+        bg="subtle-bg"
         justifyContent="space-between"
         px={3}
         py={2}
       >
         <HStack>
           <Tooltip hasArrow label={dag.description}>
-            <Heading color={dagIdColor} fontSize="md">
+            <Heading color="subtle-text" fontSize="md">
               {dag.dag_display_name}
             </Heading>
           </Tooltip>

--- a/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -21,6 +21,7 @@ import {
   Box,
   Flex,
   HStack,
+  Heading,
   SimpleGrid,
   Text,
   Tooltip,
@@ -60,9 +61,9 @@ export const DagCard = ({ dag }: Props) => {
       >
         <HStack>
           <Tooltip hasArrow label={dag.description}>
-            <Text color={dagIdColor} fontWeight="bold">
+            <Heading color={dagIdColor} fontSize="md">
               {dag.dag_display_name}
-            </Text>
+            </Heading>
           </Tooltip>
           {dag.tags.length ? (
             <HStack spacing={1}>
@@ -93,11 +94,11 @@ export const DagCard = ({ dag }: Props) => {
         </HStack>
       </Flex>
       <SimpleGrid columns={4} height={20} px={3} py={2} spacing={4}>
-        <Box />
+        <div />
         <VStack align="flex-start" spacing={1}>
-          <Text color="gray.500" fontSize="sm">
+          <Heading color="gray.500" fontSize="xs">
             Next Run
-          </Text>
+          </Heading>
           {Boolean(dag.next_dagrun) ? (
             <Text fontSize="sm">{dag.next_dagrun}</Text>
           ) : undefined}
@@ -111,8 +112,8 @@ export const DagCard = ({ dag }: Props) => {
             </Tooltip>
           ) : undefined}
         </VStack>
-        <Box />
-        <Box />
+        <div />
+        <div />
       </SimpleGrid>
     </Box>
   );

--- a/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -1,0 +1,80 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box, Flex, HStack, SimpleGrid, Text, VStack } from "@chakra-ui/react";
+import { FiCalendar, FiTag } from "react-icons/fi";
+
+import type { DAGResponse } from "openapi/requests/types.gen";
+import { TogglePause } from "src/components/TogglePause";
+
+type Props = {
+  readonly dag: DAGResponse;
+};
+
+export const DagCard = ({ dag }: Props) => (
+  <Box
+    borderColor="gray.100"
+    borderRadius={8}
+    borderWidth={1}
+    overflow="hidden"
+  >
+    <Flex
+      alignItems="center"
+      bg="blue.50"
+      justifyContent="space-between"
+      px={3}
+      py={2}
+    >
+      <HStack>
+        <Text color="blue.600" fontWeight="bold">
+          {dag.dag_display_name}
+        </Text>
+        {dag.tags.length ? (
+          <HStack spacing={1}>
+            <FiTag />
+            {dag.tags.map((tag, index) => (
+              <Text fontSize="sm" key={tag.name}>
+                {tag.name}
+                {index === dag.tags.length - 1 ? undefined : ","}
+              </Text>
+            ))}
+          </HStack>
+        ) : undefined}
+      </HStack>
+      <HStack>
+        <TogglePause dagId={dag.dag_id} isPaused={dag.is_paused} />
+      </HStack>
+    </Flex>
+    <SimpleGrid columns={4} height={20} px={3} py={2} spacing={4}>
+      <Box />
+      {Boolean(dag.next_dagrun) ? (
+        <VStack align="flex-start" spacing={1}>
+          <Text color="gray.500" fontSize="sm">
+            Next Run
+          </Text>
+          <Text fontSize="sm">
+            {dag.next_dagrun} <FiCalendar style={{ display: "inline" }} />{" "}
+            {dag.timetable_description}
+          </Text>
+        </VStack>
+      ) : undefined}
+      <Box />
+      <Box />
+    </SimpleGrid>
+  </Box>
+);

--- a/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -22,7 +22,6 @@ import {
   HStack,
   Select,
   Skeleton,
-  Spinner,
   VStack,
 } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
@@ -53,6 +52,9 @@ const columns: Array<ColumnDef<DAGResponse>> = [
     ),
     enableSorting: false,
     header: "",
+    meta: {
+      skeletonWidth: 10,
+    },
   },
   {
     accessorKey: "dag_id",
@@ -131,50 +133,47 @@ export const DagsList = () => {
 
   return (
     <>
-      {isLoading ? <Spinner /> : undefined}
-      {!isLoading && Boolean(data?.dags) && (
-        <>
-          <VStack alignItems="none">
-            <SearchBar
-              buttonProps={{ isDisabled: true }}
-              inputProps={{ isDisabled: true }}
-            />
-            <DagsFilters />
-            <HStack justifyContent="space-between">
-              <Heading py={3} size="md">
-                {pluralize("DAG", data?.total_entries)}
-              </Heading>
-              {display === "card" ? (
-                <Select
-                  onChange={handleSortChange}
-                  placeholder="Sort by…"
-                  value={orderBy}
-                  variant="flushed"
-                  width="200px"
-                >
-                  <option value="dag_id">Sort by DAG ID (A-Z)</option>
-                  <option value="-dag_id">Sort by DAG ID (Z-A)</option>
-                </Select>
-              ) : (
-                false
-              )}
-            </HStack>
-          </VStack>
-          <ToggleTableDisplay display={display} setDisplay={setDisplay} />
-          <DataTable
-            cardDef={cardDef}
-            columns={columns}
-            data={data?.dags ?? []}
-            displayMode={display}
-            initialState={tableURLState}
-            isFetching={isFetching}
-            isLoading={isLoading}
-            modelName="DAG"
-            onStateChange={setTableURLState}
-            total={data?.total_entries}
-          />
-        </>
-      )}
+      <VStack alignItems="none">
+        <SearchBar
+          buttonProps={{ isDisabled: true }}
+          inputProps={{ isDisabled: true }}
+        />
+        <DagsFilters />
+        <HStack justifyContent="space-between">
+          <Heading py={3} size="md">
+            {pluralize("DAG", data?.total_entries)}
+          </Heading>
+          {display === "card" ? (
+            <Select
+              data-testid="sort-by-select"
+              onChange={handleSortChange}
+              placeholder="Sort by…"
+              value={orderBy}
+              variant="flushed"
+              width="200px"
+            >
+              <option value="dag_id">Sort by DAG ID (A-Z)</option>
+              <option value="-dag_id">Sort by DAG ID (Z-A)</option>
+            </Select>
+          ) : (
+            false
+          )}
+        </HStack>
+      </VStack>
+      <ToggleTableDisplay display={display} setDisplay={setDisplay} />
+      <DataTable
+        cardDef={cardDef}
+        columns={columns}
+        data={data?.dags ?? []}
+        displayMode={display}
+        initialState={tableURLState}
+        isFetching={isFetching}
+        isLoading={isLoading}
+        modelName="DAG"
+        onStateChange={setTableURLState}
+        skeletonCount={display === "card" ? 5 : undefined}
+        total={data?.total_entries}
+      />
     </>
   );
 };

--- a/airflow/ui/src/theme.ts
+++ b/airflow/ui/src/theme.ts
@@ -24,39 +24,33 @@ import { createMultiStyleConfigHelpers, extendTheme } from "@chakra-ui/react";
 const { defineMultiStyleConfig, definePartsStyle } =
   createMultiStyleConfigHelpers(tableAnatomy.keys);
 
-const baseStyle = definePartsStyle((props) => {
-  const { colorMode, colorScheme } = props;
-
-  return {
-    tbody: {
-      tr: {
-        "&:nth-of-type(even)": {
-          "th, td": {
-            borderBottomWidth: "0px",
-          },
+const baseStyle = definePartsStyle(() => ({
+  tbody: {
+    tr: {
+      "&:nth-of-type(even)": {
+        "th, td": {
+          borderBottomWidth: "0px",
         },
-        "&:nth-of-type(odd)": {
-          td: {
-            background:
-              colorMode === "light" ? `${colorScheme}.50` : `gray.900`,
-          },
-          "th, td": {
-            borderBottomWidth: "0px",
-            borderColor:
-              colorMode === "light" ? `${colorScheme}.50` : `gray.900`,
-          },
+      },
+      "&:nth-of-type(odd)": {
+        td: {
+          background: "subtle-bg",
+        },
+        "th, td": {
+          borderBottomWidth: "0px",
+          borderColor: "subtle-bg",
         },
       },
     },
-    thead: {
-      tr: {
-        th: {
-          borderBottomWidth: 0,
-        },
+  },
+  thead: {
+    tr: {
+      th: {
+        borderBottomWidth: 0,
       },
     },
-  };
-});
+  },
+}));
 
 export const tableTheme = defineMultiStyleConfig({ baseStyle });
 
@@ -71,6 +65,12 @@ const theme = extendTheme({
   },
   config: {
     useSystemColorMode: true,
+  },
+  semanticTokens: {
+    colors: {
+      "subtle-bg": { _dark: "gray.900", _light: "blue.50" },
+      "subtle-text": { _dark: "blue.500", _light: "blue.600" },
+    },
   },
   styles: {
     global: {


### PR DESCRIPTION
Add a card list component to oru shared table component to allow toggling between a regular table view or a card list.

<img width="1330" alt="Screenshot 2024-10-03 at 5 44 44 PM" src="https://github.com/user-attachments/assets/375ca2c2-d334-41ed-b109-199bb975f007">
<img width="1326" alt="Screenshot 2024-10-03 at 5 44 50 PM" src="https://github.com/user-attachments/assets/ea18b25f-4dd0-45c8-92c2-d333753ec033">

Closes #42698 and #42734


Also, added loading states:
<img width="1195" alt="Screenshot 2024-10-04 at 11 10 50 AM" src="https://github.com/user-attachments/assets/ca25c22a-614c-4549-a64e-95a1f50c37e8">
<img width="1199" alt="Screenshot 2024-10-04 at 11 10 57 AM" src="https://github.com/user-attachments/assets/4c85239d-d477-4c46-a0ae-3663de5ea0e0">

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
