### PR TITLE
Fix failing tests for test log handler

### DIFF
--- a/tests/providers/celery/log_handlers/__init__.py
+++ b/tests/providers/celery/log_handlers/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/providers/celery/log_handlers/test_log_handlers.py
+++ b/tests/providers/celery/log_handlers/test_log_handlers.py
@@ -35,7 +35,7 @@ from airflow.utils.session import create_session
 from airflow.utils.state import TaskInstanceState
 from airflow.utils.timezone import datetime
 from airflow.utils.types import DagRunType
-from tests.test_utils.compat import AIRFLOW_V_3_0_PLUS
+from tests.test_utils.compat import AIRFLOW_V_2_9_PLUS, AIRFLOW_V_3_0_PLUS
 from tests.test_utils.config import conf_vars
 
 if AIRFLOW_V_3_0_PLUS:
@@ -63,6 +63,7 @@ class TestFileTaskLogHandler:
     def teardown_method(self):
         self.clean_up()
 
+    @pytest.mark.skipif(not AIRFLOW_V_2_9_PLUS, reason="The tests should be skipped for Airflow < 2.9")
     def test__read_for_celery_executor_fallbacks_to_worker(self, create_task_instance):
         """Test for executors which do not have `get_task_log` method, it fallbacks to reading
         log from worker"""

--- a/tests/providers/celery/log_handlers/test_log_handlers.py
+++ b/tests/providers/celery/log_handlers/test_log_handlers.py
@@ -1,0 +1,83 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import logging
+import logging.config
+from unittest import mock
+
+import pytest
+
+from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
+from airflow.models.dagrun import DagRun
+from airflow.models.taskinstance import TaskInstance
+from airflow.utils.log.file_task_handler import (
+    FileTaskHandler,
+)
+from airflow.utils.session import create_session
+from airflow.utils.state import TaskInstanceState
+from airflow.utils.timezone import datetime
+from airflow.utils.types import DagRunType
+from tests.test_utils.compat import AIRFLOW_V_3_0_PLUS
+from tests.test_utils.config import conf_vars
+
+if AIRFLOW_V_3_0_PLUS:
+    pass
+
+pytestmark = [pytest.mark.db_test, pytest.mark.skip_if_database_isolation_mode]
+
+DEFAULT_DATE = datetime(2016, 1, 1)
+TASK_LOGGER = "airflow.task"
+FILE_TASK_HANDLER = "task"
+
+
+class TestFileTaskLogHandler:
+    def clean_up(self):
+        with create_session() as session:
+            session.query(DagRun).delete()
+            session.query(TaskInstance).delete()
+
+    def setup_method(self):
+        logging.config.dictConfig(DEFAULT_LOGGING_CONFIG)
+        logging.root.disabled = False
+        self.clean_up()
+        # We use file task handler by default.
+
+    def teardown_method(self):
+        self.clean_up()
+
+    def test__read_for_celery_executor_fallbacks_to_worker(self, create_task_instance):
+        """Test for executors which do not have `get_task_log` method, it fallbacks to reading
+        log from worker"""
+        executor_name = "CeleryExecutor"
+
+        ti = create_task_instance(
+            dag_id="dag_for_testing_celery_executor_log_read",
+            task_id="task_for_testing_celery_executor_log_read",
+            run_type=DagRunType.SCHEDULED,
+            execution_date=DEFAULT_DATE,
+        )
+        ti.state = TaskInstanceState.RUNNING
+        with conf_vars({("core", "executor"): executor_name}):
+            fth = FileTaskHandler("")
+
+            fth._read_from_logs_server = mock.Mock()
+            fth._read_from_logs_server.return_value = ["this message"], ["this\nlog\ncontent"]
+            actual = fth._read(ti=ti, try_number=1)
+            fth._read_from_logs_server.assert_called_once()
+        assert actual == ("*** this message\nthis\nlog\ncontent", {"end_of_log": True, "log_pos": 16})

