### PR TITLE
gitSync from multiple git repository or branch

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -108,8 +108,16 @@ spec:
       image: {{ template "pod_template_image" . }}
       imagePullPolicy: {{ .Values.images.pod_template.pullPolicy }}
       securityContext: {{ $containerSecurityContext | nindent 8 }}
+      # In order to make the multirepo sync change work ,
+      # postStart LifeCycle Hook is created
+      # Check the airflow.dags_poststart in _helpers.yaml
+      {{- if or $containerLifecycleHooks .Values.dags.gitSync.enabled }}
       {{- if $containerLifecycleHooks }}
-      lifecycle: {{- tpl (toYaml $containerLifecycleHooks) . | nindent 8 }}
+      lifecycle: {{- tpl (toYaml $containerLifecycleHooks) . | nindent 12 }}
+      {{ include "airflow.dags_poststart" . | nindent 12 }}
+      {{- else }}
+      lifecycle: {{ include "airflow.dags_poststart" . | nindent 12 }}
+      {{- end }}
       {{- end }}
       name: base
       {{- if .Values.workers.command }}
@@ -213,14 +221,21 @@ spec:
   topologySpreadConstraints: {{- toYaml $topologySpreadConstraints | nindent 4 }}
   serviceAccountName: {{ include "worker.serviceAccountName" . }}
   volumes:
+  # multirepo gitSync , separate volumes for each containers
   {{- if .Values.dags.persistence.enabled }}
   - name: dags
     persistentVolumeClaim:
       claimName: {{ template "airflow_dags_volume_claim" . }}
   {{- else if .Values.dags.gitSync.enabled }}
-  - name: dags
-    emptyDir: {{- toYaml (default (dict) .Values.dags.gitSync.emptyDirConfig) | nindent 6 }}
+  {{- range $repo := .Values.dags.gitSync.repositories }}
+  - name: repo-volume-{{ $repo.containerName }}
+    emptyDir: {{- toYaml (default (dict) $repo.emptyDirConfig) | nindent 12 }}
+  {{- if or $repo.sshKeySecret $repo.sshKey}}
+    {{- include "git_sync_ssh_key_volume" . | indent 8 }}
   {{- end }}
+  {{- end }}
+  {{- end }}
+    # end of multirepo gitSync changes
   {{- if .Values.logs.persistence.enabled }}
   - name: logs
     persistentVolumeClaim:
@@ -228,9 +243,6 @@ spec:
   {{- else }}
   - emptyDir: {{- toYaml (default (dict) .Values.logs.emptyDirConfig) | nindent 6 }}
     name: logs
-  {{- end }}
-  {{- if and  .Values.dags.gitSync.enabled  .Values.dags.gitSync.sshKeySecret }}
-    {{- include "git_sync_ssh_key_volume" . | nindent 2 }}
   {{- end }}
   - configMap:
       name: {{ include "airflow_config" . }}

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -142,7 +142,9 @@ WARNING:
 {{- end }}
 {{- end }}
 
-{{- if and .Values.dags.gitSync.enabled .Values.dags.gitSync.sshKeySecret (not .Values.dags.gitSync.knownHosts)}}
+{{- if and .Values.dags.gitSync.enabled }}
+{{- range $repo := .Values.dags.gitSync.repositories }}
+{{- if and $repo.sshKeySecret (not $repo.knownHosts ) }}
 
 #####################################################
 #  WARNING: You should set dags.gitSync.knownHosts  #
@@ -154,6 +156,8 @@ making you susceptible to man-in-the-middle attacks!
 Information on how to set knownHosts can be found here:
 https://airflow.apache.org/docs/helm-chart/stable/production-guide.html#knownhosts
 
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{- if .Values.flower.extraNetworkPolicies }}
@@ -204,3 +208,21 @@ https://airflow.apache.org/docs/helm-chart/stable/production-guide.html#webserve
 {{- if ne .Values.executor (tpl .Values.config.core.executor $) }}
    {{ fail "Please configure the executor with `executor`, not `config.core.executor`." }}
 {{- end }}
+
+###########################################################
+#  INFO: MultiRepo GitSync setup has been initiated       #
+#  gitSync container name should be unique                #
+#  If dags persistence enabled make sure it is RWX or RWO #
+###########################################################
+
+{{- if .Values.dags.persistence.enabled }}
+ Dags Persistence enabled, GitSync containers will not be created
+{{- else }}
+{{- if .Values.dags.gitSync.enabled }}
+ GitSync Enabled : {{ .Values.dags.gitSync.enabled }}
+ Number of Repositories : {{ len .Values.dags.gitSync.repositories }}
+{{- else }}
+ GitSync Enabled : {{ .Values.dags.gitSync.enabled }}
+{{- end }}
+{{- end }}
+

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -184,31 +184,42 @@ If release name contains chart name it will be used as a full name.
   {{- end }}
 {{- end }}
 
+# multirepo sync changes
+# Handling custom git-sync-environment for all repos
+
 {{/* User defined gitSync container environment from */}}
 {{- define "custom_git_sync_environment_from" }}
   {{- $Global := . }}
-  {{- with .Values.dags.gitSync.envFrom }}
+  {{- with .envFrom }}
     {{- tpl . $Global | nindent 2 }}
   {{- end }}
 {{- end }}
 
+# multirepo sync changes
+# git-ssh-key-volume for every repo
+
 {{/*  Git ssh key volume */}}
 {{- define "git_sync_ssh_key_volume" }}
-- name: git-sync-ssh-key
+- name: {{ printf "git-sync-ssh-key-%s" .containerName }}
   secret:
     secretName: {{ template "git_sync_ssh_key" . }}
     defaultMode: 288
 {{- end }}
 
+# multirepo sync changes
+# Create a container ( init also ) , for each repo
+
 {{/*  Git sync container */}}
 {{- define "git_sync_container" }}
-- name: {{ .Values.dags.gitSync.containerName }}{{ if .is_init }}-init{{ end }}
-  image: {{ template "git_sync_image" . }}
-  imagePullPolicy: {{ .Values.images.gitSync.pullPolicy }}
-  securityContext: {{- include "localContainerSecurityContext" .Values.dags.gitSync | nindent 4 }}
-  envFrom: {{- include "custom_git_sync_environment_from" . | default "\n  []" | indent 2 }}
+{{- $is_init := .is_init }}
+{{- range $repo := .Values.dags.gitSync.repositories }}
+- name: {{ $repo.containerName }}{{ if $is_init }}-init{{ end }}
+  image: {{ template "git_sync_image" $ }}
+  imagePullPolicy: {{ $.Values.images.gitSync.pullPolicy }}
+  securityContext: {{- include "localContainerSecurityContext" $repo | nindent 4 }}
+  envFrom: {{- include "custom_git_sync_environment_from" $repo | default "\n  []" | indent 2 }}
   env:
-    {{- if or .Values.dags.gitSync.sshKeySecret .Values.dags.gitSync.sshKey }}
+    {{- if or $repo.sshKeySecret $repo.sshKey }}
     - name: GIT_SSH_KEY_FILE
       value: "/etc/git-secret/ssh"
     - name: GITSYNC_SSH_KEY_FILE
@@ -217,7 +228,7 @@ If release name contains chart name it will be used as a full name.
       value: "true"
     - name: GITSYNC_SSH
       value: "true"
-    {{- if .Values.dags.gitSync.knownHosts }}
+    {{- if $repo.knownHosts }}
     - name: GIT_KNOWN_HOSTS
       value: "true"
     - name: GITSYNC_SSH_KNOWN_HOSTS
