### PR TITLE
Add global events page to browse along with support to display only events for the dag.

### DIFF
--- a/airflow/api_fastapi/common/parameters.py
+++ b/airflow/api_fastapi/common/parameters.py
@@ -177,13 +177,12 @@ class SortParam(BaseParam[str]):
     }
 
     def __init__(
-        self,
-        allowed_attrs: list[str],
-        model: Base,
+        self, allowed_attrs: list[str], model: Base, to_replace: dict[str, str] | None = None
     ) -> None:
         super().__init__()
         self.allowed_attrs = allowed_attrs
         self.model = model
+        self.to_replace = to_replace
 
     def to_orm(self, select: Select) -> Select:
         if self.skip_none is False:
@@ -193,6 +192,9 @@ class SortParam(BaseParam[str]):
             return select
 
         lstriped_orderby = self.value.lstrip("-")
+        if self.to_replace:
+            lstriped_orderby = self.to_replace.get(lstriped_orderby, lstriped_orderby)
+
         if self.allowed_attrs and lstriped_orderby not in self.allowed_attrs:
             raise HTTPException(
                 400,

--- a/airflow/api_fastapi/core_api/routes/public/event_logs.py
+++ b/airflow/api_fastapi/core_api/routes/public/event_logs.py
@@ -86,6 +86,7 @@ def get_event_logs(
                     "extra",
                 ],
                 Log,
+                to_replace={"when": "dttm", "event_log_id": "id"},
             ).dynamic_depends()
         ),
     ],

--- a/airflow/ui/src/layouts/Nav/BrowseButton.tsx
+++ b/airflow/ui/src/layouts/Nav/BrowseButton.tsx
@@ -1,0 +1,48 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Link } from "@chakra-ui/react";
+import { FiGlobe } from "react-icons/fi";
+
+import { Menu } from "src/components/ui";
+
+import { NavButton } from "./NavButton";
+
+const links = [
+  {
+    href: `/webapp/events`,
+    title: "Events",
+  },
+];
+
+export const BrowseButton = () => (
+  <Menu.Root positioning={{ placement: "right" }}>
+    <Menu.Trigger asChild>
+      <NavButton icon={<FiGlobe size="1.75rem" />} title="Browse" />
+    </Menu.Trigger>
+    <Menu.Content>
+      {links.map((link) => (
+        <Menu.Item asChild key={link.title} value={link.title}>
+          <Link aria-label={link.title} href={link.href}>
+            {link.title}
+          </Link>
+        </Menu.Item>
+      ))}
+    </Menu.Content>
+  </Menu.Root>
+);

--- a/airflow/ui/src/layouts/Nav/Nav.tsx
+++ b/airflow/ui/src/layouts/Nav/Nav.tsx
@@ -17,17 +17,12 @@
  * under the License.
  */
 import { Box, Flex, VStack } from "@chakra-ui/react";
-import {
-  FiCornerUpLeft,
-  FiDatabase,
-  FiGlobe,
-  FiHome,
-  FiSettings,
-} from "react-icons/fi";
+import { FiCornerUpLeft, FiDatabase, FiHome, FiSettings } from "react-icons/fi";
 
 import { AirflowPin } from "src/assets/AirflowPin";
 import { DagIcon } from "src/assets/DagIcon";
 
+import { BrowseButton } from "./BrowseButton";
 import { DocsButton } from "./DocsButton";
 import { NavButton } from "./NavButton";
 import { UserSettingsButton } from "./UserSettingsButton";
