### PR TITLE
Add data-testid attributes to key UI components for unit test and automation tests

### DIFF
--- a/airflow/ui/src/components/DataTable/CardList.tsx
+++ b/airflow/ui/src/components/DataTable/CardList.tsx
@@ -32,7 +32,7 @@ export const CardList = <TData,>({
   isLoading,
   table,
 }: DataTableProps<TData>) => (
-  <Box overflow="auto" width="100%">
+  <Box data-testid="card-list" overflow="auto" width="100%">
     <SimpleGrid {...{ column: { base: 1 }, gap: 2, ...cardDef.gridProps }}>
       {table.getRowModel().rows.map((row) => (
         <Box key={row.id}>

--- a/airflow/ui/src/components/DataTable/TableList.tsx
+++ b/airflow/ui/src/components/DataTable/TableList.tsx
@@ -40,7 +40,12 @@ export const TableList = <TData,>({
   renderSubComponent,
   table,
 }: DataTableProps<TData>) => (
-  <Table.Root maxH="calc(100vh - 10rem)" overflowY="auto" striped>
+  <Table.Root
+    data-testid="table-list"
+    maxH="calc(100vh - 10rem)"
+    overflowY="auto"
+    striped
+  >
     <Table.Header bg="chakra-body-bg" position="sticky" top={0} zIndex={1}>
       {table.getHeaderGroups().map((headerGroup) => (
         <Table.Row key={headerGroup.id}>

--- a/airflow/ui/src/components/SearchBar.tsx
+++ b/airflow/ui/src/components/SearchBar.tsx
@@ -62,6 +62,7 @@ export const SearchBar = ({
       startElement={<FiSearch />}
     >
       <Input
+        data-testid="search-dags"
         placeholder="Search Dags"
         pr={150}
         {...inputProps}


### PR DESCRIPTION
**Summary**
This PR addresses [Issue #43381](https://github.com/apache/airflow/issues/43381) by adding `data-testid `attributes to key UI components to improve stability and reliability for automated testing and external tools.

**Why This Change?**
Currently, UI lacks reliable identifiers for DOM elements, making automation difficult and unstable. Using sibling and child selectors is not a dependable approach. Adding `data-testid `attributes provides a robust solution, allowing automation frameworks and external tools to interact with UI elements consistently.

**Testing**
Verified that the added `data-testid `attributes do not interfere with the UI's functionality.
Conducted tests to ensure elements are correctly identified and manipulated by automation scripts.
Related Issue
Fixes [Issue #43381](https://github.com/apache/airflow/issues/43381).




---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
