### PR TITLE
Optimize retrieval of `conn_id` and `dag_id` fields in `AirflowSecurityManagerV2`

### DIFF
--- a/airflow/www/security_manager.py
+++ b/airflow/www/security_manager.py
@@ -183,18 +183,18 @@ class AirflowSecurityManagerV2(LoggingMixin):
         def get_connection_id(resource_pk):
             if not resource_pk:
                 return None
-            connection = session.scalar(select(Connection).where(Connection.id == resource_pk).limit(1))
-            if not connection:
+            conn_id = session.scalar(select(Connection.conn_id).where(Connection.id == resource_pk).limit(1))
+            if not conn_id:
                 raise AirflowException("Connection not found")
-            return connection.conn_id
+            return conn_id
 
         def get_dag_id_from_dagrun_id(resource_pk):
             if not resource_pk:
                 return None
-            dagrun = session.scalar(select(DagRun).where(DagRun.id == resource_pk).limit(1))
-            if not dagrun:
+            dag_id = session.scalar(select(DagRun.dag_id).where(DagRun.id == resource_pk).limit(1))
+            if not dag_id:
                 raise AirflowException("DagRun not found")
-            return dagrun.dag_id
+            return dag_id
 
         def get_dag_id_from_task_instance(resource_pk):
             if not resource_pk:


### PR DESCRIPTION
This PR refactors two methods within the AirflowSecurityManagerV2 class to retrieve only the required ID fields, conn_id and dag_id, directly from the database, rather than loading entire Connection and DagRun objects -- reducing unnecessary object retrieval.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
