### PR TITLE
Fix canary build test test_cli_fastapi_api_background process termination

### DIFF
--- a/tests/cli/commands/_common_cli_classes.py
+++ b/tests/cli/commands/_common_cli_classes.py
@@ -146,3 +146,13 @@ class _CommonCLIGunicornTestClass:
                     console.print(proc.as_dict(attrs=["pid", "name", "cmdline"]))
                 pids.append(proc.pid)
         return pids
+
+    def _terminate_multiple_process(self, pid_list):
+        process = []
+        for pid in pid_list:
+            proc = psutil.Process(pid)
+            proc.terminate()
+            process.append(proc)
+        gone, alive = psutil.wait_procs(process, timeout=120)
+        for p in alive:
+            p.kill()

--- a/tests/cli/commands/test_fastapi_api_command.py
+++ b/tests/cli/commands/test_fastapi_api_command.py
@@ -22,7 +22,6 @@ import sys
 import time
 from unittest import mock
 
-import psutil
 import pytest
 from rich.console import Console
 
@@ -89,9 +88,7 @@ class TestCliFastAPI(_CommonCLIGunicornTestClass):
                 "[magenta]Terminating monitor process and expect "
                 "fastapi-api and gunicorn processes to terminate as well"
             )
-            proc = psutil.Process(pid_monitor)
-            proc.terminate()
-            assert proc.wait(120) in (0, None)
+            self._terminate_multiple_process([pid_fastapi_api, pid_monitor])
             self._check_processes(ignore_running=False)
             console.print("[magenta]All fastapi-api and gunicorn processes are terminated.")
         except Exception:

--- a/tests/cli/commands/test_internal_api_command.py
+++ b/tests/cli/commands/test_internal_api_command.py
@@ -141,13 +141,7 @@ class TestCliInternalAPI(_CommonCLIGunicornTestClass):
                 "[magenta]Terminating monitor process and expect "
                 "internal-api and gunicorn processes to terminate as well"
             )
-            internal_api_proc = psutil.Process(pid_internal_api)
-            internal_api_proc.terminate()
-            proc = psutil.Process(pid_monitor)
-            proc.terminate()
-            gone, alive = psutil.wait_procs([internal_api_proc, proc], timeout=120)
-            for p in alive:
-                p.kill()
+            self._terminate_multiple_process([pid_internal_api, pid_monitor])
             self._check_processes(ignore_running=False)
             console.print("[magenta]All internal-api and gunicorn processes are terminated.")
         except Exception:


### PR DESCRIPTION
Applying similar fix  #42773 to fast api

Moved terminate process to common cli classes.
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
