### PR TITLE
chore(docs): add required import of BranchDayOfWeekOperator

### DIFF
--- a/providers/src/airflow/providers/standard/operators/weekday.py
+++ b/providers/src/airflow/providers/standard/operators/weekday.py
@@ -40,6 +40,7 @@ class BranchDayOfWeekOperator(BaseBranchOperator):
 
         from airflow.operators.empty import EmptyOperator
         from airflow.operators.weekday import BranchDayOfWeekOperator
+        
         monday = EmptyOperator(task_id="monday")
         other_day = EmptyOperator(task_id="other_day")
 

--- a/providers/src/airflow/providers/standard/operators/weekday.py
+++ b/providers/src/airflow/providers/standard/operators/weekday.py
@@ -40,6 +40,7 @@ class BranchDayOfWeekOperator(BaseBranchOperator):
 
         from airflow.operators.empty import EmptyOperator
         from airflow.operators.weekday import BranchDayOfWeekOperator
+
         monday = EmptyOperator(task_id="monday")
         other_day = EmptyOperator(task_id="other_day")
 

--- a/providers/src/airflow/providers/standard/operators/weekday.py
+++ b/providers/src/airflow/providers/standard/operators/weekday.py
@@ -40,7 +40,6 @@ class BranchDayOfWeekOperator(BaseBranchOperator):
 
         from airflow.operators.empty import EmptyOperator
         from airflow.operators.weekday import BranchDayOfWeekOperator
-        
         monday = EmptyOperator(task_id="monday")
         other_day = EmptyOperator(task_id="other_day")
 

--- a/providers/src/airflow/providers/standard/operators/weekday.py
+++ b/providers/src/airflow/providers/standard/operators/weekday.py
@@ -39,7 +39,7 @@ class BranchDayOfWeekOperator(BaseBranchOperator):
     .. code-block:: python
 
         from airflow.operators.empty import EmptyOperator
-
+        from airflow.operators.weekday import BranchDayOfWeekOperator
         monday = EmptyOperator(task_id="monday")
         other_day = EmptyOperator(task_id="other_day")
 
@@ -59,6 +59,7 @@ class BranchDayOfWeekOperator(BaseBranchOperator):
         # import WeekDay Enum
         from airflow.utils.weekday import WeekDay
         from airflow.operators.empty import EmptyOperator
+        from airflow.operators.weekday import BranchDayOfWeekOperator
 
         workday = EmptyOperator(task_id="workday")
         weekend = EmptyOperator(task_id="weekend")


### PR DESCRIPTION
I was following the docs here: https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/operators/weekday/index.html and adapting those two code blocks.  It failed because I didn't import BranchDayOfWeekOperator.  So I'm adding it here.  Let me know if that does not follow the project's standards.