### PR TITLE
Remove non-existing field  from the ListCustomTrainingJobOperator's template_fields

### DIFF
--- a/providers/src/airflow/providers/google/cloud/operators/vertex_ai/custom_job.py
+++ b/providers/src/airflow/providers/google/cloud/operators/vertex_ai/custom_job.py
@@ -1750,7 +1750,6 @@ class ListCustomTrainingJobOperator(GoogleCloudBaseOperator):
         "region",
         "project_id",
         "impersonation_chain",
-        "display_name",
     ]
     operator_extra_links = [
         VertexAITrainingPipelinesLink(),


### PR DESCRIPTION
Fix the `ListCustomTrainingJobOperator` by removing the non-existing field `display_name` from the `template_fields`