### PR TITLE
BashOperator: Execute templated bash script as file

### DIFF
--- a/docs/apache-airflow/howto/operator/bash.rst
+++ b/docs/apache-airflow/howto/operator/bash.rst
@@ -231,7 +231,88 @@ Executing commands from files
 Both the ``BashOperator`` and ``@task.bash`` TaskFlow decorator enables you to execute Bash commands stored
 in files. The files **must** have a ``.sh`` or ``.bash`` extension.
 
-Note the space after the script name (more on this in the next section).
+With Jinja template
+"""""""""""""""""""
+
+You can execute bash script which contains Jinja templates. When you do so, Airflow
+loads the content of your file, render the templates, and write the rendered script
+into a temporary file. By default, the file is placed in a temporary directory
+(under ``/tmp``). You can change this location with the ``cwd`` parameter.
+
+.. caution::
+
+    Airflow must have write access to ``/tmp`` or the ``cwd`` directory, to be
+    able to write the temporary file to the disk.
+
+
+To execute a bash script, place it in a location relative to the directory containing
+the DAG file. So if your DAG file is in ``/usr/local/airflow/dags/test_dag.py``, you can
+move your ``test.sh`` file to any location under ``/usr/local/airflow/dags/`` (Example:
+``/usr/local/airflow/dags/scripts/test.sh``) and pass the relative path to ``bash_command``
+as shown below:
+
+.. tab-set::
+
+    .. tab-item:: @tash.bash
+        :sync: taskflow
+
+        .. code-block:: python
+
+            @task.bash
+            def bash_example():
+                # "scripts" folder is under "/usr/local/airflow/dags"
+                return "scripts/test.sh"
+
+    .. tab-item:: BashOperator
+        :sync: operator
+
+        .. code-block:: python
+
+            t2 = BashOperator(
+                task_id="bash_example",
+                # "scripts" folder is under "/usr/local/airflow/dags"
+                bash_command="scripts/test.sh",
+            )
+
+Creating separate folder for Bash scripts may be desirable for many reasons, like
+separating your script's logic and pipeline code, allowing for proper code highlighting
+in files composed in different languages, and general flexibility in structuring
+pipelines.
+
+It is also possible to define your ``template_searchpath`` as pointing to any folder
+locations in the DAG constructor call.
+
+.. tab-set::
+
+    .. tab-item:: @task.bash
+        :sync: taskflow
+
+        .. code-block:: python
+            :emphasize-lines: 1
+
+            @dag(..., template_searchpath="/opt/scripts")
+            def example_bash_dag():
+                @task.bash
+                def bash_example():
+                    return "test.sh "
+
+    .. tab-item:: BashOperator
+        :sync: operator
+
+        .. code-block:: python
+            :emphasize-lines: 1
+
+            with DAG("example_bash_dag", ..., template_searchpath="/opt/scripts"):
+                t2 = BashOperator(
+                    task_id="bash_example",
+                    bash_command="test.sh ",
+                )
+
+Without Jinja template
+""""""""""""""""""""""
+
+If your script doesn't contains any Jinja template, disable Airflow's rendering by
+adding a space after the script name.
 
 .. tab-set::
 
@@ -294,68 +375,7 @@ script name. This is because Airflow tries to apply a Jinja template to it, whic
             )
 
 However, if you want to use templating in your Bash script, do not add the space
-and instead put your Bash script in a location relative to the directory containing
-the DAG file. So if your DAG file is in ``/usr/local/airflow/dags/test_dag.py``, you can
-move your ``test.sh`` file to any location under ``/usr/local/airflow/dags/`` (Example:
-``/usr/local/airflow/dags/scripts/test.sh``) and pass the relative path to ``bash_command``
-as shown below:
-
-.. tab-set::
-
-    .. tab-item:: @tash.bash
-        :sync: taskflow
-
-        .. code-block:: python
-
-            @task.bash
-            def bash_example():
-                # "scripts" folder is under "/usr/local/airflow/dags"
-                return "scripts/test.sh"
-
-    .. tab-item:: BashOperator
-        :sync: operator
-
-        .. code-block:: python
-
-            t2 = BashOperator(
-                task_id="bash_example",
-                # "scripts" folder is under "/usr/local/airflow/dags"
-                bash_command="scripts/test.sh",
-            )
-
-Creating separate folder for Bash scripts may be desirable for many reasons, like
-separating your script's logic and pipeline code, allowing for proper code highlighting
-in files composed in different languages, and general flexibility in structuring
-pipelines.
-
-It is also possible to define your ``template_searchpath`` as pointing to any folder
-locations in the DAG constructor call.
-
-.. tab-set::
-
-    .. tab-item:: @task.bash
-        :sync: taskflow
-
-        .. code-block:: python
-            :emphasize-lines: 1
-
-            @dag(..., template_searchpath="/opt/scripts")
-            def example_bash_dag():
-                @task.bash
-                def bash_example():
-                    return "test.sh "
-
-    .. tab-item:: BashOperator
-        :sync: operator
-
-        .. code-block:: python
-            :emphasize-lines: 1
-
-            with DAG("example_bash_dag", ..., template_searchpath="/opt/scripts"):
-                t2 = BashOperator(
-                    task_id="bash_example",
-                    bash_command="test.sh ",
-                )
+and instead check the `bash script with Jinja template <#with-jinja-template>`_ section.
 
 Enriching Bash with Python
 --------------------------

--- a/newsfragments/42783.improvement.rst
+++ b/newsfragments/42783.improvement.rst
@@ -1,0 +1,1 @@
+Bash script files (``.sh`` and ``.bash``) with Jinja templating enabled (without the space after the file extension) are now rendered into a temporary file, and then executed. Instead of being directly executed as inline command.

--- a/providers/src/airflow/providers/standard/operators/bash.py
+++ b/providers/src/airflow/providers/standard/operators/bash.py
@@ -101,7 +101,7 @@ class BashOperator(BaseOperator):
 
     .. note::
 
-        To simply execute a ``.sh`` or ``.bash`` script (without any Jinja template), ddd a space after the
+        To simply execute a ``.sh`` or ``.bash`` script (without any Jinja template), add a space after the
         script name ``bash_command`` argument -- for example ``bash_command="my_script.sh "``. This
         is because Airflow tries to load this file and process it as a Jinja template when
         it ends with ``.sh`` or ``.bash``.

--- a/providers/src/airflow/providers/standard/operators/bash.py
+++ b/providers/src/airflow/providers/standard/operators/bash.py
@@ -19,13 +19,14 @@ from __future__ import annotations
 
 import os
 import shutil
+import tempfile
 import warnings
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Callable, Container, Sequence, cast
 
 from airflow.exceptions import AirflowException, AirflowSkipException
 from airflow.models.baseoperator import BaseOperator
-from airflow.providers.standard.hooks.subprocess import SubprocessHook
+from airflow.providers.standard.hooks.subprocess import SubprocessHook, SubprocessResult, working_directory
 from airflow.utils.operator_helpers import context_to_airflow_vars
 from airflow.utils.types import ArgNotSet
 
@@ -63,6 +64,9 @@ class BashOperator(BaseOperator):
         If None (default), the command is run in a temporary directory.
         To use current DAG folder as the working directory,
         you might set template ``{{ dag_run.dag.folder }}``.
+        When bash_command is a '.sh' or '.bash' file, Airflow must have write
+        access to the working directory. The script will be rendered (Jinja
+        template) into a new temporary file in this directory.
     :param output_processor: Function to further process the output of the bash script
         (default is lambda output: output).
 
@@ -97,10 +101,14 @@ class BashOperator(BaseOperator):
 
     .. note::
 
-        Add a space after the script name when directly calling a ``.sh`` script with the
-        ``bash_command`` argument -- for example ``bash_command="my_script.sh "``.  This
-        is because Airflow tries to apply load this file and process it as a Jinja template to
-        it ends with ``.sh``, which will likely not be what most users want.
+        To simply execute a ``.sh`` or ``.bash`` script (without any Jinja template), ddd a space after the
+        script name ``bash_command`` argument -- for example ``bash_command="my_script.sh "``. This
+        is because Airflow tries to load this file and process it as a Jinja template when
+        it ends with ``.sh`` or ``.bash``.
+
+        If you have Jinja template in your script, do not put any blank space. And add the script's directory
+        in the DAG's ``template_searchpath``. If you specify a ``cwd``, Airflow must have write access to
+        this directory. The script will be rendered (Jinja template) into a new temporary file in this directory.
 
     .. warning::
 
@@ -180,6 +188,11 @@ class BashOperator(BaseOperator):
         # determine whether the bash_command value needs to re-rendered.
         self._init_bash_command_not_set = isinstance(self.bash_command, ArgNotSet)
 
+        # Keep a copy of the original bash_command, without the Jinja template rendered.
+        # This is later used to determine if the bash_command is a script or an inline string command.
+        # We do this later, because the bash_command is not available in __init__ when using @task.bash.
+        self._unrendered_bash_command: str | ArgNotSet = bash_command
+
     @cached_property
     def subprocess_hook(self):
         """Returns hook for running the bash command."""
@@ -200,7 +213,7 @@ class BashOperator(BaseOperator):
 
         RenderedTaskInstanceFields._update_runtime_evaluated_template_fields(ti)
 
-    def get_env(self, context):
+    def get_env(self, context) -> dict:
         """Build the set of environment variables to be exposed for the bash command."""
         system_env = os.environ.copy()
         env = self.env
@@ -220,7 +233,7 @@ class BashOperator(BaseOperator):
         return env
 
     def execute(self, context: Context):
-        bash_path = shutil.which("bash") or "bash"
+        bash_path: str = shutil.which("bash") or "bash"
         if self.cwd is not None:
             if not os.path.exists(self.cwd):
                 raise AirflowException(f"Can not find the cwd: {self.cwd}")
@@ -234,15 +247,17 @@ class BashOperator(BaseOperator):
         # Both will ensure the correct Bash command is executed and that the Rendered Template view in the UI
         # displays the executed command (otherwise it will display as an ArgNotSet type).
         if self._init_bash_command_not_set:
+            is_inline_command = self._is_inline_command(bash_command=cast(str, self.bash_command))
             ti = cast("TaskInstance", context["ti"])
             self.refresh_bash_command(ti)
+        else:
+            is_inline_command = self._is_inline_command(bash_command=cast(str, self._unrendered_bash_command))
 
-        result = self.subprocess_hook.run_command(
-            command=[bash_path, "-c", self.bash_command],
-            env=env,
-            output_encoding=self.output_encoding,
-            cwd=self.cwd,
-        )
+        if is_inline_command:
+            result = self._run_inline_command(bash_path=bash_path, env=env)
+        else:
+            result = self._run_rendered_script_file(bash_path=bash_path, env=env)
+
         if result.exit_code in self.skip_on_exit_code:
             raise AirflowSkipException(f"Bash command returned exit code {result.exit_code}. Skipping.")
         elif result.exit_code != 0:
@@ -251,6 +266,39 @@ class BashOperator(BaseOperator):
             )
 
         return self.output_processor(result.output)
+
+    def _run_inline_command(self, bash_path: str, env: dict) -> SubprocessResult:
+        """Pass the bash command as string directly in the subprocess."""
+        return self.subprocess_hook.run_command(
+            command=[bash_path, "-c", self.bash_command],
+            env=env,
+            output_encoding=self.output_encoding,
+            cwd=self.cwd,
+        )
+
+    def _run_rendered_script_file(self, bash_path: str, env: dict) -> SubprocessResult:
+        """
+        Save the bash command into a file and execute this file.
+
+        This allows for longer commands, and prevents "Argument list too long error".
+        """
+        with working_directory(cwd=self.cwd) as cwd:
+            with tempfile.NamedTemporaryFile(mode="w", dir=cwd, suffix=".sh") as file:
+                file.write(cast(str, self.bash_command))
+                file.flush()
+
+                bash_script = os.path.basename(file.name)
+                return self.subprocess_hook.run_command(
+                    command=[bash_path, bash_script],
+                    env=env,
+                    output_encoding=self.output_encoding,
+                    cwd=cwd,
+                )
+
+    @classmethod
+    def _is_inline_command(cls, bash_command: str) -> bool:
+        """Return True if the bash command is an inline string. False if it's a bash script file."""
+        return not bash_command.endswith(tuple(cls.template_ext))
 
     def on_kill(self) -> None:
         self.subprocess_hook.send_sigterm()

