### PR TITLE
Add random_name_suffix to SparkKubernetesOperator (#43800)

### DIFF
--- a/providers/src/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
+++ b/providers/src/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
@@ -68,6 +68,7 @@ class SparkKubernetesOperator(KubernetesPodOperator):
         state, or the execution is interrupted. If True (default), delete the
         pod; if False, leave the pod.
     :param kubernetes_conn_id: the connection to Kubernetes cluster
+    :param random_name_suffix: If True, adds a random suffix to the pod name
     """
 
     template_fields = ["application_file", "namespace", "template_spec", "kubernetes_conn_id"]
@@ -94,6 +95,7 @@ class SparkKubernetesOperator(KubernetesPodOperator):
         reattach_on_restart: bool = True,
         delete_on_termination: bool = True,
         kubernetes_conn_id: str = "kubernetes_default",
+        random_name_suffix: bool = True,
         **kwargs,
     ) -> None:
         if kwargs.get("xcom_push") is not None:
@@ -112,6 +114,7 @@ class SparkKubernetesOperator(KubernetesPodOperator):
         self.get_logs = get_logs
         self.log_events_on_failure = log_events_on_failure
         self.success_run_history_limit = success_run_history_limit
+        self.random_name_suffix = random_name_suffix
 
         if self.base_container_name != self.BASE_CONTAINER_NAME:
             self.log.warning(
@@ -164,7 +167,11 @@ class SparkKubernetesOperator(KubernetesPodOperator):
             self.name or self.template_body.get("spark", {}).get("metadata", {}).get("name") or self.task_id
         )
 
-        updated_name = add_unique_suffix(name=name, max_len=MAX_LABEL_LEN)
+        if self.random_name_suffix:
+            updated_name = add_unique_suffix(name=name, max_len=MAX_LABEL_LEN)
+        else:
+            # truncation is required to maintain the same behavior as before
+            updated_name = name[:MAX_LABEL_LEN]
 
         return self._set_name(updated_name)
 

--- a/providers/tests/cncf/kubernetes/operators/test_spark_kubernetes.py
+++ b/providers/tests/cncf/kubernetes/operators/test_spark_kubernetes.py
@@ -837,12 +837,13 @@ def test_resolve_application_file_real_file_not_exists(create_task_instance_of_o
     [pytest.param(True, id="use-random_name_suffix"), pytest.param(False, id="skip-random_name_suffix")],
 )
 def test_create_job_name(random_name_suffix: bool):
-    name = f"{uuid4()}"
+    name = f"x{uuid4()}"
     op = SparkKubernetesOperator(task_id="task_id", name=name, random_name_suffix=random_name_suffix)
     pod_name = op.create_job_name()
 
     if random_name_suffix:
         assert pod_name.startswith(name)
+        assert pod_name != name
     else:
         assert pod_name == name
 


### PR DESCRIPTION
Prior to this change, `random_name_suffix` was only documented but not implemented as a configurable option. Passing this value as an argument had no effect. This commit introduces a `false` option for `random_name_suffix`, which prevents the generation of a random suffix for the pod name. For compatibility, the default value is set to `true`, ensuring the pod name will still conform to `MAX_LABEL_LEN = 63`.

Fixes: #43800 