### PR TITLE
Fix breeze panel to start EdgeWorker when EdgeExecutor is selected in breeze

### DIFF
--- a/scripts/in_container/bin/run_tmux
+++ b/scripts/in_container/bin/run_tmux
@@ -87,7 +87,7 @@ if [[ ${INTEGRATION_CELERY} == "true" && ${CELERY_FLOWER} == "true" ]]; then
     tmux split-window -h
     tmux send-keys 'airflow celery flower' C-m
 fi
-if [[ ${AIRFLOW__CORE__EXECUTOR,,} == "edgeexecutor" ]]; then
+if [[ ${AIRFLOW__CORE__EXECUTOR} == "airflow.providers.edge.executors.edge_executor.EdgeExecutor" ]]; then
     tmux select-pane -t 0
     tmux split-window -h
 


### PR DESCRIPTION
As continuing to develop EdgeExecutor / AIP-69 I noticed that the breeze integration was "broken" on another point:
- If breeze is started with EdgeExecutor the executor path needed to be tweaked in #43842
- But a moment later TMUX is starting all panels and as the name was not matching, the edge worker panel was not starting - so the setup was missing a worker...

Root cause was like PR #43842 that the executor short name was removed during review and no direct mapping from "EdgeExecutor" in airflow core exists to map to provider package module name