### PR TITLE
EdgeWorker support log file upload in chunks

### DIFF
--- a/providers/src/airflow/providers/edge/CHANGELOG.rst
+++ b/providers/src/airflow/providers/edge/CHANGELOG.rst
@@ -27,6 +27,14 @@
 Changelog
 ---------
 
+0.4.0pre0
+.........
+
+Misc
+~~~~
+
+* ``Edge Worker uploads log file in chunks. Chunk size can be defined by push_log_chunk_size value in config.``
+
 0.3.0pre0
 .........
 

--- a/providers/src/airflow/providers/edge/__init__.py
+++ b/providers/src/airflow/providers/edge/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "0.3.0pre0"
+__version__ = "0.4.0pre0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.10.0"

--- a/providers/src/airflow/providers/edge/cli/edge_command.py
+++ b/providers/src/airflow/providers/edge/cli/edge_command.py
@@ -238,7 +238,7 @@ class _EdgeWorkerCli:
                     EdgeJob.set_state(job.edge_job.key, TaskInstanceState.FAILED)
             if job.logfile.exists() and job.logfile.stat().st_size > job.logsize:
                 with job.logfile.open("r") as logfile:
-                    push_log_chunk_size = conf.getint("edge", "push_log_chunk_size", fallback=1024)
+                    push_log_chunk_size = conf.getint("edge", "push_log_chunk_size")
                     logfile.seek(job.logsize, os.SEEK_SET)
                     while True:
                         logdata = logfile.read(push_log_chunk_size)

--- a/providers/src/airflow/providers/edge/cli/edge_command.py
+++ b/providers/src/airflow/providers/edge/cli/edge_command.py
@@ -238,14 +238,18 @@ class _EdgeWorkerCli:
                     EdgeJob.set_state(job.edge_job.key, TaskInstanceState.FAILED)
             if job.logfile.exists() and job.logfile.stat().st_size > job.logsize:
                 with job.logfile.open("r") as logfile:
+                    push_log_chunk_size = conf.getint("edge", "push_log_chunk_size", fallback=1024)
                     logfile.seek(job.logsize, os.SEEK_SET)
-                    logdata = logfile.read()
-                    EdgeLogs.push_logs(
-                        task=job.edge_job.key,
-                        log_chunk_time=datetime.now(),
-                        log_chunk_data=logdata,
-                    )
-                    job.logsize += len(logdata)
+                    while True:
+                        logdata = logfile.read(push_log_chunk_size)
+                        if not logdata:
+                            break
+                        EdgeLogs.push_logs(
+                            task=job.edge_job.key,
+                            log_chunk_time=datetime.now(),
+                            log_chunk_data=logdata,
+                        )
+                        job.logsize += len(logdata)
 
     def heartbeat(self) -> None:
         """Report liveness state of worker to central site with stats."""

--- a/providers/src/airflow/providers/edge/provider.yaml
+++ b/providers/src/airflow/providers/edge/provider.yaml
@@ -104,9 +104,13 @@ config:
         default: "60"
       push_log_chunk_size:
         description: |
-          Edge Worker uploads log files in chunks. If the log file part which is uploaded exceeds the chunk size it creates a new request. This solves issue if firewall defines max size of request.
+          Edge Worker uploads log files in chunks. If the log file part which is uploaded
+          exceeds the chunk size it creates a new request. The application gateway can
+          limit the max body size see:
+          https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
+          A HTTP 413 issue can point to this value to fix the issue.
           This value must be defined in Bytes.
         version_added: ~
         type: integer
         example: ~
-        default: "1024"
+        default: "524288"

--- a/providers/src/airflow/providers/edge/provider.yaml
+++ b/providers/src/airflow/providers/edge/provider.yaml
@@ -27,7 +27,7 @@ source-date-epoch: 1729683247
 
 # note that those versions are maintained by release manager - do not update them manually
 versions:
-  - 0.3.0pre0
+  - 0.4.0pre0
 
 dependencies:
   - apache-airflow>=2.10.0
@@ -102,3 +102,11 @@ config:
         type: integer
         example: ~
         default: "60"
+      push_log_chunk_size:
+        description: |
+          Edge Worker uploads log files in chunks. If the log file part which is uploaded exceeds the chunk size it creates a new request. This solves issue if firewall defines max size of request.
+          This value must be defined in Bytes.
+        version_added: ~
+        type: integer
+        example: ~
+        default: "1024"

--- a/providers/tests/edge/cli/test_edge_command.py
+++ b/providers/tests/edge/cli/test_edge_command.py
@@ -21,7 +21,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 from subprocess import Popen
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
 import time_machine
@@ -224,6 +224,21 @@ class TestEdgeWorkerCli:
         mock_push_logs.assert_called_once_with(
             task=job.edge_job.key, log_chunk_time=datetime.now(), log_chunk_data="world"
         )
+
+    @time_machine.travel(datetime.now(), tick=False)
+    @patch("airflow.providers.edge.models.edge_logs.EdgeLogs.push_logs")
+    def test_check_running_jobs_log_push_chunks(self, mock_push_logs, worker_with_job: _EdgeWorkerCli):
+        job = worker_with_job.jobs[0]
+        job.process.generated_returncode = None
+        job.logfile.write_text("log1log2log3")
+        with conf_vars({("edge", "api_url"): "https://mock.server", ("edge", "push_log_chunk_size"): "4"}):
+            worker_with_job.check_running_jobs()
+        assert len(worker_with_job.jobs) == 1
+        calls = mock_push_logs.call_args_list
+        len(calls) == 3
+        assert calls[0] == call(task=job.edge_job.key, log_chunk_time=datetime.now(), log_chunk_data="log1")
+        assert calls[1] == call(task=job.edge_job.key, log_chunk_time=datetime.now(), log_chunk_data="log2")
+        assert calls[2] == call(task=job.edge_job.key, log_chunk_time=datetime.now(), log_chunk_data="log3")
 
     @pytest.mark.parametrize(
         "drain, jobs, expected_state",


### PR DESCRIPTION
# Description

If Firewall checks for max request sizem, Edge Worker can not push log files without running into an Exception. This PR adds the feature to split log file upload into different chunks if max log file chunk size limit was reached.

# Details about changes

* Add new config value which defined max chunk size. push_log_chunk_size
* If push_log_chunk_size value exceeds then upload split rest of log file into new request.
