### PR TITLE
fix(providers/common): fallback to DatasetDetails if ImportError encountered when importing AssetDetails

### DIFF
--- a/providers/src/airflow/providers/common/compat/assets/__init__.py
+++ b/providers/src/airflow/providers/common/compat/assets/__init__.py
@@ -33,6 +33,18 @@ if TYPE_CHECKING:
     from airflow.auth.managers.models.resource_details import AssetDetails
 else:
     try:
+        from airflow.auth.managers.models.resource_details import AssetDetails
+    except ModuleNotFoundError:
+        # 2.7.x
+        pass
+    except ImportError:
+        from packaging.version import Version
+
+        _IS_AIRFLOW_2_8_OR_HIGHER = Version(Version(AIRFLOW_VERSION).base_version) >= Version("2.8.0")
+        if _IS_AIRFLOW_2_8_OR_HIGHER:
+            from airflow.auth.managers.models.resource_details import DatasetDetails as AssetDetails
+
+    try:
         from airflow.assets import (
             Asset,
             AssetAlias,
@@ -41,19 +53,14 @@ else:
             AssetAny,
             expand_alias_to_assets,
         )
-        from airflow.auth.managers.models.resource_details import AssetDetails
     except ModuleNotFoundError:
         from packaging.version import Version
 
         _IS_AIRFLOW_2_10_OR_HIGHER = Version(Version(AIRFLOW_VERSION).base_version) >= Version("2.10.0")
         _IS_AIRFLOW_2_9_OR_HIGHER = Version(Version(AIRFLOW_VERSION).base_version) >= Version("2.9.0")
-        _IS_AIRFLOW_2_8_OR_HIGHER = Version(Version(AIRFLOW_VERSION).base_version) >= Version("2.8.0")
 
         # dataset is renamed to asset since Airflow 3.0
         from airflow.datasets import Dataset as Asset
-
-        if _IS_AIRFLOW_2_8_OR_HIGHER:
-            from airflow.auth.managers.models.resource_details import DatasetDetails as AssetDetails
 
         if _IS_AIRFLOW_2_9_OR_HIGHER:
             from airflow.datasets import (


### PR DESCRIPTION
## Why
`airflow.auth.managers.models.resource_details` exists after 2.8, trying to import `airflow.auth.managers.models.resource_details.AssetDetails` raises an `ImportError` instead of a `ModuleNotFoundError`

## What
Do not import if `ModuleNotFound` (2.7.x) is encountered and import DatasetDetails when `ImportError` is encountered (2.8 ⬆︎)

Related to https://github.com/apache/airflow/pull/43781

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
