### PR TITLE
Add data interval and next_dagrun_create_after info through tooltip to next dagrun.

### DIFF
--- a/airflow/ui/rules/react.js
+++ b/airflow/ui/rules/react.js
@@ -440,17 +440,6 @@ export const reactRules = /** @type {const} @satisfies {FlatConfig.Config} */ ({
     [`${reactNamespace}/iframe-missing-sandbox`]: ERROR,
 
     /**
-     * Enforce boolean attributes notation in JSX to never set it explicitly.
-     *
-     * @see [react/jsx-boolean-value](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/jsx-boolean-value.md)
-     */
-    [`${reactNamespace}/jsx-boolean-value`]: [
-      ERROR,
-      "never",
-      { assumeUndefinedIsFalse: true },
-    ],
-
-    /**
      * Enforce curly braces or braces in JSX props and/or children.
      *
      * @see [react/jsx-curly-brace-presence](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/jsx-curly-brace-presence.md)

--- a/airflow/ui/src/components/DagRunInfo.tsx
+++ b/airflow/ui/src/components/DagRunInfo.tsx
@@ -1,0 +1,52 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Tooltip, VStack, Text } from "@chakra-ui/react";
+
+import type { DAGResponse } from "openapi/requests/types.gen";
+import Time from "src/components/Time";
+
+type Props = {
+  readonly dag: DAGResponse;
+};
+
+const DagRunInfo = ({ dag }: Props) => (
+  <Tooltip
+    hasArrow
+    label={
+      <VStack align="left" gap={0}>
+        <Text>Data Interval</Text>
+        <Text>
+          Start: <Time datetime={dag.next_dagrun_data_interval_start} />
+        </Text>
+        <Text>
+          End: <Time datetime={dag.next_dagrun_data_interval_end} />
+        </Text>
+        <Text>
+          Run After: <Time datetime={dag.next_dagrun_create_after} />
+        </Text>
+      </VStack>
+    }
+  >
+    <Text>
+      <Time datetime={dag.next_dagrun} />
+    </Text>
+  </Tooltip>
+);
+
+export default DagRunInfo;

--- a/airflow/ui/src/components/DagRunInfo.tsx
+++ b/airflow/ui/src/components/DagRunInfo.tsx
@@ -16,10 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Tooltip, VStack, Text } from "@chakra-ui/react";
+import { VStack, Text } from "@chakra-ui/react";
 import dayjs from "dayjs";
 
 import Time from "src/components/Time";
+import { Tooltip } from "src/components/ui";
 
 type Props = {
   readonly dataIntervalEnd?: string | null;
@@ -40,8 +41,7 @@ const DagRunInfo = ({
 }: Props) =>
   Boolean(dataIntervalStart) && Boolean(dataIntervalEnd) ? (
     <Tooltip
-      hasArrow
-      label={
+      content={
         <VStack align="left" gap={0}>
           <Text>
             Data Interval Start: <Time datetime={dataIntervalStart} />
@@ -69,6 +69,7 @@ const DagRunInfo = ({
           ) : undefined}
         </VStack>
       }
+      showArrow
     >
       <Text fontSize="sm">
         <Time datetime={dataIntervalStart} showTooltip={false} />

--- a/airflow/ui/src/components/DagRunInfo.tsx
+++ b/airflow/ui/src/components/DagRunInfo.tsx
@@ -64,7 +64,7 @@ const DagRunInfo = ({
           {Boolean(startDate) && Boolean(endDate) ? (
             <Text>
               Duration:{" "}
-              {dayjs.duration(dayjs(endDate).diff(startDate)).asSeconds()}s{" "}
+              {dayjs.duration(dayjs(endDate).diff(startDate)).asSeconds()}s
             </Text>
           ) : undefined}
         </VStack>

--- a/airflow/ui/src/components/DagRunInfo.tsx
+++ b/airflow/ui/src/components/DagRunInfo.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable react/jsx-boolean-value */
+
 /*!
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -44,7 +46,7 @@ const DagRunInfo = ({ dag }: Props) => (
     }
   >
     <Text>
-      <Time datetime={dag.next_dagrun} />
+      <Time datetime={dag.next_dagrun} tooltip={false} />
     </Text>
   </Tooltip>
 );

--- a/airflow/ui/src/components/DagRunInfo.tsx
+++ b/airflow/ui/src/components/DagRunInfo.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/jsx-boolean-value */
-
 /*!
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -45,8 +43,8 @@ const DagRunInfo = ({ dag }: Props) => (
       </VStack>
     }
   >
-    <Text>
-      <Time datetime={dag.next_dagrun} tooltip={false} />
+    <Text fontSize="sm">
+      <Time datetime={dag.next_dagrun} showTooltip={false} />
     </Text>
   </Tooltip>
 );

--- a/airflow/ui/src/components/DagRunInfo.tsx
+++ b/airflow/ui/src/components/DagRunInfo.tsx
@@ -17,36 +17,63 @@
  * under the License.
  */
 import { Tooltip, VStack, Text } from "@chakra-ui/react";
+import dayjs from "dayjs";
 
-import type { DAGResponse } from "openapi/requests/types.gen";
 import Time from "src/components/Time";
 
 type Props = {
-  readonly dag: DAGResponse;
+  readonly dataIntervalEnd?: string | null;
+  readonly dataIntervalStart?: string | null;
+  readonly endDate?: string | null;
+  readonly logicalDate?: string | null;
+  readonly nextDagrunCreateAfter?: string | null;
+  readonly startDate?: string | null;
 };
 
-const DagRunInfo = ({ dag }: Props) => (
-  <Tooltip
-    hasArrow
-    label={
-      <VStack align="left" gap={0}>
-        <Text>Data Interval</Text>
-        <Text>
-          Start: <Time datetime={dag.next_dagrun_data_interval_start} />
-        </Text>
-        <Text>
-          End: <Time datetime={dag.next_dagrun_data_interval_end} />
-        </Text>
-        <Text>
-          Run After: <Time datetime={dag.next_dagrun_create_after} />
-        </Text>
-      </VStack>
-    }
-  >
-    <Text fontSize="sm">
-      <Time datetime={dag.next_dagrun} showTooltip={false} />
-    </Text>
-  </Tooltip>
-);
+const DagRunInfo = ({
+  dataIntervalEnd,
+  dataIntervalStart,
+  endDate,
+  logicalDate,
+  nextDagrunCreateAfter,
+  startDate,
+}: Props) =>
+  Boolean(dataIntervalStart) && Boolean(dataIntervalEnd) ? (
+    <Tooltip
+      hasArrow
+      label={
+        <VStack align="left" gap={0}>
+          <Text>
+            Data Interval Start: <Time datetime={dataIntervalStart} />
+          </Text>
+          <Text>
+            Data Interval End: <Time datetime={dataIntervalEnd} />
+          </Text>
+          {Boolean(nextDagrunCreateAfter) ? (
+            <Text>
+              Run After: <Time datetime={nextDagrunCreateAfter} />
+            </Text>
+          ) : undefined}
+          {Boolean(logicalDate) ? (
+            <Text>Logical Date: {logicalDate}</Text>
+          ) : undefined}
+          {Boolean(startDate) ? (
+            <Text>Start Date: {startDate}</Text>
+          ) : undefined}
+          {Boolean(endDate) ? <Text>End Date: {endDate}</Text> : undefined}
+          {Boolean(startDate) && Boolean(endDate) ? (
+            <Text>
+              Duration:{" "}
+              {dayjs.duration(dayjs(endDate).diff(startDate)).asSeconds()}s{" "}
+            </Text>
+          ) : undefined}
+        </VStack>
+      }
+    >
+      <Text fontSize="sm">
+        <Time datetime={dataIntervalStart} showTooltip={false} />
+      </Text>
+    </Tooltip>
+  ) : undefined;
 
 export default DagRunInfo;

--- a/airflow/ui/src/components/Time.tsx
+++ b/airflow/ui/src/components/Time.tsx
@@ -34,10 +34,14 @@ dayjs.extend(advancedFormat);
 type Props = {
   readonly datetime?: string | null;
   readonly format?: string;
-  readonly tooltip?: boolean;
+  readonly showTooltip?: boolean;
 };
 
-const Time = ({ datetime, format = defaultFormat, tooltip = true }: Props) => {
+const Time = ({
+  datetime,
+  format = defaultFormat,
+  showTooltip = true,
+}: Props) => {
   const { selectedTimezone } = useTimezone();
   const time = dayjs(datetime);
 
@@ -53,7 +57,7 @@ const Time = ({ datetime, format = defaultFormat, tooltip = true }: Props) => {
       dateTime={datetime}
       // show title if date is not UTC
       title={
-        selectedTimezone.toUpperCase() !== "UTC" && tooltip
+        selectedTimezone.toUpperCase() !== "UTC" && showTooltip
           ? utcTime
           : undefined
       }

--- a/airflow/ui/src/components/Time.tsx
+++ b/airflow/ui/src/components/Time.tsx
@@ -34,9 +34,10 @@ dayjs.extend(advancedFormat);
 type Props = {
   readonly datetime?: string | null;
   readonly format?: string;
+  readonly tooltip?: boolean;
 };
 
-const Time = ({ datetime, format = defaultFormat }: Props) => {
+const Time = ({ datetime, format = defaultFormat, tooltip = true }: Props) => {
   const { selectedTimezone } = useTimezone();
   const time = dayjs(datetime);
 
@@ -51,7 +52,11 @@ const Time = ({ datetime, format = defaultFormat }: Props) => {
     <time
       dateTime={datetime}
       // show title if date is not UTC
-      title={selectedTimezone.toUpperCase() === "UTC" ? undefined : utcTime}
+      title={
+        selectedTimezone.toUpperCase() !== "UTC" && tooltip
+          ? utcTime
+          : undefined
+      }
     >
       {formattedTime}
     </time>

--- a/airflow/ui/src/pages/DagsList/Dag/Header.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Header.tsx
@@ -108,20 +108,6 @@ export const Header = ({
     </Box>
     <Flex
       alignItems="center"
-      bg={grayBg}
-      borderTopColor={grayBorder}
-      borderTopWidth={1}
-      color="gray.400"
-      fontSize="sm"
-      justifyContent="space-between"
-      px={2}
-      py={1}
-    >
-      <Text>Owner: {dag?.owners.join(", ")}</Text>
-      <DagTags tags={dag?.tags ?? []} />
-    </Flex>
-    <Flex
-      alignItems="center"
       bg="bg.muted"
       borderTopColor="border"
       borderTopWidth={1}

--- a/airflow/ui/src/pages/DagsList/Dag/Header.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Header.tsx
@@ -30,7 +30,7 @@ import { FiCalendar, FiPlay } from "react-icons/fi";
 
 import type { DAGResponse, DAGRunResponse } from "openapi/requests/types.gen";
 import { DagIcon } from "src/assets/DagIcon";
-import Time from "src/components/Time";
+import DagRunInfo from "src/components/DagRunInfo";
 import { TogglePause } from "src/components/TogglePause";
 import { Tooltip } from "src/components/ui";
 
@@ -88,16 +88,26 @@ export const Header = ({
           <Heading color="fg.muted" fontSize="xs">
             Next Run
           </Heading>
-          {Boolean(dag?.next_dagrun) ? (
-            <Text fontSize="sm">
-              <Time datetime={dag?.next_dagrun} />
-            </Text>
-          ) : undefined}
+          {Boolean(dag?.next_dagrun) ? <DagRunInfo dag={dag!} /> : undefined}
         </VStack>
         <div />
         <div />
       </SimpleGrid>
     </Box>
+    <Flex
+      alignItems="center"
+      bg={grayBg}
+      borderTopColor={grayBorder}
+      borderTopWidth={1}
+      color="gray.400"
+      fontSize="sm"
+      justifyContent="space-between"
+      px={2}
+      py={1}
+    >
+      <Text>Owner: {dag?.owners.join(", ")}</Text>
+      <DagTags tags={dag?.tags ?? []} />
+    </Flex>
     <Flex
       alignItems="center"
       bg="bg.muted"

--- a/airflow/ui/src/pages/DagsList/Dag/Header.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Header.tsx
@@ -35,7 +35,6 @@ import { TogglePause } from "src/components/TogglePause";
 import { Tooltip } from "src/components/ui";
 
 import { DagTags } from "../DagTags";
-import { LatestRun } from "../LatestRun";
 
 export const Header = ({
   dag,
@@ -81,14 +80,27 @@ export const Header = ({
           <Heading color="fg.muted" fontSize="xs">
             Last Run
           </Heading>
-          <LatestRun latestRun={latestRun} />
-          <LatestRun />
+          {Boolean(latestRun) && latestRun !== undefined ? (
+            <DagRunInfo
+              dataIntervalEnd={latestRun.data_interval_end}
+              dataIntervalStart={latestRun.data_interval_start}
+              endDate={latestRun.end_date}
+              logicalDate={latestRun.logical_date}
+              startDate={latestRun.start_date}
+            />
+          ) : undefined}
         </VStack>
         <VStack align="flex-start" gap={1}>
           <Heading color="fg.muted" fontSize="xs">
             Next Run
           </Heading>
-          {Boolean(dag?.next_dagrun) ? <DagRunInfo dag={dag!} /> : undefined}
+          {Boolean(dag?.next_dagrun) && dag !== undefined ? (
+            <DagRunInfo
+              dataIntervalEnd={dag.next_dagrun_data_interval_end}
+              dataIntervalStart={dag.next_dagrun_data_interval_start}
+              nextDagrunCreateAfter={dag.next_dagrun_create_after}
+            />
+          ) : undefined}
         </VStack>
         <div />
         <div />

--- a/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -33,7 +33,6 @@ import { TogglePause } from "src/components/TogglePause";
 import { Tooltip } from "src/components/ui";
 
 import { DagTags } from "./DagTags";
-import { LatestRun } from "./LatestRun";
 import { RecentRuns } from "./RecentRuns";
 import { Schedule } from "./Schedule";
 
@@ -41,58 +40,76 @@ type Props = {
   readonly dag: DAGWithLatestDagRunsResponse;
 };
 
-export const DagCard = ({ dag }: Props) => (
-  <Box
-    borderColor="border.emphasized"
-    borderRadius={8}
-    borderWidth={1}
-    overflow="hidden"
-  >
-    <Flex
-      alignItems="center"
-      bg="bg.muted"
-      justifyContent="space-between"
-      px={3}
-      py={2}
+export const DagCard = ({ dag }: Props) => {
+  const [latestRun] = dag.latest_dag_runs;
+
+  return (
+    <Box
+      borderColor="border.emphasized"
+      borderRadius={8}
+      borderWidth={1}
+      overflow="hidden"
     >
-      <HStack>
-        <Tooltip
-          content={dag.description}
-          disabled={!Boolean(dag.description)}
-          showArrow
-        >
-          <Link asChild color="fg.info" fontWeight="bold">
-            <RouterLink to={`/dags/${dag.dag_id}`}>
-              {dag.dag_display_name}
-            </RouterLink>
-          </Link>
-        </Tooltip>
-        <DagTags tags={dag.tags} />
-      </HStack>
-      <HStack>
-        <TogglePause dagId={dag.dag_id} isPaused={dag.is_paused} />
-      </HStack>
-    </Flex>
-    <SimpleGrid columns={4} gap={4} height={20} px={3} py={2}>
-      <VStack align="flex-start" gap={1}>
-        <Heading color="gray.500" fontSize="xs">
-          Schedule
-        </Heading>
-        <Schedule dag={dag} />
-      </VStack>
-      <VStack align="flex-start" gap={1}>
-        <Heading color="gray.500" fontSize="xs">
-          Latest Run
-        </Heading>
-        <LatestRun latestRun={dag.latest_dag_runs[0]} />
-      </VStack>
-      <VStack align="flex-start" gap={1}>
-        <Heading color="gray.500" fontSize="xs">
-          Next Run
-        </Heading>
-        {Boolean(dag.next_dagrun) ? <DagRunInfo dag={dag} /> : undefined}
-      </VStack>
-      <RecentRuns latestRuns={dag.latest_dag_runs} />
-    </SimpleGrid>
-  </Box>
-);
+      <Flex
+        alignItems="center"
+        bg="bg.muted"
+        justifyContent="space-between"
+        px={3}
+        py={2}
+      >
+        <HStack>
+          <Tooltip
+            content={dag.description}
+            disabled={!Boolean(dag.description)}
+            showArrow
+          >
+            <Link asChild color="fg.info" fontWeight="bold">
+              <RouterLink to={`/dags/${dag.dag_id}`}>
+                {dag.dag_display_name}
+              </RouterLink>
+            </Link>
+          </Tooltip>
+          <DagTags tags={dag.tags} />
+        </HStack>
+        <HStack>
+          <TogglePause dagId={dag.dag_id} isPaused={dag.is_paused} />
+        </HStack>
+      </Flex>
+      <SimpleGrid columns={4} gap={4} height={20} px={3} py={2}>
+        <VStack align="flex-start" gap={1}>
+          <Heading color="gray.500" fontSize="xs">
+            Schedule
+          </Heading>
+          <Schedule dag={dag} />
+        </VStack>
+        <VStack align="flex-start" gap={1}>
+          <Heading color="gray.500" fontSize="xs">
+            Latest Run
+          </Heading>
+          {latestRun ? (
+            <DagRunInfo
+              dataIntervalEnd={latestRun.data_interval_end}
+              dataIntervalStart={latestRun.data_interval_start}
+              endDate={latestRun.end_date}
+              logicalDate={latestRun.logical_date}
+              startDate={latestRun.start_date}
+            />
+          ) : undefined}
+        </VStack>
+        <VStack align="flex-start" gap={1}>
+          <Heading color="gray.500" fontSize="xs">
+            Next Run
+          </Heading>
+          {Boolean(dag.next_dagrun) ? (
+            <DagRunInfo
+              dataIntervalEnd={dag.next_dagrun_data_interval_end}
+              dataIntervalStart={dag.next_dagrun_data_interval_start}
+              nextDagrunCreateAfter={dag.next_dagrun_create_after}
+            />
+          ) : undefined}
+        </VStack>
+        <RecentRuns latestRuns={dag.latest_dag_runs} />
+      </SimpleGrid>
+    </Box>
+  );
+};

--- a/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -28,7 +28,7 @@ import {
 import { Link as RouterLink } from "react-router-dom";
 
 import type { DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
-import Time from "src/components/Time";
+import DagRunInfo from "src/components/DagRunInfo";
 import { TogglePause } from "src/components/TogglePause";
 import { Tooltip } from "src/components/ui";
 
@@ -90,7 +90,7 @@ export const DagCard = ({ dag }: Props) => (
         <Heading color="gray.500" fontSize="xs">
           Next Run
         </Heading>
-        <Time datetime={dag.next_dagrun} />
+        {Boolean(dag.next_dagrun) ? <DagRunInfo dag={dag} /> : undefined}
       </VStack>
       <RecentRuns latestRuns={dag.latest_dag_runs} />
     </SimpleGrid>

--- a/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -53,7 +53,6 @@ import { pluralize } from "src/utils";
 import { DagCard } from "./DagCard";
 import { DagTags } from "./DagTags";
 import { DagsFilters } from "./DagsFilters";
-import { LatestRun } from "./LatestRun";
 import { Schedule } from "./Schedule";
 
 const columns: Array<ColumnDef<DAGWithLatestDagRunsResponse>> = [
@@ -88,15 +87,28 @@ const columns: Array<ColumnDef<DAGWithLatestDagRunsResponse>> = [
   {
     accessorKey: "next_dagrun",
     cell: ({ row: { original } }) =>
-      Boolean(original.next_dagrun) ? <DagRunInfo dag={original} /> : undefined,
+      Boolean(original.next_dagrun) ? (
+        <DagRunInfo
+          dataIntervalEnd={original.next_dagrun_data_interval_end}
+          dataIntervalStart={original.next_dagrun_data_interval_start}
+          nextDagrunCreateAfter={original.next_dagrun_create_after}
+        />
+      ) : undefined,
     enableSorting: false,
     header: "Next Dag Run",
   },
   {
     accessorKey: "latest_dag_runs",
-    cell: ({ row: { original } }) => (
-      <LatestRun latestRun={original.latest_dag_runs[0]} />
-    ),
+    cell: ({ row: { original } }) =>
+      original.latest_dag_runs[0] ? (
+        <DagRunInfo
+          dataIntervalEnd={original.latest_dag_runs[0].data_interval_end}
+          dataIntervalStart={original.latest_dag_runs[0].data_interval_start}
+          endDate={original.latest_dag_runs[0].end_date}
+          logicalDate={original.latest_dag_runs[0].logical_date}
+          startDate={original.latest_dag_runs[0].start_date}
+        />
+      ) : undefined,
     enableSorting: false,
     header: "Last Dag Run",
   },

--- a/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -34,13 +34,13 @@ import type {
   DagRunState,
   DAGWithLatestDagRunsResponse,
 } from "openapi/requests/types.gen";
+import DagRunInfo from "src/components/DagRunInfo";
 import { DataTable } from "src/components/DataTable";
 import { ToggleTableDisplay } from "src/components/DataTable/ToggleTableDisplay";
 import type { CardDef } from "src/components/DataTable/types";
 import { useTableURLState } from "src/components/DataTable/useTableUrlState";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import { SearchBar } from "src/components/SearchBar";
-import Time from "src/components/Time";
 import { TogglePause } from "src/components/TogglePause";
 import { Select } from "src/components/ui";
 import {
@@ -88,9 +88,7 @@ const columns: Array<ColumnDef<DAGWithLatestDagRunsResponse>> = [
   {
     accessorKey: "next_dagrun",
     cell: ({ row: { original } }) =>
-      Boolean(original.next_dagrun) ? (
-        <Time datetime={original.next_dagrun} />
-      ) : undefined,
+      Boolean(original.next_dagrun) ? <DagRunInfo dag={original} /> : undefined,
     enableSorting: false,
     header: "Next Dag Run",
   },


### PR DESCRIPTION
Legacy home page displays data interval start for next dagrun which might be confusing to users who are looking for next_dagrun_create_after which is when the next dagrun will be scheduled. There is a tooltip in the legacy UI. Similar tooltip can be added on hover to new UI as well for clarification.

Review notes : 

* I would like to keep tooltip for UTC to be displayed on non-UTC timezones in `<Time />` and skip tooltip for next dagrun component since they collide with each other in UI. I tried to keep it as true by default and then pass `tooltip={false}` but eslint complains about this rule and removes it. I have disabled this rule only for the file. Maybe there is a better way to have this logic. 

https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md

* I have named this as `DagRunInfo` but this is closely tied to next dagrun only for now with next_dagrun_create_after. Legacy UI also has tooltip for last dagrun. Maybe this could be updated after last dagrun info is updated in https://github.com/apache/airflow/pull/43489 to pass data_interval_start, data_interval_end and next_dagrun_create_after as optional. Please add in your thoughts.

Screenshot

![image](https://github.com/user-attachments/assets/af76d1a7-1e35-461a-8503-5a062a8cd303)


Thanks