### PR TITLE
AIP-84 Migrate the public endpoint Get DAG to FastAPI

### DIFF
--- a/airflow/api_fastapi/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/openapi/v1-generated.yaml
@@ -252,13 +252,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /public/dags/{dag_id}/details:
+  /public/dags/{dag_id}:
     get:
       tags:
       - DAG
-      summary: Get Dag Details
-      description: Get details of DAG.
-      operationId: get_dag_details
+      summary: Get Dag
+      description: Get basic information about a DAG.
+      operationId: get_dag
       parameters:
       - name: dag_id
         in: path
@@ -272,7 +272,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DAGDetailsResponse'
+                $ref: '#/components/schemas/DAGResponse'
         '400':
           content:
             application/json:
@@ -303,7 +303,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPExceptionResponse'
           description: Unprocessable Entity
-  /public/dags/{dag_id}:
     patch:
       tags:
       - DAG
@@ -370,6 +369,57 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /public/dags/{dag_id}/details:
+    get:
+      tags:
+      - DAG
+      summary: Get Dag Details
+      description: Get details of DAG.
+      operationId: get_dag_details
+      parameters:
+      - name: dag_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Dag Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DAGDetailsResponse'
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Bad Request
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Unauthorized
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Forbidden
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Not Found
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Unprocessable Entity
   /public/connections/{connection_id}:
     delete:
       tags:

--- a/airflow/api_fastapi/serializers/dags.py
+++ b/airflow/api_fastapi/serializers/dags.py
@@ -24,9 +24,9 @@ from typing import Any, Iterable
 from itsdangerous import URLSafeSerializer
 from pendulum.tz.timezone import FixedTimezone, Timezone
 from pydantic import (
-    AliasChoices,
+    AliasGenerator,
     BaseModel,
-    Field,
+    ConfigDict,
     computed_field,
     field_validator,
 )
@@ -77,6 +77,14 @@ class DAGResponse(BaseModel):
             return v.split(",")
         return v
 
+    @field_validator("timetable_summary", mode="before")
+    @classmethod
+    def get_timetable_summary(cls, tts: str | None) -> str | None:
+        """Validate the string representation of timetable_summary."""
+        if tts is None or tts == "None":
+            return None
+        return str(tts)
+
     # Mypy issue https://github.com/python/mypy/issues/1362
     @computed_field  # type: ignore[misc]
     @property
@@ -103,9 +111,7 @@ class DAGDetailsResponse(DAGResponse):
     """Specific serializer for DAG Details responses."""
 
     catchup: bool
-    dag_run_timeout: timedelta | None = Field(
-        validation_alias=AliasChoices("dag_run_timeout", "dagrun_timeout")
-    )
+    dag_run_timeout: timedelta | None
     dataset_expression: dict | None
     doc_md: str | None
     start_date: datetime | None
@@ -114,11 +120,19 @@ class DAGDetailsResponse(DAGResponse):
     orientation: str
     params: abc.MutableMapping | None
     render_template_as_native_obj: bool
-    template_search_path: Iterable[str] | None = Field(
-        validation_alias=AliasChoices("template_search_path", "template_searchpath")
-    )
+    template_search_path: Iterable[str] | None
     timezone: str | None
-    last_parsed: datetime | None = Field(validation_alias=AliasChoices("last_parsed", "last_loaded"))
+    last_parsed: datetime | None
+
+    model_config = ConfigDict(
+        alias_generator=AliasGenerator(
+            validation_alias=lambda field_name: {
+                "dag_run_timeout": "dagrun_timeout",
+                "last_parsed": "last_loaded",
+                "template_search_path": "template_searchpath",
+            }.get(field_name, field_name),
+        )
+    )
 
     @field_validator("timezone", mode="before")
     @classmethod
@@ -127,14 +141,6 @@ class DAGDetailsResponse(DAGResponse):
         if tz is None:
             return None
         return str(tz)
