### PR TITLE
Asset timetable summary should display assets on which it's scheduled

### DIFF
--- a/airflow/timetables/simple.py
+++ b/airflow/timetables/simple.py
@@ -174,7 +174,7 @@ class AssetTriggeredTimetable(_TrivialTimetable):
         if not next(self.asset_condition.iter_assets(), False):
             self._summary = AssetTriggeredTimetable.UNRESOLVED_ALIAS_SUMMARY
         else:
-            self._summary = "Asset"
+            self._summary = self.asset_condition.summary()
 
     @classmethod
     def deserialize(cls, data: dict[str, Any]) -> Timetable:


### PR DESCRIPTION
Currently, timetables expose `summary`:

```
        This is used to display the timetable in the web UI. A cron expression
        timetable, for example, can use this to display the expression. The
        default implementation returns the timetable's type name.
```

However, `AssetTriggeredTimetable`'s summary is not very useful: while different `DataIntervalTimetable` expose the data interval on which the timetable was created, `AssetTriggeredTimetable`'s summary does not display assets on which the DAG will be scheduled.

I think the potential contention might be the multiple condition naming: would appreciate comments on what would be the most clear name. 