### PR TITLE
refactor(utils/decorators): rewrite remove task decorator to use cst

### DIFF
--- a/airflow/utils/decorators.py
+++ b/airflow/utils/decorators.py
@@ -38,11 +38,13 @@ class _TaskDecoratorRemover(cst.CSTTransformer):
     def _is_task_decorator(self, decorator: cst.Decorator) -> bool:
         if isinstance(decorator.decorator, cst.Name):
             return decorator.decorator.value in self.decorators_to_remove
-        elif isinstance(decorator.decorator, cst.Attribute) and isinstance(decorator.decorator.value, cst.Name):
-                return (
-                    f"{decorator.decorator.value.value}.{decorator.decorator.attr.value}"
-                    in self.decorators_to_remove
-                )
+        elif isinstance(decorator.decorator, cst.Attribute) and isinstance(
+            decorator.decorator.value, cst.Name
+        ):
+            return (
+                f"{decorator.decorator.value.value}.{decorator.decorator.attr.value}"
+                in self.decorators_to_remove
+            )
         elif isinstance(decorator.decorator, cst.Call):
             return self._is_task_decorator(cst.Decorator(decorator=decorator.decorator.func))
         return False

--- a/airflow/utils/decorators.py
+++ b/airflow/utils/decorators.py
@@ -35,18 +35,18 @@ class _TaskDecoratorRemover(cst.CSTTransformer):
             task_decorator_name.strip("@"),
         }
 
