### PR TITLE
GlueJobOperator: add option to wait for cleanup before returning job status

### DIFF
--- a/providers/src/airflow/providers/amazon/aws/hooks/glue.py
+++ b/providers/src/airflow/providers/amazon/aws/hooks/glue.py
@@ -282,13 +282,16 @@ class GlueJobHook(AwsBaseHook):
             log_group_error, continuation_tokens.error_stream_continuation
         )
 
-    def job_completion(self, job_name: str, run_id: str, verbose: bool = False) -> dict[str, str]:
+    def job_completion(
+        self, job_name: str, run_id: str, verbose: bool = False, sleep_before_return: int = 0
+    ) -> dict[str, str]:
         """
         Wait until Glue job with job_name finishes; return final state if finished or raises AirflowException.
 
         :param job_name: unique job name per AWS account
         :param run_id: The job-run ID of the predecessor job run
         :param verbose: If True, more Glue Job Run logs show in the Airflow Task Logs.  (default: False)
+        :param sleep_before_return: time in seconds to wait before returning final status.
         :return: Dict of JobRunState and JobRunId
         """
         next_log_tokens = self.LogContinuationTokens()
@@ -296,6 +299,7 @@ class GlueJobHook(AwsBaseHook):
             job_run_state = self.get_job_state(job_name, run_id)
             ret = self._handle_state(job_run_state, job_name, run_id, verbose, next_log_tokens)
             if ret:
+                time.sleep(sleep_before_return)
                 return ret
             else:
                 time.sleep(self.job_poll_interval)


### PR DESCRIPTION
This changes to solve a bug around the case of concurrency=1. In that scenario Glue returns final state before actually cleaning up the resources. This leads to a problem we can have more than 1 concurrent job in Glue.
To avoid this and according to AWS recommendation adding the option to wait (5-10) seconds before returning the job status 

Not sure how to test this one (if we need testing for this at all?).
It just adds sleep before returning the final status