@@ -61,12 +56,7 @@ export const Nav = () => (
         title="Assets"
         to="assets"
       />
-      <NavButton
-        disabled
-        icon={<FiGlobe size="1.75rem" />}
-        title="Browse"
-        to="browse"
-      />
+      <BrowseButton />
       <NavButton
         disabled
         icon={<FiSettings size="1.75rem" />}

--- a/airflow/ui/src/pages/Events/Events.tsx
+++ b/airflow/ui/src/pages/Events/Events.tsx
@@ -1,0 +1,142 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box } from "@chakra-ui/react";
+import type { ColumnDef } from "@tanstack/react-table";
+import { useParams } from "react-router-dom";
+
+import { useEventLogServiceGetEventLogs } from "openapi/queries";
+import type { EventLogResponse } from "openapi/requests/types.gen";
+import { DataTable } from "src/components/DataTable";
+import { useTableURLState } from "src/components/DataTable/useTableUrlState";
+import { ErrorAlert } from "src/components/ErrorAlert";
+import Time from "src/components/Time";
+
+export const Events = () => {
+  const { dagId } = useParams();
+
+  const { setTableURLState, tableURLState } = useTableURLState({
+    sorting: [{ desc: true, id: "when" }],
+  });
+  const { pagination, sorting } = tableURLState;
+  const [sort] = sorting;
+
+  const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : undefined;
+
+  const {
+    data,
+    error: EventsError,
+    isFetching,
+    isLoading,
+  } = useEventLogServiceGetEventLogs({
+    dagId,
+    limit: pagination.pageSize,
+    offset: pagination.pageIndex * pagination.pageSize,
+    orderBy,
+  });
+
+  const columns: Array<ColumnDef<EventLogResponse>> = [
+    {
+      accessorKey: "when",
+      cell: ({ row: { original } }) => <Time datetime={original.when} />,
+      enableSorting: true,
+      header: "When",
+      meta: {
+        skeletonWidth: 10,
+      },
+    },
+    ...(Boolean(dagId)
+      ? []
+      : [
+          {
+            accessorKey: "dag_id",
+            enableSorting: true,
+            header: "Dag ID",
+            meta: {
+              skeletonWidth: 10,
+            },
+          },
+        ]),
+    {
+      accessorKey: "run_id",
+      enableSorting: true,
+      header: "Run ID",
+      meta: {
+        skeletonWidth: 10,
+      },
+    },
+    {
+      accessorKey: "task_id",
+      enableSorting: true,
+      header: "Task ID",
+      meta: {
+        skeletonWidth: 10,
+      },
+    },
+    {
+      accessorKey: "map_index",
+      enableSorting: false,
+      header: "Map Index",
+      meta: {
+        skeletonWidth: 10,
+      },
+    },
+    {
+      accessorKey: "try_number",
+      enableSorting: false,
+      header: "Try Number",
+      meta: {
+        skeletonWidth: 10,
+      },
+    },
+    {
+      accessorKey: "event",
+      enableSorting: true,
+      header: "Event",
+      meta: {
+        skeletonWidth: 10,
+      },
+    },
+    {
+      accessorKey: "owner",
+      enableSorting: true,
+      header: "User",
+      meta: {
+        skeletonWidth: 10,
+      },
+    },
+  ];
+
+  return (
+    <Box>
+      <ErrorAlert error={EventsError} />
+      <DataTable
+        columns={columns}
+        data={data ? data.event_logs : []}
+        displayMode="table"
+        initialState={tableURLState}
+        isFetching={isFetching}
+        isLoading={isLoading}
+        modelName="Events"
+        onStateChange={setTableURLState}
+        skeletonCount={undefined}
+        total={data ? data.total_entries : 0}
+      />
+    </Box>
+  );
+};

--- a/airflow/ui/src/pages/Events/Events.tsx
+++ b/airflow/ui/src/pages/Events/Events.tsx
@@ -27,9 +27,82 @@ import { useTableURLState } from "src/components/DataTable/useTableUrlState";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import Time from "src/components/Time";
 
+const eventsColumn = (
+  dagId: string | undefined,
+): Array<ColumnDef<EventLogResponse>> => [
+  {
+    accessorKey: "when",
+    cell: ({ row: { original } }) => <Time datetime={original.when} />,
+    enableSorting: true,
+    header: "When",
+    meta: {
+      skeletonWidth: 10,
+    },
+  },
+  ...(Boolean(dagId)
+    ? []
+    : [
+        {
+          accessorKey: "dag_id",
+          enableSorting: true,
+          header: "Dag ID",
+          meta: {
+            skeletonWidth: 10,
+          },
+        },
+      ]),
+  {
+    accessorKey: "run_id",
+    enableSorting: true,
+    header: "Run ID",
+    meta: {
+      skeletonWidth: 10,
+    },
+  },
+  {
+    accessorKey: "task_id",
+    enableSorting: true,
+    header: "Task ID",
+    meta: {
+      skeletonWidth: 10,
+    },
+  },
+  {
+    accessorKey: "map_index",
+    enableSorting: false,
+    header: "Map Index",
+    meta: {
+      skeletonWidth: 10,
+    },
+  },
+  {
+    accessorKey: "try_number",
+    enableSorting: false,
+    header: "Try Number",
+    meta: {
+      skeletonWidth: 10,
+    },
+  },
+  {
+    accessorKey: "event",
+    enableSorting: true,
+    header: "Event",
+    meta: {
+      skeletonWidth: 10,
+    },
+  },
+  {
+    accessorKey: "owner",
+    enableSorting: true,
+    header: "User",
+    meta: {
+      skeletonWidth: 10,
+    },
+  },
+];
+
 export const Events = () => {
   const { dagId } = useParams();
-
   const { setTableURLState, tableURLState } = useTableURLState({
     sorting: [{ desc: true, id: "when" }],
   });
@@ -50,89 +123,17 @@ export const Events = () => {
     orderBy,
   });
 