--- a/providers/tests/standard/operators/test_bash.py
+++ b/providers/tests/standard/operators/test_bash.py
@@ -290,6 +290,7 @@ class TestBashOperator:
         assert task.env == {"FOO": "2024-02-01"}
         assert task.cwd == Path(__file__).absolute().parent.as_posix()
 
+    @pytest.mark.db_test
     def test_templated_bash_script(self, dag_maker, tmp_path, session):
         """
         Creates a .sh script with Jinja template.

--- a/providers/tests/standard/operators/test_bash.py
+++ b/providers/tests/standard/operators/test_bash.py
@@ -23,6 +23,7 @@ import signal
 from datetime import datetime, timedelta
 from pathlib import Path
 from time import sleep
+from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
@@ -37,6 +38,9 @@ from tests_common.test_utils.compat import AIRFLOW_V_3_0_PLUS
 
 if AIRFLOW_V_3_0_PLUS:
     from airflow.utils.types import DagRunTriggeredByType
+
+if TYPE_CHECKING:
+    from airflow.models import TaskInstance
 
 DEFAULT_DATE = datetime(2016, 1, 1, tzinfo=timezone.utc)
 END_DATE = datetime(2016, 1, 2, tzinfo=timezone.utc)
@@ -60,6 +64,7 @@ class TestBashOperator:
         assert op.skip_on_exit_code == [99]
         assert op.cwd is None
         assert op._init_bash_command_not_set is False
+        assert op._unrendered_bash_command == "echo"
 
     @pytest.mark.db_test
     @pytest.mark.parametrize(
@@ -284,3 +289,26 @@ class TestBashOperator:
         assert task.bash_command == 'echo "test_templated_fields_dag"'
         assert task.env == {"FOO": "2024-02-01"}
         assert task.cwd == Path(__file__).absolute().parent.as_posix()
+
+    def test_templated_bash_script(self, dag_maker, tmp_path, session):
+        """
+        Creates a .sh script with Jinja template.
+        Pass it to the BashOperator and ensure it gets correctly rendered and executed.
+        """
+        bash_script: str = "sample.sh"
+        path: Path = tmp_path / bash_script
+        path.write_text('echo "{{ ti.task_id }}"')
+
+        with dag_maker(
+            dag_id="test_templated_bash_script", session=session, template_searchpath=os.fspath(path.parent)
+        ):
+            BashOperator(task_id="test_templated_fields_task", bash_command=bash_script)
+        ti: TaskInstance = dag_maker.create_dagrun().task_instances[0]
+        session.add(ti)
+        session.commit()
+        context = ti.get_template_context(session=session)
+        ti.render_templates(context=context)
+
+        task: BashOperator = ti.task
+        result = task.execute(context=context)
+        assert result == "test_templated_fields_task"

--- a/tests/decorators/test_bash.py
+++ b/tests/decorators/test_bash.py
@@ -507,6 +507,7 @@ class TestBashDecorator:
             ti.run()
         assert ti.task.bash_command == f"{DEFAULT_DATE.date()}; exit 1;"
 
+    @pytest.mark.db_test
     def test_templated_bash_script(self, dag_maker, tmp_path, session):
         """
         Creates a .sh script with Jinja template.

