### PR TITLE
fix(assets/managers): fix error handling file loc when asset alias resolved into new assets

### DIFF
--- a/airflow/assets/manager.py
+++ b/airflow/assets/manager.py
@@ -266,14 +266,14 @@ class AssetManager(LoggingMixin):
                 return None
             return req.fileloc
 
-        (_send_dag_priority_parsing_request_if_needed(fileloc) for fileloc in file_locs)
+        [_send_dag_priority_parsing_request_if_needed(fileloc) for fileloc in file_locs]
 
     @classmethod
     def _postgres_send_dag_priority_parsing_request(cls, file_locs: Iterable[str], session: Session) -> None:
         from sqlalchemy.dialects.postgresql import insert
 
         stmt = insert(DagPriorityParsingRequest).on_conflict_do_nothing()
-        session.execute(stmt, {"fileloc": fileloc for fileloc in file_locs})
+        session.execute(stmt, [{"fileloc": fileloc} for fileloc in file_locs])
 
 
 def resolve_asset_manager() -> AssetManager:

--- a/airflow/assets/manager.py
+++ b/airflow/assets/manager.py
@@ -266,7 +266,8 @@ class AssetManager(LoggingMixin):
                 return None
             return req.fileloc
 
-        [_send_dag_priority_parsing_request_if_needed(fileloc) for fileloc in file_locs]
+        for fileloc in file_locs:
+            _send_dag_priority_parsing_request_if_needed(fileloc)
 
     @classmethod
     def _postgres_send_dag_priority_parsing_request(cls, file_locs: Iterable[str], session: Session) -> None:

--- a/tests/assets/test_manager.py
+++ b/tests/assets/test_manager.py
@@ -24,11 +24,19 @@ from unittest import mock
 import pytest
 from sqlalchemy import delete
 
-from airflow.assets import Asset
+from airflow.assets import Asset, AssetAlias
 from airflow.assets.manager import AssetManager
 from airflow.listeners.listener import get_listener_manager
-from airflow.models.asset import AssetDagRunQueue, AssetEvent, AssetModel, DagScheduleAssetReference
+from airflow.models.asset import (
+    AssetAliasModel,
+    AssetDagRunQueue,
+    AssetEvent,
+    AssetModel,
+    DagScheduleAssetAliasReference,
+    DagScheduleAssetReference,
+)
 from airflow.models.dag import DagModel
+from airflow.models.dagbag import DagPriorityParsingRequest
 from airflow.serialization.pydantic.taskinstance import TaskInstancePydantic
 from tests.listeners import asset_listener
 
@@ -36,6 +44,15 @@ pytestmark = pytest.mark.db_test
 
 
 pytest.importorskip("pydantic", minversion="2.0.0")
+
+
+@pytest.fixture
+def clear_assets():
+    from tests.test_utils.db import clear_db_assets
+
+    clear_db_assets()
+    yield
+    clear_db_assets()
 
 
 @pytest.fixture
@@ -92,15 +109,16 @@ def create_mock_dag():
 
 class TestAssetManager:
     def test_register_asset_change_asset_doesnt_exist(self, mock_task_instance):
-        dsem = AssetManager()
-
         asset = Asset(uri="asset_doesnt_exist")
 
         mock_session = mock.Mock()
         # Gotta mock up the query results
         mock_session.scalar.return_value = None
 
-        dsem.register_asset_change(task_instance=mock_task_instance, asset=asset, session=mock_session)
+        asset_manger = AssetManager()
+        asset_manger.register_asset_change(
+            task_instance=mock_task_instance, asset=asset, session=mock_session
+        )
 
         # Ensure that we have ignored the asset and _not_ created a AssetEvent or
         # AssetDagRunQueue rows
@@ -108,9 +126,9 @@ class TestAssetManager:
         mock_session.merge.assert_not_called()
 
     def test_register_asset_change(self, session, dag_maker, mock_task_instance):
-        dsem = AssetManager()
+        asset_manager = AssetManager()
 
-        ds = Asset(uri="test_asset_uri")
+        asset = Asset(uri="test_asset_uri")
         dag1 = DagModel(dag_id="dag1", is_active=True)
         dag2 = DagModel(dag_id="dag2", is_active=True)
         session.add_all([dag1, dag2])
@@ -121,23 +139,58 @@ class TestAssetManager:
         session.execute(delete(AssetDagRunQueue))
         session.flush()
 
