### PR TITLE
require 1.2.1 common.compat for openlineage provider

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -965,7 +965,7 @@
   },
   "openlineage": {
     "deps": [
-      "apache-airflow-providers-common-compat>=1.2.0",
+      "apache-airflow-providers-common-compat>=1.2.1",
       "apache-airflow-providers-common-sql>=1.6.0",
       "apache-airflow>=2.8.0",
       "attrs>=22.2",

--- a/providers/src/airflow/providers/openlineage/provider.yaml
+++ b/providers/src/airflow/providers/openlineage/provider.yaml
@@ -51,7 +51,7 @@ versions:
 dependencies:
   - apache-airflow>=2.8.0
   - apache-airflow-providers-common-sql>=1.6.0
-  - apache-airflow-providers-common-compat>=1.2.0
+  - apache-airflow-providers-common-compat>=1.2.1
   - attrs>=22.2
   - openlineage-integration-common>=1.22.0
   - openlineage-python>=1.22.0


### PR DESCRIPTION
https://github.com/apache/airflow/pull/41348 introduced breaking change for OpenLineage provider (importing `from airflow.providers.common.compat.openlineage.utils.utils import translate_airflow_asset`) that was added in the same PR in common.compat provider, but without bumping the required version in OL provider.  