### PR TITLE
Fix oracle bulk insert issue when leftover chunk is empty

### DIFF
--- a/providers/src/airflow/providers/oracle/hooks/oracle.py
+++ b/providers/src/airflow/providers/oracle/hooks/oracle.py
@@ -390,10 +390,11 @@ class OracleHook(DbApiHook):
                 # Empty chunk
                 row_chunk = []
         # Commit the leftover chunk
-        cursor.prepare(prepared_stm)
-        cursor.executemany(None, row_chunk)
-        conn.commit()  # type: ignore[attr-defined]
-        self.log.info("[%s] inserted %s rows", table, row_count)
+        if row_chunk:
+            cursor.prepare(prepared_stm)
+            cursor.executemany(None, row_chunk)
+            conn.commit()  # type: ignore[attr-defined]
+            self.log.info("[%s] inserted %s rows", table, row_count)
         cursor.close()
         conn.close()  # type: ignore[attr-defined]
 

--- a/providers/tests/oracle/hooks/test_oracle.py
+++ b/providers/tests/oracle/hooks/test_oracle.py
@@ -399,6 +399,24 @@ class TestOracleHook:
                 "table", rows, target_fields, sequence_column=sequence_column, sequence_name=sequence_name
             )
 
+    def test_bulk_insert_commit_leftovers_only_if_exists(self):
+        rows = [(1, 2, 3), (4, 5, 6), (7, 8, 9), (1, 2, 3), (4, 5, 6), (7, 8, 9)]
+        target_fields = ["col1", "col2", "col3"]
+        sequence_column = "id"
+        sequence_name = "my_sequence"
+
+        self.db_hook.bulk_insert_rows(
+            "table",
+            rows,
+            target_fields,
+            sequence_column=sequence_column,
+            sequence_name=sequence_name,
+            commit_every=3,
+        )
+
+        # executemany should be called exactly 2 times because there is no leftovers
+        assert self.cur.executemany.call_count == 2
+
     def test_callproc_none(self):
         parameters = None
 
@@ -408,7 +426,7 @@ class TestOracleHook:
 
         self.cur.bindvars = None
         result = self.db_hook.callproc("proc", True, parameters)
-        assert self.cur.execute.mock_calls == [mock.call("BEGIN proc(); END;")]
+        assert self.cur.executemany.mock_calls == [mock.call("BEGIN proc(); END;")]
         assert result == parameters
 
     def test_callproc_dict(self):

--- a/providers/tests/oracle/hooks/test_oracle.py
+++ b/providers/tests/oracle/hooks/test_oracle.py
@@ -426,7 +426,7 @@ class TestOracleHook:
 
         self.cur.bindvars = None
         result = self.db_hook.callproc("proc", True, parameters)
-        assert self.cur.executemany.mock_calls == [mock.call("BEGIN proc(); END;")]
+        assert self.cur.execute.mock_calls == [mock.call("BEGIN proc(); END;")]
         assert result == parameters
 
     def test_callproc_dict(self):


### PR DESCRIPTION
closes: https://github.com/apache/airflow/pull/42606
with cherry-pick: @mfatemipour
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
