### PR TITLE
fix path to providers dir for mount sources breeze flag

### DIFF
--- a/scripts/ci/docker-compose/providers-and-tests-sources.yml
+++ b/scripts/ci/docker-compose/providers-and-tests-sources.yml
@@ -31,7 +31,7 @@ services:
       # but keep tests
       - ../../../tests/:/opt/airflow/tests:cached
       # and providers
-      - ../../../airflow/providers:/opt/airflow/airflow/providers:cached
+      - ../../../providers/src/airflow/providers:/opt/airflow/airflow/providers:cached
       # and entrypoint and in_container scripts for testing
       - ../../../scripts/docker/entrypoint_ci.sh:/entrypoint
       - ../../../scripts/in_container/:/opt/airflow/scripts/in_container


### PR DESCRIPTION
After moving providers directory, the `--mount-sources` Breeze flag pointed at the old directory.