### PR TITLE
Fix accessibility with sorting tables and zIndex with tags selector

### DIFF
--- a/airflow/ui/src/components/DataTable/CardList.tsx
+++ b/airflow/ui/src/components/DataTable/CardList.tsx
@@ -17,26 +17,19 @@
  * under the License.
  */
 import { Box, SimpleGrid, Skeleton } from "@chakra-ui/react";
-import {
-  type CoreRow,
-  flexRender,
-  type Table as TanStackTable,
-} from "@tanstack/react-table";
-import type { SyntheticEvent } from "react";
+import { flexRender, type Table as TanStackTable } from "@tanstack/react-table";
 
 import type { CardDef } from "./types";
 
 type DataTableProps<TData> = {
   readonly cardDef: CardDef<TData>;
   readonly isLoading?: boolean;
-  readonly onRowClick?: (e: SyntheticEvent, row: CoreRow<TData>) => void;
   readonly table: TanStackTable<TData>;
 };
 
 export const CardList = <TData,>({
   cardDef,
   isLoading,
-  onRowClick,
   table,
 }: DataTableProps<TData>) => {
   const defaultGridProps = { column: { base: 1 }, spacing: 2 };
@@ -45,12 +38,7 @@ export const CardList = <TData,>({
     <Box overflow="auto" width="100%">
       <SimpleGrid {...{ ...defaultGridProps, ...cardDef.gridProps }}>
         {table.getRowModel().rows.map((row) => (
-          <Box
-            _hover={onRowClick ? { cursor: "pointer" } : undefined}
-            key={row.id}
-            onClick={onRowClick ? (event) => onRowClick(event, row) : undefined}
-            title={onRowClick ? "View details" : undefined}
-          >
+          <Box key={row.id}>
             {Boolean(isLoading) &&
               (cardDef.meta?.customSkeleton ?? (
                 <Skeleton

--- a/airflow/ui/src/components/DataTable/TableList.tsx
+++ b/airflow/ui/src/components/DataTable/TableList.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import {
+  Button,
   Table as ChakraTable,
   TableContainer,
   Tbody,
@@ -57,40 +58,62 @@ export const TableList = <TData,>({
               ({ colSpan, column, getContext, id, isPlaceholder }) => {
                 const sort = column.getIsSorted();
                 const canSort = column.getCanSort();
+                const text = flexRender(column.columnDef.header, getContext());
 
-                return (
-                  <Th
-                    colSpan={colSpan}
-                    cursor={column.getCanSort() ? "pointer" : undefined}
-                    key={id}
-                    onClick={column.getToggleSortingHandler()}
-                    whiteSpace="nowrap"
-                  >
-                    {isPlaceholder ? undefined : (
-                      <>{flexRender(column.columnDef.header, getContext())}</>
-                    )}
-                    {canSort && sort === false ? (
+                let rightIcon;
+
+                if (canSort) {
+                  if (sort === "desc") {
+                    rightIcon = (
+                      <TiArrowSortedDown
+                        aria-label="sorted descending"
+                        size="1em"
+                        style={{ display: "inline" }}
+                      />
+                    );
+                  } else if (sort === "asc") {
+                    rightIcon = (
+                      <TiArrowSortedUp
+                        aria-label="sorted ascending"
+                        size="1em"
+                        style={{ display: "inline" }}
+                      />
+                    );
+                  } else {
+                    rightIcon = (
                       <TiArrowUnsorted
                         aria-label="unsorted"
                         size="1em"
                         style={{ display: "inline" }}
                       />
-                    ) : undefined}
-                    {canSort && sort !== false ? (
-                      sort === "desc" ? (
-                        <TiArrowSortedDown
-                          aria-label="sorted descending"
-                          size="1em"
-                          style={{ display: "inline" }}
-                        />
-                      ) : (
-                        <TiArrowSortedUp
-                          aria-label="sorted ascending"
-                          size="1em"
-                          style={{ display: "inline" }}
-                        />
-                      )
-                    ) : undefined}
+                    );
+                  }
+
+                  return (
+                    <Th colSpan={colSpan} key={id} whiteSpace="nowrap">
+                      {isPlaceholder ? undefined : (
+                        <Button
+                          aria-label="sort"
+                          fontSize="inherit"
+                          fontWeight="inherit"
+                          isDisabled={!canSort}
+                          minWidth={0}
+                          onClick={column.getToggleSortingHandler()}
+                          padding={0}
+                          rightIcon={rightIcon}
+                          textTransform="inherit"
+                          variant="unstyled"
+                        >
+                          {text}
+                        </Button>
+                      )}
+                    </Th>
+                  );
+                }
+
+                return (
+                  <Th colSpan={colSpan} key={id} whiteSpace="nowrap">
+                    {isPlaceholder ? undefined : text}
                   </Th>
                 );
               },

--- a/airflow/ui/src/pages/DagsList/DagsFilters.tsx
+++ b/airflow/ui/src/pages/DagsList/DagsFilters.tsx
@@ -163,6 +163,10 @@ export const DagsFilters = () => {
             ...provided,
             minWidth: 64,
           }),
+          menu: (provided) => ({
+            ...provided,
+            zIndex: 2,
+          }),
         }}
         isClearable
         isMulti


### PR DESCRIPTION
- Move table sorting to a button inside of Th so it can be picked up by screen readers and tab controls
- Fix z-index of tags option dropdown

Before:
<img width="331" alt="Screenshot 2024-10-24 at 3 40 19 PM" src="https://github.com/user-attachments/assets/d89830b7-9667-4377-9911-70ef71999af7">



After:
<img width="504" alt="Screenshot 2024-10-24 at 3 39 59 PM" src="https://github.com/user-attachments/assets/db7973c9-18e6-4d24-ba90-1c0735d6e5b8">

note that the DAG button now has the highlight from tabbing across the page
<img width="627" alt="Screenshot 2024-10-24 at 3 40 06 PM" src="https://github.com/user-attachments/assets/19d9d0c3-22d1-4d07-9306-4a5376005327">


---


**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
