### PR TITLE
Handle FileNotFound Error returned by missing uv or pipx

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/reinstall.py
+++ b/dev/breeze/src/airflow_breeze/utils/reinstall.py
@@ -39,14 +39,20 @@ def reinstall_breeze(breeze_sources: Path, re_run: bool = True):
     get_console().print(f"\n[info]Reinstalling Breeze from {breeze_sources}\n")
     breeze_installed_with_uv = False
     breeze_installed_with_pipx = False
-    result_uv = subprocess.run(["uv", "tool", "list"], text=True, capture_output=True, check=False)
-    if result_uv.returncode == 0:
-        if "apache-airflow-breeze" in result_uv.stdout:
-            breeze_installed_with_uv = True
-    result_pipx = subprocess.run(["pipx", "list"], text=True, capture_output=True, check=False)
-    if result_pipx.returncode == 0:
-        if "apache-airflow-breeze" in result_pipx.stdout:
-            breeze_installed_with_pipx = True
+    try:
+        result_uv = subprocess.run(["uv", "tool", "list"], text=True, capture_output=True, check=False)
+        if result_uv.returncode == 0:
+            if "apache-airflow-breeze" in result_uv.stdout:
+                breeze_installed_with_uv = True
+    except FileNotFoundError:
+        pass
+    try:
+        result_pipx = subprocess.run(["pipx", "list"], text=True, capture_output=True, check=False)
+        if result_pipx.returncode == 0:
+            if "apache-airflow-breeze" in result_pipx.stdout:
+                breeze_installed_with_pipx = True
+    except FileNotFoundError:
+        pass
     if breeze_installed_with_uv and breeze_installed_with_pipx:
         get_console().print(
             "[error]Breeze is installed both with `uv` and `pipx`. This is not supported.[/]\n"


### PR DESCRIPTION
Subprocess.run raises FileNotFound when uv or pipx are not installed at all. This PR will handle it.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