@@ -232,95 +243,120 @@ If release name contains chart name it will be used as a full name.
     - name: GITSYNC_SSH_KNOWN_HOSTS
       value: "false"
     {{- end }}
-    {{ else if .Values.dags.gitSync.credentialsSecret }}
+    {{ else if $repo.credentialsSecret }}
     - name: GIT_SYNC_USERNAME
       valueFrom:
         secretKeyRef:
-          name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
+          name: {{ $repo.credentialsSecret | quote }}
           key: GIT_SYNC_USERNAME
     - name: GITSYNC_USERNAME
       valueFrom:
         secretKeyRef:
-          name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
+          name: {{ $repo.credentialsSecret | quote }}
           key: GITSYNC_USERNAME
     - name: GIT_SYNC_PASSWORD
       valueFrom:
         secretKeyRef:
-          name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
+          name: {{ $repo.credentialsSecret | quote }}
           key: GIT_SYNC_PASSWORD
     - name: GITSYNC_PASSWORD
       valueFrom:
         secretKeyRef:
-          name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
+          name: {{ $repo.credentialsSecret | quote }}
           key: GITSYNC_PASSWORD
     {{- end }}
     - name: GIT_SYNC_REV
-      value: {{ .Values.dags.gitSync.rev | quote }}
+      value: {{ $repo.rev | quote }}
     - name: GITSYNC_REF
-      value: {{ .Values.dags.gitSync.ref | quote }}
+      value: {{ $repo.ref | quote }}
     - name: GIT_SYNC_BRANCH
-      value: {{ .Values.dags.gitSync.branch | quote }}
+      value: {{ $repo.branch | quote }}
     - name: GIT_SYNC_REPO
-      value: {{ .Values.dags.gitSync.repo | quote }}
+      value: {{ $repo.repo | quote }}
     - name: GITSYNC_REPO
-      value: {{ .Values.dags.gitSync.repo | quote }}
+      value: {{ $repo.repo | quote }}
     - name: GIT_SYNC_DEPTH
-      value: {{ .Values.dags.gitSync.depth | quote }}
+      value: {{ $repo.depth | quote }}
     - name: GITSYNC_DEPTH
-      value: {{ .Values.dags.gitSync.depth | quote }}
+      value: {{ $repo.depth | quote }}
     - name: GIT_SYNC_ROOT
       value: "/git"
     - name: GITSYNC_ROOT
       value: "/git"
     - name: GIT_SYNC_DEST
-      value: "repo"
+      value: {{ $repo.containerName | quote }}
     - name: GITSYNC_LINK
-      value: "repo"
+      value: {{ $repo.containerName | quote }}
     - name: GIT_SYNC_ADD_USER
       value: "true"
     - name: GITSYNC_ADD_USER
       value: "true"
-    {{- if .Values.dags.gitSync.wait }}
+    {{- if $repo.wait }}
     - name: GIT_SYNC_WAIT
-      value: {{ .Values.dags.gitSync.wait | quote }}
+      value: {{ $repo.wait | quote }}
     {{- end }}
     - name: GITSYNC_PERIOD
-      value: {{ .Values.dags.gitSync.period | quote }}
+      value: {{ $repo.period | quote }}
     - name: GIT_SYNC_MAX_SYNC_FAILURES
-      value: {{ .Values.dags.gitSync.maxFailures | quote }}
+      value: {{ $repo.maxFailures | quote }}
     - name: GITSYNC_MAX_FAILURES
-      value: {{ .Values.dags.gitSync.maxFailures | quote }}
-    {{- if .is_init }}
+      value: {{ $repo.maxFailures | quote }}
+    {{- if $is_init }}
     - name: GIT_SYNC_ONE_TIME
       value: "true"
     - name: GITSYNC_ONE_TIME
       value: "true"
     {{- end }}
-    {{- with .Values.dags.gitSync.env }}
+    {{- with $repo.env }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  resources: {{ toYaml .Values.dags.gitSync.resources | nindent 4 }}
+  resources: {{ toYaml $repo.resources | nindent 4 }}
   volumeMounts:
-  - name: dags
-    mountPath: /git
-  {{- if or .Values.dags.gitSync.sshKeySecret .Values.dags.gitSync.sshKey }}
-  - name: git-sync-ssh-key
-    mountPath: /etc/git-secret/ssh
-    readOnly: true
-    subPath: gitSshKey
-  {{- if .Values.dags.gitSync.knownHosts }}
-  - name: config
-    mountPath: /etc/git-secret/known_hosts
-    readOnly: true
-    subPath: known_hosts
+    - name: repo-volume-{{ $repo.containerName }}
+      mountPath: /git
+  {{- if or $repo.sshKeySecret $repo.sshKey }}
+    - name: git-sync-ssh-key-{{ $repo.containerName }}
+      mountPath: /etc/git-secret/ssh
+      readOnly: true
+      subPath: gitSshKey
+  {{- if $repo.knownHosts }}
+    - name: config
+      mountPath: /etc/git-secret/known_hosts
+      readOnly: true
+      subPath: known_hosts
   {{- end }}
   {{- end }}
-  {{- if .Values.dags.gitSync.extraVolumeMounts }}
-    {{- tpl (toYaml .Values.dags.gitSync.extraVolumeMounts) . | nindent 2 }}
+  {{- if $repo.extraVolumeMounts }}
+    {{- tpl (toYaml $repo.extraVolumeMounts) . | nindent 2 }}
   {{- end }}
-  {{- if and .Values.dags.gitSync.containerLifecycleHooks (not .is_init) }}
-  lifecycle: {{- tpl (toYaml .Values.dags.gitSync.containerLifecycleHooks) . | nindent 4 }}
+  {{- if and $repo.containerLifecycleHooks (not $is_init) }}
+  lifecycle: {{- tpl (toYaml $repo.containerLifecycleHooks) . | nindent 4 }}
   {{- end }}
+{{- end }}
+{{- end }}
+
+# multirepo sync changes
+# Create a symlink for each repo setup
+# The symlink is created in airflowhome/dags/bags folder if dags mountpath is not enabled
+
+{{- define "airflow.dags_poststart" }}
+postStart:
+  exec:
+    command:
+      - /bin/bash
+      - -c
+      - |
+        {{- if .Values.dags.mountPath }}
+        mkdir {{ printf "%s/bags;" .Values.dags.mountPath }}
+        {{- range $repo := .Values.dags.gitSync.repositories }}
+        ln -sf {{ printf "%s/%s/%s/%s %s/bags/%s;" $.Values.dags.mountPath $repo.containerName $repo.containerName $repo.subPath $.Values.airflowHome $repo.containerName }}
+        {{- end }}
+        {{- else }}
+        mkdir {{ printf "%s/dags/bags;" .Values.airflowHome }}
+        {{- range $repo := .Values.dags.gitSync.repositories }}
+        ln -sf {{ printf "%s/dags/%s/%s/%s %s/dags/bags/%s;" $.Values.airflowHome $repo.containerName $repo.containerName $repo.subPath $.Values.airflowHome $repo.containerName }}
+        {{- end }}
+        {{- end }}
 {{- end }}
 
 {{/* This helper will change when customers deploy a new image */}}
@@ -439,9 +475,10 @@ If release name contains chart name it will be used as a full name.
   {{- printf "%s/%s" .Values.kerberos.ccacheMountPath .Values.kerberos.ccacheFileName }}
 {{- end }}
 
+# multirepo sync changes
 {{/* Create the name of the git sync ssh secret to use */}}
 {{- define "git_sync_ssh_key" -}}
-  {{- default (printf "%s-ssh-secret" (include "airflow.fullname" .)) .Values.dags.gitSync.sshKeySecret }}
+  {{- default (printf "%s-ssh-secret" .containerName) .sshKeySecret }}
 {{- end }}
 
 {{- define "celery_executor_namespace" -}}
@@ -513,16 +550,20 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- end }}
 {{- end }}
 