-
-    @field_validator("timetable_summary", mode="before")
-    @classmethod
-    def get_timetable_summary(cls, tts: str | None) -> str | None:
-        """Validate the string representation of timetable_summary."""
-        if tts is None or tts == "None":
-            return None
-        return str(tts)
 
     @field_validator("params", mode="before")
     @classmethod

--- a/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow/ui/openapi-gen/queries/common.ts
@@ -75,6 +75,22 @@ export const UseDagServiceGetDagsKeyFn = (
     },
   ]),
 ];
+export type DagServiceGetDagDefaultResponse = Awaited<
+  ReturnType<typeof DagService.getDag>
+>;
+export type DagServiceGetDagQueryResult<
+  TData = DagServiceGetDagDefaultResponse,
+  TError = unknown,
+> = UseQueryResult<TData, TError>;
+export const useDagServiceGetDagKey = "DagServiceGetDag";
+export const UseDagServiceGetDagKeyFn = (
+  {
+    dagId,
+  }: {
+    dagId: string;
+  },
+  queryKey?: Array<unknown>,
+) => [useDagServiceGetDagKey, ...(queryKey ?? [{ dagId }])];
 export type DagServiceGetDagDetailsDefaultResponse = Awaited<
   ReturnType<typeof DagService.getDagDetails>
 >;

--- a/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -99,6 +99,26 @@ export const prefetchUseDagServiceGetDags = (
       }),
   });
 /**
+ * Get Dag
+ * Get basic information about a DAG.
+ * @param data The data for the request.
+ * @param data.dagId
+ * @returns DAGResponse Successful Response
+ * @throws ApiError
+ */
+export const prefetchUseDagServiceGetDag = (
+  queryClient: QueryClient,
+  {
+    dagId,
+  }: {
+    dagId: string;
+  },
+) =>
+  queryClient.prefetchQuery({
+    queryKey: Common.UseDagServiceGetDagKeyFn({ dagId }),
+    queryFn: () => DagService.getDag({ dagId }),
+  });
+/**
  * Get Dag Details
  * Get details of DAG.
  * @param data The data for the request.

--- a/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow/ui/openapi-gen/queries/queries.ts
@@ -120,6 +120,32 @@ export const useDagServiceGetDags = <
     ...options,
   });
 /**
+ * Get Dag
+ * Get basic information about a DAG.
+ * @param data The data for the request.
+ * @param data.dagId
+ * @returns DAGResponse Successful Response
+ * @throws ApiError
+ */
+export const useDagServiceGetDag = <
+  TData = Common.DagServiceGetDagDefaultResponse,
+  TError = unknown,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  {
+    dagId,
+  }: {
+    dagId: string;
+  },
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
+) =>
+  useQuery<TData, TError>({
+    queryKey: Common.UseDagServiceGetDagKeyFn({ dagId }, queryKey),
+    queryFn: () => DagService.getDag({ dagId }) as TData,
+    ...options,
+  });
+/**
  * Get Dag Details
  * Get details of DAG.
  * @param data The data for the request.

--- a/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow/ui/openapi-gen/queries/suspense.ts
@@ -114,6 +114,32 @@ export const useDagServiceGetDagsSuspense = <
     ...options,
   });
 /**
+ * Get Dag
+ * Get basic information about a DAG.
+ * @param data The data for the request.
+ * @param data.dagId
+ * @returns DAGResponse Successful Response
+ * @throws ApiError
+ */
+export const useDagServiceGetDagSuspense = <
+  TData = Common.DagServiceGetDagDefaultResponse,
+  TError = unknown,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  {
+    dagId,
+  }: {
+    dagId: string;
+  },
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
+) =>
+  useSuspenseQuery<TData, TError>({
+    queryKey: Common.UseDagServiceGetDagKeyFn({ dagId }, queryKey),
+    queryFn: () => DagService.getDag({ dagId }) as TData,
+    ...options,
+  });
+/**
  * Get Dag Details
  * Get details of DAG.
  * @param data The data for the request.

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -9,10 +9,12 @@ import type {
   GetDagsResponse,
   PatchDagsData,
   PatchDagsResponse,
-  GetDagDetailsData,
-  GetDagDetailsResponse,
+  GetDagData,
+  GetDagResponse,
   PatchDagData,
   PatchDagResponse,
+  GetDagDetailsData,
+  GetDagDetailsResponse,
   DeleteConnectionData,
   DeleteConnectionResponse,
   GetConnectionData,
@@ -134,19 +136,17 @@ export class DagService {
   }
 
   /**
-   * Get Dag Details
-   * Get details of DAG.
+   * Get Dag
+   * Get basic information about a DAG.
    * @param data The data for the request.
    * @param data.dagId
-   * @returns DAGDetailsResponse Successful Response
+   * @returns DAGResponse Successful Response
    * @throws ApiError
    */