-    def _is_task_decorator(self, decorator: cst.Decorator) -> bool:
-        if isinstance(decorator.decorator, cst.Name):
-            return decorator.decorator.value in self.decorators_to_remove
-        elif isinstance(decorator.decorator, cst.Attribute) and isinstance(
-            decorator.decorator.value, cst.Name
+    def _is_task_decorator(self, decorator_node: cst.Decorator) -> bool:
+        if isinstance(decorator_node.decorator, cst.Name):
+            return decorator_node.decorator.value in self.decorators_to_remove
+        elif isinstance(decorator_node.decorator, cst.Attribute) and isinstance(
+            decorator_node.decorator.value, cst.Name
         ):
             return (
-                f"{decorator.decorator.value.value}.{decorator.decorator.attr.value}"
+                f"{decorator_node.decorator.value.value}.{decorator_node.decorator.attr.value}"
                 in self.decorators_to_remove
             )
-        elif isinstance(decorator.decorator, cst.Call):
-            return self._is_task_decorator(cst.Decorator(decorator=decorator.decorator.func))
+        elif isinstance(decorator_node.decorator, cst.Call):
+            return self._is_task_decorator(cst.Decorator(decorator=decorator_node.decorator.func))
         return False
 
     def leave_FunctionDef(

--- a/airflow/utils/decorators.py
+++ b/airflow/utils/decorators.py
@@ -26,7 +26,7 @@ T = TypeVar("T", bound=Callable)
 
 
 class _TaskDecoratorRemover(cst.CSTTransformer):
-    def __init__(self, task_decorator_name):
+    def __init__(self, task_decorator_name: str) -> None:
         self.decorators_to_remove: set[str] = {
             "setup",
             "teardown",

--- a/airflow/utils/decorators.py
+++ b/airflow/utils/decorators.py
@@ -38,8 +38,7 @@ class _TaskDecoratorRemover(cst.CSTTransformer):
     def _is_task_decorator(self, decorator: cst.Decorator) -> bool:
         if isinstance(decorator.decorator, cst.Name):
             return decorator.decorator.value in self.decorators_to_remove
-        elif isinstance(decorator.decorator, cst.Attribute):
-            if isinstance(decorator.decorator.value, cst.Name):
+        elif isinstance(decorator.decorator, cst.Attribute) and isinstance(decorator.decorator.value, cst.Name):
                 return (
                     f"{decorator.decorator.value.value}.{decorator.decorator.attr.value}"
                     in self.decorators_to_remove

--- a/airflow/utils/decorators.py
+++ b/airflow/utils/decorators.py
@@ -27,7 +27,7 @@ T = TypeVar("T", bound=Callable)
 
 class _TaskDecoratorRemover(cst.CSTTransformer):
     def __init__(self, task_decorator_name):
-        self.decorators_to_remove = {
+        self.decorators_to_remove: set[str] = {
             "setup",
             "teardown",
             "task.skip_if",

--- a/airflow/utils/decorators.py
+++ b/airflow/utils/decorators.py
@@ -36,7 +36,8 @@ class _TaskDecoratorRemover(cst.CSTTransformer):
         }
 
     def _is_task_decorator(self, decorator_node: cst.Decorator) -> bool:
-        if isinstance(decorator_node.decorator, cst.Name):
+        decorator_expr = decorator_node.decorator
+        if isinstance(decorator_expr, cst.Name):
             return decorator_node.decorator.value in self.decorators_to_remove
         elif isinstance(decorator_node.decorator, cst.Attribute) and isinstance(
             decorator_node.decorator.value, cst.Name

--- a/airflow/utils/decorators.py
+++ b/airflow/utils/decorators.py
@@ -18,10 +18,43 @@
 from __future__ import annotations
 
 import sys
-from collections import deque
 from typing import Callable, TypeVar
 
+import libcst as cst
+
 T = TypeVar("T", bound=Callable)
+
+
+class _TaskDecoratorRemover(cst.CSTTransformer):
+    def __init__(self, task_decorator_name):
+        self.decorators_to_remove = {
+            "setup",
+            "teardown",
+            "task.skip_if",
+            "task.run_if",
+            task_decorator_name.strip("@"),
+        }
+
+    def _is_task_decorator(self, decorator: cst.Decorator) -> bool:
+        if isinstance(decorator.decorator, cst.Name):
+            return decorator.decorator.value in self.decorators_to_remove
+        elif isinstance(decorator.decorator, cst.Attribute):
+            if isinstance(decorator.decorator.value, cst.Name):
+                return (
+                    f"{decorator.decorator.value.value}.{decorator.decorator.attr.value}"
+                    in self.decorators_to_remove
+                )
+        elif isinstance(decorator.decorator, cst.Call):
+            return self._is_task_decorator(cst.Decorator(decorator=decorator.decorator.func))
+        return False
+
+    def leave_FunctionDef(
+        self, original_node: cst.FunctionDef, updated_node: cst.FunctionDef
+    ) -> cst.FunctionDef:
+        new_decorators = [dec for dec in updated_node.decorators if not self._is_task_decorator(dec)]
+        if len(new_decorators) == len(updated_node.decorators):
+            return updated_node
+        return updated_node.with_changes(decorators=new_decorators)
 
 
 def remove_task_decorator(python_source: str, task_decorator_name: str) -> str:
@@ -30,42 +63,10 @@ def remove_task_decorator(python_source: str, task_decorator_name: str) -> str:
 
     :param python_source: The python source code
     :param task_decorator_name: the decorator name
-
-    TODO: Python 3.9+: Rewrite this to use ast.parse and ast.unparse
     """
-
-    def _remove_task_decorator(py_source, decorator_name):
-        # if no line starts with @decorator_name, we can early exit
-        for line in py_source.split("\n"):
-            if line.startswith(decorator_name):
-                break
-        else:
-            return python_source
-        split = python_source.split(decorator_name, 1)
-        before_decorator, after_decorator = split[0], split[1]
-        if after_decorator[0] == "(":
-            after_decorator = _balance_parens(after_decorator)
-        if after_decorator[0] == "\n":
-            after_decorator = after_decorator[1:]
-        return before_decorator + after_decorator
-
-    decorators = ["@setup", "@teardown", "@task.skip_if", "@task.run_if", task_decorator_name]
-    for decorator in decorators:
-        python_source = _remove_task_decorator(python_source, decorator)
-    return python_source
-
-
-def _balance_parens(after_decorator):
-    num_paren = 1
-    after_decorator = deque(after_decorator)
-    after_decorator.popleft()
-    while num_paren:
-        current = after_decorator.popleft()
-        if current == "(":
-            num_paren = num_paren + 1
-        elif current == ")":
-            num_paren = num_paren - 1
-    return "".join(after_decorator)
+    source_tree = cst.parse_module(python_source)
+    modified_tree = source_tree.visit(_TaskDecoratorRemover(task_decorator_name))
+    return modified_tree.code
 
 
 class _autostacklevel_warn:

--- a/airflow/utils/decorators.py
+++ b/airflow/utils/decorators.py
@@ -38,16 +38,11 @@ class _TaskDecoratorRemover(cst.CSTTransformer):
     def _is_task_decorator(self, decorator_node: cst.Decorator) -> bool:
         decorator_expr = decorator_node.decorator
         if isinstance(decorator_expr, cst.Name):
-            return decorator_node.decorator.value in self.decorators_to_remove
-        elif isinstance(decorator_node.decorator, cst.Attribute) and isinstance(
-            decorator_node.decorator.value, cst.Name
-        ):
-            return (
-                f"{decorator_node.decorator.value.value}.{decorator_node.decorator.attr.value}"
-                in self.decorators_to_remove
-            )
-        elif isinstance(decorator_node.decorator, cst.Call):
-            return self._is_task_decorator(cst.Decorator(decorator=decorator_node.decorator.func))
+            return decorator_expr.value in self.decorators_to_remove
+        elif isinstance(decorator_expr, cst.Attribute) and isinstance(decorator_expr.value, cst.Name):
+            return f"{decorator_expr.value.value}.{decorator_expr.attr.value}" in self.decorators_to_remove
+        elif isinstance(decorator_expr, cst.Call):
+            return self._is_task_decorator(cst.Decorator(decorator=decorator_expr.func))
         return False
 
     def leave_FunctionDef(

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -391,6 +391,7 @@ DEPENDENCIES = [
     "jinja2>=3.0.0",
     "jsonschema>=4.18.0",
     "lazy-object-proxy>=1.2.0",
+    "libcst >=1.1.0",
     "linkify-it-py>=2.0.0",
     "lockfile>=0.12.2",
     "markdown-it-py>=2.1.0",

--- a/providers/standard/tests/provider_tests/standard/utils/test_python_virtualenv.py
+++ b/providers/standard/tests/provider_tests/standard/utils/test_python_virtualenv.py
@@ -213,8 +213,8 @@ class TestPrepareVirtualenv:
             import funcsigs
         """
         )
-        py_source = decorator + SCRIPT
-        expected_source = expected_decorator + SCRIPT if expected_decorator else SCRIPT.lstrip()
+        py_source = f"{decorator}{SCRIPT}"
+        expected_source = f"{expected_decorator}{SCRIPT}" if expected_decorator else SCRIPT.lstrip()
 
         res = remove_task_decorator(python_source=py_source, task_decorator_name="@task.virtualenv")
         assert res == expected_source

--- a/providers/standard/tests/provider_tests/standard/utils/test_python_virtualenv.py
+++ b/providers/standard/tests/provider_tests/standard/utils/test_python_virtualenv.py
@@ -192,25 +192,25 @@ class TestPrepareVirtualenv:
         )
 
     def test_remove_task_decorator(self):
-        py_source = '@task.virtualenv(serializer="dill")\ndef f():\nimport funcsigs'
+        py_source = '@task.virtualenv(serializer="dill")\ndef f():\n    import funcsigs'
         res = remove_task_decorator(python_source=py_source, task_decorator_name="@task.virtualenv")
-        assert res == "def f():\nimport funcsigs"
+        assert res == "def f():\n    import funcsigs"
 
     def test_remove_decorator_no_parens(self):
-        py_source = "@task.virtualenv\ndef f():\nimport funcsigs"
+        py_source = "@task.virtualenv\ndef f():\n    import funcsigs"
         res = remove_task_decorator(python_source=py_source, task_decorator_name="@task.virtualenv")
-        assert res == "def f():\nimport funcsigs"
+        assert res == "def f():\n    import funcsigs"
 
     def test_remove_decorator_including_comment(self):
-        py_source = "@task.virtualenv\ndef f():\n# @task.virtualenv\nimport funcsigs"
+        py_source = "@task.virtualenv\ndef f():\n# @task.virtualenv\n    import funcsigs"
         res = remove_task_decorator(python_source=py_source, task_decorator_name="@task.virtualenv")
-        assert res == "def f():\n# @task.virtualenv\nimport funcsigs"
+        assert res == "def f():\n# @task.virtualenv\n    import funcsigs"
 
     def test_remove_decorator_nested(self):
-        py_source = "@foo\n@task.virtualenv\n@bar\ndef f():\nimport funcsigs"
+        py_source = "@foo\n@task.virtualenv\n@bar\ndef f():\n    import funcsigs"
         res = remove_task_decorator(python_source=py_source, task_decorator_name="@task.virtualenv")
-        assert res == "@foo\n@bar\ndef f():\nimport funcsigs"
+        assert res == "@foo\n@bar\ndef f():\n    import funcsigs"
 
-        py_source = "@foo\n@task.virtualenv()\n@bar\ndef f():\nimport funcsigs"
+        py_source = "@foo\n@task.virtualenv()\n@bar\ndef f():\n    import funcsigs"
         res = remove_task_decorator(python_source=py_source, task_decorator_name="@task.virtualenv")
-        assert res == "@foo\n@bar\ndef f():\nimport funcsigs"
+        assert res == "@foo\n@bar\ndef f():\n    import funcsigs"

--- a/providers/standard/tests/provider_tests/standard/utils/test_python_virtualenv.py
+++ b/providers/standard/tests/provider_tests/standard/utils/test_python_virtualenv.py
@@ -204,7 +204,7 @@ class TestPrepareVirtualenv:
         ids=["without_parens", "parens", "with_args", "nested_without_parens", "nested_with_parens"],
     )
     def test_remove_task_decorator(self, decorators: list[str], expected_decorators: list[str]):
-        decorator = "\n".join(decorators)
+        concated_decorators = "\n".join(decorators)
         expected_decorator = "\n".join(expected_decorators)
         SCRIPT = dedent(
             """
@@ -213,8 +213,8 @@ class TestPrepareVirtualenv:
             import funcsigs
         """
         )
-        py_source = f"{decorator}{SCRIPT}"
-        expected_source = f"{expected_decorator}{SCRIPT}" if expected_decorator else SCRIPT.lstrip()
+        py_source = concated_decorators + SCRIPT
+        expected_source = expected_decorator + SCRIPT if expected_decorator else SCRIPT.lstrip()
 
         res = remove_task_decorator(python_source=py_source, task_decorator_name="@task.virtualenv")
         assert res == expected_source

--- a/tests/utils/test_preexisting_python_virtualenv_decorator.py
+++ b/tests/utils/test_preexisting_python_virtualenv_decorator.py
@@ -37,7 +37,7 @@ class TestExternalPythonDecorator:
         ids=["without_parens", "parens", "with_args", "nested_without_parens", "nested_with_parens"],
     )
     def test_remove_task_decorator(self, decorators: list[str], expected_decorators: list[str]):
-        decorator = "\n".join(decorators)
+        concated_decorators = "\n".join(decorators)
         expected_decorator = "\n".join(expected_decorators)
         SCRIPT = dedent(
             """
@@ -45,7 +45,7 @@ class TestExternalPythonDecorator:
             import funcsigs
         """
         )
-        py_source = decorator + SCRIPT
+        py_source = concated_decorators + SCRIPT
         expected_source = expected_decorator + SCRIPT if expected_decorator else SCRIPT.lstrip()
 
         res = remove_task_decorator(python_source=py_source, task_decorator_name="@task.external_python")

--- a/tests/utils/test_preexisting_python_virtualenv_decorator.py
+++ b/tests/utils/test_preexisting_python_virtualenv_decorator.py
@@ -22,20 +22,20 @@ from airflow.utils.decorators import remove_task_decorator
 
 class TestExternalPythonDecorator:
     def test_remove_task_decorator(self):
-        py_source = '@task.external_python(serializer="dill")\ndef f():\nimport funcsigs'
+        py_source = '@task.external_python(serializer="dill")\ndef f():\n    import funcsigs'
         res = remove_task_decorator(python_source=py_source, task_decorator_name="@task.external_python")
-        assert res == "def f():\nimport funcsigs"
+        assert res == "def f():\n    import funcsigs"
 
     def test_remove_decorator_no_parens(self):
-        py_source = "@task.external_python\ndef f():\nimport funcsigs"
+        py_source = "@task.external_python\ndef f():\n    import funcsigs"
         res = remove_task_decorator(python_source=py_source, task_decorator_name="@task.external_python")
-        assert res == "def f():\nimport funcsigs"
+        assert res == "def f():\n    import funcsigs"
 
     def test_remove_decorator_nested(self):
-        py_source = "@foo\n@task.external_python\n@bar\ndef f():\nimport funcsigs"
+        py_source = "@foo\n@task.external_python\n@bar\ndef f():\n    import funcsigs"
         res = remove_task_decorator(python_source=py_source, task_decorator_name="@task.external_python")
-        assert res == "@foo\n@bar\ndef f():\nimport funcsigs"
+        assert res == "@foo\n@bar\ndef f():\n    import funcsigs"
 
-        py_source = "@foo\n@task.external_python()\n@bar\ndef f():\nimport funcsigs"
+        py_source = "@foo\n@task.external_python()\n@bar\ndef f():\n    import funcsigs"
         res = remove_task_decorator(python_source=py_source, task_decorator_name="@task.external_python")
-        assert res == "@foo\n@bar\ndef f():\nimport funcsigs"
+        assert res == "@foo\n@bar\ndef f():\n    import funcsigs"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
due to #42766 the dropping of python3.8 support, I rewrite the  `remove_task_decorator` to achieve the same purpose through CST.

TODO:
- [x] implementation
- [x] update unit tests

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
