### PR TITLE
Upgrade FAB to 4.5.1

### DIFF
--- a/airflow/www/security_manager.py
+++ b/airflow/www/security_manager.py
@@ -108,8 +108,9 @@ class AirflowSecurityManagerV2(LoggingMixin):
         g.user = get_auth_manager().get_user()
 
     def create_limiter(self) -> Limiter:
-        limiter = Limiter(key_func=get_remote_address)
-        limiter.init_app(self.appbuilder.get_app)
+        app = self.appbuilder.get_app
+        limiter = Limiter(key_func=app.config.get("RATELIMIT_KEY_FUNC", get_remote_address))
+        limiter.init_app(app)
         return limiter
 
     def register_views(self):

--- a/dev/breeze/tests/test_packages.py
+++ b/dev/breeze/tests/test_packages.py
@@ -169,7 +169,7 @@ def test_get_documentation_package_path():
             """
     "apache-airflow-providers-common-compat>=1.2.1",
     "apache-airflow>=2.9.0",
-    "flask-appbuilder==4.5.0",
+    "flask-appbuilder==4.5.1",
     "flask-login>=0.6.2",
     "flask>=2.2,<2.3",
     "google-re2>=1.0",
@@ -183,7 +183,7 @@ def test_get_documentation_package_path():
             """
     "apache-airflow-providers-common-compat>=1.2.1.dev0",
     "apache-airflow>=2.9.0.dev0",
-    "flask-appbuilder==4.5.0",
+    "flask-appbuilder==4.5.1",
     "flask-login>=0.6.2",
     "flask>=2.2,<2.3",
     "google-re2>=1.0",
@@ -197,7 +197,7 @@ def test_get_documentation_package_path():
             """
     "apache-airflow-providers-common-compat>=1.2.1b0",
     "apache-airflow>=2.9.0b0",
-    "flask-appbuilder==4.5.0",
+    "flask-appbuilder==4.5.1",
     "flask-login>=0.6.2",
     "flask>=2.2,<2.3",
     "google-re2>=1.0",

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -572,7 +572,7 @@
     "deps": [
       "apache-airflow-providers-common-compat>=1.2.1",
       "apache-airflow>=2.9.0",
-      "flask-appbuilder==4.5.0",
+      "flask-appbuilder==4.5.1",
       "flask-login>=0.6.2",
       "flask>=2.2,<2.3",
       "google-re2>=1.0",

--- a/providers/src/airflow/providers/fab/provider.yaml
+++ b/providers/src/airflow/providers/fab/provider.yaml
@@ -55,7 +55,7 @@ dependencies:
   # Every time we update FAB version here, please make sure that you review the classes and models in
   # `airflow/providers/fab/auth_manager/security_manager/override.py` with their upstream counterparts.
   # In particular, make sure any breaking changes, for example any new methods, are accounted for.
-  - flask-appbuilder==4.5.0
+  - flask-appbuilder==4.5.1
   - flask-login>=0.6.2
   - google-re2>=1.0
   - jmespath>=0.7.0


### PR DESCRIPTION
FAB 4.5.1 has been released in September with a few small fixes. This change updates fab to 4.5.1 including changing the rate limiter creation that is vendored in. It has been changed in https://github.com/dpgaspar/Flask-AppBuilder/pull/2254 and relased in 4.5.1. That's the only dfference in security manager between 4.5.0 and 4.5.1.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
