### PR TITLE
Replace `principle` by `principal` in kerberos-related code

### DIFF
--- a/airflow/security/kerberos.py
+++ b/airflow/security/kerberos.py
@@ -60,7 +60,7 @@ class KerberosMode(Enum):
     ONE_TIME = "one-time"
 
 
-def get_kerberos_principle(principal: str | None) -> str:
+def get_kerberos_principal(principal: str | None) -> str:
     """Retrieve Kerberos principal. Fallback to principal from Airflow configuration if not provided."""
     return principal or conf.get_mandatory_value("kerberos", "principal").replace("_HOST", get_hostname())
 
@@ -77,7 +77,7 @@ def renew_from_kt(principal: str | None, keytab: str, exit_on_fail: bool = True)
     # minutes to give ourselves a large renewal buffer.
     renewal_lifetime = f"{conf.getint('kerberos', 'reinit_frequency')}m"
 
-    cmd_principal = get_kerberos_principle(principal)
+    cmd_principal = get_kerberos_principal(principal)
     if conf.getboolean("kerberos", "forwardable"):
         forwardable = "-f"
     else:

--- a/newsfragments/43679.misc.rst
+++ b/newsfragments/43679.misc.rst
@@ -1,0 +1,1 @@
+Renamed ``airflow.security.kerberos.get_kerberos_principle`` to ``airflow.security.kerberos.get_kerberos_principal`` due to misspelling.

--- a/tests/security/test_kerberos.py
+++ b/tests/security/test_kerberos.py
@@ -24,7 +24,7 @@ from unittest import mock
 import pytest
 
 from airflow.security import kerberos
-from airflow.security.kerberos import get_kerberos_principle, renew_from_kt
+from airflow.security.kerberos import get_kerberos_principal, renew_from_kt
 
 from tests_common.test_utils.config import conf_vars
 
@@ -285,13 +285,13 @@ class TestKerberos:
             mock.call("test-principal", "/tmp/keytab"),
         ]
 
-    def test_get_kerberos_principle(self):
+    def test_get_kerberos_principal(self):
         expected_principal = "test-principal"
-        principal = get_kerberos_principle(expected_principal)
+        principal = get_kerberos_principal(expected_principal)
         assert principal == expected_principal
 
     @mock.patch("airflow.security.kerberos.get_hostname", return_value="REPLACEMENT_HOST")
     @mock.patch("airflow.security.kerberos.conf.get_mandatory_value", return_value="test-principal/_HOST")
-    def test_get_kerberos_principle_resolve_null_principal(self, get_madantory_value_mock, get_hostname_mock):
-        principal = get_kerberos_principle(principal=None)
+    def test_get_kerberos_principal_resolve_null_principal(self, get_madantory_value_mock, get_hostname_mock):
+        principal = get_kerberos_principal(principal=None)
         assert principal == "test-principal/REPLACEMENT_HOST"


### PR DESCRIPTION
Kerberos has the notion of a [principal](https://web.mit.edu/kerberos/krb5-1.5/krb5-1.5.4/doc/krb5-user/What-is-a-Kerberos-Principal_003f.html). "principle" seemed to be a typo.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
