### PR TITLE
PyDocStyle Check - PT005: Fixture returns a value, remove leading underscore

### DIFF
--- a/providers/tests/ssh/operators/test_ssh.py
+++ b/providers/tests/ssh/operators/test_ssh.py
@@ -66,7 +66,7 @@ class TestSSHOperator:
 
     # Make sure nothing in this test actually connects to SSH -- that's for hook tests.
     @pytest.fixture(autouse=True)
-    def _patch_exec_ssh_client(self):
+    def patch_exec_ssh_client(self):
         with mock.patch.object(self.hook, "exec_ssh_client_command") as exec_ssh_client_command:
             self.exec_ssh_client_command = exec_ssh_client_command
             exec_ssh_client_command.return_value = (0, b"airflow", "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -295,7 +295,6 @@ ignore = [
     "E731", # Do not assign a lambda expression, use a def
     "TCH003", # Do not move imports from stdlib to TYPE_CHECKING block
     "PT004", # Fixture does not return anything, add leading underscore
-    "PT005", # Fixture returns a value, remove leading underscore
     "PT006", # Wrong type of names in @pytest.mark.parametrize
     "PT007", # Wrong type of values in @pytest.mark.parametrize
     "PT013", # silly rule prohibiting e.g. `from pytest import param`


### PR DESCRIPTION
Issue: #40567 
Fix 1 remaining PT005 (Fixture returns a value, remove leading underscore) failing style check, and remove PT005 from the`ignore` list

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
