### PR TITLE
Provide default for EXCLUDED_PROVIDERS lookup.

### DIFF
--- a/scripts/in_container/is_provider_excluded.py
+++ b/scripts/in_container/is_provider_excluded.py
@@ -23,7 +23,7 @@ import os
 from in_container_utils import console
 
 if __name__ == "__main__":
-    excluded_providers = json.loads(os.environ["EXCLUDED_PROVIDERS"])
+    excluded_providers = json.loads(os.environ.get("EXCLUDED_PROVIDERS", "{}"))
     extra = os.environ["EXTRA"]
     console.print(f"[bright_blue]Check if provider {extra} is excluded in {excluded_providers}")
     python_version = os.environ["PYTHON_MAJOR_MINOR_VERSION"]


### PR DESCRIPTION
The current code throws a KeyError when the environment variable EXCLUDED_PROVIDERS is not defined. This commit adds an empty map as a default to prevent this failure.


This was discovered while trying to replicate the issue with microsoft-kiota-http logged here:
https://github.com/microsoftgraph/msgraph-sdk-python-core/issues/706


> breeze testing tests --force-lowest-dependencies --test-type "Providers[microsoft.azure]"

### Before:
Forcing dependencies to lowest versions for provider: [microsoft-azure]

Traceback (most recent call last):
  File "/opt/airflow/scripts/in_container/is_provider_excluded.py", line 26, in <module>
    excluded_providers = json.loads(os.environ["EXCLUDED_PROVIDERS"])
  File "/usr/local/lib/python3.9/os.py", line 679, in __getitem__
    raise KeyError(key) from None
KeyError: 'EXCLUDED_PROVIDERS'

### After:
Forcing dependencies to lowest versions for provider: [microsoft-azure]

Check if provider  is excluded in {}
Provider  is not excluded.