### PR TITLE
Remove airflow_version from k8s executor pod selector

### DIFF
--- a/airflow/providers/cncf/kubernetes/pod_generator.py
+++ b/airflow/providers/cncf/kubernetes/pod_generator.py
@@ -477,6 +477,7 @@ class PodGenerator:
         execution_date=None,
         run_id=None,
         airflow_worker=None,
+        include_version=False,
     ):
         """
         Generate selector for kubernetes executor pod.
@@ -491,6 +492,7 @@ class PodGenerator:
             execution_date=execution_date,
             run_id=run_id,
             airflow_worker=airflow_worker,
+            include_version=include_version,
         )
         label_strings = [f"{label_id}={label}" for label_id, label in sorted(labels.items())]
         selector = ",".join(label_strings)
@@ -509,6 +511,7 @@ class PodGenerator:
         map_index=None,
         execution_date=None,
         run_id=None,
+        include_version=True,
     ):
         """
         Generate labels for kubernetes executor pod.
@@ -520,8 +523,9 @@ class PodGenerator:
             "task_id": make_safe_label_value(task_id),
             "try_number": str(try_number),
             "kubernetes_executor": "True",
-            "airflow_version": airflow_version.replace("+", "-"),
         }
+        if include_version:
+            labels["airflow_version"] = airflow_version.replace("+", "-")
         if airflow_worker is not None:
             labels["airflow-worker"] = make_safe_label_value(str(airflow_worker))
         if map_index is not None and map_index >= 0:

--- a/tests/providers/cncf/kubernetes/test_pod_generator.py
+++ b/tests/providers/cncf/kubernetes/test_pod_generator.py
@@ -821,6 +821,7 @@ class TestPodGenerator:
         )
         labels = PodGenerator.build_labels_for_k8s_executor_pod(**kwargs, **extra)
         assert labels == {**expected, **extra_expected}
+        del labels["airflow_version"]  # excluded from selector in case upgrade
         items = [f"{k}={v}" for k, v in sorted(labels.items())]
         if "airflow_worker" not in extra:
             items.append("airflow-worker")


### PR DESCRIPTION
When there is a task running and upgrade in flight then there will be version mismatch.  So we should not include the airflow version in the selector.
