### PR TITLE
Update Breeze UI_Files to match pnpm lock file

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -154,6 +154,7 @@ CI_FILE_GROUP_MATCHES = HashableDict(
         FileGroupForCi.JAVASCRIPT_PRODUCTION_FILES: [
             r"^airflow/.*\.[jt]sx?",
             r"^airflow/.*\.lock",
+            r"^airflow/ui/.*\.yaml$",
         ],
         FileGroupForCi.API_TEST_FILES: [
             r"^airflow/api/",
@@ -189,12 +190,7 @@ CI_FILE_GROUP_MATCHES = HashableDict(
             r"^chart/values\.schema\.json",
             r"^chart/values\.json",
         ],
-        FileGroupForCi.UI_FILES: [
-            r"^airflow/ui/.*\.ts[x]?$",
-            r"^airflow/ui/.*\.js[x]?$",
-            r"^airflow/ui/[^/]+\.json$",
-            r"^airflow/ui/.*\.yaml$",
-        ],
+        FileGroupForCi.UI_FILES: [r"^airflow/ui/"],
         FileGroupForCi.LEGACY_WWW_FILES: [
             r"^airflow/www/.*\.ts[x]?$",
             r"^airflow/www/.*\.js[x]?$",

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -193,7 +193,7 @@ CI_FILE_GROUP_MATCHES = HashableDict(
             r"^airflow/ui/.*\.ts[x]?$",
             r"^airflow/ui/.*\.js[x]?$",
             r"^airflow/ui/[^/]+\.json$",
-            r"^airflow/ui/.*\.lock$",
+            r"^airflow/ui/.*\.yaml$",
         ],
         FileGroupForCi.LEGACY_WWW_FILES: [
             r"^airflow/www/.*\.ts[x]?$",


### PR DESCRIPTION
For the CI, we just copied over the www files over to the UI_FILES, but as caught [here](https://github.com/apache/airflow/pull/43633#issuecomment-2455138419), pnpm's lock file is yaml and wasn't being caught.


Now, we will just have all files inside of `airflow/ui` count. Then, changes to the html file,`.prettierrc`, or anything else also don't force the CI to run everything.

Also, added the pnpm lock yaml file to the javascript production files check.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
