### PR TITLE
fix(scheduler_job_runner/asset): fix how asset dag warning is added

### DIFF
--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -2138,14 +2138,14 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         session.execute(
             delete(DagWarning).where(
                 DagWarning.warning_type == DagWarningType.ASSET_CONFLICT,
-                DagWarning.dag_id.in_(warnings_to_have),
+                DagWarning.dag_id.not_in(warnings_to_have),
             )
         )
         existing_warned_dag_ids: set[str] = set(
             session.scalars(
                 select(DagWarning.dag_id).where(
                     DagWarning.warning_type == DagWarningType.ASSET_CONFLICT,
-                    DagWarning.dag_id.not_in(warnings_to_have),
+                    DagWarning.dag_id.in_(warnings_to_have),
                 )
             )
         )

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -29,7 +29,7 @@ from datetime import timedelta
 from functools import lru_cache, partial
 from itertools import groupby
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Collection, Iterable, Iterator, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Collection, Iterable, Iterator
 
 from sqlalchemy import and_, delete, exists, func, not_, select, text, update
 from sqlalchemy.exc import OperationalError
@@ -2136,17 +2136,14 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 incoming_uri_to_name[asset.uri] = asset.name
                 session.add(AssetActive.for_asset(asset))
 
-        def _get_first_item(x: Sequence[Any]) -> Any:
-            return x[0]
-
         warnings_to_have = {
             dag_id: DagWarning(
                 dag_id=dag_id,
-                error_type=DagWarningType.ASSET_CONFLICT,
-                message="\n".join([row[1] for row in group]),
+                warning_type=DagWarningType.ASSET_CONFLICT,
+                message="\n".join([message for _, message in group]),
             )
             for dag_id, group in groupby(
-                sorted(_activate_assets_generate_warnings(), key=_get_first_item), key=_get_first_item
+                sorted(_activate_assets_generate_warnings()), key=operator.itemgetter(0)
             )
         }
 

--- a/airflow/models/dagwarning.py
+++ b/airflow/models/dagwarning.py
@@ -38,7 +38,7 @@ class DagWarning(Base):
     A table to store DAG warnings.
 
     DAG warnings are problems that don't rise to the level of failing the DAG parse
-    but which users should nonetheless be warned about.  These warnings are recorded
+    but which users should nonetheless be warned about. These warnings are recorded
     when parsing DAG and displayed on the Webserver in a flash message.
     """
 

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -57,6 +57,7 @@ from airflow.models.dag import DAG, DagModel
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagbag import DagBag
 from airflow.models.dagrun import DagRun
+from airflow.models.dagwarning import DagWarning
 from airflow.models.db_callback_request import DbCallbackRequest
 from airflow.models.pool import Pool
 from airflow.models.serialized_dag import SerializedDagModel
@@ -6284,6 +6285,88 @@ class TestSchedulerJob:
         assert not DagRun.find(dag_id="testdag1", session=session)
         # Check if the second dagrun was created
         assert DagRun.find(dag_id="testdag2", session=session)
+
+    def test_activate_referenced_assets_with_no_existing_warning(self, session):
+        dag_warnings = session.query(DagWarning).all()
+        assert dag_warnings == []
+
+        dag_id1 = "test_asset_dag1"
+        asset1_name = "asset1"
+        asset_extra = {"foo": "bar"}
+
+        asset1 = Asset(name=asset1_name, uri="s3://bucket/key/1", extra=asset_extra)
+        asset1_1 = Asset(name=asset1_name, uri="it's duplicate", extra=asset_extra)
+        dag1 = DAG(dag_id=dag_id1, start_date=DEFAULT_DATE, schedule=[asset1, asset1_1])
+
+        DAG.bulk_write_to_db([dag1], session=session)
+
+        asset_models = session.scalars(select(AssetModel)).all()
+
+        SchedulerJobRunner._activate_referenced_assets(asset_models, session=session)
+        session.flush()
+
+        dag_warning = session.scalar(
+            select(DagWarning).where(
+                DagWarning.dag_id == dag_id1, DagWarning.warning_type == "asset conflict"
+            )
+        )
+        assert dag_warning.message == (
+            "Cannot activate asset AssetModel(name='asset1', uri=\"it's duplicate\", extra={'foo': 'bar'}); "
+            "name is already associated to 's3://bucket/key/1'"
+        )
+
+    def test_activate_referenced_assets_with_existing_warnings(self, session):
+        dag_ids = [f"test_asset_dag{i}" for i in range(1, 4)]
+        asset1_name = "asset1"
+        asset_extra = {"foo": "bar"}
+
+        session.add_all(
+            [
+                DagWarning(dag_id=dag_id, warning_type="asset conflict", message="will not exist")
+                for dag_id in dag_ids
+            ]
+        )
+
+        asset1 = Asset(name=asset1_name, uri="s3://bucket/key/1", extra=asset_extra)
+        asset1_1 = Asset(name=asset1_name, uri="it's duplicate", extra=asset_extra)
+        asset1_2 = Asset(name=asset1_name, uri="it's duplicate 2", extra=asset_extra)
+        dag1 = DAG(dag_id=dag_ids[0], start_date=DEFAULT_DATE, schedule=[asset1, asset1_1])
+        dag2 = DAG(dag_id=dag_ids[1], start_date=DEFAULT_DATE)
+        dag3 = DAG(dag_id=dag_ids[2], start_date=DEFAULT_DATE, schedule=[asset1_2])
+
+        DAG.bulk_write_to_db([dag1, dag2, dag3], session=session)
+
+        asset_models = session.scalars(select(AssetModel)).all()
+
+        SchedulerJobRunner._activate_referenced_assets(asset_models, session=session)
+        session.flush()
+
+        dag_warning = session.scalar(
+            select(DagWarning).where(
+                DagWarning.dag_id == dag_ids[0], DagWarning.warning_type == "asset conflict"
+            )
+        )
+        assert dag_warning.message == (
+            "Cannot activate asset AssetModel(name='asset1', uri=\"it's duplicate\", extra={'foo': 'bar'}); "
+            "name is already associated to 's3://bucket/key/1'"
+        )
+
+        dag_warning = session.scalar(
+            select(DagWarning).where(
+                DagWarning.dag_id == dag_ids[1], DagWarning.warning_type == "asset conflict"
+            )
+        )
+        assert dag_warning is None
+
+        dag_warning = session.scalar(
+            select(DagWarning).where(
+                DagWarning.dag_id == dag_ids[2], DagWarning.warning_type == "asset conflict"
+            )
+        )
+        assert dag_warning.message == (
+            "Cannot activate asset AssetModel(name='asset1', uri=\"it's duplicate 2\", extra={'foo': 'bar'}); "
+            "name is already associated to 's3://bucket/key/1'"
+        )
 
 
 @pytest.mark.need_serialized_dag


### PR DESCRIPTION
## Why
The logic for activating assets is not correct now.

## What
The correct logic is
1. Find the warning that should exist after this round
2. Delete the warnings that no longer needed
3. Update the warnings if they already exist and add new warnings if they do not yet exists

Related PR: https://github.com/apache/airflow/pull/43693 (that one fix the logic in the wrong way and is fixed in this PR)
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
