### PR TITLE
Fix mark as success when pod fails while fetching log

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -789,9 +789,8 @@ class KubernetesPodOperator(BaseOperator):
                         follow=follow,
                         since_time=last_log_time,
                     )
-                    print("hadar")
+
                     self.invoke_defer_method(pod_log_status.last_log_time)
-                    print("hadar1")
                 else:
                     self.invoke_defer_method()
 

--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -790,9 +790,7 @@ class KubernetesPodOperator(BaseOperator):
                         since_time=last_log_time,
                     )
 
-                    if pod_log_status.running:
-                        self.log.info("Container still running; deferring again.")
-                        self.invoke_defer_method(pod_log_status.last_log_time)
+                    self.invoke_defer_method(pod_log_status.last_log_time)
                 else:
                     self.invoke_defer_method()
 

--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -789,8 +789,9 @@ class KubernetesPodOperator(BaseOperator):
                         follow=follow,
                         since_time=last_log_time,
                     )
-
+                    print("hadar")
                     self.invoke_defer_method(pod_log_status.last_log_time)
+                    print("hadar1")
                 else:
                     self.invoke_defer_method()
 


### PR DESCRIPTION
closes: https://github.com/apache/airflow/pull/40891
with cherry-picking from: @peloyeje 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
