### PR TITLE
Fix dag warning documentation

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3463,7 +3463,7 @@ components:
       allOf:
         - type: object
           properties:
-            import_errors:
+            dag_warnings:
               type: array
               items:
                 $ref: "#/components/schemas/DagWarning"

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1263,7 +1263,7 @@ export interface components {
     };
     /** @description Collection of DAG warnings. */
     DagWarningCollection: {
-      import_errors?: components["schemas"]["DagWarning"][];
+      dag_warnings?: components["schemas"]["DagWarning"][];
     } & components["schemas"]["CollectionInfo"];
     SetDagRunNote: {
       /** @description Custom notes left by users for this Dag Run. */


### PR DESCRIPTION
Fix the documentation that is not in lined with the actual response. `dag_warnings` is returned while the documentation and spec specify `import_errrors`:
![Screenshot 2024-10-09 at 15 59 19](https://github.com/user-attachments/assets/1bce5db8-e787-4675-b685-87cba32c8b3f)
![Screenshot 2024-10-09 at 15 59 48](https://github.com/user-attachments/assets/1d118af7-b9c1-4798-846e-89f94841d4a3)
