### PR TITLE
SSHHook expose auth_timeout parameter

### DIFF
--- a/providers/src/airflow/providers/ssh/hooks/ssh.py
+++ b/providers/src/airflow/providers/ssh/hooks/ssh.py
@@ -74,6 +74,7 @@ class SSHHook(BaseHook):
         iterable of algorithm identifiers, which will be disabled for the
         lifetime of the transport
     :param ciphers: list of ciphers to use in order of preference
+    :param auth_timeout: timeout (in seconds) for the attempt to authenticate with the remote_host
     """
 
     # List of classes to try loading private keys as, ordered (roughly) by most common to least common
@@ -121,6 +122,7 @@ class SSHHook(BaseHook):
         banner_timeout: float = 30.0,
         disabled_algorithms: dict | None = None,
         ciphers: list[str] | None = None,
+        auth_timeout: int | None = None,
     ) -> None:
         super().__init__()
         self.ssh_conn_id = ssh_conn_id
@@ -138,6 +140,7 @@ class SSHHook(BaseHook):
         self.disabled_algorithms = disabled_algorithms
         self.ciphers = ciphers
         self.host_proxy_cmd = None
+        self.auth_timeout = auth_timeout
 
         # Default values, overridable from Connection
         self.compress = True
@@ -332,6 +335,7 @@ class SSHHook(BaseHook):
             "sock": self.host_proxy,
             "look_for_keys": self.look_for_keys,
             "banner_timeout": self.banner_timeout,
+            "auth_timeout": self.auth_timeout,
         }
 
         if self.password:

--- a/providers/tests/ssh/hooks/test_ssh.py
+++ b/providers/tests/ssh/hooks/test_ssh.py
@@ -362,6 +362,7 @@ class TestSSHHook:
                 port="port",
                 sock=None,
                 look_for_keys=True,
+                auth_timeout=None,
             )
 
     @mock.patch("airflow.providers.ssh.hooks.ssh.paramiko.SSHClient")
@@ -381,6 +382,7 @@ class TestSSHHook:
                 port="port",
                 sock=None,
                 look_for_keys=True,
+                auth_timeout=None,
             )
 
     @mock.patch("airflow.providers.ssh.hooks.ssh.SSHTunnelForwarder")
@@ -569,6 +571,7 @@ class TestSSHHook:
                 port="port",
                 sock=None,
                 look_for_keys=True,
+                auth_timeout=None,
             )
 
     @mock.patch("airflow.providers.ssh.hooks.ssh.paramiko.SSHClient")
@@ -592,6 +595,7 @@ class TestSSHHook:
                 port="port",
                 sock=None,
                 look_for_keys=True,
+                auth_timeout=None,
             )
 
     @mock.patch("airflow.providers.ssh.hooks.ssh.paramiko.SSHClient")
@@ -654,6 +658,7 @@ class TestSSHHook:
             password="password",
             conn_timeout=20,
             key_file="fake.file",
+            auth_timeout=10,
         )
 
         with hook.get_conn():
@@ -668,6 +673,7 @@ class TestSSHHook:
                 port="port",
                 sock=None,
                 look_for_keys=True,
+                auth_timeout=10,
             )
 
     @mock.patch("airflow.providers.ssh.hooks.ssh.paramiko.SSHClient")
@@ -695,6 +701,7 @@ class TestSSHHook:
                 port="port",
                 sock=None,
                 look_for_keys=True,
+                auth_timeout=None,
             )
 
     @mock.patch("airflow.providers.ssh.hooks.ssh.paramiko.SSHClient")
@@ -718,6 +725,7 @@ class TestSSHHook:
                 port="port",
                 sock=None,
                 look_for_keys=True,
+                auth_timeout=None,
             )
 
     @mock.patch("airflow.providers.ssh.hooks.ssh.paramiko.SSHClient")
@@ -743,6 +751,7 @@ class TestSSHHook:
                 port="port",
                 sock=None,
                 look_for_keys=True,
+                auth_timeout=None,
             )
 
     @mock.patch("airflow.providers.ssh.hooks.ssh.paramiko.SSHClient")
@@ -768,6 +777,7 @@ class TestSSHHook:
                 port="port",
                 sock=None,
                 look_for_keys=True,
+                auth_timeout=None,
             )
 
     @pytest.mark.parametrize(
@@ -837,6 +847,7 @@ class TestSSHHook:
                 port="port",
                 sock=None,
                 look_for_keys=True,
+                auth_timeout=None,
             )
 
     @pytest.mark.parametrize(
@@ -901,6 +912,7 @@ class TestSSHHook:
                 sock=None,
                 look_for_keys=True,
                 disabled_algorithms=TEST_DISABLED_ALGORITHMS,
+                auth_timeout=None,
             )
 
     @mock.patch("airflow.providers.ssh.hooks.ssh.paramiko.SSHClient")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Expose an existing parameter on `SSHHook` so that it can be passed down to the `paramiko.SSHClient`

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
