### PR TITLE
[Edge] Worker tiggeres graceful shutdown after different version detection.

### DIFF
--- a/providers/src/airflow/providers/edge/CHANGELOG.rst
+++ b/providers/src/airflow/providers/edge/CHANGELOG.rst
@@ -27,6 +27,14 @@
 Changelog
 ---------
 
+0.5.0pre0
+.........
+
+Misc
+~~~~
+
+* ``Edge worker triggers graceful shutdown, if worker version and main instance do not match.``
+
 0.4.0pre0
 .........
 

--- a/providers/src/airflow/providers/edge/__init__.py
+++ b/providers/src/airflow/providers/edge/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.0pre0"
+__version__ = "0.5.0pre0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.10.0"

--- a/providers/src/airflow/providers/edge/cli/edge_command.py
+++ b/providers/src/airflow/providers/edge/cli/edge_command.py
@@ -259,7 +259,13 @@ class _EdgeWorkerCli:
             else EdgeWorkerState.IDLE
         )
         sysinfo = self._get_sysinfo()
-        self.queues = EdgeWorker.set_state(self.hostname, state, len(self.jobs), sysinfo)
+        result: EdgeWorker.SetStateReturn = EdgeWorker.set_state(
+            self.hostname, state, len(self.jobs), sysinfo
+        )
+        if not self.drain and result.version_mismatch:
+            logger.info("Version mismatch of Edge worker and Core. Shutting down worker.")
+            self.drain = True
+        self.queues = result.queues
 
     def interruptible_sleep(self):
         """Sleeps but stops sleeping if drain is made."""

--- a/providers/src/airflow/providers/edge/models/edge_worker.py
+++ b/providers/src/airflow/providers/edge/models/edge_worker.py
@@ -147,7 +147,7 @@ class EdgeWorker(BaseModel, LoggingMixin):
     class SetStateReturn(BaseModel):
         """Defines return type of set_state function."""
 
-        queues: list[str] | None = None
+        queues: Optional[List[str]] = None  # noqa: UP006,UP007 - prevent Sphinx failing
         version_mismatch: bool = False
 
     @staticmethod

--- a/providers/src/airflow/providers/edge/provider.yaml
+++ b/providers/src/airflow/providers/edge/provider.yaml
@@ -27,7 +27,7 @@ source-date-epoch: 1729683247
 
 # note that those versions are maintained by release manager - do not update them manually
 versions:
-  - 0.4.0pre0
+  - 0.5.0pre0
 
 dependencies:
   - apache-airflow>=2.10.0


### PR DESCRIPTION
# Description

The EdgeWorker currently raises an exception if heatbeat is triggered and the version of the edge worker is different to the version of the main application. Idea is by detecting a different version that the worker executes a graceful shutdown of the worker.

# Details about changes

* EdgeWorker checks on heartbeat if version is different and triggers graceful shutdown of the worker.
* So worker task will end without crashing worker
* No new job will be reservert by the worker.