--- a/tests/providers/celery/log_handlers/test_log_handlers.py
+++ b/tests/providers/celery/log_handlers/test_log_handlers.py
@@ -19,11 +19,13 @@ from __future__ import annotations
 
 import logging
 import logging.config
+from importlib import reload
 from unittest import mock
 
 import pytest
 
 from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
+from airflow.executors import executor_loader
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance
 from airflow.utils.log.file_task_handler import (
@@ -74,6 +76,7 @@ class TestFileTaskLogHandler:
         )
         ti.state = TaskInstanceState.RUNNING
         with conf_vars({("core", "executor"): executor_name}):
+            reload(executor_loader)
             fth = FileTaskHandler("")
 
             fth._read_from_logs_server = mock.Mock()

--- a/tests/providers/cncf/kubernetes/log_handlers/__init__.py
+++ b/tests/providers/cncf/kubernetes/log_handlers/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/providers/cncf/kubernetes/log_handlers/test_log_handlers.py
+++ b/tests/providers/cncf/kubernetes/log_handlers/test_log_handlers.py
@@ -1,0 +1,169 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import logging
+import logging.config
+import re
+from importlib import reload
+from unittest import mock
+from unittest.mock import patch
+
+import pytest
+from kubernetes.client import models as k8s
+
+from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
+from airflow.executors import executor_loader
+from airflow.models.dag import DAG
+from airflow.models.dagrun import DagRun
+from airflow.models.taskinstance import TaskInstance
+from airflow.operators.python import PythonOperator
+from airflow.utils.log.file_task_handler import (
+    FileTaskHandler,
+)
+from airflow.utils.log.logging_mixin import set_context
+from airflow.utils.session import create_session
+from airflow.utils.state import State, TaskInstanceState
+from airflow.utils.timezone import datetime
+from airflow.utils.types import DagRunType
+from tests.test_utils.compat import AIRFLOW_V_3_0_PLUS
+from tests.test_utils.config import conf_vars
+
+if AIRFLOW_V_3_0_PLUS:
+    from airflow.utils.types import DagRunTriggeredByType
+
+pytestmark = [pytest.mark.db_test, pytest.mark.skip_if_database_isolation_mode]
+
+DEFAULT_DATE = datetime(2016, 1, 1)
+TASK_LOGGER = "airflow.task"
+FILE_TASK_HANDLER = "task"
+
+
+class TestFileTaskLogHandler:
+    def clean_up(self):
+        with create_session() as session:
+            session.query(DagRun).delete()
+            session.query(TaskInstance).delete()
+
+    def setup_method(self):
+        logging.config.dictConfig(DEFAULT_LOGGING_CONFIG)
+        logging.root.disabled = False
+        self.clean_up()
+        # We use file task handler by default.
+
+    def teardown_method(self):
+        self.clean_up()
+
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.executors.kubernetes_executor.KubernetesExecutor.get_task_log"
+    )
+    @pytest.mark.parametrize("state", [TaskInstanceState.RUNNING, TaskInstanceState.SUCCESS])
+    def test__read_for_k8s_executor(self, mock_k8s_get_task_log, create_task_instance, state):
+        """Test for k8s executor, the log is read from get_task_log method"""
+        mock_k8s_get_task_log.return_value = ([], [])
+        executor_name = "KubernetesExecutor"
+        ti = create_task_instance(
+            dag_id="dag_for_testing_k8s_executor_log_read",
+            task_id="task_for_testing_k8s_executor_log_read",
+            run_type=DagRunType.SCHEDULED,
+            execution_date=DEFAULT_DATE,
+        )
+        ti.state = state
+        ti.triggerer_job = None
+        with conf_vars({("core", "executor"): executor_name}):
+            reload(executor_loader)
+            fth = FileTaskHandler("")
+            fth._read(ti=ti, try_number=2)
+        if state == TaskInstanceState.RUNNING:
+            mock_k8s_get_task_log.assert_called_once_with(ti, 2)
+        else:
+            mock_k8s_get_task_log.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "pod_override, namespace_to_call",
+        [
+            pytest.param(k8s.V1Pod(metadata=k8s.V1ObjectMeta(namespace="namespace-A")), "namespace-A"),
+            pytest.param(k8s.V1Pod(metadata=k8s.V1ObjectMeta(namespace="namespace-B")), "namespace-B"),
+            pytest.param(k8s.V1Pod(), "default"),
+            pytest.param(None, "default"),
+            pytest.param(k8s.V1Pod(metadata=k8s.V1ObjectMeta(name="pod-name-xxx")), "default"),
+        ],
+    )
+    @patch.dict("os.environ", AIRFLOW__CORE__EXECUTOR="KubernetesExecutor")
+    @patch("airflow.providers.cncf.kubernetes.kube_client.get_kube_client")
+    def test_read_from_k8s_under_multi_namespace_mode(
+        self, mock_kube_client, pod_override, namespace_to_call
+    ):
+        mock_read_log = mock_kube_client.return_value.read_namespaced_pod_log
+        mock_list_pod = mock_kube_client.return_value.list_namespaced_pod
+
+        def task_callable(ti):
+            ti.log.info("test")
+
+        with DAG("dag_for_testing_file_task_handler", schedule=None, start_date=DEFAULT_DATE) as dag:
+            task = PythonOperator(
+                task_id="task_for_testing_file_log_handler",
+                python_callable=task_callable,
+                executor_config={"pod_override": pod_override},
+            )
+        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
+        dagrun = dag.create_dagrun(
+            run_type=DagRunType.MANUAL,
+            state=State.RUNNING,
+            execution_date=DEFAULT_DATE,
+            data_interval=dag.timetable.infer_manual_data_interval(run_after=DEFAULT_DATE),
+            **triggered_by_kwargs,
+        )
+        ti = TaskInstance(task=task, run_id=dagrun.run_id)
+        ti.try_number = 3
+
+        logger = ti.log
+        ti.log.disabled = False
+
+        file_handler = next((h for h in logger.handlers if h.name == FILE_TASK_HANDLER), None)
+        set_context(logger, ti)
+        ti.run(ignore_ti_state=True)
+        ti.state = TaskInstanceState.RUNNING
+        file_handler.read(ti, 2)
+
+        # first we find pod name
+        mock_list_pod.assert_called_once()
+        actual_kwargs = mock_list_pod.call_args.kwargs
+        assert actual_kwargs["namespace"] == namespace_to_call
+        actual_selector = actual_kwargs["label_selector"]
+        assert re.match(
+            (
+                "dag_id=dag_for_testing_file_task_handler,"
+                "kubernetes_executor=True,"
+                "run_id=manual__2016-01-01T0000000000-2b88d1d57,"
+                "task_id=task_for_testing_file_log_handler,"
+                "try_number=2,"
+                "airflow-worker"
+            ),
+            actual_selector,
+        )
+
+        # then we read log
+        mock_read_log.assert_called_once_with(
+            name=mock_list_pod.return_value.items[0].metadata.name,
+            namespace=namespace_to_call,
+            container="base",
+            follow=False,
+            tail_lines=100,
+            _preload_content=False,
+        )

