### PR TITLE
added MultipleFilesWebHdfsSensor

### DIFF
--- a/providers/src/airflow/providers/apache/hdfs/sensors/web_hdfs.py
+++ b/providers/src/airflow/providers/apache/hdfs/sensors/web_hdfs.py
@@ -61,13 +61,13 @@ class MultipleFilesWebHdfsSensor(BaseSensorOperator):
         from airflow.providers.apache.hdfs.hooks.webhdfs import WebHDFSHook
 
         hook = WebHDFSHook(self.webhdfs_conn_id)
-        conn: 'Union[KerberosClient|InsecureClient]' = hook.get_conn()
+        conn: 'KerberosClient | InsecureClient' = hook.get_conn()
 
         actual_files = set(conn.list(self.directory_path))
-        self.log.debug(f"Files Found in directory: {actual_files}")
+        self.log.debug("Files Found in directory: %s", actual_files)
 
         missing_files = set(self.expected_filenames) - actual_files
         if missing_files:
-            self.log.info(f"There are missing files: {missing_files}")
+            self.log.info("There are missing files: %s", missing_files)
             return False
         return True

--- a/providers/src/airflow/providers/apache/hdfs/sensors/web_hdfs.py
+++ b/providers/src/airflow/providers/apache/hdfs/sensors/web_hdfs.py
@@ -54,7 +54,7 @@ class MultipleFilesWebHdfsSensor(BaseSensorOperator):
                  webhdfs_conn_id: str = "webhdfs_default", **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.directory_path = directory_path
-        self.expected_filenames = set(expected_filenames)
+        self.expected_filenames = expected_filenames
         self.webhdfs_conn_id = webhdfs_conn_id
 
     def poke(self, context: Context) -> bool:
@@ -66,7 +66,7 @@ class MultipleFilesWebHdfsSensor(BaseSensorOperator):
         actual_files = set(conn.list(self.directory_path))
         self.log.debug(f"Files Found in directory: {actual_files}")
 
-        missing_files = self.expected_filenames - actual_files
+        missing_files = set(self.expected_filenames) - actual_files
         if missing_files:
             self.log.info(f"There are missing files: {missing_files}")
             return False

--- a/providers/tests/apache/hdfs/sensors/test_web_hdfs.py
+++ b/providers/tests/apache/hdfs/sensors/test_web_hdfs.py
@@ -62,7 +62,7 @@ class TestWebHdfsSensor:
 
 class TestMultipleFilesWebHdfsSensor:
     @mock.patch("airflow.providers.apache.hdfs.hooks.webhdfs.WebHDFSHook")
