### PR TITLE
Specify asyncio_default_fixture_loop_scope in pytest.ini

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -567,6 +567,9 @@ python_files = [
 testpaths = [
     "tests",
 ]
+
+asyncio_default_fixture_loop_scope = "function"
+
 # Keep temporary directories (created by `tmp_path`) for 2 recent runs only failed tests.
 tmp_path_retention_count = "2"
 tmp_path_retention_policy = "failed"


### PR DESCRIPTION
Previously we were getting 'PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.'  This sets it to the new default, and makes the warning go away.
