### PR TITLE
Check for empty list of integration tests before evaluation inside marix that requires a value.

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -59,6 +59,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   tests-integration:
     timeout-minutes: 130
+    if: inputs.testable-integrations != '[]'
     name: "Integration Tests: ${{ matrix.integration }}"
     runs-on: ${{ fromJSON(inputs.runs-on-as-json-public) }}
     strategy:


### PR DESCRIPTION
When there is a PR with only new UI changes the list of integration tests is empty. The empty list causes annotation error in matrix step. The PR is green with tests that ran but it sends an email notification that PR run failed due to this annotation error causing confusion. Hence add a check before evaluation to execute integration tests only when the list is not empty. This was due to my previous change in https://github.com/apache/airflow/pull/43512

Solution found in https://github.com/dorny/paths-filter/issues/66#issuecomment-778267385
Ref error : https://github.com/apache/airflow/actions/runs/11610447563?pr=43501

> Tests
Error when evaluating 'strategy' for job 'tests-integration'. apache/airflow/.github/workflows/integration-tests.yml@0481b8e617fc357cd1c33c2d94f76e958903c42d (Line: 67, Col: 22): Matrix vector 'integration' does not contain any values
