### PR TITLE
Fix v2-10 build dependencies

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -671,7 +671,7 @@
                         "tag": {
                             "description": "The StatsD image tag.",
                             "type": "string",
-                            "default": "v0.27.2-pr579"
+                            "default": "v0.27.2"
                         },
                         "pullPolicy": {
                             "description": "The StatsD image pull policy.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -105,7 +105,7 @@ images:
     pullPolicy: IfNotPresent
   statsd:
     repository: quay.io/prometheus/statsd-exporter
-    tag: v0.27.2-pr579
+    tag: v0.27.2
     pullPolicy: IfNotPresent
   redis:
     repository: redis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,8 @@ requires = [
     "pathspec==0.12.1",
     "pluggy==1.5.0",
     "smmap==5.0.1",
-    "tomli==2.0.1; python_version < '3.11'",
-    "trove-classifiers==2024.9.12",
+    "tomli==2.0.2; python_version < '3.11'",
+    "trove-classifiers==2024.10.13",
 ]
 build-backend = "hatchling.build"
 


### PR DESCRIPTION
I saw tests on v2-10-test failing, this makes the builds successful again by updating needed dependencies

See: https://github.com/apache/airflow/actions/runs/11352541460/job/31575571791