### PR TITLE
[Edge] Add metrics export and reset state of Edge Worker after worker timeout

### DIFF
--- a/chart/files/statsd-mappings.yml
+++ b/chart/files/statsd-mappings.yml
@@ -112,33 +112,3 @@ mappings:
     name: "airflow_executor_running_tasks"
     labels:
       executor: "$1"
-
-  - match: airflow.edge_worker.heartbeat_count.*
-    name: "airflow_edge_worker_heartbeat_count"
-    labels:
-      worker_name: "$1"
-
-  - match: airflow.edge_worker.state.*
-    name: "airflow_edge_worker_state"
-    labels:
-      worker_name: "$1"
-
-  - match: airflow.edge_worker.jobs_active.*
-    name: "airflow_edge_worker_jobs_active"
-    labels:
-      worker_name: "$1"
-
-  - match: airflow.edge_worker.concurrency.*
-    name: "airflow_edge_worker_concurrency"
-    labels:
-      worker_name: "$1"
-
-  - match: airflow.edge_worker.num_queues.*
-    name: "airflow_edge_worker_num_queues"
-    labels:
-      worker_name: "$1"
-
-  - match: airflow.edge_worker.state.*
-    name: "airflow_edge_worker_state"
-    labels:
-      worker_name: "$1"

--- a/chart/files/statsd-mappings.yml
+++ b/chart/files/statsd-mappings.yml
@@ -137,7 +137,7 @@ mappings:
     name: "airflow_edge_worker_num_queues"
     labels:
       worker_name: "$1"
-      
+
   - match: airflow.edge_worker.state.*
     name: "airflow_edge_worker_state"
     labels:

--- a/chart/files/statsd-mappings.yml
+++ b/chart/files/statsd-mappings.yml
@@ -112,3 +112,33 @@ mappings:
     name: "airflow_executor_running_tasks"
     labels:
       executor: "$1"
+
+  - match: airflow.edge_worker.heartbeat_count.*
+    name: "airflow_edge_worker_heartbeat_count"
+    labels:
+      worker_name: "$1"
+
+  - match: airflow.edge_worker.state.*
+    name: "airflow_edge_worker_state"
+    labels:
+      worker_name: "$1"
+
+  - match: airflow.edge_worker.jobs_active.*
+    name: "airflow_edge_worker_jobs_active"
+    labels:
+      worker_name: "$1"
+
+  - match: airflow.edge_worker.concurrency.*
+    name: "airflow_edge_worker_concurrency"
+    labels:
+      worker_name: "$1"
+
+  - match: airflow.edge_worker.num_queues.*
+    name: "airflow_edge_worker_num_queues"
+    labels:
+      worker_name: "$1"
+      
+  - match: airflow.edge_worker.state.*
+    name: "airflow_edge_worker_state"
+    labels:
+      worker_name: "$1"

--- a/providers/src/airflow/providers/edge/CHANGELOG.rst
+++ b/providers/src/airflow/providers/edge/CHANGELOG.rst
@@ -33,7 +33,8 @@ Changelog
 Misc
 ~~~~
 
-* ``Edge Worker exports metrics and state is set to unkown if worker heartbeat timed out.``
+* ``Edge Worker exports metrics``
+* ``State is set to unknown if worker heartbeat times out.``
 
 0.2.2re0
 .........

--- a/providers/src/airflow/providers/edge/CHANGELOG.rst
+++ b/providers/src/airflow/providers/edge/CHANGELOG.rst
@@ -33,7 +33,7 @@ Changelog
 Misc
 ~~~~
 
-* ``Edge Worker state is updated if worker disconnect.``
+* ``Edge Worker state is set ot unkown if worker heartbeat timed out.``
 
 0.2.2re0
 .........

--- a/providers/src/airflow/providers/edge/CHANGELOG.rst
+++ b/providers/src/airflow/providers/edge/CHANGELOG.rst
@@ -27,6 +27,14 @@
 Changelog
 ---------
 
+0.3.0pre0
+.........
+
+Misc
+~~~~
+
+* ``Edge Worker state is updated if worker disconnect.``
+
 0.2.2re0
 .........
 

--- a/providers/src/airflow/providers/edge/CHANGELOG.rst
+++ b/providers/src/airflow/providers/edge/CHANGELOG.rst
@@ -33,7 +33,7 @@ Changelog
 Misc
 ~~~~
 
-* ``Edge Worker state is set ot unkown if worker heartbeat timed out.``
+* ``Edge Worker exports metrics and state is set to unkown if worker heartbeat timed out.``
 
 0.2.2re0
 .........

--- a/providers/src/airflow/providers/edge/__init__.py
+++ b/providers/src/airflow/providers/edge/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.0pre0"
+__version__ = "0.3.0pre0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.10.0"

