### PR TITLE
Add additional named parameters and job parameters support to DatabricksRunNowOperator

### DIFF
--- a/providers/src/airflow/providers/databricks/operators/databricks.py
+++ b/providers/src/airflow/providers/databricks/operators/databricks.py
@@ -757,6 +757,13 @@ class DatabricksRunNowOperator(BaseOperator):
         .. seealso::
             For more information about templating see :ref:`concepts:jinja-templating`.
             https://docs.databricks.com/dev-tools/api/latest/jobs.html#operation/JobsRunNow
+
+    :param dbt_commands: A list containing the dbt commands to run using dbt command line
+        interface(CLI). This field will be templated.
+        .. seealso::
+            For full details on the dbt CLI, see :ref:`concepts:dbt-commands`.
+            https://docs.databricks.com/en/jobs/dbt.html
+            
     :param notebook_params: A dict from keys to values for jobs with notebook task,
         e.g. "notebook_params": {"name": "john doe", "age":  "35"}.
         The map is passed to the notebook and will be accessible through the

--- a/providers/src/airflow/providers/databricks/operators/databricks.py
+++ b/providers/src/airflow/providers/databricks/operators/databricks.py
@@ -743,8 +743,9 @@ class DatabricksRunNowOperator(BaseOperator):
         python_named_parameters, jar_params, spark_submit_params, and they cannot be used in
         combination.
         This field will be templated.
+
         .. seealso::
-            For more information about job parameters see: :ref:`concepts:job-parameters`.
+            For more information about job parameters see :ref:`concepts:job-parameters`.
             https://docs.databricks.com/en/workflows/jobs/settings.html#add-parameters-for-all-job-tasks
 
     :param json: A JSON object containing API parameters which will be passed
@@ -760,10 +761,11 @@ class DatabricksRunNowOperator(BaseOperator):
 
     :param dbt_commands: A list containing the dbt commands to run using dbt command line
         interface(CLI). This field will be templated.
+
         .. seealso::
             For full details on the dbt CLI, see :ref:`concepts:dbt-commands`.
             https://docs.databricks.com/en/jobs/dbt.html
-            
+
     :param notebook_params: A dict from keys to values for jobs with notebook task,
         e.g. "notebook_params": {"name": "john doe", "age":  "35"}.
         The map is passed to the notebook and will be accessible through the

--- a/providers/src/airflow/providers/databricks/operators/databricks.py
+++ b/providers/src/airflow/providers/databricks/operators/databricks.py
@@ -698,8 +698,6 @@ class DatabricksRunNowOperator(BaseOperator):
 
         spark_submit_params = ["--class", "org.apache.spark.examples.SparkPi"]
 
-        sql_params = {"customer": "alice", "min_order_total": "100.0"}
-
         notebook_run = DatabricksRunNowOperator(
             job_id=job_id,
             dbt_commands=dbt_commands,
@@ -707,7 +705,6 @@ class DatabricksRunNowOperator(BaseOperator):
             python_params=python_params,
             jar_params=jar_params,
             spark_submit_params=spark_submit_params,
-            sql_params=sql_params
         )
 
     In the case where both the json parameter **AND** the named parameters
@@ -725,7 +722,6 @@ class DatabricksRunNowOperator(BaseOperator):
         - ``python_named_parameters``
         - ``jar_params``
         - ``spark_submit_params``
-        - ``sql_params``
         - ``idempotency_token``
         - ``repair_run``
         - ``databricks_repair_reason_new_settings``
@@ -859,7 +855,6 @@ class DatabricksRunNowOperator(BaseOperator):
         python_params: list[str] | None = None,
         jar_params: list[str] | None = None,
         spark_submit_params: list[str] | None = None,
-        sql_params: dict[str, str] | None = None,
         python_named_params: dict[str, str] | None = None,
         idempotency_token: str | None = None,
         databricks_conn_id: str = "databricks_default",
