### PR TITLE
Fix pickyness of google.auth 2.36.0 for mocks

### DIFF
--- a/providers/tests/google/common/hooks/test_base_google.py
+++ b/providers/tests/google/common/hooks/test_base_google.py
@@ -1022,6 +1022,7 @@ class TestGoogleBaseAsyncHook:
     async def test_get_token_impersonation(self, mock_auth_default, monkeypatch, requests_mock) -> None:
         mock_credentials = mock.MagicMock(spec=google.auth.compute_engine.Credentials)
         mock_credentials.token = "ACCESS_TOKEN"
+        mock_credentials.universe_domain = "googleapis.com"
         mock_auth_default.return_value = (mock_credentials, "PROJECT_ID")
         monkeypatch.setenv(
             "AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT",
@@ -1045,6 +1046,7 @@ class TestGoogleBaseAsyncHook:
     @mock.patch("google.auth.default")
     async def test_get_token_impersonation_conn(self, mock_auth_default, monkeypatch, requests_mock) -> None:
         mock_credentials = mock.MagicMock(spec=google.auth.compute_engine.Credentials)
+        mock_credentials.universe_domain = "googleapis.com"
         mock_auth_default.return_value = (mock_credentials, "PROJECT_ID")
         monkeypatch.setenv(
             "AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT",


### PR DESCRIPTION
Google-auth 2.36.0 is more picky about credentials being mocked. It expects the `universe_domain` attribute to be real string not mock because it passes it as argument of `replace` string method.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
