### PR TITLE
Use updated data from Dags API for Dag with recent DagRun.

### DIFF
--- a/airflow/ui/src/queries/useDags.tsx
+++ b/airflow/ui/src/queries/useDags.tsx
@@ -69,7 +69,11 @@ export const useDags = (
       (runsDag) => runsDag.dag_id === dag.dag_id,
     );
 
-    return dagWithRuns ?? { ...dag, latest_dag_runs: [] };
+    // For dags with recent dag runs replace the dag data from useDagsServiceRecentDagRuns
+    // which might be stale with updated dag data from useDagServiceGetDags
+    return dagWithRuns
+      ? { ...dagWithRuns, ...dag }
+      : { ...dag, latest_dag_runs: [] };
   });
 
   return {


### PR DESCRIPTION
On toggling pause for a dag with recent dagrun in the dags list page only the list dags and dag detail API are invalidated. On re-render of the page the dagruns API has stale data with older value for is_paused which is used thus not reflecting the change in UI though the patch API to update the dag was successful. For dags with recent dag runs use data from dags list API which has the updated value since the cache is invalidated. Another fix would be to invalidate the recent dagruns API too through useDagsServiceRecentDagRunsKey in TogglePause success but that results in an unnecessary API call.

To reproduce : 

1. Go to dags list page with one of the filters selected like success.
2. Toggle pause slider for the dag.
3. API call for update is made but the UI doesn't reflect the changes until page is refreshed.

https://github.com/apache/airflow/blob/6d85a0466d91d501af87c8904b902ea92cee466d/airflow/ui/src/components/TogglePause.tsx#L38-L46