### PR TITLE
Detect system color theme and add active state to nav button

### DIFF
--- a/airflow/ui/src/layouts/Nav/Nav.tsx
+++ b/airflow/ui/src/layouts/Nav/Nav.tsx
@@ -68,7 +68,12 @@ export const Nav = () => {
         >
           <Icon as={AirflowPin} height="35px" width="35px" />
         </Box>
-        <NavButton icon={<FiHome size="1.75rem" />} isDisabled title="Home" />
+        <NavButton
+          icon={<FiHome size="1.75rem" />}
+          isDisabled
+          title="Home"
+          to="/"
+        />
         <NavButton
           icon={<DagIcon height={7} width={7} />}
           title="DAGs"
@@ -78,29 +83,33 @@ export const Nav = () => {
           icon={<FiDatabase size="1.75rem" />}
           isDisabled
           title="Assets"
+          to="assets"
         />
         <NavButton
           icon={<FiBarChart2 size="1.75rem" />}
           isDisabled
           title="DAG Runs"
+          to="dag_runs"
         />
         <NavButton
           icon={<FiGlobe size="1.75rem" />}
           isDisabled
           title="Browse"
+          to="browse"
         />
         <NavButton
           icon={<FiSettings size="1.75rem" />}
           isDisabled
           title="Admin"
+          to="admin"
         />
       </Flex>
       <Flex flexDir="column">
         <NavButton
           as={Link}
-          href={import.meta.env.VITE_LEGACY_API_URL}
           icon={<FiCornerUpLeft size="1.5rem" />}
           title="Return to legacy UI"
+          to={import.meta.env.VITE_LEGACY_API_URL}
         />
         <DocsButton />
         <UserSettingsButton />

--- a/airflow/ui/src/layouts/Nav/NavButton.tsx
+++ b/airflow/ui/src/layouts/Nav/NavButton.tsx
@@ -23,15 +23,13 @@ import { NavLink } from "react-router-dom";
 import { navButtonProps } from "./navButtonProps";
 
 type NavButtonProps = {
-  readonly href?: string;
   readonly icon: ReactElement;
-  readonly target?: string;
   readonly title?: string;
-  readonly to?: string;
+  readonly to: string;
 } & ButtonProps;
 
 export const NavButton = ({ icon, title, to, ...rest }: NavButtonProps) => (
-  <Box as={NavLink} to={to ?? ""}>
+  <Box as={NavLink} to={to}>
     {({ isActive }: { readonly isActive: boolean }) => (
       <Button isActive={isActive} {...navButtonProps} {...rest}>
         <Box alignSelf="center">{icon}</Box>

--- a/airflow/ui/src/layouts/Nav/NavButton.tsx
+++ b/airflow/ui/src/layouts/Nav/NavButton.tsx
@@ -18,7 +18,7 @@
  */
 import { Box, Button, type ButtonProps } from "@chakra-ui/react";
 import type { ReactElement } from "react";
-import { Link as RouterLink } from "react-router-dom";
+import { NavLink } from "react-router-dom";
 
 import { navButtonProps } from "./navButtonProps";
 
@@ -31,8 +31,12 @@ type NavButtonProps = {
 } & ButtonProps;
 
 export const NavButton = ({ icon, title, to, ...rest }: NavButtonProps) => (
-  <Button as={RouterLink} to={to} {...navButtonProps} {...rest}>
-    <Box alignSelf="center">{icon}</Box>
-    <Box fontSize="xs">{title}</Box>
-  </Button>
+  <Box as={NavLink} to={to ?? ""}>
+    {({ isActive }: { readonly isActive: boolean }) => (
+      <Button isActive={isActive} {...navButtonProps} {...rest}>
+        <Box alignSelf="center">{icon}</Box>
+        <Box fontSize="xs">{title}</Box>
+      </Button>
+    )}
+  </Box>
 );

--- a/airflow/ui/src/theme.ts
+++ b/airflow/ui/src/theme.ts
@@ -64,6 +64,7 @@ const theme = extendTheme({
     },
   },
   config: {
+    initialColorMode: "system",
     useSystemColorMode: true,
   },
   semanticTokens: {


### PR DESCRIPTION
Fix the theme config to set the initial theme to system and make sure nav buttons are active when on the appropriate route.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
