### PR TITLE
Move all scroll logic to page level

### DIFF
--- a/airflow/ui/dev/index.html
+++ b/airflow/ui/dev/index.html
@@ -1,6 +1,6 @@
 <!-- Entry html file when the Vite dev server is running -->
 <!doctype html>
-<html lang="en">
+<html lang="en" style="height: 100%">
   <head>
     <meta charset="UTF-8" />
     <link
@@ -20,8 +20,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Airflow 3.0</title>
   </head>
-  <body>
-    <div id="root"></div>
+  <body style="height: 100%">
+    <div id="root" style="height: 100%"></div>
     <script type="module" src="http://localhost:5173/src/main.tsx"></script>
   </body>
 </html>

--- a/airflow/ui/index.html
+++ b/airflow/ui/index.html
@@ -1,13 +1,13 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" style="height: 100%">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/pin_32.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Airflow 3.0</title>
   </head>
-  <body>
-    <div id="root"></div>
+  <body style="height: 100%">
+    <div id="root" style="height: 100%"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/airflow/ui/src/components/DataTable/CardList.tsx
+++ b/airflow/ui/src/components/DataTable/CardList.tsx
@@ -32,23 +32,23 @@ export const CardList = <TData,>({
   isLoading,
   table,
 }: DataTableProps<TData>) => (
-  <Box data-testid="card-list" overflow="auto" width="100%">
-    <SimpleGrid {...{ column: { base: 1 }, gap: 2, ...cardDef.gridProps }}>
-      {table.getRowModel().rows.map((row) => (
-        <Box key={row.id}>
-          {Boolean(isLoading) &&
-            (cardDef.meta?.customSkeleton ?? (
-              <Skeleton
-                data-testid="skeleton"
-                display="inline-block"
-                height={80}
-                width="100%"
-              />
-            ))}
-          {!Boolean(isLoading) &&
-            flexRender(cardDef.card, { row: row.original })}
-        </Box>
-      ))}
-    </SimpleGrid>
-  </Box>
+  <SimpleGrid
+    data-testid="card-list"
+    {...{ column: { base: 1 }, gap: 2, ...cardDef.gridProps }}
+  >
+    {table.getRowModel().rows.map((row) => (
+      <Box key={row.id}>
+        {Boolean(isLoading) &&
+          (cardDef.meta?.customSkeleton ?? (
+            <Skeleton
+              data-testid="skeleton"
+              display="inline-block"
+              height={80}
+              width="100%"
+            />
+          ))}
+        {!Boolean(isLoading) && flexRender(cardDef.card, { row: row.original })}
+      </Box>
+    ))}
+  </SimpleGrid>
 );

--- a/airflow/ui/src/components/DataTable/TableList.tsx
+++ b/airflow/ui/src/components/DataTable/TableList.tsx
@@ -40,12 +40,7 @@ export const TableList = <TData,>({
   renderSubComponent,
   table,
 }: DataTableProps<TData>) => (
-  <Table.Root
-    data-testid="table-list"
-    maxH="calc(100vh - 10rem)"
-    overflowY="auto"
-    striped
-  >
+  <Table.Root data-testid="table-list" striped>
     <Table.Header bg="chakra-body-bg" position="sticky" top={0} zIndex={1}>
       {table.getHeaderGroups().map((headerGroup) => (
         <Table.Row key={headerGroup.id}>

--- a/airflow/ui/src/layouts/BaseLayout.tsx
+++ b/airflow/ui/src/layouts/BaseLayout.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box } from "@chakra-ui/react";
+import { Flex } from "@chakra-ui/react";
 import type { PropsWithChildren } from "react";
 import { Outlet } from "react-router-dom";
 
@@ -25,8 +25,8 @@ import { Nav } from "./Nav";
 export const BaseLayout = ({ children }: PropsWithChildren) => (
   <>
     <Nav />
-    <Box ml={20} p={3}>
+    <Flex flexFlow="column" height="100%" ml={20} p={3}>
       {children ?? <Outlet />}
-    </Box>
+    </Flex>
   </>
 );

--- a/airflow/ui/src/pages/DagsList/Dag/Dag.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Dag.tsx
@@ -68,7 +68,7 @@ export const Dag = () => {
 
   return (
     <>
-      <Box bg="bg" position="sticky" top={0} zIndex={1}>
+      <Box>
         <Button asChild colorPalette="blue" variant="ghost">
           <RouterLink to="/dags">
             <FiChevronsLeft />
@@ -96,7 +96,9 @@ export const Dag = () => {
           </Tabs.List>
         </Tabs.Root>
       </Box>
-      <Outlet />
+      <Box overflow="auto">
+        <Outlet />
+      </Box>
     </>
   );
 };

--- a/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -24,6 +24,7 @@ import {
   Link,
   createListCollection,
   type SelectValueChangeDetails,
+  Box,
 } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
 import { type ChangeEvent, useCallback, useState } from "react";
@@ -252,20 +253,22 @@ export const DagsList = () => {
         </HStack>
       </VStack>
       <ToggleTableDisplay display={display} setDisplay={setDisplay} />
-      <DataTable
-        cardDef={cardDef}
-        columns={columns}
-        data={data.dags}
-        displayMode={display}
-        errorMessage={<ErrorAlert error={error} />}
-        initialState={tableURLState}
-        isFetching={isFetching}
-        isLoading={isLoading}
-        modelName="Dag"
-        onStateChange={setTableURLState}
-        skeletonCount={display === "card" ? 5 : undefined}
-        total={data.total_entries}
-      />
+      <Box overflow="auto">
+        <DataTable
+          cardDef={cardDef}
+          columns={columns}
+          data={data.dags}
+          displayMode={display}
+          errorMessage={<ErrorAlert error={error} />}
+          initialState={tableURLState}
+          isFetching={isFetching}
+          isLoading={isLoading}
+          modelName="Dag"
+          onStateChange={setTableURLState}
+          skeletonCount={display === "card" ? 5 : undefined}
+          total={data.total_entries}
+        />
+      </Box>
     </>
   );
 };


### PR DESCRIPTION
Problem: We were not consistent with how scrolling worked. Which led to zIndex and position issues. Scrolling could happen on the webpage but also inside of individual components.

Solution:
Move scroll logic to the page level. In this case on the DagsList and Dag components

![code](https://github.com/user-attachments/assets/c9a42168-af13-4176-8343-28c27a7b1248)
![card](https://github.com/user-attachments/assets/cd13c728-3218-4920-b71f-7e678f4fa7bb)
![table](https://github.com/user-attachments/assets/07904e24-2293-4af3-b77f-0486fba32f07)


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
