### PR TITLE
Add latest dag run info to dags list and dag details

### DIFF
--- a/airflow/ui/src/layouts/Nav/Nav.tsx
+++ b/airflow/ui/src/layouts/Nav/Nav.tsx
@@ -19,7 +19,6 @@
 import { Box, Flex, Icon, VStack } from "@chakra-ui/react";
 import { motion } from "framer-motion";
 import {
-  FiBarChart2,
   FiCornerUpLeft,
   FiDatabase,
   FiGlobe,
@@ -69,12 +68,6 @@ export const Nav = () => (
         isDisabled
         title="Assets"
         to="assets"
-      />
-      <NavButton
-        icon={<FiBarChart2 size="1.75rem" />}
-        isDisabled
-        title="Dag Runs"
-        to="dag_runs"
       />
       <NavButton
         icon={<FiGlobe size="1.75rem" />}

--- a/airflow/ui/src/pages/DagsList/Dag/Dag.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Dag.tsx
@@ -29,7 +29,10 @@ import {
 import { FiChevronsLeft } from "react-icons/fi";
 import { Link as RouterLink, useParams } from "react-router-dom";
 
-import { useDagServiceGetDagDetails } from "openapi/queries";
+import {
+  useDagServiceGetDagDetails,
+  useDagsServiceRecentDagRuns,
+} from "openapi/queries";
 import { ErrorAlert } from "src/components/ErrorAlert";
 
 import { Header } from "./Header";
@@ -45,6 +48,17 @@ export const Dag = () => {
     dagId: dagId ?? "",
   });
 
+  // TODO: replace with with a list dag runs by dag id request
+  const {
+    data: runsData,
+    error: runsError,
+    isLoading: isLoadingRuns,
+  } = useDagsServiceRecentDagRuns({ dagIdPattern: dagId ?? "" });
+
+  const runs =
+    runsData?.dags.find((dagWithRuns) => dagWithRuns.dag_id === dagId)
+      ?.latest_dag_runs ?? [];
+
   return (
     <Box>
       <Button
@@ -56,18 +70,19 @@ export const Dag = () => {
       >
         Back to all dags
       </Button>
-      <Header dag={dag} dagId={dagId} />
-      <ErrorAlert error={error} />
+      <Header dag={dag} dagId={dagId} latestRun={runs[0]} />
+      <ErrorAlert error={error ?? runsError} />
       <Progress
         isIndeterminate
         size="xs"
-        visibility={isLoading ? "visible" : "hidden"}
+        visibility={isLoading || isLoadingRuns ? "visible" : "hidden"}
       />
       <Tabs>
         <TabList>
           <Tab>Overview</Tab>
           <Tab>Runs</Tab>
           <Tab>Tasks</Tab>
+          <Tab>Events</Tab>
         </TabList>
 
         <TabPanels>

--- a/airflow/ui/src/pages/DagsList/Dag/Header.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Header.tsx
@@ -30,19 +30,22 @@ import {
 } from "@chakra-ui/react";
 import { FiCalendar, FiPlay } from "react-icons/fi";
 
-import type { DAGResponse } from "openapi/requests/types.gen";
+import type { DAGResponse, DAGRunResponse } from "openapi/requests/types.gen";
 import { DagIcon } from "src/assets/DagIcon";
 import Time from "src/components/Time";
 import { TogglePause } from "src/components/TogglePause";
 
 import { DagTags } from "../DagTags";
+import { LatestRun } from "../LatestRun";
 
 export const Header = ({
   dag,
   dagId,
+  latestRun,
 }: {
   readonly dag?: DAGResponse;
   readonly dagId?: string;
+  readonly latestRun?: DAGRunResponse;
 }) => {
   const grayBg = useColorModeValue("gray.100", "gray.900");
   const grayBorder = useColorModeValue("gray.200", "gray.700");
@@ -74,6 +77,8 @@ export const Header = ({
             <Heading color="gray.500" fontSize="xs">
               Last Run
             </Heading>
+            <LatestRun latestRun={latestRun} />
+            <LatestRun />
           </VStack>
           <VStack align="flex-start" spacing={1}>
             <Heading color="gray.500" fontSize="xs">

--- a/airflow/ui/src/pages/DagsList/DagCard.test.tsx
+++ b/airflow/ui/src/pages/DagsList/DagCard.test.tsx
@@ -20,8 +20,8 @@
  */
 import { render, screen } from "@testing-library/react";
 import type {
-  DAGResponse,
   DagTagPydantic,
+  DAGWithLatestDagRunsResponse,
 } from "openapi-gen/requests/types.gen";
 import { afterEach, describe, it, vi, expect } from "vitest";
 
@@ -44,6 +44,7 @@ const mockDag = {
   last_expired: null,
   last_parsed_time: "2024-08-22T13:50:10.372238+00:00",
   last_pickled: null,
+  latest_dag_runs: [],
   max_active_runs: 16,
   max_active_tasks: 16,
   max_consecutive_failed_dag_runs: 0,
@@ -56,7 +57,7 @@ const mockDag = {
   tags: [],
   timetable_description: "",
   timetable_summary: "",
-} satisfies DAGResponse;
+} satisfies DAGWithLatestDagRunsResponse;
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -77,7 +78,10 @@ describe("DagCard", () => {
       { dag_id: "id", name: "tag4" },
     ] satisfies Array<DagTagPydantic>;
 
-    const expandedMockDag = { ...mockDag, tags } satisfies DAGResponse;
+    const expandedMockDag = {
+      ...mockDag,
+      tags,
+    } satisfies DAGWithLatestDagRunsResponse;
 
     render(<DagCard dag={expandedMockDag} />, { wrapper: Wrapper });
     expect(screen.getByTestId("dag-tag")).toBeInTheDocument();

--- a/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -22,22 +22,23 @@ import {
   HStack,
   Heading,
   SimpleGrid,
-  Text,
   Tooltip,
   VStack,
   Link,
 } from "@chakra-ui/react";
-import { FiCalendar } from "react-icons/fi";
 import { Link as RouterLink } from "react-router-dom";
 
-import type { DAGResponse } from "openapi/requests/types.gen";
+import type { DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
 import Time from "src/components/Time";
 import { TogglePause } from "src/components/TogglePause";
 
 import { DagTags } from "./DagTags";
+import { LatestRun } from "./LatestRun";
+import { RecentRuns } from "./RecentRuns";
+import { Schedule } from "./Schedule";
 
 type Props = {
-  readonly dag: DAGResponse;
+  readonly dag: DAGWithLatestDagRunsResponse;
 };
 
 export const DagCard = ({ dag }: Props) => (
@@ -73,30 +74,25 @@ export const DagCard = ({ dag }: Props) => (
       </HStack>
     </Flex>
     <SimpleGrid columns={4} height={20} px={3} py={2} spacing={4}>
-      <div />
       <VStack align="flex-start" spacing={1}>
         <Heading color="gray.500" fontSize="xs">
-          Last Run
+          Schedule
         </Heading>
+        <Schedule dag={dag} />
+      </VStack>
+      <VStack align="flex-start" spacing={1}>
+        <Heading color="gray.500" fontSize="xs">
+          Latest Run
+        </Heading>
+        <LatestRun latestRun={dag.latest_dag_runs[0]} />
       </VStack>
       <VStack align="flex-start" spacing={1}>
         <Heading color="gray.500" fontSize="xs">
           Next Run
         </Heading>
-        <Text fontSize="sm">
-          <Time datetime={dag.next_dagrun} />
-        </Text>
-        {Boolean(dag.timetable_summary) ? (
-          <Tooltip hasArrow label={dag.timetable_description}>
-            <Text fontSize="sm">
-              {" "}
-              <FiCalendar style={{ display: "inline" }} />{" "}
-              {dag.timetable_summary}
-            </Text>
-          </Tooltip>
-        ) : undefined}
+        <Time datetime={dag.next_dagrun} />
       </VStack>
-      <div />
+      <RecentRuns latestRuns={dag.latest_dag_runs} />
     </SimpleGrid>
   </Box>
 );

--- a/airflow/ui/src/pages/DagsList/DagTags.tsx
+++ b/airflow/ui/src/pages/DagsList/DagTags.tsx
@@ -24,13 +24,14 @@ import type { DagTagPydantic } from "openapi/requests/types.gen";
 const MAX_TAGS = 3;
 
 type Props = {
+  readonly hideIcon?: boolean;
   readonly tags: Array<DagTagPydantic>;
 };
 
-export const DagTags = ({ tags }: Props) =>
+export const DagTags = ({ hideIcon = false, tags }: Props) =>
   tags.length ? (
     <Flex alignItems="center" ml={2}>
-      <FiTag data-testid="dag-tag" />
+      {hideIcon ? undefined : <FiTag data-testid="dag-tag" />}
       <Text ml={1}>
         {tags
           .slice(0, MAX_TAGS)

--- a/airflow/ui/src/pages/DagsList/DagsFilters.tsx
+++ b/airflow/ui/src/pages/DagsList/DagsFilters.tsx
@@ -133,7 +133,7 @@ export const DagsFilters = () => {
             onClick={handleStateChange}
             value="success"
           >
-            Successful
+            Success
           </QuickFilterButton>
         </HStack>
         <Select

--- a/airflow/ui/src/pages/DagsList/LatestRun.tsx
+++ b/airflow/ui/src/pages/DagsList/LatestRun.tsx
@@ -1,0 +1,41 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box, HStack, Text } from "@chakra-ui/react";
+
+import type { DAGRunResponse } from "openapi/requests/types.gen";
+import Time from "src/components/Time";
+import { stateColor } from "src/utils/stateColor";
+
+type Props = {
+  readonly latestRun?: DAGRunResponse;
+};
+
+export const LatestRun = ({ latestRun }: Props) =>
+  latestRun ? (
+    <HStack fontSize="sm">
+      <Time datetime={latestRun.logical_date} />
+      <Box
+        bg={stateColor[latestRun.state]}
+        borderRadius="50%"
+        height={2}
+        width={2}
+      />
+      <Text color={stateColor[latestRun.state]}>{latestRun.state}</Text>
+    </HStack>
+  ) : undefined;

--- a/airflow/ui/src/pages/DagsList/RecentRuns.tsx
+++ b/airflow/ui/src/pages/DagsList/RecentRuns.tsx
@@ -64,6 +64,7 @@ export const RecentRuns = ({
               <Text>Duration: {run.duration.toFixed(2)}s</Text>
             </Box>
           }
+          offset={[10, 5]}
           placement="bottom-start"
         >
           <Box p={1}>

--- a/airflow/ui/src/pages/DagsList/RecentRuns.tsx
+++ b/airflow/ui/src/pages/DagsList/RecentRuns.tsx
@@ -1,0 +1,82 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Flex, Box, Tooltip, Text } from "@chakra-ui/react";
+import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
+
+import type { DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
+import Time from "src/components/Time";
+import { stateColor } from "src/utils/stateColor";
+
+dayjs.extend(duration);
+
+const BAR_HEIGHT = 60;
+
+export const RecentRuns = ({
+  latestRuns,
+}: {
+  readonly latestRuns: DAGWithLatestDagRunsResponse["latest_dag_runs"];
+}) => {
+  if (!latestRuns.length) {
+    return undefined;
+  }
+
+  const runsWithDuration = latestRuns.map((run) => ({
+    ...run,
+    duration: dayjs
+      .duration(dayjs(run.end_date).diff(run.start_date))
+      .asSeconds(),
+  }));
+
+  const max = Math.max.apply(
+    undefined,
+    runsWithDuration.map((run) => run.duration),
+  );
+
+  return (
+    <Flex alignItems="flex-end" flexDirection="row-reverse">
+      {runsWithDuration.map((run) => (
+        <Tooltip
+          hasArrow
+          key={run.run_id}
+          label={
+            <Box>
+              <Text>State: {run.state}</Text>
+              <Text>
+                Logical Date: <Time datetime={run.logical_date} />
+              </Text>
+              <Text>Duration: {run.duration.toFixed(2)}s</Text>
+            </Box>
+          }
+          placement="bottom-start"
+        >
+          <Box p={1}>
+            <Box
+              bg={stateColor[run.state]}
+              borderRadius="4px"
+              height={`${(run.duration / max) * BAR_HEIGHT}px`}
+              minHeight={1}
+              width="4px"
+            />
+          </Box>
+        </Tooltip>
+      ))}
+    </Flex>
+  );
+};

--- a/airflow/ui/src/pages/DagsList/Schedule.tsx
+++ b/airflow/ui/src/pages/DagsList/Schedule.tsx
@@ -1,0 +1,36 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Text, Tooltip } from "@chakra-ui/react";
+import { FiCalendar } from "react-icons/fi";
+
+import type { DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
+
+type Props = {
+  readonly dag: DAGWithLatestDagRunsResponse;
+};
+
+export const Schedule = ({ dag }: Props) =>
+  Boolean(dag.timetable_summary) &&
+  dag.timetable_description !== "Never, external triggers only" ? (
+    <Tooltip hasArrow label={dag.timetable_description}>
+      <Text fontSize="sm">
+        <FiCalendar style={{ display: "inline" }} /> {dag.timetable_summary}
+      </Text>
+    </Tooltip>
+  ) : undefined;

--- a/airflow/ui/src/queries/useDags.tsx
+++ b/airflow/ui/src/queries/useDags.tsx
@@ -1,0 +1,81 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {
+  useDagServiceGetDags,
+  useDagsServiceRecentDagRuns,
+} from "openapi/queries";
+import type { DagRunState } from "openapi/requests/types.gen";
+
+const queryOptions = {
+  refetchOnMount: true,
+  refetchOnReconnect: false,
+  refetchOnWindowFocus: false,
+  staleTime: 5 * 60 * 1000,
+};
+
+export const useDags = (
+  searchParams: {
+    dagDisplayNamePattern?: string;
+    dagIdPattern?: string;
+    lastDagRunState?: DagRunState;
+    limit?: number;
+    offset?: number;
+    onlyActive?: boolean;
+    orderBy?: string;
+    owners?: Array<string>;
+    paused?: boolean;
+    tags?: Array<string>;
+  } = {},
+) => {
+  const { data, error, isFetching, isLoading } = useDagServiceGetDags(
+    searchParams,
+    undefined,
+    queryOptions,
+  );
+
+  const { lastDagRunState, orderBy, ...runsParams } = searchParams;
+  const {
+    data: runsData,
+    error: runsError,
+    isFetching: isRunsFetching,
+    isLoading: isRunsLoading,
+  } = useDagsServiceRecentDagRuns(
+    {
+      ...runsParams,
+      dagRunsLimit: 14,
+    },
+    undefined,
+    queryOptions,
+  );
+
+  const dags = (data?.dags ?? []).map((dag) => {
+    const dagWithRuns = runsData?.dags.find(
+      (runsDag) => runsDag.dag_id === dag.dag_id,
+    );
+
+    return dagWithRuns ?? { ...dag, latest_dag_runs: [] };
+  });
+
+  return {
+    data: { dags, total_entries: data?.total_entries ?? 0 },
+    error: error ?? runsError,
+    isFetching: isFetching || isRunsFetching,
+    isLoading: isLoading || isRunsLoading,
+  };
+};

--- a/airflow/ui/src/utils/stateColor.ts
+++ b/airflow/ui/src/utils/stateColor.ts
@@ -1,0 +1,36 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// TODO: replace this with Airflow config values
+
+export const stateColor = {
+  deferred: "mediumpurple",
+  failed: "red",
+  null: "lightblue",
+  queued: "gray",
+  removed: "lightgrey",
+  restarting: "violet",
+  running: "lime",
+  scheduled: "tan",
+  skipped: "hotpink",
+  success: "green",
+  up_for_reschedule: "turquoise",
+  up_for_retry: "gold",
+  upstream_failed: "orange",
+};


### PR DESCRIPTION
Add latest dag runs info to the new UI to better fill out the dags list and dag details header:

<img width="909" alt="Screenshot 2024-10-29 at 1 13 58 PM" src="https://github.com/user-attachments/assets/69e76c49-b29d-4cbc-9b22-e38c0d60d661">
<img width="1369" alt="Screenshot 2024-10-29 at 1 13 50 PM" src="https://github.com/user-attachments/assets/d327e150-5988-4716-a88f-7d4770246d1c">
<img width="695" alt="Screenshot 2024-10-29 at 1 13 38 PM" src="https://github.com/user-attachments/assets/707ce51a-227e-4c8e-ad77-525459b5de29">
<img width="654" alt="Screenshot 2024-10-29 at 1 21 57 PM" src="https://github.com/user-attachments/assets/6aae4c65-4e0c-4c5c-8a60-e92e08b40b5d">





---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
