### PR TITLE
Add type hints to DAG test utils

### DIFF
--- a/providers/tests/alibaba/cloud/log/test_oss_task_handler.py
+++ b/providers/tests/alibaba/cloud/log/test_oss_task_handler.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 from unittest import mock
 from unittest.mock import PropertyMock
 
@@ -29,6 +30,9 @@ from airflow.utils.timezone import datetime
 
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import clear_db_dags, clear_db_runs
+
+if TYPE_CHECKING:
+    from tests_common.pytest_plugin import CreateTaskInstance, DagMaker
 
 pytestmark = pytest.mark.db_test
 
@@ -48,7 +52,7 @@ class TestOSSTaskHandler:
         self.oss_task_handler = OSSTaskHandler(self.base_log_folder, self.oss_log_folder)
 
     @pytest.fixture(autouse=True)
-    def task_instance(self, create_task_instance, dag_maker):
+    def task_instance(self, create_task_instance: CreateTaskInstance, dag_maker: DagMaker):
         self.ti = ti = create_task_instance(
             dag_id="dag_for_testing_oss_task_handler",
             task_id="task_for_testing_oss_task_handler",

--- a/providers/tests/amazon/aws/sensors/test_ecs.py
+++ b/providers/tests/amazon/aws/sensors/test_ecs.py
@@ -115,7 +115,7 @@ class TestEcsClusterStateSensor(EcsBaseTestCase):
             m.assert_called_once_with(cluster_name=TEST_CLUSTER_NAME)
 
     @pytest.mark.parametrize("return_state", ["FAILED", "INACTIVE"])
-    def test_default_values_terminal_state(self, create_task_of_operator, return_state):
+    def test_default_values_terminal_state(self, return_state):
         task = self.create_rendered_task(EcsClusterStateSensor, cluster_name=TEST_CLUSTER_NAME)
         with mock.patch.object(task.hook, "get_cluster_state") as m:
             m.return_value = return_state

--- a/tests_common/pytest_plugin.py
+++ b/tests_common/pytest_plugin.py
@@ -26,16 +26,29 @@ import sys
 from contextlib import ExitStack, suppress
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable, Generator, Protocol, TypeVar
 
 import pytest
 import time_machine
 
 if TYPE_CHECKING:
     from itsdangerous import URLSafeSerializer
+    from sqlalchemy.orm import Session
+
+    from airflow.models.baseoperator import BaseOperator
+    from airflow.models.dag import DAG, ScheduleArg
+    from airflow.models.dagrun import DagRun, DagRunType
+    from airflow.models.taskinstance import TaskInstance
+    from airflow.operators.empty import EmptyOperator
+    from airflow.timetables.base import DataInterval
+    from airflow.typing_compat import Self
+    from airflow.utils.state import DagRunState, TaskInstanceState
+    from airflow.utils.trigger_rule import TriggerRule
 
     from tests_common._internals.capture_warnings import CaptureWarningsPlugin  # noqa: F401
     from tests_common._internals.forbidden_warnings import ForbiddenWarningsPlugin  # noqa: F401
+
+    Op = TypeVar("Op", bound=BaseOperator)
 
 # https://docs.pytest.org/en/stable/reference/reference.html#stash
 capture_warnings_key = pytest.StashKey["CaptureWarningsPlugin"]()
@@ -721,8 +734,41 @@ def frozen_sleep(monkeypatch):
         traveller.stop()
 
 
+class DagMaker(Protocol):
+    """
+    Interface definition for dag_maker return value.
+
+    This class exists so tests can import the class for type hints. The actual
+    implementation is done in the dag_maker fixture.
+    """
+
+    session: Session
+
+    def __enter__(self) -> DAG: ...
+
+    def __exit__(self, type, value, traceback) -> None: ...
+
+    def get_serialized_data(self) -> dict[str, Any]: ...
+
+    def create_dagrun(self, **kwargs) -> DagRun: ...
+
+    def create_dagrun_after(self, dagrun: DagRun, **kwargs) -> DagRun: ...
+
+    def __call__(
+        self,
+        dag_id: str = "test_dag",
+        schedule: ScheduleArg = timedelta(days=1),
+        serialized: bool = ...,
+        activate_assets: bool = ...,
+        fileloc: str | None = None,
+        processor_subdir: str | None = None,
+        session: Session | None = None,
+        **kwargs,
+    ) -> Self: ...
+
+
 @pytest.fixture
-def dag_maker(request):
+def dag_maker(request) -> Generator[DagMaker, None, None]:
     """
     Fixture to help create DAG, DagModel, and SerializedDAG automatically.
 
@@ -771,7 +817,7 @@ def dag_maker(request):
 
     from airflow.utils.log.logging_mixin import LoggingMixin
 
-    class DagFactory(LoggingMixin):
+    class DagFactory(LoggingMixin, DagMaker):
         _own_session = False
 
         def __init__(self):
@@ -997,8 +1043,32 @@ def dag_maker(request):
             del factory.session
 
 
+class CreateDummyDAG(Protocol):
+    """Type stub for create_dummy_dag."""
+
+    def __call__(
+        self,
+        *,
+        dag_id: str = "dag",
+        task_id: str = "op1",
+        task_display_name: str = ...,
+        max_active_tis_per_dag: int = 16,
+        max_active_tis_per_dagrun: int = ...,
+        pool: str = "default_pool",
+        executor_config: dict = ...,
+        trigger_rule: TriggerRule = ...,
+        on_success_callback: Callable = ...,
+        on_execute_callback: Callable = ...,
+        on_failure_callback: Callable = ...,
+        on_retry_callback: Callable = ...,
+        email: str = ...,
+        with_dagrun_type="scheduled",
+        **kwargs,
+    ) -> tuple[DAG, EmptyOperator]: ...
+
+
 @pytest.fixture
-def create_dummy_dag(dag_maker):
+def create_dummy_dag(dag_maker: DagMaker) -> CreateDummyDAG:
     """
     Create a `DAG` with a single `EmptyOperator` task.
 
@@ -1062,12 +1132,39 @@ def create_dummy_dag(dag_maker):
     return create_dag
 
 
-if TYPE_CHECKING:
-    from airflow.models.taskinstance import TaskInstance
+class CreateTaskInstance(Protocol):
+    """Type stub for create_task_instance."""
+
+    def __call__(
+        self,
+        *,
+        execution_date: datetime = ...,
+        dagrun_state: DagRunState = ...,
+        state: TaskInstanceState = ...,
+        run_id: str = ...,
+        run_type: DagRunType = ...,
+        data_interval: DataInterval = ...,
+        external_executor_id: str = ...,
+        dag_id: str = "dag",
+        task_id: str = "op1",
+        task_display_name: str = ...,
+        max_active_tis_per_dag: int = 16,
+        max_active_tis_per_dagrun: int = ...,
+        pool: str = "default_pool",
+        executor_config: dict = ...,
+        trigger_rule: TriggerRule = ...,
+        on_success_callback: Callable = ...,
+        on_execute_callback: Callable = ...,
+        on_failure_callback: Callable = ...,
+        on_retry_callback: Callable = ...,
+        email: str = ...,
+        map_index: int = -1,
+        **kwargs,
+    ) -> TaskInstance: ...
 
 
 @pytest.fixture
-def create_task_instance(dag_maker, create_dummy_dag):
+def create_task_instance(dag_maker: DagMaker, create_dummy_dag: CreateDummyDAG) -> CreateTaskInstance:
     """
     Create a TaskInstance, and associated DB rows (DagRun, DagModel, etc).
 
@@ -1154,7 +1251,7 @@ def create_task_instance(dag_maker, create_dummy_dag):
 
 
 @pytest.fixture
-def create_serialized_task_instance_of_operator(dag_maker):
+def create_serialized_task_instance_of_operator(dag_maker: DagMaker):
     def _create_task_instance(
         operator_class,
         *,
@@ -1175,8 +1272,14 @@ def create_serialized_task_instance_of_operator(dag_maker):
     return _create_task_instance
 
 
+class CreateTaskInstanceOfOperator(Protocol):
+    """Type stub for create_task_instance_of_operator."""
+
+    def __call__(self, operator_class: type[BaseOperator], *args, **kwargs) -> TaskInstance: ...
+
+
 @pytest.fixture
-def create_task_instance_of_operator(dag_maker):
+def create_task_instance_of_operator(dag_maker: DagMaker) -> CreateTaskInstanceOfOperator:
     def _create_task_instance(
         operator_class,
         *,
@@ -1197,8 +1300,14 @@ def create_task_instance_of_operator(dag_maker):
     return _create_task_instance
 
 
+class CreateTaskOfOperator(Protocol):
+    """Type stub for create_task_of_operator."""
+
+    def __call__(self, operator_class: type[Op], *args, **kwargs) -> Op: ...
+
+
 @pytest.fixture
-def create_task_of_operator(dag_maker):
+def create_task_of_operator(dag_maker: DagMaker) -> CreateTaskOfOperator:
     def _create_task_of_operator(operator_class, *, dag_id, session=None, **operator_kwargs):
         with dag_maker(dag_id=dag_id, session=session):
             task = operator_class(**operator_kwargs)


### PR DESCRIPTION
Now you can annotate a fixture argument and get type hints and autocompletion in tests. I’ll probably add more annotations (for example, to `create_dagrun`), but this is good enough for now.