### PR TITLE
Remove strict_asset_uri_validation

### DIFF
--- a/airflow/assets/__init__.py
+++ b/airflow/assets/__init__.py
@@ -36,9 +36,6 @@ if TYPE_CHECKING:
 
     from sqlalchemy.orm.session import Session
 
-
-from airflow.configuration import conf
-
 __all__ = ["Asset", "AssetAll", "AssetAny", "Dataset"]
 
 
@@ -104,19 +101,7 @@ def _sanitize_uri(uri: str) -> str:
         fragment="",  # Ignore any fragments.
     )
     if (normalizer := _get_uri_normalizer(normalized_scheme)) is not None:
-        try:
-            parsed = normalizer(parsed)
-        except ValueError as exception:
-            if conf.getboolean("core", "strict_asset_uri_validation", fallback=True):
-                log.error(
-                    (
-                        "The Asset URI %s is not AIP-60 compliant: %s. "
-                        "Please check https://airflow.apache.org/docs/apache-airflow/stable/authoring-and-scheduling/assets.html"
-                    ),
-                    uri,
-                    exception,
-                )
-                raise
+        parsed = normalizer(parsed)
     return urllib.parse.urlunsplit(parsed)
 
 

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -482,13 +482,6 @@ core:
       sensitive: true
       default: ~
       example: '{"some_param": "some_value"}'
-    strict_asset_uri_validation:
-      description: |
-        Asset URI validation should raise an exception if it is not compliant with AIP-60.
-      default: "True"
-      example: ~
-      version_added: 2.9.2
-      type: boolean
     database_access_isolation:
       description: (experimental) Whether components should use Airflow Internal API for DB connectivity.
       version_added: 2.6.0

--- a/newsfragments/41348.significant.rst
+++ b/newsfragments/41348.significant.rst
@@ -187,7 +187,7 @@
 
     * Rename function ``has_access_dataset`` as ``has_access_asset``
 
-* Rename configuration ``core.strict_dataset_uri_validation`` as ``core.strict_asset_uri_validation``, ``core.dataset_manager_class`` as ``core.asset_manager_class`` and ``core.dataset_manager_class`` as ``core.asset_manager_class``
+* Rename configuration ``core.dataset_manager_class`` as ``core.asset_manager_class`` and ``core.dataset_manager_class`` as ``core.asset_manager_class``
 * Rename example dags  ``example_dataset_alias.py``, ``example_dataset_alias_with_no_taskflow.py``, ``example_datasets.py`` as ``example_asset_alias.py``, ``example_asset_alias_with_no_taskflow.py``, ``example_assets.py``
 * Rename DagDependency name ``dataset-alias``, ``dataset`` as ``asset-alias``, ``asset``
 * Rename context key ``triggering_dataset_events`` as ``triggering_asset_events``

--- a/newsfragments/43915.significant.rst
+++ b/newsfragments/43915.significant.rst
@@ -1,0 +1,4 @@
+Configuration ``[core] strict_dataset_uri_validation`` is removed
+
+Asset URI with a defined scheme will now always be validated strictly, raising
+a hard error on validation failure.


### PR DESCRIPTION
An invalid asset URI now should always raise a hard error instead, as specified in AIP-60.

A separate PR will be submitted later to add this to the warning message in Airflow 2 to explicitly tell users to fix the URI.