### PR TITLE
Allow building docs for not-ready providers

### DIFF
--- a/dev/README_AIRFLOW3_DEV.md
+++ b/dev/README_AIRFLOW3_DEV.md
@@ -147,7 +147,7 @@ TBD
 
 Milestone will be added only to the original PR.
 
-1. PR targeting `v2-10-test` directly - mlinestone will be on that PR.
+1. PR targeting `v2-10-test` directly - milestone will be on that PR.
 2. PR targeting `main` with backport PR targeting `v2-10-test`. Milestone will be added only on the PR targeting `v2-10-main`.
 
 ## Set 2.11 milestone

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -765,6 +765,7 @@ autoapi_ignore = [
     # These sub-folders aren't really providers, but we need __init__.py files else various tools (ruff, mypy)
     # get confused by providers/tests/systems/cncf/kubernetes and think that folder is the top level
     # kubernetes module!
+    "*/providers/src/airflow/providers/__init__.py",
     "*/providers/tests/__init__.py",
     "*/providers/tests/cncf/__init__.py",
     "*/providers/tests/common/__init__.py",

--- a/docs/exts/provider_yaml_utils.py
+++ b/docs/exts/provider_yaml_utils.py
@@ -70,7 +70,7 @@ def load_package_data(include_suspended: bool = False) -> list[dict[str, Any]]:
         except jsonschema.ValidationError as ex:
             msg = f"Unable to parse: {provider_yaml_path}. Original error {type(ex).__name__}: {ex}"
             raise RuntimeError(msg)
-        if provider["state"] in ["suspended", "not-ready"] and not include_suspended:
+        if provider["state"] == "suspended" and not include_suspended:
             continue
         provider_yaml_dir = os.path.dirname(provider_yaml_path)
         provider["python-module"] = _filepath_to_module(provider_yaml_dir)


### PR DESCRIPTION
The `not-ready` providers were skipped in https://github.com/apache/airflow/pull/42873 as we were releasing a batch of providers.

I have manually gone ahead and uploaded inventories for edge & standard providers so this is no longer a problem.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
