### PR TITLE
Add directions to build a provider package locally.

### DIFF
--- a/contributing-docs/11_provider_packages.rst
+++ b/contributing-docs/11_provider_packages.rst
@@ -128,13 +128,11 @@ local1. First, add this new version number to the top of the provider.yaml file.
 an environment variable PACKAGE_LIST. For providers in nested directories, replace the directory separator
 (/) with a period. For example, to build the Microsoft Azure provider, set the provider ID to microsoft.azure.
 
-.. code-block::
-   export PACKAGE_LIST=microsoft.azure
+``export PACKAGE_LIST=microsoft.azure``
 
 Then build the provider:
 
-.. code-block::
-   breeze release-management prepare-provider-packages --package-format both --version-suffix-for-pypi=local1
+``breeze release-management prepare-provider-packages --package-format both --version-suffix-for-pypi=local1``
 
 Finally, copy the wheel file from the dist directory to the a directory your airflow deployment can use:
 

--- a/contributing-docs/11_provider_packages.rst
+++ b/contributing-docs/11_provider_packages.rst
@@ -117,6 +117,30 @@ as a sub-folder of the ``airflow.providers`` package, add the ``provider.yaml`` 
 in development mode - then capabilities of your provider will be discovered by airflow and you will see
 the provider among other providers in ``airflow providers`` command output.
 
+
+Local Development Release of a Specific Provider
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When you develop a provider, you can release it locally and test it in your Airflow environment. This should
+be accomplished using breeze. First, choose a version number that will never be used in an official release.
+For example, if the latest release is 10.5.1, you can release your provider as 10.5.1.1 with the suffix
+local1. First, add this new version number to the top of the provider.yaml file. Then, set the provider id in
+an environment variable PACKAGE_LIST. For providers in nested directories, replace the directory separator
+(/) with a period. For example, to build the Microsoft Azure provider, set the provider ID to microsoft.azure.
+
+.. code-block::
+   export PACKAGE_LIST=microsoft.azure
+
+Then build the provider:
+
+.. code-block::
+   breeze release-management prepare-provider-packages --package-format both --version-suffix-for-pypi=local1
+
+Finally, copy the wheel file from the dist directory to the a directory your airflow deployment can use:
+
+cp dist/apache_airflow_providers_microsoft_azure-10.5.2rc1-py3-none-any.whl ~/airflow/test-airflow/local_providers/
+
+
 Naming Conventions for provider packages
 ----------------------------------------
 
@@ -133,6 +157,7 @@ The rules are as follows:
   further split into sub-packages (for example 'apache' package has 'cassandra', 'druid' ... providers ) out
   of which several different provider packages are produced (apache.cassandra, apache.druid). This is
   case when the providers are connected under common umbrella but very loosely coupled on the code level.
+  Please note the separator of the provider-package ID is a period, not a dash like the package names in PyPI(microsoft.azure vs apache-airflow-providers-microsoft-azure).
 
 * In some cases the package can have sub-packages but they are all delivered as single provider
   package (for example 'google' package contains 'ads', 'cloud' etc. sub-packages). This is in case

--- a/contributing-docs/11_provider_packages.rst
+++ b/contributing-docs/11_provider_packages.rst
@@ -134,9 +134,9 @@ Then build the provider:
 
 ``breeze release-management prepare-provider-packages --package-format both --version-suffix-for-pypi=local1``
 
-Finally, copy the wheel file from the dist directory to the a directory your airflow deployment can use:
+Finally, copy the wheel file from the dist directory to the a directory your airflow deployment can use. If this is ~/airflow/test-airflow/local_providers, you can use the following command:
 
-cp dist/apache_airflow_providers_microsoft_azure-10.5.2rc1-py3-none-any.whl ~/airflow/test-airflow/local_providers/
+``cp dist/apache_airflow_providers_microsoft_azure-10.5.2rc1-py3-none-any.whl ~/airflow/test-airflow/local_providers/``
 
 
 Naming Conventions for provider packages

