### PR TITLE
AIP-84: delete connection endpoint : missing 400 status code

### DIFF
--- a/airflow/api_fastapi/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/openapi/v1-generated.yaml
@@ -476,6 +476,12 @@ paths:
       responses:
         '204':
           description: Successful Response
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Bad Request
         '401':
           content:
             application/json:

--- a/airflow/api_fastapi/views/public/connections.py
+++ b/airflow/api_fastapi/views/public/connections.py
@@ -33,7 +33,7 @@ connections_router = AirflowRouter(tags=["Connection"], prefix="/connections")
 @connections_router.delete(
     "/{connection_id}",
     status_code=204,
-    responses=create_openapi_http_exception_doc([401, 403, 404]),
+    responses=create_openapi_http_exception_doc([400, 401, 403, 404]),
 )
 async def delete_connection(
     connection_id: str,

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -275,6 +275,7 @@ export class ConnectionService {
         connection_id: data.connectionId,
       },
       errors: {
+        400: "Bad Request",
         401: "Unauthorized",
         403: "Forbidden",
         404: "Not Found",

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -536,6 +536,10 @@ export type $OpenApiTs = {
          */
         204: void;
         /**
+         * Bad Request
+         */
+        400: HTTPExceptionResponse;
+        /**
          * Unauthorized
          */
         401: HTTPExceptionResponse;


### PR DESCRIPTION
As per legacy API for delete connection endpoint : [Link](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html#operation/delete_connection)

400 is a valid return status code. This PR fixes the FastApi's delete connection endpoint return codes