### PR TITLE
Add documentation and modify breeze to use uv for pre-commits

### DIFF
--- a/contributing-docs/03_contributors_quick_start.rst
+++ b/contributing-docs/03_contributors_quick_start.rst
@@ -478,7 +478,7 @@ You can still add uv support for pre-commit if you use pipx using the commands:
     pipx inject
     pipx inject pre-commit pre-commit-uv
 
-Also, if you already use ``uvx`` instead of ``pipx``:
+Also, if you already use ``uvx`` instead of ``pipx``, use this command:
 
 .. code-block:: bash
 

--- a/contributing-docs/03_contributors_quick_start.rst
+++ b/contributing-docs/03_contributors_quick_start.rst
@@ -470,7 +470,7 @@ Installing pre-commit is best done with ``pipx``:
 
     pipx install pre-commit
 
-You can still add uv support for pre-commit if you use pipx
+You can still add uv support for pre-commit if you use pipx using the commands:
 
 .. code-block:: bash
 

--- a/contributing-docs/03_contributors_quick_start.rst
+++ b/contributing-docs/03_contributors_quick_start.rst
@@ -452,6 +452,39 @@ tests are applied when you commit your code.
 
 To avoid burden on CI infrastructure and to save time, Pre-commit hooks can be run locally before committing changes.
 
+.. note::
+
+    We have recently started to recommend ``uv`` for our local development. Currently (October 2024) ``uv``
+    speeds up installation more than 10x comparing to ``pip``. While we still describe ``pip`` and ``pipx``
+    below, we also show the ``uv`` alternatives.
+
+.. note::
+
+    Remember to have global python set to Python >= 3.9 - Python 3.8 is end-of-life already and we've
+    started to use Python 3.9+ features in Airflow and accompanying scripts.
+
+
+Installing pre-commit is best done with ``pipx``:
+
+.. code-block:: bash
+
+    pipx install pre-commit
+
+You can still add uv support for pre-commit if you use pipx
+
+.. code-block:: bash
+
+    pipx install pre-commit
+    pipx inject
+    pipx inject pre-commit pre-commit-uv
+
+Also, if you already use ``uvx`` instead of ``pipx``:
+
+.. code-block:: bash
+
+    uv tool install pre-commit --with pre-commit-uv --force-reinstall
+
+
 1.  Installing required packages
 
 on Debian / Ubuntu, install via

--- a/dev/breeze/README.md
+++ b/dev/breeze/README.md
@@ -66,6 +66,6 @@ PLEASE DO NOT MODIFY THE HASH BELOW! IT IS AUTOMATICALLY UPDATED BY PRE-COMMIT.
 
 ---------------------------------------------------------------------------------------------------------
 
-Package config hash: 2ae1201c56227b6fcb599f020360a906100a80b32ed3a0d4927c8721e738afee3867f9ed567fd75ec9f368933c3a94c1336f8ab068f7892ed1ebe6244ccf20fe
+Package config hash: f13c42703e0a262d9f3c1bee608ff32c368be4c6a11f150a2f95809938641f5ec07904d5cc2e3944dfe4d206dc52846f8b81193fc279a333ff898dd033e07be4
 
 ---------------------------------------------------------------------------------------------------------

--- a/dev/breeze/doc/04_troubleshooting.rst
+++ b/dev/breeze/doc/04_troubleshooting.rst
@@ -97,6 +97,8 @@ This can be done (if you use ``pipx`` to install ``pre-commit``):
 
     pipx uninstall pre-commit
     pipx install pre-commit --python $(which python3.9) --force
+    # This one allows pre-commit to use uv for venvs installed by pre-commit
+    pipx inject pre-commit pre-commit-uv
     pre-commit clean
     pre-commit install
 

--- a/dev/breeze/pyproject.toml
+++ b/dev/breeze/pyproject.toml
@@ -62,6 +62,7 @@ dependencies = [
     "packaging>=23.2",
     "pipx>=1.4.1",
     "pre-commit>=3.5.0",
+    "pre-commit-uv>=4.1.3",
     "psutil>=5.9.6",
     "pygithub>=2.1.1",
     "pytest-xdist>=3.3.1",


### PR DESCRIPTION
While pre-commit author refuses to add `uv` support, tox developers release a package that patches pre-commit with `uv` support - this should allow to speed up initial installation and upgrade of pre-commit venvs.

Our CI uses breeze-installed uv, rather than pipx installed one, so this PR extends breeze to also install `pre-commit-uv` package, so that UV can be used in CI.

Also documentation was updated to explain how to switch pre-commit installation to be able to use `uv` for the venvs.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
