### PR TITLE
Fix flaky `test_get_dags` in FastAPI routes

### DIFF
--- a/tests/api_fastapi/core_api/routes/public/test_dags.py
+++ b/tests/api_fastapi/core_api/routes/public/test_dags.py
@@ -135,37 +135,37 @@ class TestGetDags(TestDagEndpoint):
         "query_params, expected_total_entries, expected_ids",
         [
             # Filters
-            ({}, 2, [DAG1_ID, DAG2_ID]),
-            ({"limit": 1}, 2, [DAG1_ID]),
-            ({"offset": 1}, 2, [DAG2_ID]),
-            ({"tags": ["example"]}, 1, [DAG1_ID]),
-            ({"only_active": False}, 3, [DAG1_ID, DAG2_ID, DAG3_ID]),
-            ({"paused": True, "only_active": False}, 1, [DAG3_ID]),
-            ({"paused": False}, 2, [DAG1_ID, DAG2_ID]),
-            ({"owners": ["airflow"]}, 2, [DAG1_ID, DAG2_ID]),
-            ({"owners": ["test_owner"], "only_active": False}, 1, [DAG3_ID]),
-            ({"last_dag_run_state": "success", "only_active": False}, 1, [DAG3_ID]),
-            ({"last_dag_run_state": "failed", "only_active": False}, 1, [DAG1_ID]),
+            ({}, 2, {DAG1_ID, DAG2_ID}),
+            ({"limit": 1}, 2, {DAG1_ID}),
+            ({"offset": 1}, 2, {DAG2_ID}),
+            ({"tags": ["example"]}, 1, {DAG1_ID}),
+            ({"only_active": False}, 3, {DAG1_ID, DAG2_ID, DAG3_ID}),
+            ({"paused": True, "only_active": False}, 1, {DAG3_ID}),
+            ({"paused": False}, 2, {DAG1_ID, DAG2_ID}),
+            ({"owners": ["airflow"]}, 2, {DAG1_ID, DAG2_ID}),
+            ({"owners": ["test_owner"], "only_active": False}, 1, {DAG3_ID}),
+            ({"last_dag_run_state": "success", "only_active": False}, 1, {DAG3_ID}),
+            ({"last_dag_run_state": "failed", "only_active": False}, 1, {DAG1_ID}),
             # # Sort
-            ({"order_by": "-dag_id"}, 2, [DAG2_ID, DAG1_ID]),
-            ({"order_by": "-dag_display_name"}, 2, [DAG2_ID, DAG1_ID]),
-            ({"order_by": "dag_display_name"}, 2, [DAG1_ID, DAG2_ID]),
-            ({"order_by": "next_dagrun", "only_active": False}, 3, [DAG3_ID, DAG1_ID, DAG2_ID]),
-            ({"order_by": "last_run_state", "only_active": False}, 3, [DAG1_ID, DAG3_ID, DAG2_ID]),
-            ({"order_by": "-last_run_state", "only_active": False}, 3, [DAG3_ID, DAG1_ID, DAG2_ID]),
+            ({"order_by": "-dag_id"}, 2, {DAG2_ID, DAG1_ID}),
+            ({"order_by": "-dag_display_name"}, 2, {DAG2_ID, DAG1_ID}),
+            ({"order_by": "dag_display_name"}, 2, {DAG1_ID, DAG2_ID}),
+            ({"order_by": "next_dagrun", "only_active": False}, 3, {DAG3_ID, DAG1_ID, DAG2_ID}),
+            ({"order_by": "last_run_state", "only_active": False}, 3, {DAG1_ID, DAG3_ID, DAG2_ID}),
+            ({"order_by": "-last_run_state", "only_active": False}, 3, {DAG3_ID, DAG1_ID, DAG2_ID}),
             (
                 {"order_by": "last_run_start_date", "only_active": False},
                 3,
-                [DAG1_ID, DAG3_ID, DAG2_ID],
+                {DAG1_ID, DAG3_ID, DAG2_ID},
             ),
             (
                 {"order_by": "-last_run_start_date", "only_active": False},
                 3,
-                [DAG3_ID, DAG1_ID, DAG2_ID],
+                {DAG3_ID, DAG1_ID, DAG2_ID},
             ),
             # Search
-            ({"dag_id_pattern": "1"}, 1, [DAG1_ID]),
-            ({"dag_display_name_pattern": "test_dag2"}, 1, [DAG2_ID]),
+            ({"dag_id_pattern": "1"}, 1, {DAG1_ID}),
+            ({"dag_display_name_pattern": "test_dag2"}, 1, {DAG2_ID}),
         ],
     )
     def test_get_dags(self, test_client, query_params, expected_total_entries, expected_ids):
@@ -175,7 +175,7 @@ class TestGetDags(TestDagEndpoint):
         body = response.json()
 
         assert body["total_entries"] == expected_total_entries
-        assert [dag["dag_id"] for dag in body["dags"]] == expected_ids
+        assert set(dag["dag_id"] for dag in body["dags"]) == expected_ids
 
 
 class TestPatchDag(TestDagEndpoint):


### PR DESCRIPTION
closes https://github.com/apache/airflow/issues/43099

Solution: changed them to sets since the order doesn't matter for what we are trying to verify

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
