### PR TITLE
fix: replace \s with space

### DIFF
--- a/providers/pyproject.toml
+++ b/providers/pyproject.toml
@@ -56,9 +56,6 @@ extend-exclude = [
 # Ignore Doc rules et al for anything outside of tests
 "!src/*" = ["D", "TID253", "S101", "TRY002"]
 
-# https://github.com/apache/airflow/issues/39252
-"src/airflow/providers/amazon/aws/hooks/eks.py" = ["W605"]
-
 # All of the modules which have an extra license header (i.e. that we copy from another project) need to
 # ignore E402 -- module level import not at top level
 "tests/amazon/aws/auth_manager/security_manager/test_aws_security_manager_override.py" = ["E402"]
@@ -93,6 +90,3 @@ extend-exclude = [
 "tests/qdrant/operators/test_qdrant.py" = ["E402"]
 "tests/snowflake/operators/test_snowflake_sql.py" = ["E402"]
 "tests/yandex/**/*.py" = ["E402"]
-
-# https://github.com/apache/airflow/issues/39252
-"airflow/providers/amazon/aws/hooks/eks.py" = ["W605"]

--- a/providers/src/airflow/providers/amazon/aws/hooks/eks.py
+++ b/providers/src/airflow/providers/amazon/aws/hooks/eks.py
@@ -85,8 +85,8 @@ COMMAND = """
                 exit 1
             fi
 
-            expiration_timestamp=$(echo "$output" | grep -oP 'expirationTimestamp:\s*\K[^,]+')
-            token=$(echo "$output" | grep -oP 'token:\s*\K[^,]+')
+            expiration_timestamp=$(echo "$output" | grep -oP 'expirationTimestamp: \\K[^,]+')
+            token=$(echo "$output" | grep -oP 'token: \\K[^,]+')
 
             json_string=$(printf '{{"kind": "ExecCredential","apiVersion": \
                 "client.authentication.k8s.io/v1alpha1","spec": {{}},"status": \


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #39252
related: #39428, #38734, #38864

Remove deprecated "\s" with " " (single space). This is okay because output is from running [eks_get_token.py](./providers/src/airflow/providers/amazon/aws/utils/eks_get_token.py), which we know is just a sinlge space. Extra backslash is from running ruff.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
