### PR TITLE
Fix selective checks when only pyproject.toml changes

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -232,6 +232,7 @@ CI_FILE_GROUP_MATCHES = HashableDict(
             r"^task_sdk/src/",
             r"^task_sdk/tests/",
             r"^tests",
+            r"^tests_common",
             r"^kubernetes_tests",
         ],
         FileGroupForCi.SYSTEM_TEST_FILES: [
@@ -732,11 +733,21 @@ class SelectiveChecks:
 
     @cached_property
     def run_tests(self) -> bool:
+        # we should run all test
         return self._should_be_run(FileGroupForCi.ALL_SOURCE_FILES)
 
     @cached_property
     def ci_image_build(self) -> bool:
-        return self.run_tests or self.docs_build or self.run_kubernetes_tests or self.needs_helm_tests
+        # in case pyproject.toml changed, CI image should be built - even if no build dependencies
+        # changes because some of our tests - those that need CI image might need to be run depending on
+        # changed rules for static checks that are part of the pyproject.toml file
+        return (
+            self.run_tests
+            or self.docs_build
+            or self.run_kubernetes_tests
+            or self.needs_helm_tests
+            or self.pyproject_toml_changed
+        )
 
     @cached_property
     def prod_image_build(self) -> bool:
@@ -936,6 +947,8 @@ class SelectiveChecks:
     def pyproject_toml_changed(self) -> bool:
         if not self._commit_ref:
             get_console().print("[warning]Cannot determine pyproject.toml changes as commit is missing[/]")
+            return False
+        if "pyproject.toml" not in self._files:
             return False
         new_result = run_command(
             ["git", "show", f"{self._commit_ref}:pyproject.toml"],

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -133,6 +133,15 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
         ),
         (
             pytest.param(
+                ("pyproject.toml",),
+                {
+                    "ci-image-build": "true",
+                },
+                id="CI image build and when pyproject.toml change",
+            )
+        ),
+        (
+            pytest.param(
                 ("airflow/api/file.py",),
                 {
                     "affected-providers-list-as-string": "common.compat fab",


### PR DESCRIPTION
In case only pyproject.toml changes we should automatically build CI image as we need to run full set of static checks - including mypy and other tools.

This change triggers ci-image for such case and it also fixes a subtle bug where "pyproject_toml_changed" was always set to true (but nothing depended on it, because we are checking if build dependencies changed in pyproject.toml to trigger full build as most of the build logic and dependencies is in hatch_build.py

The change first now attempts to see if the pyprject.toml changed at all (i.e. if pyprooject.toml is in the list of files that are changed in the commit) and only then reads the content of old and new version of pyproject.toml to compare them. This will make selective checks a bit faster as it won't run two git commands when pyproject.toml has not changed.

Also tests_common are now added to "all sources" group which should trigger tests when only tests_common change.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
