### PR TITLE
Add timezone selection to new UI

### DIFF
--- a/airflow/ui/package.json
+++ b/airflow/ui/package.json
@@ -24,6 +24,7 @@
     "@tanstack/react-table": "^8.20.1",
     "axios": "^1.7.7",
     "chakra-react-select": "^4.9.2",
+    "dayjs": "^1.11.13",
     "framer-motion": "^11.3.29",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/airflow/ui/pnpm-lock.yaml
+++ b/airflow/ui/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       chakra-react-select:
         specifier: ^4.9.2
         version: 4.9.2(uzcvocchpeesoxvtkif6ppnvaq)
+      dayjs:
+        specifier: ^1.11.13
+        version: 1.11.13
       framer-motion:
         specifier: ^11.3.29
         version: 11.3.29(@emotion/is-prop-valid@1.3.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1724,6 +1727,9 @@ packages:
   data-view-byte-offset@1.0.0:
     resolution: {integrity: sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==}
     engines: {node: '>= 0.4'}
+
+  dayjs@1.11.13:
+    resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
 
   debug@4.3.6:
     resolution: {integrity: sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==}
@@ -5241,6 +5247,8 @@ snapshots:
       call-bind: 1.0.7
       es-errors: 1.3.0
       is-data-view: 1.0.1
+
+  dayjs@1.11.13: {}
 
   debug@4.3.6:
     dependencies:

--- a/airflow/ui/src/components/Time.test.tsx
+++ b/airflow/ui/src/components/Time.test.tsx
@@ -1,0 +1,64 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render, screen } from "@testing-library/react";
+import dayjs from "dayjs";
+import { describe, it, expect, vi } from "vitest";
+
+import { TimezoneContext } from "src/context/timezone";
+import { Wrapper } from "src/utils/Wrapper";
+
+import Time, { defaultFormat, defaultFormatWithTZ } from "./Time";
+
+describe("Test Time and TimezoneProvider", () => {
+  it("Displays a UTC time correctly", () => {
+    const now = new Date();
+
+    render(<Time datetime={now.toISOString()} />, {
+      wrapper: Wrapper,
+    });
+
+    const utcTime = screen.getByText(dayjs.utc(now).format(defaultFormat));
+
+    expect(utcTime).toBeDefined();
+    expect(utcTime.title).toBeFalsy();
+  });
+
+  it("Displays a set timezone, includes UTC date in title", () => {
+    const now = new Date();
+    const tz = "US/Samoa";
+
+    render(
+      <TimezoneContext.Provider
+        value={{ selectedTimezone: tz, setSelectedTimezone: vi.fn() }}
+      >
+        <Time datetime={now.toISOString()} />
+      </TimezoneContext.Provider>,
+      {
+        wrapper: Wrapper,
+      },
+    );
+
+    const samoaTime = screen.getByText(dayjs(now).tz(tz).format(defaultFormat));
+
+    expect(samoaTime).toBeDefined();
+    expect(samoaTime.title).toEqual(
+      dayjs().tz("UTC").format(defaultFormatWithTZ),
+    );
+  });
+});

--- a/airflow/ui/src/components/Time.tsx
+++ b/airflow/ui/src/components/Time.tsx
@@ -1,0 +1,61 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import dayjs from "dayjs";
+import advancedFormat from "dayjs/plugin/advancedFormat";
+import tz from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
+
+import { useTimezone } from "src/context/timezone";
+
+export const defaultFormat = "YYYY-MM-DD, HH:mm:ss";
+export const defaultFormatWithTZ = `${defaultFormat} z`;
+export const defaultTZFormat = "z (Z)";
+
+dayjs.extend(utc);
+dayjs.extend(tz);
+dayjs.extend(advancedFormat);
+
+type Props = {
+  readonly datetime?: string | null;
+  readonly format?: string;
+};
+
+const Time = ({ datetime, format = defaultFormat }: Props) => {
+  const { selectedTimezone } = useTimezone();
+  const time = dayjs(datetime);
+
+  if (datetime === null || datetime === undefined || !time.isValid()) {
+    return undefined;
+  }
+
+  const formattedTime = time.tz(selectedTimezone).format(format);
+  const utcTime = time.tz("UTC").format(defaultFormatWithTZ);
+
+  return (
+    <time
+      dateTime={datetime}
+      // show title if date is not UTC
+      title={selectedTimezone.toUpperCase() === "UTC" ? undefined : utcTime}
+    >
+      {formattedTime}
+    </time>
+  );
+};
+
+export default Time;

