### PR TITLE
Fix System test type in breeze

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/run_tests.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_tests.py
@@ -170,7 +170,6 @@ TEST_TYPE_MAP_TO_PYTEST_ARGS: dict[str, list[str]] = {
     "Serialization": [
         "tests/serialization",
     ],
-    "System": ["tests/system"],
     "TaskSDK": ["task_sdk/tests"],
     "WWW": [
         "tests/www",
@@ -255,7 +254,7 @@ def convert_test_type_to_pytest_args(
         else:
             return [INTEGRATION_TESTS]
     if test_type == "System":
-        return [SYSTEM_TESTS]
+        return []
     if skip_provider_tests and test_type.startswith("Providers"):
         return []
     if test_type.startswith(PROVIDERS_LIST_EXCLUDE_PREFIX):

--- a/dev/breeze/tests/test_pytest_args_for_test_types.py
+++ b/dev/breeze/tests/test_pytest_args_for_test_types.py
@@ -63,7 +63,7 @@ from airflow_breeze.utils.run_tests import convert_parallel_types_to_folders, co
         ),
         (
             "System",
-            ["tests/system"],
+            [],
             False,
         ),
         (


### PR DESCRIPTION
Adjust the behaviour of the `System` test type in Breeze testing tests. Remove the path appending to the beginning of the breeze command (because as we've discussed before with the reorganization of our test directories this creates a non-top level loading of a pytest plugin which pytest disallows). This allow us to still specify the System test type because that option controls other beahviours we need (like disabling db init).

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