-    def test_poke(self, mock_hook):
+    def test_poke(self, mock_hook, caplog):
         mock_hook.return_value.get_conn.return_value.list.return_value = TEST_HDFS_FILENAMES
 
         sensor = MultipleFilesWebHdfsSensor(
@@ -74,13 +74,14 @@ class TestMultipleFilesWebHdfsSensor:
         result = sensor.poke(dict())
 
         assert result
+        assert "Files Found in directory: " in caplog.text
 
         mock_hook.return_value.get_conn.return_value.list.assert_called_once_with(TEST_HDFS_DIRECTORY)
         mock_hook.return_value.get_conn.assert_called_once()
         mock_hook.assert_called_once_with(TEST_HDFS_CONN)
 
     @mock.patch("airflow.providers.apache.hdfs.hooks.webhdfs.WebHDFSHook")
-    def test_poke_should_return_false_for_missing_file(self, mock_hook):
+    def test_poke_should_return_false_for_missing_file(self, mock_hook, caplog):
         mock_hook.return_value.get_conn.return_value.list.return_value = TEST_HDFS_FILENAMES[0]
 
         sensor = MultipleFilesWebHdfsSensor(
@@ -92,6 +93,8 @@ class TestMultipleFilesWebHdfsSensor:
         exists = sensor.poke(dict())
 
         assert not exists
+        assert "Files Found in directory: " in caplog.text
+        assert "There are missing files: " in caplog.text
 
         mock_hook.return_value.get_conn.return_value.list.assert_called_once_with(TEST_HDFS_DIRECTORY)
         mock_hook.return_value.get_conn.assert_called_once()

--- a/providers/tests/apache/hdfs/sensors/test_web_hdfs.py
+++ b/providers/tests/apache/hdfs/sensors/test_web_hdfs.py
@@ -17,12 +17,15 @@
 # under the License.
 from __future__ import annotations
 
+import os
 from unittest import mock
 
-from airflow.providers.apache.hdfs.sensors.web_hdfs import WebHdfsSensor
+from airflow.providers.apache.hdfs.sensors.web_hdfs import WebHdfsSensor, MultipleFilesWebHdfsSensor
 
 TEST_HDFS_CONN = "webhdfs_default"
-TEST_HDFS_PATH = "hdfs://user/hive/warehouse/airflow.db/static_babynames"
+TEST_HDFS_DIRECTORY = "hdfs://user/hive/warehouse/airflow.db"
+TEST_HDFS_FILENAMES = ["static_babynames1", "static_babynames2", "static_babynames3"]
+TEST_HDFS_PATH = os.path.join(TEST_HDFS_DIRECTORY, TEST_HDFS_FILENAMES[0])
 
 
 class TestWebHdfsSensor:
@@ -54,4 +57,42 @@ class TestWebHdfsSensor:
         assert not exists
 
         mock_hook.return_value.check_for_path.assert_called_once_with(hdfs_path=TEST_HDFS_PATH)
+        mock_hook.assert_called_once_with(TEST_HDFS_CONN)
+
+
+class TestMultipleFilesWebHdfsSensor:
+    @mock.patch("airflow.providers.apache.hdfs.hooks.webhdfs.WebHDFSHook")
+    def test_poke(self, mock_hook):
+        mock_hook.return_value.get_conn.return_value.list.return_value = TEST_HDFS_FILENAMES
+
+        sensor = MultipleFilesWebHdfsSensor(
+            task_id="test_task",
+            webhdfs_conn_id=TEST_HDFS_CONN,
+            directory_path=TEST_HDFS_DIRECTORY,
+            expected_filenames=TEST_HDFS_FILENAMES
+        )
+        result = sensor.poke(dict())
+
+        assert result
+
+        mock_hook.return_value.get_conn.return_value.list.assert_called_once_with(TEST_HDFS_DIRECTORY)
+        mock_hook.return_value.get_conn.assert_called_once()
+        mock_hook.assert_called_once_with(TEST_HDFS_CONN)
+
+    @mock.patch("airflow.providers.apache.hdfs.hooks.webhdfs.WebHDFSHook")
+    def test_poke_should_return_false_for_missing_file(self, mock_hook):
+        mock_hook.return_value.get_conn.return_value.list.return_value = TEST_HDFS_FILENAMES[0]
+
+        sensor = MultipleFilesWebHdfsSensor(
+            task_id="test_task",
+            webhdfs_conn_id=TEST_HDFS_CONN,
+            directory_path=TEST_HDFS_DIRECTORY,
+            expected_filenames=TEST_HDFS_FILENAMES
+        )
+        exists = sensor.poke(dict())
+
+        assert not exists
+
+        mock_hook.return_value.get_conn.return_value.list.assert_called_once_with(TEST_HDFS_DIRECTORY)
+        mock_hook.return_value.get_conn.assert_called_once()
         mock_hook.assert_called_once_with(TEST_HDFS_CONN)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

I added `MultipleFilesWebHdfsSensor` class in `providers.apache.hdfs.sensors.web_hdfs`.

The current existing `WebHdfsSensor` can check if one file exists, which requires many tasks to check many files (in my org we had 350+ sensors for a single DAG).

The new `MultipleFilesWebHdfsSensor` can list a whole directory and succeeds only when all the expected files landed in the hdfs.

This is my first contribution so I would greatly appreciate any guidance :)

<!-- Please keep an empty line above the dashes. -->
---


