### PR TITLE
Added condition to check if it is a scheduled save or rerun

### DIFF
--- a/providers/src/airflow/providers/dbt/cloud/operators/dbt.py
+++ b/providers/src/airflow/providers/dbt/cloud/operators/dbt.py
@@ -149,6 +149,8 @@ class DbtCloudRunJobOperator(BaseOperator):
                 self.run_id = non_terminal_runs[0]["id"]
                 job_run_url = non_terminal_runs[0]["href"]
 
+        is_retry = context["task_instance"].try_number != 1
+
         if not self.reuse_existing_run or not non_terminal_runs:
             trigger_job_response = self.hook.trigger_job_run(
                 account_id=self.account_id,
@@ -156,7 +158,7 @@ class DbtCloudRunJobOperator(BaseOperator):
                 cause=self.trigger_reason,
                 steps_override=self.steps_override,
                 schema_override=self.schema_override,
-                retry_from_failure=self.retry_from_failure,
+                retry_from_failure=is_retry and self.retry_from_failure,
                 additional_run_config=self.additional_run_config,
             )
             self.run_id = trigger_job_response.json()["data"]["id"]

--- a/providers/src/airflow/providers/dbt/cloud/operators/dbt.py
+++ b/providers/src/airflow/providers/dbt/cloud/operators/dbt.py
@@ -149,7 +149,7 @@ class DbtCloudRunJobOperator(BaseOperator):
                 self.run_id = non_terminal_runs[0]["id"]
                 job_run_url = non_terminal_runs[0]["href"]
 
-        is_retry = context["task_instance"].try_number != 1
+        is_retry = context["ti"].try_number != 1
 
         if not self.reuse_existing_run or not non_terminal_runs:
             trigger_job_response = self.hook.trigger_job_run(

--- a/providers/tests/dbt/cloud/operators/test_dbt.py
+++ b/providers/tests/dbt/cloud/operators/test_dbt.py
@@ -64,6 +64,17 @@ EXPLICIT_ACCOUNT_JOB_RUN_RESPONSE = {
         ),
     }
 }
+JOB_RUN_ERROR_RESPONSE = {
+    "data": [
+        {
+            "id": RUN_ID,
+            "href": EXPECTED_JOB_RUN_OP_EXTRA_LINK.format(
+                account_id=ACCOUNT_ID, project_id=PROJECT_ID, run_id=RUN_ID
+            ),
+            "status": DbtCloudJobRunStatus.ERROR.value,
+        }
+    ]
+}
 
 
 def mock_response_json(response: dict):
@@ -420,6 +431,73 @@ class TestDbtCloudRunJobOperator:
             retry_from_failure=True,
             additional_run_config=self.config["additional_run_config"],
         )
+
+    @patch.object(DbtCloudHook, "_run_and_get_response")
+    @pytest.mark.parametrize(
+        "conn_id, account_id",
+        [(ACCOUNT_ID_CONN, None), (NO_ACCOUNT_ID_CONN, ACCOUNT_ID)],
+        ids=["default_account", "explicit_account"],
+    )
+    def test_execute_retry_from_failure_run(self, mock_run_req, conn_id, account_id):
+        operator = DbtCloudRunJobOperator(
+            task_id=TASK_ID,
+            dbt_cloud_conn_id=conn_id,
+            account_id=account_id,
+            trigger_reason=None,
+            dag=self.dag,
+            retry_from_failure=True,
+            **self.config,
+        )
+        self.mock_context["ti"].try_number = 1
+
+        assert operator.dbt_cloud_conn_id == conn_id
+        assert operator.job_id == self.config["job_id"]
+        assert operator.account_id == account_id
+        assert operator.check_interval == self.config["check_interval"]
+        assert operator.timeout == self.config["timeout"]
+        assert operator.retry_from_failure
+        assert operator.steps_override == self.config["steps_override"]
+        assert operator.schema_override == self.config["schema_override"]
+        assert operator.additional_run_config == self.config["additional_run_config"]
+
+        operator.execute(context=self.mock_context)
+
+        mock_run_req.assert_called()
+
+    @patch.object(
+        DbtCloudHook, "_run_and_get_response", return_value=mock_response_json(JOB_RUN_ERROR_RESPONSE)
+    )
+    @patch.object(DbtCloudHook, "retry_failed_job_run")
+    @pytest.mark.parametrize(
+        "conn_id, account_id",
+        [(ACCOUNT_ID_CONN, None), (NO_ACCOUNT_ID_CONN, ACCOUNT_ID)],
+        ids=["default_account", "explicit_account"],
+    )
+    def test_execute_retry_from_failure_rerun(self, mock_run_req, mock_rerun_req, conn_id, account_id):
+        operator = DbtCloudRunJobOperator(
+            task_id=TASK_ID,
+            dbt_cloud_conn_id=conn_id,
+            account_id=account_id,
+            trigger_reason=None,
+            dag=self.dag,
+            retry_from_failure=True,
+            **self.config,
+        )
+        self.mock_context["ti"].try_number = 2
+
+        assert operator.dbt_cloud_conn_id == conn_id
+        assert operator.job_id == self.config["job_id"]
+        assert operator.account_id == account_id
+        assert operator.check_interval == self.config["check_interval"]
+        assert operator.timeout == self.config["timeout"]
+        assert operator.retry_from_failure
+        assert operator.steps_override == self.config["steps_override"]
+        assert operator.schema_override == self.config["schema_override"]
+        assert operator.additional_run_config == self.config["additional_run_config"]
+
+        operator.execute(context=self.mock_context)
+
+        mock_rerun_req.assert_called_once()
 
     @patch.object(DbtCloudHook, "trigger_job_run")
     @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #43347
related: #43347

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
## What?
I added a condition distinguishing a scheduled run from a rerun.
- a scheduled run always starts a run of all models
- rerun, when the flag `retry_from_failure=True` is set, should only build models that failed in the previous run.
## Why?
The problem is that if there is an error in one model that can't be resolved (e.g., due to a data source issue), the flag prevented the other models from being refreshed, even in subsequent scheduled runs.
## How?
- first run calls `{account_id}/jobs/{job_id}/run/`
- next runs calls `{account_id}/jobs/{job_id}/rerun/`

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
