### PR TITLE
Remove more burdensome eslint rules

### DIFF
--- a/airflow/ui/rules/core.js
+++ b/airflow/ui/rules/core.js
@@ -292,13 +292,6 @@ export const coreRules = /** @type {const} @satisfies {FlatConfig.Config} */ ({
     "max-nested-callbacks": [ERROR, { max: 3 }],
 
     /**
-     * Enforce a maximum number of statements allowed in function blocks to 10.
-     *
-     * @see [max-statements](https://eslint.org/docs/latest/rules/max-statements)
-     */
-    "max-statements": [WARN, { max: 10 }],
-
-    /**
      * Disallow use of `alert`, `confirm`, and `prompt`.
      *
      * @see [no-alert](https://eslint.org/docs/latest/rules/no-alert)

--- a/airflow/ui/src/components/DataTable/searchParams.ts
+++ b/airflow/ui/src/components/DataTable/searchParams.ts
@@ -24,7 +24,6 @@ export const LIMIT_PARAM = "limit";
 export const OFFSET_PARAM = "offset";
 export const SORT_PARAM = "sort";
 
-// eslint-disable-next-line max-statements
 export const stateToSearchParams = (
   state: TableState,
   defaultTableState?: TableState,


### PR DESCRIPTION
Remove another rule.

This was forcing an ignore on our code, and raising more warnings on new PRs such as https://github.com/apache/airflow/pull/42779/files#diff-66d17c201c22426a3c37398877656f048b04eb7a41d5bfa827a0a2e7a5eb0beaL29

A component can quickly becomes bigger than that leaving that at the discretion of the contributor/