### PR TITLE
Add min version to ipykernel,scrapbook, pywinrm

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -841,7 +841,7 @@
       "msgraph-core>=1.0.0"
     ],
     "devel-deps": [
-      "pywinrm"
+      "pywinrm>=0.4"
     ],
     "plugins": [],
     "cross-providers-deps": [
@@ -1043,7 +1043,7 @@
   "papermill": {
     "deps": [
       "apache-airflow>=2.8.0",
-      "ipykernel",
+      "ipykernel>=6.29.4",
       "pandas>=1.5.3,<2.2;python_version<\"3.9\"",
       "pandas>=2.1.2,<2.2;python_version>=\"3.9\"",
       "papermill[all]>=2.6.0",

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -1047,7 +1047,7 @@
       "pandas>=1.5.3,<2.2;python_version<\"3.9\"",
       "pandas>=2.1.2,<2.2;python_version>=\"3.9\"",
       "papermill[all]>=2.6.0",
-      "scrapbook[all]"
+      "scrapbook[all]>=0.5.0"
     ],
     "devel-deps": [],
     "plugins": [],

--- a/providers/src/airflow/providers/microsoft/azure/provider.yaml
+++ b/providers/src/airflow/providers/microsoft/azure/provider.yaml
@@ -119,7 +119,7 @@ dependencies:
   - microsoft-kiota-abstractions<1.4.0
 
 devel-dependencies:
-  - pywinrm
+  - pywinrm>=0.4
 
 integrations:
   - integration-name: Microsoft Azure Batch

--- a/providers/src/airflow/providers/papermill/provider.yaml
+++ b/providers/src/airflow/providers/papermill/provider.yaml
@@ -55,7 +55,7 @@ dependencies:
   - apache-airflow>=2.8.0
   - papermill[all]>=2.6.0
   - scrapbook[all]
-  - ipykernel
+  - ipykernel>=6.29.4
   - pandas>=2.1.2,<2.2;python_version>="3.9"
   - pandas>=1.5.3,<2.2;python_version<"3.9"
 

--- a/providers/src/airflow/providers/papermill/provider.yaml
+++ b/providers/src/airflow/providers/papermill/provider.yaml
@@ -54,7 +54,7 @@ versions:
 dependencies:
   - apache-airflow>=2.8.0
   - papermill[all]>=2.6.0
-  - scrapbook[all]
+  - scrapbook[all]>=0.5.0
   - ipykernel>=6.29.4
   - pandas>=2.1.2,<2.2;python_version>="3.9"
   - pandas>=1.5.3,<2.2;python_version<"3.9"

--- a/providers/tests/system/papermill/conftest.py
+++ b/providers/tests/system/papermill/conftest.py
@@ -36,7 +36,7 @@ def remote_kernel(request):
         [
             "python3",
             "-m",
-            "ipykernel",
+            "ipykernel>=6.29.4",
             '--Session.key=b""',
             f"--hb={JUPYTER_KERNEL_HB_PORT}",
             f"--shell={JUPYTER_KERNEL_SHELL_PORT}",


### PR DESCRIPTION
Adding min versions as mentioned below:

1. pywinrm>=0.4 (We already have a pin on `pywinrm` in one of the providers. Now, adding pin to msft provider)
2. ipykernel>=6.29.4 (Released in March 2024.)
3. scrapbook[all]>=0.5.0 (This is the only version ever released and it was released in Jan 2021)

closes https://github.com/apache/airflow/issues/42989