### PR TITLE
API-84 Add fastapi subapps to plugin system

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -4359,6 +4359,12 @@ components:
             type: string
             nullable: true
           description: The flask blueprints
+        fastapi_apps:
+          type: array
+          items:
+            type: object
+            nullable: true
+          description: The fastapi apps
         appbuilder_views:
           type: array
           items:

--- a/airflow/api_connexion/schemas/plugin_schema.py
+++ b/airflow/api_connexion/schemas/plugin_schema.py
@@ -29,6 +29,7 @@ class PluginSchema(Schema):
     executors = fields.List(fields.String(dump_only=True))
     macros = fields.List(fields.String(dump_only=True))
     flask_blueprints = fields.List(fields.String(dump_only=True))
+    fastapi_apps = fields.List(fields.Dict(dump_only=True))
     appbuilder_views = fields.List(fields.Dict(dump_only=True))
     appbuilder_menu_items = fields.List(fields.Dict(dump_only=True))
     global_operator_extra_links = fields.List(fields.String(dump_only=True))

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1762,6 +1762,8 @@ export interface components {
       macros?: (string | null)[];
       /** @description The flask blueprints */
       flask_blueprints?: (string | null)[];
+      /** @description The fastapi apps */
+      fastapi_apps?: ({ [key: string]: unknown } | null)[];
       /** @description The appuilder views */
       appbuilder_views?: ({ [key: string]: unknown } | null)[];
       /** @description The Flask Appbuilder menu items */

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -4402,6 +4402,7 @@ class PluginView(AirflowBaseView):
         plugins_manager.integrate_executor_plugins()
         plugins_manager.initialize_extra_operators_links_plugins()
         plugins_manager.initialize_web_ui_plugins()
+        plugins_manager.initialize_fastapi_plugins()
 
         plugins = []
         for plugin_no, plugin in enumerate(plugins_manager.plugins, 1):

--- a/docs/apache-airflow/authoring-and-scheduling/plugins.rst
+++ b/docs/apache-airflow/authoring-and-scheduling/plugins.rst
@@ -114,6 +114,8 @@ looks like:
         macros = []
         # A list of Blueprint object created from flask.Blueprint. For use with the flask_appbuilder based GUI
         flask_blueprints = []
+        # A list of dictionaries contanning FastAPI object and some metadata. See example below.
+        fastapi_apps = []
         # A list of dictionaries containing FlaskAppBuilder BaseView object and some metadata. See example below
         appbuilder_views = []
         # A list of dictionaries containing kwargs for FlaskAppBuilder add_link. See example below
@@ -171,6 +173,7 @@ definitions in Airflow.
     from airflow.security import permissions
     from airflow.www.auth import has_access
 
+    from fastapi import FastAPI
     from flask import Blueprint
     from flask_appbuilder import expose, BaseView as AppBuilderBaseView
 
@@ -198,6 +201,17 @@ definitions in Airflow.
         static_folder="static",
         static_url_path="/static/test_plugin",
     )
+
+    # Creating a FastAPI application to integrate in airflow Rest API.
+    app = FastAPI()
+
+
+    @app.get("/")
+    async def root():
+        return {"message": "Hello World from FastAPI plugin"}
+
+
+    app_with_metadata = {"app": app, "url_prefix": "/some_prefix", "name": "Name of the App"}
 
 
     # Creating a flask appbuilder BaseView
@@ -256,6 +270,7 @@ definitions in Airflow.
         hooks = [PluginHook]
         macros = [plugin_macro]
         flask_blueprints = [bp]
+        fastapi_apps = [app_with_metadata]
         appbuilder_views = [v_appbuilder_package, v_appbuilder_nomenu_package]
         appbuilder_menu_items = [appbuilder_mitem, appbuilder_mitem_toplevel]
 

--- a/tests/api_connexion/endpoints/test_plugin_endpoint.py
+++ b/tests/api_connexion/endpoints/test_plugin_endpoint.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import inspect
 
 import pytest
+from fastapi import FastAPI
 from flask import Blueprint
 from flask_appbuilder import BaseView
 
@@ -49,6 +50,10 @@ class MockOperatorLink(BaseOperatorLink):
 
 
 bp = Blueprint("mock_blueprint", __name__, url_prefix="/mock_blueprint")
+
+app = FastAPI()
+
+app_with_metadata = {"app": app, "url_prefix": "/some_prefix", "name": "App name"}
 
 
 class MockView(BaseView): ...
@@ -89,6 +94,7 @@ class MyCustomListener:
 class MockPlugin(AirflowPlugin):
     name = "mock_plugin"
     flask_blueprints = [bp]
+    fastapi_apps = [app_with_metadata]
     appbuilder_views = [{"view": mockview}]
     appbuilder_menu_items = [appbuilder_menu_items]
     global_operator_extra_links = [MockOperatorLink()]
@@ -141,6 +147,13 @@ class TestGetPlugins(TestPluginsEndpoint):
                     "executors": [],
                     "flask_blueprints": [
                         f"<{qualname(bp.__class__)}: name={bp.name!r} import_name={bp.import_name!r}>"
+                    ],
+                    "fastapi_apps": [
+                        {
+                            "app": "fastapi.applications.FastAPI",
+                            "name": "App name",
+                            "url_prefix": "/some_prefix",
+                        }
                     ],
                     "global_operator_extra_links": [f"<{qualname(MockOperatorLink().__class__)} object>"],
                     "hooks": [qualname(PluginHook)],

