### PR TITLE
Redirect old location module imports to standard provider

### DIFF
--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -154,7 +154,7 @@ class ModuleRedirectFinder(MetaPathFinder):
         return None
 
 
-module_redirects_references = {
+module_redirects_references: dict[str, str] = {
     "airflow.operators.python": "airflow.providers.standard.operators.python",
     "airflow.operators.bash": "airflow.providers.standard.operators.bash",
     "airflow.operators.datetime": "airflow.providers.standard.operators.datetime",

--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -168,6 +168,6 @@ module_redirects_references = {
     "airflow.hooks.filesystem": "airflow.providers.standard.hooks.filesystem",
     "airflow.hooks.package_index": "airflow.providers.standard.hooks.package_index",
     "airflow.hooks.subprocess": "airflow.providers.standard.hooks.subprocess",
-    "airflow.utils.python_virtualenv.py": "airflow.providers.standard.utils.python_virtualenv.py",
+    "airflow.utils.python_virtualenv": "airflow.providers.standard.utils.python_virtualenv",
 }
 sys.meta_path.append(ModuleRedirectFinder(module_redirects_references))

--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -30,6 +30,7 @@ __version__ = "3.0.0.dev0"
 import os
 import sys
 import warnings
+from importlib.abc import MetaPathFinder
 from typing import TYPE_CHECKING
 
 if os.environ.get("_AIRFLOW_PATCH_GEVENT"):
@@ -133,3 +134,40 @@ if not settings.LAZY_LOAD_PLUGINS:
     from airflow import plugins_manager
 
     plugins_manager.ensure_plugins_loaded()
+
+
+class ModuleRedirectFinder(MetaPathFinder):
+    def __init__(self, redirects: dict[str, str]):
+        self.redirects: dict[str, str] = redirects
+
+    def find_spec(self, old_module: str, path, target=None):
+        import importlib
+
+        if old_module in self.redirects:
+            new_module_name = self.redirects[old_module]
+            warnings.warn(
+                f"Module '{old_module}' is deprecated, Please import it from '{new_module_name}'.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return importlib.util.find_spec(new_module_name)
+        return None
+
+
+module_redirects_references = {
+    "airflow.operators.python": "airflow.providers.standard.operators.python",
+    "airflow.operators.bash": "airflow.providers.standard.operators.bash",
+    "airflow.operators.datetime": "airflow.providers.standard.operators.datetime",
+    "airflow.operators.weekday": "airflow.providers.standard.operators.weekday",
+    "airflow.sensors.bash": "airflow.providers.standard.sensors.bash",
+    "airflow.sensors.date_time": "airflow.providers.standard.sensors.date_time",
+    "airflow.sensors.python": "airflow.providers.standard.sensors.python",
+    "airflow.sensors.time": "airflow.providers.standard.sensors.time",
+    "airflow.sensors.time_delta": "airflow.providers.standard.sensors.time_delta",
+    "airflow.sensors.weekday": "airflow.providers.standard.sensors.weekday",
+    "airflow.hooks.filesystem": "airflow.providers.standard.hooks.filesystem",
+    "airflow.hooks.package_index": "airflow.providers.standard.hooks.package_index",
+    "airflow.hooks.subprocess": "airflow.providers.standard.hooks.subprocess",
+    "airflow.utils.python_virtualenv.py": "airflow.providers.standard.utils.python_virtualenv.py",
+}
+sys.meta_path.append(ModuleRedirectFinder(module_redirects_references))

--- a/providers/tests/standard/test_module_redirect_finder.py
+++ b/providers/tests/standard/test_module_redirect_finder.py
@@ -25,22 +25,25 @@ from tests_common.test_utils.compat import AIRFLOW_V_3_0_PLUS
 
 @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Valid for Airflow 3.0+ only")
 class TestModuleRedirectFinder:
-    @pytest.mark.parametrize("old_module, new_module", [
-        ("airflow.operators.python", "airflow.providers.standard.operators.python"),
-        ("airflow.operators.bash", "airflow.providers.standard.operators.bash"),
-        ("airflow.operators.datetime", "airflow.providers.standard.operators.datetime"),
-        ("airflow.operators.weekday", "airflow.providers.standard.operators.weekday"),
-        ("airflow.sensors.bash", "airflow.providers.standard.sensors.bash"),
-        ("airflow.sensors.date_time", "airflow.providers.standard.sensors.date_time"),
-        ("airflow.sensors.python", "airflow.providers.standard.sensors.python"),
-        ("airflow.sensors.time", "airflow.providers.standard.sensors.time"),
-        ("airflow.sensors.time_delta", "airflow.providers.standard.sensors.time_delta"),
-        ("airflow.sensors.weekday", "airflow.providers.standard.sensors.weekday"),
-        ("airflow.hooks.filesystem", "airflow.providers.standard.hooks.filesystem"),
-        ("airflow.hooks.package_index", "airflow.providers.standard.hooks.package_index"),
-        ("airflow.hooks.subprocess", "airflow.providers.standard.hooks.subprocess"),
-        ("airflow.utils.python_virtualenv", "airflow.providers.standard.utils.python_virtualenv"),
-    ])
+    @pytest.mark.parametrize(
+        "old_module, new_module",
+        [
+            ("airflow.operators.python", "airflow.providers.standard.operators.python"),
+            ("airflow.operators.bash", "airflow.providers.standard.operators.bash"),
+            ("airflow.operators.datetime", "airflow.providers.standard.operators.datetime"),
+            ("airflow.operators.weekday", "airflow.providers.standard.operators.weekday"),
+            ("airflow.sensors.bash", "airflow.providers.standard.sensors.bash"),
+            ("airflow.sensors.date_time", "airflow.providers.standard.sensors.date_time"),
+            ("airflow.sensors.python", "airflow.providers.standard.sensors.python"),
+            ("airflow.sensors.time", "airflow.providers.standard.sensors.time"),
+            ("airflow.sensors.time_delta", "airflow.providers.standard.sensors.time_delta"),
+            ("airflow.sensors.weekday", "airflow.providers.standard.sensors.weekday"),
+            ("airflow.hooks.filesystem", "airflow.providers.standard.hooks.filesystem"),
+            ("airflow.hooks.package_index", "airflow.providers.standard.hooks.package_index"),
+            ("airflow.hooks.subprocess", "airflow.providers.standard.hooks.subprocess"),
+            ("airflow.utils.python_virtualenv", "airflow.providers.standard.utils.python_virtualenv"),
+        ],
+    )
     def test_module_redirect_finder_for_old_location(self, old_module, new_module):
         try:
             assert importlib.import_module(old_module).__name__ == new_module

--- a/providers/tests/standard/test_module_redirect_finder.py
+++ b/providers/tests/standard/test_module_redirect_finder.py
@@ -25,26 +25,24 @@ from tests_common.test_utils.compat import AIRFLOW_V_3_0_PLUS
 
 @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Valid for Airflow 3.0+ only")
 class TestModuleRedirectFinder:
-    def test_module_redirect_finder_for_old_location(self):
-        module_redirects_references: dict[str, str] = {
-            "airflow.operators.python": "airflow.providers.standard.operators.python",
-            "airflow.operators.bash": "airflow.providers.standard.operators.bash",
-            "airflow.operators.datetime": "airflow.providers.standard.operators.datetime",
-            "airflow.operators.weekday": "airflow.providers.standard.operators.weekday",
-            "airflow.sensors.bash": "airflow.providers.standard.sensors.bash",
-            "airflow.sensors.date_time": "airflow.providers.standard.sensors.date_time",
-            "airflow.sensors.python": "airflow.providers.standard.sensors.python",
-            "airflow.sensors.time": "airflow.providers.standard.sensors.time",
-            "airflow.sensors.time_delta": "airflow.providers.standard.sensors.time_delta",
-            "airflow.sensors.weekday": "airflow.providers.standard.sensors.weekday",
-            "airflow.hooks.filesystem": "airflow.providers.standard.hooks.filesystem",
-            "airflow.hooks.package_index": "airflow.providers.standard.hooks.package_index",
-            "airflow.hooks.subprocess": "airflow.providers.standard.hooks.subprocess",
-            "airflow.utils.python_virtualenv": "airflow.providers.standard.utils.python_virtualenv",
-        }
-
-        for old_module, new_module in module_redirects_references.items():
-            try:
-                assert importlib.import_module(old_module).__name__ == new_module
-            except ImportError:
-                pytest.fail(f"Failed to import module, incorrect reference: {old_module} -> {new_module}")
+    @pytest.mark.parametrize("old_module, new_module", [
+        ("airflow.operators.python", "airflow.providers.standard.operators.python"),
+        ("airflow.operators.bash", "airflow.providers.standard.operators.bash"),
+        ("airflow.operators.datetime", "airflow.providers.standard.operators.datetime"),
+        ("airflow.operators.weekday", "airflow.providers.standard.operators.weekday"),
+        ("airflow.sensors.bash", "airflow.providers.standard.sensors.bash"),
+        ("airflow.sensors.date_time", "airflow.providers.standard.sensors.date_time"),
+        ("airflow.sensors.python", "airflow.providers.standard.sensors.python"),
+        ("airflow.sensors.time", "airflow.providers.standard.sensors.time"),
+        ("airflow.sensors.time_delta", "airflow.providers.standard.sensors.time_delta"),
+        ("airflow.sensors.weekday", "airflow.providers.standard.sensors.weekday"),
+        ("airflow.hooks.filesystem", "airflow.providers.standard.hooks.filesystem"),
+        ("airflow.hooks.package_index", "airflow.providers.standard.hooks.package_index"),
+        ("airflow.hooks.subprocess", "airflow.providers.standard.hooks.subprocess"),
+        ("airflow.utils.python_virtualenv", "airflow.providers.standard.utils.python_virtualenv"),
+    ])
+    def test_module_redirect_finder_for_old_location(self, old_module, new_module):
+        try:
+            assert importlib.import_module(old_module).__name__ == new_module
+        except ImportError:
+            pytest.fail(f"Failed to import module, incorrect reference: {old_module} -> {new_module}")

--- a/providers/tests/standard/test_module_redirect_finder.py
+++ b/providers/tests/standard/test_module_redirect_finder.py
@@ -26,7 +26,22 @@ from tests_common.test_utils.compat import AIRFLOW_V_3_0_PLUS
 @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Valid for Airflow 3.0+ only")
 class TestModuleRedirectFinder:
     def test_module_redirect_finder_for_old_location(self):
-        from airflow import module_redirects_references
+        module_redirects_references: dict[str, str] = {
+            "airflow.operators.python": "airflow.providers.standard.operators.python",
+            "airflow.operators.bash": "airflow.providers.standard.operators.bash",
+            "airflow.operators.datetime": "airflow.providers.standard.operators.datetime",
+            "airflow.operators.weekday": "airflow.providers.standard.operators.weekday",
+            "airflow.sensors.bash": "airflow.providers.standard.sensors.bash",
+            "airflow.sensors.date_time": "airflow.providers.standard.sensors.date_time",
+            "airflow.sensors.python": "airflow.providers.standard.sensors.python",
+            "airflow.sensors.time": "airflow.providers.standard.sensors.time",
+            "airflow.sensors.time_delta": "airflow.providers.standard.sensors.time_delta",
+            "airflow.sensors.weekday": "airflow.providers.standard.sensors.weekday",
+            "airflow.hooks.filesystem": "airflow.providers.standard.hooks.filesystem",
+            "airflow.hooks.package_index": "airflow.providers.standard.hooks.package_index",
+            "airflow.hooks.subprocess": "airflow.providers.standard.hooks.subprocess",
+            "airflow.utils.python_virtualenv": "airflow.providers.standard.utils.python_virtualenv",
+        }
 
         for old_module, new_module in module_redirects_references.items():
             try:

--- a/providers/tests/standard/test_module_redirect_finder.py
+++ b/providers/tests/standard/test_module_redirect_finder.py
@@ -26,72 +26,10 @@ from tests_common.test_utils.compat import AIRFLOW_V_3_0_PLUS
 @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Valid for Airflow 3.0+ only")
 class TestModuleRedirectFinder:
     def test_module_redirect_finder_for_old_location(self):
-        assert (
-            importlib.import_module("airflow.operators.python").__name__
-            == "airflow.providers.standard.operators.python"
-        )
+        from airflow import module_redirects_references
 
-        assert (
-            importlib.import_module("airflow.operators.bash").__name__
-            == "airflow.providers.standard.operators.bash"
-        )
-
-        assert (
-            importlib.import_module("airflow.operators.datetime").__name__
-            == "airflow.providers.standard.operators.datetime"
-        )
-
-        assert (
-            importlib.import_module("airflow.operators.weekday").__name__
-            == "airflow.providers.standard.operators.weekday"
-        )
-
-        assert (
-            importlib.import_module("airflow.sensors.bash").__name__
-            == "airflow.providers.standard.sensors.bash"
-        )
-
-        assert (
-            importlib.import_module("airflow.sensors.date_time").__name__
-            == "airflow.providers.standard.sensors.date_time"
-        )
-
-        assert (
-            importlib.import_module("airflow.sensors.python").__name__
-            == "airflow.providers.standard.sensors.python"
-        )
-
-        assert (
-            importlib.import_module("airflow.sensors.time").__name__
-            == "airflow.providers.standard.sensors.time"
-        )
-
-        assert (
-            importlib.import_module("airflow.sensors.time_delta").__name__
-            == "airflow.providers.standard.sensors.time_delta"
-        )
-
-        assert (
-            importlib.import_module("airflow.sensors.weekday").__name__
-            == "airflow.providers.standard.sensors.weekday"
-        )
-
-        assert (
-            importlib.import_module("airflow.hooks.filesystem").__name__
-            == "airflow.providers.standard.hooks.filesystem"
-        )
-
-        assert (
-            importlib.import_module("airflow.hooks.package_index").__name__
-            == "airflow.providers.standard.hooks.package_index"
-        )
-
-        assert (
-            importlib.import_module("airflow.hooks.subprocess").__name__
-            == "airflow.providers.standard.hooks.subprocess"
-        )
-
-        assert (
-            importlib.import_module("airflow.utils.python_virtualenv").__name__
-            == "airflow.providers.standard.utils.python_virtualenv"
-        )
+        for old_module, new_module in module_redirects_references.items():
+            try:
+                assert importlib.import_module(old_module).__name__ == new_module
+            except ImportError:
+                pytest.fail(f"Failed to import module, incorrect reference: {old_module} -> {new_module}")

--- a/providers/tests/standard/test_module_redirect_finder.py
+++ b/providers/tests/standard/test_module_redirect_finder.py
@@ -1,0 +1,98 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from tests_common.test_utils.compat import AIRFLOW_V_3_0_PLUS
+
+pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Valid for Airflow 3.0+ only")
+
+
+class TestModuleRedirectFinder:
+    def test_module_redirect_finder_for_old_location(self):
+        assert (
+            importlib.import_module("airflow.operators.python").__name__
+            == "airflow.providers.standard.operators.python"
+        )
+
+        assert (
+            importlib.import_module("airflow.operators.bash").__name__
+            == "airflow.providers.standard.operators.bash"
+        )
+
+        assert (
+            importlib.import_module("airflow.operators.datetime").__name__
+            == "airflow.providers.standard.operators.datetime"
+        )
+
+        assert (
+            importlib.import_module("airflow.operators.weekday").__name__
+            == "airflow.providers.standard.operators.weekday"
+        )
+
+        assert (
+            importlib.import_module("airflow.sensors.bash").__name__
+            == "airflow.providers.standard.sensors.bash"
+        )
+
+        assert (
+            importlib.import_module("airflow.sensors.date_time").__name__
+            == "airflow.providers.standard.sensors.date_time"
+        )
+
+        assert (
+            importlib.import_module("airflow.sensors.python").__name__
+            == "airflow.providers.standard.sensors.python"
+        )
+
+        assert (
+            importlib.import_module("airflow.sensors.time").__name__
+            == "airflow.providers.standard.sensors.time"
+        )
+
+        assert (
+            importlib.import_module("airflow.sensors.time_delta").__name__
+            == "airflow.providers.standard.sensors.time_delta"
+        )
+
+        assert (
+            importlib.import_module("airflow.sensors.weekday").__name__
+            == "airflow.providers.standard.sensors.weekday"
+        )
+
+        assert (
+            importlib.import_module("airflow.hooks.filesystem").__name__
+            == "airflow.providers.standard.hooks.filesystem"
+        )
+
+        assert (
+            importlib.import_module("airflow.hooks.package_index").__name__
+            == "airflow.providers.standard.hooks.package_index"
+        )
+
+        assert (
+            importlib.import_module("airflow.hooks.subprocess").__name__
+            == "airflow.providers.standard.hooks.subprocess"
+        )
+
+        assert (
+            importlib.import_module("airflow.utils.python_virtualenv").__name__
+            == "airflow.providers.standard.utils.python_virtualenv"
+        )

--- a/providers/tests/standard/test_module_redirect_finder.py
+++ b/providers/tests/standard/test_module_redirect_finder.py
@@ -22,9 +22,8 @@ import pytest
 
 from tests_common.test_utils.compat import AIRFLOW_V_3_0_PLUS
 
-pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Valid for Airflow 3.0+ only")
 
-
+@pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Valid for Airflow 3.0+ only")
 class TestModuleRedirectFinder:
     def test_module_redirect_finder_for_old_location(self):
         assert (


### PR DESCRIPTION
We have moved the operators/sensors/hooks/utils to standard provider from core area location.

This change is to support in ariflow 3.0.0 when user tries to import from old location, 
it redirects to standard provider.

So far the following operators/sensors/hooks/utils has been moved to standard provider.

#41564 
#42506
#42081
#42252

related: #43582
related: #43641
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #43582

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
