### PR TITLE
Changed conf property from str to dict in SparkSqlOperator

### DIFF
--- a/providers/src/airflow/providers/apache/spark/hooks/spark_sql.py
+++ b/providers/src/airflow/providers/apache/spark/hooks/spark_sql.py
@@ -82,7 +82,7 @@ class SparkSqlHook(BaseHook):
     def __init__(
         self,
         sql: str,
-        conf: str | None = None,
+        conf: dict[str, Any] | None = None,
         conn_id: str = default_conn_name,
         total_executor_cores: int | None = None,
         executor_cores: int | None = None,
@@ -143,8 +143,8 @@ class SparkSqlHook(BaseHook):
         """
         connection_cmd = ["spark-sql"]
         if self._conf:
-            for conf_el in self._conf.split(","):
-                connection_cmd += ["--conf", conf_el]
+            for key in self._conf:
+                connection_cmd += ["--conf", f"{key}={self._conf[key]}"]
         if self._total_executor_cores:
             connection_cmd += ["--total-executor-cores", str(self._total_executor_cores)]
         if self._executor_cores:

--- a/providers/src/airflow/providers/apache/spark/hooks/spark_sql.py
+++ b/providers/src/airflow/providers/apache/spark/hooks/spark_sql.py
@@ -82,7 +82,7 @@ class SparkSqlHook(BaseHook):
     def __init__(
         self,
         sql: str,
-        conf: dict[str, Any] | None = None,
+        conf: dict[str, Any] | str | None = None,
         conn_id: str = default_conn_name,
         total_executor_cores: int | None = None,
         executor_cores: int | None = None,
@@ -143,8 +143,13 @@ class SparkSqlHook(BaseHook):
         """
         connection_cmd = ["spark-sql"]
         if self._conf:
-            for key in self._conf:
-                connection_cmd += ["--conf", f"{key}={self._conf[key]}"]
+            conf = self._conf
+            if isinstance(conf, dict):
+                for key in conf:
+                    connection_cmd += ["--conf", f"{key}={conf[key]}"]
+            elif isinstance(conf, str):
+                for conf_el in conf.split(","):
+                    connection_cmd += ["--conf", conf_el]
         if self._total_executor_cores:
             connection_cmd += ["--total-executor-cores", str(self._total_executor_cores)]
         if self._executor_cores:

--- a/providers/src/airflow/providers/apache/spark/hooks/spark_sql.py
+++ b/providers/src/airflow/providers/apache/spark/hooks/spark_sql.py
@@ -145,8 +145,8 @@ class SparkSqlHook(BaseHook):
         if self._conf:
             conf = self._conf
             if isinstance(conf, dict):
-                for key in conf:
-                    connection_cmd += ["--conf", f"{key}={conf[key]}"]
+                for key, value in conf.items():
+                    connection_cmd += ["--conf", f"{key}={value}"]
             elif isinstance(conf, str):
                 for conf_el in conf.split(","):
                     connection_cmd += ["--conf", conf_el]

--- a/providers/src/airflow/providers/apache/spark/operators/spark_sql.py
+++ b/providers/src/airflow/providers/apache/spark/operators/spark_sql.py
@@ -63,7 +63,7 @@ class SparkSqlOperator(BaseOperator):
         self,
         *,
         sql: str,
-        conf: dict[str, Any] | None = None,
+        conf: dict[str, Any] | str | None = None,
         conn_id: str = "spark_sql_default",
         total_executor_cores: int | None = None,
         executor_cores: int | None = None,

--- a/providers/src/airflow/providers/apache/spark/operators/spark_sql.py
+++ b/providers/src/airflow/providers/apache/spark/operators/spark_sql.py
@@ -63,7 +63,7 @@ class SparkSqlOperator(BaseOperator):
         self,
         *,
         sql: str,
-        conf: str | None = None,
+        conf: dict[str, Any] | None = None,
         conn_id: str = "spark_sql_default",
         total_executor_cores: int | None = None,
         executor_cores: int | None = None,

--- a/providers/tests/apache/spark/hooks/test_spark_sql.py
+++ b/providers/tests/apache/spark/hooks/test_spark_sql.py
@@ -50,7 +50,7 @@ class TestSparkSqlHook:
         "num_executors": 10,
         "verbose": True,
         "sql": " /path/to/sql/file.sql ",
-        "conf": {"key": "value", "PROP": "VALUE"}
+        "conf": {"key": "value", "PROP": "VALUE"},
     }
 
     @classmethod

--- a/providers/tests/apache/spark/hooks/test_spark_sql.py
+++ b/providers/tests/apache/spark/hooks/test_spark_sql.py
@@ -50,7 +50,7 @@ class TestSparkSqlHook:
         "num_executors": 10,
         "verbose": True,
         "sql": " /path/to/sql/file.sql ",
-        "conf": "key=value,PROP=VALUE",
+        "conf": {"key": "value", "PROP": "VALUE"}
     }
 
     @classmethod
@@ -78,8 +78,7 @@ class TestSparkSqlHook:
         assert self._config["sql"].strip() == sql_path
 
         # Check if all config settings are there
-        for key_value in self._config["conf"].split(","):
-            k, v = key_value.split("=")
+        for k, v in self._config["conf"].items():
             assert f"--conf {k}={v}" in cmd
 
         if self._config["verbose"]:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

Changes the conf property from str to dict in SparkSqlOperator
closes: https://github.com/apache/airflow/issues/40507

The previous PR was closed due to inactivity, I had time this week to fix it