### PR TITLE
Ensure lifespans of mounted FastAPI sub-apps are called

### DIFF
--- a/airflow/api_fastapi/execution_api/app.py
+++ b/airflow/api_fastapi/execution_api/app.py
@@ -17,7 +17,16 @@
 
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Context manager for the lifespan of the FastAPI app. For now does nothing."""
+    app.state.lifespan_called = True
+    yield
 
 
 def create_task_execution_api_app(app: FastAPI) -> FastAPI:
@@ -28,6 +37,7 @@ def create_task_execution_api_app(app: FastAPI) -> FastAPI:
     task_exec_api_app = FastAPI(
         title="Airflow Task Execution API",
         description="The private Airflow Task Execution API.",
+        lifespan=lifespan,
     )
 
     task_exec_api_app.include_router(execution_api_router)

--- a/tests/api_fastapi/test_app.py
+++ b/tests/api_fastapi/test_app.py
@@ -19,6 +19,15 @@ from __future__ import annotations
 from unittest import mock
 
 
+def test_main_app_lifespan(client):
+    with client() as test_client:
+        test_app = test_client.app
+
+        # assert the app was created and lifespan was called
+        assert test_app
+        assert test_app.state.lifespan_called, "Lifespan not called on Execution API app."
+
+
 @mock.patch("airflow.api_fastapi.app.init_dag_bag")
 @mock.patch("airflow.api_fastapi.app.init_views")
 @mock.patch("airflow.api_fastapi.app.init_plugins")
@@ -53,6 +62,16 @@ def test_execution_api_app(
     mock_init_dag_bag.assert_not_called()
     mock_init_views.assert_not_called()
     mock_init_plugins.assert_not_called()
+
+
+def test_execution_api_app_lifespan(client):
+    with client(apps="execution") as test_client:
+        test_app = test_client.app
+
+        # assert the execution app was created and lifespan was called
+        execution_app = [route.app for route in test_app.router.routes if route.path == "/execution"]
+        assert execution_app, "Execution API app not found in FastAPI app."
+        assert execution_app[0].state.lifespan_called, "Lifespan not called on Execution API app."
 
 
 @mock.patch("airflow.api_fastapi.app.init_dag_bag")


### PR DESCRIPTION
FastAPI does not run Starlette lifespan events in mounted sub-applications by default (see [docs](https://fastapi.tiangolo.com/advanced/events/#sub-applications)), so we use the suggestion in [this issue](https://github.com/fastapi/fastapi/issues/811#issuecomment-1870030103) to run all mounted sub-application lifespans using an async context manager stack.

To ensure that lifespan events are run in the TestApp we use a context manager for the test_app as outlined [here](https://www.starlette.io/lifespan/#running-lifespan-in-tests). To allow assertions about the lifespans we add a simple boolean variable to application state to indicate the lifespan has been run.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
