### PR TITLE
Fix Try Selector in Mapped Tasks also on Index 0

### DIFF
--- a/airflow/www/static/js/api/useTIHistory.ts
+++ b/airflow/www/static/js/api/useTIHistory.ts
@@ -48,7 +48,7 @@ export default function useTIHistory({
         .replace("_DAG_RUN_ID_", dagRunId)
         .replace("_TASK_ID_", taskId);
 
-      if (mapIndex && mapIndex > -1) {
+      if (typeof mapIndex !== "undefined" && mapIndex > -1) {
         tiHistoryUrl = tiHistoryUrl.replace("/tries", `/${mapIndex}/tries`);
       }
 

--- a/airflow/www/static/js/api/useTIHistory.ts
+++ b/airflow/www/static/js/api/useTIHistory.ts
@@ -48,7 +48,7 @@ export default function useTIHistory({
         .replace("_DAG_RUN_ID_", dagRunId)
         .replace("_TASK_ID_", taskId);
 
-      if (typeof mapIndex !== "undefined" && mapIndex > -1) {
+      if (mapIndex !== undefined && mapIndex > -1) {
         tiHistoryUrl = tiHistoryUrl.replace("/tries", `/${mapIndex}/tries`);
       }
 


### PR DESCRIPTION
While doing a regression on release tests on 2.10.3rc2 I noticed that the fixed logic still has a problem on mapped in dex 0 - seem I did not click on the first mapped element when testing :-(

This PR fixes the logic such that the try history is correctly fetched also for index 0 if dynamic mapped tasks.

Hope we get rid of this code in Airflow 3, this manual client function is really error prone.

related: #43565 #42357
