### PR TITLE
Change check for SQLite for FastAPI tests

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -459,8 +459,8 @@ def configure_orm(disable_connection_pool=False, pool_class=None):
     else:
         connect_args = {}
 
-    if os.environ.get("AIRFLOW__CORE__UNIT_TEST_MODE") == "True" and os.environ.get("BACKEND") == "sqlite":
-        # FastAPI runs sync endpoints in a separate thread. SQLite does note allow
+    if os.environ.get("AIRFLOW__CORE__UNIT_TEST_MODE") == "True" and SQL_ALCHEMY_CONN.startswith("sqlite"):
+        # FastAPI runs sync endpoints in a separate thread. SQLite does not allow
         # to use objects created in another threads by default. Allowing that in test
         # to so the `test` thread and the tested endpoints can use common objects.
         connect_args["check_same_thread"] = False

--- a/tests/core/test_sqlalchemy_config.py
+++ b/tests/core/test_sqlalchemy_config.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import os
 from unittest.mock import patch
 
 import pytest
@@ -60,7 +59,9 @@ class TestSqlAlchemySettings:
         settings.configure_orm()
         mock_create_engine.assert_called_once_with(
             settings.SQL_ALCHEMY_CONN,
-            connect_args={} if os.environ["BACKEND"] != "sqlite" else {"check_same_thread": False},
+            connect_args={}
+            if not settings.SQL_ALCHEMY_CONN.startswith("sqlite")
+            else {"check_same_thread": False},
             encoding="utf-8",
             max_overflow=10,
             pool_pre_ping=True,


### PR DESCRIPTION
This changes the current check for Sqlite that relies on `BACKEND` env var set by Breeze. This allow running same tests outside of Breeze.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
