### PR TITLE
Remove burdensome eslint rules

### DIFF
--- a/airflow/ui/.prettierignore
+++ b/airflow/ui/.prettierignore
@@ -3,3 +3,4 @@ templates/**/*.html
 dist/
 *.md
 *.yaml
+coverage/*

--- a/airflow/ui/eslint.config.js
+++ b/airflow/ui/eslint.config.js
@@ -34,7 +34,7 @@ import { unicornRules } from "./rules/unicorn.js";
  */
 export default /** @type {const} @satisfies {ReadonlyArray<FlatConfig.Config>} */ ([
   // Global ignore of dist directory
-  { ignores: ["**/dist/"] },
+  { ignores: ["**/dist/", "**coverage/"] },
   // Base rules
   coreRules,
   typescriptRules,

--- a/airflow/ui/rules/core.js
+++ b/airflow/ui/rules/core.js
@@ -97,13 +97,6 @@ export const coreRules = /** @type {const} @satisfies {FlatConfig.Config} */ ({
     "arrow-body-style": ERROR,
 
     /**
-     * Limit cyclomatic complexity to a maximum of 10.
-     *
-     * @see [complexity](https://eslint.org/docs/latest/rules/complexity)
-     */
-    complexity: [WARN, 10],
-
-    /**
      * Require curly around all control statements.
      *
      * @example
@@ -289,17 +282,6 @@ export const coreRules = /** @type {const} @satisfies {FlatConfig.Config} */ ({
     "max-lines": [
       ERROR,
       { max: 250, skipBlankLines: true, skipComments: true },
-    ],
-
-    /**
-     * Enforce a maximum number of 100 lines of code in a function.
-     * Need more? Move it to another function.
-     *
-     * @see [max-lines-per-function](https://eslint.org/docs/latest/rules/max-lines-per-function)
-     */
-    "max-lines-per-function": [
-      ERROR,
-      { max: 100, skipBlankLines: true, skipComments: true },
     ],
 
     /**

--- a/airflow/ui/rules/react.js
+++ b/airflow/ui/rules/react.js
@@ -479,13 +479,6 @@ export const reactRules = /** @type {const} @satisfies {FlatConfig.Config} */ ({
     [`${reactNamespace}/jsx-max-depth`]: [ERROR, { max: 5 }],
 
     /**
-     * Disallow `Function#bind` or arrow functions in JSX props.
-     *
-     * @see [react/jsx-no-bind](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/jsx-no-bind.md)
-     */
-    [`${reactNamespace}/jsx-no-bind`]: ERROR,
-
-    /**
      * Disallow comments from being inserted as text nodes.
      *
      * @see [react/jsx-no-comment-textnodes](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/jsx-no-comment-textnodes.md)

--- a/airflow/ui/src/App.test.tsx
+++ b/airflow/ui/src/App.test.tsx
@@ -26,6 +26,9 @@ import type { DAGCollectionResponse } from "openapi/requests/types.gen";
 import { App } from "./App";
 import { Wrapper } from "./utils/Wrapper";
 
+// The null fields actually have to be null instead of undefined
+/* eslint-disable unicorn/no-null */
+
 const mockListDags: DAGCollectionResponse = {
   dags: [
     {

--- a/airflow/ui/src/components/DataTable/DataTable.tsx
+++ b/airflow/ui/src/components/DataTable/DataTable.tsx
@@ -63,7 +63,6 @@ type DataTableProps<TData> = {
 
 const defaultGetRowCanExpand = () => false;
 
-// eslint-disable-next-line max-lines-per-function
 export const DataTable = <TData,>({
   columns,
   data,

--- a/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -85,7 +85,6 @@ const columns: Array<ColumnDef<DAGResponse>> = [
 
 const PAUSED_PARAM = "paused";
 
-// eslint-disable-next-line complexity
 export const DagsList = ({ cardView = false }) => {
   const [searchParams] = useSearchParams();
 


### PR DESCRIPTION
Remove three eslint rules that proved to be too prescriptive. Based on discussion over at https://github.com/apache/airflow/pull/42711#discussion_r1787630877

- `jsx-no-bind` forces premature use of `useCallback`, which itself can lead to performance issues. Maintainers should still try to encourage defining functions outside of the component.
- `complexity` quite subjective. Maintainers should use discretion.
- `max-lines-per-function` also very subjective. Maintainers should use direction.

Other changes:
- make sure that `coverage` reports are ignored by eslint and prettier
- Add eslint-ignore for the test mocks that use null. If we have to do this a lot outside of mocks, we can revisit changing that rule too.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
