### PR TITLE
Implement basic backfill dry run

### DIFF
--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -325,6 +325,11 @@ ARG_MAX_ACTIVE_RUNS = Arg(
     type=positive_int(allow_zero=False),
     help="Max active runs for this backfill.",
 )
+ARG_BACKFILL_DRY_RUN = Arg(
+    ("--dry-run",),
+    help="Perform a dry run",
+    action="store_true",
+)
 
 
 # misc
@@ -1030,6 +1035,7 @@ BACKFILL_COMMANDS = (
             ARG_DAG_RUN_CONF,
             ARG_RUN_BACKWARDS,
             ARG_MAX_ACTIVE_RUNS,
+            ARG_BACKFILL_DRY_RUN,
         ),
     ),
 )

--- a/airflow/cli/commands/backfill_command.py
+++ b/airflow/cli/commands/backfill_command.py
@@ -34,11 +34,21 @@ def create_backfill(args) -> None:
     logging.basicConfig(level=settings.LOGGING_LEVEL, format=settings.SIMPLE_LOG_FORMAT)
     signal.signal(signal.SIGTERM, sigint_handler)
 
-    _create_backfill(
+    params = dict(
         dag_id=args.dag,
         from_date=args.from_date,
         to_date=args.to_date,
         max_active_runs=args.max_active_runs,
         reverse=args.run_backwards,
         dag_run_conf=args.dag_run_conf,
+        dry_run=args.dry_run,
     )
+    obj = _create_backfill(**params)
+    print("Performing dry run of backfill.")
+    print("Printing params:")
+    for k, v in params.items():
+        print(f"    - {k} = {v}")
+    if isinstance(obj, list):
+        print("Logical dates:")
+        for info in obj:
+            print(f"    - {info.logical_date}")

--- a/airflow/cli/commands/backfill_command.py
+++ b/airflow/cli/commands/backfill_command.py
@@ -29,7 +29,7 @@ from airflow.utils.providers_configuration_loader import providers_configuration
 from airflow.utils.session import create_session
 
 
-def _do_dry_run(*, params, dag_id, from_date, to_date):
+def _do_dry_run(*, params, dag_id, from_date, to_date, reverse):
     print("Performing dry run of backfill.")
     print("Printing params:")
     for k, v in params.items():
@@ -41,6 +41,7 @@ def _do_dry_run(*, params, dag_id, from_date, to_date):
         dag=serdag.dag,
         from_date=from_date,
         to_date=to_date,
+        reverse=reverse,
     )
     print("Logical dates to be attempted:")
     for info in info_list:
@@ -54,6 +55,22 @@ def create_backfill(args) -> None:
     logging.basicConfig(level=settings.LOGGING_LEVEL, format=settings.SIMPLE_LOG_FORMAT)
     signal.signal(signal.SIGTERM, sigint_handler)
 
