### PR TITLE
Add filter, sorting and pagination changes as dependency for API.

### DIFF
--- a/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -164,7 +164,7 @@ export const DagsList = () => {
       orderBy,
       paused: showPaused === null ? undefined : showPaused === "true",
     },
-    [dagDisplayNamePattern, showPaused],
+    [dagDisplayNamePattern, showPaused, lastDagRunState, pagination, orderBy],
     {
       refetchOnMount: true,
       refetchOnReconnect: false,


### PR DESCRIPTION
The API calls were not made on changing filters, sort and pagination since only changes to search and paused were declared as dependency to the API call. This PR adds all other parameters.

Ideally, I think changing from last dag run state from running to success and then changing it back to running should trigger another API call to filter by running so that users always see fresh data. There is no refresh button in the UI like legacy UI so either a refresh button should be added or each change should trigger an API call. This seems to be due to staleTime parameter added to the API call options.