### PR TITLE
Remove unused functions from `airflow.utils.dates`

### DIFF
--- a/airflow/utils/dates.py
+++ b/airflow/utils/dates.py
@@ -18,11 +18,10 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Collection
+from typing import TYPE_CHECKING
 
 from croniter import croniter
 
-from airflow.typing_compat import Literal
 from airflow.utils import timezone
 
 cron_presets: dict[str, str] = {
@@ -121,41 +120,6 @@ def round_time(
     # in the special case when start_date > dt the search for upper will
     # immediately stop for upper == 1 which results in lower = upper // 2 = 0
     # and this function returns start_date.
-
-
-TimeUnit = Literal["days", "hours", "minutes", "seconds"]
-
-
-def infer_time_unit(time_seconds_arr: Collection[float]) -> TimeUnit:
-    """
-    Determine the most appropriate time unit for given durations (in seconds).
-
-    e.g. 5400 seconds => 'minutes', 36000 seconds => 'hours'
-    """
-    if not time_seconds_arr:
-        return "hours"
-    max_time_seconds = max(time_seconds_arr)
-    if max_time_seconds <= 60 * 2:
-        return "seconds"
-    elif max_time_seconds <= 60 * 60 * 2:
-        return "minutes"
-    elif max_time_seconds <= 24 * 60 * 60 * 2:
-        return "hours"
-    else:
-        return "days"
-
-
-def scale_time_units(time_seconds_arr: Collection[float], unit: TimeUnit) -> Collection[float]:
-    """Convert an array of time durations in seconds to the specified time unit."""
-    if unit == "minutes":
-        factor = 60
-    elif unit == "hours":
-        factor = 60 * 60
-    elif unit == "days":
-        factor = 24 * 60 * 60
-    else:
-        factor = 1
-    return [x / factor for x in time_seconds_arr]
 
 
 def parse_execution_date(execution_date_str):

--- a/tests/utils/test_dates.py
+++ b/tests/utils/test_dates.py
@@ -17,10 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from datetime import timedelta
-
 import pytest
-from dateutil.relativedelta import relativedelta
 
 from airflow.utils import dates, timezone
 
@@ -37,53 +34,3 @@ class TestDates:
         )
         with pytest.raises(ValueError):
             dates.parse_execution_date(bad_execution_date_str)
-
-    def test_round_time(self):
-        rt1 = dates.round_time(timezone.datetime(2015, 1, 1, 6), timedelta(days=1))
-        assert timezone.datetime(2015, 1, 1, 0, 0) == rt1
-
-        rt2 = dates.round_time(timezone.datetime(2015, 1, 2), relativedelta(months=1))
-        assert timezone.datetime(2015, 1, 1, 0, 0) == rt2
-
-        rt3 = dates.round_time(
-            timezone.datetime(2015, 9, 16, 0, 0), timedelta(1), timezone.datetime(2015, 9, 14, 0, 0)
-        )
-        assert timezone.datetime(2015, 9, 16, 0, 0) == rt3
-
-        rt4 = dates.round_time(
-            timezone.datetime(2015, 9, 15, 0, 0), timedelta(1), timezone.datetime(2015, 9, 14, 0, 0)
-        )
-        assert timezone.datetime(2015, 9, 15, 0, 0) == rt4
-
-        rt5 = dates.round_time(
-            timezone.datetime(2015, 9, 14, 0, 0), timedelta(1), timezone.datetime(2015, 9, 14, 0, 0)
-        )
-        assert timezone.datetime(2015, 9, 14, 0, 0) == rt5
-
-        rt6 = dates.round_time(
-            timezone.datetime(2015, 9, 13, 0, 0), timedelta(1), timezone.datetime(2015, 9, 14, 0, 0)
-        )
-        assert timezone.datetime(2015, 9, 14, 0, 0) == rt6
-
-    def test_infer_time_unit(self):
-        assert dates.infer_time_unit([130, 5400, 10]) == "minutes"
-
-        assert dates.infer_time_unit([110, 50, 10, 100]) == "seconds"
-
-        assert dates.infer_time_unit([100000, 50000, 10000, 20000]) == "hours"
-
-        assert dates.infer_time_unit([200000, 100000]) == "days"
-
-    def test_scale_time_units(self):
-        # floating point arrays
-        arr1 = dates.scale_time_units([130, 5400, 10], "minutes")
-        assert arr1 == pytest.approx([2.1667, 90.0, 0.1667], rel=1e-3)
-
-        arr2 = dates.scale_time_units([110, 50, 10, 100], "seconds")
-        assert arr2 == pytest.approx([110.0, 50.0, 10.0, 100.0])
-
-        arr3 = dates.scale_time_units([100000, 50000, 10000, 20000], "hours")
-        assert arr3 == pytest.approx([27.7778, 13.8889, 2.7778, 5.5556], rel=1e-3)
-
-        arr4 = dates.scale_time_units([200000, 100000], "days")
-        assert arr4 == pytest.approx([2.3147, 1.1574], rel=1e-3)


### PR DESCRIPTION
The code that used it was removed in https://github.com/apache/airflow/pull/37988 already. It was used in FAB views.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
