### PR TITLE
fix error: AttributeError: 'bool' object has no attribute 'lower' by:…

### DIFF
--- a/airflow/providers/mongo/hooks/mongo.py
+++ b/airflow/providers/mongo/hooks/mongo.py
@@ -136,11 +136,11 @@ class MongoHook(BaseHook):
         self.client: MongoClient | None = None
         self.uri = self._create_uri()
 
-        self.allow_insecure = self.extras.pop("allow_insecure", "false").lower() == "true"
-        self.ssl_enabled = (
-            self.extras.get("ssl", "false").lower() == "true"
-            or self.extras.get("tls", "false").lower() == "true"
-        )
+        allow_insecure = self.extras.pop("allow_insecure", "false")
+        if isinstance(allow_insecure, str):
+            self.allow_insecure = allow_insecure.lower() == "true"
+        else:
+            self.allow_insecure = bool(allow_insecure)
 
         if self.ssl_enabled and not self.allow_insecure:
             # Case: HTTPS


### PR DESCRIPTION
since I found the problem when using **MongoDB To Amazon S3 transfer operator**

Then, connection provider with MongoDB give me fix extra values

{
  "srv": false,
  "ssl": false,
  "allow_insecure": false
}

Which all the values string. But the part of checking if allow_insecure is to receive string and .lower()

The error looks likes:
```
File "/home/airflow/.local/lib/python3.12/site-packages/airflow/providers/mongo/hooks/mongo.py", line 139, in __init__
    self.allow_insecure = self.extras.pop("allow_insecure", "false").lower() == "true"
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'bool' object has no attribute 'lower'
```

If there are other solutions, I am happy for the contribution

ref: https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/transfer/mongo_to_s3.html