### PR TITLE
Add GZipMiddleware to compress response content.

### DIFF
--- a/airflow/api_fastapi/core_api/app.py
+++ b/airflow/api_fastapi/core_api/app.py
@@ -114,5 +114,9 @@ def init_config(app: FastAPI) -> None:
             allow_headers=allow_headers,
         )
 
-    app.add_middleware(GZipMiddleware, minimum_size=1000, compresslevel=5)
+    # Compress responses greater than 1kB with optimal compression level as 5
+    # with level ranging from 1 to 9 with 1 (fastest, least compression)
+    # and 9 (slowest, most compression)
+    app.add_middleware(GZipMiddleware, minimum_size=1024, compresslevel=5)
+
     app.state.secret_key = conf.get("webserver", "secret_key")

--- a/airflow/api_fastapi/core_api/app.py
+++ b/airflow/api_fastapi/core_api/app.py
@@ -23,6 +23,7 @@ from typing import cast
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.gzip import GZipMiddleware
 from starlette.requests import Request
 from starlette.responses import HTMLResponse
 from starlette.staticfiles import StaticFiles
@@ -113,4 +114,5 @@ def init_config(app: FastAPI) -> None:
             allow_headers=allow_headers,
         )
 
+    app.add_middleware(GZipMiddleware, minimum_size=1000, compresslevel=5)
     app.state.secret_key = conf.get("webserver", "secret_key")


### PR DESCRIPTION
Closes #43640 

The change adds GZipMiddleware to compress response content. Minimum response size for compression is greater than 1kB and compress level is 5 with values ranging from 1 to 9 with 1 (fastest, lowest compression) and 9 (slowest, most compression)

Docs : https://fastapi.tiangolo.com/advanced/middleware/#gzipmiddleware

Dag list page with 75 dags

|compress level  | original size (kB)  | compressed size (kB)   |
|---|---|---|
| 1 | 48.40  | 6.28  |
|  5 | 48.40  | 5.68  |
|  9 | 48.40  | 5.51  |