### PR TITLE
Initialize dashboard page with health info

### DIFF
--- a/airflow/ui/src/layouts/Nav/Nav.tsx
+++ b/airflow/ui/src/layouts/Nav/Nav.tsx
@@ -16,14 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  Box,
-  Flex,
-  Icon,
-  Link,
-  useColorModeValue,
-  VStack,
-} from "@chakra-ui/react";
+import { Box, Flex, Icon, useColorModeValue, VStack } from "@chakra-ui/react";
 import { motion } from "framer-motion";
 import {
   FiBarChart2,
@@ -68,12 +61,7 @@ export const Nav = () => {
         >
           <Icon as={AirflowPin} height="35px" width="35px" />
         </Box>
-        <NavButton
-          icon={<FiHome size="1.75rem" />}
-          isDisabled
-          title="Home"
-          to="/"
-        />
+        <NavButton icon={<FiHome size="1.75rem" />} title="Home" to="/" />
         <NavButton
           icon={<DagIcon height={7} width={7} />}
           title="DAGs"
@@ -106,7 +94,6 @@ export const Nav = () => {
       </Flex>
       <Flex flexDir="column">
         <NavButton
-          as={Link}
           icon={<FiCornerUpLeft size="1.5rem" />}
           title="Return to legacy UI"
           to={import.meta.env.VITE_LEGACY_API_URL}

--- a/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -46,7 +46,7 @@ import {
   SearchParamsKeys,
   type SearchParamsKeysType,
 } from "src/constants/searchParams";
-import { pluralize } from "src/utils/pluralize";
+import { pluralize } from "src/utils";
 
 import { DagCard } from "./DagCard";
 import { DagsFilters } from "./DagsFilters";

--- a/airflow/ui/src/pages/Dashboard/Dashboard.tsx
+++ b/airflow/ui/src/pages/Dashboard/Dashboard.tsx
@@ -16,18 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Route, Routes } from "react-router-dom";
+import { Box, Heading } from "@chakra-ui/react";
 
-import { DagsList } from "src/pages/DagsList";
-import { Dashboard } from "src/pages/Dashboard";
+import { Health } from "./Health";
 
-import { BaseLayout } from "./layouts/BaseLayout";
+export const Dashboard = () => (
+  <Box>
+    <Heading mb={4}>Welcome</Heading>
 
-export const App = () => (
-  <Routes>
-    <Route element={<BaseLayout />} path="/">
-      <Route element={<Dashboard />} index />
-      <Route element={<DagsList />} path="dags" />
-    </Route>
-  </Routes>
+    <Box>
+      <Health />
+    </Box>
+  </Box>
 );

--- a/airflow/ui/src/pages/Dashboard/Health.tsx
+++ b/airflow/ui/src/pages/Dashboard/Health.tsx
@@ -1,0 +1,67 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box, Flex, Heading, HStack } from "@chakra-ui/react";
+import { FiClipboard } from "react-icons/fi";
+
+import { useMonitorServiceGetHealth } from "openapi/queries";
+import { ErrorAlert } from "src/components/ErrorAlert";
+
+import { HealthTag } from "./HealthTag";
+
+export const Health = () => {
+  const { data, error, isLoading } = useMonitorServiceGetHealth();
+
+  return (
+    <Box>
+      <Flex color="gray.500" mb={2}>
+        <FiClipboard />
+        <Heading ml={1} size="xs">
+          Health
+        </Heading>
+      </Flex>
+      <ErrorAlert error={error} />
+      <HStack alignItems="center" spacing={2}>
+        <HealthTag
+          isLoading={isLoading}
+          status={data?.metadatabase.status}
+          title="MetaDatabase"
+        />
+        <HealthTag
+          isLoading={isLoading}
+          latestHeartbeat={data?.scheduler.latest_scheduler_heartbeat}
+          status={data?.scheduler.status}
+          title="Scheduler"
+        />
+        <HealthTag
+          isLoading={isLoading}
+          latestHeartbeat={data?.triggerer.latest_triggerer_heartbeat}
+          status={data?.triggerer.status}
+          title="Triggerer"
+        />
+        {/* TODO add is_standalone to API to determine when to render this */}
+        <HealthTag
+          isLoading={isLoading}
+          latestHeartbeat={data?.dag_processor.latest_dag_processor_heartbeat}
+          status={data?.dag_processor.status}
+          title="Dag Processor"
+        />
+      </HStack>
+    </Box>
+  );
+};

--- a/airflow/ui/src/pages/Dashboard/HealthSection.tsx
+++ b/airflow/ui/src/pages/Dashboard/HealthSection.tsx
@@ -1,0 +1,59 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Skeleton, Tag, TagLabel, Text, Tooltip } from "@chakra-ui/react";
+
+export const HealthSection = ({
+  isLoading,
+  latestHeartbeat,
+  status,
+  title,
+}: {
+  readonly isLoading: boolean;
+  readonly latestHeartbeat?: null | string;
+  readonly status?: null | string;
+  readonly title: string;
+}) => {
+  if (isLoading) {
+    return <Skeleton borderRadius="full" height={34} width={100} />;
+  }
+
+  return (
+    <Tooltip
+      hasArrow
+      isDisabled={!Boolean(latestHeartbeat)}
+      label={
+        <div>
+          <Text>Status: {status}</Text>
+          <Text>Last Heartbeat: {latestHeartbeat}</Text>
+        </div>
+      }
+      shouldWrapChildren
+    >
+      <Tag
+        borderColor={status === "healthy" ? "success.100" : "error.100"}
+        borderRadius="full"
+        borderWidth={1}
+        colorScheme={status === "healthy" ? "success" : "error"}
+        size="lg"
+      >
+        <TagLabel>{title}</TagLabel>
+      </Tag>
+    </Tooltip>
+  );
+};

--- a/airflow/ui/src/pages/Dashboard/HealthTag.tsx
+++ b/airflow/ui/src/pages/Dashboard/HealthTag.tsx
@@ -1,0 +1,59 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Skeleton, Tag, TagLabel, Text, Tooltip } from "@chakra-ui/react";
+
+import { capitalize } from "src/utils";
+
+export const HealthTag = ({
+  isLoading,
+  latestHeartbeat,
+  status,
+  title,
+}: {
+  readonly isLoading: boolean;
+  readonly latestHeartbeat?: null | string;
+  readonly status?: null | string;
+  readonly title: string;
+}) => {
+  if (isLoading) {
+    return <Skeleton borderRadius="full" height={8} width={24} />;
+  }
+
+  return (
+    <Tooltip
+      hasArrow
+      isDisabled={!Boolean(latestHeartbeat)}
+      label={
+        <div>
+          <Text>Status: {capitalize(status)}</Text>
+          <Text>Last Heartbeat: {latestHeartbeat}</Text>
+        </div>
+      }
+      shouldWrapChildren
+    >
+      <Tag
+        borderRadius="full"
+        colorScheme={status === "healthy" ? "green" : "red"}
+        size="lg"
+      >
+        <TagLabel>{title}</TagLabel>
+      </Tag>
+    </Tooltip>
+  );
+};