--- a/providers/src/airflow/providers/edge/executors/edge_executor.py
+++ b/providers/src/airflow/providers/edge/executors/edge_executor.py
@@ -96,6 +96,7 @@ class EdgeExecutor(BaseExecutor):
             session.query(EdgeWorkerModel)
             .filter(
                 EdgeWorkerModel.state != EdgeWorkerState.UNKNOWN
+                and EdgeWorkerModel.state != EdgeWorkerState.OFFLINE
                 and EdgeWorkerModel.last_update
                 < (timezone.utcnow() - timedelta(seconds=heartbeat_interval * 5))
             )

--- a/providers/src/airflow/providers/edge/executors/edge_executor.py
+++ b/providers/src/airflow/providers/edge/executors/edge_executor.py
@@ -95,8 +95,7 @@ class EdgeExecutor(BaseExecutor):
         lifeless_workers: list[EdgeWorkerModel] = (
             session.query(EdgeWorkerModel)
             .filter(
-                EdgeWorkerModel.state != EdgeWorkerState.UNKNOWN
-                and EdgeWorkerModel.state != EdgeWorkerState.OFFLINE
+                EdgeWorkerModel.state not in (EdgeWorkerState.UNKNOWN, EdgeWorkerState.OFFLINE)
                 and EdgeWorkerModel.last_update
                 < (timezone.utcnow() - timedelta(seconds=heartbeat_interval * 5))
             )

--- a/providers/src/airflow/providers/edge/executors/edge_executor.py
+++ b/providers/src/airflow/providers/edge/executors/edge_executor.py
@@ -95,9 +95,8 @@ class EdgeExecutor(BaseExecutor):
         lifeless_workers: list[EdgeWorkerModel] = (
             session.query(EdgeWorkerModel)
             .filter(
-                EdgeWorkerModel.state not in (EdgeWorkerState.UNKNOWN, EdgeWorkerState.OFFLINE)
-                and EdgeWorkerModel.last_update
-                < (timezone.utcnow() - timedelta(seconds=heartbeat_interval * 5))
+                EdgeWorkerModel.state.not_in([EdgeWorkerState.UNKNOWN, EdgeWorkerState.OFFLINE]),
+                EdgeWorkerModel.last_update < (timezone.utcnow() - timedelta(seconds=heartbeat_interval * 5)),
             )
             .all()
         )

--- a/providers/src/airflow/providers/edge/executors/edge_executor.py
+++ b/providers/src/airflow/providers/edge/executors/edge_executor.py
@@ -105,7 +105,7 @@ class EdgeExecutor(BaseExecutor):
         for worker in lifeless_workers:
             changed = True
             worker.state = EdgeWorkerState.UNKNOWN
-            session.add(worker)
+            session.update(worker)
             EdgeWorker.reset_metrics(worker.worker_name)
 
         return changed

--- a/providers/src/airflow/providers/edge/executors/edge_executor.py
+++ b/providers/src/airflow/providers/edge/executors/edge_executor.py
@@ -30,7 +30,9 @@ from airflow.models.taskinstance import TaskInstanceState
 from airflow.providers.edge.cli.edge_command import EDGE_COMMANDS
 from airflow.providers.edge.models.edge_job import EdgeJobModel
 from airflow.providers.edge.models.edge_logs import EdgeLogsModel
-from airflow.providers.edge.models.edge_worker import EdgeWorkerModel
+from airflow.providers.edge.models.edge_worker import EdgeWorkerModel, EdgeWorkerState
+from airflow.stats import Stats
+from airflow.utils import timezone
 from airflow.utils.db import DBLocks, create_global_lock
 from airflow.utils.session import NEW_SESSION, provide_session
 
@@ -86,9 +88,32 @@ class EdgeExecutor(BaseExecutor):
             )
         )
 
-    @provide_session
-    def sync(self, session: Session = NEW_SESSION) -> None:
-        """Sync will get called periodically by the heartbeat method."""
+    def _check_alive_worker(self, session: Session) -> bool:
+        """Reset worker state if heartbeat timed out."""
+        changed = False
+        heartbeat_interval: int = conf.getint("edge", "heartbeat_interval")
+        workers: list[EdgeWorkerModel] = session.query(EdgeWorkerModel).all()
+
+        for worker in workers:
+            connected = 1
+            if not worker.last_update or worker.last_update < (
+                timezone.utcnow() - timedelta(seconds=heartbeat_interval * 5)
+            ):
+                changed = True
+                connected = 0
+                worker.state = EdgeWorkerState.UNKNOWN
+                session.add(worker)
+
+            Stats.gauge(
+                "edge_worker.state",
+                connected,
+                tags={"worker_name": worker.worker_name, "state": worker.state},
+            )
+
+        return changed
+
+    def _purge_jobs(self, session: Session) -> bool:
+        """Clean finished jobs."""
         purged_marker = False
         job_success_purge = conf.getint("edge", "job_success_purge")
         job_fail_purge = conf.getint("edge", "job_fail_purge")
@@ -140,7 +165,13 @@ class EdgeExecutor(BaseExecutor):
                         EdgeLogsModel.try_number == job.try_number,
                     )
                 )
-        if purged_marker:
+
+        return purged_marker
+
+    @provide_session
+    def sync(self, session: Session = NEW_SESSION) -> None:
+        """Sync will get called periodically by the heartbeat method."""
+        if self._purge_jobs(session) or self._check_alive_worker(session):
             session.commit()
 
     def end(self) -> None:

