### PR TITLE
Fix venv numpy example which needs to be 1.26 at least to be working in Python 3.12

### DIFF
--- a/airflow/example_dags/example_branch_operator_decorator.py
+++ b/airflow/example_dags/example_branch_operator_decorator.py
@@ -112,7 +112,7 @@ with DAG(
     #       Run the example a second time and see that it re-uses it and is faster.
     VENV_CACHE_PATH = tempfile.gettempdir()
 
-    @task.branch_virtualenv(requirements=["numpy~=1.24.4"], venv_cache_path=VENV_CACHE_PATH)
+    @task.branch_virtualenv(requirements=["numpy~=1.26.0"], venv_cache_path=VENV_CACHE_PATH)
     def branching_virtualenv(choices) -> str:
         import random
 
@@ -132,7 +132,7 @@ with DAG(
     for option in options:
 
         @task.virtualenv(
-            task_id=f"venv_{option}", requirements=["numpy~=1.24.4"], venv_cache_path=VENV_CACHE_PATH
+            task_id=f"venv_{option}", requirements=["numpy~=1.26.0"], venv_cache_path=VENV_CACHE_PATH
         )
         def some_venv_task():
             import numpy as np


### PR DESCRIPTION
Fix example DAG which is not installing/working with Python 3.12 again ad numpy must be upgraded to at least 1.26.0 to be working with Python 3.12