### PR TITLE
Add TimeoutError to be a retryable error in databricks provider

### DIFF
--- a/providers/src/airflow/providers/databricks/hooks/databricks_base.py
+++ b/providers/src/airflow/providers/databricks/hooks/databricks_base.py
@@ -28,13 +28,14 @@ from __future__ import annotations
 import copy
 import platform
 import time
+from asyncio.exceptions import TimeoutError
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit
 
 import aiohttp
 import requests
-from aiohttp.client_exceptions import ClientConnectorError, ServerTimeoutError
+from aiohttp.client_exceptions import ClientConnectorError
 from requests import PreparedRequest, exceptions as requests_exceptions
 from requests.auth import AuthBase, HTTPBasicAuth
 from requests.exceptions import JSONDecodeError
@@ -679,7 +680,7 @@ class BaseDatabricksHook(BaseHook):
             if exception.status >= 500 or exception.status == 429:
                 return True
 
-        if isinstance(exception, (ClientConnectorError, ServerTimeoutError)):
+        if isinstance(exception, (ClientConnectorError, TimeoutError)):
             return True
 
         return False

--- a/providers/src/airflow/providers/databricks/hooks/databricks_base.py
+++ b/providers/src/airflow/providers/databricks/hooks/databricks_base.py
@@ -34,7 +34,7 @@ from urllib.parse import urlsplit
 
 import aiohttp
 import requests
-from aiohttp.client_exceptions import ClientConnectorError
+from aiohttp.client_exceptions import ClientConnectorError, ServerTimeoutError
 from requests import PreparedRequest, exceptions as requests_exceptions
 from requests.auth import AuthBase, HTTPBasicAuth
 from requests.exceptions import JSONDecodeError
@@ -679,7 +679,7 @@ class BaseDatabricksHook(BaseHook):
             if exception.status >= 500 or exception.status == 429:
                 return True
 
-        if isinstance(exception, ClientConnectorError):
+        if isinstance(exception, (ClientConnectorError, ServerTimeoutError)):
             return True
 
         return False

--- a/providers/tests/databricks/hooks/test_databricks.py
+++ b/providers/tests/databricks/hooks/test_databricks.py
@@ -21,6 +21,7 @@ import itertools
 import json
 import ssl
 import time
+from asyncio.exceptions import TimeoutError
 from unittest import mock
 from unittest.mock import AsyncMock
 
@@ -1554,7 +1555,7 @@ class TestDatabricksHookAsyncMethods:
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.databricks.hooks.databricks_base.aiohttp.ClientSession.get")
     async def test_do_api_call_retries_with_client_timeout_error(self, mock_get):
-        mock_get.side_effect = aiohttp.ServerTimeoutError()
+        mock_get.side_effect = TimeoutError()
         with mock.patch.object(self.hook.log, "error") as mock_errors:
             async with self.hook:
                 with pytest.raises(AirflowException):


### PR DESCRIPTION
closes #43128 


`aiohttp.client_exception.ServerTimeoutError` extends `asyncio.exceptions.TimeoutError`. Hence, used `ServerTimeoutError` when checking for type using isinstance. That should cover `TimeoutError`