### PR TITLE
feat(providers/common/sql): add warning to connection setter

### DIFF
--- a/airflow/providers/common/sql/hooks/sql.py
+++ b/airflow/providers/common/sql/hooks/sql.py
@@ -212,14 +212,15 @@ class DbApiHook(BaseHook):
 
     @connection.setter
     def connection(self, value: Any) -> None:
-        # This setter is for backward compatibility and should not be used.
-        # Since the introduction of connection property, the providers listed below
-        # breaks due to assigning value to self.connection
-        #
-        # apache-airflow-providers-mysql<5.7.1
-        # apache-airflow-providers-elasticsearch<5.5.1
-        # apache-airflow-providers-postgres<5.13.0
-        pass
+        if value != self.connection:
+            self.log.warning(
+                "This setter is for backward compatibility and should not be used.\n"
+                "Since the introduction of connection property, the providers listed below "
+                "breaks due to assigning value to self.connection in their __init__ method.\n"
+                "* apache-airflow-providers-mysql<5.7.1\n"
+                "* apache-airflow-providers-elasticsearch<5.5.1\n"
+                "* apache-airflow-providers-postgres<5.13.0"
+            )
 
     @property
     def connection_extra(self) -> dict:


### PR DESCRIPTION
## Why
Users might not expect a setter that does nothing.

## What
Add a warning if user is trying to assign a value different from the _connection

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
