### PR TITLE
Add test for behavior for paused backfill

### DIFF
--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -5167,7 +5167,7 @@ class TestSchedulerJob:
 
         session.commit()
 
-        # now let's run scheduler it once
+        # now let's run scheduler once
         self.job_runner._start_queued_dagruns(session)
         session.flush()
 


### PR DESCRIPTION
Just add test to verify the behavior that new dag runs not started when dag backfill is paused.