### PR TITLE
Remove `astunparse` dependency

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -240,7 +240,6 @@ DEVEL_EXTRAS: dict[str, list[str]] = {
         "blinker>=1.7.0",
     ],
     "devel-static-checks": [
-        "astunparse>=1.6.3; python_version < '3.9'",
         "black>=23.12.0",
         "pre-commit>=3.5.0",
         "ruff==0.7.1",

--- a/scripts/ci/pre_commit/check_deferrable_default.py
+++ b/scripts/ci/pre_commit/check_deferrable_default.py
@@ -25,12 +25,6 @@ import os
 import sys
 from typing import Iterator
 
-if hasattr(ast, "unparse"):
-    # Py 3.9+
-    unparse = ast.unparse
-else:
-    from astunparse import unparse  # type: ignore[no-redef]
-
 import libcst as cst
 from libcst.codemod import CodemodContext
 from libcst.codemod.visitors import AddImportsVisitor
@@ -84,7 +78,7 @@ class DefaultDeferrableTransformer(cst.CSTTransformer):
 
 def _is_valid_deferrable_default(default: ast.AST) -> bool:
     """Check whether default is 'conf.getboolean("operators", "default_deferrable", fallback=False)'"""
-    return unparse(default) == "conf.getboolean('operators', 'default_deferrable', fallback=False)"
+    return ast.unparse(default) == "conf.getboolean('operators', 'default_deferrable', fallback=False)"
 
 
 def iter_check_deferrable_default_errors(module_filename: str) -> Iterator[str]:


### PR DESCRIPTION
Since the minimium required Python in Airflow main is now >=3.9 since https://github.com/apache/airflow/pull/42766, we can drop this dep

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
