### PR TITLE
nit: remove taskgroup's tooltip from OL's AirflowJobFacet

### DIFF
--- a/providers/src/airflow/providers/openlineage/utils/utils.py
+++ b/providers/src/airflow/providers/openlineage/utils/utils.py
@@ -482,7 +482,6 @@ def _get_task_groups_details(dag: DAG) -> dict:
     return {
         tg_id: {
             "parent_group": tg.parent_group.group_id,
-            "tooltip": tg.tooltip,
             "ui_color": tg.ui_color,
             "ui_fgcolor": tg.ui_fgcolor,
             "ui_label": tg.label,

--- a/providers/tests/openlineage/utils/test_utils.py
+++ b/providers/tests/openlineage/utils/test_utils.py
@@ -79,7 +79,6 @@ def test_get_airflow_job_facet():
             taskGroups={
                 "section_1": {
                     "parent_group": None,
-                    "tooltip": "",
                     "ui_color": "CornflowerBlue",
                     "ui_fgcolor": "#000",
                     "ui_label": "section_1",
@@ -516,21 +515,18 @@ def test_get_task_groups_details():
     expected = {
         "tg1": {
             "parent_group": None,
-            "tooltip": "",
             "ui_color": "CornflowerBlue",
             "ui_fgcolor": "#000",
             "ui_label": "tg1",
         },
         "tg2": {
             "parent_group": None,
-            "tooltip": "",
             "ui_color": "CornflowerBlue",
             "ui_fgcolor": "#000",
             "ui_label": "tg2",
         },
         "tg3": {
             "parent_group": None,
-            "tooltip": "",
             "ui_color": "CornflowerBlue",
             "ui_fgcolor": "#000",
             "ui_label": "tg3",
@@ -551,21 +547,18 @@ def test_get_task_groups_details_nested():
     expected = {
         "tg1": {
             "parent_group": None,
-            "tooltip": "",
             "ui_color": "CornflowerBlue",
             "ui_fgcolor": "#000",
             "ui_label": "tg1",
         },
         "tg1.tg2": {
             "parent_group": "tg1",
-            "tooltip": "",
             "ui_color": "CornflowerBlue",
             "ui_fgcolor": "#000",
             "ui_label": "tg2",
         },
         "tg1.tg2.tg3": {
             "parent_group": "tg1.tg2",
-            "tooltip": "",
             "ui_color": "CornflowerBlue",
             "ui_fgcolor": "#000",
             "ui_label": "tg3",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Removing TaskGroup's tooltip from AirflowJobFacet that's included in DAG start event. The tooltip is already included in task level OpenLineage events and it might be long (docstring for taskflow API functions), so there is no need to duplicate that information. The DAG start event should only contain information necessary to deduce task dependencies and DAG structure, so the tooltip is not needed at that time.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
