### PR TITLE
Remove note about MySQL 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,7 @@ Apache Airflow is tested with:
 
 \* Experimental
 
-**Note**: MySQL 5.x versions are unable to or have limitations with
-running multiple schedulers -- please see the [Scheduler docs](https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/scheduler.html).
-MariaDB is not tested/recommended.
+**Note**: MariaDB is not tested/recommended.
 
 **Note**: SQLite is used in Airflow tests. Do not use it in production. We recommend
 using the latest stable version of SQLite for local development.

--- a/generated/PYPI_README.md
+++ b/generated/PYPI_README.md
@@ -65,9 +65,7 @@ Apache Airflow is tested with:
 
 \* Experimental
 
-**Note**: MySQL 5.x versions are unable to or have limitations with
-running multiple schedulers -- please see the [Scheduler docs](https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/scheduler.html).
-MariaDB is not tested/recommended.
+**Note**: MariaDB is not tested/recommended.
 
 **Note**: SQLite is used in Airflow tests. Do not use it in production. We recommend
 using the latest stable version of SQLite for local development.


### PR DESCRIPTION
We no longer support MySQL 5 as backend so we can remove the specific note about it with HA scheduler