### PR TITLE
Consider both commit authors and PR authors in status of testing issue

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -3476,6 +3476,22 @@ def generate_issue_content(
                 continue
 
             pull_requests[pr_number] = pr
+
+            # retrieve and append commit authors (to handle cherry picks)
+            if hasattr(pr, "get_commits"):
+                try:
+                    commits = pr.get_commits()
+                    for commit in commits:
+                        author = commit.author
+                        if author:
+                            users.setdefault(pr_number, set()).add(author.login)
+                            progress.console.print(f"Added commit author {author.login} for PR#{pr_number}")
+
+                except Exception as e:
+                    progress.console.print(
+                        f"[warn]Could not retrieve commits for PR#{pr_number}: {e}, skipping[/]"
+                    )
+
             # GitHub does not have linked issues in PR - but we quite rigorously add Fixes/Closes
             # Relate so we can find those from the body
             if pr.body:

--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -3484,7 +3484,7 @@ def generate_issue_content(
                     for commit in commits:
                         author = commit.author
                         if author:
-                            users.setdefault(pr_number, set()).add(author.login)
+                            users[pr_number].add(author.login)
                             progress.console.print(f"Added commit author {author.login} for PR#{pr_number}")
 
                 except Exception as e:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

For the status of testing issue like this one: https://github.com/apache/airflow/issues/41956, the cherry pick owner was only tagged in the testing issue but the cherry pick author can be different from the commit author. We should add and tag the commit authors too.

Output with the change:
```
We are kindly requesting that contributors to [Apache Airflow RC 2.10.1rc1](https://pypi.org/project/apache-airflow/2.10.1rc1/) help test the RC.

Please let us know by commenting if the issue is addressed in the latest RC.

- [ ] [Handle Example dags case when checking for missing files (#41856) (#41874)](https://github.com/apache/airflow/pull/41874): @utkarsharma2
     Linked issues:
     - [DAGs are not marked as stale if the AIRFLOW__CORE__DAGS_FOLDER changes (#41432)](https://github.com/apache/airflow/issues/41432)
- [ ] [Bump webpack from 5.76.0 to 5.94.0 in /airflow/www (#41864) (#41879)](https://github.com/apache/airflow/pull/41879): @potiuk
- [ ] [Adding tojson filter to example_inlet_event_extra example dag (#41873) (#41890)](https://github.com/apache/airflow/pull/41890): @potiuk @amoghrajesh
- [ ] [Make Scarf usage reporting in major+minor versions and counters in buckets (#41898) (#41900)](https://github.com/apache/airflow/pull/41900): @jscheffl
- [ ] [Add backcompat check for executors that don't inherit BaseExecutor (#… (#41927)](https://github.com/apache/airflow/pull/41927): @potiuk @dstandish
- [ ] [Protect against None components of universal pathlib xcom backend (#4… (#41938)](https://github.com/apache/airflow/pull/41938): @potiuk
     Linked issues:
     - [Universal-pathlib 0.2.3 seems to break compatibility with 0.2.2 (at least breaks mypy checks). (#41723)](https://github.com/apache/airflow/issues/41723)
- [ ] [Lower down universal-pathlib minimum to 0.2.2 (#41939) (#41943)](https://github.com/apache/airflow/pull/41943): @potiuk


Thanks to all who contributed to the release (probably not a complete list!):
@jscheffl @dependabot[bot] @potiuk @dstandish @utkarsharma2 @amoghrajesh
```

closes: #41969 

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
