### PR TITLE
pin min opentelemetry-exporter-prometheus version

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -104,7 +104,7 @@ CORE_EXTRAS: dict[str, list[str]] = {
         "plyvel>=1.5.1",
     ],
     "otel": [
-        "opentelemetry-exporter-prometheus",
+        "opentelemetry-exporter-prometheus>=0.47b0",
     ],
     "pandas": [
         # In pandas 2.2 minimal version of the sqlalchemy is 2.0


### PR DESCRIPTION
Latest version of opentelemetry-exporter-prometheus is 0.48b. But there's another older release that happened within the past 6 months. So, using that as a min version. When using without a pin, we install 0.48b version. So, we can also go with 0.48b, if required.

related to #42989

