### PR TITLE
More executor cleanup to remove Plugin support

### DIFF
--- a/airflow/executors/executor_constants.py
+++ b/airflow/executors/executor_constants.py
@@ -24,7 +24,6 @@ class ConnectorSource(Enum):
     """Enum of supported executor import sources."""
 
     CORE = "core"
-    PLUGIN = "plugin"
     CUSTOM_PATH = "custom path"
 
 

--- a/airflow/executors/executor_loader.py
+++ b/airflow/executors/executor_loader.py
@@ -94,7 +94,7 @@ class ExecutorLoader:
                 # paths won't be provided by the user in that case.
                 if core_executor_module := cls.executors.get(name):
                     executor_names.append(ExecutorName(alias=name, module_path=core_executor_module))
-                # Only a module path or plugin name was provided
+                # A module path was provided
                 else:
                     executor_names.append(ExecutorName(alias=None, module_path=name))
             # An alias was provided with the module path
@@ -104,12 +104,12 @@ class ExecutorLoader:
                 # (e.g. my_local_exec_alias:LocalExecutor). Allowing this makes things unnecessarily
                 # complicated. Multiple Executors of the same type will be supported by a future multitenancy
                 # AIP.
-                # The module component should always be a module or plugin path.
+                # The module component should always be a module path.
                 module_path = split_name[1]
                 if not module_path or module_path in CORE_EXECUTOR_NAMES or "." not in module_path:
                     raise AirflowConfigException(
                         "Incorrectly formatted executor configuration. Second portion of an executor "
-                        f"configuration must be a module path or plugin but received: {module_path}"
+                        f"configuration must be a module path but received: {module_path}"
                     )
                 else:
                     executor_names.append(ExecutorName(alias=split_name[0], module_path=split_name[1]))
@@ -117,7 +117,7 @@ class ExecutorLoader:
                 raise AirflowConfigException(f"Incorrectly formatted executor configuration: {name}")
 
         # As of now, we do not allow duplicate executors.
-        # Add all module paths/plugin names to a set, since the actual code is what is unique
+        # Add all module paths to a set, since the actual code is what is unique
         unique_modules = set([exec_name.module_path for exec_name in executor_names])
         if len(unique_modules) < len(executor_names):
             msg = (
@@ -216,7 +216,6 @@ class ExecutorLoader:
 
         This supports the following formats:
         * by executor name for core executor
-        * by ``{plugin_name}.{class_name}`` for executor from plugins
         * by import path
         * by class name of the Executor
         * by ExecutorName object specification
@@ -271,7 +270,7 @@ class ExecutorLoader:
 
         Supports the same formats as ExecutorLoader.load_executor.
 
-        :param executor_name: Name of core executor or module path to provider provided as a plugin.
+        :param executor_name: Name of core executor or module path to executor.
         :param validate: Whether or not to validate the executor before returning
 
         :return: executor class via executor_name and executor import source

--- a/airflow/executors/executor_utils.py
+++ b/airflow/executors/executor_utils.py
@@ -31,17 +31,8 @@ class ExecutorName(LoggingMixin):
     def set_connector_source(self):
         if self.alias in CORE_EXECUTOR_NAMES:
             self.connector_source = ConnectorSource.CORE
-        # If there is only one dot, then this is likely a plugin. This is the best we can do
-        # to determine.
-        elif self.module_path.count(".") == 1:
-            self.log.debug(
-                "The executor name looks like the plugin path (executor_name=%s) due to having "
-                "just two period delimited parts. Treating executor as a plugin",
-                self.module_path,
-            )
-            self.connector_source = ConnectorSource.PLUGIN
-        # Executor must be a module
         else:
+            # Executor must be a module
             self.connector_source = ConnectorSource.CUSTOM_PATH
 
     def __repr__(self):

--- a/tests/executors/test_executor_loader.py
+++ b/tests/executors/test_executor_loader.py
@@ -102,7 +102,7 @@ class TestExecutorLoader:
                     ),
                 ],
             ),
-            # Core executors and custom module path executor and plugin
+            # Core executors and custom module path executor
             (
                 "CeleryExecutor, LocalExecutor, tests.executors.test_executor_loader.FakeExecutor",
                 [
@@ -120,7 +120,7 @@ class TestExecutorLoader:
                     ),
                 ],
             ),
-            # Core executors and custom module path executor and plugin with aliases
+            # Core executors and custom module path executor with aliases
             (
                 (
                     "CeleryExecutor, LocalExecutor, fake_exec:tests.executors.test_executor_loader.FakeExecutor"


### PR DESCRIPTION
Support for loading executors via plugins was removed in #43289 but a few bits remained left behind.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
