### PR TITLE
Deprecate session auth backend (backport)

### DIFF
--- a/airflow/api/auth/backend/session.py
+++ b/airflow/api/auth/backend/session.py
@@ -18,14 +18,22 @@
 
 from __future__ import annotations
 
+import warnings
 from functools import wraps
 from typing import Any, Callable, TypeVar, cast
 
 from flask import Response
 
+from airflow.exceptions import RemovedInAirflow3Warning
 from airflow.www.extensions.init_auth_manager import get_auth_manager
 
 CLIENT_AUTH: tuple[str, str] | Any | None = None
+
+warnings.warn(
+    "This module is deprecated. Please use `airflow.providers.fab.auth_manager.api.auth.backend.session` instead.",
+    RemovedInAirflow3Warning,
+    stacklevel=2,
+)
 
 
 def init_app(_):

--- a/tests/api_connexion/test_auth.py
+++ b/tests/api_connexion/test_auth.py
@@ -21,6 +21,7 @@ from base64 import b64encode
 import pytest
 from flask_login import current_user
 
+from airflow.exceptions import RemovedInAirflow3Warning
 from tests.test_utils.api_connexion_utils import assert_401
 from tests.test_utils.config import conf_vars
 from tests.test_utils.db import clear_db_pools
@@ -137,7 +138,8 @@ class TestSessionAuth(BaseTestAuth):
 
         try:
             with conf_vars({("api", "auth_backends"): "airflow.api.auth.backend.session"}):
-                init_api_experimental_auth(minimal_app_for_api)
+                with pytest.warns(RemovedInAirflow3Warning):
+                    init_api_experimental_auth(minimal_app_for_api)
                 yield
         finally:
             setattr(minimal_app_for_api, "api_auth", old_auth)
@@ -174,6 +176,7 @@ class TestSessionAuth(BaseTestAuth):
             assert_401(response)
 
 
+@pytest.mark.filterwarnings("default::airflow.exceptions.RemovedInAirflow3Warning")
 class TestSessionWithBasicAuthFallback(BaseTestAuth):
     @pytest.fixture(autouse=True, scope="class")
     def with_basic_auth_backend(self, minimal_app_for_api):


### PR DESCRIPTION
Backport #42909 in `v2-10-test`

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
