### PR TITLE
Add context to Azure Service Bus Message callback

### DIFF
--- a/providers/src/airflow/providers/microsoft/azure/CHANGELOG.rst
+++ b/providers/src/airflow/providers/microsoft/azure/CHANGELOG.rst
@@ -27,6 +27,12 @@
 Changelog
 ---------
 
+Breaking changes
+~~~~~~~~~~~~~~~~
+.. warning::
+   * We changed the message callback for Azure Service Bus messages to take two parameters, the message and the context, rather than just the message. This allows pushing message information into XComs. To upgrade from the previous version, which only took the message, please update your callback to take the context as a second parameter.
+
+
 10.5.1
 ......
 

--- a/providers/src/airflow/providers/microsoft/azure/operators/asb.py
+++ b/providers/src/airflow/providers/microsoft/azure/operators/asb.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
     from airflow.utils.context import Context
 
-    MessageCallback = Callable[[ServiceBusMessage], None]
+    MessageCallback = Callable[[ServiceBusMessage, Context], None]
 
 
 class AzureServiceBusCreateQueueOperator(BaseOperator):
@@ -176,6 +176,7 @@ class AzureServiceBusReceiveMessageOperator(BaseOperator):
         # Receive message
         hook.receive_message(
             self.queue_name,
+            context,
             max_message_count=self.max_message_count,
             max_wait_time=self.max_wait_time,
             message_callback=self.message_callback,
@@ -562,6 +563,7 @@ class ASBReceiveSubscriptionMessageOperator(BaseOperator):
         hook.receive_subscription_message(
             self.topic_name,
             self.subscription_name,
+            context,
             self.max_message_count,
             self.max_wait_time,
             message_callback=self.message_callback,


### PR DESCRIPTION
The original callback only took the message as a parameter. However, users may want to push status or location information into XComs and so callbacks need access to the context (or the XComs, but context is more general). This commit changes the code to pass the context.

NOTE: This is a **BREAKING CHANGE**.

Closes #43361