-        dsem.register_asset_change(task_instance=mock_task_instance, asset=ds, session=session)
+        asset_manager.register_asset_change(task_instance=mock_task_instance, asset=asset, session=session)
         session.flush()
 
         # Ensure we've created an asset
         assert session.query(AssetEvent).filter_by(dataset_id=asm.id).count() == 1
         assert session.query(AssetDagRunQueue).count() == 2
 
-    def test_register_asset_change_no_downstreams(self, session, mock_task_instance):
-        dsem = AssetManager()
+    @pytest.mark.usefixtures("clear_assets")
+    def test_register_asset_change_with_alias(self, session, dag_maker, mock_task_instance):
+        consumer_dag_1 = DagModel(dag_id="conumser_1", is_active=True, fileloc="dag1.py")
+        consumer_dag_2 = DagModel(dag_id="conumser_2", is_active=True, fileloc="dag2.py")
+        session.add_all([consumer_dag_1, consumer_dag_2])
 
-        ds = Asset(uri="never_consumed")
+        asm = AssetModel(uri="test_asset_uri")
+        session.add(asm)
+
+        asam = AssetAliasModel(name="test_alias_name")
+        session.add(asam)
+        asam.consuming_dags = [
+            DagScheduleAssetAliasReference(alias_id=asam.id, dag_id=dag.dag_id)
+            for dag in (consumer_dag_1, consumer_dag_2)
+        ]
+        session.execute(delete(AssetDagRunQueue))
+        session.flush()
+
+        asset = Asset(uri="test_asset_uri")
+        asset_alias = AssetAlias(name="test_alias_name")
+        asset_manager = AssetManager()
+        asset_manager.register_asset_change(
+            task_instance=mock_task_instance,
+            asset=asset,
+            aliases=[asset_alias],
+            source_alias_names=["test_alias_name"],
+            session=session,
+        )
+        session.flush()
+
+        # Ensure we've created an asset
+        assert session.query(AssetEvent).filter_by(dataset_id=asm.id).count() == 1
+        assert session.query(AssetDagRunQueue).count() == 2
+        assert session.query(DagPriorityParsingRequest).count() == 2
+
+    def test_register_asset_change_no_downstreams(self, session, mock_task_instance):
+        asset_manager = AssetManager()
+
+        asset = Asset(uri="never_consumed")
         asm = AssetModel(uri="never_consumed")
         session.add(asm)
         session.execute(delete(AssetDagRunQueue))
         session.flush()
 
-        dsem.register_asset_change(task_instance=mock_task_instance, asset=ds, session=session)
+        asset_manager.register_asset_change(task_instance=mock_task_instance, asset=asset, session=session)
         session.flush()
 
         # Ensure we've created an asset
@@ -146,11 +199,11 @@ class TestAssetManager:
 
     @pytest.mark.skip_if_database_isolation_mode
     def test_register_asset_change_notifies_asset_listener(self, session, mock_task_instance):
-        dsem = AssetManager()
+        asset_manager = AssetManager()
         asset_listener.clear()
         get_listener_manager().add_listener(asset_listener)
 
-        ds = Asset(uri="test_asset_uri_2")
+        asset = Asset(uri="test_asset_uri_2")
         dag1 = DagModel(dag_id="dag3")
         session.add(dag1)
 
@@ -159,12 +212,12 @@ class TestAssetManager:
         asm.consuming_dags = [DagScheduleAssetReference(dag_id=dag1.dag_id)]
         session.flush()
 
-        dsem.register_asset_change(task_instance=mock_task_instance, asset=ds, session=session)
+        asset_manager.register_asset_change(task_instance=mock_task_instance, asset=asset, session=session)
         session.flush()
 
         # Ensure the listener was notified
         assert len(asset_listener.changed) == 1
-        assert asset_listener.changed[0].uri == ds.uri
+        assert asset_listener.changed[0].uri == asset.uri
 
     @pytest.mark.skip_if_database_isolation_mode
     def test_create_assets_notifies_asset_listener(self, session):


### PR DESCRIPTION
## Why
Detailed in https://github.com/apache/airflow/issues/42704. values should be list of dict instead of dict

## What
Pass a list of file locations as a dictionary for DAG priority parsing request when asset aliases are resolved into new assets.


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