-  public static getDagDetails(
-    data: GetDagDetailsData,
-  ): CancelablePromise<GetDagDetailsResponse> {
+  public static getDag(data: GetDagData): CancelablePromise<GetDagResponse> {
     return __request(OpenAPI, {
       method: "GET",
-      url: "/public/dags/{dag_id}/details",
+      url: "/public/dags/{dag_id}",
       path: {
         dag_id: data.dagId,
       },
@@ -190,6 +190,33 @@ export class DagService {
         403: "Forbidden",
         404: "Not Found",
         422: "Validation Error",
+      },
+    });
+  }
+
+  /**
+   * Get Dag Details
+   * Get details of DAG.
+   * @param data The data for the request.
+   * @param data.dagId
+   * @returns DAGDetailsResponse Successful Response
+   * @throws ApiError
+   */
+  public static getDagDetails(
+    data: GetDagDetailsData,
+  ): CancelablePromise<GetDagDetailsResponse> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/public/dags/{dag_id}/details",
+      path: {
+        dag_id: data.dagId,
+      },
+      errors: {
+        400: "Bad Request",
+        401: "Unauthorized",
+        403: "Forbidden",
+        404: "Not Found",
+        422: "Unprocessable Entity",
       },
     });
   }

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -196,11 +196,11 @@ export type PatchDagsData = {
 
 export type PatchDagsResponse = DAGCollectionResponse;
 
-export type GetDagDetailsData = {
+export type GetDagData = {
   dagId: string;
 };
 
-export type GetDagDetailsResponse = DAGDetailsResponse;
+export type GetDagResponse = DAGResponse;
 
 export type PatchDagData = {
   dagId: string;
@@ -209,6 +209,12 @@ export type PatchDagData = {
 };
 
 export type PatchDagResponse = DAGResponse;
+
+export type GetDagDetailsData = {
+  dagId: string;
+};
+
+export type GetDagDetailsResponse = DAGDetailsResponse;
 
 export type DeleteConnectionData = {
   connectionId: string;
@@ -290,6 +296,66 @@ export type $OpenApiTs = {
       };
     };
   };
+  "/public/dags/{dag_id}": {
+    get: {
+      req: GetDagData;
+      res: {
+        /**
+         * Successful Response
+         */
+        200: DAGResponse;
+        /**
+         * Bad Request
+         */
+        400: HTTPExceptionResponse;
+        /**
+         * Unauthorized
+         */
+        401: HTTPExceptionResponse;
+        /**
+         * Forbidden
+         */
+        403: HTTPExceptionResponse;
+        /**
+         * Not Found
+         */
+        404: HTTPExceptionResponse;
+        /**
+         * Unprocessable Entity
+         */
+        422: HTTPExceptionResponse;
+      };
+    };
+    patch: {
+      req: PatchDagData;
+      res: {
+        /**
+         * Successful Response
+         */
+        200: DAGResponse;
+        /**
+         * Bad Request
+         */
+        400: HTTPExceptionResponse;
+        /**
+         * Unauthorized
+         */
+        401: HTTPExceptionResponse;
+        /**
+         * Forbidden
+         */
+        403: HTTPExceptionResponse;
+        /**
+         * Not Found
+         */
+        404: HTTPExceptionResponse;
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError;
+      };
+    };
+  };
   "/public/dags/{dag_id}/details": {
     get: {
       req: GetDagDetailsData;
@@ -318,37 +384,6 @@ export type $OpenApiTs = {
          * Unprocessable Entity
          */
         422: HTTPExceptionResponse;
-      };
-    };
-  };
-  "/public/dags/{dag_id}": {
-    patch: {
-      req: PatchDagData;
-      res: {
-        /**
-         * Successful Response
-         */
-        200: DAGResponse;
-        /**
-         * Bad Request
-         */
-        400: HTTPExceptionResponse;
-        /**
-         * Unauthorized
-         */
-        401: HTTPExceptionResponse;
-        /**
-         * Forbidden
-         */
-        403: HTTPExceptionResponse;
-        /**
-         * Not Found
-         */
-        404: HTTPExceptionResponse;
-        /**
-         * Validation Error
-         */
-        422: HTTPValidationError;
       };
     };
   };

--- a/tests/api_fastapi/views/public/test_dags.py
+++ b/tests/api_fastapi/views/public/test_dags.py
@@ -302,3 +302,51 @@ def test_dag_details(test_client, query_params, dag_id, expected_status_code, da
         "timezone": UTC_JSON_REPR,
     }
     assert res_json == expected
+
+
+@pytest.mark.parametrize(
+    "query_params, dag_id, expected_status_code, dag_display_name",
+    [
+        ({}, "fake_dag_id", 404, "fake_dag"),
+        ({}, DAG2_ID, 200, DAG2_DISPLAY_NAME),
+    ],
+)
+def test_dag(test_client, query_params, dag_id, expected_status_code, dag_display_name):
+    response = test_client.get(f"/public/dags/{dag_id}", params=query_params)
+    assert response.status_code == expected_status_code
+    if expected_status_code != 200:
+        return
+
+    # Match expected and actual responses below.
+    res_json = response.json()
+    last_parsed_time = res_json["last_parsed_time"]
+    file_token = res_json["file_token"]
+    expected = {
+        "dag_id": dag_id,
+        "dag_display_name": dag_display_name,
+        "description": None,
+        "fileloc": "/opt/airflow/tests/api_fastapi/views/public/test_dags.py",
+        "file_token": file_token,
+        "is_paused": False,
+        "is_active": True,
+        "owners": ["airflow"],
+        "timetable_summary": None,
+        "tags": [],
+        "next_dagrun": None,
+        "has_task_concurrency_limits": True,
+        "next_dagrun_data_interval_start": None,
+        "next_dagrun_data_interval_end": None,
+        "max_active_runs": 16,
+        "max_consecutive_failed_dag_runs": 0,
+        "next_dagrun_create_after": None,
+        "last_expired": None,
+        "max_active_tasks": 16,
+        "last_pickled": None,
+        "default_view": "grid",
+        "last_parsed_time": last_parsed_time,
+        "scheduler_lock": None,
+        "timetable_description": "Never, external triggers only",
+        "has_import_errors": False,
+        "pickle_id": None,
+    }
+    assert res_json == expected

--- a/tests/api_fastapi/views/public/test_dags.py
+++ b/tests/api_fastapi/views/public/test_dags.py
@@ -311,7 +311,7 @@ def test_dag_details(test_client, query_params, dag_id, expected_status_code, da
         ({}, DAG2_ID, 200, DAG2_DISPLAY_NAME),
     ],
 )
-def test_dag(test_client, query_params, dag_id, expected_status_code, dag_display_name):
+def test_get_dag(test_client, query_params, dag_id, expected_status_code, dag_display_name):
     response = test_client.get(f"/public/dags/{dag_id}", params=query_params)
     assert response.status_code == expected_status_code
     if expected_status_code != 200:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #42652
related: #42370

This migrates the Get DAG API from `api_connexion` to `api_fastapi`, with a supporting test.

Additionally, this replaces `AliasChoices` with a single `AliasGenerator`. The lowest direct dependency resolution tests that were previously failing for `AliasGenerator` will now pass, thanks to the Pydantic min version update in https://github.com/apache/airflow/pull/42694.
