### PR TITLE
Add UV support to venv operators

### DIFF
--- a/airflow/example_dags/example_branch_operator_decorator.py
+++ b/airflow/example_dags/example_branch_operator_decorator.py
@@ -112,7 +112,7 @@ with DAG(
     #       Run the example a second time and see that it re-uses it and is faster.
     VENV_CACHE_PATH = tempfile.gettempdir()
 
-    @task.branch_virtualenv(requirements=["numpy~=1.24.4"], venv_cache_path=VENV_CACHE_PATH)
+    @task.branch_virtualenv(requirements=["numpy~=1.26.0"], venv_cache_path=VENV_CACHE_PATH)
     def branching_virtualenv(choices) -> str:
         import random
 
@@ -132,7 +132,7 @@ with DAG(
     for option in options:
 
         @task.virtualenv(
-            task_id=f"venv_{option}", requirements=["numpy~=1.24.4"], venv_cache_path=VENV_CACHE_PATH
+            task_id=f"venv_{option}", requirements=["numpy~=1.26.0"], venv_cache_path=VENV_CACHE_PATH
         )
         def some_venv_task():
             import numpy as np

--- a/airflow/example_dags/example_branch_operator_decorator.py
+++ b/airflow/example_dags/example_branch_operator_decorator.py
@@ -112,7 +112,7 @@ with DAG(
     #       Run the example a second time and see that it re-uses it and is faster.
     VENV_CACHE_PATH = tempfile.gettempdir()
 
-    @task.branch_virtualenv(requirements=["numpy~=1.26.0"], venv_cache_path=VENV_CACHE_PATH)
+    @task.branch_virtualenv(requirements=["numpy~=1.24.4"], venv_cache_path=VENV_CACHE_PATH)
     def branching_virtualenv(choices) -> str:
         import random
 
@@ -132,7 +132,7 @@ with DAG(
     for option in options:
 
         @task.virtualenv(
-            task_id=f"venv_{option}", requirements=["numpy~=1.26.0"], venv_cache_path=VENV_CACHE_PATH
+            task_id=f"venv_{option}", requirements=["numpy~=1.24.4"], venv_cache_path=VENV_CACHE_PATH
         )
         def some_venv_task():
             import numpy as np

--- a/newsfragments/43612.significant.rst
+++ b/newsfragments/43612.significant.rst
@@ -1,0 +1,8 @@
+Virtualenv installation uses ``uv`` now per default if ``uv`` is available.
+
+If you want to control how the virtualenv is created, you can use the
+AIRFLOW__STANDARD__VENV_INSTALL_METHOD option. The possible values are:
+
+- ``auto``: Automatically select, use ``uv`` if available, otherwise use ``pip``.
+- ``pip``: Use pip to install the virtual environment.
+- ``uv``: Use uv to install the virtual environment. Must be available in environment PATH.

--- a/providers/src/airflow/providers/standard/provider.yaml
+++ b/providers/src/airflow/providers/standard/provider.yaml
@@ -72,7 +72,7 @@ config:
           Which python tooling should be used to install the virtual environment.
 
           The following options are available:
-          - ``auto``: Automatically select, use `uv` if available, otherwise use ``pip``.
+          - ``auto``: Automatically select, use ``uv`` if available, otherwise use ``pip``.
           - ``pip``: Use pip to install the virtual environment.
           - ``uv``: Use uv to install the virtual environment. Must be available in environment PATH.
         version_added: ~

--- a/providers/src/airflow/providers/standard/provider.yaml
+++ b/providers/src/airflow/providers/standard/provider.yaml
@@ -62,3 +62,20 @@ hooks:
       - airflow.providers.standard.hooks.filesystem
       - airflow.providers.standard.hooks.package_index
       - airflow.providers.standard.hooks.subprocess
+
+config:
+  standard:
+    description: Options for the standard operators
+    options:
+      venv_install_method:
+        description: |
+          Which python tooling should be used to install the virtual environment.
+
+          The following options are available:
+          - ``auto``: Automatically select, use `uv` if available, otherwise use ``pip``.
+          - ``pip``: Use pip to install the virtual environment.
+          - ``uv``: Use uv to install the virtual environment. Must be available in environment PATH.
+        version_added: ~
+        type: string
+        example: uv
+        default: auto

--- a/providers/src/airflow/providers/standard/provider.yaml
+++ b/providers/src/airflow/providers/standard/provider.yaml
@@ -65,7 +65,7 @@ hooks:
 
 config:
   standard:
-    description: Options for the standard operators
+    description: Options for the standard provider operators.
     options:
       venv_install_method:
         description: |

--- a/providers/src/airflow/providers/standard/utils/python_virtualenv.py
+++ b/providers/src/airflow/providers/standard/utils/python_virtualenv.py
@@ -41,7 +41,7 @@ def _is_uv_installed() -> bool:
 
 def _generate_uv_cmd(tmp_dir: str, python_bin: str, system_site_packages: bool) -> list[str]:
     """Build the command to install the venv via UV."""
-    cmd = ["uv", "venv"]
+    cmd = ["uv", "venv", "--allow-existing", "--seed"]
     if python_bin is not None:
         cmd += ["--python", python_bin]
     if system_site_packages:

--- a/providers/src/airflow/providers/standard/utils/python_virtualenv.py
+++ b/providers/src/airflow/providers/standard/utils/python_virtualenv.py
@@ -33,7 +33,7 @@ from airflow.utils.process_utils import execute_in_subprocess
 
 def _is_uv_installed() -> bool:
     """
-    Check if the uv tool is installed via checking if it is on the path or installed as package.
+    Verify whether the uv tool is installed by checking if it's included in the system PATH or installed as a package.
 
     :return: True if it is. Whichever way of checking it works, is fine.
     """

--- a/providers/tests/standard/utils/test_python_virtualenv.py
+++ b/providers/tests/standard/utils/test_python_virtualenv.py
@@ -29,13 +29,13 @@ from tests_common.test_utils.config import conf_vars
 
 
 class TestPrepareVirtualenv:
-    @mock.patch("shutil")
-    def test_use_uv(self, mock_shutil):
+    @mock.patch("shutil.which")
+    def test_use_uv(self, mock_shutil_which):
         with conf_vars({("standard", "venv_install_method"): "auto"}):
-            mock_shutil.which.side_effect = True
+            mock_shutil_which.side_effect = [True]
             assert _use_uv() is True
 
-            mock_shutil.which.side_effect = False
+            mock_shutil_which.side_effect = [False]
             assert _use_uv() is False
 
         with conf_vars({("standard", "venv_install_method"): "uv"}):
@@ -77,7 +77,8 @@ class TestPrepareVirtualenv:
             assert term not in generated_conf
 
     @mock.patch("airflow.providers.standard.utils.python_virtualenv.execute_in_subprocess")
-    def test_should_create_virtualenv(self, mock_execute_in_subprocess):
+    @conf_vars({("standard", "venv_install_method"): "pip"})
+    def test_should_create_virtualenv_pip(self, mock_execute_in_subprocess):
         python_bin = prepare_virtualenv(
             venv_directory="/VENV", python_bin="pythonVER", system_site_packages=False, requirements=[]
         )
@@ -85,7 +86,19 @@ class TestPrepareVirtualenv:
         mock_execute_in_subprocess.assert_called_once_with(["pythonVER", "-m", "venv", "/VENV"])
 
     @mock.patch("airflow.providers.standard.utils.python_virtualenv.execute_in_subprocess")
-    def test_should_create_virtualenv_with_system_packages(self, mock_execute_in_subprocess):
+    @conf_vars({("standard", "venv_install_method"): "uv"})
+    def test_should_create_virtualenv_uv(self, mock_execute_in_subprocess):
+        python_bin = prepare_virtualenv(
+            venv_directory="/VENV", python_bin="pythonVER", system_site_packages=False, requirements=[]
+        )
+        assert "/VENV/bin/python" == python_bin
+        mock_execute_in_subprocess.assert_called_once_with(
+            ["uv", "venv", "--allow-existing", "--seed", "--python", "pythonVER", "/VENV"]
+        )
+
+    @mock.patch("airflow.providers.standard.utils.python_virtualenv.execute_in_subprocess")
+    @conf_vars({("standard", "venv_install_method"): "pip"})
+    def test_should_create_virtualenv_with_system_packages_pip(self, mock_execute_in_subprocess):
         python_bin = prepare_virtualenv(
             venv_directory="/VENV", python_bin="pythonVER", system_site_packages=True, requirements=[]
         )
@@ -95,7 +108,28 @@ class TestPrepareVirtualenv:
         )
 
     @mock.patch("airflow.providers.standard.utils.python_virtualenv.execute_in_subprocess")
-    def test_pip_install_options(self, mock_execute_in_subprocess):
+    @conf_vars({("standard", "venv_install_method"): "uv"})
+    def test_should_create_virtualenv_with_system_packages_uv(self, mock_execute_in_subprocess):
+        python_bin = prepare_virtualenv(
+            venv_directory="/VENV", python_bin="pythonVER", system_site_packages=True, requirements=[]
+        )
+        assert "/VENV/bin/python" == python_bin
+        mock_execute_in_subprocess.assert_called_once_with(
+            [
+                "uv",
+                "venv",
+                "--allow-existing",
+                "--seed",
+                "--python",
+                "pythonVER",
+                "--system-site-packages",
+                "/VENV",
+            ]
+        )
+
+    @mock.patch("airflow.providers.standard.utils.python_virtualenv.execute_in_subprocess")
+    @conf_vars({("standard", "venv_install_method"): "pip"})
+    def test_pip_install_options_pip(self, mock_execute_in_subprocess):
         pip_install_options = ["--no-deps"]
         python_bin = prepare_virtualenv(
             venv_directory="/VENV",
@@ -106,15 +140,30 @@ class TestPrepareVirtualenv:
         )
 
         assert "/VENV/bin/python" == python_bin
-        mock_execute_in_subprocess.assert_any_call(
-            ["pythonVER", "-m", "venv", "/VENV", "--system-site-packages"]
-        )
         mock_execute_in_subprocess.assert_called_with(
             ["/VENV/bin/pip", "install", *pip_install_options, "apache-beam[gcp]"]
         )
 
     @mock.patch("airflow.providers.standard.utils.python_virtualenv.execute_in_subprocess")
-    def test_should_create_virtualenv_with_extra_packages(self, mock_execute_in_subprocess):
+    @conf_vars({("standard", "venv_install_method"): "uv"})
+    def test_pip_install_options_uv(self, mock_execute_in_subprocess):
+        pip_install_options = ["--no-deps"]
+        python_bin = prepare_virtualenv(
+            venv_directory="/VENV",
+            python_bin="pythonVER",
+            system_site_packages=True,
+            requirements=["apache-beam[gcp]"],
+            pip_install_options=pip_install_options,
+        )
+
+        assert "/VENV/bin/python" == python_bin
+        mock_execute_in_subprocess.assert_called_with(
+            ["uv", "pip", "install", "--python", "/VENV/bin/python", *pip_install_options, "apache-beam[gcp]"]
+        )
+
+    @mock.patch("airflow.providers.standard.utils.python_virtualenv.execute_in_subprocess")
+    @conf_vars({("standard", "venv_install_method"): "pip"})
+    def test_should_create_virtualenv_with_extra_packages_pip(self, mock_execute_in_subprocess):
         python_bin = prepare_virtualenv(
             venv_directory="/VENV",
             python_bin="pythonVER",
@@ -126,6 +175,21 @@ class TestPrepareVirtualenv:
         mock_execute_in_subprocess.assert_any_call(["pythonVER", "-m", "venv", "/VENV"])
 
         mock_execute_in_subprocess.assert_called_with(["/VENV/bin/pip", "install", "apache-beam[gcp]"])
+
+    @mock.patch("airflow.providers.standard.utils.python_virtualenv.execute_in_subprocess")
+    @conf_vars({("standard", "venv_install_method"): "uv"})
+    def test_should_create_virtualenv_with_extra_packages_uv(self, mock_execute_in_subprocess):
+        python_bin = prepare_virtualenv(
+            venv_directory="/VENV",
+            python_bin="pythonVER",
+            system_site_packages=False,
+            requirements=["apache-beam[gcp]"],
+        )
+        assert "/VENV/bin/python" == python_bin
+
+        mock_execute_in_subprocess.assert_called_with(
+            ["uv", "pip", "install", "--python", "/VENV/bin/python", "apache-beam[gcp]"]
+        )
 
     def test_remove_task_decorator(self):
         py_source = "@task.virtualenv(use_dill=True)\ndef f():\nimport funcsigs"


### PR DESCRIPTION
Follow-up on #43553 and #43568

Adds support for UV for the VirtualEnv operators.

Don't know if it is acceptable like this, it is auto-detecting: if UV is installed then it is using UV.
Do we need to make this configurable or is an auto-detection sufficient?