### PR TITLE
Expand and improve the kerberos api authentication documentation

### DIFF
--- a/docs/apache-airflow-providers-fab/auth-manager/api-authentication.rst
+++ b/docs/apache-airflow-providers-fab/auth-manager/api-authentication.rst
@@ -48,7 +48,7 @@ command as in the example below.
 Kerberos authentication
 '''''''''''''''''''''''
 
-Kerberos authentication is currently supported for the API.
+Kerberos authentication is currently supported for the API, both experimental and stable.
 
 To enable Kerberos authentication, set the following in the configuration:
 
@@ -60,11 +60,29 @@ To enable Kerberos authentication, set the following in the configuration:
     [kerberos]
     keytab = <KEYTAB>
 
-The Kerberos service is configured as ``airflow/fully.qualified.domainname@REALM``. Make sure this
-principal exists in the keytab file.
+The airflow Kerberos service is configured as ``airflow/fully.qualified.domainname@REALM``. Make sure this
+principal exists `in both the Kerberos database as well as in the keytab file </docs/apache-airflow/stable/security/kerberos.html#enabling-kerberos>`_.
 
 You have to make sure to name your users with the kerberos full username/realm in order to make it
-works. This means that your user name should be ``user_name@KERBEROS-REALM``.
+work. This means that your user name should be ``user_name@REALM``.
+
+.. code-block:: bash
+
+    kinit user_name@REALM
+    ENDPOINT_URL="http://localhost:8080/"
+    curl -X GET  \
+        --negotiate \  # enables Negotiate (SPNEGO) authentication
+        --service airflow \  # matches the `airflow` service name in the `airflow/fully.qualified.domainname@REALM` principal
+        --user : \
+        "${ENDPOINT_URL}/api/v1/pools"
+
+
+.. note::
+
+    Remember that the stable API is secured by both authentication and `access control <./access-control.html>`_.
+    This means that your user needs to have a Role with necessary associated permissions, otherwise you'll receive
+    a 403 response.
+
 
 Basic authentication
 ''''''''''''''''''''


### PR DESCRIPTION
The following improvemenrs were added to the API Kerberos authentication documentation section:
- unify `@REALM` and `@KERBEROS-REALM`: the fact that they read different was confusing and prompted the question whether they were two different names for the same realm value or not
- provide a `curl` example
- mention that the stable API is authorized _and_ access-controled, so the authenticated user should have the required permissions to request the API
- fix a typo

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
