### PR TITLE
fix(providers/fab): alias is_authorized_dataset to is_authorized_asset

### DIFF
--- a/providers/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/providers/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import argparse
+import warnings
 from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Container
@@ -46,7 +47,7 @@ from airflow.cli.cli_config import (
     GroupCommand,
 )
 from airflow.configuration import conf
-from airflow.exceptions import AirflowConfigException, AirflowException
+from airflow.exceptions import AirflowConfigException, AirflowException, AirflowProviderDeprecationWarning
 from airflow.models import DagModel
 from airflow.providers.fab.auth_manager.cli_commands.definition import (
     DB_COMMANDS,
@@ -270,6 +271,16 @@ class FabAuthManager(BaseAuthManager):
         self, *, method: ResourceMethod, details: AssetDetails | None = None, user: BaseUser | None = None
     ) -> bool:
         return self._is_authorized(method=method, resource_type=RESOURCE_ASSET, user=user)
+
+    def is_authorized_dataset(
+        self, *, method: ResourceMethod, details: AssetDetails | None = None, user: BaseUser | None = None
+    ) -> bool:
+        warnings.warn(
+            "is_authorized_dataset will be renamed as is_authorized_asset in Airflow 3 and will be removed when the minimum Airflow version is set to 3.0 for the fab provider",
+            AirflowProviderDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.is_authorized_asset(method=method, user=user)
 
     def is_authorized_pool(
         self, *, method: ResourceMethod, details: PoolDetails | None = None, user: BaseUser | None = None

--- a/providers/tests/fab/auth_manager/views/__init__.py
+++ b/providers/tests/fab/auth_manager/views/__init__.py
@@ -18,12 +18,17 @@
 from __future__ import annotations
 
 from airflow import __version__ as airflow_version
+from airflow.exceptions import AirflowProviderDeprecationWarning
 
 
-def _assert_dataset_deprecation_warning(record) -> None:
+def _assert_dataset_deprecation_warning(recwarn) -> None:
     if airflow_version.startswith("2"):
-        assert len(record) == 1
+        warning = recwarn.pop(AirflowProviderDeprecationWarning)
+        assert warning.category == AirflowProviderDeprecationWarning
         assert (
-            record[0].message.args[0]
+            str(warning.message)
             == "is_authorized_dataset will be renamed as is_authorized_asset in Airflow 3 and will be removed when the minimum Airflow version is set to 3.0 for the fab provider"
         )
+
+
+__all__ = ["_assert_dataset_deprecation_warning"]

--- a/providers/tests/fab/auth_manager/views/__init__.py
+++ b/providers/tests/fab/auth_manager/views/__init__.py
@@ -15,3 +15,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
+
+from airflow import __version__ as airflow_version
+
+
+def _assert_dataset_deprecation_warning(record) -> None:
+    if airflow_version.startswith("2"):
+        assert len(record) == 1
+        assert (
+            record[0].message.args[0]
+            == "is_authorized_dataset will be renamed as is_authorized_asset in Airflow 3 and will be removed when the minimum Airflow version is set to 3.0 for the fab provider"
+        )

--- a/providers/tests/fab/auth_manager/views/test_permissions.py
+++ b/providers/tests/fab/auth_manager/views/test_permissions.py
@@ -19,10 +19,12 @@ from __future__ import annotations
 
 import pytest
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.security import permissions
 from airflow.www import app as application
 
 from providers.tests.fab.auth_manager.api_endpoints.api_connexion_utils import create_user, delete_user
+from providers.tests.fab.auth_manager.views import _assert_dataset_deprecation_warning
 from tests_common.test_utils.compat import AIRFLOW_V_2_9_PLUS
 from tests_common.test_utils.www import client_with_login
 
@@ -66,13 +68,22 @@ def client_permissions_reader(fab_app, user_permissions_reader):
 @pytest.mark.db_test
 class TestPermissionsView:
     def test_action_model_view(self, client_permissions_reader):
-        resp = client_permissions_reader.get("/actions/list/", follow_redirects=True)
+        with pytest.warns(AirflowProviderDeprecationWarning) as record:
+            resp = client_permissions_reader.get("/actions/list/", follow_redirects=True)
+
+        _assert_dataset_deprecation_warning(record)
         assert resp.status_code == 200
 
     def test_permission_pair_model_view(self, client_permissions_reader):
-        resp = client_permissions_reader.get("/permissions/list/", follow_redirects=True)
+        with pytest.warns(AirflowProviderDeprecationWarning) as record:
+            resp = client_permissions_reader.get("/permissions/list/", follow_redirects=True)
+
+        _assert_dataset_deprecation_warning(record)
         assert resp.status_code == 200
 
     def test_resource_model_view(self, client_permissions_reader):
-        resp = client_permissions_reader.get("/resources/list/", follow_redirects=True)
+        with pytest.warns(AirflowProviderDeprecationWarning) as record:
+            resp = client_permissions_reader.get("/resources/list/", follow_redirects=True)
+
+        _assert_dataset_deprecation_warning(record)
         assert resp.status_code == 200

--- a/providers/tests/fab/auth_manager/views/test_permissions.py
+++ b/providers/tests/fab/auth_manager/views/test_permissions.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import pytest
 
-from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.security import permissions
 from airflow.www import app as application
 
@@ -67,23 +66,20 @@ def client_permissions_reader(fab_app, user_permissions_reader):
 
 @pytest.mark.db_test
 class TestPermissionsView:
-    def test_action_model_view(self, client_permissions_reader):
-        with pytest.warns(AirflowProviderDeprecationWarning) as record:
-            resp = client_permissions_reader.get("/actions/list/", follow_redirects=True)
+    def test_action_model_view(self, client_permissions_reader, recwarn):
+        resp = client_permissions_reader.get("/actions/list/", follow_redirects=True)
 
-        _assert_dataset_deprecation_warning(record)
+        _assert_dataset_deprecation_warning(recwarn)
         assert resp.status_code == 200
 
-    def test_permission_pair_model_view(self, client_permissions_reader):
-        with pytest.warns(AirflowProviderDeprecationWarning) as record:
-            resp = client_permissions_reader.get("/permissions/list/", follow_redirects=True)
+    def test_permission_pair_model_view(self, client_permissions_reader, recwarn):
+        resp = client_permissions_reader.get("/permissions/list/", follow_redirects=True)
 
-        _assert_dataset_deprecation_warning(record)
+        _assert_dataset_deprecation_warning(recwarn)
         assert resp.status_code == 200
 
-    def test_resource_model_view(self, client_permissions_reader):
-        with pytest.warns(AirflowProviderDeprecationWarning) as record:
-            resp = client_permissions_reader.get("/resources/list/", follow_redirects=True)
+    def test_resource_model_view(self, client_permissions_reader, recwarn):
+        resp = client_permissions_reader.get("/resources/list/", follow_redirects=True)
 
-        _assert_dataset_deprecation_warning(record)
+        _assert_dataset_deprecation_warning(recwarn)
         assert resp.status_code == 200

--- a/providers/tests/fab/auth_manager/views/test_roles_list.py
+++ b/providers/tests/fab/auth_manager/views/test_roles_list.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import pytest
 
-from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.security import permissions
 from airflow.www import app as application
 
@@ -65,9 +64,8 @@ def client_roles_reader(fab_app, user_roles_reader):
 
 @pytest.mark.db_test
 class TestRolesListView:
-    def test_role_model_view(self, client_roles_reader):
-        with pytest.warns(AirflowProviderDeprecationWarning) as record:
-            resp = client_roles_reader.get("/roles/list/", follow_redirects=True)
+    def test_role_model_view(self, client_roles_reader, recwarn):
+        resp = client_roles_reader.get("/roles/list/", follow_redirects=True)
 
-        _assert_dataset_deprecation_warning(record)
+        _assert_dataset_deprecation_warning(recwarn)
         assert resp.status_code == 200

--- a/providers/tests/fab/auth_manager/views/test_roles_list.py
+++ b/providers/tests/fab/auth_manager/views/test_roles_list.py
@@ -19,10 +19,12 @@ from __future__ import annotations
 
 import pytest
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.security import permissions
 from airflow.www import app as application
 
 from providers.tests.fab.auth_manager.api_endpoints.api_connexion_utils import create_user, delete_user
+from providers.tests.fab.auth_manager.views import _assert_dataset_deprecation_warning
 from tests_common.test_utils.compat import AIRFLOW_V_2_9_PLUS
 from tests_common.test_utils.www import client_with_login
 
@@ -64,5 +66,8 @@ def client_roles_reader(fab_app, user_roles_reader):
 @pytest.mark.db_test
 class TestRolesListView:
     def test_role_model_view(self, client_roles_reader):
-        resp = client_roles_reader.get("/roles/list/", follow_redirects=True)
+        with pytest.warns(AirflowProviderDeprecationWarning) as record:
+            resp = client_roles_reader.get("/roles/list/", follow_redirects=True)
+
+        _assert_dataset_deprecation_warning(record)
         assert resp.status_code == 200

--- a/providers/tests/fab/auth_manager/views/test_user.py
+++ b/providers/tests/fab/auth_manager/views/test_user.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import pytest
 
-from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.security import permissions
 from airflow.www import app as application
 
@@ -65,9 +64,8 @@ def client_user_reader(fab_app, user_user_reader):
 
 @pytest.mark.db_test
 class TestUserView:
-    def test_user_model_view(self, client_user_reader):
-        with pytest.warns(AirflowProviderDeprecationWarning) as record:
-            resp = client_user_reader.get("/users/list/", follow_redirects=True)
+    def test_user_model_view(self, client_user_reader, recwarn):
+        resp = client_user_reader.get("/users/list/", follow_redirects=True)
 
-        _assert_dataset_deprecation_warning(record)
+        _assert_dataset_deprecation_warning(recwarn)
         assert resp.status_code == 200

--- a/providers/tests/fab/auth_manager/views/test_user.py
+++ b/providers/tests/fab/auth_manager/views/test_user.py
@@ -19,10 +19,12 @@ from __future__ import annotations
 
 import pytest
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.security import permissions
 from airflow.www import app as application
 
 from providers.tests.fab.auth_manager.api_endpoints.api_connexion_utils import create_user, delete_user
+from providers.tests.fab.auth_manager.views import _assert_dataset_deprecation_warning
 from tests_common.test_utils.compat import AIRFLOW_V_2_9_PLUS
 from tests_common.test_utils.www import client_with_login
 
@@ -64,5 +66,8 @@ def client_user_reader(fab_app, user_user_reader):
 @pytest.mark.db_test
 class TestUserView:
     def test_user_model_view(self, client_user_reader):
-        resp = client_user_reader.get("/users/list/", follow_redirects=True)
+        with pytest.warns(AirflowProviderDeprecationWarning) as record:
+            resp = client_user_reader.get("/users/list/", follow_redirects=True)
+
+        _assert_dataset_deprecation_warning(record)
         assert resp.status_code == 200

--- a/providers/tests/fab/auth_manager/views/test_user_edit.py
+++ b/providers/tests/fab/auth_manager/views/test_user_edit.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import pytest
 
-from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.security import permissions
 from airflow.www import app as application
 
@@ -65,8 +64,7 @@ def client_user_reader(fab_app, user_user_reader):
 
 @pytest.mark.db_test
 class TestUserEditView:
-    def test_reset_my_password_view(self, client_user_reader):
-        with pytest.warns(AirflowProviderDeprecationWarning) as record:
-            resp = client_user_reader.get("/resetmypassword/form", follow_redirects=True)
-        _assert_dataset_deprecation_warning(record)
+    def test_reset_my_password_view(self, client_user_reader, recwarn):
+        resp = client_user_reader.get("/resetmypassword/form", follow_redirects=True)
+        _assert_dataset_deprecation_warning(recwarn)
         assert resp.status_code == 200

--- a/providers/tests/fab/auth_manager/views/test_user_edit.py
+++ b/providers/tests/fab/auth_manager/views/test_user_edit.py
@@ -19,10 +19,12 @@ from __future__ import annotations
 
 import pytest
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.security import permissions
 from airflow.www import app as application
 
 from providers.tests.fab.auth_manager.api_endpoints.api_connexion_utils import create_user, delete_user
+from providers.tests.fab.auth_manager.views import _assert_dataset_deprecation_warning
 from tests_common.test_utils.compat import AIRFLOW_V_2_9_PLUS
 from tests_common.test_utils.www import client_with_login
 
@@ -64,5 +66,7 @@ def client_user_reader(fab_app, user_user_reader):
 @pytest.mark.db_test
 class TestUserEditView:
     def test_reset_my_password_view(self, client_user_reader):
-        resp = client_user_reader.get("/resetmypassword/form", follow_redirects=True)
+        with pytest.warns(AirflowProviderDeprecationWarning) as record:
+            resp = client_user_reader.get("/resetmypassword/form", follow_redirects=True)
+        _assert_dataset_deprecation_warning(record)
         assert resp.status_code == 200

--- a/providers/tests/fab/auth_manager/views/test_user_stats.py
+++ b/providers/tests/fab/auth_manager/views/test_user_stats.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import pytest
 
-from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.security import permissions
 from airflow.www import app as application
 
@@ -65,8 +64,7 @@ def client_user_stats_reader(fab_app, user_user_stats_reader):
 
 @pytest.mark.db_test
 class TestUserStats:
-    def test_user_stats(self, client_user_stats_reader):
-        with pytest.warns(AirflowProviderDeprecationWarning) as record:
-            resp = client_user_stats_reader.get("/userstatschartview/chart", follow_redirects=True)
-        _assert_dataset_deprecation_warning(record)
+    def test_user_stats(self, client_user_stats_reader, recwarn):
+        resp = client_user_stats_reader.get("/userstatschartview/chart", follow_redirects=True)
+        _assert_dataset_deprecation_warning(recwarn)
         assert resp.status_code == 200

--- a/providers/tests/fab/auth_manager/views/test_user_stats.py
+++ b/providers/tests/fab/auth_manager/views/test_user_stats.py
@@ -19,10 +19,12 @@ from __future__ import annotations
 
 import pytest
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.security import permissions
 from airflow.www import app as application
 
 from providers.tests.fab.auth_manager.api_endpoints.api_connexion_utils import create_user, delete_user
+from providers.tests.fab.auth_manager.views import _assert_dataset_deprecation_warning
 from tests_common.test_utils.compat import AIRFLOW_V_2_9_PLUS
 from tests_common.test_utils.www import client_with_login
 
@@ -64,5 +66,7 @@ def client_user_stats_reader(fab_app, user_user_stats_reader):
 @pytest.mark.db_test
 class TestUserStats:
     def test_user_stats(self, client_user_stats_reader):
-        resp = client_user_stats_reader.get("/userstatschartview/chart", follow_redirects=True)
+        with pytest.warns(AirflowProviderDeprecationWarning) as record:
+            resp = client_user_stats_reader.get("/userstatschartview/chart", follow_redirects=True)
+        _assert_dataset_deprecation_warning(record)
         assert resp.status_code == 200


### PR DESCRIPTION
## Why

is_authorized_dataset has been is_authorized_asset in airflow 3.0 but not yet in 2.10 which will cause insufficient permission when use airflow 2.10 with fab 1.4.1

## What

Alias is_authorized_dataset to is_authorized_asset and add a deprecation warning to is_authorized_dataset

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
