### PR TITLE
[Edge] EdgeWorker beautify queues output on overview page

### DIFF
--- a/providers/src/airflow/providers/edge/CHANGELOG.rst
+++ b/providers/src/airflow/providers/edge/CHANGELOG.rst
@@ -27,6 +27,14 @@
 Changelog
 ---------
 
+0.5.2pre0
+.........
+
+Misc
+~~~~
+
+* ``Small beautification for host status in Edge Worker view.``
+
 0.5.1pre0
 .........
 

--- a/providers/src/airflow/providers/edge/__init__.py
+++ b/providers/src/airflow/providers/edge/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "0.5.1pre0"
+__version__ = "0.5.2pre0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.10.0"

--- a/providers/src/airflow/providers/edge/plugins/templates/edge_worker_hosts.html
+++ b/providers/src/airflow/providers/edge/plugins/templates/edge_worker_hosts.html
@@ -67,7 +67,17 @@
                 <span class="label" style="color:white; background-color:hotpink;" title="Current State: {{ host.state }}">{{ host.state }}</span>
               {%- endif -%}
             </td>
-            <td>{% if host.queues %}{{ host.queues }}{% else %}(all){% endif %}</td>
+            <td>
+              {% if host.queues %}
+                <ul>
+                  {% for item in host.queues %}
+                    <li>{{ item }}</li>
+                  {% endfor %}
+                </ul>
+              {% else %}
+                (all)
+              {% endif %}
+            </td>
             <td><time datetime="{{ host.first_online }}">{{ host.first_online }}</time></td>
             <td>{% if host.last_update %}<time datetime="{{ host.last_update }}">{{ host.last_update }}</time>{% endif %}</td>
             <td>{{ host.jobs_active }}</td>

--- a/providers/src/airflow/providers/edge/provider.yaml
+++ b/providers/src/airflow/providers/edge/provider.yaml
@@ -27,7 +27,7 @@ source-date-epoch: 1729683247
 
 # note that those versions are maintained by release manager - do not update them manually
 versions:
-  - 0.5.1pre0
+  - 0.5.2pre0
 
 dependencies:
   - apache-airflow>=2.10.0


### PR DESCRIPTION
# Description

This PR does only do a small beautify of the EdgeWorker overview page. The queues are now presented as list and not the string in the queues filed of the table.

