### PR TITLE
Skip integration tests for new UI only PR. Run docs build only when needed. 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,6 +314,7 @@ jobs:
       ci-image-build: ${{ needs.build-info.outputs.ci-image-build }}
       include-success-outputs: ${{ needs.build-info.outputs.include-success-outputs }}
       debug-resources: ${{ needs.build-info.outputs.debug-resources }}
+      docs-build: ${{ steps.selective-checks.outputs.docs-build }}
 
   providers:
     name: "Provider checks"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,7 +314,7 @@ jobs:
       ci-image-build: ${{ needs.build-info.outputs.ci-image-build }}
       include-success-outputs: ${{ needs.build-info.outputs.include-success-outputs }}
       debug-resources: ${{ needs.build-info.outputs.debug-resources }}
-      docs-build: ${{ steps.selective-checks.outputs.docs-build }}
+      docs-build: ${{ needs.build-info.outputs.docs-build }}
 
   providers:
     name: "Provider checks"

--- a/.github/workflows/static-checks-mypy-docs.yml
+++ b/.github/workflows/static-checks-mypy-docs.yml
@@ -92,6 +92,10 @@ on:  # yamllint disable-line rule:truthy
         description: "Whether to debug resources (true/false)"
         required: true
         type: string
+      docs-build:
+        description: "Whether to build docs (true/false)"
+        required: true
+        type: string
 jobs:
   static-checks:
     timeout-minutes: 45

--- a/.github/workflows/static-checks-mypy-docs.yml
+++ b/.github/workflows/static-checks-mypy-docs.yml
@@ -182,6 +182,7 @@ jobs:
     timeout-minutes: 150
     name: "Build documentation"
     runs-on: ${{ fromJSON(inputs.runs-on-as-json-default) }}
+    if: inputs.build-docs == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/static-checks-mypy-docs.yml
+++ b/.github/workflows/static-checks-mypy-docs.yml
@@ -182,7 +182,7 @@ jobs:
     timeout-minutes: 150
     name: "Build documentation"
     runs-on: ${{ fromJSON(inputs.runs-on-as-json-default) }}
-    if: inputs.build-docs == 'true'
+    if: inputs.docs-build == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/airflow/ui/src/pages/DagsList/Dag/Header.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Header.tsx
@@ -123,3 +123,5 @@ export const Header = ({
     </Box>
   );
 };
+
+// test

--- a/airflow/ui/src/pages/DagsList/Dag/Header.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Header.tsx
@@ -123,5 +123,3 @@ export const Header = ({
     </Box>
   );
 };
-
-// test

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -1344,11 +1344,22 @@ class SelectiveChecks:
 
     @cached_property
     def testable_integrations(self) -> list[str]:
-        return [
-            integration
-            for integration in TESTABLE_INTEGRATIONS
-            if integration not in DISABLE_TESTABLE_INTEGRATIONS_FROM_CI
-        ]
+        all_source_files = self._matching_files(
+            FileGroupForCi.ALL_SOURCE_FILES, CI_FILE_GROUP_MATCHES, CI_FILE_GROUP_EXCLUDES
+        )
+        test_ui_files = self._matching_files(
+            FileGroupForCi.UI_FILES, CI_FILE_GROUP_MATCHES, CI_FILE_GROUP_EXCLUDES
+        )
+        remaining_files = set(all_source_files) - set(test_ui_files)
+
+        if not remaining_files:
+            return []
+        else:
+            return [
+                integration
+                for integration in TESTABLE_INTEGRATIONS
+                if integration not in DISABLE_TESTABLE_INTEGRATIONS_FROM_CI
+            ]
 
     @cached_property
     def is_committer_build(self):

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -1343,16 +1343,25 @@ class SelectiveChecks:
         return json.dumps(sorted_providers_to_exclude)
 
     @cached_property
-    def testable_integrations(self) -> list[str]:
-        all_source_files = self._matching_files(
-            FileGroupForCi.ALL_SOURCE_FILES, CI_FILE_GROUP_MATCHES, CI_FILE_GROUP_EXCLUDES
+    def only_new_ui_files(self) -> bool:
+        all_source_files = set(
+            self._matching_files(
+                FileGroupForCi.ALL_SOURCE_FILES, CI_FILE_GROUP_MATCHES, CI_FILE_GROUP_EXCLUDES
+            )
         )
-        test_ui_files = self._matching_files(
-            FileGroupForCi.UI_FILES, CI_FILE_GROUP_MATCHES, CI_FILE_GROUP_EXCLUDES
+        new_ui_source_files = set(
+            self._matching_files(FileGroupForCi.UI_FILES, CI_FILE_GROUP_MATCHES, CI_FILE_GROUP_EXCLUDES)
         )
-        remaining_files = set(all_source_files) - set(test_ui_files)
+        remaining_files = all_source_files - new_ui_source_files
 
-        if not remaining_files:
+        if all_source_files and new_ui_source_files and not remaining_files:
+            return True
+        else:
+            return False
+
+    @cached_property
+    def testable_integrations(self) -> list[str]:
+        if self.only_new_ui_files:
             return []
         else:
             return [

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -871,6 +871,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "needs-mypy": "false",
                     "mypy-checks": "[]",
                     "run-ui-tests": "true",
+                    "only-new-ui-files": "true",
                     "testable-integrations": "[]",
                 },
                 id="Run only ui tests for PR with new UI only changes.",

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -871,6 +871,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "needs-mypy": "false",
                     "mypy-checks": "[]",
                     "run-ui-tests": "true",
+                    "testable-integrations": "[]",
                 },
                 id="Run only ui tests for PR with new UI only changes.",
             )


### PR DESCRIPTION
This is a follow-up on #43503 . Following are the changes.

1. Made `only_new_ui_files` as an attribute that is true when there are any source files and they contain only new UI changes. Sometimes the PR has no source code changes so instead of diff on 2 empty sets this ensures there are source files and changes in new UI folder with no remaining files left. I am thinking of skipping db tests that now run with "always" that takes 2 mins down from 20 mins earlier but is not needed in new UI only PRs.
2. `docs-build` flag is not used in the CI configuration causing docs build to always run that is not needed in new UI only PRs that don't change any user facing docs. Sometimes the build runs for an hour or more with intermittent failures and retry. This ensures to build docs only when needed. If there are scenarios where the flag is False with docs required then this could be improved.
3. Integration tests are still executed since there is a default list of integrations. Using the `only_new_ui_files` return an empty list so that these tests are skipped for PR with only new UI changes. Each test takes 2 minutes.