### PR TITLE
Fix PythonOperator DAG error when DAG has hyphen in name

### DIFF
--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -355,7 +355,6 @@ def get_unique_dag_module_name(file_path: str) -> str:
     """Return a unique module name in the format unusual_prefix_{sha1 of module's file path}_{original module name}."""
     if isinstance(file_path, str):
         path_hash = hashlib.sha1(file_path.encode("utf-8")).hexdigest()
-        org_mod_name = Path(file_path).stem
-        org_mod_name = org_mod_name.replace("-", "_")
+        org_mod_name = re2.sub(r"[.-]", "_", Path(file_path).stem)
         return MODIFIED_DAG_MODULE_NAME.format(path_hash=path_hash, module_name=org_mod_name)
     raise ValueError("file_path should be a string to generate unique module name")

--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -356,5 +356,6 @@ def get_unique_dag_module_name(file_path: str) -> str:
     if isinstance(file_path, str):
         path_hash = hashlib.sha1(file_path.encode("utf-8")).hexdigest()
         org_mod_name = Path(file_path).stem
+        org_mod_name = org_mod_name.replace("-", "_")
         return MODIFIED_DAG_MODULE_NAME.format(path_hash=path_hash, module_name=org_mod_name)
     raise ValueError("file_path should be a string to generate unique module name")

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -212,3 +212,17 @@ class TestListPyFilesPath:
         modules = list(file_utils.iter_airflow_imports(file_path))
 
         assert len(modules) == 0
+
+
+def test_get_unique_dag_module_name():
+    edge_filenames = [
+        "test_dag.py",
+        "test-dag.py",
+        "test-dag-1.py",
+        "test-dag_1.py",
+        "test-dag.dev.py",
+        "test_dag.prod.py",
+    ]
+    for filename in edge_filenames:
+        assert "-" not in file_utils.get_unique_dag_module_name(filename)
+        assert "." not in file_utils.get_unique_dag_module_name(filename)

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
+import re2
 
 from airflow.utils import file as file_utils
 from airflow.utils.file import correct_maybe_zipped, find_path_from_directory, open_maybe_zipped
@@ -223,6 +224,15 @@ def test_get_unique_dag_module_name():
         "test-dag.dev.py",
         "test_dag.prod.py",
     ]
-    for filename in edge_filenames:
-        assert "-" not in file_utils.get_unique_dag_module_name(filename)
-        assert "." not in file_utils.get_unique_dag_module_name(filename)
+    # sha1 of file_path in middle
+    expected_regex = [
+        r"unusual_prefix_[0-9a-f]{40}_test_dag",
+        r"unusual_prefix_[0-9a-f]{40}_test_dag",
+        r"unusual_prefix_[0-9a-f]{40}_test_dag_1",
+        r"unusual_prefix_[0-9a-f]{40}_test_dag_1",
+        r"unusual_prefix_[0-9a-f]{40}_test_dag_dev",
+        r"unusual_prefix_[0-9a-f]{40}_test_dag_prod",
+    ]
+    for idx, filename in enumerate(edge_filenames):
+        modify_module_name = file_utils.get_unique_dag_module_name(filename)
+        assert re2.match(re2.compile(expected_regex[idx]), modify_module_name) is not None


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #42796

After reproducing the issue, I found that the generated DAG file looks like this:
```python
import types

unusual_prefix_3f65a6a886883f41209c142108053b32fdfbaf99_my-dag  = types.ModuleType("unusual_prefix_3f65a6a886883f41209c142108053b32fdfbaf99_my-dag")

unusual_prefix_3f65a6a886883f41209c142108053b32fdfbaf99_my-dag.callable_virtualenv = callable_virtualenv

sys.modules["unusual_prefix_3f65a6a886883f41209c142108053b32fdfbaf99_my-dag"] = unusual_prefix_3f65a6a886883f41209c142108053b32fdfbaf99_my-dag

# ...
```
Replace the hyphen with dash in original module name to solve this issue.