--- a/tests/providers/common/sql/hooks/test_dbapi.py
+++ b/tests/providers/common/sql/hooks/test_dbapi.py
@@ -19,11 +19,13 @@ from __future__ import annotations
 
 import json
 import logging
+import logging.config
 from unittest import mock
 
 import pytest
 from pyodbc import Cursor
 
+from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
 from airflow.hooks.base import BaseHook
 from airflow.models import Connection
 from airflow.providers.common.sql.hooks.sql import DbApiHook, fetch_all_handler, fetch_one_handler
@@ -66,6 +68,9 @@ class TestDbApiHook:
 
             def get_db_log_messages(self, conn) -> None:
                 return conn.get_messages()
+
+        logging.config.dictConfig(DEFAULT_LOGGING_CONFIG)
+        logging.root.disabled = True
 
         self.db_hook = DbApiHookMock(**kwargs)
         self.db_hook_no_log_sql = DbApiHookMock(log_sql=False)

--- a/tests/providers/common/sql/hooks/test_sql.py
+++ b/tests/providers/common/sql/hooks/test_sql.py
@@ -19,11 +19,13 @@
 from __future__ import annotations
 
 import logging
+import logging.config
 import warnings
 from unittest.mock import MagicMock
 
 import pytest
 
+from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import Connection
 from airflow.providers.common.sql.hooks.sql import DbApiHook, fetch_all_handler
