### PR TITLE
Made usage of Path explicit for Edge Worker pid files

### DIFF
--- a/providers/src/airflow/providers/edge/CHANGELOG.rst
+++ b/providers/src/airflow/providers/edge/CHANGELOG.rst
@@ -27,6 +27,14 @@
 Changelog
 ---------
 
+0.2.2re0
+.........
+
+Misc
+~~~~
+
+* ``Fixed type confusion for PID file paths (#43308)``
+
 0.2.1re0
 .........
 

--- a/providers/src/airflow/providers/edge/cli/edge_command.py
+++ b/providers/src/airflow/providers/edge/cli/edge_command.py
@@ -95,9 +95,9 @@ def _pid_file_path(pid_file: str | None) -> str:
     return cli_utils.setup_locations(process=EDGE_WORKER_PROCESS_NAME, pid=pid_file)[0]
 
 
-def _write_pid_to_pidfile(pid_file_path):
+def _write_pid_to_pidfile(pid_file_path: str):
     """Write PIDs for Edge Workers to disk, handling existing PID files."""
-    if pid_file_path.exists():
+    if Path(pid_file_path).exists():
         # Handle existing PID files on disk
         logger.info("An existing PID file has been found: %s.", pid_file_path)
         pid_stored_in_pid_file = read_pid_from_pidfile(pid_file_path)
@@ -142,7 +142,7 @@ class _EdgeWorkerCli:
 
     def __init__(
         self,
-        pid_file_path: Path,
+        pid_file_path: str,
         hostname: str,
         queues: list[str] | None,
         concurrency: int,

--- a/providers/src/airflow/providers/edge/provider.yaml
+++ b/providers/src/airflow/providers/edge/provider.yaml
@@ -23,10 +23,10 @@ description: |
   Handle edge workers on remote sites via HTTP(s) connection and orchestrates work over distributed sites
 
 state: not-ready
-source-date-epoch: 1729588146
+source-date-epoch: 1729683247
 # note that those versions are maintained by release manager - do not update them manually
 versions:
-  - 0.2.1pre0
+  - 0.2.2pre0
 
 dependencies:
   - apache-airflow>=2.10.0

--- a/providers/tests/edge/cli/test_edge_command.py
+++ b/providers/tests/edge/cli/test_edge_command.py
@@ -120,7 +120,7 @@ class TestEdgeWorkerCli:
 
     @pytest.fixture
     def worker_with_job(self, tmp_path: Path, dummy_joblist: list[_Job]) -> _EdgeWorkerCli:
-        test_worker = _EdgeWorkerCli(tmp_path / "dummy.pid", "dummy", None, 8, 5, 5)
+        test_worker = _EdgeWorkerCli(str(tmp_path / "dummy.pid"), "dummy", None, 8, 5, 5)
         test_worker.jobs = dummy_joblist
         return test_worker
 

--- a/providers/tests/edge/models/test_edge_worker.py
+++ b/providers/tests/edge/models/test_edge_worker.py
@@ -39,7 +39,7 @@ pytestmark = pytest.mark.db_test
 class TestEdgeWorker:
     @pytest.fixture
     def cli_worker(self, tmp_path: Path) -> _EdgeWorkerCli:
-        test_worker = _EdgeWorkerCli(tmp_path / "dummy.pid", "dummy", None, 8, 5, 5)
+        test_worker = _EdgeWorkerCli(str(tmp_path / "dummy.pid"), "dummy", None, 8, 5, 5)
         return test_worker
 
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary

This PR fixes a type confusion in the pid file path in the Edge worker.
Now, pid_file_path is explicitly treated as string in the entire implementation of the Edge Worker cli, which interfaces with the lib `lockfile.pidlockfile` for pid file interaction, consuming file path as string only

## Changes in Detail

- updated function _write_pid_to_pidfile to consume pid file path as string (as any other function in the module `edge_command`
- converted property `pid_file_path` of class `_EdgeWorkerCli`from `Path` to `str`