### PR TITLE
Fix PostgresHook bug when getting AWS Redshift Serverless credentials

### DIFF
--- a/providers/src/airflow/providers/postgres/hooks/postgres.py
+++ b/providers/src/airflow/providers/postgres/hooks/postgres.py
@@ -293,8 +293,8 @@ class PostgresHook(DbApiHook):
                 dbName=self.database or conn.schema,
                 workgroupName=workgroup_name,
             )
-            token = cluster_creds["DbPassword"]
-            login = cluster_creds["DbUser"]
+            token = cluster_creds["dbPassword"]
+            login = cluster_creds["dbUser"]
         else:
             port = conn.port or 5432
             rds_client = AwsBaseHook(aws_conn_id=aws_conn_id, client_type="rds").conn

--- a/providers/tests/postgres/hooks/test_postgres.py
+++ b/providers/tests/postgres/hooks/test_postgres.py
@@ -274,8 +274,8 @@ class TestPostgresHookConn:
         }
         if aws_conn_id is not NOTSET:
             mock_conn_extra["aws_conn_id"] = aws_conn_id
-        if conn_workgroup_name is not NOTSET:  # change to workgroup
-            mock_conn_extra["workgroup-name"] = conn_workgroup_name  # change to workgroup
+        if conn_workgroup_name is not NOTSET:
+            mock_conn_extra["workgroup-name"] = conn_workgroup_name
 
         self.connection.extra = json.dumps(mock_conn_extra)
         self.connection.host = host
@@ -287,8 +287,8 @@ class TestPostgresHookConn:
         mock_aws_hook_instance = mock_aws_hook_class.return_value
         mock_client = mock.MagicMock()
         mock_client.get_credentials.return_value = {
-            "DbPassword": mock_db_pass,
-            "DbUser": mock_db_user,
+            "dbPassword": mock_db_pass,
+            "dbUser": mock_db_user,
         }
         type(mock_aws_hook_instance).conn = mock.PropertyMock(return_value=mock_client)
 


### PR DESCRIPTION
#43669 used the wrong keys for retrieving user and password from the boto3 redshift-serverless client response, leading to `KeyError` exceptions. This change uses the correct camel-cased `dbUser` and `dbPassword` keys; the boto3 redshift client response returns the Pascal-cased `DbUser` and `DbPassword` and these were mistakenly copied into the serverless code block (and the associated test code).

Unfortunately moto does not yet support redshift-serverless, which might have caught this bug in the first PR.

related: #43669 
