### PR TITLE
AIP-72: Add "Get Connection" endpoint for Execution API

### DIFF
--- a/airflow/api_fastapi/execution_api/routes/__init__.py
+++ b/airflow/api_fastapi/execution_api/routes/__init__.py
@@ -17,9 +17,11 @@
 from __future__ import annotations
 
 from airflow.api_fastapi.common.router import AirflowRouter
+from airflow.api_fastapi.execution_api.routes.connections import connection_router
 from airflow.api_fastapi.execution_api.routes.health import health_router
 from airflow.api_fastapi.execution_api.routes.task_instance import ti_router
 
 execution_api_router = AirflowRouter()
+execution_api_router.include_router(connection_router)
 execution_api_router.include_router(health_router)
 execution_api_router.include_router(ti_router)

--- a/airflow/api_fastapi/execution_api/routes/connections.py
+++ b/airflow/api_fastapi/execution_api/routes/connections.py
@@ -1,0 +1,88 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import Depends, HTTPException, status
+from typing_extensions import Annotated
+
+from airflow.api_fastapi.common.router import AirflowRouter
+from airflow.api_fastapi.execution_api import schemas
+from airflow.exceptions import AirflowNotFoundException
+from airflow.models.connection import Connection
+
+# TODO: Add dependency on JWT token
+connection_router = AirflowRouter(
+    prefix="/connection",
+    tags=["Connection"],
+    responses={status.HTTP_404_NOT_FOUND: {"description": "Connection not found"}},
+)
+
+log = logging.getLogger(__name__)
+
+
+def get_task_token() -> schemas.TIToken:
+    """TODO: Placeholder for task identity authentication. This should be replaced with actual JWT decoding and validation."""
+    return schemas.TIToken(ti_key="test_key")
+
+
+@connection_router.get(
+    "/{connection_id}",
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {"description": "Unauthorized"},
+        status.HTTP_403_FORBIDDEN: {"description": "Task does not have access to the connection"},
+    },
+)
+async def get_connection(
+    connection_id: str,
+    token: Annotated[schemas.TIToken, Depends(get_task_token)],
+) -> schemas.ConnectionResponse:
+    """Get an Airflow connection."""
+    if not has_connection_access(connection_id, token):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "reason": "access_denied",
+                "message": f"Task does not have access to connection {connection_id}",
+            },
+        )
+    try:
+        connection = Connection.get_connection_from_secrets(connection_id)
+    except AirflowNotFoundException:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            detail={
+                "reason": "not_found",
+                "message": f"Connection with ID {connection_id} not found",
+            },
+        )
+    return schemas.ConnectionResponse.model_validate(connection, from_attributes=True)
+
+
+def has_connection_access(connection_id: str, token: schemas.TIToken) -> bool:
+    """Check if the task has access to the connection."""
+    # TODO: Placeholder for actual implementation
+
+    ti_key = token.ti_key
+    log.debug(
+        "Checking access for task instance with key '%s' to connection '%s'",
+        ti_key,
+        connection_id,
+    )
+    return True

--- a/airflow/api_fastapi/execution_api/schemas.py
+++ b/airflow/api_fastapi/execution_api/schemas.py
@@ -119,3 +119,23 @@ class TIHeartbeatInfo(BaseModel):
 
     hostname: str
     pid: int
+
+
+class ConnectionResponse(BaseModel):
+    """Connection schema for responses with fields that are needed for Runtime."""
+
+    conn_id: str
+    conn_type: str
+    host: str | None
+    schema_: str | None = Field(alias="schema")
+    login: str | None
+    password: str | None
+    port: int | None
+    extra: str | None
+
+
+# TODO: This is a placeholder for Task Identity Token schema.
+class TIToken(BaseModel):
+    """Task Identity Token."""
+
+    ti_key: str

--- a/tests/api_fastapi/execution_api/routes/test_connection.py
+++ b/tests/api_fastapi/execution_api/routes/test_connection.py
@@ -1,0 +1,107 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from airflow.models.connection import Connection
+
+pytestmark = pytest.mark.db_test
+
+
+class TestGetConnection:
+    def test_connection_get_from_db(self, client, session):
+        connection = Connection(
+            conn_id="test_conn",
+            conn_type="http",
+            description="description",
+            host="localhost",
+            login="root",
+            password="admin",
+            schema="http",
+            port=8080,
+            extra='{"x_secret": "testsecret", "y_secret": "test"}',
+        )
+
+        session.add(connection)
+        session.commit()
+
+        response = client.get("/execution/connection/test_conn")
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "conn_id": "test_conn",
+            "conn_type": "http",
+            "host": "localhost",
+            "login": "root",
+            "password": "admin",
+            "schema": "http",
+            "port": 8080,
+            "extra": '{"x_secret": "testsecret", "y_secret": "test"}',
+        }
+
+        # Remove connection
+        session.delete(connection)
+        session.commit()
+
+    @mock.patch.dict(
+        "os.environ",
+        {"AIRFLOW_CONN_TEST_CONN2": '{"uri": "http://root:admin@localhost:8080/https?headers=header"}'},
+    )
+    def test_connection_get_from_env_var(self, client, session):
+        response = client.get("/execution/connection/test_conn2")
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "conn_id": "test_conn2",
+            "conn_type": "http",
+            "host": "localhost",
+            "login": "root",
+            "password": "admin",
+            "schema": "https",
+            "port": 8080,
+            "extra": '{"headers": "header"}',
+        }
+
+    def test_connection_get_not_found(self, client):
+        response = client.get("/execution/connection/non_existent_test_conn")
+
+        assert response.status_code == 404
+        assert response.json() == {
+            "detail": {
+                "message": "Connection with ID non_existent_test_conn not found",
+                "reason": "not_found",
+            }
+        }
+
+    def test_connection_get_access_denied(self, client):
+        with mock.patch(
+            "airflow.api_fastapi.execution_api.routes.connections.has_connection_access", return_value=False
+        ):
+            response = client.get("/execution/connection/test_conn")
+
+        # Assert response status code and detail for access denied
+        assert response.status_code == 403
+        assert response.json() == {
+            "detail": {
+                "reason": "access_denied",
+                "message": "Task does not have access to connection test_conn",
+            }
+        }


### PR DESCRIPTION
AIP doc: https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-72+Task+Execution+Interface+aka+Task+SDK
Part of https://github.com/orgs/apache/projects/405/views/1

This commit introduces a new endpoint, `/execution/connection/{connection_id}`, in the Execution API to retrieve connection details. 

### Changes:

This PR adds:
- `get_connection` endpoint to fetch connection details by `connection_id` from all secrets backend. For the deployments that don’t want to get conns from all secres backend — they could not set Secrets backend on API Server.. that way it falls back to DB.
- Placeholder function `get_task_token()` for token-based access control.
- Placeholder `check_connection_access` function to validate task permissions for each connection request.

### Access control
- Access to connections is determined by the `allowed_connections` attribute in the task token (currently mocked).
- Endpoint returns a 403 Forbidden status if the task does not have permission for the requested connection.
- Placeholder `get_task_token()` function simulates task authentication; future updates will include JWT-based authentication.

### Future Work
- Replace the placeholder `get_task_token()` with actual JWT-based authentication to dynamically determine task permissions. This would be done more holistically.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
