### PR TITLE
Move scheduler health unit test to utils folder

### DIFF
--- a/tests/cli/commands/test_scheduler_command.py
+++ b/tests/cli/commands/test_scheduler_command.py
@@ -17,17 +17,15 @@
 # under the License.
 from __future__ import annotations
 
-from http.server import BaseHTTPRequestHandler
 from importlib import reload
 from unittest import mock
-from unittest.mock import MagicMock
 
 import pytest
 
 from airflow.cli import cli_parser
 from airflow.cli.commands import scheduler_command
 from airflow.executors import executor_loader
-from airflow.utils.scheduler_health import HealthServer, serve_health_check
+from airflow.utils.scheduler_health import serve_health_check
 from airflow.utils.serve_logs import serve_logs
 
 from tests_common.test_utils.config import conf_vars
@@ -224,51 +222,3 @@ class TestSchedulerCommand:
         )
         mock_process.assert_called_once_with(target=serve_logs)
         mock_process().terminate.assert_called_once_with()
-
-
-# Creating MockServer subclass of the HealthServer handler so that we can test the do_GET logic
-class MockServer(HealthServer):
-    def __init__(self):
-        # Overriding so we don't need to initialize with BaseHTTPRequestHandler.__init__ params
-        pass
-
-    def do_GET(self, path):
-        self.path = path
-        super().do_GET()
-
-
-class TestSchedulerHealthServer:
-    def setup_method(self) -> None:
-        self.mock_server = MockServer()
-
-    @mock.patch.object(BaseHTTPRequestHandler, "send_error")
-    def test_incorrect_endpoint(self, mock_send_error):
-        self.mock_server.do_GET("/incorrect")
-        mock_send_error.assert_called_with(404)
-
-    @mock.patch.object(BaseHTTPRequestHandler, "end_headers")
-    @mock.patch.object(BaseHTTPRequestHandler, "send_response")
-    @mock.patch("airflow.utils.scheduler_health.create_session")
-    def test_healthy_scheduler(self, mock_session, mock_send_response, mock_end_headers):
-        mock_scheduler_job = MagicMock()
-        mock_scheduler_job.is_alive.return_value = True
-        mock_session.return_value.__enter__.return_value.query.return_value = mock_scheduler_job
-        self.mock_server.do_GET("/health")
-        mock_send_response.assert_called_once_with(200)
-        mock_end_headers.assert_called_once()
-
-    @mock.patch.object(BaseHTTPRequestHandler, "send_error")
-    @mock.patch("airflow.utils.scheduler_health.create_session")
-    def test_unhealthy_scheduler(self, mock_session, mock_send_error):
-        mock_scheduler_job = MagicMock()
-        mock_scheduler_job.is_alive.return_value = False
-        mock_session.return_value.__enter__.return_value.query.return_value = mock_scheduler_job
-        self.mock_server.do_GET("/health")
-        mock_send_error.assert_called_with(503)
-
-    @mock.patch.object(BaseHTTPRequestHandler, "send_error")
-    @mock.patch("airflow.utils.scheduler_health.create_session")
-    def test_missing_scheduler(self, mock_session, mock_send_error):
-        mock_session.return_value.__enter__.return_value.query.return_value = None
-        self.mock_server.do_GET("/health")
-        mock_send_error.assert_called_with(503)

