### PR TITLE
Update theme colors in new ui

### DIFF
--- a/airflow/ui/src/layouts/Nav/Nav.tsx
+++ b/airflow/ui/src/layouts/Nav/Nav.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Flex, Icon, useColorModeValue, VStack } from "@chakra-ui/react";
+import { Box, Flex, Icon, VStack } from "@chakra-ui/react";
 import { motion } from "framer-motion";
 import {
   FiBarChart2,
@@ -34,73 +34,69 @@ import { DocsButton } from "./DocsButton";
 import { NavButton } from "./NavButton";
 import { UserSettingsButton } from "./UserSettingsButton";
 
-export const Nav = () => {
-  const navBg = useColorModeValue("blue.100", "blue.900");
-
-  return (
-    <VStack
-      alignItems="center"
-      bg={navBg}
-      height="100%"
-      justifyContent="space-between"
-      left={0}
-      position="fixed"
-      py={3}
-      top={0}
-      width={24}
-      zIndex={1}
-    >
-      <Flex alignItems="center" flexDir="column" width="100%">
-        <Box
-          as={motion.div}
-          mb={3}
-          whileHover={{
-            transform: ["rotate(0)", "rotate(360deg)"],
-            transition: { duration: 1.5, ease: "linear", repeat: Infinity },
-          }}
-        >
-          <Icon as={AirflowPin} height="35px" width="35px" />
-        </Box>
-        <NavButton icon={<FiHome size="1.75rem" />} title="Home" to="/" />
-        <NavButton
-          icon={<DagIcon height={7} width={7} />}
-          title="Dags"
-          to="dags"
-        />
-        <NavButton
-          icon={<FiDatabase size="1.75rem" />}
-          isDisabled
-          title="Assets"
-          to="assets"
-        />
-        <NavButton
-          icon={<FiBarChart2 size="1.75rem" />}
-          isDisabled
-          title="Dag Runs"
-          to="dag_runs"
-        />
-        <NavButton
-          icon={<FiGlobe size="1.75rem" />}
-          isDisabled
-          title="Browse"
-          to="browse"
-        />
-        <NavButton
-          icon={<FiSettings size="1.75rem" />}
-          isDisabled
-          title="Admin"
-          to="admin"
-        />
-      </Flex>
-      <Flex flexDir="column">
-        <NavButton
-          icon={<FiCornerUpLeft size="1.5rem" />}
-          title="Return to legacy UI"
-          to={import.meta.env.VITE_LEGACY_API_URL}
-        />
-        <DocsButton />
-        <UserSettingsButton />
-      </Flex>
-    </VStack>
-  );
-};
+export const Nav = () => (
+  <VStack
+    alignItems="center"
+    bg="muted"
+    height="100%"
+    justifyContent="space-between"
+    left={0}
+    position="fixed"
+    py={3}
+    top={0}
+    width={24}
+    zIndex={1}
+  >
+    <Flex alignItems="center" flexDir="column" width="100%">
+      <Box
+        as={motion.div}
+        mb={3}
+        whileHover={{
+          transform: ["rotate(0)", "rotate(360deg)"],
+          transition: { duration: 1.5, ease: "linear", repeat: Infinity },
+        }}
+      >
+        <Icon as={AirflowPin} height="35px" width="35px" />
+      </Box>
+      <NavButton icon={<FiHome size="1.75rem" />} title="Home" to="/" />
+      <NavButton
+        icon={<DagIcon height={7} width={7} />}
+        title="Dags"
+        to="dags"
+      />
+      <NavButton
+        icon={<FiDatabase size="1.75rem" />}
+        isDisabled
+        title="Assets"
+        to="assets"
+      />
+      <NavButton
+        icon={<FiBarChart2 size="1.75rem" />}
+        isDisabled
+        title="Dag Runs"
+        to="dag_runs"
+      />
+      <NavButton
+        icon={<FiGlobe size="1.75rem" />}
+        isDisabled
+        title="Browse"
+        to="browse"
+      />
+      <NavButton
+        icon={<FiSettings size="1.75rem" />}
+        isDisabled
+        title="Admin"
+        to="admin"
+      />
+    </Flex>
+    <Flex flexDir="column">
+      <NavButton
+        icon={<FiCornerUpLeft size="1.5rem" />}
+        title="Return to legacy UI"
+        to={import.meta.env.VITE_LEGACY_API_URL}
+      />
+      <DocsButton />
+      <UserSettingsButton />
+    </Flex>
+  </VStack>
+);

--- a/airflow/ui/src/layouts/Nav/Nav.tsx
+++ b/airflow/ui/src/layouts/Nav/Nav.tsx
@@ -37,7 +37,7 @@ import { UserSettingsButton } from "./UserSettingsButton";
 export const Nav = () => (
   <VStack
     alignItems="center"
-    bg="muted"
+    bg="blue.muted"
     height="100%"
     justifyContent="space-between"
     left={0}

--- a/airflow/ui/src/layouts/Nav/navButtonProps.ts
+++ b/airflow/ui/src/layouts/Nav/navButtonProps.ts
@@ -19,6 +19,12 @@
 import type { ButtonProps } from "@chakra-ui/react";
 
 export const navButtonProps: ButtonProps = {
+  _active: {
+    backgroundColor: "emphasized",
+  },
+  _hover: {
+    backgroundColor: "solid",
+  },
   alignItems: "center",
   borderRadius: "none",
   flexDir: "column",

--- a/airflow/ui/src/layouts/Nav/navButtonProps.ts
+++ b/airflow/ui/src/layouts/Nav/navButtonProps.ts
@@ -20,10 +20,10 @@ import type { ButtonProps } from "@chakra-ui/react";
 
 export const navButtonProps: ButtonProps = {
   _active: {
-    backgroundColor: "emphasized",
+    backgroundColor: "blue.emphasized",
   },
   _hover: {
-    backgroundColor: "solid",
+    backgroundColor: "blue.solid",
   },
   alignItems: "center",
   borderRadius: "none",

--- a/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -40,17 +40,22 @@ type Props = {
 const MAX_TAGS = 3;
 
 export const DagCard = ({ dag }: Props) => (
-  <Box borderColor="minimal" borderRadius={8} borderWidth={1} overflow="hidden">
+  <Box
+    borderColor="blue.minimal"
+    borderRadius={8}
+    borderWidth={1}
+    overflow="hidden"
+  >
     <Flex
       alignItems="center"
-      bg="minimal"
+      bg="blue.minimal"
       justifyContent="space-between"
       px={3}
       py={2}
     >
       <HStack>
         <Tooltip hasArrow label={dag.description}>
-          <Heading color="contrast" fontSize="md">
+          <Heading color="blue.contrast" fontSize="md">
             {dag.dag_display_name}
           </Heading>
         </Tooltip>

--- a/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -25,7 +25,6 @@ import {
   SimpleGrid,
   Text,
   Tooltip,
-  useColorModeValue,
   VStack,
 } from "@chakra-ui/react";
 import { FiCalendar, FiTag } from "react-icons/fi";
@@ -40,82 +39,71 @@ type Props = {
 
 const MAX_TAGS = 3;
 
-export const DagCard = ({ dag }: Props) => {
-  const cardBorder = useColorModeValue("gray.100", "gray.700");
-  const tooltipBg = useColorModeValue("gray.200", "gray.700");
-
-  return (
-    <Box
-      borderColor={cardBorder}
-      borderRadius={8}
-      borderWidth={1}
-      overflow="hidden"
+export const DagCard = ({ dag }: Props) => (
+  <Box borderColor="minimal" borderRadius={8} borderWidth={1} overflow="hidden">
+    <Flex
+      alignItems="center"
+      bg="minimal"
+      justifyContent="space-between"
+      px={3}
+      py={2}
     >
-      <Flex
-        alignItems="center"
-        bg="subtle-bg"
-        justifyContent="space-between"
-        px={3}
-        py={2}
-      >
-        <HStack>
-          <Tooltip hasArrow label={dag.description}>
-            <Heading color="subtle-text" fontSize="md">
-              {dag.dag_display_name}
-            </Heading>
-          </Tooltip>
-          {dag.tags.length ? (
-            <HStack spacing={1}>
-              <FiTag data-testid="dag-tag" />
-              {dag.tags.slice(0, MAX_TAGS).map((tag) => (
-                <Badge key={tag.name}>{tag.name}</Badge>
-              ))}
-              {dag.tags.length > MAX_TAGS && (
-                <Tooltip
-                  bg={tooltipBg}
-                  hasArrow
-                  label={
-                    <VStack p={1} spacing={1}>
-                      {dag.tags.slice(MAX_TAGS).map((tag) => (
-                        <Badge key={tag.name}>{tag.name}</Badge>
-                      ))}
-                    </VStack>
-                  }
-                >
-                  <Badge>+{dag.tags.length - MAX_TAGS} more</Badge>
-                </Tooltip>
-              )}
-            </HStack>
-          ) : undefined}
-        </HStack>
-        <HStack>
-          <TogglePause dagId={dag.dag_id} isPaused={dag.is_paused} />
-        </HStack>
-      </Flex>
-      <SimpleGrid columns={4} height={20} px={3} py={2} spacing={4}>
-        <div />
-        <VStack align="flex-start" spacing={1}>
-          <Heading color="gray.500" fontSize="xs">
-            Next Run
+      <HStack>
+        <Tooltip hasArrow label={dag.description}>
+          <Heading color="contrast" fontSize="md">
+            {dag.dag_display_name}
           </Heading>
-          {Boolean(dag.next_dagrun) ? (
+        </Tooltip>
+        {dag.tags.length ? (
+          <HStack spacing={1}>
+            <FiTag data-testid="dag-tag" />
+            {dag.tags.slice(0, MAX_TAGS).map((tag) => (
+              <Badge key={tag.name}>{tag.name}</Badge>
+            ))}
+            {dag.tags.length > MAX_TAGS && (
+              <Tooltip
+                hasArrow
+                label={
+                  <VStack p={1} spacing={1}>
+                    {dag.tags.slice(MAX_TAGS).map((tag) => (
+                      <Badge key={tag.name}>{tag.name}</Badge>
+                    ))}
+                  </VStack>
+                }
+              >
+                <Badge>+{dag.tags.length - MAX_TAGS} more</Badge>
+              </Tooltip>
+            )}
+          </HStack>
+        ) : undefined}
+      </HStack>
+      <HStack>
+        <TogglePause dagId={dag.dag_id} isPaused={dag.is_paused} />
+      </HStack>
+    </Flex>
+    <SimpleGrid columns={4} height={20} px={3} py={2} spacing={4}>
+      <div />
+      <VStack align="flex-start" spacing={1}>
+        <Heading color="gray.500" fontSize="xs">
+          Next Run
+        </Heading>
+        {Boolean(dag.next_dagrun) ? (
+          <Text fontSize="sm">
+            <Time datetime={dag.next_dagrun} />
+          </Text>
+        ) : undefined}
+        {Boolean(dag.timetable_summary) ? (
+          <Tooltip hasArrow label={dag.timetable_description}>
             <Text fontSize="sm">
-              <Time datetime={dag.next_dagrun} />
+              {" "}
+              <FiCalendar style={{ display: "inline" }} />{" "}
+              {dag.timetable_summary}
             </Text>
-          ) : undefined}
-          {Boolean(dag.timetable_summary) ? (
-            <Tooltip hasArrow label={dag.timetable_description}>
-              <Text fontSize="sm">
-                {" "}
-                <FiCalendar style={{ display: "inline" }} />{" "}
-                {dag.timetable_summary}
-              </Text>
-            </Tooltip>
-          ) : undefined}
-        </VStack>
-        <div />
-        <div />
-      </SimpleGrid>
-    </Box>
-  );
-};
+          </Tooltip>
+        ) : undefined}
+      </VStack>
+      <div />
+      <div />
+    </SimpleGrid>
+  </Box>
+);

--- a/airflow/ui/src/theme.ts
+++ b/airflow/ui/src/theme.ts
@@ -32,11 +32,11 @@ const baseStyle = definePartsStyle(() => ({
       },
       "&:nth-of-type(odd)": {
         td: {
-          background: "minimal",
+          background: "blue.minimal",
         },
         "th, td": {
           borderBottomWidth: "0px",
-          borderColor: "subtle",
+          borderColor: "blue.subtle",
         },
       },
     },
@@ -72,16 +72,18 @@ const theme = extendTheme({
   },
   semanticTokens: {
     colors: {
-      /* eslint-disable perfectionist/sort-objects */
-      contrast: { _dark: "blue.200", _light: "blue.600" },
-      focusRing: "blue.500",
-      fg: { _dark: "blue.600", _light: "blue.400" },
-      emphasized: { _dark: "blue.700", _light: "blue.300" },
-      solid: { _dark: "blue.800", _light: "blue.200" },
-      muted: { _dark: "blue.900", _light: "blue.100" },
-      subtle: { _dark: "blue.950", _light: "blue.50" },
-      minimal: { _dark: "gray.900", _light: "blue.50" },
-      /* eslint-enable perfectionist/sort-objects */
+      blue: {
+        /* eslint-disable perfectionist/sort-objects */
+        contrast: { _dark: "blue.200", _light: "blue.600" },
+        focusRing: "blue.500",
+        fg: { _dark: "blue.600", _light: "blue.400" },
+        emphasized: { _dark: "blue.700", _light: "blue.300" },
+        solid: { _dark: "blue.800", _light: "blue.200" },
+        muted: { _dark: "blue.900", _light: "blue.100" },
+        subtle: { _dark: "blue.950", _light: "blue.50" },
+        minimal: { _dark: "gray.900", _light: "blue.50" },
+        /* eslint-enable perfectionist/sort-objects */
+      },
     },
   },
   styles: {

--- a/airflow/ui/src/theme.ts
+++ b/airflow/ui/src/theme.ts
@@ -32,11 +32,11 @@ const baseStyle = definePartsStyle(() => ({
       },
       "&:nth-of-type(odd)": {
         td: {
-          background: "subtle-bg",
+          background: "minimal",
         },
         "th, td": {
           borderBottomWidth: "0px",
-          borderColor: "subtle-bg",
+          borderColor: "subtle",
         },
       },
     },
@@ -53,6 +53,11 @@ const baseStyle = definePartsStyle(() => ({
 export const tableTheme = defineMultiStyleConfig({ baseStyle });
 
 const theme = extendTheme({
+  colors: {
+    blue: {
+      950: "#0c142e",
+    },
+  },
   components: {
     Table: tableTheme,
     Tooltip: {
@@ -67,8 +72,16 @@ const theme = extendTheme({
   },
   semanticTokens: {
     colors: {
-      "subtle-bg": { _dark: "gray.900", _light: "blue.50" },
-      "subtle-text": { _dark: "blue.500", _light: "blue.600" },
+      /* eslint-disable perfectionist/sort-objects */
+      contrast: { _dark: "blue.200", _light: "blue.600" },
+      focusRing: "blue.500",
+      fg: { _dark: "blue.600", _light: "blue.400" },
+      emphasized: { _dark: "blue.700", _light: "blue.300" },
+      solid: { _dark: "blue.800", _light: "blue.200" },
+      muted: { _dark: "blue.900", _light: "blue.100" },
+      subtle: { _dark: "blue.950", _light: "blue.50" },
+      minimal: { _dark: "gray.900", _light: "blue.50" },
+      /* eslint-enable perfectionist/sort-objects */
     },
   },
   styles: {


### PR DESCRIPTION
Taking some inspiration from the [Chakra-UI 3 announcement](https://www.chakra-ui.com/blog/00-announcing-v3) to improve how we handle colors. Make our own version of semantic colors for our common accent color, blue. Only worry about dark/light mode in our theme and not in components themselves.

We may switch to Chakra UI v3 once its had a few patch releases.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