+    if args.dry_run:
+        _do_dry_run(
+            params=dict(
+                dag_id=args.dag,
+                from_date=args.from_date,
+                to_date=args.to_date,
+                max_active_runs=args.max_active_runs,
+                reverse=args.run_backwards,
+                dag_run_conf=args.dag_run_conf,
+            ),
+            dag_id=args.dag,
+            from_date=args.from_date,
+            to_date=args.to_date,
+            reverse=args.run_backwards,
+        )
+        return
     _create_backfill(
         dag_id=args.dag,
         from_date=args.from_date,

--- a/airflow/cli/commands/backfill_command.py
+++ b/airflow/cli/commands/backfill_command.py
@@ -21,10 +21,30 @@ import logging
 import signal
 
 from airflow import settings
-from airflow.models.backfill import _create_backfill
+from airflow.models.backfill import _create_backfill, _get_info_list
+from airflow.models.serialized_dag import SerializedDagModel
 from airflow.utils import cli as cli_utils
 from airflow.utils.cli import sigint_handler
 from airflow.utils.providers_configuration_loader import providers_configuration_loaded
+from airflow.utils.session import create_session
+
+
+def _do_dry_run(*, params, dag_id, from_date, to_date):
+    print("Performing dry run of backfill.")
+    print("Printing params:")
+    for k, v in params.items():
+        print(f"    - {k} = {v}")
+    with create_session() as session:
+        serdag = session.get(SerializedDagModel, dag_id)
+
+    info_list = _get_info_list(
+        dag=serdag.dag,
+        from_date=from_date,
+        to_date=to_date,
+    )
+    print("Logical dates to be attempted:")
+    for info in info_list:
+        print(f"    - {info.logical_date}")
 
 
 @cli_utils.action_cli
@@ -34,21 +54,11 @@ def create_backfill(args) -> None:
     logging.basicConfig(level=settings.LOGGING_LEVEL, format=settings.SIMPLE_LOG_FORMAT)
     signal.signal(signal.SIGTERM, sigint_handler)
 
-    params = dict(
+    _create_backfill(
         dag_id=args.dag,
         from_date=args.from_date,
         to_date=args.to_date,
         max_active_runs=args.max_active_runs,
         reverse=args.run_backwards,
         dag_run_conf=args.dag_run_conf,
-        dry_run=args.dry_run,
     )
-    obj = _create_backfill(**params)
-    print("Performing dry run of backfill.")
-    print("Printing params:")
-    for k, v in params.items():
-        print(f"    - {k} = {v}")
-    if isinstance(obj, list):
-        print("Logical dates:")
-        for info in obj:
-            print(f"    - {info.logical_date}")

--- a/airflow/models/backfill.py
+++ b/airflow/models/backfill.py
@@ -44,8 +44,6 @@ from airflow.utils.types import DagRunTriggeredByType, DagRunType
 if TYPE_CHECKING:
     from datetime import datetime
 
-    from airflow.timetables.base import DagRunInfo
-
 
 log = logging.getLogger(__name__)
 
@@ -192,7 +190,7 @@ def _create_backfill(
     max_active_runs: int,
     reverse: bool,
     dag_run_conf: dict | None,
-) -> Backfill | None | list[DagRunInfo]:
+) -> Backfill | None:
     from airflow.models.serialized_dag import SerializedDagModel
 
     with create_session() as session:


### PR DESCRIPTION
Add simple dry run functionality.  Does not check whether these runs exist.  Just doing the basic thing first.  Sample console output

```
Performing dry run of backfill.
Printing params:
    - dag_id = example_bash_operator
    - from_date = 2021-01-01 00:00:00+00:00
    - to_date = 2021-02-01 00:00:00+00:00
    - max_active_runs = None
    - reverse = False
    - dag_run_conf = None
    - dry_run = True
Logical dates:
    - 2021-01-01 00:00:00+00:00
    - 2021-01-02 00:00:00+00:00
    - 2021-01-03 00:00:00+00:00
    - 2021-01-04 00:00:00+00:00
    - 2021-01-05 00:00:00+00:00
    - 2021-01-06 00:00:00+00:00
    - 2021-01-07 00:00:00+00:00
    - 2021-01-08 00:00:00+00:00
    - 2021-01-09 00:00:00+00:00
    - 2021-01-10 00:00:00+00:00
    - 2021-01-11 00:00:00+00:00
    - 2021-01-12 00:00:00+00:00
    - 2021-01-13 00:00:00+00:00
    - 2021-01-14 00:00:00+00:00
    - 2021-01-15 00:00:00+00:00
    - 2021-01-16 00:00:00+00:00
    - 2021-01-17 00:00:00+00:00
    - 2021-01-18 00:00:00+00:00
    - 2021-01-19 00:00:00+00:00
    - 2021-01-20 00:00:00+00:00
    - 2021-01-21 00:00:00+00:00
    - 2021-01-22 00:00:00+00:00
    - 2021-01-23 00:00:00+00:00
    - 2021-01-24 00:00:00+00:00
    - 2021-01-25 00:00:00+00:00
    - 2021-01-26 00:00:00+00:00
    - 2021-01-27 00:00:00+00:00
    - 2021-01-28 00:00:00+00:00
    - 2021-01-29 00:00:00+00:00
    - 2021-01-30 00:00:00+00:00
    - 2021-01-31 00:00:00+00:00
    - 2021-02-01 00:00:00+00:00
```

