### PR TITLE
Fixes behaviour of example dag tests for main/other branches

### DIFF
--- a/tests/always/test_example_dags.py
+++ b/tests/always/test_example_dags.py
@@ -114,7 +114,14 @@ def get_python_excluded_providers_folders() -> list[str]:
 
 
 def example_not_excluded_dags(xfail_db_exception: bool = False):
-    example_dirs = ["airflow/**/example_dags/example_*.py", "tests/system/**/example_*.py"]
+    example_dirs = [
+        "airflow/**/example_dags/example_*.py",
+        "tests/system/**/example_*.py",
+        "providers/**/example_*.py",
+    ]
+
+    default_branch = os.environ.get("DEFAULT_BRANCH", "main")
+    include_providers = default_branch == "main"
 
     suspended_providers_folders = get_suspended_providers_folders()
     current_python_excluded_providers_folders = get_python_excluded_providers_folders()
@@ -129,14 +136,7 @@ def example_not_excluded_dags(xfail_db_exception: bool = False):
         for provider in current_python_excluded_providers_folders
     ]
     providers_folders = tuple([AIRFLOW_SOURCES_ROOT.joinpath(pp).as_posix() for pp in PROVIDERS_PREFIXES])
-
-    default_branch = os.environ.get("DEFAULT_BRANCH", "main")
-    include_providers = default_branch == "main"
-
     for example_dir in example_dirs:
-        if not include_providers and "providers/" in example_dir:
-            print(f"Skipping {example_dir} because providers are not included for {default_branch} branch.")
-            continue
         candidates = glob(f"{AIRFLOW_SOURCES_ROOT.as_posix()}/{example_dir}", recursive=True)
         for candidate in sorted(candidates):
             param_marks = []
@@ -157,6 +157,11 @@ def example_not_excluded_dags(xfail_db_exception: bool = False):
                             param_marks.append(pytest.mark.skip(reason=reason))
 
             if candidate.startswith(providers_folders):
+                if not include_providers:
+                    print(
+                        f"Skipping {candidate} because providers are not included for {default_branch} branch."
+                    )
+                    continue
                 # Do not raise an error for airflow.exceptions.RemovedInAirflow3Warning.
                 # We should not rush to enforce new syntax updates in providers
                 # because a version of Airflow that deprecates certain features may not yet be released.


### PR DESCRIPTION
While the #43260 attempted to address the problem where example dag importability tests should skip provider tests on non-main, it did not actually solve the problem.

While debugging it, it turned out that since #42505, the provider tests were not executed in main "at all" - the "providers" directory was not included in the list of places to check for the example dags (they were in "airflow" in v2-10-test") this is why it "looked like" the solution worked in "main".

This PR fixes both problems:

* brings back importability of provider's example_dags in main branch
* properly excludes the providers examples in non-main branch

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
