### PR TITLE
Update min version of Celery library to 5.5.0

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -353,7 +353,7 @@
   "celery": {
     "deps": [
       "apache-airflow>=2.9.0",
-      "celery[redis]>=5.4.0,<6",
+      "celery[redis]>=5.5.0,<6",
       "flower>=1.0.0"
     ],
     "devel-deps": [],

--- a/providers/celery/README.rst
+++ b/providers/celery/README.rst
@@ -54,7 +54,7 @@ Requirements
 PIP package         Version required
 ==================  ==================
 ``apache-airflow``  ``>=2.9.0``
-``celery[redis]``   ``>=5.4.0,<6``
+``celery[redis]``   ``>=5.5.0,<6``
 ``flower``          ``>=1.0.0``
 ==================  ==================
 

--- a/providers/celery/pyproject.toml
+++ b/providers/celery/pyproject.toml
@@ -61,7 +61,8 @@ dependencies = [
     # The Celery is known to introduce problems when upgraded to a MAJOR version. Airflow Core
     # Uses Celery for CeleryExecutor, and we also know that Kubernetes Python client follows SemVer
     # (https://docs.celeryq.dev/en/stable/contributing.html?highlight=semver#versions).
-    "celery[redis]>=5.4.0,<6",
+    # Updating min version to 5.5.0 to avoid redis import bug https://github.com/apache/airflow/issues/41359
+    "celery[redis]>=5.5.0,<6",
     "flower>=1.0.0",
 ]
 

--- a/providers/celery/src/airflow/providers/celery/get_provider_info.py
+++ b/providers/celery/src/airflow/providers/celery/get_provider_info.py
@@ -298,7 +298,7 @@ def get_provider_info():
                 },
             },
         },
-        "dependencies": ["apache-airflow>=2.9.0", "celery[redis]>=5.4.0,<6", "flower>=1.0.0"],
+        "dependencies": ["apache-airflow>=2.9.0", "celery[redis]>=5.5.0,<6", "flower>=1.0.0"],
         "optional-dependencies": {"cncf.kubernetes": ["apache-airflow-providers-cncf-kubernetes>=7.4.0"]},
         "devel-dependencies": [],
     }


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/41359
Closes: https://github.com/apache/airflow/issues/26542


I'm not sure if it fixes the problem described but it prevents other related bugs associated with the older versions

Celery 5.5.0 ~hasn't been released yet.~
https://pypi.org/project/celery/#history
~waiting for it~ has been released