### PR TITLE
added "name" and "hostname" to template_fields in KubernetesPodOperator

### DIFF
--- a/providers/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -261,6 +261,7 @@ class KubernetesPodOperator(BaseOperator):
         "node_selector",
         "kubernetes_conn_id",
         "name",
+        "hostname",
     )
     template_fields_renderers = {"env_vars": "py"}
 

--- a/providers/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -390,7 +390,6 @@ class KubernetesPodOperator(BaseOperator):
         self.priority_class_name = priority_class_name
         self.pod_template_file = pod_template_file
         self.pod_template_dict = pod_template_dict
-        name = self._set_name(name)
         self.name = name
         self.random_name_suffix = random_name_suffix
         self.termination_grace_period = termination_grace_period
@@ -597,6 +596,8 @@ class KubernetesPodOperator(BaseOperator):
 
     def execute(self, context: Context):
         """Based on the deferrable parameter runs the pod asynchronously or synchronously."""
+        context["task"].name = self._set_name(context["task"].name)  # type: ignore[attr-defined]
+
         if not self.deferrable:
             return self.execute_sync(context)
 

--- a/providers/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -596,7 +596,7 @@ class KubernetesPodOperator(BaseOperator):
 
     def execute(self, context: Context):
         """Based on the deferrable parameter runs the pod asynchronously or synchronously."""
-        context["task"].name = self._set_name(context["task"].name)  # type: ignore[attr-defined]
+        self.name = self._set_name(self.name)
 
         if not self.deferrable:
             return self.execute_sync(context)

--- a/providers/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -260,6 +260,7 @@ class KubernetesPodOperator(BaseOperator):
         "env_from",
         "node_selector",
         "kubernetes_conn_id",
+        "name",
     )
     template_fields_renderers = {"env_vars": "py"}
 
@@ -388,7 +389,8 @@ class KubernetesPodOperator(BaseOperator):
         self.priority_class_name = priority_class_name
         self.pod_template_file = pod_template_file
         self.pod_template_dict = pod_template_dict
-        self.name = self._set_name(name)
+        name = self._set_name(name)
+        self.name = name
         self.random_name_suffix = random_name_suffix
         self.termination_grace_period = termination_grace_period
         self.pod_request_obj: k8s.V1Pod | None = None

--- a/providers/tests/cncf/kubernetes/operators/test_pod.py
+++ b/providers/tests/cncf/kubernetes/operators/test_pod.py
@@ -143,6 +143,8 @@ class TestKubernetesPodOperator:
             session=session,
             dag_id=dag_id,
             task_id="task-id",
+            name="{{ dag.dag_id }}",
+            hostname="{{ dag.dag_id }}",
             namespace="{{ dag.dag_id }}",
             container_resources=k8s.V1ResourceRequirements(
                 requests={"memory": "{{ dag.dag_id }}", "cpu": "{{ dag.dag_id }}"},
@@ -184,6 +186,8 @@ class TestKubernetesPodOperator:
         assert dag_id == rendered.container_resources.requests["cpu"]
         assert dag_id == rendered.volume_mounts[0].name
         assert dag_id == rendered.volume_mounts[0].sub_path
+        assert dag_id == ti.task.hostname
+        assert dag_id == ti.task.name
         assert dag_id == ti.task.image
         assert dag_id == ti.task.cmds
         assert dag_id == ti.task.namespace


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #43480 
related: #43480 

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Hi,

This PR closes: #43480.
It's a small change, which involves adding the `name` and `hostname` to the `template_fields` in the `KubernetesPodOperator`.

I decided to use a different approach from the one suggested by the issue creator.
This was to avoid changing the class API by renaming `self.name` to `self.pod_name`.

What do you think?

<!-- Please keep an empty line above the dashes. -->
---
