### PR TITLE
feat(providers/fab): Use asset in common provider

### DIFF
--- a/dev/breeze/tests/test_packages.py
+++ b/dev/breeze/tests/test_packages.py
@@ -167,7 +167,7 @@ def test_get_documentation_package_path():
             "fab",
             "",
             """
-    "apache-airflow-providers-common-compat>=1.2.0",
+    "apache-airflow-providers-common-compat>=1.2.1",
     "apache-airflow>=2.9.0",
     "flask-appbuilder==4.5.0",
     "flask-login>=0.6.2",
@@ -181,7 +181,7 @@ def test_get_documentation_package_path():
             "fab",
             "dev0",
             """
-    "apache-airflow-providers-common-compat>=1.2.0.dev0",
+    "apache-airflow-providers-common-compat>=1.2.1.dev0",
     "apache-airflow>=2.9.0.dev0",
     "flask-appbuilder==4.5.0",
     "flask-login>=0.6.2",
@@ -195,7 +195,7 @@ def test_get_documentation_package_path():
             "fab",
             "beta0",
             """
-    "apache-airflow-providers-common-compat>=1.2.0b0",
+    "apache-airflow-providers-common-compat>=1.2.1b0",
     "apache-airflow>=2.9.0b0",
     "flask-appbuilder==4.5.0",
     "flask-login>=0.6.2",

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -569,7 +569,7 @@
   },
   "fab": {
     "deps": [
-      "apache-airflow-providers-common-compat>=1.2.0",
+      "apache-airflow-providers-common-compat>=1.2.1",
       "apache-airflow>=2.9.0",
       "flask-appbuilder==4.5.0",
       "flask-login>=0.6.2",

--- a/providers/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/providers/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -96,10 +96,7 @@ if TYPE_CHECKING:
     from airflow.providers.fab.auth_manager.security_manager.override import FabAirflowSecurityManagerOverride
     from airflow.security.permissions import RESOURCE_ASSET
 else:
-    try:
-        from airflow.security.permissions import RESOURCE_ASSET
-    except ImportError:
-        from airflow.security.permissions import RESOURCE_DATASET as RESOURCE_ASSET
+    from airflow.providers.common.compat.security.permissions import RESOURCE_ASSET
 
 
 _MAP_DAG_ACCESS_ENTITY_TO_FAB_RESOURCE_TYPE: dict[DagAccessEntity, tuple[str, ...]] = {

--- a/providers/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -117,10 +117,7 @@ if TYPE_CHECKING:
     from airflow.auth.managers.base_auth_manager import ResourceMethod
     from airflow.security.permissions import RESOURCE_ASSET
 else:
-    try:
-        from airflow.security.permissions import RESOURCE_ASSET
-    except ImportError:
-        from airflow.security.permissions import RESOURCE_DATASET as RESOURCE_ASSET
+    from airflow.providers.common.compat.security.permissions import RESOURCE_ASSET
 
 log = logging.getLogger(__name__)
 

--- a/providers/src/airflow/providers/fab/provider.yaml
+++ b/providers/src/airflow/providers/fab/provider.yaml
@@ -48,7 +48,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.9.0
-  - apache-airflow-providers-common-compat>=1.2.0
+  - apache-airflow-providers-common-compat>=1.2.1
   - flask>=2.2,<2.3
   # We are tightly coupled with FAB version as we vendored-in part of FAB code related to security manager
   # This is done as part of preparation to removing FAB as dependency, but we are not ready for it yet

--- a/providers/tests/fab/auth_manager/test_fab_auth_manager.py
+++ b/providers/tests/fab/auth_manager/test_fab_auth_manager.py
@@ -38,6 +38,7 @@ with ignore_provider_compatibility_error("2.9.0+", __file__):
     from airflow.providers.fab.auth_manager.models import User
     from airflow.providers.fab.auth_manager.security_manager.override import FabAirflowSecurityManagerOverride
 
+from airflow.providers.common.compat.security.permissions import RESOURCE_ASSET
 from airflow.security.permissions import (
     ACTION_CAN_ACCESS_MENU,
     ACTION_CAN_CREATE,
@@ -61,14 +62,6 @@ from airflow.www.extensions.init_appbuilder import init_appbuilder
 
 if TYPE_CHECKING:
     from airflow.auth.managers.base_auth_manager import ResourceMethod
-    from airflow.security.permissions import RESOURCE_ASSET
-else:
-    try:
-        from airflow.security.permissions import RESOURCE_ASSET
-    except ImportError:
-        from airflow.security.permissions import (
-            RESOURCE_DATASET as RESOURCE_ASSET,
-        )
 
 
 IS_AUTHORIZED_METHODS_SIMPLE = {

--- a/providers/tests/fab/auth_manager/test_security.py
+++ b/providers/tests/fab/auth_manager/test_security.py
@@ -66,10 +66,7 @@ from tests_common.test_utils.permissions import _resource_name
 if TYPE_CHECKING:
     from airflow.security.permissions import RESOURCE_ASSET
 else:
-    try:
-        from airflow.security.permissions import RESOURCE_ASSET
-    except ImportError:
-        from airflow.security.permissions import RESOURCE_DATASET as RESOURCE_ASSET
+    from airflow.providers.common.compat.security.permissions import RESOURCE_ASSET
 
 
 pytestmark = pytest.mark.db_test


### PR DESCRIPTION
## Why
As apache-airflow-providers-common-compat 1.2.1 has been released, we can reuse the asset-related code inside it.

## What
Reuse asset-related code in apache-airflow-providers-common-compat 1.2.1


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