--- a/contributing-docs/11_provider_packages.rst
+++ b/contributing-docs/11_provider_packages.rst
@@ -126,7 +126,7 @@ be accomplished using breeze. First, choose a version number that will never be 
 For example, if the latest release is 10.5.1, you can release your provider as 10.5.1.1 with the suffix
 local1. First, add this new version number to the top of the provider.yaml file. Then, set the provider id in
 an environment variable PACKAGE_LIST. For providers in nested directories, replace the directory separator
-(/) with a period. For example, to build the Microsoft Azure provider, set the provider ID to microsoft.azure.
+(/) with a period. For example, to build the Microsoft Azure provider, set the provider ID to 'microsoft.azure'.
 
 ``export PACKAGE_LIST=microsoft.azure``
 

--- a/contributing-docs/11_provider_packages.rst
+++ b/contributing-docs/11_provider_packages.rst
@@ -122,21 +122,25 @@ Local Development Release of a Specific Provider
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When you develop a provider, you can release it locally and test it in your Airflow environment. This should
-be accomplished using breeze. First, choose a version number that will never be used in an official release.
-For example, if the latest release is 10.5.1, you can release your provider as 10.5.1.1 with the suffix
-local1. First, add this new version number to the top of the provider.yaml file. Then, set the provider id in
-an environment variable PACKAGE_LIST. For providers in nested directories, replace the directory separator
-(/) with a period. For example, to build the Microsoft Azure provider, set the provider ID to 'microsoft.azure'.
+be accomplished using breeze. Choose a suffix for the release such as "dev1" and run the breeze build for
+that provider. Remember Provider IDs use a dot ('.') for directory separators so the Provider ID for the
+Microsoft Azure provider is 'microsoft.azure'. This can be provided in the PACKAGE_LIST environment variable
+or passed on the command line.
 
 ``export PACKAGE_LIST=microsoft.azure``
 
-Then build the provider:
+Then build the provider (you don't need to pass the package ID if you set the environment variable above):
 
-``breeze release-management prepare-provider-packages --package-format both --version-suffix-for-pypi=local1``
+```bash
+breeze release-management prepare-provider-packages \
+    --package-format both --version-suffix-for-pypi=dev1 \
+    --skip-tag-check microsoft.azure
+```
 
-Finally, copy the wheel file from the dist directory to the a directory your airflow deployment can use. If this is ~/airflow/test-airflow/local_providers, you can use the following command:
+Finally, copy the wheel file from the dist directory to the a directory your airflow deployment can use.
+If this is ~/airflow/test-airflow/local_providers, you can use the following command:
 
-``cp dist/apache_airflow_providers_microsoft_azure-10.5.2rc1-py3-none-any.whl ~/airflow/test-airflow/local_providers/``
+``cp dist/apache_airflow_providers_microsoft_azure-10.5.2+dev1-py3-none-any.whl ~/airflow/test-airflow/local_providers/``
 
 
 Naming Conventions for provider packages

--- a/dev/PROVIDER_PACKAGE_DETAILS.md
+++ b/dev/PROVIDER_PACKAGE_DETAILS.md
@@ -50,6 +50,10 @@ Backport providers are a great way to migrate your DAGs to Airflow-2.0 compatibl
 switch to the new Airflow-2.0 packages in your DAGs, long before you attempt to migrate
 airflow to 2.0 line.
 
+Note: the provider ID in the package uses a dash ('-') as the separator but the breeze package ID
+use a dot ('.') as the separator. So the package for microsoft azure is
+'apache-airflow-providers-microsoft-azure' but the build package ID is 'microsoft.azure'.
+
 # Deciding when to release
 
 Each provider package has its own version maintained separately when contributors implement changes,


### PR DESCRIPTION
No directions exist for building a provider locally to test with an existing airflow installation. This PR provides directions to build provider so they can be installed locally for integration testing.