### PR TITLE
Fix side-effect of setting log handlers in tests

### DIFF
--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -1070,7 +1070,7 @@ class TestLoggerMutationHelper:
         assert tgt.propagate is False if target_name else True  # root propagate unchanged
         assert tgt.level == -1
 
-    def test_apply_no_replace(self):
+    def test_apply_no_replace(self, clear_all_logger_handlers):
         """
         Handlers, level and propagate should be applied on target.
         """

--- a/tests/jobs/test_triggerer_job.py
+++ b/tests/jobs/test_triggerer_job.py
@@ -49,6 +49,7 @@ from airflow.utils.types import DagRunType
 
 from tests.core.test_logging_config import reset_logging
 from tests_common.test_utils.db import clear_db_dags, clear_db_runs
+from tests_common.test_utils.log_handlers import non_pytest_handlers
 
 pytestmark = pytest.mark.db_test
 
@@ -771,9 +772,6 @@ def test_queue_listener():
     reset_logging()
     importlib.reload(airflow_local_settings)
     configure_logging()
-
-    def non_pytest_handlers(val):
-        return [h for h in val if "pytest" not in h.__module__]
 
     import logging
 

--- a/tests/jobs/test_triggerer_job_logging.py
+++ b/tests/jobs/test_triggerer_job_logging.py
@@ -32,22 +32,13 @@ from airflow.utils.log.logging_mixin import RedirectStdHandler
 from airflow.utils.log.trigger_handler import DropTriggerLogsFilter, TriggererHandlerWrapper
 
 from tests_common.test_utils.config import conf_vars
-
-
-def non_pytest_handlers(val):
-    return [h for h in val if "pytest" not in h.__module__]
+from tests_common.test_utils.log_handlers import non_pytest_handlers
 
 
 def assert_handlers(logger, *classes):
     handlers = non_pytest_handlers(logger.handlers)
     assert [x.__class__ for x in handlers] == list(classes or [])
     return handlers
-
-
-def clear_logger_handlers(log):
-    for h in log.handlers[:]:
-        if "pytest" not in h.__module__:
-            log.removeHandler(h)
 
 
 @pytest.fixture(autouse=True)
@@ -64,7 +55,6 @@ def test_configure_trigger_log_handler_file():
     """
     # reset logging
     root_logger = logging.getLogger()
-    clear_logger_handlers(root_logger)
     configure_logging()
 
     # before config
@@ -168,15 +158,12 @@ not_found_message = ["Could not find log handler suitable for individual trigger
         ("non_file_task_handler", logging.Handler, not_found_message),
     ],
 )
-def test_configure_trigger_log_handler_not_file_task_handler(cfg, cls, msg):
+def test_configure_trigger_log_handler_not_file_task_handler(cfg, cls, msg, clear_all_logger_handlers):
     """
     No root handler configured.
     When non FileTaskHandler is configured, don't modify.
     When an incompatible subclass of FileTaskHandler is configured, don't modify.
     """
-    # reset handlers
-    root_logger = logging.getLogger()
-    clear_logger_handlers(root_logger)
 
     with conf_vars(
         {
@@ -190,6 +177,7 @@ def test_configure_trigger_log_handler_not_file_task_handler(cfg, cls, msg):
         configure_logging()
 
     # no root handlers
+    root_logger = logging.getLogger()
     assert_handlers(root_logger)
 
     # default task logger
@@ -328,7 +316,7 @@ root_not_file_task = {
 }
 
 
-def test_configure_trigger_log_handler_root_not_file_task():
+def test_configure_trigger_log_handler_root_not_file_task(clear_all_logger_handlers):
     """
     root: A handler that doesn't support trigger or inherit FileTaskHandler
     task: Supports triggerer

--- a/tests_common/test_utils/log_handlers.py
+++ b/tests_common/test_utils/log_handlers.py
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+
+def non_pytest_handlers(handlers):
+    return [h for h in handlers if "pytest" not in h.__module__]


### PR DESCRIPTION
In some of our tests, handlers for loggers were set to the "logging.Handler()" and that created a side effect where when they were not cleaned by another test, they produced `NotImplementedError: emit must be implemented by Handler subclasses` message - because indeed `logging.Handler()` emit message raised NotImplementedError.

The problem was that those tests (and some others) cleaned-up the handlers only BEFORE the tests but not AFTER - so if it happened that the same "test worker" run another test afterwards, that cleaned the handlers but did not set the handlers back, the side effect was gone. But when xdist arranged the tests to different pytest workers, the Handlers could remain registered in loggers so other tests could attempt to emit some logs in case they logged something to a parent logger.

The fix applied is to create a fixture that cleans all loggers BEFORE and AFTER a test - and add the fixture to tests that modify handlers.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
