### PR TITLE
Added host_proxy_cmd field in the ssh hooks extra options

### DIFF
--- a/docs/apache-airflow-providers-ssh/connections/ssh.rst
+++ b/docs/apache-airflow-providers-ssh/connections/ssh.rst
@@ -57,6 +57,7 @@ Extra (optional)
     * ``host_key`` - The base64 encoded ssh-rsa public key of the host or "ssh-<key type> <key data>" (as you would find in the ``known_hosts`` file). Specifying this allows making the connection if and only if the public key of the endpoint matches this value.
     * ``disabled_algorithms`` - A dictionary mapping algorithm type to an iterable of algorithm identifiers, which will be disabled for the lifetime of the transport.
     * ``ciphers`` - A list of ciphers to use in order of preference.
+    * ``host_proxy_cmd`` - A proxy command to be executed.
 
     Example "extras" field:
 

--- a/providers/src/airflow/providers/ssh/hooks/ssh.py
+++ b/providers/src/airflow/providers/ssh/hooks/ssh.py
@@ -260,8 +260,8 @@ class SSHHook(BaseHook):
             with open(user_ssh_config_filename) as config_fd:
                 ssh_conf.parse(config_fd)
             host_info = ssh_conf.lookup(self.remote_host)
-            """If the proxy command is already set via the extra options - pass"""
-            if self.host_proxy_cmd is None:
+            # If the proxy command is already set via the extra options, it will not be overwritten"""
+            if not self.host_proxy_cmd:
                 if host_info and host_info.get("proxycommand"):
                     self.host_proxy_cmd = host_info["proxycommand"]
 

--- a/providers/tests/ssh/hooks/test_ssh.py
+++ b/providers/tests/ssh/hooks/test_ssh.py
@@ -755,7 +755,7 @@ class TestSSHHook:
             transport = ssh_mock.return_value.get_transport.return_value
             assert transport.get_security_options.return_value.ciphers == TEST_CIPHERS
 
-    def test_host_proxy_cmd_in_extra():
+    def test_host_proxy_cmd_in_extra(self):
         TEST_HOST_PROXY_CMD = "ncat --proxy-auth proxy_user:**** --proxy proxy_host:port %h %p"
         session = settings.Session()
         try:

--- a/providers/tests/ssh/hooks/test_ssh.py
+++ b/providers/tests/ssh/hooks/test_ssh.py
@@ -755,6 +755,24 @@ class TestSSHHook:
             transport = ssh_mock.return_value.get_transport.return_value
             assert transport.get_security_options.return_value.ciphers == TEST_CIPHERS
 
+    def test_host_proxy_cmd_in_extra():
+        TEST_HOST_PROXY_CMD = "ncat --proxy-auth proxy_user:**** --proxy proxy_host:port %h %p"
+        session = settings.Session()
+        try:
+            conn = Connection(
+                conn_id="ssh_with_proxy_cmd",
+                host="localhost",
+                conn_type="ssh",
+                extra={"host_proxy_cmd": TEST_HOST_PROXY_CMD},
+            )
+            session.add(conn)
+            session.flush()
+            hook = SSHHook(ssh_conn_id=conn.conn_id)
+            assert hook.host_proxy_cmd == TEST_HOST_PROXY_CMD
+        finally:
+            session.delete(conn)
+            session.commit()
+
     def test_openssh_private_key(self):
         # Paramiko behaves differently with OpenSSH generated keys to paramiko
         # generated keys, so we need a test one.


### PR DESCRIPTION

closes: #43636

One can now add the key: `host_proxy_cmd` to the `extra_options` of the SSHHook.

This is the now preferred option of setting an external command. Only if the `host_proxy_cmd` attribute of the class is not set via the `extra_options`, it will be read from the hosts `~/.ssh/config`.
I have also added a unit test for the new functionality.

If there is anything I should change / add, let me know.

---