### PR TITLE
Remove a portion of PR #41531 (retrieve output from swarm), added xcom support for Docker swarm logs

### DIFF
--- a/providers/src/airflow/providers/docker/operators/docker.py
+++ b/providers/src/airflow/providers/docker/operators/docker.py
@@ -472,22 +472,23 @@ class DockerOperator(BaseOperator):
         This uses Docker's ``get_archive`` function. If the file is not yet
         ready, *None* is returned.
         """
+
+        def copy_from_docker(container_id, src):
+            archived_result, stat = self.cli.get_archive(container_id, src)
+            if stat["size"] == 0:
+                # 0 byte file, it can't be anything else than None
+                return None
+            # no need to port to a file since we intend to deserialize
+            with BytesIO(b"".join(archived_result)) as f:
+                tar = tarfile.open(fileobj=f)
+                file = tar.extractfile(stat["name"])
+                lib = getattr(self, "pickling_library", pickle)
+                return lib.load(file)
+
         try:
-            return self._copy_from_docker(self.container["Id"], self.retrieve_output_path)
+            return copy_from_docker(self.container["Id"], self.retrieve_output_path)
         except APIError:
             return None
-
-    def _copy_from_docker(self, container_id, src):
-        archived_result, stat = self.cli.get_archive(container_id, src)
-        if stat["size"] == 0:
-            # 0 byte file, it can't be anything else than None
-            return None
-        # no need to port to a file since we intend to deserialize
-        with BytesIO(b"".join(archived_result)) as f:
-            tar = tarfile.open(fileobj=f)
-            file = tar.extractfile(stat["name"])
-            lib = getattr(self, "pickling_library", pickle)
-            return lib.load(file)
 
     def execute(self, context: Context) -> list[str] | str | None:
         # Pull the docker image if `force_pull` is set or image does not exist locally

--- a/providers/src/airflow/providers/docker/operators/docker_swarm.py
+++ b/providers/src/airflow/providers/docker/operators/docker_swarm.py
@@ -22,7 +22,7 @@ import re
 import shlex
 from datetime import datetime
 from time import sleep
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from docker import types
 
@@ -116,6 +116,7 @@ class DockerSwarmOperator(DockerOperator):
         networks: list[str | types.NetworkAttachmentConfig] | None = None,
         placement: types.Placement | list[types.Placement] | None = None,
         container_resources: types.Resources | None = None,
+        hosts: Optional[dict[str, str]],
         **kwargs,
     ) -> None:
         super().__init__(image=image, **kwargs)
@@ -128,6 +129,7 @@ class DockerSwarmOperator(DockerOperator):
         self.networks = networks
         self.placement = placement
         self.container_resources = container_resources or types.Resources(mem_limit=self.mem_limit)
+        self.hosts = hosts or {}
 
     def execute(self, context: Context) -> None:
         self.environment["AIRFLOW_TMP_DIR"] = self.tmp_dir
@@ -145,6 +147,7 @@ class DockerSwarmOperator(DockerOperator):
                     env=self.environment,
                     user=self.user,
                     tty=self.tty,
+                    hosts=self.hosts,
                     configs=self.configs,
                     secrets=self.secrets,
                 ),

--- a/providers/src/airflow/providers/docker/operators/docker_swarm.py
+++ b/providers/src/airflow/providers/docker/operators/docker_swarm.py
@@ -182,8 +182,9 @@ class DockerSwarmOperator(DockerOperator):
                 # Get all logs
                 logs = "\n".join(all_logs)
             else:
-                # get last log
-                logs = all_logs[-1] 
+                if len(all_logs):
+                    # get last log
+                    logs = all_logs[-1] 
         self.log.info("auto_removeauto_removeauto_removeauto_removeauto_remove : %s", str(self.auto_remove))
         if self.service and self._service_status() != "complete":
             if self.auto_remove == "success":


### PR DESCRIPTION
- PR #41531 doesn't work on a mutli node environment since `inspect_container` from the docker sdk will not work if the docker container did run on the node which call the api.  This results in a container not found error preventing the Operator from running.  The code was since been removed since there is no way to guarantee the placement of the docker container.

- adding Xcom support for docker logs.  If do_xcom_push is true (default) the last line of the docker logs will be push to the xcom results.  If xcom_all is set to true, all results will be push to xcom.


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
