### PR TITLE
Update the "legacy command" help text for backfill

### DIFF
--- a/airflow/cli/commands/legacy_commands.py
+++ b/airflow/cli/commands/legacy_commands.py
@@ -52,7 +52,10 @@ COMMAND_MAP = {
 def check_legacy_command(action, value):
     """Check command value and raise error if value is in removed command."""
     new_command = COMMAND_MAP.get(value)
+    if not hasattr(action, "_prog_prefix"):
+        return
     prefix = action._prog_prefix.replace("airflow ", "")
+
     full_command = f"{prefix} {value}"
     if not new_command:
         new_command = COMMAND_MAP.get(full_command)

--- a/airflow/cli/commands/legacy_commands.py
+++ b/airflow/cli/commands/legacy_commands.py
@@ -26,7 +26,6 @@ COMMAND_MAP = {
     "show_dag": "dags show",
     "list_dag": "dags list",
     "dag_status": "dags status",
-    "backfill": "dags backfill",
     "list_dag_runs": "dags list-runs",
     "pause": "dags pause",
     "unpause": "dags unpause",
@@ -46,12 +45,17 @@ COMMAND_MAP = {
     "list_users": "users list",
     "create_user": "users create",
     "delete_user": "users delete",
+    "dags backfill": "backfill create",
 }
 
 
 def check_legacy_command(action, value):
     """Check command value and raise error if value is in removed command."""
     new_command = COMMAND_MAP.get(value)
+    prefix = action._prog_prefix.replace("airflow ", "")
+    full_command = f"{prefix} {value}"
+    if not new_command:
+        new_command = COMMAND_MAP.get(full_command)
     if new_command is not None:
-        msg = f"`airflow {value}` command, has been removed, please use `airflow {new_command}`"
+        msg = f"Command `{full_command}` has been removed. Please use `airflow {new_command}`"
         raise ArgumentError(action, msg)

--- a/tests/cli/commands/test_legacy_commands.py
+++ b/tests/cli/commands/test_legacy_commands.py
@@ -35,7 +35,7 @@ LEGACY_COMMANDS = [
     "show_dag",
     "list_dag",
     "dag_status",
-    "backfill",
+    "dags backfill",
     "list_dag_runs",
     "pause",
     "unpause",
@@ -69,8 +69,8 @@ class TestCliDeprecatedCommandsValue:
 
         assert 2 == ctx.value.code
         assert (
-            "`airflow worker` command, has been removed, "
-            "please use `airflow celery worker`, see help above." in temp_stderr.getvalue().strip()
+            "Command `airflow worker` has been removed. "
+            "Please use `airflow celery worker`" in temp_stderr.getvalue().strip()
         )
 
     def test_command_map(self):
@@ -78,10 +78,11 @@ class TestCliDeprecatedCommandsValue:
             assert COMMAND_MAP[item] is not None
 
     def test_check_legacy_command(self):
-        action = MagicMock()
-        with pytest.raises(ArgumentError) as ctx:
-            check_legacy_command(action, "list_users")
-        assert (
-            str(ctx.value)
-            == "argument : `airflow list_users` command, has been removed, please use `airflow users list`"
-        )
+        mock_action = MagicMock()
+        mock_action._prog_prefix = "airflow"
+        with pytest.raises(
+            ArgumentError,
+            match="argument : Command `airflow list_users` has been removed. "
+            "Please use `airflow users list`",
+        ):
+            check_legacy_command(mock_action, "list_users")


### PR DESCRIPTION
In 1.x there was an `airflow backfill` command.  In 2.x it became `airflow dags backfill`.

In 3.x it's back to `airflow backfill`.

Need to update the "yo, your command been moved" text.