-  const columns: Array<ColumnDef<EventLogResponse>> = [
-    {
-      accessorKey: "when",
-      cell: ({ row: { original } }) => <Time datetime={original.when} />,
-      enableSorting: true,
-      header: "When",
-      meta: {
-        skeletonWidth: 10,
-      },
-    },
-    ...(Boolean(dagId)
-      ? []
-      : [
-          {
-            accessorKey: "dag_id",
-            enableSorting: true,
-            header: "Dag ID",
-            meta: {
-              skeletonWidth: 10,
-            },
-          },
-        ]),
-    {
-      accessorKey: "run_id",
-      enableSorting: true,
-      header: "Run ID",
-      meta: {
-        skeletonWidth: 10,
-      },
-    },
-    {
-      accessorKey: "task_id",
-      enableSorting: true,
-      header: "Task ID",
-      meta: {
-        skeletonWidth: 10,
-      },
-    },
-    {
-      accessorKey: "map_index",
-      enableSorting: false,
-      header: "Map Index",
-      meta: {
-        skeletonWidth: 10,
-      },
-    },
-    {
-      accessorKey: "try_number",
-      enableSorting: false,
-      header: "Try Number",
-      meta: {
-        skeletonWidth: 10,
-      },
-    },
-    {
-      accessorKey: "event",
-      enableSorting: true,
-      header: "Event",
-      meta: {
-        skeletonWidth: 10,
-      },
-    },
-    {
-      accessorKey: "owner",
-      enableSorting: true,
-      header: "User",
-      meta: {
-        skeletonWidth: 10,
-      },
-    },
-  ];
-
   return (
     <Box>
       <ErrorAlert error={EventsError} />
       <DataTable
-        columns={columns}
+        columns={eventsColumn(dagId)}
         data={data ? data.event_logs : []}
         displayMode="table"
         initialState={tableURLState}
         isFetching={isFetching}
         isLoading={isLoading}
-        modelName="Events"
+        modelName="Event"
         onStateChange={setTableURLState}
         skeletonCount={undefined}
         total={data ? data.total_entries : 0}

--- a/airflow/ui/src/pages/Events/index.tsx
+++ b/airflow/ui/src/pages/Events/index.tsx
@@ -1,0 +1,20 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export { Events } from "./Events";

--- a/airflow/ui/src/router.tsx
+++ b/airflow/ui/src/router.tsx
@@ -25,6 +25,7 @@ import { BaseLayout } from "./layouts/BaseLayout";
 import { Dag } from "./pages/DagsList/Dag";
 import { Code } from "./pages/DagsList/Dag/Code";
 import { ErrorPage } from "./pages/Error";
+import { Events } from "./pages/Events";
 
 export const router = createBrowserRouter(
   [
@@ -39,11 +40,15 @@ export const router = createBrowserRouter(
           path: "dags",
         },
         {
+          element: <Events />,
+          path: "events",
+        },
+        {
           children: [
             { element: <div>Overview</div>, path: "" },
             { element: <div>Runs</div>, path: "runs" },
             { element: <div>Tasks</div>, path: "tasks" },
-            { element: <div>Events</div>, path: "events" },
+            { element: <Events />, path: "events" },
             { element: <Code />, path: "code" },
           ],
           element: <Dag />,


### PR DESCRIPTION
This adds support to display all events under browse page. This also adds support to display events only related to the dag under events tab in dag details which is basically filter by dag_id in the API when dag_id is present in the URL. The events per dag skips dag_id column which is redundant.

Add support to filter by when, event_log_id which needs to be replaced in the backend before querying. This was done in the legacy API connexion code and the same support is added here https://github.com/apache/airflow/blob/e50206563001337befad7a8fe70e9c3df1a98fcc/airflow/api_connexion/endpoints/event_log_endpoint.py#L78

Notes for self and review : 

1. eslint fails with below error that `<Time />` cannot be constructed for `when` column but I have seen this pattern used elsewhere and also previously when dags list page only had timestamp for next/last dagrun as `<Time />`

> /home/karthikeyan/stuff/python/airflow/airflow/ui/src/pages/Events/Events.tsx
> 56:13  error  Do not define components during render. React will see a new component type on every render and destroy the entire subtree’s DOM nodes and state (https://reactjs.org/docs/reconciliation.html#elements-of-different-types). Instead, move this component definition out of the parent component “Events” and pass data as props. If you want to allow component creation in props, set allowAsProps option to true  react/no-unstable-nested-component

2. Legacy UI does sorting by `when` in descending manner by default to display latest events first. I have passed it to `useTableURLState` as default yet somehow this is not working.
3. When there are no events the page displays `No Eventss found` where Events has a double s which needs to be fixed.
4. extra column is usually a json and might need a followup PR in new UI to pretty display JSON like legacy UI.
5. The events table under the dag details tab on scroll pushes the column of the table up and needs to be fixed. This is not observed in the code page.

Related

#43704 
#43705 

Screenshots 

![image](https://github.com/user-attachments/assets/858621f1-58c5-4d71-997a-48b6950c5329)

![image](https://github.com/user-attachments/assets/4c2d1c63-eaf7-4ad8-83be-123a381d19cb)
