### PR TITLE
Pass Task Instance ids in API response

### DIFF
--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -3667,6 +3667,9 @@ components:
       description: Schema for Scheduler info.
     TaskInstanceResponse:
       properties:
+        id:
+          type: string
+          title: Id
         task_id:
           type: string
           title: Task Id
@@ -3787,6 +3790,7 @@ components:
           - type: 'null'
       type: object
       required:
+      - id
       - task_id
       - dag_id
       - dag_run_id

--- a/airflow/api_fastapi/core_api/serializers/task_instances.py
+++ b/airflow/api_fastapi/core_api/serializers/task_instances.py
@@ -31,6 +31,7 @@ class TaskInstanceResponse(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
+    id: str
     task_id: str
     dag_id: str
     run_id: str = Field(alias="dag_run_id")

--- a/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -2300,6 +2300,10 @@ export const $SchedulerInfoSchema = {
 
 export const $TaskInstanceResponse = {
   properties: {
+    id: {
+      type: "string",
+      title: "Id",
+    },
     task_id: {
       type: "string",
       title: "Task Id",
@@ -2529,6 +2533,7 @@ export const $TaskInstanceResponse = {
   },
   type: "object",
   required: [
+    "id",
     "task_id",
     "dag_id",
     "dag_run_id",

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -536,6 +536,7 @@ export type SchedulerInfoSchema = {
  * TaskInstance serializer for responses.
  */
 export type TaskInstanceResponse = {
+  id: string;
   task_id: string;
   dag_id: string;
   dag_run_id: string;

--- a/tests/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/tests/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import datetime as dt
 import urllib
+from unittest import mock
 
 import pendulum
 import pytest
@@ -180,6 +181,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "executor": None,
             "executor_config": "{}",
             "hostname": "",
+            "id": mock.ANY,
             "map_index": -1,
             "max_tries": 0,
             "note": "placeholder-note",
@@ -237,6 +239,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "executor": None,
             "executor_config": "{}",
             "hostname": "",
+            "id": mock.ANY,
             "map_index": -1,
             "max_tries": 0,
             "note": "placeholder-note",
@@ -283,6 +286,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "executor": None,
             "executor_config": "{}",
             "hostname": "",
+            "id": mock.ANY,
             "map_index": -1,
             "max_tries": 0,
             "note": "placeholder-note",
@@ -325,6 +329,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "executor": None,
             "executor_config": "{}",
             "hostname": "",
+            "id": mock.ANY,
             "map_index": -1,
             "max_tries": 0,
             "note": "placeholder-note",
@@ -424,6 +429,7 @@ class TestGetMappedTaskInstance(TestTaskInstanceEndpoint):
                 "executor": None,
                 "executor_config": "{}",
                 "hostname": "",
+                "id": mock.ANY,
                 "map_index": map_index,
                 "max_tries": 0,
                 "note": "placeholder-note",


### PR DESCRIPTION
https://github.com/apache/airflow/pull/43243 added Task Instance "id" as primary key. This PR passes the same API to API responses.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
