### PR TITLE
Fix UI lint pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1159,7 +1159,7 @@ repos:
         description: TS types generation / ESLint / Prettier new UI files
         language: node
         types_or: [javascript, ts, tsx, yaml, css, json]
-        files: ^airflow/ui/|^airflow/api_fastapi/openapi/v1-generated\.yaml$
+        files: ^airflow/ui/|^airflow/api_fastapi/core_api/openapi/v1-generated\.yaml$
         entry: ./scripts/ci/pre_commit/lint_ui.py
         additional_dependencies: ['pnpm@9.7.1']
         pass_filenames: false


### PR DESCRIPTION
With the recent reshape of the FastAPI API filestructure, I think we missed that point. Pre-commit was failing to detect updates on the generated-spec, and the frontend code was not regenerated.

> Be carefull with AIP-84 PRs that might have rebased while the fix was not there. CI will be green but can be in fact red, be extra cautious and ask to rebase to avoid breaking main.