### PR TITLE
Improve the cursor type definition of mysql 

### DIFF
--- a/providers/src/airflow/providers/mysql/hooks/mysql.py
+++ b/providers/src/airflow/providers/mysql/hooks/mysql.py
@@ -127,12 +127,17 @@ class MySqlHook(DbApiHook):
         if conn.extra_dejson.get("cursor", False):
             import MySQLdb.cursors
 
-            if (conn.extra_dejson["cursor"]).lower() == "sscursor":
-                conn_config["cursorclass"] = MySQLdb.cursors.SSCursor
-            elif (conn.extra_dejson["cursor"]).lower() == "dictcursor":
-                conn_config["cursorclass"] = MySQLdb.cursors.DictCursor
-            elif (conn.extra_dejson["cursor"]).lower() == "ssdictcursor":
-                conn_config["cursorclass"] = MySQLdb.cursors.SSDictCursor
+            cursor_type = conn.extra_dejson.get("cursor", "").lower()
+            # Dictionary mapping cursor types to their respective classes
+            cursor_classes = {
+                "sscursor": MySQLdb.cursors.SSCursor,
+                "dictcursor": MySQLdb.cursors.DictCursor,
+                "ssdictcursor": MySQLdb.cursors.SSDictCursor,
+            }
+            # Set the cursor class in the connection configuration based on the cursor type
+            if cursor_type in cursor_classes:
+                conn_config["cursorclass"] = cursor_classes[cursor_type]
+
         if conn.extra_dejson.get("ssl", False):
             # SSL parameter for MySQL has to be a dictionary and in case
             # of extra/dejson we can get string if extra is passed via


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
This PR will improve the cursor type definition of mysql hooks code in `hooks/mysql.py`.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