+# multirepo sync changes
+# Defined the dags_folder
+# If gitSync is enabled then the dags_folder should be dags/bags inside airflowhome
+
 {{- define "airflow_dags" -}}
   {{- if .Values.dags.mountPath }}
     {{- if .Values.dags.gitSync.enabled }}
-      {{- printf "%s/repo/%s" .Values.dags.mountPath .Values.dags.gitSync.subPath }}
+      {{- printf "%s/bags" .Values.dags.mountPath }}
     {{- else }}
       {{- printf "%s" .Values.dags.mountPath }}
     {{- end }}
   {{- else }}
     {{- if .Values.dags.gitSync.enabled }}
-      {{- printf "%s/dags/repo/%s" .Values.airflowHome .Values.dags.gitSync.subPath }}
+      {{- printf "%s/dags/bags" .Values.airflowHome }}
     {{- else }}
       {{- printf "%s/dags" .Values.airflowHome }}
     {{- end }}
@@ -537,7 +578,21 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- end }}
 {{- end }}
 
+# multirepo sync changes
+# mounting the gitSync output to repo wise folders inside airflowhome / dags
+
 {{- define "airflow_dags_mount" -}}
+{{- if .Values.dags.gitSync.enabled }}
+{{- range $repo := .Values.dags.gitSync.repositories }}
+- name: repo-volume-{{ $repo.containerName }}
+  {{- if $.Values.dags.mountPath }}
+  mountPath: {{ printf "%s/%s" $.Values.dags.mountPath $repo.containerName }}
+  {{- else }}
+  mountPath: {{ printf "%s/dags/%s" $.Values.airflowHome $repo.containerName }}
+  readOnly: true
+  {{- end }}
+{{- end }}
+{{- else }}
 - name: dags
   {{- if .Values.dags.mountPath }}
   mountPath: {{ .Values.dags.mountPath }}
@@ -547,7 +602,8 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.dags.persistence.subPath }}
   subPath: {{ .Values.dags.persistence.subPath }}
   {{- end }}
-  readOnly: {{ .Values.dags.gitSync.enabled | ternary "True" "False" }}
+  readOnly: false
+{{- end }}
 {{- end }}
 
 {{- define "airflow_config_path" -}}

--- a/chart/templates/check-values.yaml
+++ b/chart/templates/check-values.yaml
@@ -72,3 +72,61 @@ The sole purpose of this yaml file is it to check the values file is consistent 
     {{- end }}
 
   {{- end }}
+
+{{- /*
+#####################################
+   Multirepo GitSync Related Changes
+   We will check Below Rules
+    1 . Duplicate Entry of git-repos and branch combinations in repositories section in values.yaml
+    2 . ContainerName should be unique for every repos
+######################################
+*/
+-}}
+
+  {{- if .Values.dags.gitSync.enabled }}
+
+    {{- if hasKey .Values.dags.gitSync "repositories" }}
+
+      {{- if lt (len .Values.dags.gitSync.repositories) 1 }}
+        {{- fail (printf " gitSync is enabled : Please provide git repo information under repositories. Please check the values.yaml for more information ") }}
+
+      {{- else }}
+
+        {{- $repoCount := len .Values.dags.gitSync.repositories }}
+        {{- $uniqueNames := dict }}
+        {{- $uniqueContainer := dict }}
+
+        # Check if repositories list has duplicate repo and branch combination
+
+        {{- range .Values.dags.gitSync.repositories }}
+          {{- $key_names := printf "%s-%s" .repo .branch }}  # Create a unique key based on repo and branch
+          {{- $key_container := printf "%s" .containerName }} # Create a unique key based on containerName
+          {{- if not (hasKey $uniqueNames $key_names) }}  # Check if the key is not already in the dictionary
+            {{- $_ := set $uniqueNames $key_names $key_names }}  # Add the key to the dictionary
+          {{- end }}
+          {{- if not (hasKey $uniqueContainer $key_container) }}  # Check if the key is not already in the dictionary
+            {{- $_ := set $uniqueContainer $key_container $key_container }}  # Add the key to the dictionary
+          {{- end }}
+        {{- end }}
+
+        {{- $uniqueNamesCount := len $uniqueNames }}  # Count the number of unique combinations
+        {{- $uniqueContainerCount := len $uniqueContainer }}  # Count the number of unique combinations
+
+        {{- if not (eq $uniqueNamesCount $repoCount) }}
+          {{- fail (printf " Validation Error: Duplicate Entry Found , %d unique repo-branch combinations, but the number of repositories provided : %d. "
+          $uniqueNamesCount (len .Values.dags.gitSync.repositories)) }}
+        {{- end }}
+
+        {{- if not (eq $uniqueContainerCount $repoCount) }}
+          {{- fail (printf " Validation Error: Duplicate Entry Found , %d unique containerNames, but the number of repositories provided : %d. "
+          $uniqueContainerCount (len .Values.dags.gitSync.repositories)) }}
+        {{- end }}
+
+      {{- end }}
+
+    {{- else }}
+      {{- fail (printf " gitSync is enabled : repositories section can not be nil ") }}
+
+    {{- end }}
+
+  {{- end }}

--- a/chart/templates/configmaps/configmap.yaml
+++ b/chart/templates/configmaps/configmap.yaml
@@ -52,9 +52,13 @@ data:
     {{- tpl .Values.airflowLocalSettings . | nindent 4 }}
   {{- end }}
 
-  {{- if and .Values.dags.gitSync.enabled .Values.dags.gitSync.knownHosts }}
+  {{- if .Values.dags.gitSync.enabled }}
   known_hosts: |-
-    {{- .Values.dags.gitSync.knownHosts | nindent 4 }}
+    {{- range $repo := .Values.dags.gitSync.repositories }}
+    {{- if $repo.knownHosts }}
+      {{- $repo.knownHosts | nindent 4 }}
+    {{- end }}
+    {{- end }}
   {{- end }}
 
 {{- if or (eq $.Values.executor "LocalKubernetesExecutor") (eq $.Values.executor "KubernetesExecutor") (eq $.Values.executor "CeleryKubernetesExecutor") }}

