### PR TITLE
Suppress warnings when masking sensitive confs

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -777,7 +777,7 @@ class AirflowConfigParser(ConfigParser):
 
         for section, key in self.sensitive_config_values:
             try:
-                value = self.get(section, key)
+                value = self.get(section, key, suppress_warnings=True)
             except AirflowConfigException:
                 log.debug(
                     "Could not retrieve value from section %s, for key %s. Skipping redaction of this conf.",


### PR DESCRIPTION
This is to prevent issues such as https://github.com/apache/airflow/pull/43334 . This occurred when https://github.com/apache/airflow/pull/43040 was merged. This PR fixes it.

**Before**:

```
root@131e2fda270d:/opt/airflow# airflow providers list
[2024-10-23T23:24:17.970+0000] {configuration.py:995} WARNING - section/key [core/asset_manager_kwargs] not found in config
[2024-10-23T23:24:17.971+0000] {configuration.py:995} WARNING - section/key [database/sql_alchemy_engine_args] not found in config
package_name                              | description                                                                                             | version
==========================================+=========================================================================================================+==========
apache-airflow-providers-airbyte          | Airbyte https://airbyte.com/                                                                            | 4.0.0
apache-airflow-providers-alibaba          | Alibaba Cloud integration (including Alibaba Cloud https://www.alibabacloud.com/)                       | 2.9.1
```

**After**:

```
root@131e2fda270d:/opt/airflow# airflow providers list
package_name                              | description                                                                                             | version
==========================================+=========================================================================================================+==========
apache-airflow-providers-airbyte          | Airbyte https://airbyte.com/                                                                            | 4.0.0
apache-airflow-providers-alibaba          | Alibaba Cloud integration (including Alibaba Cloud https://www.alibabacloud.com/)                       | 2.9.1
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
