### PR TITLE
Add min version to python-ldap

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -98,7 +98,7 @@ CORE_EXTRAS: dict[str, list[str]] = {
         "thrift-sasl>=0.2.0",
     ],
     "ldap": [
-        "python-ldap>=3.4.0",
+        "python-ldap>=3.4.4",
     ],
     "leveldb": [
         "plyvel",

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -98,7 +98,7 @@ CORE_EXTRAS: dict[str, list[str]] = {
         "thrift-sasl>=0.2.0",
     ],
     "ldap": [
-        "python-ldap",
+        "python-ldap>=3.4.0",
     ],
     "leveldb": [
         "plyvel",


### PR DESCRIPTION
The latest `python-ldap` version available is 3.4.4, and it was released in November 2023. 

When we install python-ldap without a pin, we install 3.4.4. Hence, I'm making the min version to be 3.4.4. 

related to https://github.com/apache/airflow/issues/42989