### PR TITLE
Ensure stable secondary ordering

### DIFF
--- a/airflow/api_fastapi/common/parameters.py
+++ b/airflow/api_fastapi/common/parameters.py
@@ -17,7 +17,6 @@
 
 from __future__ import annotations
 
-import importlib
 from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Callable, Generic, List, TypeVar
@@ -195,32 +194,27 @@ class SortParam(BaseParam[str]):
         # Reset default sorting
         select = select.order_by(None)
 
+        primary_key_column = self.get_primary_key_column()
+
         if self.value[0] == "-":
-            return select.order_by(nullscheck, column.desc(), column.desc())
+            return select.order_by(nullscheck, column.desc(), primary_key_column)
         else:
-            return select.order_by(nullscheck, column.asc(), column.asc())
+            return select.order_by(nullscheck, column.asc(), primary_key_column)
 
-    def get_primary_key(self) -> str:
-        """Get the primary key of the model of SortParam object."""
-        return inspect(self.model).primary_key[0].name
+    def get_primary_key_column(self) -> Column:
+        """Get the primary key column of the model of SortParam object."""
+        return inspect(self.model).primary_key[0]
 
-    @staticmethod
-    def get_primary_key_of_given_model_string(model_string: str) -> str:
-        """
-        Get the primary key of given 'airflow.models' class as a string. The class should have driven be from 'airflow.models.base'.
-
-        :param model_string: The string representation of the model class.
-        :return: The primary key of the model class.
-        """
-        dynamic_return_model = getattr(importlib.import_module("airflow.models"), model_string)
-        return inspect(dynamic_return_model).primary_key[0].name
+    def get_primary_key_string(self) -> str:
+        """Get the primary key string of the model of SortParam object."""
+        return self.get_primary_key_column().name
 
     def depends(self, *args: Any, **kwargs: Any) -> Self:
         raise NotImplementedError("Use dynamic_depends, depends not implemented.")
 
     def dynamic_depends(self) -> Callable:
-        def inner(order_by: str = self.get_primary_key()) -> SortParam:
-            return self.set_value(self.get_primary_key() if order_by == "" else order_by)
+        def inner(order_by: str = self.get_primary_key_string()) -> SortParam:
+            return self.set_value(self.get_primary_key_string() if order_by == "" else order_by)
 
         return inner
 


### PR DESCRIPTION
The secondary default ordering is just to be sure that in case of equality on the primary ordering criteria objects follow a stable ordering. This is not the case by default and I added that because I obversed some flakyness on some tests due to that. 

Was removed in https://github.com/apache/airflow/pull/42782 by mistake. (secondary ordering is the same as the first one)