### PR TITLE
Remove execution_date and logical_date from arguments in api_connexion

### DIFF
--- a/airflow/api_connexion/endpoints/task_instance_endpoint.py
+++ b/airflow/api_connexion/endpoints/task_instance_endpoint.py
@@ -197,7 +197,7 @@ def get_mapped_task_instances(
     # Other search criteria
     base_query = _apply_range_filter(
         base_query,
-        key=DR.execution_date,
+        key=DR.logical_date,
         value_range=(execution_date_gte, execution_date_lte),
     )
     base_query = _apply_range_filter(
@@ -334,7 +334,7 @@ def get_task_instances(
         base_query = base_query.where(TI.run_id == dag_run_id)
     base_query = _apply_range_filter(
         base_query,
-        key=DR.execution_date,
+        key=DR.logical_date,
         value_range=(execution_date_gte, execution_date_lte),
     )
     base_query = _apply_range_filter(
@@ -396,7 +396,7 @@ def get_task_instances_batch(session: Session = NEW_SESSION) -> APIResponse:
     base_query = _apply_array_filter(base_query, key=TI.task_id, values=data["task_ids"])
     base_query = _apply_range_filter(
         base_query,
-        key=DR.execution_date,
+        key=DR.logical_date,
         value_range=(data["execution_date_gte"], data["execution_date_lte"]),
     )
     base_query = _apply_range_filter(
@@ -519,23 +519,7 @@ def post_set_task_instances_state(*, dag_id: str, session: Session = NEW_SESSION
     if not task:
         error_message = f"Task ID {task_id} not found"
         raise NotFound(error_message)
-
-    execution_date = data.get("execution_date")
     run_id = data.get("dag_run_id")
-    if (
-        execution_date
-        and (
-            session.scalars(
-                select(TI).where(
-                    TI.task_id == task_id, TI.dag_id == dag_id, TI.execution_date == execution_date
-                )
-            ).one_or_none()
-        )
-        is None
-    ):
-        raise NotFound(
-            detail=f"Task instance not found for task {task_id!r} on execution_date {execution_date}"
-        )
 
     select_stmt = select(TI).where(
         TI.dag_id == dag_id, TI.task_id == task_id, TI.run_id == run_id, TI.map_index == -1
@@ -548,7 +532,6 @@ def post_set_task_instances_state(*, dag_id: str, session: Session = NEW_SESSION
     tis = dag.set_task_instance_state(
         task_id=task_id,
         run_id=run_id,
-        execution_date=execution_date,
         state=data["new_state"],
         upstream=data["include_upstream"],
         downstream=data["include_downstream"],

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -4751,14 +4751,9 @@ components:
           description: The task ID.
           type: string
 
-        execution_date:
-          description: The execution date. Either set this or dag_run_id but not both.
-          type: string
-          format: datetime
-
         dag_run_id:
           description: |
-            The task instance's DAG run ID. Either set this or execution_date but not both.
+            The task instance's DAG run ID.
 
             *New in version 2.3.0*
           type: string

--- a/airflow/api_connexion/schemas/asset_schema.py
+++ b/airflow/api_connexion/schemas/asset_schema.py
@@ -119,7 +119,7 @@ class BasicDAGRunSchema(SQLAlchemySchema):
 
     run_id = auto_field(data_key="dag_run_id")
     dag_id = auto_field(dump_only=True)
-    execution_date = auto_field(data_key="logical_date", dump_only=True)
+    logical_date = auto_field(data_key="logical_date", dump_only=True)
     start_date = auto_field(dump_only=True)
     end_date = auto_field(dump_only=True)
     state = auto_field(dump_only=True)

--- a/airflow/api_connexion/schemas/task_instance_schema.py
+++ b/airflow/api_connexion/schemas/task_instance_schema.py
@@ -45,7 +45,7 @@ class TaskInstanceSchema(SQLAlchemySchema):
     dag_id = auto_field()
     run_id = auto_field(data_key="dag_run_id")
     map_index = auto_field()
-    execution_date = auto_field()
+    logical_date = auto_field()
     start_date = auto_field()
     end_date = auto_field()
     duration = auto_field()
@@ -196,7 +196,7 @@ class SetTaskInstanceStateFormSchema(Schema):
 
     dry_run = fields.Boolean(load_default=True)
     task_id = fields.Str(required=True)
-    execution_date = fields.DateTime(validate=validate_istimezone)
+    logical_date = fields.DateTime(validate=validate_istimezone)
     dag_run_id = fields.Str()
     include_upstream = fields.Boolean(required=True)
     include_downstream = fields.Boolean(required=True)
@@ -212,8 +212,8 @@ class SetTaskInstanceStateFormSchema(Schema):
     @validates_schema
     def validate_form(self, data, **kwargs):
         """Validate set task instance state form."""
-        if not exactly_one(data.get("execution_date"), data.get("dag_run_id")):
-            raise ValidationError("Exactly one of execution_date or dag_run_id must be provided")
+        if not exactly_one(data.get("logical_date"), data.get("dag_run_id")):
+            raise ValidationError("Exactly one of logical_date or dag_run_id must be provided")
 
 
 class SetSingleTaskInstanceStateFormSchema(Schema):
@@ -234,7 +234,7 @@ class TaskInstanceReferenceSchema(Schema):
     task_id = fields.Str()
     run_id = fields.Str(data_key="dag_run_id")
     dag_id = fields.Str()
-    execution_date = fields.DateTime()
+    logical_date = fields.DateTime()
 
 
 class TaskInstanceReferenceCollection(NamedTuple):

--- a/airflow/api_connexion/schemas/xcom_schema.py
+++ b/airflow/api_connexion/schemas/xcom_schema.py
@@ -34,7 +34,7 @@ class XComCollectionItemSchema(SQLAlchemySchema):
 
     key = auto_field()
     timestamp = auto_field()
-    execution_date = auto_field()
+    logical_date = auto_field()
     map_index = auto_field()
     task_id = auto_field()
     dag_id = auto_field()

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -285,7 +285,7 @@ class DagRun(Base, LoggingMixin):
         return prune_dict({"dag_id": self.dag_id, "run_type": self.run_type})
 
     @property
-    def logical_date(self) -> datetime:
+    def logical_date(self):
         return self.execution_date
 
     def get_state(self):

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -2111,12 +2111,7 @@ export interface components {
       /** @description The task ID. */
       task_id?: string;
       /**
-       * Format: datetime
-       * @description The execution date. Either set this or dag_run_id but not both.
-       */
-      execution_date?: string;
-      /**
-       * @description The task instance's DAG run ID. Either set this or execution_date but not both.
+       * @description The task instance's DAG run ID.
        *
        * *New in version 2.3.0*
        */


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
This PR removes the `execution_date` and `logical_date` arguments from `api_connexion` that are used to retrieve DAG runs, aligning with the broader changes introduced in Airflow 2.2 and preparing for Airflow 3.0. The functions now use `run_id` as the sole identifier for DAG runs, simplifying the process and eliminating deprecated behaviour.

### **Motivation**:
In Airflow, `execution_date` has historically been used to distinguish different DAG run instances. However, the introduction of `run_id` and the DAG run concept in Airflow 2.2 shifts away from using `execution_date` as an identifier. Continuing to rely on `execution_date` introduces limitations, such as the inability to handle multiple DAG runs at the same logical time, especially in cases like `TriggerDagRunOperator` when dynamic runs are generated.

By removing `execution_date` in favor of `run_id`, this PR eliminates these limitations. This also removes the unique constraint on `execution_date` at the database level, paving the way for a cleaner and more flexible scheduling system in Airflow 3.0.



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
