### PR TITLE
Dep: Revert changes for cloudant python specifier

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -352,6 +352,7 @@
   "cloudant": {
     "deps": [
       "apache-airflow>=2.8.0",
+      "ibmcloudant==0.7.0 ; python_version < \"3.10\"",
       "ibmcloudant==0.9.1 ; python_version >= \"3.10\""
     ],
     "devel-deps": [],

--- a/providers/src/airflow/providers/cloudant/provider.yaml
+++ b/providers/src/airflow/providers/cloudant/provider.yaml
@@ -49,9 +49,12 @@ versions:
 
 dependencies:
   - apache-airflow>=2.8.0
-  # Even though 3.9 is excluded below, we need to make this python_version aware so that `uv` can generate a
-  # full lock file when building lock file from provider sources
+  # Even though 3.9 is excluded below, we need to make this python_version aware so that `uv` (at least as of
+  # 0.4.25) can generate a full lock file when building lock file from provider sources. Seeing the duplicate
+  # dep makes the UV resolver correctly "fork" and try to come up with alternative solutions.
+  # https://github.com/astral-sh/uv/issues/4668
   - 'ibmcloudant==0.9.1 ; python_version >= "3.10"'
+  - 'ibmcloudant==0.7.0 ; python_version < "3.10"'
 
 excluded-python-versions:
   # ibmcloudant transitively brings in urllib3 2.x, but the snowflake provider has a dependency that pins


### PR DESCRIPTION
Unfortunately uv 0.4.28 did not solve this

https://github.com/apache/airflow/pull/43451

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
