### PR TITLE
Revert "Remove `sqlalchemy-redshift` dependency from Amazon provider"

### DIFF
--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -105,6 +105,7 @@ dependencies:
   - watchtower>=3.0.0,!=3.3.0,<4
   - jsonpath_ng>=1.5.3
   - redshift_connector>=2.0.918
+  - sqlalchemy_redshift>=0.8.6
   - asgiref>=2.3.0
   - PyAthena>=3.0.10
   - jmespath>=0.7.0

--- a/docs/apache-airflow-providers-amazon/index.rst
+++ b/docs/apache-airflow-providers-amazon/index.rst
@@ -119,6 +119,7 @@ PIP package                                 Version required
 ``watchtower``                              ``>=3.0.0,!=3.3.0,<4``
 ``jsonpath_ng``                             ``>=1.5.3``
 ``redshift_connector``                      ``>=2.0.918``
+``sqlalchemy_redshift``                     ``>=0.8.6``
 ``asgiref``                                 ``>=2.3.0``
 ``PyAthena``                                ``>=3.0.10``
 ``jmespath``                                ``>=0.7.0``

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -38,6 +38,7 @@
       "jsonpath_ng>=1.5.3",
       "python3-saml>=1.16.0",
       "redshift_connector>=2.0.918",
+      "sqlalchemy_redshift>=0.8.6",
       "watchtower>=3.0.0,!=3.3.0,<4"
     ],
     "devel-deps": [


### PR DESCRIPTION
Reverts apache/airflow#42830 - this breaks tests https://github.com/apache/airflow/actions/runs/11250263626
