### PR TITLE
Correct provider path details in docs

### DIFF
--- a/providers/src/airflow/providers/MANAGING_PROVIDERS_LIFECYCLE.rst
+++ b/providers/src/airflow/providers/MANAGING_PROVIDERS_LIFECYCLE.rst
@@ -60,54 +60,54 @@ triggers (and the list changes continuously).
 
   .. code-block:: bash
 
-    └── airflow/
-        ├── providers/
-        │   ├── src/
-        │   │   └── airflow/
-        │   │       └── providers/<NEW_PROVIDER>/
-        │   │           ├── __init__.py
-        │   │           ├── executors/
-        │   │           │   ├── __init__.py
-        │   │           │   └── *.py
-        │   │           ├── hooks/
-        │   │           │   ├── __init__.py
-        │   │           │   └── *.py
-        │   │           ├── notifications/
-        │   │           │   ├── __init__.py
-        │   │           │   └── *.py
-        │   │           ├── operators/
-        │   │           │   ├── __init__.py
-        │   │           │   └── *.py
-        │   │           ├── transfers/
-        │   │           │   ├── __init__.py
-        │   │           │   └── *.py
-        │   │           └── triggers/
-        │   │               ├── __init__.py
-        │   │               └── *.py
-        │   └── tests/
-        │       └── providers/<NEW_PROVIDER>/
-        │           ├── __init__.py
-        │           ├── executors/
-        │           │   ├── __init__.py
-        │           │   └── test_*.py
-        │           ├── hooks/
-        │           │   ├── __init__.py
-        │           │   └── test_*.py
-        │           ├── notifications/
-        │           │   ├── __init__.py
-        │           │   └── test_*.py
-        │           ├── operators/
-        │           │   ├── __init__.py
-        │           │   └── test_*.py
-        │           ├── transfers/
-        │           │   ├── __init__.py
-        │           │   └── test_*.py
-        │           └── triggers/
-        │               ├── __init__.py
-        │               └── test_*.py
-        └── tests/system/providers/<NEW_PROVIDER>/
-            ├── __init__.py
-            └── example_*.py
+    GIT apache/airflow/
+    ├── providers/
+    │   ├── src/
+    │   │   └── airflow/
+    │   │       └── providers/<NEW_PROVIDER>/
+    │   │           ├── __init__.py
+    │   │           ├── executors/
+    │   │           │   ├── __init__.py
+    │   │           │   └── *.py
+    │   │           ├── hooks/
+    │   │           │   ├── __init__.py
+    │   │           │   └── *.py
+    │   │           ├── notifications/
+    │   │           │   ├── __init__.py
+    │   │           │   └── *.py
+    │   │           ├── operators/
+    │   │           │   ├── __init__.py
+    │   │           │   └── *.py
+    │   │           ├── transfers/
+    │   │           │   ├── __init__.py
+    │   │           │   └── *.py
+    │   │           └── triggers/
+    │   │               ├── __init__.py
+    │   │               └── *.py
+    │   └── tests/
+    │       └── providers/<NEW_PROVIDER>/
+    │           ├── __init__.py
+    │           ├── executors/
+    │           │   ├── __init__.py
+    │           │   └── test_*.py
+    │           ├── hooks/
+    │           │   ├── __init__.py
+    │           │   └── test_*.py
+    │           ├── notifications/
+    │           │   ├── __init__.py
+    │           │   └── test_*.py
+    │           ├── operators/
+    │           │   ├── __init__.py
+    │           │   └── test_*.py
+    │           ├── transfers/
+    │           │   ├── __init__.py
+    │           │   └── test_*.py
+    │           └── triggers/
+    │               ├── __init__.py
+    │               └── test_*.py
+    └── tests/system/providers/<NEW_PROVIDER>/
+        ├── __init__.py
+        └── example_*.py
 
 .. note::
       The above structure is work in progress and subject to change till Task SDK feature is complete.
@@ -217,11 +217,10 @@ by ``breeze release-management`` command by release manager when providers are r
   .. code-block:: bash
 
      ├── pyproject.toml
-     ├── airflow/
-     │   └── providers/
-     │       └── <NEW_PROVIDER>/
-     │           ├── provider.yaml
-     │           └── CHANGELOG.rst
+     ├── providers/src/airflow/providers/
+     │   └── <NEW_PROVIDER>/
+     │       ├── provider.yaml
+     │       └── CHANGELOG.rst
      │
      └── docs/
          ├── apache-airflow/
@@ -266,7 +265,7 @@ Operator has extra-parameters.
       The NewProviderOperator requires a ``connection_id`` and this other awesome parameter.
       You can see an example below:
 
