### PR TITLE
CI failure Fix json schema lint hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -967,7 +967,7 @@ repos:
         entry: ./scripts/ci/pre_commit/json_schema.py
         args:
           - --spec-url
-          - https://json-schema.org/draft-07/schema
+          - https://raw.githubusercontent.com/json-schema-org/json-schema-spec/refs/heads/draft-07/schema.json
         language: python
         pass_filenames: true
         files: .*\.schema\.json$


### PR DESCRIPTION
all the builds are failing with json schema lint hook, not able to fetch from the 
`https://json-schema.org/draft-07/schema` getting 
``
requests.exceptions.HTTPError: 403 Client Error: Forbidden for url: https://json-schema.org/draft-07/schema
``, for it 403 means its access issue, need more investigation on this.


https://github.com/apache/airflow/actions/runs/11322945179/job/31485015966#step:8:162

As a temporary fix we can source point the github source content.
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