@@ -221,6 +223,10 @@ def test_query(
 
 
 class TestDbApiHook:
+    def setup_method(self, **kwargs):
+        logging.config.dictConfig(DEFAULT_LOGGING_CONFIG)
+        logging.root.disabled = True
+
     @pytest.mark.db_test
     @pytest.mark.parametrize(
         "empty_statement",

--- a/tests/utils/test_log_handlers.py
+++ b/tests/utils/test_log_handlers.py
@@ -29,7 +29,6 @@ from unittest.mock import patch
 
 import pendulum
 import pytest
-from kubernetes.client import models as k8s
 from pydantic.v1.utils import deep_update
 from requests.adapters import Response
 
@@ -382,52 +381,6 @@ class TestFileTaskLogHandler:
             ["file1 content", "file2 content"],
         )
 
-    @mock.patch(
-        "airflow.providers.cncf.kubernetes.executors.kubernetes_executor.KubernetesExecutor.get_task_log"
-    )
-    @pytest.mark.parametrize("state", [TaskInstanceState.RUNNING, TaskInstanceState.SUCCESS])
-    def test__read_for_k8s_executor(self, mock_k8s_get_task_log, create_task_instance, state):
-        """Test for k8s executor, the log is read from get_task_log method"""
-        mock_k8s_get_task_log.return_value = ([], [])
-        executor_name = "KubernetesExecutor"
-        ti = create_task_instance(
-            dag_id="dag_for_testing_k8s_executor_log_read",
-            task_id="task_for_testing_k8s_executor_log_read",
-            run_type=DagRunType.SCHEDULED,
-            execution_date=DEFAULT_DATE,
-        )
-        ti.state = state
-        ti.triggerer_job = None
-        with conf_vars({("core", "executor"): executor_name}):
-            reload(executor_loader)
-            fth = FileTaskHandler("")
-            fth._read(ti=ti, try_number=2)
-        if state == TaskInstanceState.RUNNING:
-            mock_k8s_get_task_log.assert_called_once_with(ti, 2)
-        else:
-            mock_k8s_get_task_log.assert_not_called()
-
-    def test__read_for_celery_executor_fallbacks_to_worker(self, create_task_instance):
-        """Test for executors which do not have `get_task_log` method, it fallbacks to reading
-        log from worker"""
-        executor_name = "CeleryExecutor"
-
-        ti = create_task_instance(
-            dag_id="dag_for_testing_celery_executor_log_read",
-            task_id="task_for_testing_celery_executor_log_read",
-            run_type=DagRunType.SCHEDULED,
-            execution_date=DEFAULT_DATE,
-        )
-        ti.state = TaskInstanceState.RUNNING
-        with conf_vars({("core", "executor"): executor_name}):
-            fth = FileTaskHandler("")
-
-            fth._read_from_logs_server = mock.Mock()
-            fth._read_from_logs_server.return_value = ["this message"], ["this\nlog\ncontent"]
-            actual = fth._read(ti=ti, try_number=1)
-            fth._read_from_logs_server.assert_called_once()
-        assert actual == ("*** this message\nthis\nlog\ncontent", {"end_of_log": True, "log_pos": 16})
-
     @pytest.mark.parametrize(
         "remote_logs, local_logs, served_logs_checked",
         [
@@ -475,81 +428,6 @@ class TestFileTaskLogHandler:
             fth._read_from_logs_server.assert_not_called()
             assert actual[0]
             assert actual[1]
-
-    @pytest.mark.parametrize(
-        "pod_override, namespace_to_call",
-        [
-            pytest.param(k8s.V1Pod(metadata=k8s.V1ObjectMeta(namespace="namespace-A")), "namespace-A"),
-            pytest.param(k8s.V1Pod(metadata=k8s.V1ObjectMeta(namespace="namespace-B")), "namespace-B"),
-            pytest.param(k8s.V1Pod(), "default"),
-            pytest.param(None, "default"),
-            pytest.param(k8s.V1Pod(metadata=k8s.V1ObjectMeta(name="pod-name-xxx")), "default"),
-        ],
-    )
-    @patch.dict("os.environ", AIRFLOW__CORE__EXECUTOR="KubernetesExecutor")
-    @patch("airflow.providers.cncf.kubernetes.kube_client.get_kube_client")
-    def test_read_from_k8s_under_multi_namespace_mode(
-        self, mock_kube_client, pod_override, namespace_to_call
-    ):
-        mock_read_log = mock_kube_client.return_value.read_namespaced_pod_log
-        mock_list_pod = mock_kube_client.return_value.list_namespaced_pod
-
-        def task_callable(ti):
-            ti.log.info("test")
-
-        with DAG("dag_for_testing_file_task_handler", schedule=None, start_date=DEFAULT_DATE) as dag:
-            task = PythonOperator(
-                task_id="task_for_testing_file_log_handler",
-                python_callable=task_callable,
-                executor_config={"pod_override": pod_override},
-            )
-        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
-        dagrun = dag.create_dagrun(
-            run_type=DagRunType.MANUAL,
-            state=State.RUNNING,
-            execution_date=DEFAULT_DATE,
-            data_interval=dag.timetable.infer_manual_data_interval(run_after=DEFAULT_DATE),
-            **triggered_by_kwargs,
-        )
-        ti = TaskInstance(task=task, run_id=dagrun.run_id)
-        ti.try_number = 3
-
-        logger = ti.log
-        ti.log.disabled = False
-
-        file_handler = next((h for h in logger.handlers if h.name == FILE_TASK_HANDLER), None)
-        set_context(logger, ti)
-        ti.run(ignore_ti_state=True)
-        ti.state = TaskInstanceState.RUNNING
-        file_handler.read(ti, 2)
-
-        # first we find pod name
-        mock_list_pod.assert_called_once()
-        actual_kwargs = mock_list_pod.call_args.kwargs
-        assert actual_kwargs["namespace"] == namespace_to_call
-        actual_selector = actual_kwargs["label_selector"]
-        assert re.match(
-            (
-                "airflow_version=.+?,"
-                "dag_id=dag_for_testing_file_task_handler,"
-                "kubernetes_executor=True,"
-                "run_id=manual__2016-01-01T0000000000-2b88d1d57,"
-                "task_id=task_for_testing_file_log_handler,"
-                "try_number=2,"
-                "airflow-worker"
-            ),
-            actual_selector,
-        )
-
-        # then we read log
-        mock_read_log.assert_called_once_with(
-            name=mock_list_pod.return_value.items[0].metadata.name,
-            namespace=namespace_to_call,
-            container="base",
-            follow=False,
-            tail_lines=100,
-            _preload_content=False,
-        )
 
     def test_add_triggerer_suffix(self):
         sample = "any/path/to/thing.txt"


### PR DESCRIPTION
Unable to push to #42762 branch, therefore attempt to fix in parallel:

The https://github.com/apache/airflow/pull/42751 removed airflow_version from k8s log handler and apparently some tests in tests_utils still use kubernetes provider and k8s test handler. Also it turned out some other tests used Celery Executor as well.

Fixed the tests and move them to K8S / Celery provider respectively.