@@ -911,8 +906,6 @@ class DatabricksRunNowOperator(BaseOperator):
             self.json["job_parameters"] = job_parameters
         if dbt_commands is not None:
             self.json["dbt_commands"] = dbt_commands
-        if sql_params is not None:
-            self.json["sql_params"] = sql_params
         if self.json:
             self.json = normalise_json_content(self.json)
         # This variable will be used in case our task gets killed.

--- a/providers/src/airflow/providers/databricks/operators/databricks.py
+++ b/providers/src/airflow/providers/databricks/operators/databricks.py
@@ -739,13 +739,12 @@ class DatabricksRunNowOperator(BaseOperator):
 
     :param job_parameters: A dict from keys to values that override or augment the job's
         parameters for this run. Job parameters are passed to any of the job's tasks that
-        accept key-value parameters. Job parameters supersede notebook_params, python_params,
-        python_named_parameters, jar_params, spark_submit_params, and they cannot be used in
+        accept key-value parameters. Job parameters supersede ``notebook_params``, ``python_params``,
+        ``python_named_parameters``, ``jar_params``, ``spark_submit_params``, and they cannot be used in
         combination.
         This field will be templated.
 
         .. seealso::
-            For more information about job parameters see :ref:`concepts:job-parameters`.
             https://docs.databricks.com/en/workflows/jobs/settings.html#add-parameters-for-all-job-tasks
 
     :param json: A JSON object containing API parameters which will be passed
@@ -759,11 +758,10 @@ class DatabricksRunNowOperator(BaseOperator):
             For more information about templating see :ref:`concepts:jinja-templating`.
             https://docs.databricks.com/dev-tools/api/latest/jobs.html#operation/JobsRunNow
 
-    :param dbt_commands: A list containing the dbt commands to run using dbt command line
-        interface(CLI). This field will be templated.
+    :param dbt_commands: A list containing the dbt commands to run using the dbt command line
+        interface. This field will be templated.
 
         .. seealso::
-            For full details on the dbt CLI, see :ref:`concepts:dbt-commands`.
             https://docs.databricks.com/en/jobs/dbt.html
 
     :param notebook_params: A dict from keys to values for jobs with notebook task,

--- a/providers/tests/databricks/operators/test_databricks.py
+++ b/providers/tests/databricks/operators/test_databricks.py
@@ -73,7 +73,6 @@ RENDERED_TEMPLATED_JAR_PARAMS = [f"/test-{DATE}"]
 TEMPLATED_JAR_PARAMS = ["/test-{{ ds }}"]
 PYTHON_PARAMS = ["john doe", "35"]
 SPARK_SUBMIT_PARAMS = ["--class", "org.apache.spark.examples.SparkPi"]
-SQL_PARAMS = {"customer":"alice", "min_order_total":"100.0"}
 DBT_TASK = {
     "commands": ["dbt deps", "dbt seed", "dbt run"],
     "schema": "jaffle_shop",
@@ -1186,7 +1185,6 @@ class TestDatabricksRunNowOperator:
             "jar_params": JAR_PARAMS,
             "python_params": PYTHON_PARAMS,
             "spark_submit_params": SPARK_SUBMIT_PARAMS,
-            "sql_params": SQL_PARAMS,
             "job_id": JOB_ID,
             "repair_run": False,
         }
@@ -1199,7 +1197,6 @@ class TestDatabricksRunNowOperator:
                 "jar_params": JAR_PARAMS,
                 "python_params": PYTHON_PARAMS,
                 "spark_submit_params": SPARK_SUBMIT_PARAMS,
-                "sql_params": SQL_PARAMS,
                 "job_id": JOB_ID,
                 "repair_run": False,
             }
@@ -1226,7 +1223,6 @@ class TestDatabricksRunNowOperator:
             python_params=PYTHON_PARAMS,
             jar_params=override_jar_params,
             spark_submit_params=SPARK_SUBMIT_PARAMS,
