### PR TITLE
Temporarily limits WTForms to below 3.2.0

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -376,9 +376,16 @@ DEPENDENCIES = [
     "fastapi[standard]>=0.112.2",
     "flask-caching>=2.0.0",
     # Flask-Session 0.6 add new arguments into the SqlAlchemySessionInterface constructor as well as
-    # all parameters now are mandatory which make AirflowDatabaseSessionInterface incopatible with this version.
+    # all parameters now are mandatory which make AirflowDatabaseSessionInterface incompatible with this version.
     "flask-session>=0.4.0,<0.6",
     "flask-wtf>=1.1.0",
+    # WTForms are limited to 3.2.0 because of the error in tests. We technically do not need it directly
+    # as this is a dependency of Flask-WTF, but we need to specify it here to add the limitation
+    # The issue to track it is https://github.com/pallets-eco/wtforms/issues/863
+    # Note. 3.2.0 has been broken because of imports https://github.com/pallets-eco/wtforms/issues/861 which
+    # was fixed in 3.2.1, but after import was fixed, the tests started to work with 3.2.1
+    # when the issue 863 is fixed, we should likely leave the line below and specify !=3.2.0,!=3.2.1
+    "wtforms>=3.1.0,<3.2.0",
     # Flask 2.3 is scheduled to introduce a number of deprecation removals - some of them might be breaking
     # for our dependencies - notably `_app_ctx_stack` and `_request_ctx_stack` removals.
     # We should remove the limitation after 2.3 is released and our dependencies are updated to handle it


### PR DESCRIPTION
WTForms are limited to 3.2.0 because of the error in tests. We technically do not need it directly as this is a dependency of Flask-WTF, but we need to specify it here to add the limitation The issue to track it is https://github.com/pallets-eco/flask-wtf/issues/608 Note. 3.2.0 has been broken because of imports https://github.com/pallets-eco/wtforms/issues/861 which was fixed in 3.2.1, but after import was fixed, the tests started to work with 3.2.1 when the issue 863 is fixed, we should likely leave the line below and specify !=3.2.0,!=3.2.1

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