--- a/airflow/ui/src/context/timezone/TimezoneProvider.tsx
+++ b/airflow/ui/src/context/timezone/TimezoneProvider.tsx
@@ -1,0 +1,59 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {
+  createContext,
+  useState,
+  useMemo,
+  type PropsWithChildren,
+} from "react";
+
+export type TimezoneContextType = {
+  selectedTimezone: string;
+  setSelectedTimezone: (timezone: string) => void;
+};
+
+export const TimezoneContext = createContext<TimezoneContextType | undefined>(
+  undefined,
+);
+
+const TIMEZONE_KEY = "timezone";
+
+export const TimezoneProvider = ({ children }: PropsWithChildren) => {
+  const [selectedTimezone, setSelectedTimezone] = useState(() => {
+    const timezone = localStorage.getItem(TIMEZONE_KEY);
+
+    return timezone ?? "UTC";
+  });
+
+  const selectTimezone = (tz: string) => {
+    localStorage.setItem(TIMEZONE_KEY, tz);
+    setSelectedTimezone(tz);
+  };
+
+  const value = useMemo<TimezoneContextType>(
+    () => ({ selectedTimezone, setSelectedTimezone: selectTimezone }),
+    [selectedTimezone],
+  );
+
+  return (
+    <TimezoneContext.Provider value={value}>
+      {children}
+    </TimezoneContext.Provider>
+  );
+};

--- a/airflow/ui/src/context/timezone/index.ts
+++ b/airflow/ui/src/context/timezone/index.ts
@@ -16,29 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { ChakraProvider } from "@chakra-ui/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import type { PropsWithChildren } from "react";
-import { MemoryRouter } from "react-router-dom";
 
-import { TimezoneProvider } from "src/context/timezone";
-
-export const Wrapper = ({ children }: PropsWithChildren) => {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        staleTime: Infinity,
-      },
-    },
-  });
-
-  return (
-    <ChakraProvider>
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <TimezoneProvider>{children}</TimezoneProvider>
-        </MemoryRouter>
-      </QueryClientProvider>
-    </ChakraProvider>
-  );
-};
+export * from "./TimezoneProvider";
+export * from "./useTimezone";

--- a/airflow/ui/src/context/timezone/useTimezone.ts
+++ b/airflow/ui/src/context/timezone/useTimezone.ts
@@ -16,29 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { ChakraProvider } from "@chakra-ui/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import type { PropsWithChildren } from "react";
-import { MemoryRouter } from "react-router-dom";
+import { useContext } from "react";
 
-import { TimezoneProvider } from "src/context/timezone";
+import { TimezoneContext, type TimezoneContextType } from "./TimezoneProvider";
 
-export const Wrapper = ({ children }: PropsWithChildren) => {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        staleTime: Infinity,
-      },
-    },
-  });
+export const useTimezone = (): TimezoneContextType => {
+  const context = useContext(TimezoneContext);
 
-  return (
-    <ChakraProvider>
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <TimezoneProvider>{children}</TimezoneProvider>
-        </MemoryRouter>
-      </QueryClientProvider>
-    </ChakraProvider>
-  );
+  if (context === undefined) {
+    throw new Error("useTimezone must be used within a TimezoneProvider");
+  }
+
+  return context;
 };

--- a/airflow/ui/src/layouts/Nav/TimezoneModal.tsx
+++ b/airflow/ui/src/layouts/Nav/TimezoneModal.tsx
@@ -16,29 +16,34 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { ChakraProvider } from "@chakra-ui/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import type { PropsWithChildren } from "react";
-import { MemoryRouter } from "react-router-dom";
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalCloseButton,
+} from "@chakra-ui/react";
+import React from "react";
 
-import { TimezoneProvider } from "src/context/timezone";
+import TimezoneSelector from "./TimezoneSelector";
 
-export const Wrapper = ({ children }: PropsWithChildren) => {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        staleTime: Infinity,
-      },
-    },
-  });
-
-  return (
-    <ChakraProvider>
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <TimezoneProvider>{children}</TimezoneProvider>
-        </MemoryRouter>
-      </QueryClientProvider>
-    </ChakraProvider>
-  );
+type TimezoneModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
 };
