### PR TITLE
Make the warnings capture plugin know about the provider workspace folder

### DIFF
--- a/tests_common/_internals/capture_warnings.py
+++ b/tests_common/_internals/capture_warnings.py
@@ -117,10 +117,10 @@ class CapturedWarning:
         But we should not use it to filter it out, only for show in different groups.
         """
         if self.filename.startswith("airflow/"):
-            if self.filename.startswith("airflow/providers/"):
-                return "providers"
             return "airflow"
-        elif self.filename.startswith("tests/"):
+        elif self.filename.startswith("providers/src/"):
+            return "providers"
+        elif self.filename.startswith("tests/") or self.filename.startswith("providers/tests/"):
             return "tests"
         return "other"
 


### PR DESCRIPTION
While digging in to #43280 I noticed that the grouping for warnings wasn't correct anymore after the move to uv-workspace folders

This isn't the cause of the issue in that PR, but should be fixed anyway
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