-            sql_params=SQL_PARAMS
         )
 
         expected = utils.normalise_json_content(
@@ -1236,7 +1232,6 @@ class TestDatabricksRunNowOperator:
                 "jar_params": override_jar_params,
                 "python_params": PYTHON_PARAMS,
                 "spark_submit_params": SPARK_SUBMIT_PARAMS,
-                "sql_params": SQL_PARAMS,
                 "job_id": JOB_ID,
             }
         )

--- a/providers/tests/databricks/operators/test_databricks.py
+++ b/providers/tests/databricks/operators/test_databricks.py
@@ -66,12 +66,14 @@ RUN_PAGE_URL = "run-page-url"
 JOB_ID = "42"
 JOB_NAME = "job-name"
 JOB_DESCRIPTION = "job-description"
+DBT_COMMANDS = ["dbt deps", "dbt seed", "dbt run"]
 NOTEBOOK_PARAMS = {"dry-run": "true", "oldest-time-to-consider": "1457570074236"}
 JAR_PARAMS = ["param1", "param2"]
 RENDERED_TEMPLATED_JAR_PARAMS = [f"/test-{DATE}"]
 TEMPLATED_JAR_PARAMS = ["/test-{{ ds }}"]
 PYTHON_PARAMS = ["john doe", "35"]
 SPARK_SUBMIT_PARAMS = ["--class", "org.apache.spark.examples.SparkPi"]
+SQL_PARAMS = {"customer":"alice", "min_order_total":"100.0"}
 DBT_TASK = {
     "commands": ["dbt deps", "dbt seed", "dbt run"],
     "schema": "jaffle_shop",
@@ -1179,10 +1181,12 @@ class TestDatabricksRunNowOperator:
         Test the initializer with json data.
         """
         json = {
+            "dbt_commands": DBT_COMMANDS,
             "notebook_params": NOTEBOOK_PARAMS,
             "jar_params": JAR_PARAMS,
             "python_params": PYTHON_PARAMS,
             "spark_submit_params": SPARK_SUBMIT_PARAMS,
+            "sql_params": SQL_PARAMS,
             "job_id": JOB_ID,
             "repair_run": False,
         }
@@ -1190,10 +1194,12 @@ class TestDatabricksRunNowOperator:
 
         expected = utils.normalise_json_content(
             {
+                "dbt_commands": DBT_COMMANDS,
                 "notebook_params": NOTEBOOK_PARAMS,
                 "jar_params": JAR_PARAMS,
                 "python_params": PYTHON_PARAMS,
                 "spark_submit_params": SPARK_SUBMIT_PARAMS,
+                "sql_params": SQL_PARAMS,
                 "job_id": JOB_ID,
                 "repair_run": False,
             }
@@ -1215,18 +1221,22 @@ class TestDatabricksRunNowOperator:
             task_id=TASK_ID,
             json=json,
             job_id=JOB_ID,
+            dbt_commands=DBT_COMMANDS,
             notebook_params=override_notebook_params,
             python_params=PYTHON_PARAMS,
             jar_params=override_jar_params,
             spark_submit_params=SPARK_SUBMIT_PARAMS,
+            sql_params=SQL_PARAMS
         )
 
         expected = utils.normalise_json_content(
             {
+                "dbt_commands": DBT_COMMANDS,
                 "notebook_params": override_notebook_params,
                 "jar_params": override_jar_params,
                 "python_params": PYTHON_PARAMS,
                 "spark_submit_params": SPARK_SUBMIT_PARAMS,
+                "sql_params": SQL_PARAMS,
                 "job_id": JOB_ID,
             }
         )


### PR DESCRIPTION
- Changes
  -  Added additional named parameters support to `DatabricksRunNowOperator`: 
      - `dbt_commands`
      - `job_parameters` 
 - How is it tested
   - Updated the tests to check the new changes 
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