--- a/airflow/ui/src/pages/Dashboard/index.tsx
+++ b/airflow/ui/src/pages/Dashboard/index.tsx
@@ -16,18 +16,5 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Route, Routes } from "react-router-dom";
 
-import { DagsList } from "src/pages/DagsList";
-import { Dashboard } from "src/pages/Dashboard";
-
-import { BaseLayout } from "./layouts/BaseLayout";
-
-export const App = () => (
-  <Routes>
-    <Route element={<BaseLayout />} path="/">
-      <Route element={<Dashboard />} index />
-      <Route element={<DagsList />} path="dags" />
-    </Route>
-  </Routes>
-);
+export { Dashboard } from "./Dashboard";

--- a/airflow/ui/src/utils/capitalize.ts
+++ b/airflow/ui/src/utils/capitalize.ts
@@ -16,18 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Route, Routes } from "react-router-dom";
 
-import { DagsList } from "src/pages/DagsList";
-import { Dashboard } from "src/pages/Dashboard";
-
-import { BaseLayout } from "./layouts/BaseLayout";
-
-export const App = () => (
-  <Routes>
-    <Route element={<BaseLayout />} path="/">
-      <Route element={<Dashboard />} index />
-      <Route element={<DagsList />} path="dags" />
-    </Route>
-  </Routes>
-);
+// eslint-disable-next-line perfectionist/sort-union-types
+export const capitalize = (string: string | null | undefined) =>
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+  string ? string.charAt(0).toUpperCase() + string.slice(1).toLowerCase() : "";

--- a/airflow/ui/src/utils/index.ts
+++ b/airflow/ui/src/utils/index.ts
@@ -16,18 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Route, Routes } from "react-router-dom";
 
-import { DagsList } from "src/pages/DagsList";
-import { Dashboard } from "src/pages/Dashboard";
-
-import { BaseLayout } from "./layouts/BaseLayout";
-
-export const App = () => (
-  <Routes>
-    <Route element={<BaseLayout />} path="/">
-      <Route element={<Dashboard />} index />
-      <Route element={<DagsList />} path="dags" />
-    </Route>
-  </Routes>
-);
+export { capitalize } from "./capitalize";
+export { pluralize } from "./pluralize";


### PR DESCRIPTION
Initialize the Dashboard page with the health stats

Related: #42825

Dark:
<img width="661" alt="Screenshot 2024-10-16 at 1 37 17 PM" src="https://github.com/user-attachments/assets/489670ca-98f8-41a9-b919-f921698e8c51">


Light:
<img width="630" alt="Screenshot 2024-10-16 at 1 34 56 PM" src="https://github.com/user-attachments/assets/d986c0e1-cef1-4ee7-bf89-e0af2ce7dace">

Follow up PRs needed:
- pass is_standalone variable to determine when to render dag_processor
- update theme to color blind friendly colors
- fix some eslint rules that are annoying
- add timezone provider to improve timestamp rendering

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