--- a/providers/src/airflow/providers/edge/executors/edge_executor.py
+++ b/providers/src/airflow/providers/edge/executors/edge_executor.py
@@ -105,7 +105,6 @@ class EdgeExecutor(BaseExecutor):
         for worker in lifeless_workers:
             changed = True
             worker.state = EdgeWorkerState.UNKNOWN
-            session.update(worker)
             EdgeWorker.reset_metrics(worker.worker_name)
 
         return changed

--- a/providers/src/airflow/providers/edge/models/edge_worker.py
+++ b/providers/src/airflow/providers/edge/models/edge_worker.py
@@ -277,8 +277,8 @@ class EdgeWorker(BaseModel, LoggingMixin):
         Stats.incr("edge_worker.heartbeat_count", 1, 1, tags={"worker_name": worker_name})
         EdgeWorker.set_metrics(
             worker_name=worker_name,
-            state=EdgeWorkerState.UNKNOWN,
-            connected=False,
+            state=state,
+            connected=True,
             jobs_active=jobs_active,
             concurrency=int(sysinfo["concurrency"]),
             queues=worker.queues,

--- a/providers/src/airflow/providers/edge/models/edge_worker.py
+++ b/providers/src/airflow/providers/edge/models/edge_worker.py
@@ -279,7 +279,7 @@ class EdgeWorker(BaseModel, LoggingMixin):
             state=EdgeWorkerState.UNKNOWN,
             connected=False,
             jobs_active=jobs_active,
-            concurrency=sysinfo["concurrency"],
+            concurrency=int(sysinfo["concurrency"]),
             queues=worker.queues,
         )
         return worker.queues

--- a/providers/src/airflow/providers/edge/models/edge_worker.py
+++ b/providers/src/airflow/providers/edge/models/edge_worker.py
@@ -273,6 +273,7 @@ class EdgeWorker(BaseModel, LoggingMixin):
         worker.sysinfo = json.dumps(sysinfo)
         worker.last_update = timezone.utcnow()
         session.commit()
+        Stats.incr(f"edge_worker.heartbeat_count.{worker_name}", 1, 1)
         Stats.incr("edge_worker.heartbeat_count", 1, 1, tags={"worker_name": worker_name})
         EdgeWorker.set_metrics(
             worker_name=worker_name,

--- a/providers/src/airflow/providers/edge/provider.yaml
+++ b/providers/src/airflow/providers/edge/provider.yaml
@@ -26,7 +26,7 @@ state: not-ready
 source-date-epoch: 1729683247
 # note that those versions are maintained by release manager - do not update them manually
 versions:
-  - 0.2.2pre0
+  - 0.3.0pre0
 
 dependencies:
   - apache-airflow>=2.10.0

--- a/providers/src/airflow/providers/edge/provider.yaml
+++ b/providers/src/airflow/providers/edge/provider.yaml
@@ -24,6 +24,7 @@ description: |
 
 state: not-ready
 source-date-epoch: 1729683247
+
 # note that those versions are maintained by release manager - do not update them manually
 versions:
   - 0.3.0pre0

--- a/providers/tests/edge/executors/test_edge_executor.py
+++ b/providers/tests/edge/executors/test_edge_executor.py
@@ -162,7 +162,6 @@ class TestEdgeExecutor:
         with create_session() as session:
             for worker_name, last_heartbeat in [
                 ("inactive_timed_out_worker", datetime(2023, 1, 1, 0, 59, 0, tzinfo=timezone.utc)),
-                ("inactive_not_connected_worker", None),
                 ("active_worker", datetime(2023, 1, 1, 0, 59, 10, tzinfo=timezone.utc)),
             ]:
                 session.add(


### PR DESCRIPTION
# Description

This PR enables the Edgeworker with metrics output to get live date of the state of the worker on a Dashboard. The PR also enables the EdgeExecutor to check if the Worker is still connected. If not then the state is reseted to UNKNOWN. 

# Details about changes 

* Exports the following metrics:
  * edge_executor.sync.duration: measures the duration of the  sync call of the edge executor
  * edge_worker.heartbeat_count: Heartbeat counter whihc is increased every time the heatbeat was received
  * edge_worker.state: 0 -> shows worker is disconnected, 1 shows worker is connected. tag shows details nameing of the state.
  * edge_worker.jobs_active: shows number of active jobs on this worker
  * edge_worker.concurrency: shows the current concurrency value of the worker
  * edge_worker.num_queues: shows the number of queues and tags contains queue names
* If 5 times the heatbeat was not received the heatbeat the state is set to UNKNOW.
* If worker disconnected the gauge metrics are reseted.

# Background information about metrics

As the tags are ignored in the statsd exporting and open telemetry is not enabled by default I orientated me on the implementation of dag_processing.last_duration like (https://github.com/apache/airflow/blob/main/airflow/dag_processing/manager.py#L1173) So currently double export. Hope we can get delete this in the future.