### PR TITLE
add min versions to types- tabulate,termcolor,toml

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -234,9 +234,9 @@ DEVEL_EXTRAS: dict[str, list[str]] = {
         # hence, 2.31.0.6 is required for aiobotocore>=2.9.0
         "types-requests>=2.31.0.6",
         "types-setuptools>=69.5.0.20240423",
-        "types-tabulate",
-        "types-termcolor",
-        "types-toml",
+        "types-tabulate>=0.9.0.20240106",
+        "types-termcolor>=1.1.6.2",
+        "types-toml>=0.10.8.20240310",
     ],
     "devel-sentry": [
         "blinker>=1.7.0",


### PR DESCRIPTION
Adding min versions as mentioned below:

1. `types-tabulate>=0.9.0.20240106` (This is the latest version and was released Jan 2024)
2. `types-termcolor>=1.1.6.2` (This is the latest version and was released March 2023)
3. `types-toml>=0.10.8.20240310` (This is the latest version and was released March 2024)


related to https://github.com/apache/airflow/issues/42989