-      .. exampleinclude:: /../../airflow/providers/<NEW_PROVIDER>/example_dags/example_<NEW_PROVIDER>.py
+      .. exampleinclude:: /../../providers/src/airflow/providers/<NEW_PROVIDER>/example_dags/example_<NEW_PROVIDER>.py
           :language: python
           :start-after: [START howto_operator_<NEW_PROVIDER>]
           :end-before: [END howto_operator_<NEW_PROVIDER>]
@@ -286,7 +285,7 @@ At least those docs should be present
 
 Make sure to update/add all information that are specific for the new provider.
 
-In the ``airflow/providers/<NEW_PROVIDER>/provider.yaml`` add information of your provider:
+In the ``providers/src/airflow/providers/<NEW_PROVIDER>/provider.yaml`` add information of your provider:
 
   .. code-block:: yaml
 

--- a/providers/src/airflow/providers/MANAGING_PROVIDERS_LIFECYCLE.rst
+++ b/providers/src/airflow/providers/MANAGING_PROVIDERS_LIFECYCLE.rst
@@ -61,53 +61,53 @@ triggers (and the list changes continuously).
   .. code-block:: bash
 
     GIT apache/airflow/
-    ├── providers/
-    │   ├── src/
-    │   │   └── airflow/
-    │   │       └── providers/<NEW_PROVIDER>/
-    │   │           ├── __init__.py
-    │   │           ├── executors/
-    │   │           │   ├── __init__.py
-    │   │           │   └── *.py
-    │   │           ├── hooks/
-    │   │           │   ├── __init__.py
-    │   │           │   └── *.py
-    │   │           ├── notifications/
-    │   │           │   ├── __init__.py
-    │   │           │   └── *.py
-    │   │           ├── operators/
-    │   │           │   ├── __init__.py
-    │   │           │   └── *.py
-    │   │           ├── transfers/
-    │   │           │   ├── __init__.py
-    │   │           │   └── *.py
-    │   │           └── triggers/
-    │   │               ├── __init__.py
-    │   │               └── *.py
-    │   └── tests/
-    │       └── providers/<NEW_PROVIDER>/
-    │           ├── __init__.py
-    │           ├── executors/
-    │           │   ├── __init__.py
-    │           │   └── test_*.py
-    │           ├── hooks/
-    │           │   ├── __init__.py
-    │           │   └── test_*.py
-    │           ├── notifications/
-    │           │   ├── __init__.py
-    │           │   └── test_*.py
-    │           ├── operators/
-    │           │   ├── __init__.py
-    │           │   └── test_*.py
-    │           ├── transfers/
-    │           │   ├── __init__.py
-    │           │   └── test_*.py
-    │           └── triggers/
-    │               ├── __init__.py
-    │               └── test_*.py
-    └── tests/system/providers/<NEW_PROVIDER>/
-        ├── __init__.py
-        └── example_*.py
+    └── providers/
+        ├── src/
+        │   └── airflow/
+        │       └── providers/<NEW_PROVIDER>/
+        │           ├── __init__.py
+        │           ├── executors/
+        │           │   ├── __init__.py
+        │           │   └── *.py
+        │           ├── hooks/
+        │           │   ├── __init__.py
+        │           │   └── *.py
+        │           ├── notifications/
+        │           │   ├── __init__.py
+        │           │   └── *.py
+        │           ├── operators/
+        │           │   ├── __init__.py
+        │           │   └── *.py
+        │           ├── transfers/
+        │           │   ├── __init__.py
+        │           │   └── *.py
+        │           └── triggers/
+        │               ├── __init__.py
+        │               └── *.py
+        └── tests/
+            ├── <NEW_PROVIDER>/
+            |   ├── __init__.py
+            |   ├── executors/
+            |   │   ├── __init__.py
+            |   │   └── test_*.py
+            |   ├── hooks/
+            |   │   ├── __init__.py
+            |   │   └── test_*.py
+            |   ├── notifications/
+            |   │   ├── __init__.py
+            |   │   └── test_*.py
+            |   ├── operators/
+            |   │   ├── __init__.py
+            |   │   └── test_*.py
+            |   ├── transfers/
+            |   │   ├── __init__.py
+            |   │   └── test_*.py
+            |   └── triggers/
+            |       ├── __init__.py
+            |       └── test_*.py
+            └── system/<NEW_PROVIDER>/
+                ├── __init__.py
+                └── example_*.py
 
 .. note::
       The above structure is work in progress and subject to change till Task SDK feature is complete.


### PR DESCRIPTION
Some leftovers from the repo adjustments were in the providers docs, small PR to correct the file layout