### PR TITLE
add min version to types- deprecated, markdown, pymysql, pyyaml

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -216,10 +216,10 @@ DEVEL_EXTRAS: dict[str, list[str]] = {
         # Make sure to upgrade the mypy version in update-common-sql-api-stubs in .pre-commit-config.yaml
         # when you upgrade it here !!!!
         "mypy==1.9.0",
-        "types-Deprecated",
-        "types-Markdown",
-        "types-PyMySQL",
-        "types-PyYAML",
+        "types-Deprecated>=1.2.9.20240311",
+        "types-Markdown>=3.6.0.20240316",
+        "types-PyMySQL>=1.1.0.20240425",
+        "types-PyYAML>=6.0.12.20240724",
         "types-aiofiles",
         "types-certifi",
         "types-croniter",


### PR DESCRIPTION
Adding min versions as mentioned below:

1. types-Deprecated>=1.2.9.20240311 (Released In March 2024 and is the latest. Prior version in Jan 2024)
2. types-Markdown>=3.6.0.20240316 (Released in March 2024(not the latest release), Prior version was also released in March)
3. types-PyMySQL>=1.1.0.20240425 (Released in April 2024. Prior version released in July 2023)
4. types-PyYAML>=6.0.12.20240724(Released in July 2024. Prior version released in March 2024)


Related to #42989