### PR TITLE
Fix EdgeExecutor breeze call

### DIFF
--- a/dev/breeze/src/airflow_breeze/params/shell_params.py
+++ b/dev/breeze/src/airflow_breeze/params/shell_params.py
@@ -497,6 +497,9 @@ class ShellParams:
         _set_var(_env, "AIRFLOW__CELERY__BROKER_URL", self.airflow_celery_broker_url)
         _set_var(_env, "AIRFLOW__CORE__EXECUTOR", self.executor)
         if self.executor == EDGE_EXECUTOR:
+            _set_var(
+                _env, "AIRFLOW__CORE__EXECUTOR", "airflow.providers.edge.executors.edge_executor.EdgeExecutor"
+            )
             _set_var(_env, "AIRFLOW__EDGE__API_ENABLED", "true")
             _set_var(_env, "AIRFLOW__EDGE__API_URL", "http://localhost:8080/edge_worker/v1/rpcapi")
         _set_var(_env, "ANSWER", get_forced_answer() or "")


### PR DESCRIPTION
During development of EdgeExecutor I noticed to to rework to merge, local run via breeze was broken.

If you start breeze via 
```
breeze start-airflow --python 3.12 --load-example-dags --backend postgres --executor EdgeExecutor
```
...the executor can not be loaded because dottet mapping is missing
...but if you add the dottet mapping, breeze does not accept the executor name.

This 3 lines add the mapping to the call for shell params in beeeze