### PR TITLE
Fix TrySelector for Mapped Tasks in Logs and Details Grid Panel

### DIFF
--- a/airflow/www/static/js/api/useTIHistory.ts
+++ b/airflow/www/static/js/api/useTIHistory.ts
@@ -43,13 +43,13 @@ export default function useTIHistory({
   return useQuery<TaskInstanceCollection>(
     ["tiHistory", dagId, dagRunId, taskId, mapIndex],
     () => {
-      const tiHistoryUrl = getMetaValue("task_tries_api")
+      let tiHistoryUrl = getMetaValue("task_tries_api")
         .replace("_DAG_ID_", dagId)
         .replace("_DAG_RUN_ID_", dagRunId)
         .replace("_TASK_ID_", taskId);
 
       if (mapIndex && mapIndex > -1) {
-        tiHistoryUrl.replace("/tries", `/${mapIndex}/tries`);
+        tiHistoryUrl = tiHistoryUrl.replace("/tries", `/${mapIndex}/tries`);
       }
 
       return axios.get(tiHistoryUrl);


### PR DESCRIPTION
Fixing try selector in UI for mapped tasks in Logs and Details panel. This bothered us in production really hard... was hoping somebody else was jumping on this and am wondering if nobody else is affected by this?

Took a moment to find the root cause, actually it was a simple thing: String replacement was not taken over for the effective call URL, such no history could be found, no history... no try selector buttons...

How to test: Run and retry a mapped task from the examples and see that the selector is showing up!

![image](https://github.com/user-attachments/assets/3a53d126-6fa9-48c6-b307-bb7bd55442bb)

closes: #42357

Somewhat 2.10.3rc1 was cut.. hping some other issue is found that this find's its way to the next release, if too late for 2.10.3 then hopefully 2.10.4!

FYI @AutomationDev85 @clellmann @majorosdonat @OliverWannenwetsch 