### PR TITLE
More correctly work around `uv sync` issue with python 3.10+ only dep

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -353,6 +353,7 @@
   "cloudant": {
     "deps": [
       "apache-airflow>=2.8.0",
+      "ibmcloudant==0.7.0 ; python_version < \"3.10\"",
       "ibmcloudant==0.9.1 ; python_version >= \"3.10\""
     ],
     "devel-deps": [],

--- a/providers/src/airflow/providers/cloudant/provider.yaml
+++ b/providers/src/airflow/providers/cloudant/provider.yaml
@@ -48,9 +48,11 @@ versions:
 
 dependencies:
   - apache-airflow>=2.8.0
-  # Even though 3.9 is excluded below, we need to make this python_version aware so that `uv` can generate a
-  # full lock file when building lock file from provider sources
+  # Even though 3.9 is excluded below, we need to make this python_version aware so that `uv` (at least as of
+  # 0.4.25) can generate a full lock file when building lock file from provider sources. Seeing the duplicate
+  # dep makes the UV resolver correctly "fork" and try to come up with alternative solutions.
   - 'ibmcloudant==0.9.1 ; python_version >= "3.10"'
+  - 'ibmcloudant==0.7.0 ; python_version < "3.10"'
 
 excluded-python-versions:
   # ibmcloudant transitively brings in urllib3 2.x, but the snowflake provider has a dependency that pins

--- a/providers/src/airflow/providers/cloudant/provider.yaml
+++ b/providers/src/airflow/providers/cloudant/provider.yaml
@@ -51,6 +51,7 @@ dependencies:
   # Even though 3.9 is excluded below, we need to make this python_version aware so that `uv` (at least as of
   # 0.4.25) can generate a full lock file when building lock file from provider sources. Seeing the duplicate
   # dep makes the UV resolver correctly "fork" and try to come up with alternative solutions.
+  # https://github.com/astral-sh/uv/issues/4668
   - 'ibmcloudant==0.9.1 ; python_version >= "3.10"'
   - 'ibmcloudant==0.7.0 ; python_version < "3.10"'
 


### PR DESCRIPTION
Just having the python_version requirement doesn't seem to correctly make uv
"fork" the resolver path (Charlie's words/terms), so we either need to specify
both module versions here. The other option that could work is putting this in
our pyproject.toml

```
[tool.uv]
environments = ["python_version >= '3.10'", "python_version < '3.10'"]
```

But having both versions specified keeps the fix localized into the provider
so I have chosen this approach.

This is likely why the `exclued-python-version` setting we already had wasn't working for `uv sync`.