### PR TITLE
Ignore attr-defined for compat import

### DIFF
--- a/providers/src/airflow/providers/openlineage/utils/utils.py
+++ b/providers/src/airflow/providers/openlineage/utils/utils.py
@@ -678,7 +678,7 @@ def translate_airflow_asset(asset: Asset, lineage_context) -> OpenLineageDataset
         from airflow.assets import _get_normalized_scheme
     except ModuleNotFoundError:
         try:
-            from airflow.datasets import _get_normalized_scheme  # type: ignore[no-redef]
+            from airflow.datasets import _get_normalized_scheme  # type: ignore[no-redef, attr-defined]
         except ImportError:
             return None
 


### PR DESCRIPTION
This seems to start failing recently in unrelated CI runs after #43142 was merged.