### PR TITLE
Check _is_canary_run/pr condition in is_legacy_ui_api_labeled method

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -1370,6 +1370,9 @@ class SelectiveChecks:
     def is_legacy_ui_api_labeled(self) -> bool:
         # Selective check for legacy UI/API updates.
         # It is to ping the maintainer to add the label and make them aware of the changes.
+        if self._is_canary_run():
+            return False
+
         if (
             self._matching_files(
                 FileGroupForCi.LEGACY_API_FILES, CI_FILE_GROUP_MATCHES, CI_FILE_GROUP_EXCLUDES

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -1370,7 +1370,10 @@ class SelectiveChecks:
     def is_legacy_ui_api_labeled(self) -> bool:
         # Selective check for legacy UI/API updates.
         # It is to ping the maintainer to add the label and make them aware of the changes.
-        if self._is_canary_run():
+        if self._is_canary_run() or self._github_event not in (
+            GithubEvents.PULL_REQUEST,
+            GithubEvents.PULL_REQUEST_TARGET,
+        ):
             return False
 
         if (


### PR DESCRIPTION
Currently, in CI, if changes are detected in the legacy UI/API files, the build fails with an error.

CI failures: https://github.com/apache/airflow/actions/runs/11275130446/job/31374289057#step:8:271

The `is_legacy_ui_api_labeled` flag uses the changed_files to determine the labels. Currently, the changed_files condition relies on the commit_ref, which is the Git SHA ID. This condition is always true, in my opinion. Here's an example: 

https://github.com/apache/airflow/actions/runs/11275130446/job/31374289057#step:2:15

The logic for changed_files is built as shown here:
https://github.com/apache/airflow/blob/main/dev/breeze/src/airflow_breeze/commands/ci_commands.py#L257

In the case of canary builds, full tests are triggered, so the `is_legacy_ui_api_labeled` check becomes unnecessary.

I see two possible solutions for fixing this issue:

1. Set changed_files to an empty list during canary builds.
2. Add a condition to check `_is_canary_run`.

I recommend going with the second option, as I'm unsure of the potential side effects of the first.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
