### PR TITLE
Minor Improvements to public FastAPI XCom endpoint

### DIFF
--- a/airflow/api_fastapi/core_api/datamodels/xcom.py
+++ b/airflow/api_fastapi/core_api/datamodels/xcom.py
@@ -42,8 +42,8 @@ class XComResponseNative(XComResponse):
 class XComResponseString(XComResponse):
     """XCom response serializer with string return type."""
 
-    value: Any
+    value: str | None
 
-    @field_validator("value")
+    @field_validator("value", mode="before")
     def value_to_string(cls, v):
         return str(v) if v is not None else None

--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -3141,6 +3141,7 @@ paths:
         required: false
         schema:
           type: integer
+          minimum: -1
           default: -1
           title: Map Index
       - name: deserialize
@@ -5285,6 +5286,9 @@ components:
           type: string
           title: Dag Id
         value:
+          anyOf:
+          - type: string
+          - type: 'null'
           title: Value
       type: object
       required:

--- a/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -3172,6 +3172,14 @@ export const $XComResponseString = {
       title: "Dag Id",
     },
     value: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
       title: "Value",
     },
   },

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -773,7 +773,7 @@ export type XComResponseString = {
   map_index: number;
   task_id: string;
   dag_id: string;
-  value: unknown;
+  value: string | null;
 };
 
 export type NextRunAssetsData = {


### PR DESCRIPTION
- Remove "print" statement, thought it was added as a mistake
- Change the status code from raw int to named constants
- Change Query params to use Query and added validation of `>=-1` for map index
- Added validation for response type to `str | None` instead of previous generic of `Any`

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
