### PR TITLE
Workaround strange resolution bug in `uv` with opentelemetry downgrades

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1408,7 +1408,14 @@ COPY --from=scripts install_airflow.sh /scripts/docker/
 # force them on the main Airflow package. Currently we need no extra limits as PIP 23.1+ has much better
 # dependency resolution and we do not need to limit the versions of the dependencies
 #
-ARG EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS=""
+# Apparently `uv 0.4.30` has some strange resolution bug that results in inconsistent dependencies
+# in opentelemetry that are detected by `pip check` when we are running eager upgrade. This is
+# described in detail in https://github.com/astral-sh/uv/issues/8871 . Until the issue is diagnosed and
+# Solved, we workaround it by providing a hint to `uv` to use higher version of opentelemetry-proto than
+# it wants to downgrade to - for no apparent reason. Also it seems that it also triggers a weird
+# behaviour that when installing packages from `pypi` it tries to install `apache-beam` in version
+# 2.0.0 which fails to build. See https://github.com/apache/airflow/pull/43768#issuecomment-2461071604
+ARG EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS="opentelemetry-proto>=1.27.0 apache-beam>=2.60.0"
 ARG UPGRADE_INVALIDATION_STRING=""
 ARG VERSION_SUFFIX_FOR_PYPI=""
 


### PR DESCRIPTION
Apparently `uv 0.4.30` has some strange resolution bug that results in inconsistent dependencies in opentelemetry that are detected by `pip check` when we are running eager upgrade. This is described in detail in https://github.com/astral-sh/uv/issues/8871 . Until the issue is diagnosed and Solved, we workaround it by providing a hint to `uv` to use higher version of opentelemetry-proto than it wants to downgrade to - for no apparent reason.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
