### PR TITLE
AIP-84 Add Lists Jobs with Filters API

### DIFF
--- a/airflow/api_fastapi/common/parameters.py
+++ b/airflow/api_fastapi/common/parameters.py
@@ -40,6 +40,7 @@ from sqlalchemy import Column, case, or_
 from sqlalchemy.inspection import inspect
 
 from airflow.api_connexion.endpoints.task_instance_endpoint import _convert_ti_states
+from airflow.jobs.job import Job
 from airflow.models import Base, Connection
 from airflow.models.asset import AssetEvent, AssetModel, DagScheduleAssetReference, TaskOutletAssetReference
 from airflow.models.dag import DagModel, DagTag
@@ -450,6 +451,54 @@ class _DagTagNamePatternSearch(_SearchParam):
         return self.set_value(tag_name_pattern)
 
 
+class _JobTypeFilter(BaseParam[str]):
+    """Filter on job_type."""
+
+    def to_orm(self, select: Select) -> Select:
+        if self.value is None and self.skip_none:
+            return select
+        return select.where(Job.job_type == self.value)
+
+    def depends(self, job_type: str | None = None) -> _JobTypeFilter:
+        return self.set_value(job_type)
+
+
+class _JobStateFilter(BaseParam[str]):
+    """Filter on job_state."""
+
+    def to_orm(self, select: Select) -> Select:
+        if self.value is None and self.skip_none:
+            return select
+        return select.where(Job.state == self.value)
+
+    def depends(self, job_state: str | None = None) -> _JobStateFilter:
+        return self.set_value(job_state)
+
+
+class _JobHostnameFilter(BaseParam[str]):
+    """Filter on hostname."""
+
+    def to_orm(self, select: Select) -> Select:
+        if self.value is None and self.skip_none:
+            return select
+        return select.where(Job.hostname == self.value)
+
+    def depends(self, hostname: str | None = None) -> _JobHostnameFilter:
+        return self.set_value(hostname)
+
+
+class _JobExecutorClassFilter(BaseParam[str]):
+    """Filter on executor_class."""
+
+    def to_orm(self, select: Select) -> Select:
+        if self.value is None and self.skip_none:
+            return select
+        return select.where(Job.executor_class == self.value)
+
+    def depends(self, executor_class: str | None = None) -> _JobExecutorClassFilter:
+        return self.set_value(executor_class)
+
+
 def _safe_parse_datetime(date_to_check: str) -> datetime:
     """
     Parse datetime and raise error for invalid dates.
@@ -719,6 +768,11 @@ QueryTIStateFilter = Annotated[TIStateFilter, Depends(TIStateFilter().depends)]
 QueryTIPoolFilter = Annotated[TIPoolFilter, Depends(TIPoolFilter().depends)]
 QueryTIQueueFilter = Annotated[TIQueueFilter, Depends(TIQueueFilter().depends)]
 QueryTIExecutorFilter = Annotated[TIExecutorFilter, Depends(TIExecutorFilter().depends)]
+# Job
+QueryJobTypeFilter = Annotated[_JobTypeFilter, Depends(_JobTypeFilter().depends)]
+QueryJobStateFilter = Annotated[_JobStateFilter, Depends(_JobStateFilter().depends)]
+QueryJobHostnameFilter = Annotated[_JobHostnameFilter, Depends(_JobHostnameFilter().depends)]
+QueryJobExecutorClassFilter = Annotated[_JobExecutorClassFilter, Depends(_JobExecutorClassFilter().depends)]
 
 # Assets
 QueryUriPatternSearch = Annotated[_UriPatternSearch, Depends(_UriPatternSearch().depends)]

--- a/airflow/api_fastapi/core_api/datamodels/job.py
+++ b/airflow/api_fastapi/core_api/datamodels/job.py
@@ -34,3 +34,10 @@ class JobResponse(BaseModel):
     executor_class: datetime | None
     hostname: str | None
     unixname: str | None
+
+
+class JobCollectionResponse(BaseModel):
+    """Job Collection Response."""
+
+    jobs: list[JobResponse]
+    total_entries: int

--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -3008,38 +3008,6 @@ paths:
       description: Get all jobs.
       operationId: get_jobs
       parameters:
-      - name: state
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: State
-      - name: job_type
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Job Type
-      - name: hostname
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Hostname
-      - name: executor_class
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Executor Class
       - name: is_alive
         in: query
         required: false
@@ -3107,6 +3075,38 @@ paths:
           type: string
           default: id
           title: Order By
+      - name: job_state
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Job State
+      - name: job_type
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Job Type
+      - name: hostname
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Hostname
+      - name: executor_class
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Executor Class
       responses:
         '200':
           description: Successful Response

--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -3000,6 +3000,144 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /public/jobs/:
+    get:
+      tags:
+      - Job
+      summary: Get Jobs
+      description: Get all jobs.
+      operationId: get_jobs
+      parameters:
+      - name: state
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: State
+      - name: job_type
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Job Type
+      - name: hostname
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Hostname
+      - name: executor_class
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Executor Class
+      - name: is_alive
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Is Alive
+      - name: start_date_gte
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Start Date Gte
+      - name: start_date_lte
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Start Date Lte
+      - name: end_date_gte
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: End Date Gte
+      - name: end_date_lte
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: End Date Lte
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          default: 100
+          title: Limit
+      - name: offset
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          default: 0
+          title: Offset
+      - name: order_by
+        in: query
+        required: false
+        schema:
+          type: string
+          default: id
+          title: Order By
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobCollectionResponse'
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Unauthorized
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Forbidden
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Bad Request
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /public/plugins:
     get:
       tags:
@@ -6708,6 +6846,22 @@ components:
       - stack_trace
       title: ImportErrorResponse
       description: Import Error Response.
+    JobCollectionResponse:
+      properties:
+        jobs:
+          items:
+            $ref: '#/components/schemas/JobResponse'
+          type: array
+          title: Jobs
+        total_entries:
+          type: integer
+          title: Total Entries
+      type: object
+      required:
+      - jobs
+      - total_entries
+      title: JobCollectionResponse
+      description: Job Collection Response.
     JobResponse:
       properties:
         id:

--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -3000,7 +3000,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /public/jobs/:
+  /public/jobs:
     get:
       tags:
       - Job

--- a/airflow/api_fastapi/core_api/routes/public/__init__.py
+++ b/airflow/api_fastapi/core_api/routes/public/__init__.py
@@ -32,6 +32,7 @@ from airflow.api_fastapi.core_api.routes.public.dag_warning import dag_warning_r
 from airflow.api_fastapi.core_api.routes.public.dags import dags_router
 from airflow.api_fastapi.core_api.routes.public.event_logs import event_logs_router
 from airflow.api_fastapi.core_api.routes.public.import_error import import_error_router
+from airflow.api_fastapi.core_api.routes.public.job import job_router
 from airflow.api_fastapi.core_api.routes.public.log import task_instances_log_router
 from airflow.api_fastapi.core_api.routes.public.monitor import monitor_router
 from airflow.api_fastapi.core_api.routes.public.plugins import plugins_router
@@ -61,6 +62,7 @@ authenticated_router.include_router(dag_warning_router)
 authenticated_router.include_router(dags_router)
 authenticated_router.include_router(event_logs_router)
 authenticated_router.include_router(import_error_router)
+authenticated_router.include_router(job_router)
 authenticated_router.include_router(plugins_router)
 authenticated_router.include_router(pools_router)
 authenticated_router.include_router(providers_router)

--- a/airflow/api_fastapi/core_api/routes/public/job.py
+++ b/airflow/api_fastapi/core_api/routes/public/job.py
@@ -49,7 +49,7 @@ job_router = AirflowRouter(tags=["Job"], prefix="/jobs")
 
 
 @job_router.get(
-    "/",
+    "",
     responses=create_openapi_http_exception_doc([status.HTTP_400_BAD_REQUEST]),
 )
 def get_jobs(

--- a/airflow/api_fastapi/core_api/routes/public/job.py
+++ b/airflow/api_fastapi/core_api/routes/public/job.py
@@ -1,0 +1,128 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from fastapi import Depends, status
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from typing_extensions import Annotated
+
+from airflow.api_fastapi.common.db.common import (
+    get_session,
+    paginated_select,
+)
+from airflow.api_fastapi.common.parameters import (
+    QueryLimit,
+    QueryOffset,
+    RangeFilter,
+    SortParam,
+    datetime_range_filter_factory,
+)
+from airflow.api_fastapi.common.router import AirflowRouter
+from airflow.api_fastapi.core_api.datamodels.job import (
+    JobCollectionResponse,
+    JobResponse,
+)
+from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
+from airflow.jobs.job import Job
+from airflow.utils.state import JobState
+
+job_router = AirflowRouter(tags=["Job"], prefix="/jobs")
+
+
+@job_router.get(
+    "/",
+    responses=create_openapi_http_exception_doc(
+        [status.HTTP_400_BAD_REQUEST, status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]
+    ),
+)
+def get_jobs(
+    start_date_range: Annotated[
+        RangeFilter,
+        Depends(datetime_range_filter_factory("start_date", Job)),
+    ],
+    end_date_range: Annotated[
+        RangeFilter,
+        Depends(datetime_range_filter_factory("end_date", Job)),
+    ],
+    limit: QueryLimit,
+    offset: QueryOffset,
+    order_by: Annotated[
+        SortParam,
+        Depends(
+            SortParam(
+                [
+                    "id",
+                    "dag_id",
+                    "state",
+                    "job_type",
+                    "start_date",
+                    "end_date",
+                    "latest_heartbeat",
+                    "executor_class",
+                    "hostname",
+                    "unixname",
+                ],
+                Job,
+            ).dynamic_depends(default="id")
+        ),
+    ],
+    session: Annotated[Session, Depends(get_session)],
+    state: str | None = None,
+    job_type: str | None = None,
+    hostname: str | None = None,
+    executor_class: str | None = None,
+    is_alive: bool | None = None,
+) -> JobCollectionResponse:
+    """Get all jobs."""
+    base_select = select(Job).where(Job.state == JobState.RUNNING).order_by(Job.latest_heartbeat.desc())
+    # TODO: Refactor using the `FilterParam` class in commit `574b72e41cc5ed175a2bbf4356522589b836bb11`
+    if state:
+        base_select = base_select.where(Job.state == state)
+    if job_type:
+        base_select = base_select.where(Job.job_type == job_type)
+    if hostname:
+        base_select = base_select.where(Job.hostname == hostname)
+    if executor_class:
+        base_select = base_select.where(Job.executor_class == executor_class)
+
+    jobs_select, total_entries = paginated_select(
+        base_select,
+        [
+            start_date_range,
+            end_date_range,
+        ],
+        order_by,
+        limit,
+        offset,
+        session,
+    )
+    jobs = session.scalars(jobs_select).all()
+
+    if is_alive is not None:
+        jobs = [job for job in jobs if job.is_alive()]
+
+    return JobCollectionResponse(
+        jobs=[
+            JobResponse.model_validate(
+                job,
+                from_attributes=True,
+            )
+            for job in jobs
+        ],
+        total_entries=total_entries,
+    )

--- a/airflow/api_fastapi/core_api/routes/public/job.py
+++ b/airflow/api_fastapi/core_api/routes/public/job.py
@@ -95,8 +95,8 @@ def get_jobs(
     # TODO: Refactor using the `FilterParam` class in commit `574b72e41cc5ed175a2bbf4356522589b836bb11`
 
     jobs_select, total_entries = paginated_select(
-        base_select,
-        [
+        select=base_select,
+        filters=[
             start_date_range,
             end_date_range,
             state,
@@ -104,10 +104,11 @@ def get_jobs(
             hostname,
             executor_class,
         ],
-        order_by,
-        limit,
-        offset,
-        session,
+        order_by=order_by,
+        limit=limit,
+        offset=offset,
+        session=session,
+        return_total_entries=True,
     )
     jobs = session.scalars(jobs_select).all()
 

--- a/airflow/api_fastapi/core_api/routes/public/job.py
+++ b/airflow/api_fastapi/core_api/routes/public/job.py
@@ -50,9 +50,7 @@ job_router = AirflowRouter(tags=["Job"], prefix="/jobs")
 
 @job_router.get(
     "/",
-    responses=create_openapi_http_exception_doc(
-        [status.HTTP_400_BAD_REQUEST, status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]
-    ),
+    responses=create_openapi_http_exception_doc([status.HTTP_400_BAD_REQUEST]),
 )
 def get_jobs(
     start_date_range: Annotated[

--- a/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow/ui/openapi-gen/queries/common.ts
@@ -821,26 +821,26 @@ export const UseJobServiceGetJobsKeyFn = (
     executorClass,
     hostname,
     isAlive,
+    jobState,
     jobType,
     limit,
     offset,
     orderBy,
     startDateGte,
     startDateLte,
-    state,
   }: {
     endDateGte?: string;
     endDateLte?: string;
     executorClass?: string;
     hostname?: string;
     isAlive?: boolean;
+    jobState?: string;
     jobType?: string;
     limit?: number;
     offset?: number;
     orderBy?: string;
     startDateGte?: string;
     startDateLte?: string;
-    state?: string;
   } = {},
   queryKey?: Array<unknown>,
 ) => [
@@ -852,13 +852,13 @@ export const UseJobServiceGetJobsKeyFn = (
       executorClass,
       hostname,
       isAlive,
+      jobState,
       jobType,
       limit,
       offset,
       orderBy,
       startDateGte,
       startDateLte,
-      state,
     },
   ]),
 ];

--- a/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow/ui/openapi-gen/queries/common.ts
@@ -15,6 +15,7 @@ import {
   DashboardService,
   EventLogService,
   ImportErrorService,
+  JobService,
   MonitorService,
   PluginService,
   PoolService,
@@ -804,6 +805,62 @@ export const UseImportErrorServiceGetImportErrorsKeyFn = (
 ) => [
   useImportErrorServiceGetImportErrorsKey,
   ...(queryKey ?? [{ limit, offset, orderBy }]),
+];
+export type JobServiceGetJobsDefaultResponse = Awaited<
+  ReturnType<typeof JobService.getJobs>
+>;
+export type JobServiceGetJobsQueryResult<
+  TData = JobServiceGetJobsDefaultResponse,
+  TError = unknown,
+> = UseQueryResult<TData, TError>;
+export const useJobServiceGetJobsKey = "JobServiceGetJobs";
+export const UseJobServiceGetJobsKeyFn = (
+  {
+    endDateGte,
+    endDateLte,
+    executorClass,
+    hostname,
+    isAlive,
+    jobType,
+    limit,
+    offset,
+    orderBy,
+    startDateGte,
+    startDateLte,
+    state,
+  }: {
+    endDateGte?: string;
+    endDateLte?: string;
+    executorClass?: string;
+    hostname?: string;
+    isAlive?: boolean;
+    jobType?: string;
+    limit?: number;
+    offset?: number;
+    orderBy?: string;
+    startDateGte?: string;
+    startDateLte?: string;
+    state?: string;
+  } = {},
+  queryKey?: Array<unknown>,
+) => [
+  useJobServiceGetJobsKey,
+  ...(queryKey ?? [
+    {
+      endDateGte,
+      endDateLte,
+      executorClass,
+      hostname,
+      isAlive,
+      jobType,
+      limit,
+      offset,
+      orderBy,
+      startDateGte,
+      startDateLte,
+      state,
+    },
+  ]),
 ];
 export type PluginServiceGetPluginsDefaultResponse = Awaited<
   ReturnType<typeof PluginService.getPlugins>

--- a/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -15,6 +15,7 @@ import {
   DashboardService,
   EventLogService,
   ImportErrorService,
+  JobService,
   MonitorService,
   PluginService,
   PoolService,
@@ -1043,6 +1044,86 @@ export const prefetchUseImportErrorServiceGetImportErrors = (
     }),
     queryFn: () =>
       ImportErrorService.getImportErrors({ limit, offset, orderBy }),
+  });
+/**
+ * Get Jobs
+ * Get all jobs.
+ * @param data The data for the request.
+ * @param data.state
+ * @param data.jobType
+ * @param data.hostname
+ * @param data.executorClass
+ * @param data.isAlive
+ * @param data.startDateGte
+ * @param data.startDateLte
+ * @param data.endDateGte
+ * @param data.endDateLte
+ * @param data.limit
+ * @param data.offset
+ * @param data.orderBy
+ * @returns JobCollectionResponse Successful Response
+ * @throws ApiError
+ */
+export const prefetchUseJobServiceGetJobs = (
+  queryClient: QueryClient,
+  {
+    endDateGte,
+    endDateLte,
+    executorClass,
+    hostname,
+    isAlive,
+    jobType,
+    limit,
+    offset,
+    orderBy,
+    startDateGte,
+    startDateLte,
+    state,
+  }: {
+    endDateGte?: string;
+    endDateLte?: string;
+    executorClass?: string;
+    hostname?: string;
+    isAlive?: boolean;
+    jobType?: string;
+    limit?: number;
+    offset?: number;
+    orderBy?: string;
+    startDateGte?: string;
+    startDateLte?: string;
+    state?: string;
+  } = {},
+) =>
+  queryClient.prefetchQuery({
+    queryKey: Common.UseJobServiceGetJobsKeyFn({
+      endDateGte,
+      endDateLte,
+      executorClass,
+      hostname,
+      isAlive,
+      jobType,
+      limit,
+      offset,
+      orderBy,
+      startDateGte,
+      startDateLte,
+      state,
+    }),
+    queryFn: () =>
+      JobService.getJobs({
+        endDateGte,
+        endDateLte,
+        executorClass,
+        hostname,
+        isAlive,
+        jobType,
+        limit,
+        offset,
+        orderBy,
+        startDateGte,
+        startDateLte,
+        state,
+      }),
   });
 /**
  * Get Plugins

--- a/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -1049,10 +1049,6 @@ export const prefetchUseImportErrorServiceGetImportErrors = (
  * Get Jobs
  * Get all jobs.
  * @param data The data for the request.
- * @param data.state
- * @param data.jobType
- * @param data.hostname
- * @param data.executorClass
  * @param data.isAlive
  * @param data.startDateGte
  * @param data.startDateLte
@@ -1061,6 +1057,10 @@ export const prefetchUseImportErrorServiceGetImportErrors = (
  * @param data.limit
  * @param data.offset
  * @param data.orderBy
+ * @param data.jobState
+ * @param data.jobType
+ * @param data.hostname
+ * @param data.executorClass
  * @returns JobCollectionResponse Successful Response
  * @throws ApiError
  */
@@ -1072,26 +1072,26 @@ export const prefetchUseJobServiceGetJobs = (
     executorClass,
     hostname,
     isAlive,
+    jobState,
     jobType,
     limit,
     offset,
     orderBy,
     startDateGte,
     startDateLte,
-    state,
   }: {
     endDateGte?: string;
     endDateLte?: string;
     executorClass?: string;
     hostname?: string;
     isAlive?: boolean;
+    jobState?: string;
     jobType?: string;
     limit?: number;
     offset?: number;
     orderBy?: string;
     startDateGte?: string;
     startDateLte?: string;
-    state?: string;
   } = {},
 ) =>
   queryClient.prefetchQuery({
@@ -1101,13 +1101,13 @@ export const prefetchUseJobServiceGetJobs = (
       executorClass,
       hostname,
       isAlive,
+      jobState,
       jobType,
       limit,
       offset,
       orderBy,
       startDateGte,
       startDateLte,
-      state,
     }),
     queryFn: () =>
       JobService.getJobs({
@@ -1116,13 +1116,13 @@ export const prefetchUseJobServiceGetJobs = (
         executorClass,
         hostname,
         isAlive,
+        jobState,
         jobType,
         limit,
         offset,
         orderBy,
         startDateGte,
         startDateLte,
-        state,
       }),
   });
 /**

--- a/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow/ui/openapi-gen/queries/queries.ts
@@ -1288,10 +1288,6 @@ export const useImportErrorServiceGetImportErrors = <
  * Get Jobs
  * Get all jobs.
  * @param data The data for the request.
- * @param data.state
- * @param data.jobType
- * @param data.hostname
- * @param data.executorClass
  * @param data.isAlive
  * @param data.startDateGte
  * @param data.startDateLte
@@ -1300,6 +1296,10 @@ export const useImportErrorServiceGetImportErrors = <
  * @param data.limit
  * @param data.offset
  * @param data.orderBy
+ * @param data.jobState
+ * @param data.jobType
+ * @param data.hostname
+ * @param data.executorClass
  * @returns JobCollectionResponse Successful Response
  * @throws ApiError
  */
@@ -1314,26 +1314,26 @@ export const useJobServiceGetJobs = <
     executorClass,
     hostname,
     isAlive,
+    jobState,
     jobType,
     limit,
     offset,
     orderBy,
     startDateGte,
     startDateLte,
-    state,
   }: {
     endDateGte?: string;
     endDateLte?: string;
     executorClass?: string;
     hostname?: string;
     isAlive?: boolean;
+    jobState?: string;
     jobType?: string;
     limit?: number;
     offset?: number;
     orderBy?: string;
     startDateGte?: string;
     startDateLte?: string;
-    state?: string;
   } = {},
   queryKey?: TQueryKey,
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
@@ -1346,13 +1346,13 @@ export const useJobServiceGetJobs = <
         executorClass,
         hostname,
         isAlive,
+        jobState,
         jobType,
         limit,
         offset,
         orderBy,
         startDateGte,
         startDateLte,
-        state,
       },
       queryKey,
     ),
@@ -1363,13 +1363,13 @@ export const useJobServiceGetJobs = <
         executorClass,
         hostname,
         isAlive,
+        jobState,
         jobType,
         limit,
         offset,
         orderBy,
         startDateGte,
         startDateLte,
-        state,
       }) as TData,
     ...options,
   });

--- a/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow/ui/openapi-gen/queries/queries.ts
@@ -20,6 +20,7 @@ import {
   DashboardService,
   EventLogService,
   ImportErrorService,
+  JobService,
   MonitorService,
   PluginService,
   PoolService,
@@ -1281,6 +1282,95 @@ export const useImportErrorServiceGetImportErrors = <
     ),
     queryFn: () =>
       ImportErrorService.getImportErrors({ limit, offset, orderBy }) as TData,
+    ...options,
+  });
+/**
+ * Get Jobs
+ * Get all jobs.
+ * @param data The data for the request.
+ * @param data.state
+ * @param data.jobType
+ * @param data.hostname
+ * @param data.executorClass
+ * @param data.isAlive
+ * @param data.startDateGte
+ * @param data.startDateLte
+ * @param data.endDateGte
+ * @param data.endDateLte
+ * @param data.limit
+ * @param data.offset
+ * @param data.orderBy
+ * @returns JobCollectionResponse Successful Response
+ * @throws ApiError
+ */
+export const useJobServiceGetJobs = <
+  TData = Common.JobServiceGetJobsDefaultResponse,
+  TError = unknown,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  {
+    endDateGte,
+    endDateLte,
+    executorClass,
+    hostname,
+    isAlive,
+    jobType,
+    limit,
+    offset,
+    orderBy,
+    startDateGte,
+    startDateLte,
+    state,
+  }: {
+    endDateGte?: string;
+    endDateLte?: string;
+    executorClass?: string;
+    hostname?: string;
+    isAlive?: boolean;
+    jobType?: string;
+    limit?: number;
+    offset?: number;
+    orderBy?: string;
+    startDateGte?: string;
+    startDateLte?: string;
+    state?: string;
+  } = {},
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
+) =>
+  useQuery<TData, TError>({
+    queryKey: Common.UseJobServiceGetJobsKeyFn(
+      {
+        endDateGte,
+        endDateLte,
+        executorClass,
+        hostname,
+        isAlive,
+        jobType,
+        limit,
+        offset,
+        orderBy,
+        startDateGte,
+        startDateLte,
+        state,
+      },
+      queryKey,
+    ),
+    queryFn: () =>
+      JobService.getJobs({
+        endDateGte,
+        endDateLte,
+        executorClass,
+        hostname,
+        isAlive,
+        jobType,
+        limit,
+        offset,
+        orderBy,
+        startDateGte,
+        startDateLte,
+        state,
+      }) as TData,
     ...options,
   });
 /**

--- a/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow/ui/openapi-gen/queries/suspense.ts
@@ -1268,10 +1268,6 @@ export const useImportErrorServiceGetImportErrorsSuspense = <
  * Get Jobs
  * Get all jobs.
  * @param data The data for the request.
- * @param data.state
- * @param data.jobType
- * @param data.hostname
- * @param data.executorClass
  * @param data.isAlive
  * @param data.startDateGte
  * @param data.startDateLte
@@ -1280,6 +1276,10 @@ export const useImportErrorServiceGetImportErrorsSuspense = <
  * @param data.limit
  * @param data.offset
  * @param data.orderBy
+ * @param data.jobState
+ * @param data.jobType
+ * @param data.hostname
+ * @param data.executorClass
  * @returns JobCollectionResponse Successful Response
  * @throws ApiError
  */
@@ -1294,26 +1294,26 @@ export const useJobServiceGetJobsSuspense = <
     executorClass,
     hostname,
     isAlive,
+    jobState,
     jobType,
     limit,
     offset,
     orderBy,
     startDateGte,
     startDateLte,
-    state,
   }: {
     endDateGte?: string;
     endDateLte?: string;
     executorClass?: string;
     hostname?: string;
     isAlive?: boolean;
+    jobState?: string;
     jobType?: string;
     limit?: number;
     offset?: number;
     orderBy?: string;
     startDateGte?: string;
     startDateLte?: string;
-    state?: string;
   } = {},
   queryKey?: TQueryKey,
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
@@ -1326,13 +1326,13 @@ export const useJobServiceGetJobsSuspense = <
         executorClass,
         hostname,
         isAlive,
+        jobState,
         jobType,
         limit,
         offset,
         orderBy,
         startDateGte,
         startDateLte,
-        state,
       },
       queryKey,
     ),
@@ -1343,13 +1343,13 @@ export const useJobServiceGetJobsSuspense = <
         executorClass,
         hostname,
         isAlive,
+        jobState,
         jobType,
         limit,
         offset,
         orderBy,
         startDateGte,
         startDateLte,
-        state,
       }) as TData,
     ...options,
   });

--- a/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow/ui/openapi-gen/queries/suspense.ts
@@ -15,6 +15,7 @@ import {
   DashboardService,
   EventLogService,
   ImportErrorService,
+  JobService,
   MonitorService,
   PluginService,
   PoolService,
@@ -1261,6 +1262,95 @@ export const useImportErrorServiceGetImportErrorsSuspense = <
     ),
     queryFn: () =>
       ImportErrorService.getImportErrors({ limit, offset, orderBy }) as TData,
+    ...options,
+  });
+/**
+ * Get Jobs
+ * Get all jobs.
+ * @param data The data for the request.
+ * @param data.state
+ * @param data.jobType
+ * @param data.hostname
+ * @param data.executorClass
+ * @param data.isAlive
+ * @param data.startDateGte
+ * @param data.startDateLte
+ * @param data.endDateGte
+ * @param data.endDateLte
+ * @param data.limit
+ * @param data.offset
+ * @param data.orderBy
+ * @returns JobCollectionResponse Successful Response
+ * @throws ApiError
+ */
+export const useJobServiceGetJobsSuspense = <
+  TData = Common.JobServiceGetJobsDefaultResponse,
+  TError = unknown,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  {
+    endDateGte,
+    endDateLte,
+    executorClass,
+    hostname,
+    isAlive,
+    jobType,
+    limit,
+    offset,
+    orderBy,
+    startDateGte,
+    startDateLte,
+    state,
+  }: {
+    endDateGte?: string;
+    endDateLte?: string;
+    executorClass?: string;
+    hostname?: string;
+    isAlive?: boolean;
+    jobType?: string;
+    limit?: number;
+    offset?: number;
+    orderBy?: string;
+    startDateGte?: string;
+    startDateLte?: string;
+    state?: string;
+  } = {},
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
+) =>
+  useSuspenseQuery<TData, TError>({
+    queryKey: Common.UseJobServiceGetJobsKeyFn(
+      {
+        endDateGte,
+        endDateLte,
+        executorClass,
+        hostname,
+        isAlive,
+        jobType,
+        limit,
+        offset,
+        orderBy,
+        startDateGte,
+        startDateLte,
+        state,
+      },
+      queryKey,
+    ),
+    queryFn: () =>
+      JobService.getJobs({
+        endDateGte,
+        endDateLte,
+        executorClass,
+        hostname,
+        isAlive,
+        jobType,
+        limit,
+        offset,
+        orderBy,
+        startDateGte,
+        startDateLte,
+        state,
+      }) as TData,
     ...options,
   });
 /**

--- a/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -2732,6 +2732,26 @@ export const $ImportErrorResponse = {
   description: "Import Error Response.",
 } as const;
 
+export const $JobCollectionResponse = {
+  properties: {
+    jobs: {
+      items: {
+        $ref: "#/components/schemas/JobResponse",
+      },
+      type: "array",
+      title: "Jobs",
+    },
+    total_entries: {
+      type: "integer",
+      title: "Total Entries",
+    },
+  },
+  type: "object",
+  required: ["jobs", "total_entries"],
+  title: "JobCollectionResponse",
+  description: "Job Collection Response.",
+} as const;
+
 export const $JobResponse = {
   properties: {
     id: {

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -98,6 +98,8 @@ import type {
   GetImportErrorResponse,
   GetImportErrorsData,
   GetImportErrorsResponse,
+  GetJobsData,
+  GetJobsResponse,
   GetPluginsData,
   GetPluginsResponse,
   DeletePoolData,
@@ -1642,6 +1644,56 @@ export class ImportErrorService {
         order_by: data.orderBy,
       },
       errors: {
+        401: "Unauthorized",
+        403: "Forbidden",
+        422: "Validation Error",
+      },
+    });
+  }
+}
+
+export class JobService {
+  /**
+   * Get Jobs
+   * Get all jobs.
+   * @param data The data for the request.
+   * @param data.state
+   * @param data.jobType
+   * @param data.hostname
+   * @param data.executorClass
+   * @param data.isAlive
+   * @param data.startDateGte
+   * @param data.startDateLte
+   * @param data.endDateGte
+   * @param data.endDateLte
+   * @param data.limit
+   * @param data.offset
+   * @param data.orderBy
+   * @returns JobCollectionResponse Successful Response
+   * @throws ApiError
+   */
+  public static getJobs(
+    data: GetJobsData = {},
+  ): CancelablePromise<GetJobsResponse> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/public/jobs/",
+      query: {
+        state: data.state,
+        job_type: data.jobType,
+        hostname: data.hostname,
+        executor_class: data.executorClass,
+        is_alive: data.isAlive,
+        start_date_gte: data.startDateGte,
+        start_date_lte: data.startDateLte,
+        end_date_gte: data.endDateGte,
+        end_date_lte: data.endDateLte,
+        limit: data.limit,
+        offset: data.offset,
+        order_by: data.orderBy,
+      },
+      errors: {
+        400: "Bad Request",
         401: "Unauthorized",
         403: "Forbidden",
         422: "Validation Error",

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -1657,10 +1657,6 @@ export class JobService {
    * Get Jobs
    * Get all jobs.
    * @param data The data for the request.
-   * @param data.state
-   * @param data.jobType
-   * @param data.hostname
-   * @param data.executorClass
    * @param data.isAlive
    * @param data.startDateGte
    * @param data.startDateLte
@@ -1669,6 +1665,10 @@ export class JobService {
    * @param data.limit
    * @param data.offset
    * @param data.orderBy
+   * @param data.jobState
+   * @param data.jobType
+   * @param data.hostname
+   * @param data.executorClass
    * @returns JobCollectionResponse Successful Response
    * @throws ApiError
    */
@@ -1679,10 +1679,6 @@ export class JobService {
       method: "GET",
       url: "/public/jobs/",
       query: {
-        state: data.state,
-        job_type: data.jobType,
-        hostname: data.hostname,
-        executor_class: data.executorClass,
         is_alive: data.isAlive,
         start_date_gte: data.startDateGte,
         start_date_lte: data.startDateLte,
@@ -1691,6 +1687,10 @@ export class JobService {
         limit: data.limit,
         offset: data.offset,
         order_by: data.orderBy,
+        job_state: data.jobState,
+        job_type: data.jobType,
+        hostname: data.hostname,
+        executor_class: data.executorClass,
       },
       errors: {
         400: "Bad Request",

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -1677,7 +1677,7 @@ export class JobService {
   ): CancelablePromise<GetJobsResponse> {
     return __request(OpenAPI, {
       method: "GET",
-      url: "/public/jobs/",
+      url: "/public/jobs",
       query: {
         is_alive: data.isAlive,
         start_date_gte: data.startDateGte,

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -689,6 +689,14 @@ export type ImportErrorResponse = {
 };
 
 /**
+ * Job Collection Response.
+ */
+export type JobCollectionResponse = {
+  jobs: Array<JobResponse>;
+  total_entries: number;
+};
+
+/**
  * Job serializer for responses.
  */
 export type JobResponse = {
@@ -1548,6 +1556,23 @@ export type GetImportErrorsData = {
 };
 
 export type GetImportErrorsResponse = ImportErrorCollectionResponse;
+
+export type GetJobsData = {
+  endDateGte?: string | null;
+  endDateLte?: string | null;
+  executorClass?: string | null;
+  hostname?: string | null;
+  isAlive?: boolean | null;
+  jobType?: string | null;
+  limit?: number;
+  offset?: number;
+  orderBy?: string;
+  startDateGte?: string | null;
+  startDateLte?: string | null;
+  state?: string | null;
+};
+
+export type GetJobsResponse = JobCollectionResponse;
 
 export type GetPluginsData = {
   limit?: number;
@@ -3064,6 +3089,33 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: ImportErrorCollectionResponse;
+        /**
+         * Unauthorized
+         */
+        401: HTTPExceptionResponse;
+        /**
+         * Forbidden
+         */
+        403: HTTPExceptionResponse;
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError;
+      };
+    };
+  };
+  "/public/jobs/": {
+    get: {
+      req: GetJobsData;
+      res: {
+        /**
+         * Successful Response
+         */
+        200: JobCollectionResponse;
+        /**
+         * Bad Request
+         */
+        400: HTTPExceptionResponse;
         /**
          * Unauthorized
          */

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -3104,7 +3104,7 @@ export type $OpenApiTs = {
       };
     };
   };
-  "/public/jobs/": {
+  "/public/jobs": {
     get: {
       req: GetJobsData;
       res: {

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1563,13 +1563,13 @@ export type GetJobsData = {
   executorClass?: string | null;
   hostname?: string | null;
   isAlive?: boolean | null;
+  jobState?: string | null;
   jobType?: string | null;
   limit?: number;
   offset?: number;
   orderBy?: string;
   startDateGte?: string | null;
   startDateLte?: string | null;
-  state?: string | null;
 };
 
 export type GetJobsResponse = JobCollectionResponse;

--- a/tests/api_fastapi/core_api/routes/public/test_event_logs.py
+++ b/tests/api_fastapi/core_api/routes/public/test_event_logs.py
@@ -24,6 +24,7 @@ from airflow.models.log import Log
 from airflow.utils.session import provide_session
 
 from tests_common.test_utils.db import clear_db_logs, clear_db_runs
+from tests_common.test_utils.format_datetime import datetime_zulu_format
 
 pytestmark = pytest.mark.db_test
 
@@ -160,14 +161,14 @@ class TestGetEventLog(TestEventLogsEndpoint):
 
         expected_json = {
             "event_log_id": event_log_id,
-            "when": event_log.dttm.isoformat().replace("+00:00", "Z") if event_log.dttm else None,
+            "when": datetime_zulu_format(event_log.dttm) if event_log.dttm else None,
             "dag_id": expected_body.get("dag_id"),
             "task_id": expected_body.get("task_id"),
             "run_id": expected_body.get("run_id"),
             "map_index": event_log.map_index,
             "try_number": event_log.try_number,
             "event": expected_body.get("event"),
-            "logical_date": event_log.logical_date.isoformat().replace("+00:00", "Z")
+            "logical_date": datetime_zulu_format(event_log.logical_date)
             if event_log.logical_date
             else None,
             "owner": expected_body.get("owner"),

--- a/tests/api_fastapi/core_api/routes/public/test_event_logs.py
+++ b/tests/api_fastapi/core_api/routes/public/test_event_logs.py
@@ -168,9 +168,7 @@ class TestGetEventLog(TestEventLogsEndpoint):
             "map_index": event_log.map_index,
             "try_number": event_log.try_number,
             "event": expected_body.get("event"),
-            "logical_date": datetime_zulu_format(event_log.logical_date)
-            if event_log.logical_date
-            else None,
+            "logical_date": datetime_zulu_format(event_log.logical_date) if event_log.logical_date else None,
             "owner": expected_body.get("owner"),
             "extra": expected_body.get("extra"),
         }

--- a/tests/api_fastapi/core_api/routes/public/test_event_logs.py
+++ b/tests/api_fastapi/core_api/routes/public/test_event_logs.py
@@ -24,7 +24,7 @@ from airflow.models.log import Log
 from airflow.utils.session import provide_session
 
 from tests_common.test_utils.db import clear_db_logs, clear_db_runs
-from tests_common.test_utils.format_datetime import datetime_zulu_format
+from tests_common.test_utils.format_datetime import datetime_zulu_format, datetime_zulu_format_without_ms
 
 pytestmark = pytest.mark.db_test
 
@@ -168,7 +168,9 @@ class TestGetEventLog(TestEventLogsEndpoint):
             "map_index": event_log.map_index,
             "try_number": event_log.try_number,
             "event": expected_body.get("event"),
-            "logical_date": datetime_zulu_format(event_log.logical_date) if event_log.logical_date else None,
+            "logical_date": datetime_zulu_format_without_ms(event_log.logical_date)
+            if event_log.logical_date
+            else None,
             "owner": expected_body.get("owner"),
             "extra": expected_body.get("extra"),
         }

--- a/tests/api_fastapi/core_api/routes/public/test_import_error.py
+++ b/tests/api_fastapi/core_api/routes/public/test_import_error.py
@@ -24,6 +24,7 @@ from airflow.models.errors import ParseImportError
 from airflow.utils.session import provide_session
 
 from tests_common.test_utils.db import clear_db_import_errors
+from tests_common.test_utils.format_datetime import datetime_zulu_format_without_ms
 
 pytestmark = pytest.mark.db_test
 
@@ -115,7 +116,7 @@ class TestGetImportError(TestImportErrorEndpoint):
             return
         expected_json = {
             "import_error_id": import_error_id,
-            "timestamp": expected_body["timestamp"].isoformat().replace("+00:00", "Z"),
+            "timestamp": datetime_zulu_format_without_ms(expected_body["timestamp"]),
             "filename": expected_body["filename"],
             "stack_trace": expected_body["stack_trace"],
         }

--- a/tests/api_fastapi/core_api/routes/public/test_job.py
+++ b/tests/api_fastapi/core_api/routes/public/test_job.py
@@ -26,6 +26,7 @@ from airflow.utils.session import provide_session
 from airflow.utils.state import JobState, State
 
 from tests_common.test_utils.db import clear_db_jobs
+from tests_common.test_utils.format_datetime import datetime_zulu_format
 
 pytestmark = pytest.mark.db_test
 
@@ -154,11 +155,9 @@ class TestGetJobs(TestJobEndpoint):
                 "dag_id": None,
                 "state": "running",
                 "job_type": "SchedulerJob",
-                "start_date": self.scheduler_jobs[idx].start_date.isoformat().replace("+00:00", "Z"),
+                "start_date": datetime_zulu_format(self.scheduler_jobs[idx].start_date),
                 "end_date": None,
-                "latest_heartbeat": self.scheduler_jobs[idx]
-                .latest_heartbeat.isoformat()
-                .replace("+00:00", "Z"),
+                "latest_heartbeat": datetime_zulu_format(self.scheduler_jobs[idx].latest_heartbeat),
                 "executor_class": None,
                 "hostname": self.scheduler_jobs[idx].hostname,
                 "unixname": self.scheduler_jobs[idx].unixname,

--- a/tests/api_fastapi/core_api/routes/public/test_job.py
+++ b/tests/api_fastapi/core_api/routes/public/test_job.py
@@ -142,7 +142,7 @@ class TestGetJobs(TestJobEndpoint):
     ):
         # setup testcase at runtime based on the `testcase` parameter
         self.setup(testcase)
-        response = test_client.get("/public/jobs/", params=query_params)
+        response = test_client.get("/public/jobs", params=query_params)
         assert response.status_code == expected_status_code
         if expected_status_code != 200:
             return

--- a/tests/api_fastapi/core_api/routes/public/test_job.py
+++ b/tests/api_fastapi/core_api/routes/public/test_job.py
@@ -1,0 +1,166 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import Literal
+
+import pytest
+
+from airflow.jobs.job import Job
+from airflow.jobs.scheduler_job_runner import SchedulerJobRunner
+from airflow.utils.session import provide_session
+from airflow.utils.state import JobState, State
+
+from tests_common.test_utils.db import clear_db_jobs
+
+pytestmark = pytest.mark.db_test
+
+TESTCASE_TYPE = Literal[
+    "should_report_success_for_one_working_scheduler",
+    "should_report_success_for_one_working_scheduler_with_hostname",
+    "should_report_success_for_ha_schedulers",
+    "should_ignore_not_running_jobs",
+    "should_raise_exception_for_multiple_scheduler_on_one_host",
+]
+TESTCASE_ONE_SCHEDULER = "should_report_success_for_one_working_scheduler"
+TESTCASE_ONE_SCHEDULER_WITH_HOSTNAME = "should_report_success_for_one_working_scheduler_with_hostname"
+TESTCASE_HA_SCHEDULERS = "should_report_success_for_ha_schedulers"
+TESTCASE_IGNORE_NOT_RUNNING = "should_ignore_not_running_jobs"
+TESTCASE_MULTIPLE_SCHEDULERS_ON_ONE_HOST = "should_raise_exception_for_multiple_scheduler_on_one_host"
+TESTCASE_MULTIPLE_RUNNER = "should_report_success_for_multiple_runners"
+
+
+class TestJobEndpoint:
+    """Common class for /public/jobs related unit tests."""
+
+    scheduler_jobs: list[Job] | None = None
+    job_runners: list[SchedulerJobRunner] | None = None
+
+    def _setup_should_report_success_for_one_working_scheduler(self, session=None):
+        scheduler_job = Job()
+        job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job.state = State.RUNNING
+        session.add(scheduler_job)
+        session.commit()
+        self.scheduler_jobs.append(scheduler_job)
+        self.job_runners.append(job_runner)
+        scheduler_job.heartbeat(heartbeat_callback=job_runner.heartbeat_callback)
+
+    def _setup_should_report_success_for_one_working_scheduler_with_hostname(self, session=None):
+        scheduler_job = Job()
+        job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job.state = State.RUNNING
+        scheduler_job.hostname = "HOSTNAME"
+        session.add(scheduler_job)
+        self.scheduler_jobs.append(scheduler_job)
+        self.job_runners.append(job_runner)
+        session.commit()
+        scheduler_job.heartbeat(heartbeat_callback=job_runner.heartbeat_callback)
+
+    def _setup_should_report_success_for_ha_schedulers(self, session=None):
+        for _ in range(3):
+            scheduler_job = Job()
+            job_runner = SchedulerJobRunner(job=scheduler_job)
+            scheduler_job.state = State.RUNNING
+            session.add(scheduler_job)
+            self.scheduler_jobs.append(scheduler_job)
+            self.job_runners.append(job_runner)
+        session.commit()
+        scheduler_job.heartbeat(heartbeat_callback=job_runner.heartbeat_callback)
+
+    def _setup_should_ignore_not_running_jobs(self, session=None):
+        for _ in range(3):
+            scheduler_job = Job()
+            job_runner = SchedulerJobRunner(job=scheduler_job)
+            scheduler_job.state = JobState.FAILED
+            session.add(scheduler_job)
+            self.scheduler_jobs.append(scheduler_job)
+            self.job_runners.append(job_runner)
+        session.commit()
+
+    def _setup_should_raise_exception_for_multiple_scheduler_on_one_host(self, session=None):
+        for _ in range(3):
+            scheduler_job = Job()
+            job_runner = SchedulerJobRunner(job=scheduler_job)
+            job_runner.job = scheduler_job
+            scheduler_job.state = State.RUNNING
+            scheduler_job.hostname = "HOSTNAME"
+            session.add(scheduler_job)
+            self.scheduler_jobs.append(scheduler_job)
+            self.job_runners.append(job_runner)
+        session.commit()
+        scheduler_job.heartbeat(heartbeat_callback=job_runner.heartbeat_callback)
+
+    @provide_session
+    def setup(self, testcase: TESTCASE_TYPE, session=None) -> None:
+        """
+        Setup testcase at runtime based on the `testcase` provided by `pytest.mark.parametrize`.
+        """
+        clear_db_jobs()
+        self.scheduler_jobs = []
+        self.job_runners = []
+        setup_method = getattr(self, f"_setup_{testcase}")
+        setup_method(session)
+
+    def teardown_method(self) -> None:
+        if self.job_runners:
+            for job_runner in self.job_runners:
+                if job_runner.processor_agent:
+                    job_runner.processor_agent.end()
+        clear_db_jobs()
+
+
+class TestGetJobs(TestJobEndpoint):
+    @pytest.mark.parametrize(
+        "testcase, query_params, expected_status_code, expected_total_entries",
+        [
+            # original testcases refactor from tests/cli/commands/test_jobs_command.py
+            (TESTCASE_ONE_SCHEDULER, {}, 200, 1),
+            (TESTCASE_ONE_SCHEDULER_WITH_HOSTNAME, {"hostname": "HOSTNAME"}, 200, 1),
+            (TESTCASE_HA_SCHEDULERS, {"limit": 100}, 200, 3),
+            (TESTCASE_IGNORE_NOT_RUNNING, {}, 200, 0),
+            (TESTCASE_MULTIPLE_SCHEDULERS_ON_ONE_HOST, {"limit": 100}, 200, 3),
+        ],
+    )
+    def test_get_jobs(
+        self, test_client, testcase, query_params, expected_status_code, expected_total_entries
+    ):
+        # setup testcase at runtime based on the `testcase` parameter
+        self.setup(testcase)
+        response = test_client.get("/public/jobs/", params=query_params)
+        assert response.status_code == expected_status_code
+        if expected_status_code != 200:
+            return
+        response_json = response.json()
+        assert response_json["total_entries"] == expected_total_entries
+
+        for idx, resp_job in enumerate(response_json["jobs"]):
+            expected_job = {
+                "id": self.scheduler_jobs[idx].id,
+                "dag_id": None,
+                "state": "running",
+                "job_type": "SchedulerJob",
+                "start_date": self.scheduler_jobs[idx].start_date.isoformat().replace("+00:00", "Z"),
+                "end_date": None,
+                "latest_heartbeat": self.scheduler_jobs[idx]
+                .latest_heartbeat.isoformat()
+                .replace("+00:00", "Z"),
+                "executor_class": None,
+                "hostname": self.scheduler_jobs[idx].hostname,
+                "unixname": self.scheduler_jobs[idx].unixname,
+            }
+            assert resp_job == expected_job

--- a/tests_common/test_utils/format_datetime.py
+++ b/tests_common/test_utils/format_datetime.py
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from datetime import datetime
+
+
+def datetime_zulu_format(dt: datetime) -> str:
+    """Format a datetime object to a string in Zulu time."""
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def datetime_zulu_format_without_ms(dt: datetime) -> str:
+    """Format a datetime object to a string in Zulu time without milliseconds."""
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION


Closes: #43660  
Related: #43657  

### Feature

I’ve placed the endpoint in `airflow/api_fastapi/core_api/routes/public/job.py`, but I’m not certain if this is the most appropriate location—perhaps `airflow/api_fastapi/core_api/routes/cli/job.py` would also fine ?
The query parameters, response data models, and implementation are consistent with the rest of the public API, utilizing `common.parameters` and `paginated_select`.

### Tests

The test cases are refactored from the original [airflow/tests/cli/commands/test_jobs_command.py](https://github.com/apache/airflow/blob/main/tests/cli/commands/test_jobs_command.py), as the CLI should yield the same results when leveraging the API instead of direct DB access.

### Question

Hi @bugraoz93, I’m curious about the distinction between this PR’s endpoint (List Jobs with filters) and #43661 (List Jobs), as both endpoints seem to provide job listings. From my perspective, calling this "List Jobs with filters" endpoint without query parameters would yield the same response as the "List Jobs" endpoint.  
cc @josix  