--- a/tests/utils/test_scheduler_health.py
+++ b/tests/utils/test_scheduler_health.py
@@ -1,0 +1,74 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from airflow.utils.scheduler_health import HealthServer, serve_health_check
+from http.server import BaseHTTPRequestHandler
+from unittest import mock
+from unittest.mock import MagicMock
+
+pytestmark = pytest.mark.db_test
+
+
+class MockServer(HealthServer):
+    def __init__(self):
+        # Overriding so we don't need to initialize with BaseHTTPRequestHandler.__init__ params
+        pass
+
+    def do_GET(self, path):
+        self.path = path
+        super().do_GET()
+
+
+class TestSchedulerHealthServer:
+    def setup_method(self) -> None:
+        self.mock_server = MockServer()
+
+    @mock.patch.object(BaseHTTPRequestHandler, "send_error")
+    def test_incorrect_endpoint(self, mock_send_error):
+        self.mock_server.do_GET("/incorrect")
+        mock_send_error.assert_called_with(404)
+
+    @mock.patch.object(BaseHTTPRequestHandler, "end_headers")
+    @mock.patch.object(BaseHTTPRequestHandler, "send_response")
+    @mock.patch("airflow.utils.scheduler_health.create_session")
+    def test_healthy_scheduler(self, mock_session, mock_send_response, mock_end_headers):
+        mock_scheduler_job = MagicMock()
+        mock_scheduler_job.is_alive.return_value = True
+        mock_session.return_value.__enter__.return_value.query.return_value = mock_scheduler_job
+        self.mock_server.do_GET("/health")
+        mock_send_response.assert_called_once_with(200)
+        mock_end_headers.assert_called_once()
+
+    @mock.patch.object(BaseHTTPRequestHandler, "send_error")
+    @mock.patch("airflow.utils.scheduler_health.create_session")
+    def test_unhealthy_scheduler(self, mock_session, mock_send_error):
+        mock_scheduler_job = MagicMock()
+        mock_scheduler_job.is_alive.return_value = False
+        mock_session.return_value.__enter__.return_value.query.return_value = mock_scheduler_job
+        self.mock_server.do_GET("/health")
+        mock_send_error.assert_called_with(503)
+
+    @mock.patch.object(BaseHTTPRequestHandler, "send_error")
+    @mock.patch("airflow.utils.scheduler_health.create_session")git 
+    def test_missing_scheduler(self, mock_session, mock_send_error):
+        mock_session.return_value.__enter__.return_value.query.return_value = None
+        self.mock_server.do_GET("/health")
+        mock_send_error.assert_called_with(503)

--- a/tests/utils/test_scheduler_health.py
+++ b/tests/utils/test_scheduler_health.py
@@ -67,7 +67,7 @@ class TestSchedulerHealthServer:
         mock_send_error.assert_called_with(503)
 
     @mock.patch.object(BaseHTTPRequestHandler, "send_error")
-    @mock.patch("airflow.utils.scheduler_health.create_session")git 
+    @mock.patch("airflow.utils.scheduler_health.create_session")gi
     def test_missing_scheduler(self, mock_session, mock_send_error):
         mock_session.return_value.__enter__.return_value.query.return_value = None
         self.mock_server.do_GET("/health")

--- a/tests/utils/test_scheduler_health.py
+++ b/tests/utils/test_scheduler_health.py
@@ -48,7 +48,7 @@ class TestSchedulerHealthServer:
         self.mock_server.do_GET("/incorrect")
         mock_send_error.assert_called_with(404)
 
-    # This test is to ensure that if the scheduler is healthy, it returns a 200 status code.
+    # This test is to ensure that if the scheduler is healthy, it returns 200 status code.
     @mock.patch.object(BaseHTTPRequestHandler, "end_headers")
     @mock.patch.object(BaseHTTPRequestHandler, "send_response")
     @mock.patch("airflow.utils.scheduler_health.create_session")
@@ -60,7 +60,7 @@ class TestSchedulerHealthServer:
         mock_send_response.assert_called_once_with(200)
         mock_end_headers.assert_called_once()
 
-    # This test is to ensure that if the scheduler is unhealthy, it returns a 503 error code.
+    # This test is to ensure that if the scheduler is unhealthy, it returns 503 error code.
     @mock.patch.object(BaseHTTPRequestHandler, "send_error")
     @mock.patch("airflow.utils.scheduler_health.create_session")
     def test_unhealthy_scheduler(self, mock_session, mock_send_error):
@@ -70,7 +70,7 @@ class TestSchedulerHealthServer:
         self.mock_server.do_GET("/health")
         mock_send_error.assert_called_with(503)
 
