### PR TITLE
Fix production image build in main

### DIFF
--- a/docker_tests/test_prod_image.py
+++ b/docker_tests/test_prod_image.py
@@ -90,7 +90,11 @@ class TestPythonPackages:
             packages_to_install = set(REGULAR_IMAGE_PROVIDERS)
             package_file = PROD_IMAGE_PROVIDERS_FILE_PATH
         assert len(packages_to_install) != 0
-        output = run_bash_in_docker("airflow providers list --output json", image=default_docker_image)
+        output = run_bash_in_docker(
+            "airflow providers list --output json",
+            image=default_docker_image,
+            envs={"AIRFLOW__LOGGING__LOGGING_LEVEL": "ERROR"},
+        )
         providers = json.loads(output)
         packages_installed = set(d["package_name"] for d in providers)
         assert len(packages_installed) != 0


### PR DESCRIPTION
Currently, main branch fails in Production image built with following error

https://github.com/apache/airflow/actions/runs/11489117758/job/31977767455?pr=43331

```
>           obj, end = self.scan_once(s, idx)
E           json.decoder.JSONDecodeError: Expecting ',' delimiter: line 1 column 6 (char 5)
```

This is because the test `test_required_providers_are_installed` relies on output of `"airflow providers list --output json"`:

https://github.com/apache/airflow/blob/da7ce4ab7efcee4a5b431bf6779c2051c1a826ad/docker_tests/test_prod_image.py#L85-L94

and the output in main right now is, notice the warnings:

```
[2024-10-23T22:45:37.453+0000] {configuration.py:994} WARNING - section/key [database/sql_alchemy_engine_args] not found in config
[2024-10-23T22:45:37.455+0000] {configuration.py:994} WARNING - section/key [core/asset_manager_kwargs] not found in config
  [{"package_name": "apache-airflow-providers-amazon", "description": "Amazon integration (including Amazon Web Services (AWS) https://aws.amazon.com/)", "version": "9.0.0.dev0"}, {"package_name": "apache-airflow-providers-celery", "description": "Celery https://docs.celeryq.dev/en/stable/", "version": "3.8.3.dev0"}, {"package_name": "apache-airflow-providers-cncf-kubernetes", "description": "Kubernetes https://kubernetes.io/", "version": "9.0.0.dev0"}, {"package_name": "apache-airflow-providers-common-compat", "description": "Common Compatibility Provider - providing compatibility code for previous Airflow versions.", "version": "1.2.1.dev0"}, {"package_name": "apache-airflow-providers-common-io", "description": "Common IO Provider", "version": "1.4.2.dev0"}, {"package_name": "apache-airflow-providers-common-sql", "description": "Common SQL Provider https://en.wikipedia.org/wiki/SQL", "version": "1.18.0.dev0"}, {"package_name": "apache-airflow-providers-docker", "description": "Docker https://www.docker.com/", "version": "3.14.0.dev0"}, {"package_name": "apache-airflow-providers-elasticsearch", "description": "Elasticsearch https://www.elastic.co/elasticsearch", "version": "5.5.2.dev0"}, {"package_name": "apache-airflow-providers-fab", "description": "Flask App Builder https://flask-appbuilder.readthedocs.io/", "version": "1.4.1.dev0"}, {"package_name": "apache-airflow-providers-ftp", "description": "File Transfer Protocol (FTP) https://tools.ietf.org/html/rfc114", "version": "3.11.1.dev0"}, {"package_name": "apache-airflow-providers-google", "description": "Google services including:\n\n  - Google Ads https://ads.google.com/\n  - Google Cloud (GCP) https://cloud.google.com/\n  - Google Firebase https://firebase.google.com/\n  - Google LevelDB https://github.com/google/leveldb/\n  - Google Marketing Platform https://marketingplatform.google.com/\n  - Google Workspace https://workspace.google.com/ (formerly Google Suite)", "version": "10.24.0.dev0"}, {"package_name": "apache-airflow-providers-grpc", "description": "gRPC https://grpc.io/", "version": "3.6.0.dev0"}, {"package_name": "apache-airflow-providers-hashicorp", "description": "Hashicorp including Hashicorp Vault https://www.vaultproject.io/", "version": "3.8.0.dev0"}, {"package_name": "apache-airflow-providers-http", "description": "Hypertext Transfer Protocol (HTTP) https://www.w3.org/Protocols/", "version": "4.13.1.dev0"}, {"package_name": "apache-airflow-providers-imap", "description": "Internet Message Access Protocol (IMAP) https://tools.ietf.org/html/rfc3501", "version": "3.7.0.dev0"}, {"package_name": "apache-airflow-providers-microsoft-azure", "description": "Microsoft Azure https://azure.microsoft.com/", "version": "10.5.1.dev0"}, {"package_name": "apache-airflow-providers-mysql", "description": "MySQL https://www.mysql.com/", "version": "5.7.2.dev0"}, {"package_name": "apache-airflow-providers-odbc", "description": "ODBC https://github.com/mkleehammer/pyodbc/wiki", "version": "4.7.1.dev0"}, {"package_name": "apache-airflow-providers-openlineage", "description": "OpenLineage https://openlineage.io/", "version": "1.12.2.dev0"}, {"package_name": "apache-airflow-providers-postgres", "description": "PostgreSQL https://www.postgresql.org/", "version": "5.13.1.dev0"}, {"package_name": "apache-airflow-providers-redis", "description": "Redis https://redis.io/", "version": "3.8.0.dev0"}, {"package_name": "apache-airflow-providers-sendgrid", "description": "Sendgrid https://sendgrid.com/", "version": "3.6.0.dev0"}, {"package_name": "apache-airflow-providers-sftp", "description": "SSH File Transfer Protocol (SFTP) https://tools.ietf.org/wg/secsh/draft-ietf-secsh-filexfer/", "version": "4.11.1.dev0"}, {"package_name": "apache-airflow-providers-slack", "description": "Slack https://slack.com/ services integration including:\n\n  - Slack API https://api.slack.com/\n  - Slack Incoming Webhook https://api.slack.com/messaging/webhooks", "version": "8.9.0.dev0"}, {"package_name": "apache-airflow-providers-smtp", "description": "Simple Mail Transfer Protocol (SMTP) https://tools.ietf.org/html/rfc5321", "version": "1.8.0.dev0"}, {"package_name": "apache-airflow-providers-snowflake", "description": "Snowflake https://www.snowflake.com/", "version": "5.8.0.dev0"}, {"package_name": "apache-airflow-providers-sqlite", "description": "SQLite https://www.sqlite.org/", "version": "3.9.0.dev0"}, {"package_name": "apache-airflow-providers-ssh", "description": "Secure Shell (SSH) https://tools.ietf.org/html/rfc4251", "version": "3.13.1.dev0"}, {"package_name": "apache-airflow-providers-standard", "description": "Airflow Standard Provider", "version": "1.0.0.dev0"}]
```

To fix this and make test more resilient, we change Airflow logging level to ERROR so warnings aren't shown on CLI, since we use its output

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
