### PR TITLE
Fixed failing static checks & provider tests

### DIFF
--- a/providers/src/airflow/providers/apache/hdfs/sensors/web_hdfs.py
+++ b/providers/src/airflow/providers/apache/hdfs/sensors/web_hdfs.py
@@ -17,14 +17,15 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence
 
 from airflow.sensors.base import BaseSensorOperator
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
-    from hdfs.ext.kerberos import KerberosClient
     from hdfs import InsecureClient
+    from hdfs.ext.kerberos import KerberosClient
+
+    from airflow.utils.context import Context
 
 
 class WebHdfsSensor(BaseSensorOperator):
@@ -50,8 +51,14 @@ class MultipleFilesWebHdfsSensor(BaseSensorOperator):
 
     template_fields: Sequence[str] = ("directory_path", "expected_filenames")
 
-    def __init__(self, *, directory_path: str, expected_filenames: Sequence[str],
-                 webhdfs_conn_id: str = "webhdfs_default", **kwargs: Any) -> None:
+    def __init__(
+        self,
+        *,
+        directory_path: str,
+        expected_filenames: Sequence[str],
+        webhdfs_conn_id: str = "webhdfs_default",
+        **kwargs: Any,
+    ) -> None:
         super().__init__(**kwargs)
         self.directory_path = directory_path
         self.expected_filenames = expected_filenames
@@ -61,7 +68,7 @@ class MultipleFilesWebHdfsSensor(BaseSensorOperator):
         from airflow.providers.apache.hdfs.hooks.webhdfs import WebHDFSHook
 
         hook = WebHDFSHook(self.webhdfs_conn_id)
-        conn: 'KerberosClient | InsecureClient' = hook.get_conn()
+        conn: KerberosClient | InsecureClient = hook.get_conn()
 
         actual_files = set(conn.list(self.directory_path))
         self.log.debug("Files Found in directory: %s", actual_files)

--- a/providers/tests/apache/hdfs/sensors/test_web_hdfs.py
+++ b/providers/tests/apache/hdfs/sensors/test_web_hdfs.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import os
 from unittest import mock
 
-from airflow.providers.apache.hdfs.sensors.web_hdfs import WebHdfsSensor, MultipleFilesWebHdfsSensor
+from airflow.providers.apache.hdfs.sensors.web_hdfs import MultipleFilesWebHdfsSensor, WebHdfsSensor
 
 TEST_HDFS_CONN = "webhdfs_default"
 TEST_HDFS_DIRECTORY = "hdfs://user/hive/warehouse/airflow.db"
@@ -69,7 +69,7 @@ class TestMultipleFilesWebHdfsSensor:
             task_id="test_task",
             webhdfs_conn_id=TEST_HDFS_CONN,
             directory_path=TEST_HDFS_DIRECTORY,
-            expected_filenames=TEST_HDFS_FILENAMES
+            expected_filenames=TEST_HDFS_FILENAMES,
         )
         result = sensor.poke(dict())
 
@@ -88,7 +88,7 @@ class TestMultipleFilesWebHdfsSensor:
             task_id="test_task",
             webhdfs_conn_id=TEST_HDFS_CONN,
             directory_path=TEST_HDFS_DIRECTORY,
-            expected_filenames=TEST_HDFS_FILENAMES
+            expected_filenames=TEST_HDFS_FILENAMES,
         )
         exists = sensor.poke(dict())
 

--- a/providers/tests/apache/hdfs/sensors/test_web_hdfs.py
+++ b/providers/tests/apache/hdfs/sensors/test_web_hdfs.py
@@ -71,7 +71,9 @@ class TestMultipleFilesWebHdfsSensor:
             directory_path=TEST_HDFS_DIRECTORY,
             expected_filenames=TEST_HDFS_FILENAMES,
         )
-        result = sensor.poke(dict())
+
+        with caplog.at_level("DEBUG", logger="airflow.task"):
+            result = sensor.poke(dict())
 
         assert result
         assert "Files Found in directory: " in caplog.text
@@ -93,7 +95,6 @@ class TestMultipleFilesWebHdfsSensor:
         exists = sensor.poke(dict())
 
         assert not exists
-        assert "Files Found in directory: " in caplog.text
         assert "There are missing files: " in caplog.text
 
         mock_hook.return_value.get_conn.return_value.list.assert_called_once_with(TEST_HDFS_DIRECTORY)


### PR DESCRIPTION
Main is failing on static checks. Example: https://github.com/apache/airflow/actions/runs/11387569851/job/31683018728?pr=43121

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
