### PR TITLE
Fix prepare-provider-packages for fab and standard providers

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -197,7 +197,7 @@ jobs:
       - name: "Prepare FAB+standard provider packages: wheel"
         run: >
             breeze release-management prepare-provider-packages fab standard \
-              --package-format wheel --skip-tag-check
+              --package-format wheel --skip-tag-check --version-suffix-for-pypi dev0
       - name: "Install Airflow with fab for webserver tests"
         run: pip install . dist/apache_airflow_providers_fab-*.whl
       - name: "Install Airflow with standard provider for webserver tests"


### PR DESCRIPTION
This should unblock the issue in https://github.com/apache/airflow/pull/41916

```
The conflict is caused by:
    apache-airflow 3.0.0.dev0 depends on apache-airflow-providers-common-sql
    apache-airflow-providers-standard 0.0.1 depends on apache-airflow-providers-common-sql>=1.20.0
```