### PR TITLE
Update cloudant versions to be py-version aware so `uv lock` can work.

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -353,7 +353,7 @@
   "cloudant": {
     "deps": [
       "apache-airflow>=2.8.0",
-      "ibmcloudant>=0.9.1"
+      "ibmcloudant==0.9.1 ; python_version >= \"3.10\""
     ],
     "devel-deps": [],
     "plugins": [],

--- a/providers/src/airflow/providers/cloudant/provider.yaml
+++ b/providers/src/airflow/providers/cloudant/provider.yaml
@@ -48,7 +48,9 @@ versions:
 
 dependencies:
   - apache-airflow>=2.8.0
-  - ibmcloudant>=0.9.1
+  # Even though 3.9 is excluded below, we need to make this python_version aware so that `uv` can generate a
+  # full lock file when building lock file from provider sources
+  - 'ibmcloudant==0.9.1 ; python_version >= "3.10"'
 
 excluded-python-versions:
   # ibmcloudant transitively brings in urllib3 2.x, but the snowflake provider has a dependency that pins


### PR DESCRIPTION
We already have this:

```yaml
excluded-python-versions:
  # ibmcloudant transitively brings in urllib3 2.x, but the snowflake provider has a dependency that pins
  # urllib3 to 1.x on Python 3.9; thus we exclude those Python versions from taking the update
  # to ibmcloudant.
  # See #21004, #41555, and https://github.com/snowflakedb/snowflake-connector-python/issues/2016
  - "3.9"
```


However when uv is looking at requirements it doesn't/can't respect this field, so we have to make
the dependency aware of python version too.

This makes `uv lock` and `uv sync` both worth, which should be the required
step for switching uv to the local venv workflow.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
