### PR TITLE
Allow null for end_date to fetch dags in running state without end_date.

### DIFF
--- a/tests/api_fastapi/core_api/routes/ui/test_dashboard.py
+++ b/tests/api_fastapi/core_api/routes/ui/test_dashboard.py
@@ -132,12 +132,12 @@ class TestHistoricalMetricsDataEndpoint:
         response = test_client.get("/ui/dashboard/historical_metrics_data", params=params)
         assert response.status_code == 200
         assert response.json() == {
-            "dag_run_states": {"failed": 1, "queued": 0, "running": 0, "success": 0},
+            "dag_run_states": {"failed": 1, "queued": 0, "running": 1, "success": 0},
             "dag_run_types": {"backfill": 0, "asset_triggered": 1, "manual": 0, "scheduled": 0},
             "task_instance_states": {
                 "deferred": 0,
                 "failed": 2,
-                "no_status": 0,
+                "no_status": 2,
                 "queued": 0,
                 "removed": 0,
                 "restarting": 0,


### PR DESCRIPTION
While working on https://github.com/apache/airflow/issues/42700 I found that dagruns in running state without `end_date` are not returned even with current time sent as `end_date`. It seems that in the query `end_date` on being null uses `timezone.utcnow()` which will have a value greater than the frontend `end_date` value due to HTTP latency in the order of milliseconds to seconds thus never returning running dagruns and task instances associated with the corresponding dagrun. It's okay to allow dagruns with a start_date and no end_date which usually means they are in running state. Please correct me if I am missing any scenario regarding this.

https://github.com/apache/airflow/blob/340a70bfe7289e01898ddd75f8edfaf7772e9d09/airflow/api_fastapi/core_api/routes/ui/dashboard.py#L56-L58

cc: @bugraoz93 for https://github.com/apache/airflow/pull/42629