-    # This test is to ensure that if there's no scheduler job running, it returns a 503 error code.
+    # This test is to ensure that if there's no scheduler job running, it returns 503 error code.
     @mock.patch.object(BaseHTTPRequestHandler, "send_error")
     @mock.patch("airflow.utils.scheduler_health.create_session")
     def test_missing_scheduler(self, mock_session, mock_send_error):

--- a/tests/utils/test_scheduler_health.py
+++ b/tests/utils/test_scheduler_health.py
@@ -67,7 +67,7 @@ class TestSchedulerHealthServer:
         mock_send_error.assert_called_with(503)
 
     @mock.patch.object(BaseHTTPRequestHandler, "send_error")
-    @mock.patch("airflow.utils.scheduler_health.create_session")gi
+    @mock.patch("airflow.utils.scheduler_health.create_session")
     def test_missing_scheduler(self, mock_session, mock_send_error):
         mock_session.return_value.__enter__.return_value.query.return_value = None
         self.mock_server.do_GET("/health")

--- a/tests/utils/test_scheduler_health.py
+++ b/tests/utils/test_scheduler_health.py
@@ -42,11 +42,13 @@ class TestSchedulerHealthServer:
     def setup_method(self) -> None:
         self.mock_server = MockServer()
 
+    # This test is to ensure that the server responds correctly to a GET request on the correct endpoint.
     @mock.patch.object(BaseHTTPRequestHandler, "send_error")
     def test_incorrect_endpoint(self, mock_send_error):
         self.mock_server.do_GET("/incorrect")
         mock_send_error.assert_called_with(404)
 
+    # This test is to ensure that if the scheduler is healthy, it returns a 200 status code.
     @mock.patch.object(BaseHTTPRequestHandler, "end_headers")
     @mock.patch.object(BaseHTTPRequestHandler, "send_response")
     @mock.patch("airflow.utils.scheduler_health.create_session")

--- a/tests/utils/test_scheduler_health.py
+++ b/tests/utils/test_scheduler_health.py
@@ -58,6 +58,7 @@ class TestSchedulerHealthServer:
         mock_send_response.assert_called_once_with(200)
         mock_end_headers.assert_called_once()
 
+    # This test is to ensure that if the scheduler is unhealthy, it returns a 503 error code.
     @mock.patch.object(BaseHTTPRequestHandler, "send_error")
     @mock.patch("airflow.utils.scheduler_health.create_session")
     def test_unhealthy_scheduler(self, mock_session, mock_send_error):
@@ -67,6 +68,7 @@ class TestSchedulerHealthServer:
         self.mock_server.do_GET("/health")
         mock_send_error.assert_called_with(503)
 
+    # This test is to ensure that if there's no scheduler job running, it returns a 503 error code.
     @mock.patch.object(BaseHTTPRequestHandler, "send_error")
     @mock.patch("airflow.utils.scheduler_health.create_session")
     def test_missing_scheduler(self, mock_session, mock_send_error):

--- a/tests/utils/test_scheduler_health.py
+++ b/tests/utils/test_scheduler_health.py
@@ -17,12 +17,13 @@
 # under the License.
 from __future__ import annotations
 
-import pytest
-
-from airflow.utils.scheduler_health import HealthServer, serve_health_check
 from http.server import BaseHTTPRequestHandler
 from unittest import mock
 from unittest.mock import MagicMock
+
+import pytest
+
+from airflow.utils.scheduler_health import HealthServer
 
 pytestmark = pytest.mark.db_test
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
The scheduler health unit test now is in `tests/cli/commands/test_scheduler_command.py`, actually, the scheduler health code is in `airflow/utils/scheduler_health.py`.
So it's better to move the unit test code to `tests/utils` folder. And this PR will remove the test code in `tests/cli/commands/test_scheduler_command.py` to a new test file `tests/utils/test_scheduler_health.py`  to realize that.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