--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -151,8 +151,16 @@ spec:
           image: {{ template "airflow_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           securityContext: {{ $containerSecurityContext | nindent 12 }}
-          {{- if $containerLifecycleHooks  }}
+          # In order to make the multirepo sync change work ,
+          # postStart LifeCycle Hook is created
+          # Check the airflow.dags_poststart in _helpers.yaml
+          {{- if or $containerLifecycleHooks .Values.dags.gitSync.enabled }}
+          {{- if $containerLifecycleHooks }}
           lifecycle: {{- tpl (toYaml $containerLifecycleHooks) . | nindent 12 }}
+          {{ include "airflow.dags_poststart" . | nindent 12 }}
+          {{- else }}
+          lifecycle: {{ include "airflow.dags_poststart" . | nindent 12 }}
+          {{- end }}
           {{- end }}
           {{- if .Values.dagProcessor.command }}
           command: {{ tpl (toYaml .Values.dagProcessor.command) . | nindent 12 }}
@@ -238,17 +246,21 @@ spec:
           configMap:
             name: {{ template "airflow_webserver_config_configmap_name" . }}
         {{- end }}
+        # multirepo gitSync , separate volumes for each containers
         {{- if .Values.dags.persistence.enabled }}
         - name: dags
           persistentVolumeClaim:
             claimName: {{ template "airflow_dags_volume_claim" . }}
         {{- else if .Values.dags.gitSync.enabled }}
-        - name: dags
-          emptyDir: {{- toYaml (default (dict) .Values.dags.gitSync.emptyDirConfig) | nindent 12 }}
-        {{- end }}
-        {{- if and .Values.dags.gitSync.enabled (or .Values.dags.gitSync.sshKeySecret .Values.dags.gitSync.sshKey) }}
+        {{- range $repo := .Values.dags.gitSync.repositories }}
+        - name: repo-volume-{{ $repo.containerName }}
+          emptyDir: {{- toYaml (default (dict) $repo.emptyDirConfig) | nindent 12 }}
+        {{- if or $repo.sshKeySecret $repo.sshKey}}
           {{- include "git_sync_ssh_key_volume" . | indent 8 }}
         {{- end }}
+        {{- end }}
+        {{- end }}
+        # end of multirepo gitSync changes
         {{- if .Values.volumes }}
           {{- toYaml .Values.volumes | nindent 8 }}
         {{- end }}

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -180,8 +180,16 @@ spec:
           image: {{ template "airflow_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           securityContext: {{ $containerSecurityContext | nindent 12 }}
+          # In order to make the multirepo sync change work ,
+          # postStart LifeCycle Hook is created
+          # Check the airflow.dags_poststart in _helpers.yaml
+          {{- if or $containerLifecycleHooks .Values.dags.gitSync.enabled }}
           {{- if $containerLifecycleHooks }}
           lifecycle: {{- tpl (toYaml $containerLifecycleHooks) . | nindent 12 }}
+          {{ include "airflow.dags_poststart" . | nindent 12 }}
+          {{- else }}
+          lifecycle: {{ include "airflow.dags_poststart" . | nindent 12 }}
+          {{- end }}
           {{- end }}
           {{- if .Values.scheduler.command }}
           command: {{ tpl (toYaml .Values.scheduler.command) . | nindent 12 }}
@@ -297,17 +305,21 @@ spec:
             name: {{ template "airflow_webserver_config_configmap_name" . }}
         {{- end }}
         {{- if $localOrDagProcessorDisabled }}
+        # multirepo gitSync , separate volumes for each containers
         {{- if .Values.dags.persistence.enabled }}
         - name: dags
           persistentVolumeClaim:
             claimName: {{ template "airflow_dags_volume_claim" . }}
         {{- else if .Values.dags.gitSync.enabled }}
-        - name: dags
-          emptyDir: {{- toYaml (default (dict) .Values.dags.gitSync.emptyDirConfig) | nindent 12 }}
-        {{- if or .Values.dags.gitSync.sshKeySecret .Values.dags.gitSync.sshKey}}
+        {{- range $repo := .Values.dags.gitSync.repositories }}
+        - name: repo-volume-{{ $repo.containerName }}
+          emptyDir: {{- toYaml (default (dict) $repo.emptyDirConfig) | nindent 12 }}
+        {{- if or $repo.sshKeySecret $repo.sshKey}}
           {{- include "git_sync_ssh_key_volume" . | indent 8 }}
         {{- end }}
         {{- end }}
+        {{- end }}
+        # end of multirepo gitSync changes
         {{- end }}
         {{- if .Values.volumes }}
           {{- toYaml .Values.volumes | nindent 8 }}

--- a/chart/templates/secrets/git-ssh-key-secret.yaml
+++ b/chart/templates/secrets/git-ssh-key-secret.yaml
@@ -17,18 +17,25 @@
  under the License.
 */}}
 
-{{- if and .Values.dags.gitSync.sshKey .Values.dags.gitSync.enabled}}
+# multirepo gitSync changes
+# To handle sshKey for repo wise
+
+{{- if .Values.dags.gitSync.enabled}}
+{{- range $repo := .Values.dags.gitSync.repositories }}
+{{- if $repo.sshKey }}
 apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    release: {{ .Release.Name }}
-    chart: {{ .Chart.Name }}
-    heritage: {{ .Release.Service }}
-    {{- with .Values.labels }}
-      {{- toYaml . | nindent 4 }}
+    release: {{ $.Release.Name }}
+    chart: {{ $.Chart.Name }}
+    heritage: {{ $.Release.Service }}
+    {{- with $.Values.labels }}
+      {{- toYaml $ | nindent 4 }}
     {{- end }}
   name: {{ template "git_sync_ssh_key" . }}
 data:
-  gitSshKey: {{ .Values.dags.gitSync.sshKey | b64enc | quote }}
+  gitSshKey: {{ $repo.sshKey | b64enc | quote }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -173,8 +173,16 @@ spec:
           image: {{ template "airflow_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           securityContext: {{ $containerSecurityContext | nindent 12 }}
+          # In order to make the multirepo sync change work ,
+          # postStart LifeCycle Hook is created
+          # Check the airflow.dags_poststart in _helpers.yaml
+          {{- if or $containerLifecycleHooks .Values.dags.gitSync.enabled }}
           {{- if $containerLifecycleHooks }}
           lifecycle: {{- tpl (toYaml $containerLifecycleHooks) . | nindent 12 }}
+          {{ include "airflow.dags_poststart" . | nindent 12 }}
+          {{- else }}
+          lifecycle: {{ include "airflow.dags_poststart" . | nindent 12 }}
+          {{- end }}
           {{- end }}
           {{- if .Values.triggerer.command }}
           command: {{ tpl (toYaml .Values.triggerer.command) . | nindent 12 }}
@@ -272,17 +280,21 @@ spec:
           configMap:
             name: {{ template "airflow_webserver_config_configmap_name" . }}
         {{- end }}
+        # multirepo gitSync , separate volumes for each containers
         {{- if .Values.dags.persistence.enabled }}
         - name: dags
           persistentVolumeClaim:
             claimName: {{ template "airflow_dags_volume_claim" . }}
         {{- else if .Values.dags.gitSync.enabled }}
-        - name: dags
-          emptyDir: {{- toYaml (default (dict) .Values.dags.gitSync.emptyDirConfig) | nindent 12 }}
-        {{- if or .Values.dags.gitSync.sshKeySecret .Values.dags.gitSync.sshKey}}
-          {{- include "git_sync_ssh_key_volume" . | nindent 8 }}
+        {{- range $repo := .Values.dags.gitSync.repositories }}
+        - name: repo-volume-{{ $repo.containerName }}
+          emptyDir: {{- toYaml (default (dict) $repo.emptyDirConfig) | nindent 12 }}
+        {{- if or $repo.sshKeySecret $repo.sshKey}}
+          {{- include "git_sync_ssh_key_volume" . | indent 8 }}
         {{- end }}
         {{- end }}
+        {{- end }}
+        # end of multirepo gitSync changes
         {{- if .Values.volumes }}
           {{- toYaml .Values.volumes | nindent 8 }}
         {{- end }}

--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -119,12 +119,12 @@ spec:
         {{- else }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  component: webserver
-              topologyKey: kubernetes.io/hostname
-            weight: 100
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    component: webserver
+                topologyKey: kubernetes.io/hostname
+              weight: 100
         {{- end }}
       tolerations: {{- toYaml $tolerations | nindent 8 }}
       topologySpreadConstraints: {{- toYaml $topologySpreadConstraints | nindent 8 }}
@@ -173,8 +173,16 @@ spec:
           image: {{ template "airflow_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           securityContext: {{ $containerSecurityContext | nindent 12 }}
-          {{- if $containerLifecycleHooks  }}
+          # In order to make the multirepo sync change work ,
+          # postStart LifeCycle Hook is created
+          # Check the airflow.dags_poststart in _helpers.yaml
+          {{- if or $containerLifecycleHooks .Values.dags.gitSync.enabled }}
+          {{- if $containerLifecycleHooks }}
           lifecycle: {{- tpl (toYaml $containerLifecycleHooks) . | nindent 12 }}
+          {{ include "airflow.dags_poststart" . | nindent 12 }}
+          {{- else }}
+          lifecycle: {{ include "airflow.dags_poststart" . | nindent 12 }}
+          {{- end }}
           {{- end }}
           {{- if .Values.webserver.command }}
           command: {{ tpl (toYaml .Values.webserver.command) . | nindent 12 }}
@@ -272,17 +280,21 @@ spec:
             name: {{ template "airflow_webserver_config_configmap_name" . }}
         {{- end }}
         {{- if (semverCompare "<2.0.0" .Values.airflowVersion) }}
+        # multirepo gitSync , separate volumes for each containers
         {{- if .Values.dags.persistence.enabled }}
         - name: dags
           persistentVolumeClaim:
             claimName: {{ template "airflow_dags_volume_claim" . }}
         {{- else if .Values.dags.gitSync.enabled }}
-        - name: dags
-          emptyDir: {{- toYaml (default (dict) .Values.dags.gitSync.emptyDirConfig) | nindent 12 }}
-        {{- if or .Values.dags.gitSync.sshKeySecret .Values.dags.gitSync.sshKey}}
+        {{- range $repo := .Values.dags.gitSync.repositories }}
+        - name: repo-volume-{{ $repo.containerName }}
+          emptyDir: {{- toYaml (default (dict) $repo.emptyDirConfig) | nindent 12 }}
+        {{- if or $repo.sshKeySecret $repo.sshKey}}
           {{- include "git_sync_ssh_key_volume" . | indent 8 }}
         {{- end }}
         {{- end }}
+        {{- end }}
+        # end of multirepo gitSync changes
         {{- end }}
         {{- if .Values.logs.persistence.enabled }}
         - name: logs

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -233,8 +233,16 @@ spec:
           image: {{ template "airflow_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           securityContext: {{ $containerSecurityContext | nindent 12 }}
-          {{- if $containerLifecycleHooks  }}
+          # In order to make the multirepo sync change work ,
+          # postStart LifeCycle Hook is created
+          # Check the airflow.dags_poststart in _helpers.yaml
+          {{- if or $containerLifecycleHooks .Values.dags.gitSync.enabled }}
+          {{- if $containerLifecycleHooks }}
           lifecycle: {{- tpl (toYaml $containerLifecycleHooks) . | nindent 12 }}
+          {{ include "airflow.dags_poststart" . | nindent 12 }}
+          {{- else }}
+          lifecycle: {{ include "airflow.dags_poststart" . | nindent 12 }}
+          {{- end }}
           {{- end }}
           {{- if .Values.workers.command }}
           command: {{ tpl (toYaml .Values.workers.command) . | nindent 12 }}
@@ -411,17 +419,21 @@ spec:
         - name: kerberos-ccache
           emptyDir: {}
         {{- end }}
+        # multirepo gitSync , separate volumes for each containers
         {{- if .Values.dags.persistence.enabled }}
         - name: dags
           persistentVolumeClaim:
             claimName: {{ template "airflow_dags_volume_claim" . }}
         {{- else if .Values.dags.gitSync.enabled }}
-        - name: dags
-          emptyDir: {{- toYaml (default (dict) .Values.dags.gitSync.emptyDirConfig) | nindent 12 }}
-        {{- if or .Values.dags.gitSync.sshKeySecret .Values.dags.gitSync.sshKey}}
+        {{- range $repo := .Values.dags.gitSync.repositories }}
+        - name: repo-volume-{{ $repo.containerName }}
+          emptyDir: {{- toYaml (default (dict) $repo.emptyDirConfig) | nindent 12 }}
+        {{- if or $repo.sshKeySecret $repo.sshKey}}
           {{- include "git_sync_ssh_key_volume" . | indent 8 }}
         {{- end }}
         {{- end }}
+        {{- end }}
+        # end of multirepo gitSync changes
   {{- if .Values.logs.persistence.enabled }}
         - name: logs
           persistentVolumeClaim:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -841,7 +841,7 @@
                         "tag": {
                             "description": "The StatsD image tag.",
                             "type": "string",
-                            "default": "v0.28.0"
+                            "default": "v0.27.2"
                         },
                         "pullPolicy": {
                             "description": "The StatsD image pull policy.",
@@ -8653,235 +8653,242 @@
                             "type": "boolean",
                             "default": false
                         },
-                        "repo": {
-                            "description": "Git repository.",
-                            "type": "string",
-                            "default": "https://github.com/apache/airflow.git"
-                        },
-                        "branch": {
-                            "description": "Git branch",
-                            "type": "string",
-                            "default": "v2-2-stable"
-                        },
-                        "rev": {
-                            "description": "Git revision.",
-                            "type": "string",
-                            "default": "HEAD"
-                        },
-                        "ref": {
-                            "description": "Git revision branch, tag, or hash.",
-                            "type": "string",
-                            "default": "v2-2-stable"
-                        },
-                        "depth": {
-                            "description": "Repository depth.",
-                            "type": "integer",
-                            "default": 1
-                        },
-                        "maxFailures": {
-                            "description": "The number of consecutive failures allowed before aborting.",
-                            "type": "integer",
-                            "default": 0
-                        },
-                        "subPath": {
-                            "description": "Subpath within the repo where dags are located.",
-                            "type": "string",
-                            "default": "tests/dags"
-                        },
-                        "wait": {
-                            "description": "Interval between git sync attempts in seconds. High values are more likely to cause DAGs to become out of sync between different components. Low values cause more traffic to the remote git repository.",
-                            "type": [
-                                "integer",
-                                "null"
-                            ],
-                            "default": null
-                        },
-                        "period": {
-                            "description": "Interval between git sync attempts in Go-style duration string. High values are more likely to cause DAGs to become out of sync between different components. Low values cause more traffic to the remote git repository.",
-                            "type": "string",
-                            "default": "5s"
-                        },
-                        "containerName": {
-                            "description": "Git sync container name.",
-                            "type": "string",
-                            "default": "git-sync"
-                        },
-                        "securityContext": {
-                            "description": "Security context for the `gitSync` container (deprecated, use `securityContexts` instead). If not set, the values from `securityContext` will be used.",
-                            "type": "object",
-                            "$ref": "#/definitions/io.k8s.api.core.v1.SecurityContext",
-                            "default": {},
-                            "examples": [
-                                {
-                                    "runAsUser": 50000,
-                                    "runAsGroup": 0
-                                }
-                            ]
-                        },
-                        "emptyDirConfig": {
-                            "description": "Configuration for dags empty dir volume.",
-                            "type": "object",
-                            "$ref": "#/definitions/io.k8s.api.core.v1.EmptyDirVolumeSource",
-                            "default": null
-                        },
-                        "containerLifecycleHooks": {
-                            "description": "Container Lifecycle Hooks definition for the git sync sidecar. If not set, the values from global `containerLifecycleHooks` will be used.",
-                            "type": "object",
-                            "$ref": "#/definitions/io.k8s.api.core.v1.Lifecycle",
-                            "default": {},
-                            "x-docsSection": "Kubernetes",
-                            "examples": [
-                                {
-                                    "postStart": {
-                                        "exec": {
-                                            "command": [
-                                                "/bin/sh",
-                                                "-c",
-                                                "echo postStart handler > /usr/share/message"
-                                            ]
-                                        }
-                                    },
-                                    "preStop": {
-                                        "exec": {
-                                            "command": [
-                                                "/bin/sh",
-                                                "-c",
-                                                "echo preStop handler > /usr/share/message"
-                                            ]
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        "securityContexts": {
-                            "description": "Security context definition for the git sync sidecar. If not set, the values from global `securityContexts` will be used.",
-                            "type": "object",
-                            "x-docsSection": "Kubernetes",
-                            "properties": {
-                                "container": {
-                                    "description": "Container security context definition for the git sync sidecar.",
+                        "repositories": {
+                            "description": "List of repositories for git sync",
+                            "type": "array",
+                            "default": [],
+                            "items": {
+                                "repo": {
+                                    "description": "Git repository.",
+                                    "type": "string",
+                                    "default": "https://github.com/apache/airflow.git"
+                                },
+                                "branch": {
+                                    "description": "Git branch",
+                                    "type": "string",
+                                    "default": "v2-2-stable"
+                                },
+                                "rev": {
+                                    "description": "Git revision.",
+                                    "type": "string",
+                                    "default": "HEAD"
+                                },
+                                "ref": {
+                                    "description": "Git revision branch, tag, or hash.",
+                                    "type": "string",
+                                    "default": "v2-2-stable"
+                                },
+                                "depth": {
+                                    "description": "Repository depth.",
+                                    "type": "integer",
+                                    "default": 1
+                                },
+                                "maxFailures": {
+                                    "description": "The number of consecutive failures allowed before aborting.",
+                                    "type": "integer",
+                                    "default": 0
+                                },
+                                "subPath": {
+                                    "description": "Subpath within the repo where dags are located.",
+                                    "type": "string",
+                                    "default": "tests/dags"
+                                },
+                                "wait": {
+                                    "description": "Interval between git sync attempts in seconds. High values are more likely to cause DAGs to become out of sync between different components. Low values cause more traffic to the remote git repository.",
+                                    "type": [
+                                        "integer",
+                                        "null"
+                                    ],
+                                    "default": null
+                                },
+                                "period": {
+                                    "description": "Interval between git sync attempts in Go-style duration string. High values are more likely to cause DAGs to become out of sync between different components. Low values cause more traffic to the remote git repository.",
+                                    "type": "string",
+                                    "default": "5s"
+                                },
+                                "containerName": {
+                                    "description": "Git sync container name.",
+                                    "type": "string",
+                                    "default": "git-sync"
+                                },
+                                "securityContext": {
+                                    "description": "Security context for the `gitSync` container (deprecated, use `securityContexts` instead). If not set, the values from `securityContext` will be used.",
                                     "type": "object",
                                     "$ref": "#/definitions/io.k8s.api.core.v1.SecurityContext",
+                                    "default": {},
+                                    "examples": [
+                                        {
+                                            "runAsUser": 50000,
+                                            "runAsGroup": 0
+                                        }
+                                    ]
+                                },
+                                "emptyDirConfig": {
+                                    "description": "Configuration for dags empty dir volume.",
+                                    "type": "object",
+                                    "$ref": "#/definitions/io.k8s.api.core.v1.EmptyDirVolumeSource",
+                                    "default": null
+                                },
+                                "containerLifecycleHooks": {
+                                    "description": "Container Lifecycle Hooks definition for the git sync sidecar. If not set, the values from global `containerLifecycleHooks` will be used.",
+                                    "type": "object",
+                                    "$ref": "#/definitions/io.k8s.api.core.v1.Lifecycle",
                                     "default": {},
                                     "x-docsSection": "Kubernetes",
                                     "examples": [
                                         {
-                                            "allowPrivilegeEscalation": false,
-                                            "capabilities": {
-                                                "drop": [
-                                                    "ALL"
-                                                ]
+                                            "postStart": {
+                                                "exec": {
+                                                    "command": [
+                                                        "/bin/sh",
+                                                        "-c",
+                                                        "echo postStart handler > /usr/share/message"
+                                                    ]
+                                                }
+                                            },
+                                            "preStop": {
+                                                "exec": {
+                                                    "command": [
+                                                        "/bin/sh",
+                                                        "-c",
+                                                        "echo preStop handler > /usr/share/message"
+                                                    ]
+                                                }
                                             }
                                         }
                                     ]
-                                }
-                            }
-                        },
-                        "uid": {
-                            "description": "Git sync container run as user parameter.",
-                            "type": "integer",
-                            "default": 65533
-                        },
-                        "extraVolumeMounts": {
-                            "description": "Mount additional volumes into git sync container.",
-                            "type": "array",
-                            "default": [],
-                            "items": {
-                                "$ref": "#/definitions/io.k8s.api.core.v1.VolumeMount"
-                            }
-                        },
-                        "credentialsSecret": {
-                            "description": "Name of a Secret containing the repo `GIT_SYNC_USERNAME` and `GIT_SYNC_PASSWORD`.",
-                            "type": [
-                                "string",
-                                "null"
-                            ],
-                            "default": null
-                        },
-                        "sshKey": {
-                            "description": "SSH private key",
-                            "type": [
-                                "string",
-                                "null"
-                            ],
-                            "default": null
-                        },
-                        "sshKeySecret": {
-                            "description": "Name of a Secret containing the repo `sshKeySecret`.",
-                            "type": [
-                                "string",
-                                "null"
-                            ],
-                            "default": null
-                        },
-                        "knownHosts": {
-                            "description": "When using a ssh private key, the contents of your `known_hosts` file.",
-                            "type": [
-                                "string",
-                                "null"
-                            ],
-                            "default": null,
-                            "examples": [
-                                "<host1>,<ip1> <key1>\n<host2>,<ip2> <key2>",
-                                "<host1>,<ip1> <key1>"
-                            ]
-                        },
-                        "env": {
-                            "description": "Environment variables for git sync container.",
-                            "type": "array",
-                            "default": [],
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "name": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": "string"
+                                },
+                                "securityContexts": {
+                                    "description": "Security context definition for the git sync sidecar. If not set, the values from global `securityContexts` will be used.",
+                                    "type": "object",
+                                    "x-docsSection": "Kubernetes",
+                                    "properties": {
+                                        "container": {
+                                            "description": "Container security context definition for the git sync sidecar.",
+                                            "type": "object",
+                                            "$ref": "#/definitions/io.k8s.api.core.v1.SecurityContext",
+                                            "default": {},
+                                            "x-docsSection": "Kubernetes",
+                                            "examples": [
+                                                {
+                                                    "allowPrivilegeEscalation": false,
+                                                    "capabilities": {
+                                                        "drop": [
+                                                            "ALL"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 },
-                                "required": [
-                                    "name",
-                                    "value"
-                                ],
-                                "additionalProperties": false
-                            },
-                            "examples": [
-                                {
-                                    "name": "GIT_SYNC_TIMEOUT",
-                                    "value": "60"
-                                }
-                            ]
-                        },
-                        "envFrom": {
-                            "description": "Extra envFrom 'items' that will be added to the definition of Airflow gitSync containers; a string or array are expected (can be templated).",
-                            "type": [
-                                "null",
-                                "string"
-                            ],
-                            "default": null,
-                            "examples": [
-                                "- secretRef:\n    name: 'proxy-config",
-                                "- configMapRef:\n    name: 'proxy-config"
-                            ]
-                        },
-                        "resources": {
-                            "description": "Resources on workers git-sync sidecar",
-                            "type": "object",
-                            "default": {},
-                            "examples": [
-                                {
-                                    "limits": {
-                                        "cpu": "100m",
-                                        "memory": "128Mi"
-                                    },
-                                    "requests": {
-                                        "cpu": "100m",
-                                        "memory": "128Mi"
+                                "uid": {
+                                    "description": "Git sync container run as user parameter.",
+                                    "type": "integer",
+                                    "default": 65533
+                                },
+                                "extraVolumeMounts": {
+                                    "description": "Mount additional volumes into git sync container.",
+                                    "type": "array",
+                                    "default": [],
+                                    "items": {
+                                        "$ref": "#/definitions/io.k8s.api.core.v1.VolumeMount"
                                     }
+                                },
+                                "credentialsSecret": {
+                                    "description": "Name of a Secret containing the repo `GIT_SYNC_USERNAME` and `GIT_SYNC_PASSWORD`.",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "default": null
+                                },
+                                "sshKey": {
+                                    "description": "SSH private key",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "default": null
+                                },
+                                "sshKeySecret": {
+                                    "description": "Name of a Secret containing the repo `sshKeySecret`.",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "default": null
+                                },
+                                "knownHosts": {
+                                    "description": "When using a ssh private key, the contents of your `known_hosts` file.",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "default": null,
+                                    "examples": [
+                                        "<host1>,<ip1> <key1>\n<host2>,<ip2> <key2>",
+                                        "<host1>,<ip1> <key1>"
+                                    ]
+                                },
+                                "env": {
+                                    "description": "Environment variables for git sync container.",
+                                    "type": "array",
+                                    "default": [],
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "value"
+                                        ],
+                                        "additionalProperties": false
+                                    },
+                                    "examples": [
+                                        {
+                                            "name": "GIT_SYNC_TIMEOUT",
+                                            "value": "60"
+                                        }
+                                    ]
+                                },
+                                "envFrom": {
+                                    "description": "Extra envFrom 'items' that will be added to the definition of Airflow gitSync containers; a string or array are expected (can be templated).",
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ],
+                                    "default": null,
+                                    "examples": [
+                                        "- secretRef:\n    name: 'proxy-config",
+                                        "- configMapRef:\n    name: 'proxy-config"
+                                    ]
+                                },
+                                "resources": {
+                                    "description": "Resources on workers git-sync sidecar",
+                                    "type": "object",
+                                    "default": {},
+                                    "examples": [
+                                        {
+                                            "limits": {
+                                                "cpu": "100m",
+                                                "memory": "128Mi"
+                                            },
+                                            "requests": {
+                                                "cpu": "100m",
+                                                "memory": "128Mi"
+                                            }
+                                        }
+                                    ],
+                                    "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
                                 }
-                            ],
-                            "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
+                            }
                         }
                     }
                 }

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -105,7 +105,7 @@ images:
     pullPolicy: IfNotPresent
   statsd:
     repository: quay.io/prometheus/statsd-exporter
-    tag: v0.28.0
+    tag: v0.27.2
     pullPolicy: IfNotPresent
   redis:
     repository: redis
@@ -2713,112 +2713,115 @@ dags:
     # git repo clone url
     # ssh example: git@github.com:apache/airflow.git
     # https example: https://github.com/apache/airflow.git
-    repo: https://github.com/apache/airflow.git
-    branch: v2-2-stable
-    rev: HEAD
-    # The git revision (branch, tag, or hash) to check out, v4 only
-    ref: v2-2-stable
-    depth: 1
-    # the number of consecutive failures allowed before aborting
-    maxFailures: 0
-    # subpath within the repo where dags are located
-    # should be "" if dags are at repo root
-    subPath: "tests/dags"
-    # if your repo needs a user name password
-    # you can load them to a k8s secret like the one below
-    #   ---
-    #   apiVersion: v1
-    #   kind: Secret
-    #   metadata:
-    #     name: git-credentials
-    #   data:
-    #     # For git-sync v3
-    #     GIT_SYNC_USERNAME: <base64_encoded_git_username>
-    #     GIT_SYNC_PASSWORD: <base64_encoded_git_password>
-    #     # For git-sync v4
-    #     GITSYNC_USERNAME: <base64_encoded_git_username>
-    #     GITSYNC_PASSWORD: <base64_encoded_git_password>
-    # and specify the name of the secret below
-    #
-    # credentialsSecret: git-credentials
-    #
-    #
-    # If you are using an ssh clone url, you can load
-    # the ssh private key to a k8s secret like the one below
-    #   ---
-    #   apiVersion: v1
-    #   kind: Secret
-    #   metadata:
-    #     name: airflow-ssh-secret
-    #   data:
-    #     # key needs to be gitSshKey
-    #     gitSshKey: <base64_encoded_data>
-    # and specify the name of the secret below
-    # sshKeySecret: airflow-ssh-secret
-    #
-    # Or set sshKeySecret with your key
-    # sshKey: |-
-    #   -----BEGIN {OPENSSH PRIVATE KEY}-----
-    #   ...
-    #   -----END {OPENSSH PRIVATE KEY}-----
-    #
-    # If you are using an ssh private key, you can additionally
-    # specify the content of your known_hosts file, example:
-    #
-    # knownHosts: |
-    #    <host1>,<ip1> <key1>
-    #    <host2>,<ip2> <key2>
+    repositories:
+    # list of all repositories in an array format
+    # for multiple repo or branch in gitSync , cotainerName should be unique
+      - repo: https://github.com/apache/airflow.git
+        branch: v2-2-stable
+        rev: HEAD
+        # The git revision (branch, tag, or hash) to check out, v4 only
+        ref: v2-2-stable
+        depth: 1
+        # the number of consecutive failures allowed before aborting
+        maxFailures: 0
+        # subpath within the repo where dags are located
+        # should be "" if dags are at repo root
+        subPath: "tests/dags"
+        # if your repo needs a user name password
+        # you can load them to a k8s secret like the one below
+        #   ---
+        #   apiVersion: v1
+        #   kind: Secret
+        #   metadata:
+        #     name: git-credentials
+        #   data:
+        #     # For git-sync v3
+        #     GIT_SYNC_USERNAME: <base64_encoded_git_username>
+        #     GIT_SYNC_PASSWORD: <base64_encoded_git_password>
+        #     # For git-sync v4
+        #     GITSYNC_USERNAME: <base64_encoded_git_username>
+        #     GITSYNC_PASSWORD: <base64_encoded_git_password>
+        # and specify the name of the secret below
+        #
+        # credentialsSecret: git-credentials
+        #
+        #
+        # If you are using an ssh clone url, you can load
+        # the ssh private key to a k8s secret like the one below
+        #   ---
+        #   apiVersion: v1
+        #   kind: Secret
+        #   metadata:
+        #     name: airflow-ssh-secret
+        #   data:
+        #     # key needs to be gitSshKey
+        #     gitSshKey: <base64_encoded_data>
+        # and specify the name of the secret below
+        # sshKeySecret: airflow-ssh-secret
+        #
+        # Or set sshKeySecret with your key
+        # sshKey: |-
+        #   -----BEGIN {OPENSSH PRIVATE KEY}-----
+        #   ...
+        #   -----END {OPENSSH PRIVATE KEY}-----
+        #
+        # If you are using an ssh private key, you can additionally
+        # specify the content of your known_hosts file, example:
+        #
+        # knownHosts: |
+        #    <host1>,<ip1> <key1>
+        #    <host2>,<ip2> <key2>
 
-    # interval between git sync attempts in seconds
-    # high values are more likely to cause DAGs to become out of sync between different components
-    # low values cause more traffic to the remote git repository
-    # Go-style duration string (e.g. "100ms" or "0.1s" = 100ms).
-    # For backwards compatibility, wait will be used if it is specified.
-    period: 5s
-    wait: ~
-    # add variables from secret into gitSync containers, such proxy-config
-    envFrom: ~
-    # envFrom: |
-    #   - secretRef:
-    #       name: 'proxy-config'
+        # interval between git sync attempts in seconds
+        # high values are more likely to cause DAGs to become out of sync between different components
+        # low values cause more traffic to the remote git repository
+        # Go-style duration string (e.g. "100ms" or "0.1s" = 100ms).
+        # For backwards compatibility, wait will be used if it is specified.
+        period: 5s
+        wait: ~
+        # add variables from secret into gitSync containers, such proxy-config
+        envFrom: ~
+        # envFrom: |
+        #   - secretRef:
+        #       name: 'proxy-config'
 
-    containerName: git-sync
-    uid: 65533
+        containerName: git-sync
+        uid: 65533
 
-    # When not set, the values defined in the global securityContext will be used
-    securityContext: {}
-    #  runAsUser: 65533
-    #  runAsGroup: 0
+        # When not set, the values defined in the global securityContext will be used
+        securityContext: {}
+        #  runAsUser: 65533
+        #  runAsGroup: 0
 
-    securityContexts:
-      container: {}
+        securityContexts:
+          container: {}
 
-    # container level lifecycle hooks
-    containerLifecycleHooks: {}
+        # container level lifecycle hooks
+        containerLifecycleHooks: {}
 
-    # Mount additional volumes into git-sync. It can be templated like in the following example:
-    #   extraVolumeMounts:
-    #     - name: my-templated-extra-volume
-    #       mountPath: "{{ .Values.my_custom_path }}"
-    #       readOnly: true
-    extraVolumeMounts: []
-    env: []
-    # Supported env vars for gitsync can be found at https://github.com/kubernetes/git-sync
-    # - name: ""
-    #   value: ""
+        # Mount additional volumes into git-sync. It can be templated like in the following example:
+        #   extraVolumeMounts:
+        #     - name: my-templated-extra-volume
+        #       mountPath: "{{ .Values.my_custom_path }}"
+        #       readOnly: true
+        extraVolumeMounts: []
+        env: []
+        # Supported env vars for gitsync can be found at https://github.com/kubernetes/git-sync
+        # - name: ""
+        #   value: ""
 
-    # Configuration for empty dir volume
-    # emptyDirConfig:
-    #   sizeLimit: 1Gi
-    #   medium: Memory
+        # Configuration for empty dir volume
+        # emptyDirConfig:
+        #   sizeLimit: 1Gi
+        #   medium: Memory
 
-    resources: {}
-    #  limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    #  requests:
-    #   cpu: 100m
-    #   memory: 128Mi
+        resources: {}
+        #  limits:
+        #   cpu: 100m
+        #   memory: 128Mi
+        #  requests:
+        #   cpu: 100m
+        #   memory: 128Mi
 
 logs:
   # Configuration for empty dir volume (if logs.persistence.enabled == false)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).



Purpose of the PR : Git-Sync from multiple repo and branch ,
change-list:
- in dags.gitSync , now it is possible to have multiple entries
- changes in values.schema.json to amend the new schema for dags.gitSync.repositories
- changes in check-values.yaml to check the below rules
  - to check if duplicate repo and branch combinations are entered
  - containerName should be unique in values.yaml for every entry in dags.gitSync.repositories
- changes in _helpers.yml ( the helper function ) to accommodate multi-repo settings
- changes in deployment yaml to support multirepo setting
- changes in dags folder path so that symlink can be created for all repos
- changes to support known-hosts and sshKey for multiple repos or branchs

**This is a new feature which i have been working , i am ready to co-operate with all test-cases , below are the test cases i have performed**

Test Cases | Expected Behaviour | Result
-- | -- | --
multiple git-repo ( 2 Private and 1 Public ) | gitSync pulling from multiple repo or branch | PASSED
multiple git-repo ( 2 Private with ssh ) | gitSync pulling from multiple repo or branch | PASSED
single git-repo | existing behavior should not be interrupted | PASSED
multiple duplicate entry in repositories section in dags | Should raise error while helm install | PASSED
Known-hosts for all repos | Known-hosts are listed in airflow.cfg for all repos | PASSED

**Change Lists** : 

File Name | Changes
-- | --
templates/NOTES.txt | Notes added for multirepo changes , it is just a Note
templates/check-value.yaml | The Multirepo changes comes with some conditions -  <br>**1**. containerName in dags.gitSync for every repo in repositories list , should be unique  <br>**2**. whether user is providing duplicate input in the dags.gitSync.repolistories list
templates/_helpers.yaml | Below are the changes - <br>**1**. create git-sync-init and git-sync container for every entry in the dags.gitSync.repositories list <br>**2**. create seperate volumeMounts and volumes for the ssh key and repo in dags.gitSync.repositories <br>**3**. create dags folder path for all entries in dags.gitSync.repositories <br>**4**. created a new helper to create symlink for every repo and call this helper in container ( scheduler , worker , triggerer , webserver , ..  ) in their lifecycle
templates/scheduler/scheduler-deployment.yaml | changes to enlist all volumnes for all repos and as well as for sshKey , also in container lifecycle , helper airflow.dags_poststart has been called , so that it can create symlink for every repo , only after the git-sync is finished , to avoid any race-condition,
templates/worker/worker-deployment.yaml | changes to enlist all volumnes for all repos and as well as for sshKey , also in container lifecycle , helper airflow.dags_poststart has been called , so that it can create symlink for every repo , only after the git-sync is finished , to avoid any race-condition,
templates/webserver/webserver-deployment.yaml | changes to enlist all volumnes for all repos and as well as for sshKey , also in container lifecycle , helper airflow.dags_poststart has been called , so that it can create symlink for every repo , only after the git-sync is finished , to avoid any race-condition,
templates/triggerer/triggerer-deployment.yaml | changes to enlist all volumnes for all repos and as well as for sshKey , also in container lifecycle , helper airflow.dags_poststart has been called , so that it can create symlink for every repo , only after the git-sync is finished , to avoid any race-condition,
templates/secrets/git-ssh-key-secrets.yaml | changes in secrets , so that it can have secrets from multiple repos from dags.gitSync.repositories
templates/dag-processor/dag-processor-deployment.yaml | changes to enlist all volumnes for all repos and as well as for sshKey , also in container lifecycle , helper airflow.dags_poststart has been called , so that it can create symlink for every repo , only after the git-sync is finished , to avoid any race-condition,
templates/configmaps/configmap.yaml | changes to facilitate multiple known-hosts from dags.gitSync.repositories
files/pod-template-file.kubernetes-hem-yaml | changes in volumne and container lifecycle to facilitate the multirepo changes
values.yaml | introduced a new list element in dags.gitSync , this new list element named repositories which will have multiple entries of repos or branches
values-schema.json | because a new element has been introduced in dags.gitSync , the schema.json is needed to be changed .

Thanks and Regards,
koushik
