### PR TITLE
Docs: Add prominent deprecations notice via css 

### DIFF
--- a/docs/sphinx_design/static/custom.css
+++ b/docs/sphinx_design/static/custom.css
@@ -31,3 +31,12 @@
     --sd-color-tabs-underline-hover: #68d1ff;
     --sd-color-tabs-underline: transparent;
 }
+
+div.admonition.warning {
+  background: #e8cccc;
+  font-weight: bolder;
+}
+
+.rst-content .warning .admonition-title {
+  background: #cc341d;
+}


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #41532 
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
Updated deprecated Bigquery docstrings with the `.. warning::` admonition and added custom CSS styling, which will apply to all `.. warning::` admonitions found in docstrtings.

closes https://github.com/apache/airflow/issues/41532
