### PR TITLE
Rename DAG to Dag in new UI

### DIFF
--- a/airflow/ui/src/components/SearchBar.tsx
+++ b/airflow/ui/src/components/SearchBar.tsx
@@ -52,7 +52,7 @@ export const SearchBar = ({
         <FiSearch />
       </InputLeftElement>
       <Input
-        placeholder="Search DAGs"
+        placeholder="Search Dags"
         pr={150}
         {...inputProps}
         onChange={handleSearchChange}

--- a/airflow/ui/src/layouts/Nav/Nav.tsx
+++ b/airflow/ui/src/layouts/Nav/Nav.tsx
@@ -64,7 +64,7 @@ export const Nav = () => {
         <NavButton icon={<FiHome size="1.75rem" />} title="Home" to="/" />
         <NavButton
           icon={<DagIcon height={7} width={7} />}
-          title="DAGs"
+          title="Dags"
           to="dags"
         />
         <NavButton
@@ -76,7 +76,7 @@ export const Nav = () => {
         <NavButton
           icon={<FiBarChart2 size="1.75rem" />}
           isDisabled
-          title="DAG Runs"
+          title="Dag Runs"
           to="dag_runs"
         />
         <NavButton

--- a/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -70,7 +70,7 @@ const columns: Array<ColumnDef<DAGResponse>> = [
   {
     accessorKey: "dag_id",
     cell: ({ row }) => row.original.dag_display_name,
-    header: "DAG",
+    header: "Dag",
   },
   {
     accessorKey: "timetable_description",
@@ -88,7 +88,7 @@ const columns: Array<ColumnDef<DAGResponse>> = [
         <Time datetime={original.next_dagrun} />
       ) : undefined,
     enableSorting: false,
-    header: "Next DAG Run",
+    header: "Next Dag Run",
   },
   {
     accessorKey: "tags",
@@ -198,7 +198,7 @@ export const DagsList = () => {
         <DagsFilters />
         <HStack justifyContent="space-between">
           <Heading py={3} size="md">
-            {pluralize("DAG", data?.total_entries)}
+            {pluralize("Dag", data?.total_entries)}
           </Heading>
           {display === "card" ? (
             <Select
@@ -209,8 +209,8 @@ export const DagsList = () => {
               variant="flushed"
               width="200px"
             >
-              <option value="dag_id">Sort by DAG ID (A-Z)</option>
-              <option value="-dag_id">Sort by DAG ID (Z-A)</option>
+              <option value="dag_id">Sort by Dag ID (A-Z)</option>
+              <option value="-dag_id">Sort by Dag ID (Z-A)</option>
             </Select>
           ) : (
             false
@@ -227,7 +227,7 @@ export const DagsList = () => {
         initialState={tableURLState}
         isFetching={isFetching}
         isLoading={isLoading}
-        modelName="DAG"
+        modelName="Dag"
         onStateChange={setTableURLState}
         skeletonCount={display === "card" ? 5 : undefined}
         total={data?.total_entries}


### PR DESCRIPTION
Use "dag" as a word instead of an acronym.

Before:
<img width="477" alt="Screenshot 2024-10-23 at 1 14 23 PM" src="https://github.com/user-attachments/assets/d7f9a60b-cb71-4b84-b236-e67bf3f89f58">

After:
<img width="562" alt="Screenshot 2024-10-23 at 1 10 39 PM" src="https://github.com/user-attachments/assets/2cbb94b9-a043-497d-8a45-cab02e9460f5">



---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
