### PR TITLE
Resolve GlueJobTrigger serialization bug causing verbose to always be True

### DIFF
--- a/providers/src/airflow/providers/amazon/aws/triggers/glue.py
+++ b/providers/src/airflow/providers/amazon/aws/triggers/glue.py
@@ -62,7 +62,7 @@ class GlueJobCompleteTrigger(BaseTrigger):
             {
                 "job_name": self.job_name,
                 "run_id": self.run_id,
-                "verbose": str(self.verbose),
+                "verbose": self.verbose,
                 "aws_conn_id": self.aws_conn_id,
                 "job_poll_interval": self.job_poll_interval,
             },

--- a/providers/tests/amazon/aws/operators/test_glue.py
+++ b/providers/tests/amazon/aws/operators/test_glue.py
@@ -207,7 +207,6 @@ class TestGlueJobOperator:
         mock_print_job_logs.assert_not_called()
         assert glue.job_name == JOB_NAME
 
-
     @mock.patch.object(GlueJobHook, "print_job_logs")
     @mock.patch.object(GlueJobHook, "job_completion")
     @mock.patch.object(GlueJobHook, "initialize_job")

--- a/providers/tests/amazon/aws/operators/test_glue.py
+++ b/providers/tests/amazon/aws/operators/test_glue.py
@@ -183,6 +183,32 @@ class TestGlueJobOperator:
         assert glue.job_name == JOB_NAME
 
     @mock.patch.object(GlueJobHook, "print_job_logs")
+    @mock.patch.object(GlueJobHook, "get_job_state")
+    @mock.patch.object(GlueJobHook, "initialize_job")
+    @mock.patch.object(GlueJobHook, "get_conn")
+    @mock.patch.object(S3Hook, "load_file")
+    def test_execute_without_verbose_logging(
+        self, mock_load_file, mock_get_conn, mock_initialize_job, mock_get_job_state, mock_print_job_logs
+    ):
+        glue = GlueJobOperator(
+            task_id=TASK_ID,
+            job_name=JOB_NAME,
+            script_location="s3_uri",
+            s3_bucket="bucket_name",
+            iam_role_name="role_arn",
+            verbose=False,
+        )
+        mock_initialize_job.return_value = {"JobRunState": "RUNNING", "JobRunId": JOB_RUN_ID}
+        mock_get_job_state.return_value = "SUCCEEDED"
+
+        glue.execute(mock.MagicMock())
+
+        mock_initialize_job.assert_called_once_with({}, {})
+        mock_print_job_logs.assert_not_called()
+        assert glue.job_name == JOB_NAME
+
+
+    @mock.patch.object(GlueJobHook, "print_job_logs")
     @mock.patch.object(GlueJobHook, "job_completion")
     @mock.patch.object(GlueJobHook, "initialize_job")
     @mock.patch.object(GlueJobHook, "get_conn")

--- a/providers/tests/amazon/aws/triggers/test_glue.py
+++ b/providers/tests/amazon/aws/triggers/test_glue.py
@@ -82,6 +82,25 @@ class TestGlueJobTrigger:
 
         assert get_state_mock.call_count == 3
 
+    def test_serialization(self):
+        trigger = GlueJobCompleteTrigger(
+            job_name="job_name",
+            run_id="JobRunId",
+            verbose=False,
+            aws_conn_id="aws_conn_id",
+            job_poll_interval=0.1,
+        )
+        classpath, kwargs = trigger.serialize()
+        assert classpath == "airflow.providers.amazon.aws.triggers.glue.GlueJobCompleteTrigger"
+        assert bool(kwargs["verbose"]) == False
+        assert kwargs == {
+            "job_name": "job_name",
+            "run_id": "JobRunId",
+            "verbose": False,
+            "aws_conn_id": "aws_conn_id",
+            "job_poll_interval": 0.1,
+        }
+
 
 class TestGlueCatalogPartitionSensorTrigger:
     @pytest.mark.asyncio

--- a/providers/tests/amazon/aws/triggers/test_glue.py
+++ b/providers/tests/amazon/aws/triggers/test_glue.py
@@ -92,7 +92,6 @@ class TestGlueJobTrigger:
         )
         classpath, kwargs = trigger.serialize()
         assert classpath == "airflow.providers.amazon.aws.triggers.glue.GlueJobCompleteTrigger"
-        assert bool(kwargs["verbose"]) == False
         assert kwargs == {
             "job_name": "job_name",
             "run_id": "JobRunId",


### PR DESCRIPTION
related: https://github.com/apache/airflow/issues/43620
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
