### PR TITLE
[Edge]Add child processes to separate process group than main

### DIFF
--- a/docs/apache-airflow-providers-edge/edge_executor.rst
+++ b/docs/apache-airflow-providers-edge/edge_executor.rst
@@ -232,7 +232,6 @@ The following features are known missing and will be implemented in increments:
 - Edge Worker CLI
 
   - Use WebSockets instead of HTTP calls for communication
-  - Handle SIG-INT/CTRL+C and gracefully terminate and complete job (``airflow edge stop`` is working though)
   - Send logs also to TaskFileHandler if external logging services are used
   - Integration into telemetry to send metrics from remote site
   - Allow ``airflow edge stop`` to wait until completed to terminated

--- a/providers/src/airflow/providers/edge/CHANGELOG.rst
+++ b/providers/src/airflow/providers/edge/CHANGELOG.rst
@@ -33,7 +33,8 @@ Changelog
 Misc
 ~~~~
 
-* ``Fix SIGINT handling of child processes.``
+* ``Fix SIGINT handling of child processes. Ensure graceful shutdown when SIGINT in received (not killing working tasks).``
+* ``Fix SIGTERM handling of child processes. Ensure all childs are terminated on SIGTERM.``
 
 
 0.5.3pre0

--- a/providers/src/airflow/providers/edge/CHANGELOG.rst
+++ b/providers/src/airflow/providers/edge/CHANGELOG.rst
@@ -27,6 +27,15 @@
 Changelog
 ---------
 
+0.5.4pre0
+.........
+
+Misc
+~~~~
+
+* ``Fix SIGINT handling of child processes.``
+
+
 0.5.3pre0
 .........
 

--- a/providers/src/airflow/providers/edge/__init__.py
+++ b/providers/src/airflow/providers/edge/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "0.5.3pre0"
+__version__ = "0.5.4pre0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.10.0"

--- a/providers/src/airflow/providers/edge/cli/edge_command.py
+++ b/providers/src/airflow/providers/edge/cli/edge_command.py
@@ -218,7 +218,9 @@ class _EdgeWorkerCli:
             env["AIRFLOW__CORE__DATABASE_ACCESS_ISOLATION"] = "True"
             env["AIRFLOW__CORE__INTERNAL_API_URL"] = conf.get("edge", "api_url")
             env["_AIRFLOW__SKIP_DATABASE_EXECUTOR_COMPATIBILITY_CHECK"] = "1"
+            signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGINT})
             process = Popen(edge_job.command, close_fds=True, env=env)
+            signal.pthread_sigmask(signal.SIG_UNBLOCK, {signal.SIGINT})
             logfile = EdgeLogs.logfile_path(edge_job.key)
             self.jobs.append(_Job(edge_job, process, logfile, 0))
             EdgeJob.set_state(edge_job.key, TaskInstanceState.RUNNING)

--- a/providers/src/airflow/providers/edge/cli/edge_command.py
+++ b/providers/src/airflow/providers/edge/cli/edge_command.py
@@ -218,9 +218,7 @@ class _EdgeWorkerCli:
             env["AIRFLOW__CORE__DATABASE_ACCESS_ISOLATION"] = "True"
             env["AIRFLOW__CORE__INTERNAL_API_URL"] = conf.get("edge", "api_url")
             env["_AIRFLOW__SKIP_DATABASE_EXECUTOR_COMPATIBILITY_CHECK"] = "1"
-            signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGINT})
-            process = Popen(edge_job.command, close_fds=True, env=env)
-            signal.pthread_sigmask(signal.SIG_UNBLOCK, {signal.SIGINT})
+            process = Popen(edge_job.command, close_fds=True, env=env, start_new_session=True)
             logfile = EdgeLogs.logfile_path(edge_job.key)
             self.jobs.append(_Job(edge_job, process, logfile, 0))
             EdgeJob.set_state(edge_job.key, TaskInstanceState.RUNNING)

--- a/providers/src/airflow/providers/edge/provider.yaml
+++ b/providers/src/airflow/providers/edge/provider.yaml
@@ -27,7 +27,7 @@ source-date-epoch: 1729683247
 
 # note that those versions are maintained by release manager - do not update them manually
 versions:
-  - 0.5.3pre0
+  - 0.5.4pre0
 
 dependencies:
   - apache-airflow>=2.10.0


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
Currently we use subprocess.Popen to spawn a job by the edge worker. When SIGINT is raised, it will be passed down to the child process, where it is not handled, meaning that even if we handle it in the worker, the exception will be raised anyway.

This PR adds the start_new_session flag for Popen, which will call the setsid() prior to the execution of the child process, and start it in a separate process group

Since exceptions are not passed down to child tasks there is a separate method to handle SIGTERM for hard termination
 
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
