### PR TITLE
Fix issue generation for providers

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -137,6 +137,7 @@ from airflow_breeze.utils.parallel import (
     run_with_pool,
 )
 from airflow_breeze.utils.path_utils import (
+    AIRFLOW_PROVIDERS_SRC,
     AIRFLOW_SOURCES_ROOT,
     CONSTRAINTS_CACHE_DIR,
     DIST_DIR,
@@ -2125,7 +2126,7 @@ def generate_issue_content_providers(
             pull_request_list = [pull_requests[pr] for pr in provider_prs[provider_id] if pr in pull_requests]
             provider_yaml_dict = yaml.safe_load(
                 (
-                    AIRFLOW_SOURCES_ROOT
+                    AIRFLOW_PROVIDERS_SRC
                     / "airflow"
                     / "providers"
                     / provider_id.replace(".", os.sep)


### PR DESCRIPTION
```

Retrieving 53 PRs  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Traceback (most recent call last):
  File "/Users/eladkal/.local/bin/breeze", line 8, in <module>
    sys.exit(main())
  File "/Users/eladkal/.local/pipx/venvs/apache-airflow-breeze/lib/python3.9/site-packages/rich_click/rich_command.py", line 367, in __call__
    return super().__call__(*args, **kwargs)
  File "/Users/eladkal/.local/pipx/venvs/apache-airflow-breeze/lib/python3.9/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/Users/eladkal/.local/pipx/venvs/apache-airflow-breeze/lib/python3.9/site-packages/rich_click/rich_command.py", line 152, in main
    rv = self.invoke(ctx)
  File "/Users/eladkal/.local/pipx/venvs/apache-airflow-breeze/lib/python3.9/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/eladkal/.local/pipx/venvs/apache-airflow-breeze/lib/python3.9/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/eladkal/.local/pipx/venvs/apache-airflow-breeze/lib/python3.9/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/eladkal/.local/pipx/venvs/apache-airflow-breeze/lib/python3.9/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/Users/eladkal/PycharmProjects/airflow/dev/breeze/src/airflow_breeze/commands/release_management_commands.py", line 2127, in generate_issue_content_providers
    (
  File "/Users/eladkal/.local/share/rtx/installs/python/3.9.18/lib/python3.9/pathlib.py", line 1266, in read_text
    with self.open(mode='r', encoding=encoding, errors=errors) as f:
  File "/Users/eladkal/.local/share/rtx/installs/python/3.9.18/lib/python3.9/pathlib.py", line 1252, in open
    return io.open(self, mode, buffering, encoding, errors, newline,
  File "/Users/eladkal/.local/share/rtx/installs/python/3.9.18/lib/python3.9/pathlib.py", line 1120, in _opener
    return self._accessor.open(self, flags, mode)
FileNotFoundError: [Errno 2] No such file or directory: '/Users/eladkal/PycharmProjects/airflow/airflow/providers/amazon/provider.yaml'
```

Fix the location of provider folder in issue generation command after https://github.com/apache/airflow/pull/42505