### PR TITLE
Remove hatch as devel-devscript dependency

### DIFF
--- a/dev/sign.sh
+++ b/dev/sign.sh
@@ -17,7 +17,7 @@
 # under the License.
 set -euo pipefail
 
-# Use this to sign the tar balls generated via hatch
+# Use this to sign the tarballs and packages generated
 # you will still be required to type in your signing key password
 # or it needs to be available in your keychain
 

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -194,7 +194,6 @@ DEVEL_EXTRAS: dict[str, list[str]] = {
     "devel-devscripts": [
         "click>=8.0",
         "gitpython>=3.1.40",
-        "hatch>=1.9.1",
         "incremental>=24.7.2",
         "pipdeptree>=2.13.1",
         "pygithub>=2.1.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,37 +155,6 @@ Homepage = "https://airflow.apache.org/"
 Twitter = "https://twitter.com/ApacheAirflow"
 YouTube = "https://www.youtube.com/channel/UCSXwxpWZQ7XZ1WL3wqevChA/"
 
-[tool.hatch.envs.default]
-python = "3.9"
-platforms = ["linux", "macos"]
-description = "Default environment with Python 3.9 for maximum compatibility"
-features = []
-
-[tool.hatch.envs.airflow-39]
-python = "3.9"
-platforms = ["linux", "macos"]
-description = "Environment with Python 3.9. No devel installed."
-features = []
-
-[tool.hatch.envs.airflow-310]
-python = "3.10"
-platforms = ["linux", "macos"]
-description = "Environment with Python 3.10. No devel installed."
-features = []
-
-[tool.hatch.envs.airflow-311]
-python = "3.11"
-platforms = ["linux", "macos"]
-description = "Environment with Python 3.11. No devel installed"
-features = []
-
-[tool.hatch.envs.airflow-312]
-python = "3.12"
-platforms = ["linux", "macos"]
-description = "Environment with Python 3.12. No devel installed"
-features = []
-
-
 [tool.hatch.version]
 path = "airflow/__init__.py"
 
@@ -211,7 +180,6 @@ artifacts = [
     "/airflow/git_version",
     "/generated/",
 ]
-
 
 [tool.hatch.build.targets.wheel]
 include = [


### PR DESCRIPTION
We do not recommend hatch any more as development tool and none of our scripts expect hatch to be installed, also our pyproject.toml should not need hatch environment definition.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
