### PR TITLE
Improve startup of K8S tests

### DIFF
--- a/kubernetes_tests/test_base.py
+++ b/kubernetes_tests/test_base.py
@@ -215,18 +215,6 @@ class BaseK8STest:
 
         # Maybe check if we can retrieve the logs, but then we need to extend the API
 
-    def _wait_until_dag_response(self, url, payload):
-        max_attempts = 10
-        result = {}
-        while max_attempts:
-            result = self.session.patch(url, json=payload)
-            if result.status_code == 200:
-                return result
-            else:
-                time.sleep(30)
-            max_attempts -= 1
-        return result
-
     def start_dag(self, dag_id, host):
         patch_string = f"http://{host}/api/v1/dags/{dag_id}"
         print(f"Calling [start_dag]#1 {patch_string}")

--- a/kubernetes_tests/test_base.py
+++ b/kubernetes_tests/test_base.py
@@ -215,10 +215,31 @@ class BaseK8STest:
 
         # Maybe check if we can retrieve the logs, but then we need to extend the API
 
+    def _wait_until_dag_response(self, url, payload):
+        max_attempts = 10
+        result = {}
+        while max_attempts:
+            result = self.session.patch(url, json=payload)
+            if result.status_code == 200:
+                return result
+            else:
+                time.sleep(30)
+            max_attempts -= 1
+        return result
+
     def start_dag(self, dag_id, host):
         patch_string = f"http://{host}/api/v1/dags/{dag_id}"
         print(f"Calling [start_dag]#1 {patch_string}")
-        result = self.session.patch(patch_string, json={"is_paused": False})
+        max_attempts = 10
+        result = {}
+        while max_attempts:
+            result = self.session.patch(patch_string, json={"is_paused": False})
+            if result.status_code == 200:
+                break
+
+            time.sleep(30)
+            max_attempts -= 1
+
         try:
             result_json = result.json()
         except ValueError:


### PR DESCRIPTION
Loop api request until dag response receives 200, max attempts 10.

closes: #42718 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
