### PR TITLE
Deprecate session auth backend

### DIFF
--- a/airflow/api/auth/backend/session.py
+++ b/airflow/api/auth/backend/session.py
@@ -18,30 +18,21 @@
 
 from __future__ import annotations
 
-from functools import wraps
-from typing import Any, Callable, TypeVar, cast
+import warnings
+from typing import Any
 
-from flask import Response
-
-from airflow.www.extensions.init_auth_manager import get_auth_manager
+import airflow.providers.fab.auth_manager.api.auth.backend.session as fab_session
+from airflow.exceptions import RemovedInAirflow3Warning
 
 CLIENT_AUTH: tuple[str, str] | Any | None = None
 
 
-def init_app(_):
-    """Initialize authentication backend."""
+warnings.warn(
+    "This module is deprecated. Please use `airflow.providers.fab.auth_manager.api.auth.backend.session` instead.",
+    RemovedInAirflow3Warning,
+    stacklevel=2,
+)
 
 
-T = TypeVar("T", bound=Callable)
-
-
-def requires_authentication(function: T):
-    """Decorate functions that require authentication."""
-
-    @wraps(function)
-    def decorated(*args, **kwargs):
-        if not get_auth_manager().is_logged_in():
-            return Response("Unauthorized", 401, {})
-        return function(*args, **kwargs)
-
-    return cast(T, decorated)
+init_app = fab_session.init_app
+requires_authentication = fab_session.requires_authentication

--- a/providers/tests/fab/auth_manager/api_endpoints/test_auth.py
+++ b/providers/tests/fab/auth_manager/api_endpoints/test_auth.py
@@ -148,7 +148,7 @@ class TestSessionWithBasicAuthFallback(BaseTestAuth):
                     (
                         "api",
                         "auth_backends",
-                    ): "airflow.api.auth.backend.session,airflow.providers.fab.auth_manager.api.auth.backend.basic_auth"
+                    ): "airflow.providers.fab.auth_manager.api.auth.backend.session,airflow.providers.fab.auth_manager.api.auth.backend.basic_auth"
                 }
             ):
                 init_api_auth(minimal_app_for_auth_api)

--- a/providers/tests/fab/auth_manager/conftest.py
+++ b/providers/tests/fab/auth_manager/conftest.py
@@ -43,7 +43,7 @@ def minimal_app_for_auth_api():
                 (
                     "api",
                     "auth_backends",
-                ): "providers.tests.fab.auth_manager.api_endpoints.remote_user_api_auth_backend,airflow.api.auth.backend.session",
+                ): "providers.tests.fab.auth_manager.api_endpoints.remote_user_api_auth_backend,airflow.providers.fab.auth_manager.api.auth.backend.session",
                 (
                     "core",
                     "auth_manager",

--- a/tests/api_connexion/test_auth.py
+++ b/tests/api_connexion/test_auth.py
@@ -44,7 +44,9 @@ class TestSessionAuth(BaseTestAuth):
         old_auth = getattr(minimal_app_for_api, "api_auth")
 
         try:
-            with conf_vars({("api", "auth_backends"): "airflow.api.auth.backend.session"}):
+            with conf_vars(
+                {("api", "auth_backends"): "airflow.providers.fab.auth_manager.api.auth.backend.session"}
+            ):
                 init_api_auth(minimal_app_for_api)
                 yield
         finally:


### PR DESCRIPTION
Follow-up of #42878. Backport PR: #42911.

We cannot remove it in main yet because the old UI is still using it

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
