### PR TITLE
Tweak strict_dataset_uri_validation documentation wording

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -494,7 +494,7 @@ core:
       description: |
         Dataset URI validation should raise an exception if it is not compliant with AIP-60.
         By default this configuration is false, meaning that Airflow 2.x only warns the user.
-        In Airflow 3, this configuration will be enabled by default.
+        In Airflow 3, this configuration will be removed, unconditionally enabling strict validation.
       default: "False"
       example: ~
       version_added: 2.9.2


### PR DESCRIPTION
See #43915. The warning message also already says this will be a hard error in Airflow 3.

https://github.com/apache/airflow/blob/0380160eda9dee4cc13a13c23719a06499c2c398/airflow/datasets/__init__.py#L114-L119