### PR TITLE
Typo correction in 07_local_virtualenv.rst

### DIFF
--- a/contributing-docs/07_local_virtualenv.rst
+++ b/contributing-docs/07_local_virtualenv.rst
@@ -141,7 +141,7 @@ Airflow, but it is a convenient way to manage your local Python versions and vir
 Installing Hatch
 ................
 
-You can install hat using various other ways (including Gui installers).
+You can install hatch using various other ways (including Gui installers).
 
 Example using ``pipx``:
 


### PR DESCRIPTION
Corrected typo from "hat" to "hatch" in the documentation file of 07_local_virtualenv.rst