### PR TITLE
Restrict looker-sdk version 24.18.0 and microsoft-kiota-http 1.3.4

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -827,6 +827,7 @@
       "azure-storage-file-share>=12.7.0",
       "azure-synapse-artifacts>=0.17.0",
       "azure-synapse-spark>=0.2.0",
+      "microsoft-kiota-http>=1.3.0,!=1.3.4",
       "msgraph-core>=1.0.0"
     ],
     "devel-deps": [

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -681,7 +681,7 @@
       "httpx>=0.25.0",
       "immutabledict>=4.2.0",
       "json-merge-patch>=0.2",
-      "looker-sdk>=22.4.0",
+      "looker-sdk>=22.4.0,!=24.18.0",
       "pandas-gbq>=0.7.0",
       "pandas>=1.5.3,<2.2;python_version<\"3.9\"",
       "pandas>=2.1.2,<2.2;python_version>=\"3.9\"",

--- a/providers/src/airflow/providers/amazon/aws/hooks/appflow.py
+++ b/providers/src/airflow/providers/amazon/aws/hooks/appflow.py
@@ -115,11 +115,11 @@ class AppflowHook(AwsGenericHook["AppflowClient"]):
             # Clean up attribute to force on-demand trigger
             del response["triggerConfig"]["triggerProperties"]
 
-        self.conn.update_flow(
+        self.conn.update_flow(  # type: ignore[arg-type]
             flowName=response["flowName"],
             destinationFlowConfigList=response["destinationFlowConfigList"],
             sourceFlowConfig=response["sourceFlowConfig"],
             triggerConfig=response["triggerConfig"],
             description=response.get("description", "Flow description."),
             tasks=tasks,
-        )  # type: ignore[arg-type]
+        )

--- a/providers/src/airflow/providers/amazon/aws/hooks/appflow.py
+++ b/providers/src/airflow/providers/amazon/aws/hooks/appflow.py
@@ -122,4 +122,4 @@ class AppflowHook(AwsGenericHook["AppflowClient"]):
             triggerConfig=response["triggerConfig"],
             description=response.get("description", "Flow description."),
             tasks=tasks,
-        )
+        )  # type: ignore[arg-type]

--- a/providers/src/airflow/providers/amazon/aws/hooks/appflow.py
+++ b/providers/src/airflow/providers/amazon/aws/hooks/appflow.py
@@ -115,11 +115,11 @@ class AppflowHook(AwsGenericHook["AppflowClient"]):
             # Clean up attribute to force on-demand trigger
             del response["triggerConfig"]["triggerProperties"]
 
-        self.conn.update_flow(  # type: ignore[arg-type]
+        self.conn.update_flow(
             flowName=response["flowName"],
-            destinationFlowConfigList=response["destinationFlowConfigList"],
-            sourceFlowConfig=response["sourceFlowConfig"],
-            triggerConfig=response["triggerConfig"],
+            destinationFlowConfigList=response["destinationFlowConfigList"],  # type: ignore[arg-type]
+            sourceFlowConfig=response["sourceFlowConfig"],  # type: ignore[arg-type]
+            triggerConfig=response["triggerConfig"],  # type: ignore[arg-type]
             description=response.get("description", "Flow description."),
-            tasks=tasks,
+            tasks=tasks,  # type: ignore[arg-type]
         )

--- a/providers/src/airflow/providers/google/provider.yaml
+++ b/providers/src/airflow/providers/google/provider.yaml
@@ -157,7 +157,7 @@ dependencies:
   - grpcio-gcp>=0.2.2
   - httpx>=0.25.0
   - json-merge-patch>=0.2
-  - looker-sdk>=22.4.0
+  - looker-sdk>=22.4.0,!=24.18.0
   - pandas-gbq>=0.7.0
   # In pandas 2.2 minimal version of the sqlalchemy is 2.0
   # https://pandas.pydata.org/docs/whatsnew/v2.2.0.html#increased-minimum-versions-for-dependencies

--- a/providers/src/airflow/providers/google/provider.yaml
+++ b/providers/src/airflow/providers/google/provider.yaml
@@ -157,6 +157,8 @@ dependencies:
   - grpcio-gcp>=0.2.2
   - httpx>=0.25.0
   - json-merge-patch>=0.2
+  # looker-sdk 24.18.0 has issues in import looker_sdk.rtl,  No module named looker_sdk.rtl
+  # See https://github.com/looker-open-source/sdk-codegen/issues/1518
   - looker-sdk>=22.4.0,!=24.18.0
   - pandas-gbq>=0.7.0
   # In pandas 2.2 minimal version of the sqlalchemy is 2.0

--- a/providers/src/airflow/providers/microsoft/azure/provider.yaml
+++ b/providers/src/airflow/providers/microsoft/azure/provider.yaml
@@ -108,6 +108,7 @@ dependencies:
   - azure-mgmt-containerregistry>=8.0.0
   - azure-mgmt-containerinstance>=10.1.0
   - msgraph-core>=1.0.0
+  - microsoft-kiota-http>=1.3.0,!=1.3.4
 
 devel-dependencies:
   - pywinrm

--- a/providers/src/airflow/providers/microsoft/azure/provider.yaml
+++ b/providers/src/airflow/providers/microsoft/azure/provider.yaml
@@ -108,6 +108,8 @@ dependencies:
   - azure-mgmt-containerregistry>=8.0.0
   - azure-mgmt-containerinstance>=10.1.0
   - msgraph-core>=1.0.0
+  # msgraph-core has transient import failures with microsoft-kiota-http==1.3.4
+  # See https://github.com/microsoftgraph/msgraph-sdk-python-core/issues/706
   - microsoft-kiota-http>=1.3.0,!=1.3.4
 
 devel-dependencies:


### PR DESCRIPTION
The latest looker-sdk version causing import problems in our CI. so restricting 24.18.0 looker-sdk version.

https://github.com/apache/airflow/actions/runs/11295803154/job/31419668010?pr=42950#step:14:1642 

There issue already opened here: https://github.com/looker-open-source/sdk-codegen/issues/1518
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