+
+const TimezoneModal: React.FC<TimezoneModalProps> = ({ isOpen, onClose }) => (
+  <Modal isOpen={isOpen} onClose={onClose} size="xl">
+    <ModalOverlay />
+    <ModalContent>
+      <ModalHeader>Select Timezone</ModalHeader>
+      <ModalCloseButton />
+      <ModalBody>
+        <TimezoneSelector />
+      </ModalBody>
+    </ModalContent>
+  </Modal>
+);
+
+export default TimezoneModal;

--- a/airflow/ui/src/layouts/Nav/TimezoneSelector.tsx
+++ b/airflow/ui/src/layouts/Nav/TimezoneSelector.tsx
@@ -1,0 +1,89 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box, Text, VStack } from "@chakra-ui/react";
+import { Select, type SingleValue } from "chakra-react-select";
+import dayjs from "dayjs";
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
+import React, { useMemo } from "react";
+
+import { useTimezone } from "src/context/timezone";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+type TimezoneOption = {
+  label: string;
+  value: string;
+};
+
+const TimezoneSelector: React.FC = () => {
+  const { selectedTimezone, setSelectedTimezone } = useTimezone();
+  const timezones = useMemo<Array<string>>(() => {
+    const tzList = Intl.supportedValuesOf("timeZone");
+    const guessedTz = dayjs.tz.guess();
+    const uniqueTimezones = new Set([
+      "UTC",
+      ...(guessedTz ? [guessedTz] : []),
+      ...tzList,
+    ]);
+
+    return [...uniqueTimezones];
+  }, []);
+
+  const options = useMemo<Array<TimezoneOption>>(
+    () =>
+      timezones.map((tz) => ({
+        label: tz === "UTC" ? "UTC (Coordinated Universal Time)" : tz,
+        value: tz,
+      })),
+    [timezones],
+  );
+
+  const handleTimezoneChange = (
+    selectedOption: SingleValue<TimezoneOption>,
+  ) => {
+    if (selectedOption) {
+      setSelectedTimezone(selectedOption.value);
+    }
+  };
+
+  const currentTime = dayjs()
+    .tz(selectedTimezone)
+    .format("YYYY-MM-DD HH:mm:ss");
+
+  return (
+    <VStack align="stretch" spacing={6}>
+      <Select<TimezoneOption>
+        onChange={handleTimezoneChange}
+        options={options}
+        placeholder="Select a timezone"
+        value={options.find((option) => option.value === selectedTimezone)}
+      />
+      <Box borderRadius="md" boxShadow="md" p={6}>
+        <Text fontSize="lg" fontWeight="bold">
+          Current time in {selectedTimezone}:
+        </Text>
+        <Text fontSize="2xl">{currentTime}</Text>
+      </Box>
+    </VStack>
+  );
+};
+
+export default TimezoneSelector;

--- a/airflow/ui/src/layouts/Nav/UserSettingsButton.tsx
+++ b/airflow/ui/src/layouts/Nav/UserSettingsButton.tsx
@@ -23,13 +23,25 @@ import {
   useColorMode,
   MenuItem,
   MenuList,
+  useDisclosure,
 } from "@chakra-ui/react";
-import { FiMoon, FiSun, FiUser } from "react-icons/fi";
+import dayjs from "dayjs";
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
+import { FiClock, FiMoon, FiSun, FiUser } from "react-icons/fi";
 
+import { useTimezone } from "src/context/timezone";
+
+import TimezoneModal from "./TimezoneModal";
 import { navButtonProps } from "./navButtonProps";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 export const UserSettingsButton = () => {
   const { colorMode, toggleColorMode } = useColorMode();
+  const { isOpen, onClose, onOpen } = useDisclosure();
+  const { selectedTimezone } = useTimezone();
 
   return (
     <Menu placement="right">
@@ -52,7 +64,12 @@ export const UserSettingsButton = () => {
             </>
           )}
         </MenuItem>
+        <MenuItem onClick={onOpen}>
+          <FiClock size="1.25rem" style={{ marginRight: "8px" }} />
+          {dayjs().tz(selectedTimezone).format("HH:mm z (Z)")}
+        </MenuItem>
       </MenuList>
+      <TimezoneModal isOpen={isOpen} onClose={onClose} />
     </Menu>
   );
 };

