### PR TITLE
Disable XCom list ordering by execution_date

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3856,6 +3856,17 @@ class XComModelView(AirflowModelView):
     list_columns = ["key", "value", "timestamp", "dag_id", "task_id", "run_id", "map_index", "execution_date"]
     base_order = ("dag_run_id", "desc")
 
+    order_columns = [
+        "key",
+        "value",
+        "timestamp",
+        "dag_id",
+        "task_id",
+        "run_id",
+        "map_index",
+        # "execution_date", # disable to fix error before airflow 3
+    ]
+
     base_filters = [["dag_id", DagFilter, list]]
 
     formatters_columns = {

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3864,7 +3864,7 @@ class XComModelView(AirflowModelView):
         "task_id",
         "run_id",
         "map_index",
-        # "execution_date", # disable to fix error before airflow 3
+        # "execution_date", # execution_date sorting is not working and crashing the UI, disabled for now.
     ]
 
     base_filters = [["dag_id", DagFilter, list]]


### PR DESCRIPTION
I tried to fix it and make it work, some other resources (TaskInstance) are able to sort on `execution_date` but for some reason (I suspect db side / model differences) it is not working for `XCom`.

Before:
![Screenshot 2024-11-05 at 09 52 25](https://github.com/user-attachments/assets/0439343e-4f36-4ff2-9a7f-81d0818bb155)

Now:
![Screenshot 2024-11-05 at 09 51 04](https://github.com/user-attachments/assets/e1f87be2-ec5e-4a2d-a1b9-3429b6dd035a)
