### PR TITLE
Drop Python 3.8 support in provider packages

### DIFF
--- a/airflow/providers/MANAGING_PROVIDERS_LIFECYCLE.rst
+++ b/airflow/providers/MANAGING_PROVIDERS_LIFECYCLE.rst
@@ -454,7 +454,7 @@ If you have pre-commit installed, pre-commit will be run automatically on commit
 manually after commit, you can run it via ``breeze static-checks --last-commit`` some of the tests might fail
 because suspension of the provider might cause changes in the dependencies, so if you see errors about
 missing dependencies imports, non-usable classes etc., you will need to build the CI image locally
-via ``breeze build-image --python 3.8 --upgrade-to-newer-dependencies`` after the first pre-commit run
+via ``breeze build-image --python 3.9 --upgrade-to-newer-dependencies`` after the first pre-commit run
 and then run the static checks again.
 
 If you want to be absolutely sure to run all static checks you can always do this via

--- a/airflow/providers/amazon/aws/utils/mixins.py
+++ b/airflow/providers/amazon/aws/utils/mixins.py
@@ -27,12 +27,11 @@ This module contains different mixin classes for internal use within the Amazon 
 
 from __future__ import annotations
 
-from functools import cached_property
+from functools import cache, cached_property
 from typing import Any, Generic, NamedTuple, TypeVar
 
 from typing_extensions import final
 
-from airflow.compat.functools import cache
 from airflow.providers.amazon.aws.hooks.base_aws import AwsGenericHook
 
 AwsHookType = TypeVar("AwsHookType", bound=AwsGenericHook)

--- a/airflow/providers/cloudant/provider.yaml
+++ b/airflow/providers/cloudant/provider.yaml
@@ -51,10 +51,9 @@ dependencies:
 
 excluded-python-versions:
   # ibmcloudant transitively brings in urllib3 2.x, but the snowflake provider has a dependency that pins
-  # urllib3 to 1.x on Python 3.8 and 3.9; thus we exclude those Python versions from taking the update
+  # urllib3 to 1.x on Python 3.9; thus we exclude those Python versions from taking the update
   # to ibmcloudant.
   # See #21004, #41555, and https://github.com/snowflakedb/snowflake-connector-python/issues/2016
-  - "3.8"
   - "3.9"
 
 integrations:

--- a/airflow/providers/cncf/kubernetes/kubernetes_helper_functions.py
+++ b/airflow/providers/cncf/kubernetes/kubernetes_helper_functions.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import logging
 import secrets
 import string
+from functools import cache
 from typing import TYPE_CHECKING
 
 import pendulum
@@ -26,7 +27,6 @@ from deprecated import deprecated
 from kubernetes.client.rest import ApiException
 from slugify import slugify
 
-from airflow.compat.functools import cache
 from airflow.configuration import conf
 from airflow.exceptions import AirflowProviderDeprecationWarning
 

--- a/airflow/providers/openlineage/conf.py
+++ b/airflow/providers/openlineage/conf.py
@@ -35,7 +35,7 @@ if os.getenv("PYTEST_VERSION"):
 
     cache = decorator
 else:
-    from airflow.compat.functools import cache
+    from functools import cache
 from airflow.configuration import conf
 
 _CONFIG_SECTION = "openlineage"

--- a/docs/apache-airflow-providers-amazon/executors/general.rst
+++ b/docs/apache-airflow-providers-amazon/executors/general.rst
@@ -138,9 +138,9 @@ which is running the Airflow scheduler process (and thus, the |executorName|
 executor.) Apache Airflow images with specific python versions can be
 downloaded from the Dockerhub registry, and filtering tags by the
 `python
-version <https://hub.docker.com/r/apache/airflow/tags?page=1&name=3.8>`__.
-For example, the tag ``latest-python3.8`` specifies that the image will
-have python 3.8 installed.
+version <https://hub.docker.com/r/apache/airflow/tags?page=1&name=3.9>`__.
+For example, the tag ``latest-python3.9`` specifies that the image will
+have python 3.9 installed.
 
 
 Loading DAGs

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -359,7 +359,6 @@
     "plugins": [],
     "cross-providers-deps": [],
     "excluded-python-versions": [
-      "3.8",
       "3.9"
     ],
     "state": "ready"


### PR DESCRIPTION
As Python 3.8 is getting out-of support, this PR removes support from Airflow providers.

See Python release schedule: https://peps.python.org/pep-0569/

Note: This PR is provider-only.