### PR TITLE
vertex ai training operators: add display_name to rendered fields

### DIFF
--- a/providers/src/airflow/providers/google/cloud/operators/vertex_ai/auto_ml.py
+++ b/providers/src/airflow/providers/google/cloud/operators/vertex_ai/auto_ml.py
@@ -123,6 +123,8 @@ class CreateAutoMLForecastingTrainingJobOperator(AutoMLTrainingJobBaseOperator):
         forecast_horizon: int,
         data_granularity_unit: str,
         data_granularity_count: int,
+        display_name: str,
+        model_display_name: str | None = None,
         optimization_objective: str | None = None,
         column_specs: dict[str, str] | None = None,
         column_transformations: list[dict[str, dict[str, str]]] | None = None,
@@ -145,7 +147,12 @@ class CreateAutoMLForecastingTrainingJobOperator(AutoMLTrainingJobBaseOperator):
         **kwargs,
     ) -> None:
         super().__init__(
-            region=region, impersonation_chain=impersonation_chain, parent_model=parent_model, **kwargs
+            display_name=display_name,
+            model_display_name=model_display_name,
+            region=region,
+            impersonation_chain=impersonation_chain,
+            parent_model=parent_model,
+            **kwargs,
         )
         self.dataset_id = dataset_id
         self.target_column = target_column

--- a/providers/src/airflow/providers/google/cloud/operators/vertex_ai/auto_ml.py
+++ b/providers/src/airflow/providers/google/cloud/operators/vertex_ai/auto_ml.py
@@ -106,6 +106,8 @@ class CreateAutoMLForecastingTrainingJobOperator(AutoMLTrainingJobBaseOperator):
         "dataset_id",
         "region",
         "impersonation_chain",
+        "display_name",
+        "model_display_name",
     )
     operator_extra_links = (VertexAIModelLink(), VertexAITrainingLink())
 

--- a/providers/src/airflow/providers/google/cloud/operators/vertex_ai/batch_prediction_job.py
+++ b/providers/src/airflow/providers/google/cloud/operators/vertex_ai/batch_prediction_job.py
@@ -163,7 +163,7 @@ class CreateBatchPredictionJobOperator(GoogleCloudBaseOperator):
     :param poll_interval: Interval size which defines how often job status is checked in deferrable mode.
     """
 
-    template_fields = ("region", "project_id", "model_name", "impersonation_chain")
+    template_fields = ("region", "project_id", "model_name", "impersonation_chain", "job_display_name")
     operator_extra_links = (VertexAIBatchPredictionJobLink(),)
 
     def __init__(

--- a/providers/src/airflow/providers/google/cloud/operators/vertex_ai/custom_job.py
+++ b/providers/src/airflow/providers/google/cloud/operators/vertex_ai/custom_job.py
@@ -496,6 +496,8 @@ class CreateCustomContainerTrainingJobOperator(CustomTrainingJobBaseOperator):
         "parent_model",
         "dataset_id",
         "impersonation_chain",
+        "display_name",
+        "model_display_name",
     )
     operator_extra_links = (
         VertexAIModelLink(),
@@ -949,6 +951,8 @@ class CreateCustomPythonPackageTrainingJobOperator(CustomTrainingJobBaseOperator
         "region",
         "dataset_id",
         "impersonation_chain",
+        "display_name",
+        "model_display_name",
     )
     operator_extra_links = (VertexAIModelLink(), VertexAITrainingLink())
 
@@ -1405,6 +1409,8 @@ class CreateCustomTrainingJobOperator(CustomTrainingJobBaseOperator):
         "requirements",
         "dataset_id",
         "impersonation_chain",
+        "display_name",
+        "model_display_name",
     )
     operator_extra_links = (
         VertexAIModelLink(),
@@ -1732,6 +1738,7 @@ class ListCustomTrainingJobOperator(GoogleCloudBaseOperator):
         "region",
         "project_id",
         "impersonation_chain",
+        "display_name",
     ]
     operator_extra_links = [
         VertexAITrainingPipelinesLink(),

--- a/providers/src/airflow/providers/google/cloud/operators/vertex_ai/custom_job.py
+++ b/providers/src/airflow/providers/google/cloud/operators/vertex_ai/custom_job.py
@@ -509,6 +509,8 @@ class CreateCustomContainerTrainingJobOperator(CustomTrainingJobBaseOperator):
         *,
         command: Sequence[str] = [],
         region: str,
+        display_name: str,
+        model_display_name: str | None = None,
         parent_model: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         dataset_id: str | None = None,
@@ -517,6 +519,8 @@ class CreateCustomContainerTrainingJobOperator(CustomTrainingJobBaseOperator):
         **kwargs,
     ) -> None:
         super().__init__(
+            display_name=display_name,
+            model_display_name=model_display_name,
             region=region,
             parent_model=parent_model,
             impersonation_chain=impersonation_chain,
@@ -962,6 +966,8 @@ class CreateCustomPythonPackageTrainingJobOperator(CustomTrainingJobBaseOperator
         python_package_gcs_uri: str,
         python_module_name: str,
         region: str,
+        display_name: str,
+        model_display_name: str | None = None,
         parent_model: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         dataset_id: str | None = None,
@@ -970,6 +976,8 @@ class CreateCustomPythonPackageTrainingJobOperator(CustomTrainingJobBaseOperator
         **kwargs,
     ) -> None:
         super().__init__(
+            display_name=display_name,
+            model_display_name=model_display_name,
             region=region,
             parent_model=parent_model,
             impersonation_chain=impersonation_chain,
@@ -1423,6 +1431,8 @@ class CreateCustomTrainingJobOperator(CustomTrainingJobBaseOperator):
         script_path: str,
         requirements: Sequence[str] | None = None,
         region: str,
+        display_name: str,
+        model_display_name: str | None = None,
         parent_model: str | None = None,
         impersonation_chain: str | Sequence[str] | None = None,
         dataset_id: str | None = None,
@@ -1431,6 +1441,8 @@ class CreateCustomTrainingJobOperator(CustomTrainingJobBaseOperator):
         **kwargs,
     ) -> None:
         super().__init__(
+            display_name=display_name,
+            model_display_name=model_display_name,
             region=region,
             parent_model=parent_model,
             impersonation_chain=impersonation_chain,

--- a/providers/src/airflow/providers/google/cloud/operators/vertex_ai/hyperparameter_tuning_job.py
+++ b/providers/src/airflow/providers/google/cloud/operators/vertex_ai/hyperparameter_tuning_job.py
@@ -147,6 +147,7 @@ class CreateHyperparameterTuningJobOperator(GoogleCloudBaseOperator):
         "region",
         "project_id",
         "impersonation_chain",
+        "display_name",
     ]
     operator_extra_links = (VertexAITrainingLink(),)
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
closes: #43027 
-->



<!-- Please keep an empty line above the dashes. -->
---
Add display_name and model_display_name to list of rendered fields for Vertex AI operators. 