--- a/tests/decorators/test_bash.py
+++ b/tests/decorators/test_bash.py
@@ -20,6 +20,8 @@ import os
 import stat
 import warnings
 from contextlib import nullcontext as no_raise
+from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
@@ -31,6 +33,10 @@ from airflow.utils import timezone
 from airflow.utils.types import NOTSET
 
 from tests_common.test_utils.db import clear_db_dags, clear_db_runs, clear_rendered_ti_fields
+
+if TYPE_CHECKING:
+    from airflow.models import TaskInstance
+    from airflow.operators.bash import BashOperator
 
 DEFAULT_DATE = timezone.datetime(2023, 1, 1)
 
@@ -500,3 +506,32 @@ class TestBashDecorator:
         with pytest.raises(AirflowException):
             ti.run()
         assert ti.task.bash_command == f"{DEFAULT_DATE.date()}; exit 1;"
+
+    def test_templated_bash_script(self, dag_maker, tmp_path, session):
+        """
+        Creates a .sh script with Jinja template.
+        Pass it to the BashOperator and ensure it gets correctly rendered and executed.
+        """
+        bash_script: str = "sample.sh"
+        path: Path = tmp_path / bash_script
+        path.write_text('echo "{{ ti.task_id }}"')
+
+        with dag_maker(
+            dag_id="test_templated_bash_script", session=session, template_searchpath=os.fspath(path.parent)
+        ):
+
+            @task.bash
+            def test_templated_fields_task():
+                return bash_script
+
+            test_templated_fields_task()
+
+        ti: TaskInstance = dag_maker.create_dagrun().task_instances[0]
+        session.add(ti)
+        session.commit()
+        context = ti.get_template_context(session=session)
+        ti.render_templates(context=context)
+
+        op: BashOperator = ti.task
+        result = op.execute(context=context)
+        assert result == "test_templated_fields_task"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


This PR change the behavior of the BashOperator: When executing a `.sh` file with Jinja templating enabled (without the space -- `.sh `), the rendered script is written back into a temporary file, and then executed. Instead of being directly executed as inline command.

![Pasted image](https://github.com/user-attachments/assets/46e5dbc6-1d21-417c-b9b6-ee3440dca052)

*Note*: No changes / side-effect when executing a inline command or a script without Jinja templating ( `.sh ` with space).

### Why ?
When using templated bash command, the rendered string can be longer than the maximum argument length. This causes [`"Argument list too long"`](https://stackoverflow.com/questions/57251024/exact-limit-to-avoid-argument-list-too-long) error.

Without this PR, currently, the bash command is passed as argument into `["bash", "-c", command]`. The `command` cannot be longer than the max length of the system.

With this PR, the user can write his command into a bash file. The file is jinja-rendered and executed as a file, which bypass the maximum argument length limit.

### Breaking change
The BashOperator writes the rendered file to the disk. By default, it's in a temporary directory (`/tmp`) where Airflow has *write* access (in a common Linux system). However, if the user specify a `cwd` directory where Airflow cannot write, task will fail.

Backport #43191 warns the user when permissions are missing, and fallback to executing the script as inline command.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
