### PR TITLE
Replace HTTP status code with named constants

### DIFF
--- a/airflow/api_fastapi/core_api/routes/public/connections.py
+++ b/airflow/api_fastapi/core_api/routes/public/connections.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from fastapi import Depends, HTTPException
+from fastapi import Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 from typing_extensions import Annotated
@@ -37,7 +37,9 @@ connections_router = AirflowRouter(tags=["Connection"], prefix="/connections")
 @connections_router.delete(
     "/{connection_id}",
     status_code=204,
-    responses=create_openapi_http_exception_doc([401, 403, 404]),
+    responses=create_openapi_http_exception_doc(
+        [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND]
+    ),
 )
 async def delete_connection(
     connection_id: str,
@@ -47,14 +49,18 @@ async def delete_connection(
     connection = session.scalar(select(Connection).filter_by(conn_id=connection_id))
 
     if connection is None:
-        raise HTTPException(404, f"The Connection with connection_id: `{connection_id}` was not found")
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, f"The Connection with connection_id: `{connection_id}` was not found"
+        )
 
     session.delete(connection)
 
 
 @connections_router.get(
     "/{connection_id}",
-    responses=create_openapi_http_exception_doc([401, 403, 404]),
+    responses=create_openapi_http_exception_doc(
+        [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND]
+    ),
 )
 async def get_connection(
     connection_id: str,
@@ -64,14 +70,18 @@ async def get_connection(
     connection = session.scalar(select(Connection).filter_by(conn_id=connection_id))
 
     if connection is None:
-        raise HTTPException(404, f"The Connection with connection_id: `{connection_id}` was not found")
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, f"The Connection with connection_id: `{connection_id}` was not found"
+        )
 
     return ConnectionResponse.model_validate(connection, from_attributes=True)
 
 
 @connections_router.get(
     "/",
-    responses=create_openapi_http_exception_doc([401, 403, 404]),
+    responses=create_openapi_http_exception_doc(
+        [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND]
+    ),
 )
 async def get_connections(
     limit: QueryLimit,

--- a/airflow/api_fastapi/core_api/routes/public/dag_warning.py
+++ b/airflow/api_fastapi/core_api/routes/public/dag_warning.py
@@ -17,7 +17,7 @@
 
 from __future__ import annotations
 
-from fastapi import Depends
+from fastapi import Depends, status
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 from typing_extensions import Annotated
@@ -44,7 +44,10 @@ from airflow.models import DagWarning
 dag_warning_router = AirflowRouter(tags=["DagWarning"])
 
 
-@dag_warning_router.get("/dagWarnings", responses=create_openapi_http_exception_doc([401, 403]))
+@dag_warning_router.get(
+    "/dagWarnings",
+    responses=create_openapi_http_exception_doc([status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]),
+)
 async def list_dag_warnings(
     dag_id: QueryDagIdInDagWarningFilter,
     warning_type: QueryWarningTypeFilter,

--- a/airflow/api_fastapi/core_api/routes/public/dags.py
+++ b/airflow/api_fastapi/core_api/routes/public/dags.py
@@ -17,7 +17,7 @@
 
 from __future__ import annotations
 
-from fastapi import Depends, HTTPException, Query, Request, Response
+from fastapi import Depends, HTTPException, Query, Request, Response, status
 from sqlalchemy import select, update
 from sqlalchemy.orm import Session
 from typing_extensions import Annotated
@@ -99,7 +99,7 @@ async def get_dags(
 
 @dags_router.get(
     "/tags",
-    responses=create_openapi_http_exception_doc([401, 403]),
+    responses=create_openapi_http_exception_doc([status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]),
 )
 async def get_dag_tags(
     limit: QueryLimit,
@@ -130,18 +130,29 @@ async def get_dag_tags(
     return DAGTagCollectionResponse(tags=[dag_tag for dag_tag in dag_tags], total_entries=total_entries)
 
 
-@dags_router.get("/{dag_id}", responses=create_openapi_http_exception_doc([400, 401, 403, 404, 422]))
+@dags_router.get(
+    "/{dag_id}",
+    responses=create_openapi_http_exception_doc(
+        [
+            status.HTTP_400_BAD_REQUEST,
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+            status.HTTP_404_NOT_FOUND,
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+        ]
+    ),
+)
 async def get_dag(
     dag_id: str, session: Annotated[Session, Depends(get_session)], request: Request
 ) -> DAGResponse:
     """Get basic information about a DAG."""
     dag: DAG = request.app.state.dag_bag.get_dag(dag_id)
     if not dag:
-        raise HTTPException(404, f"Dag with id {dag_id} was not found")
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"Dag with id {dag_id} was not found")
 
     dag_model: DagModel = session.get(DagModel, dag_id)
     if not dag_model:
-        raise HTTPException(404, f"Unable to obtain dag with id {dag_id} from session")
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"Unable to obtain dag with id {dag_id} from session")
 
     for key, value in dag.__dict__.items():
         if not key.startswith("_") and not hasattr(dag_model, key):
@@ -157,11 +168,11 @@ async def get_dag_details(
     """Get details of DAG."""
     dag: DAG = request.app.state.dag_bag.get_dag(dag_id)
     if not dag:
-        raise HTTPException(404, f"Dag with id {dag_id} was not found")
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"Dag with id {dag_id} was not found")
 
     dag_model: DagModel = session.get(DagModel, dag_id)
     if not dag_model:
-        raise HTTPException(404, f"Unable to obtain dag with id {dag_id} from session")
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"Unable to obtain dag with id {dag_id} from session")
 
     for key, value in dag.__dict__.items():
         if not key.startswith("_") and not hasattr(dag_model, key):
@@ -170,7 +181,17 @@ async def get_dag_details(
     return DAGDetailsResponse.model_validate(dag_model, from_attributes=True)
 
 
-@dags_router.patch("/{dag_id}", responses=create_openapi_http_exception_doc([400, 401, 403, 404]))
+@dags_router.patch(
+    "/{dag_id}",
+    responses=create_openapi_http_exception_doc(
+        [
+            status.HTTP_400_BAD_REQUEST,
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+            status.HTTP_404_NOT_FOUND,
+        ]
+    ),
+)
 async def patch_dag(
     dag_id: str,
     patch_body: DAGPatchBody,
@@ -181,11 +202,13 @@ async def patch_dag(
     dag = session.get(DagModel, dag_id)
 
     if dag is None:
-        raise HTTPException(404, f"Dag with id: {dag_id} was not found")
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"Dag with id: {dag_id} was not found")
 
     if update_mask:
         if update_mask != ["is_paused"]:
-            raise HTTPException(400, "Only `is_paused` field can be updated through the REST API")
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST, "Only `is_paused` field can be updated through the REST API"
+            )
 
     else:
         update_mask = ["is_paused"]
@@ -197,7 +220,17 @@ async def patch_dag(
     return DAGResponse.model_validate(dag, from_attributes=True)
 
 
-@dags_router.patch("/", responses=create_openapi_http_exception_doc([400, 401, 403, 404]))
+@dags_router.patch(
+    "/",
+    responses=create_openapi_http_exception_doc(
+        [
+            status.HTTP_400_BAD_REQUEST,
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+            status.HTTP_404_NOT_FOUND,
+        ]
+    ),
+)
 async def patch_dags(
     patch_body: DAGPatchBody,
     limit: QueryLimit,
@@ -214,7 +247,9 @@ async def patch_dags(
     """Patch multiple DAGs."""
     if update_mask:
         if update_mask != ["is_paused"]:
-            raise HTTPException(400, "Only `is_paused` field can be updated through the REST API")
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST, "Only `is_paused` field can be updated through the REST API"
+            )
     else:
         update_mask = ["is_paused"]
 
@@ -244,7 +279,18 @@ async def patch_dags(
     )
 
 
-@dags_router.delete("/{dag_id}", responses=create_openapi_http_exception_doc([400, 401, 403, 404, 422]))
+@dags_router.delete(
+    "/{dag_id}",
+    responses=create_openapi_http_exception_doc(
+        [
+            status.HTTP_400_BAD_REQUEST,
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+            status.HTTP_404_NOT_FOUND,
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+        ]
+    ),
+)
 async def delete_dag(
     dag_id: str,
     session: Annotated[Session, Depends(get_session)],
@@ -253,7 +299,9 @@ async def delete_dag(
     try:
         delete_dag_module.delete_dag(dag_id, session=session)
     except DagNotFound:
-        raise HTTPException(404, f"Dag with id: {dag_id} was not found")
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"Dag with id: {dag_id} was not found")
     except AirflowException:
-        raise HTTPException(409, f"Task instances of dag with id: '{dag_id}' are still running")
-    return Response(status_code=204)
+        raise HTTPException(
+            status.HTTP_409_CONFLICT, f"Task instances of dag with id: '{dag_id}' are still running"
+        )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/airflow/api_fastapi/core_api/routes/public/event_logs.py
+++ b/airflow/api_fastapi/core_api/routes/public/event_logs.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from fastapi import Depends, HTTPException
+from fastapi import Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 from typing_extensions import Annotated
@@ -36,7 +36,9 @@ event_logs_router = AirflowRouter(tags=["Event Log"], prefix="/eventLogs")
 
 @event_logs_router.get(
     "/{event_log_id}",
-    responses=create_openapi_http_exception_doc([401, 403, 404]),
+    responses=create_openapi_http_exception_doc(
+        [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND]
+    ),
 )
 async def get_event_log(
     event_log_id: int,
@@ -44,7 +46,7 @@ async def get_event_log(
 ) -> EventLogResponse:
     event_log = session.scalar(select(Log).where(Log.id == event_log_id))
     if event_log is None:
-        raise HTTPException(404, f"The Event Log with id: `{event_log_id}` not found")
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"The Event Log with id: `{event_log_id}` not found")
     return EventLogResponse.model_validate(
         event_log,
         from_attributes=True,

--- a/airflow/api_fastapi/core_api/routes/ui/assets.py
+++ b/airflow/api_fastapi/core_api/routes/ui/assets.py
@@ -17,7 +17,7 @@
 
 from __future__ import annotations
 
-from fastapi import Depends, HTTPException, Request
+from fastapi import Depends, HTTPException, Request, status
 from sqlalchemy import and_, func, select
 from sqlalchemy.orm import Session
 from typing_extensions import Annotated
@@ -39,12 +39,12 @@ async def next_run_assets(
     dag = request.app.state.dag_bag.get_dag(dag_id)
 
     if not dag:
-        raise HTTPException(404, f"can't find dag {dag_id}")
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"can't find dag {dag_id}")
 
     dag_model = DagModel.get_dagmodel(dag_id, session=session)
 
     if dag_model is None:
-        raise HTTPException(404, f"can't find associated dag_model {dag_id}")
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"can't find associated dag_model {dag_id}")
 
     latest_run = dag_model.get_last_dagrun(session=session)
 


### PR DESCRIPTION
Replacing the ints with named constants from https://fastapi.tiangolo.com/reference/status/

It contains a group of named constants (variables) with integer status codes.

For example:

```
200: status.HTTP_200_OK
403: status.HTTP_403_FORBIDDEN
etc.
```

It can be convenient to quickly access HTTP (and WebSocket) status codes using autocompletion for the name without having to remember the integer status codes by memory

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
