### PR TITLE
Revert "Fix flaky `test_get_dags` in FastAPI routes"

### DIFF
--- a/tests/api_fastapi/core_api/routes/public/test_dags.py
+++ b/tests/api_fastapi/core_api/routes/public/test_dags.py
@@ -135,37 +135,37 @@ class TestGetDags(TestDagEndpoint):
         "query_params, expected_total_entries, expected_ids",
         [
             # Filters
-            ({}, 2, {DAG1_ID, DAG2_ID}),
-            ({"limit": 1}, 2, {DAG1_ID}),
-            ({"offset": 1}, 2, {DAG2_ID}),
-            ({"tags": ["example"]}, 1, {DAG1_ID}),
-            ({"only_active": False}, 3, {DAG1_ID, DAG2_ID, DAG3_ID}),
-            ({"paused": True, "only_active": False}, 1, {DAG3_ID}),
-            ({"paused": False}, 2, {DAG1_ID, DAG2_ID}),
-            ({"owners": ["airflow"]}, 2, {DAG1_ID, DAG2_ID}),
-            ({"owners": ["test_owner"], "only_active": False}, 1, {DAG3_ID}),
-            ({"last_dag_run_state": "success", "only_active": False}, 1, {DAG3_ID}),
-            ({"last_dag_run_state": "failed", "only_active": False}, 1, {DAG1_ID}),
+            ({}, 2, [DAG1_ID, DAG2_ID]),
+            ({"limit": 1}, 2, [DAG1_ID]),
+            ({"offset": 1}, 2, [DAG2_ID]),
+            ({"tags": ["example"]}, 1, [DAG1_ID]),
+            ({"only_active": False}, 3, [DAG1_ID, DAG2_ID, DAG3_ID]),
+            ({"paused": True, "only_active": False}, 1, [DAG3_ID]),
+            ({"paused": False}, 2, [DAG1_ID, DAG2_ID]),
+            ({"owners": ["airflow"]}, 2, [DAG1_ID, DAG2_ID]),
+            ({"owners": ["test_owner"], "only_active": False}, 1, [DAG3_ID]),
+            ({"last_dag_run_state": "success", "only_active": False}, 1, [DAG3_ID]),
+            ({"last_dag_run_state": "failed", "only_active": False}, 1, [DAG1_ID]),
             # # Sort
-            ({"order_by": "-dag_id"}, 2, {DAG2_ID, DAG1_ID}),
-            ({"order_by": "-dag_display_name"}, 2, {DAG2_ID, DAG1_ID}),
-            ({"order_by": "dag_display_name"}, 2, {DAG1_ID, DAG2_ID}),
-            ({"order_by": "next_dagrun", "only_active": False}, 3, {DAG3_ID, DAG1_ID, DAG2_ID}),
-            ({"order_by": "last_run_state", "only_active": False}, 3, {DAG1_ID, DAG3_ID, DAG2_ID}),
-            ({"order_by": "-last_run_state", "only_active": False}, 3, {DAG3_ID, DAG1_ID, DAG2_ID}),
+            ({"order_by": "-dag_id"}, 2, [DAG2_ID, DAG1_ID]),
+            ({"order_by": "-dag_display_name"}, 2, [DAG2_ID, DAG1_ID]),
+            ({"order_by": "dag_display_name"}, 2, [DAG1_ID, DAG2_ID]),
+            ({"order_by": "next_dagrun", "only_active": False}, 3, [DAG3_ID, DAG1_ID, DAG2_ID]),
+            ({"order_by": "last_run_state", "only_active": False}, 3, [DAG1_ID, DAG3_ID, DAG2_ID]),
+            ({"order_by": "-last_run_state", "only_active": False}, 3, [DAG3_ID, DAG1_ID, DAG2_ID]),
             (
                 {"order_by": "last_run_start_date", "only_active": False},
                 3,
-                {DAG1_ID, DAG3_ID, DAG2_ID},
+                [DAG1_ID, DAG3_ID, DAG2_ID],
             ),
             (
                 {"order_by": "-last_run_start_date", "only_active": False},
                 3,
-                {DAG3_ID, DAG1_ID, DAG2_ID},
+                [DAG3_ID, DAG1_ID, DAG2_ID],
             ),
             # Search
-            ({"dag_id_pattern": "1"}, 1, {DAG1_ID}),
-            ({"dag_display_name_pattern": "test_dag2"}, 1, {DAG2_ID}),
+            ({"dag_id_pattern": "1"}, 1, [DAG1_ID]),
+            ({"dag_display_name_pattern": "test_dag2"}, 1, [DAG2_ID]),
         ],
     )
     def test_get_dags(self, test_client, query_params, expected_total_entries, expected_ids):
@@ -175,7 +175,7 @@ class TestGetDags(TestDagEndpoint):
         body = response.json()
 
         assert body["total_entries"] == expected_total_entries
-        assert set(dag["dag_id"] for dag in body["dags"]) == expected_ids
+        assert [dag["dag_id"] for dag in body["dags"]] == expected_ids
 
 
 class TestPatchDag(TestDagEndpoint):


### PR DESCRIPTION
Reverts apache/airflow#43100

This should be reverted because:
- Order actually matters, especially when we are testing `order_by` query parameters. (The returned items must follow the queried order)
- This is not specific to the `get_dags` endpoints but any endpoint returning a list, because the database natural order is not guarantee. (based on insertion etc, etc,). This happens in case of equality on the first order_by criteria.


A fix is already opened here https://github.com/apache/airflow/pull/43085. It was there in the first place but got removed by mistake in a recent PR (yesterday or the day before that). To my knowledge we didn't have any issue reported before that.