### PR TITLE
core operator python: check virtualenv is importable by importing

### DIFF
--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -68,13 +68,16 @@ if TYPE_CHECKING:
 
 def is_venv_installed() -> bool:
     """
-    Check if the virtualenv package is installed via checking if it is on the path or installed as package.
+    Check if the virtualenv package is installed by importing `venv`.
 
-    :return: True if it is. Whichever way of checking it works, is fine.
+    :return: True if no `ModuleNotFoundError` is raised, False otherwise. 
     """
-    if shutil.which("virtualenv") or importlib.util.find_spec("virtualenv"):
+    try:
+        import venv
         return True
-    return False
+    except ModuleNotFoundError:
+        return False
+    
 
 
 def task(python_callable: Callable | None = None, multiple_outputs: bool | None = None, **kwargs):

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -68,7 +68,7 @@ if TYPE_CHECKING:
 
 def is_venv_installed() -> bool:
     """
-    Check if the virtualenv package is installed by importing `venv`.
+    Check if the virtualenv package is installed by importing `virtualenv`.
 
     :return: True if no `ModuleNotFoundError` is raised, False otherwise. 
     """

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -73,7 +73,7 @@ def is_venv_installed() -> bool:
     :return: True if no `ModuleNotFoundError` is raised, False otherwise. 
     """
     try:
-        import venv
+        import virtualenv
         return True
     except ModuleNotFoundError:
         return False


### PR DESCRIPTION
This imports the module to check for `ModuleNotFoundError`. A soft import is possible but then will then import it later anyway and this will be most robust. This change is needed as a system `virtualenv` is not always available in a venv that airflow is not running in.

Closes #40420 