### PR TITLE
Add retry on error 502 and 504

### DIFF
--- a/airflow/api_internal/internal_api_call.py
+++ b/airflow/api_internal/internal_api_call.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 class AirflowHttpException(AirflowException):
     """Raise when there is a problem during an http request."""
 
-    def __init__(self, message: str, status_code: int | HTTPStatus):
+    def __init__(self, message: str, status_code: HTTPStatus):
         super().__init__(message)
         self.status_code = status_code
 
@@ -116,7 +116,7 @@ def internal_api_call(func: Callable[PS, RT]) -> Callable[PS, RT]:
     def is_retryable_exception(exception: BaseException) -> bool:
         retryable_status_codes = (HTTPStatus.BAD_GATEWAY, HTTPStatus.GATEWAY_TIMEOUT)
         return (
-            isinstance(exception, AirflowHttpException) 
+            isinstance(exception, AirflowHttpException)
             and exception.status_code in retryable_status_codes
             or isinstance(exception, (ConnectionError, NewConnectionError))
         )
@@ -145,7 +145,7 @@ def internal_api_call(func: Callable[PS, RT]) -> Callable[PS, RT]:
             raise AirflowHttpException(
                 f"Got {response.status_code}:{response.reason} when sending "
                 f"the internal api request: {response.text}",
-                response.status_code,
+                HTTPStatus(response.status_code),
             )
         return response.content
 

--- a/airflow/api_internal/internal_api_call.py
+++ b/airflow/api_internal/internal_api_call.py
@@ -115,7 +115,7 @@ def internal_api_call(func: Callable[PS, RT]) -> Callable[PS, RT]:
 
     def _is_retryable_exception(exception: BaseException) -> bool:
         """
-        Evaluates which exception types should be retried.
+        Evaluate which exception types to retry.
         
         This is especially demanded for cases where an application gateway or Kubernetes ingress can
         not find a running instance of a webserver hosting the API (HTTP 502+504) or when the

--- a/airflow/api_internal/internal_api_call.py
+++ b/airflow/api_internal/internal_api_call.py
@@ -41,7 +41,7 @@ RT = TypeVar("RT")
 logger = logging.getLogger(__name__)
 
 class AirflowHttpException(AirflowException):
-    """Raise when there is a problem during an http request."""
+    """Raise when there is a problem during an http request on the internal API decorator."""
 
     def __init__(self, message: str, status_code: HTTPStatus):
         super().__init__(message)

--- a/tests/api_internal/test_internal_api_call.py
+++ b/tests/api_internal/test_internal_api_call.py
@@ -284,10 +284,10 @@ class TestInternalApiCall:
         response.reason = "Bad Gateway"
         response._content = b"Bad Gateway"
 
-        mock_sleep = lambda *_, **__: None
+        mock_sleep = lambda *_, **__: None  # noqa: F841
         mock_requests.post.return_value = response
         with pytest.raises(RetryError):
-            result = TestInternalApiCall.fake_method_with_params("fake-dag", task_id=123, session="session")
+            TestInternalApiCall.fake_method_with_params("fake-dag", task_id=123, session="session")
         assert mock_requests.post.call_count == 10
 
     @conf_vars(

--- a/tests/api_internal/test_internal_api_call.py
+++ b/tests/api_internal/test_internal_api_call.py
@@ -21,14 +21,14 @@ from __future__ import annotations
 import json
 from argparse import Namespace
 from typing import TYPE_CHECKING
-from tenacity import RetryError
 from unittest import mock
 
 import pytest
 import requests
+from tenacity import RetryError
 
 from airflow.__main__ import configure_internal_api
-from airflow.api_internal.internal_api_call import AirflowHttpException, InternalApiConfig, internal_api_call
+from airflow.api_internal.internal_api_call import InternalApiConfig, internal_api_call
 from airflow.configuration import conf
 from airflow.models.taskinstance import TaskInstance
 from airflow.operators.empty import EmptyOperator

--- a/tests/api_internal/test_internal_api_call.py
+++ b/tests/api_internal/test_internal_api_call.py
@@ -283,7 +283,7 @@ class TestInternalApiCall:
         response.status_code = 502
         response.reason = "Bad Gateway"
         response._content = b"Bad Gateway"
-        
+
         mock_sleep = lambda *_, **__: None
         mock_requests.post.return_value = response
         with pytest.raises(RetryError):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
When an application gateway or a Kubernetes ingress cannot find a running instance of a webserver hosting the API 
The edge worker crashes and restarts due to HTTP error 502 and 504 (during webserver startup). To prevent this, the retried errors are extended with "bad gateway" and "gateway timeout" in the internal api call.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
