### PR TITLE
AIP-84 Fix dag display name search

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -3125,6 +3125,13 @@ class DagModel(Base):
     def dag_display_name(self) -> str:
         return self._dag_display_property_value or self.dag_id
 
+    @dag_display_name.expression  # type: ignore[no-redef]
+    def dag_display_name(self) -> str:
+        return case(
+            (self._dag_display_property_value.isnot(None), self._dag_display_property_value),
+            else_=self.dag_id,
+        )
+
     @classmethod
     @internal_api_call
     @provide_session

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -3127,6 +3127,11 @@ class DagModel(Base):
 
     @dag_display_name.expression  # type: ignore[no-redef]
     def dag_display_name(self) -> str:
+        """
+        Expression part of the ``dag_display`` name hybrid property.
+
+        :meta private:
+        """
         return case(
             (self._dag_display_property_value.isnot(None), self._dag_display_property_value),
             else_=self.dag_id,

--- a/tests/api_fastapi/views/public/test_dags.py
+++ b/tests/api_fastapi/views/public/test_dags.py
@@ -35,7 +35,6 @@ pytestmark = pytest.mark.db_test
 DAG1_ID = "test_dag1"
 DAG1_DISPLAY_NAME = "display1"
 DAG2_ID = "test_dag2"
-DAG2_DISPLAY_NAME = "display2"
 DAG2_START_DATE = datetime(2021, 6, 15, tzinfo=timezone.utc)
 DAG3_ID = "test_dag3"
 TASK_ID = "op1"
@@ -99,7 +98,6 @@ def setup(dag_maker, session=None) -> None:
 
     with dag_maker(
         DAG2_ID,
-        dag_display_name=DAG2_DISPLAY_NAME,
         schedule=None,
         start_date=DAG2_START_DATE,
         doc_md="details",
@@ -150,7 +148,7 @@ def setup(dag_maker, session=None) -> None:
         ),
         # Search
         ({"dag_id_pattern": "1"}, 1, [DAG1_ID]),
-        ({"dag_display_name_pattern": "display2"}, 1, [DAG2_ID]),
+        ({"dag_display_name_pattern": "test_dag2"}, 1, [DAG2_ID]),
     ],
 )
 def test_get_dags(test_client, query_params, expected_total_entries, expected_ids):
@@ -239,7 +237,7 @@ def test_patch_dags(test_client, query_params, body, expected_status_code, expec
     "query_params, dag_id, expected_status_code, dag_display_name, start_date",
     [
         ({}, "fake_dag_id", 404, "fake_dag", datetime(2023, 12, 31, tzinfo=timezone.utc)),
-        ({}, DAG2_ID, 200, DAG2_DISPLAY_NAME, DAG2_START_DATE),
+        ({}, DAG2_ID, 200, DAG2_ID, DAG2_START_DATE),
     ],
 )
 def test_dag_details(test_client, query_params, dag_id, expected_status_code, dag_display_name, start_date):

--- a/tests/api_fastapi/views/public/test_dags.py
+++ b/tests/api_fastapi/views/public/test_dags.py
@@ -307,7 +307,7 @@ def test_dag_details(test_client, query_params, dag_id, expected_status_code, da
     "query_params, dag_id, expected_status_code, dag_display_name",
     [
         ({}, "fake_dag_id", 404, "fake_dag"),
-        ({}, DAG2_ID, 200, DAG2_DISPLAY_NAME),
+        ({}, DAG2_ID, 200, DAG2_ID),
     ],
 )
 def test_get_dag(test_client, query_params, dag_id, expected_status_code, dag_display_name):


### PR DESCRIPTION
Fix the dag display name search.

I had that property.expression at some point and figured it wasn't necessary anymore because tests were green even when I removed it. Apparently it was still required :)