### PR TITLE
Fix validating `parent_model` parameter in `UploadModelOperator`

### DIFF
--- a/providers/src/airflow/providers/google/cloud/hooks/vertex_ai/model_service.py
+++ b/providers/src/airflow/providers/google/cloud/hooks/vertex_ai/model_service.py
@@ -219,7 +219,7 @@ class ModelServiceHook(GoogleBaseHook):
         :param project_id: Required. The ID of the Google Cloud project that the service belongs to.
         :param region: Required. The ID of the Google Cloud region that the service belongs to.
         :param model:  Required. The Model to create.
-        :param parent_model: The name of the parent model to create a new version under.
+        :param parent_model: The ID of the parent model to create a new version under.
         :param retry: Designation of what errors, if any, should be retried.
         :param timeout: The timeout for this request.
         :param metadata: Strings which should be sent along with the request as metadata.
@@ -233,7 +233,7 @@ class ModelServiceHook(GoogleBaseHook):
         }
 
         if parent_model:
-            request["parent_model"] = parent_model
+            request["parent_model"] = client.model_path(project_id, region, parent_model)
 
         result = client.upload_model(
             request=request,

--- a/providers/src/airflow/providers/google/cloud/operators/vertex_ai/model_service.py
+++ b/providers/src/airflow/providers/google/cloud/operators/vertex_ai/model_service.py
@@ -361,8 +361,9 @@ class UploadModelOperator(GoogleCloudBaseOperator):
 
     :param project_id: Required. The ID of the Google Cloud project that the service belongs to.
     :param region: Required. The ID of the Google Cloud region that the service belongs to.
-    :param model: Required. The Model to create.
-    :param parent_model: The name of the parent model to create a new version under.
+    :param model: Required. The Model to create. Creating model with the name that already
+        exists leads to creating new version of existing model.
+    :param parent_model: The ID of the parent model to create a new version under.
     :param retry: Designation of what errors, if any, should be retried.
     :param timeout: The timeout for this request.
     :param metadata: Strings which should be sent along with the request as metadata.
@@ -377,7 +378,7 @@ class UploadModelOperator(GoogleCloudBaseOperator):
         account from the list granting this role to the originating account (templated).
     """
 
-    template_fields = ("region", "project_id", "model", "impersonation_chain")
+    template_fields = ("region", "project_id", "model", "parent_model", "impersonation_chain")
     operator_extra_links = (VertexAIModelLink(),)
 
     def __init__(

--- a/providers/tests/google/cloud/hooks/vertex_ai/test_model_service.py
+++ b/providers/tests/google/cloud/hooks/vertex_ai/test_model_service.py
@@ -37,7 +37,7 @@ TEST_GCP_CONN_ID: str = "test-gcp-conn-id"
 TEST_REGION: str = "test-region"
 TEST_PROJECT_ID: str = "test-project-id"
 TEST_MODEL = None
-TEST_PARENT_MODEL = "test-parent-model"
+TEST_PARENT_MODEL = "projects/test-project-id/locations/test-region/models/test-parent-model"
 TEST_MODEL_NAME: str = "test_model_name"
 TEST_OUTPUT_CONFIG: dict = {}
 
@@ -148,7 +148,7 @@ class TestModelServiceWithDefaultProjectIdHook:
             request=dict(
                 parent=mock_client.return_value.common_location_path.return_value,
                 model=TEST_MODEL,
-                parent_model=TEST_PARENT_MODEL,
+                parent_model=mock_client.return_value.model_path.return_value,
             ),
             metadata=(),
             retry=DEFAULT,
@@ -352,7 +352,7 @@ class TestModelServiceWithoutDefaultProjectIdHook:
             request=dict(
                 parent=mock_client.return_value.common_location_path.return_value,
                 model=TEST_MODEL,
-                parent_model=TEST_PARENT_MODEL,
+                parent_model=mock_client.return_value.model_path.return_value,
             ),
             metadata=(),
             retry=DEFAULT,

--- a/providers/tests/system/google/cloud/vertex_ai/example_vertex_ai_model_service.py
+++ b/providers/tests/system/google/cloud/vertex_ai/example_vertex_ai_model_service.py
@@ -113,6 +113,19 @@ MODEL_OBJ = {
         "health_route": "",
     },
 }
+MODEL_OBJ_V2 = {
+    "display_name": f"model-{ENV_ID}-v2",
+    "artifact_uri": "{{ti.xcom_pull('custom_task')['artifactUri']}}",
+    "container_spec": {
+        "image_uri": MODEL_SERVING_CONTAINER_URI,
+        "command": [],
+        "args": [],
+        "env": [],
+        "ports": [],
+        "predict_route": "",
+        "health_route": "",
+    },
+}
 
 
 with DAG(
@@ -229,13 +242,14 @@ with DAG(
         project_id=PROJECT_ID,
         model=MODEL_OBJ,
     )
+    upload_model_v1 = upload_model.output["model_id"]
     # [END how_to_cloud_vertex_ai_upload_model_operator]
     upload_model_with_parent_model = UploadModelOperator(
         task_id="upload_model_with_parent_model",
         region=REGION,
         project_id=PROJECT_ID,
-        model=MODEL_OBJ,
-        parent_model=MODEL_DISPLAY_NAME,
+        model=MODEL_OBJ_V2,
+        parent_model=upload_model_v1,
     )
 
     # [START how_to_cloud_vertex_ai_export_model_operator]


### PR DESCRIPTION
Fix validating parent_model parameter in UploadModelOperator + fixing system test
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
