### PR TITLE
Use url_from_endpoint inside HttpHook.

### DIFF
--- a/providers/src/airflow/providers/http/hooks/http.py
+++ b/providers/src/airflow/providers/http/hooks/http.py
@@ -169,7 +169,7 @@ class HttpHook(BaseHook):
 
         session = self.get_conn(headers)
 
-        url = _url_from_endpoint(self.base_url, endpoint)
+        url = self.url_from_endpoint(endpoint)
 
         if self.tcp_keep_alive:
             keep_alive_adapter = TCPKeepAliveAdapter(


### PR DESCRIPTION
`url_from_endpoint` was removed at https://github.com/apache/airflow/pull/37696 and returned back later at https://github.com/apache/airflow/pull/37738. Is there any reason to not use the `url_from_endpoint` inside HttpHook? That way it can be overriden in other hooks based on HttpHook to enhance URL building logic. In my case, I would like to append api key to the end of the url as query parameter.