### PR TITLE
replaced warning emoji in dev/breeze/README.md

### DIFF
--- a/dev/breeze/README.md
+++ b/dev/breeze/README.md
@@ -43,7 +43,7 @@ pipx install -e ./dev/breeze --force
 
 NOTE! If you see below warning - it means that you hit [known issue](https://github.com/pypa/pipx/issues/1092)
 with `packaging` version 23.2
-⚠️ Ignoring --editable install option. pipx disallows it for anything but a local path,
+(!) Ignoring --editable install option. pipx disallows it for anything but a local path,
 to avoid having to create a new src/ directory.
 
 The workaround is to downgrade packaging to 23.1 and re-running the `pipx install` command, for example

--- a/dev/breeze/README.md
+++ b/dev/breeze/README.md
@@ -43,7 +43,7 @@ pipx install -e ./dev/breeze --force
 
 NOTE! If you see below warning - it means that you hit [known issue](https://github.com/pypa/pipx/issues/1092)
 with `packaging` version 23.2
-(!) Ignoring --editable install option. pipx disallows it for anything but a local path,
+⚠ Ignoring --editable install option. pipx disallows it for anything but a local path,
 to avoid having to create a new src/ directory.
 
 The workaround is to downgrade packaging to 23.1 and re-running the `pipx install` command, for example


### PR DESCRIPTION
I removed an emoji from breeze's README.md file.
It caused me problems running breeze and I think it may happened to others too.
Also it's not necessary.

<details>
  <summary>The Error I Got</summary>
  I happens when python is trying to read the breeze readme and fails due to `UnicodeDecodeError`.

Traceback:
<pre>
Traceback (most recent call last):
  File "C:\Users\Eilon\AppData\Local\Programs\Python\Python310-32\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Users\Eilon\AppData\Local\Programs\Python\Python310-32\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "C:\Users\Eilon\pipx\venvs\apache-airflow-breeze\Scripts\breeze.exe\__main__.py", line 4, in <module>
  File "C:\Users\Eilon\Programming\python\open_source\airflow\dev\breeze\src\airflow_breeze\breeze.py", line 20, in <module>
    from airflow_breeze.commands.main_command import main
  File "C:\Users\Eilon\Programming\python\open_source\airflow\dev\breeze\src\airflow_breeze\commands\main_command.py", line 25, in <module>
    from airflow_breeze.commands.ci_image_commands import ci_image
  File "C:\Users\Eilon\Programming\python\open_source\airflow\dev\breeze\src\airflow_breeze\commands\ci_image_commands.py", line 32, in <module>
    from airflow_breeze.commands.common_image_options import (
  File "C:\Users\Eilon\Programming\python\open_source\airflow\dev\breeze\src\airflow_breeze\commands\common_image_options.py", line 23, in <module>
    from airflow_breeze.global_constants import (
  File "C:\Users\Eilon\Programming\python\open_source\airflow\dev\breeze\src\airflow_breeze\global_constants.py", line 30, in <module>
    from airflow_breeze.utils.path_utils import AIRFLOW_SOURCES_ROOT
  File "C:\Users\Eilon\Programming\python\open_source\airflow\dev\breeze\src\airflow_breeze\utils\path_utils.py", line 281, in <module>
    AIRFLOW_SOURCES_ROOT = find_airflow_sources_root_to_operate_on().resolve()
  File "C:\Users\Eilon\Programming\python\open_source\airflow\dev\breeze\src\airflow_breeze\utils\path_utils.py", line 266, in find_airflow_sources_root_to_operate_on
    reinstall_if_setup_changed()
  File "C:\Users\Eilon\Programming\python\open_source\airflow\dev\breeze\src\airflow_breeze\utils\path_utils.py", line 180, in reinstall_if_setup_changed
    process_breeze_readme(breeze_sources, sources_hash)
<b>  File "C:\Users\Eilon\Programming\python\open_source\airflow\dev\breeze\src\airflow_breeze\utils\path_utils.py", line 149, in process_breeze_readme
    lines = breeze_readme.read_text().splitlines(keepends=True)</b>
  File "C:\Users\Eilon\AppData\Local\Programs\Python\Python310-32\lib\pathlib.py", line 1133, in read_text
    return f.read()
  File "C:\Users\Eilon\AppData\Local\Programs\Python\Python310-32\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 2143: character maps to <undefined>
</pre>

</details>

<!-- Please keep an empty line above the dashes. -->
---

