### PR TITLE
Make sure a default sort is persisted through tableUrlState

### DIFF
--- a/airflow/ui/src/components/DataTable/searchParams.test.ts
+++ b/airflow/ui/src/components/DataTable/searchParams.test.ts
@@ -37,6 +37,7 @@ describe("searchParams", () => {
       );
     });
   });
+
   describe("searchParamsToState", () => {
     it("can parse search params back to table state", () => {
       expect(
@@ -59,6 +60,24 @@ describe("searchParams", () => {
           { desc: false, id: "name" },
           { desc: true, id: "age" },
         ],
+      });
+    });
+
+    it("uses default sort correctly", () => {
+      expect(
+        searchParamsToState(new URLSearchParams("limit=20&offset=0"), {
+          pagination: {
+            pageIndex: 1,
+            pageSize: 5,
+          },
+          sorting: [{ desc: true, id: "when" }],
+        }),
+      ).toEqual({
+        pagination: {
+          pageIndex: 0,
+          pageSize: 20,
+        },
+        sorting: [{ desc: true, id: "when" }],
       });
     });
   });

--- a/airflow/ui/src/components/DataTable/searchParams.ts
+++ b/airflow/ui/src/components/DataTable/searchParams.ts
@@ -94,7 +94,9 @@ export const searchParamsToState = (
     id: sort.replace("-", ""),
   }));
 
-  urlState = { ...urlState, sorting };
+  if (sorting.length) {
+    urlState = { ...urlState, sorting };
+  }
 
   return { ...defaultState, ...urlState };
 };


### PR DESCRIPTION
In https://github.com/apache/airflow/pull/43793 the osrt passed in the defaultState wasn't actually being persisted.

We missed an if statement of when to decide to use the url params or the defaultState. Also, I added a test to catch that bug.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
