### PR TITLE
Fix dependency check to trove-classifiers... again

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ requires = [
     "pluggy==1.5.0",
     "smmap==5.0.1",
     "tomli==2.0.2; python_version < '3.11'",
-    "trove-classifiers==2024.10.16",
+    "trove-classifiers==2024.10.21.16",
 ]
 build-backend = "hatchling.build"
 


### PR DESCRIPTION
Another round of... fix update dependencies.

Broken run: https://github.com/apache/airflow/actions/runs/11446734942/job/31846579090