### PR TITLE
Remove deprecated Plugin Test code

### DIFF
--- a/tests/plugins/test_plugin.py
+++ b/tests/plugins/test_plugin.py
@@ -25,11 +25,9 @@ from airflow.executors.base_executor import BaseExecutor
 
 # Importing base classes that we need to derive
 from airflow.hooks.base import BaseHook
-from airflow.models.baseoperator import BaseOperator
 
 # This is the class you derive to create a plugin
 from airflow.plugins_manager import AirflowPlugin
-from airflow.sensors.base import BaseSensorOperator
 from airflow.task.priority_strategy import PriorityWeightStrategy
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
 from airflow.timetables.interval import CronDataIntervalTimetable
@@ -48,16 +46,6 @@ from tests_common.test_utils.mock_operators import (
 
 # Will show up under airflow.hooks.test_plugin.PluginHook
 class PluginHook(BaseHook):
-    pass
-
-
-# Will show up under airflow.operators.test_plugin.PluginOperator
-class PluginOperator(BaseOperator):
-    pass
-
-
-# Will show up under airflow.sensors.test_plugin.PluginSensorOperator
-class PluginSensorOperator(BaseSensorOperator):
     pass
 
 
@@ -134,8 +122,6 @@ class CustomPriorityWeightStrategy(PriorityWeightStrategy):
 # Defining the plugin class
 class AirflowTestPlugin(AirflowPlugin):
     name = "test_plugin"
-    operators = [PluginOperator]
-    sensors = [PluginSensorOperator]
     hooks = [PluginHook]
     executors = [PluginExecutor]
     macros = [plugin_macro]


### PR DESCRIPTION
We had deprecated & removed support for Sensors & Operators via Plugin for Airflow 2 in Jun 25, 2020 :)

PR: https://github.com/apache/airflow/pull/12072


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
