### PR TITLE
Cope with Pycharm's oddity in detecting namespace packages

### DIFF
--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -15,12 +15,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from __future__ import annotations
 
 # Make `airflow` a namespace package, supporting installing
 # airflow.providers.* in different locations (i.e. one in site, and one in user
 # lib.)  This is required by some IDEs to resolve the import paths.
+# And it _has_ to be the first code line too. Sad panda
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+
+from __future__ import annotations  # noqa: F404
 
 __version__ = "3.0.0.dev0"
 

--- a/providers/src/airflow/providers/__init__.py
+++ b/providers/src/airflow/providers/__init__.py
@@ -16,11 +16,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import annotations
 
 # Make `airflow` a namespace package, supporting installing
 # airflow.providers.* in different locations (i.e. one in site, and one in user
 # lib.)  This is required by some IDEs to resolve the import paths.
+# And it _has_ to be the first code line too. Sad panda
 #
 # Note: this file is not installed or distributed in any distribution!
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+
+from __future__ import annotations  # noqa: F404


### PR DESCRIPTION
Without the `__path__` assignment being the very first line of the file
(including before any import) it doesn't detect this correctly.
