### PR TITLE
[Backport] Always use logical date in DAG run header

### DIFF
--- a/airflow/www/static/js/utils/index.test.ts
+++ b/airflow/www/static/js/utils/index.test.ts
@@ -146,14 +146,14 @@ describe("Test getDagRunLabel", () => {
     note: "someRandomValue",
   } as DagRun;
 
-  test("Defaults to dataIntervalStart", async () => {
+  test("Defaults to executionDate", async () => {
     const runLabel = getDagRunLabel({ dagRun });
-    expect(runLabel).toBe(dagRun.dataIntervalStart);
+    expect(runLabel).toBe(dagRun.executionDate);
   });
 
   test("Passing an order overrides default", async () => {
-    const runLabel = getDagRunLabel({ dagRun, ordering: ["executionDate"] });
-    expect(runLabel).toBe(dagRun.executionDate);
+    const runLabel = getDagRunLabel({ dagRun, ordering: ["dataIntervalEnd"] });
+    expect(runLabel).toBe(dagRun.dataIntervalEnd);
   });
 });
 

--- a/airflow/www/static/js/utils/index.ts
+++ b/airflow/www/static/js/utils/index.ts
@@ -169,7 +169,7 @@ interface RunLabelProps {
 
 const getDagRunLabel = ({
   dagRun,
-  ordering = ["dataIntervalStart", "executionDate"],
+  ordering = ["executionDate"],
 }: RunLabelProps) => dagRun[ordering[0]] ?? dagRun[ordering[1]];
 
 const getStatusBackgroundColor = (color: string, hasNote: boolean) =>


### PR DESCRIPTION
This back ports #43148 to 2.