### PR TITLE
Fix retry configuration in k8s tests

### DIFF
--- a/kubernetes_tests/test_base.py
+++ b/kubernetes_tests/test_base.py
@@ -123,7 +123,12 @@ class BaseK8STest:
     def _get_session_with_retries(self):
         session = requests.Session()
         session.auth = ("admin", "admin")
-        retries = Retry(total=3, backoff_factor=1)
+        retries = Retry(
+            total=3,
+            backoff_factor=1,
+            status_forcelist=[404],
+            allowed_methods=Retry.DEFAULT_ALLOWED_METHODS | frozenset(["PATCH", "POST"]),
+        )
         session.mount("http://", HTTPAdapter(max_retries=retries))
         session.mount("https://", HTTPAdapter(max_retries=retries))
         return session


### PR DESCRIPTION
Updating the retry configuration with `status_forcelist` and `allowed_methods`.

By default, the retry configuration's `status_forcelist` is set to None, meaning no action is taken when an error response is received.

Additionally, the default `allowed_methods` does not include the PATCH and POST methods. In k8s test, API endpoints use the PATCH and POST methods for the following routes:

`api/v1/dags/{dag_id}`: PATCH
`api/v1/dags/{dag_id}/dagRuns`: POST

https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
