### PR TITLE
Combine fab, standard and sql providers into one step in Breeze

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -194,19 +194,14 @@ jobs:
         env:
           HATCH_ENV: "test"
         working-directory: ./clients/python
-      - name: "Prepare FAB+standard provider packages: wheel"
-        run: >
-            breeze release-management prepare-provider-packages fab standard \
-              --package-format wheel --skip-tag-check --version-suffix-for-pypi dev0
-      - name: "Install Airflow with fab for webserver tests"
-        run: pip install . dist/apache_airflow_providers_fab-*.whl
-      - name: "Install Airflow with standard provider for webserver tests"
-        run: pip install . dist/apache_airflow_providers_standard-*.whl
-      - name: "Prepare Task SDK package: wheel"
-        run: >
-          breeze release-management prepare-task-sdk-package --package-format wheel
-      - name: "Install Task SDK package"
-        run: pip install ./dist/apache_airflow_task_sdk-*.whl
+      - name: "Install source version of required packages"
+        run: |
+            breeze release-management prepare-provider-packages fab standard common.sql --package-format  \
+            wheel --skip-tag-check --version-suffix-for-pypi dev0
+            pip install . dist/apache_airflow_providers_fab-*.whl \
+            dist/apache_airflow_providers_standard-*.whl dist/apache_airflow_providers_common_sql-*.whl
+            breeze release-management prepare-task-sdk-package --package-format wheel
+            pip install ./dist/apache_airflow_task_sdk-*.whl
       - name: "Install Python client"
         run: pip install ./dist/apache_airflow_client-*.whl
       - name: "Initialize Airflow DB and start webserver"


### PR DESCRIPTION
Now that standard provider also depended on common.sql lets merge the step into one