### PR TITLE
Remove warning about missing config in edge plugin loading

### DIFF
--- a/providers/src/airflow/providers/edge/CHANGELOG.rst
+++ b/providers/src/airflow/providers/edge/CHANGELOG.rst
@@ -27,6 +27,14 @@
 Changelog
 ---------
 
+0.5.1pre0
+.........
+
+Misc
+~~~~
+
+* ``Remove warning about missing config in edge plugin loading.``
+
 0.5.0pre0
 .........
 

--- a/providers/src/airflow/providers/edge/__init__.py
+++ b/providers/src/airflow/providers/edge/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "0.5.0pre0"
+__version__ = "0.5.1pre0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.10.0"

--- a/providers/src/airflow/providers/edge/plugins/edge_executor_plugin.py
+++ b/providers/src/airflow/providers/edge/plugins/edge_executor_plugin.py
@@ -106,7 +106,7 @@ class EdgeWorkerHosts(BaseView):
 
 # Check if EdgeExecutor is actually loaded
 try:
-    EDGE_EXECUTOR_ACTIVE = conf.getboolean("edge", "api_enabled")
+    EDGE_EXECUTOR_ACTIVE = conf.getboolean("edge", "api_enabled", fallback="False")
 except AirflowConfigException:
     EDGE_EXECUTOR_ACTIVE = False
 

--- a/providers/src/airflow/providers/edge/provider.yaml
+++ b/providers/src/airflow/providers/edge/provider.yaml
@@ -27,7 +27,7 @@ source-date-epoch: 1729683247
 
 # note that those versions are maintained by release manager - do not update them manually
 versions:
-  - 0.5.0pre0
+  - 0.5.1pre0
 
 dependencies:
   - apache-airflow>=2.10.0


### PR DESCRIPTION
If pytests are executed in some cases edge plugin is loaded indirectly when plugins manager is initialized. THis should not happen as well as the warning is not needed.

This small change adds a fallback such that the warning is not made, `False` is used per default.