### PR TITLE
Simplify the handle stuck in queued interface

### DIFF
--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -22,7 +22,7 @@ import logging
 import sys
 from collections import defaultdict, deque
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Sequence, Tuple
 
 import pendulum
 
@@ -540,7 +540,9 @@ class BaseExecutor(LoggingMixin):
         """Get called when the daemon receives a SIGTERM."""
         raise NotImplementedError
 
-    def cleanup_stuck_queued_tasks(self, tis: list[TaskInstance]) -> list[str]:  # pragma: no cover
+    def cleanup_stuck_queued_tasks(
+        self, tis: list[TaskInstance]
+    ) -> Iterable[TaskInstance]:  # pragma: no cover
         """
         Handle remnants of tasks that were failed because they were stuck in queued.
 

--- a/providers/src/airflow/providers/cncf/kubernetes/executors/local_kubernetes_executor.py
+++ b/providers/src/airflow/providers/cncf/kubernetes/executors/local_kubernetes_executor.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING, Generator, Sequence
 
 from airflow.configuration import conf
 from airflow.executors.base_executor import BaseExecutor
@@ -230,11 +230,11 @@ class LocalKubernetesExecutor(BaseExecutor):
             *self.kubernetes_executor.try_adopt_task_instances(kubernetes_tis),
         ]
 
-    def cleanup_stuck_queued_tasks(self, tis: list[TaskInstance]) -> list[str]:
+    def cleanup_stuck_queued_tasks(self, tis: list[TaskInstance]) -> Generator[TaskInstance, None, None]:
         # LocalExecutor doesn't have a cleanup_stuck_queued_tasks method, so we
         # will only run KubernetesExecutor's
         kubernetes_tis = [ti for ti in tis if ti.queue == self.KUBERNETES_QUEUE]
-        return self.kubernetes_executor.cleanup_stuck_queued_tasks(kubernetes_tis)
+        yield from self.kubernetes_executor.cleanup_stuck_queued_tasks(kubernetes_tis)
 
     def end(self) -> None:
         """End local and kubernetes executor."""


### PR DESCRIPTION
Proposed changes to #43520

This changes the signature of `cleanup_stuck_queued_tasks` such that it returns Iterable[TaskInstance] instead of List[str] (where the str is a repr).

What are the implications....

Old provider with new executor:
* we check what kind of object the executor is returning.  if it is a string, then we know it's old executor version.  in that case we just log to stdout of scheduler and move on.

New provider with old executor:
* New provider would be yielding TIs instead of strings.  The executor would be expecting list of repr strings.  The repr IN check would not find matches.  Thus nothing would be logged.  Nothing breaks but you don't have the log messages about stuck TIs.  So this combination should be avoided and we might want to bump min version of provider.  Or we could add backcompat code in the providers to yield the reprs in that case.  That should work ok too.
