### PR TITLE
fix: HttpSensorTrigger to include `method` when serializing

### DIFF
--- a/providers/src/airflow/providers/http/triggers/http.py
+++ b/providers/src/airflow/providers/http/triggers/http.py
@@ -167,6 +167,7 @@ class HttpSensorTrigger(BaseTrigger):
             {
                 "endpoint": self.endpoint,
                 "data": self.data,
+                "method": self.method,
                 "headers": self.headers,
                 "extra_options": self.extra_options,
                 "http_conn_id": self.http_conn_id,

--- a/providers/tests/http/triggers/test_http.py
+++ b/providers/tests/http/triggers/test_http.py
@@ -170,7 +170,7 @@ class TestHttpTrigger:
 class TestHttpSensorTrigger:
     def test_serialization(self, sensor_trigger):
         """
-        Asserts that the HttpTrigger correctly serializes its arguments
+        Asserts that the HttpSensorTrigger correctly serializes its arguments
         and classpath.
         """
         classpath, kwargs = sensor_trigger.serialize()

--- a/providers/tests/http/triggers/test_http.py
+++ b/providers/tests/http/triggers/test_http.py
@@ -30,7 +30,7 @@ from multidict import CIMultiDict, CIMultiDictProxy
 from requests.structures import CaseInsensitiveDict
 from yarl import URL
 
-from airflow.providers.http.triggers.http import HttpTrigger
+from airflow.providers.http.triggers.http import HttpSensorTrigger, HttpTrigger
 from airflow.triggers.base import TriggerEvent
 
 HTTP_PATH = "airflow.providers.http.triggers.http.{}"
@@ -50,6 +50,18 @@ def trigger():
         auth_type=TEST_AUTH_TYPE,
         method=TEST_METHOD,
         endpoint=TEST_ENDPOINT,
+        headers=TEST_HEADERS,
+        data=TEST_DATA,
+        extra_options=TEST_EXTRA_OPTIONS,
+    )
+
+
+@pytest.fixture
+def sensor_trigger():
+    return HttpSensorTrigger(
+        http_conn_id=TEST_CONN_ID,
+        endpoint=TEST_ENDPOINT,
+        method=TEST_METHOD,
         headers=TEST_HEADERS,
         data=TEST_DATA,
         extra_options=TEST_EXTRA_OPTIONS,
@@ -153,3 +165,22 @@ class TestHttpTrigger:
         assert kwargs["data"] == TEST_DATA
         assert kwargs["json"] is None
         assert kwargs["params"] is None
+
+
+class TestHttpSensorTrigger:
+    def test_serialization(self, sensor_trigger):
+        """
+        Asserts that the HttpTrigger correctly serializes its arguments
+        and classpath.
+        """
+        classpath, kwargs = sensor_trigger.serialize()
+        assert classpath == "airflow.providers.http.triggers.http.HttpSensorTrigger"
+        assert kwargs == {
+            "http_conn_id": TEST_CONN_ID,
+            "endpoint": TEST_ENDPOINT,
+            "method": TEST_METHOD,
+            "headers": TEST_HEADERS,
+            "data": TEST_DATA,
+            "extra_options": TEST_EXTRA_OPTIONS,
+            "poke_interval": 5.0,
+        }


### PR DESCRIPTION
As of now, the method passed via HttpOperator in deferrable mode is not being serialized. Hence, during the deferrable mode, HttpSensor ends up always making GET requests instead of the method originally intended 