--- a/airflow/ui/src/main.tsx
+++ b/airflow/ui/src/main.tsx
@@ -24,6 +24,7 @@ import { BrowserRouter } from "react-router-dom";
 
 import { App } from "src/App";
 
+import { TimezoneProvider } from "./context/timezone";
 import theme from "./theme";
 
 const queryClient = new QueryClient({
@@ -64,7 +65,9 @@ root.render(
   <BrowserRouter basename="/webapp">
     <ChakraProvider theme={theme}>
       <QueryClientProvider client={queryClient}>
-        <App />
+        <TimezoneProvider>
+          <App />
+        </TimezoneProvider>
       </QueryClientProvider>
     </ChakraProvider>
   </BrowserRouter>,

--- a/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -31,6 +31,7 @@ import {
 import { FiCalendar, FiTag } from "react-icons/fi";
 
 import type { DAGResponse } from "openapi/requests/types.gen";
+import Time from "src/components/Time";
 import { TogglePause } from "src/components/TogglePause";
 
 type Props = {
@@ -98,7 +99,9 @@ export const DagCard = ({ dag }: Props) => {
             Next Run
           </Heading>
           {Boolean(dag.next_dagrun) ? (
-            <Text fontSize="sm">{dag.next_dagrun}</Text>
+            <Text fontSize="sm">
+              <Time datetime={dag.next_dagrun} />
+            </Text>
           ) : undefined}
           {Boolean(dag.timetable_summary) ? (
             <Tooltip hasArrow label={dag.timetable_description}>

--- a/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -41,6 +41,7 @@ import type { CardDef } from "src/components/DataTable/types";
 import { useTableURLState } from "src/components/DataTable/useTableUrlState";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import { SearchBar } from "src/components/SearchBar";
+import Time from "src/components/Time";
 import { TogglePause } from "src/components/TogglePause";
 import {
   SearchParamsKeys,
@@ -82,6 +83,10 @@ const columns: Array<ColumnDef<DAGResponse>> = [
   },
   {
     accessorKey: "next_dagrun",
+    cell: ({ row: { original } }) =>
+      Boolean(original.next_dagrun) ? (
+        <Time datetime={original.next_dagrun} />
+      ) : undefined,
     enableSorting: false,
     header: "Next DAG Run",
   },

--- a/airflow/ui/src/pages/Dashboard/HealthTag.tsx
+++ b/airflow/ui/src/pages/Dashboard/HealthTag.tsx
@@ -18,6 +18,7 @@
  */
 import { Skeleton, Tag, TagLabel, Text, Tooltip } from "@chakra-ui/react";
 
+import Time from "src/components/Time";
 import { capitalize } from "src/utils";
 
 export const HealthTag = ({
@@ -42,7 +43,9 @@ export const HealthTag = ({
       label={
         <div>
           <Text>Status: {capitalize(status)}</Text>
-          <Text>Last Heartbeat: {latestHeartbeat}</Text>
+          <Text>
+            Last Heartbeat: <Time datetime={latestHeartbeat} />
+          </Text>
         </div>
       }
       shouldWrapChildren

--- a/airflow/ui/tsconfig.app.json
+++ b/airflow/ui/tsconfig.app.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
 


### PR DESCRIPTION
Let users specify their preferred timezone.

Add a Timezone context which reads and write to local storage, and passes the selected timezone down to all `<Time />` components. Also, always show UTC and the guessed TZ  at the top of the search list.

Closes #42817
Related #42821

<img width="355" alt="Screenshot 2024-10-17 at 4 41 44 PM" src="https://github.com/user-attachments/assets/278a5e94-fa30-4228-bc04-0c91eb003300">

<img width="614" alt="Screenshot 2024-10-17 at 4 41 48 PM" src="https://github.com/user-attachments/assets/6b2f2679-2564-48a6-a79c-f30210bf14b9">

<img width="493" alt="Screenshot 2024-10-17 at 4 41 57 PM" src="https://github.com/user-attachments/assets/26b6a26d-f439-44f6-b1ca-7f5351c83254">


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