--- a/tests/api_connexion/schemas/test_plugin_schema.py
+++ b/tests/api_connexion/schemas/test_plugin_schema.py
@@ -16,6 +16,8 @@
 # under the License.
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 from flask import Blueprint
 from flask_appbuilder import BaseView
 
@@ -53,10 +55,13 @@ appbuilder_menu_items = {
     "href": "https://example.com",
 }
 
+app = MagicMock()
+
 
 class MockPlugin(AirflowPlugin):
     name = "mock_plugin"
     flask_blueprints = [bp]
+    fastapi_apps = [{"app": app, "name": "App name", "url_prefix": "/some_prefix"}]
     appbuilder_views = [{"view": MockView()}]
     appbuilder_menu_items = [appbuilder_menu_items]
     global_operator_extra_links = [MockOperatorLink()]
@@ -82,6 +87,9 @@ class TestPluginSchema(TestPluginBase):
             "appbuilder_views": [{"view": self.mock_plugin.appbuilder_views[0]["view"]}],
             "executors": [],
             "flask_blueprints": [str(bp)],
+            "fastapi_apps": [
+                {"app": app, "name": "App name", "url_prefix": "/some_prefix"},
+            ],
             "global_operator_extra_links": [str(MockOperatorLink())],
             "hooks": [str(PluginHook)],
             "macros": [str(plugin_macro)],
@@ -106,6 +114,9 @@ class TestPluginCollectionSchema(TestPluginBase):
                     "appbuilder_views": [{"view": self.mock_plugin.appbuilder_views[0]["view"]}],
                     "executors": [],
                     "flask_blueprints": [str(bp)],
+                    "fastapi_apps": [
+                        {"app": app, "name": "App name", "url_prefix": "/some_prefix"},
+                    ],
                     "global_operator_extra_links": [str(MockOperatorLink())],
                     "hooks": [str(PluginHook)],
                     "macros": [str(plugin_macro)],
@@ -121,6 +132,9 @@ class TestPluginCollectionSchema(TestPluginBase):
                     "appbuilder_views": [{"view": self.mock_plugin.appbuilder_views[0]["view"]}],
                     "executors": [],
                     "flask_blueprints": [str(bp)],
+                    "fastapi_apps": [
+                        {"app": app, "name": "App name", "url_prefix": "/some_prefix"},
+                    ],
                     "global_operator_extra_links": [str(MockOperatorLink())],
                     "hooks": [str(PluginHook)],
                     "macros": [str(plugin_macro)],

--- a/tests/cli/commands/test_plugins_command.py
+++ b/tests/cli/commands/test_plugins_command.py
@@ -56,7 +56,7 @@ class TestPluginsCommand:
         assert "No plugins loaded" in stdout
 
     @mock_plugin_manager(plugins=[ComplexAirflowPlugin])
-    def test_should_display_one_plugins(self):
+    def test_should_display_one_plugin(self):
         with redirect_stdout(StringIO()) as temp_stdout:
             plugins_command.dump_plugins(self.parser.parse_args(["plugins", "--output=json"]))
             stdout = temp_stdout.getvalue()
@@ -71,6 +71,13 @@ class TestPluginsCommand:
                 "executors": ["tests.plugins.test_plugin.PluginExecutor"],
                 "flask_blueprints": [
                     "<flask.blueprints.Blueprint: name='test_plugin' import_name='tests.plugins.test_plugin'>"
+                ],
+                "fastapi_apps": [
+                    {
+                        "app": "fastapi.applications.FastAPI",
+                        "url_prefix": "/some_prefix",
+                        "name": "Name of the App",
+                    }
                 ],
                 "appbuilder_views": [
                     {

--- a/tests/plugins/test_plugin.py
+++ b/tests/plugins/test_plugin.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+from fastapi import FastAPI
 from flask import Blueprint
 from flask_appbuilder import BaseView as AppBuilderBaseView, expose
 
@@ -109,6 +110,11 @@ bp = Blueprint(
     static_url_path="/static/test_plugin",
 )
 
+app = FastAPI()
+
+
+app_with_metadata = {"app": app, "url_prefix": "/some_prefix", "name": "Name of the App"}
+
 
 # Extend an existing class to avoid the need to implement the full interface
 class CustomCronDataIntervalTimetable(CronDataIntervalTimetable):
@@ -133,6 +139,7 @@ class AirflowTestPlugin(AirflowPlugin):
     executors = [PluginExecutor]
     macros = [plugin_macro]
     flask_blueprints = [bp]
+    fastapi_apps = [app_with_metadata]
     appbuilder_views = [v_appbuilder_package]
     appbuilder_menu_items = [appbuilder_mitem, appbuilder_mitem_toplevel]
     global_operator_extra_links = [

--- a/tests/test_utils/mock_plugins.py
+++ b/tests/test_utils/mock_plugins.py
@@ -26,6 +26,7 @@ PLUGINS_MANAGER_NULLABLE_ATTRIBUTES = [
     "executors_modules",
     "admin_views",
     "flask_blueprints",
+    "fastapi_apps",
     "menu_links",
     "flask_appbuilder_views",
     "flask_appbuilder_menu_links",


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/42696

Add support for FastAPI plugins to extend the capabilities of the new Rest API.

<img width="1499" alt="Screenshot 2024-10-04 at 16 17 12" src="https://github.com/user-attachments/assets/62624828-2b9d-4a72-8afa-1d96ef89589f">
