### PR TITLE
Fix pre-commit selective checks

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -162,6 +162,7 @@ CI_FILE_GROUP_MATCHES = HashableDict(
         ],
         FileGroupForCi.API_CODEGEN_FILES: [
             r"^airflow/api_connexion/openapi/v1\.yaml",
+            r"^airflow/api_fastapi/core_api/openapi/v1-generated\.yaml",
             r"^clients/gen",
         ],
         FileGroupForCi.LEGACY_API_FILES: [
@@ -1107,7 +1108,12 @@ class SelectiveChecks:
             FileGroupForCi.LEGACY_WWW_FILES, CI_FILE_GROUP_MATCHES, CI_FILE_GROUP_EXCLUDES
         ):
             pre_commits_to_skip.add("ts-compile-format-lint-www")
-        if not self._matching_files(FileGroupForCi.UI_FILES, CI_FILE_GROUP_MATCHES, CI_FILE_GROUP_EXCLUDES):
+        if not (
+            self._matching_files(FileGroupForCi.UI_FILES, CI_FILE_GROUP_MATCHES, CI_FILE_GROUP_EXCLUDES)
+            or self._matching_files(
+                FileGroupForCi.API_CODEGEN_FILES, CI_FILE_GROUP_MATCHES, CI_FILE_GROUP_EXCLUDES
+            )
+        ):
             pre_commits_to_skip.add("ts-compile-format-lint-ui")
         if not self._matching_files(
             FileGroupForCi.ALL_PYTHON_FILES, CI_FILE_GROUP_MATCHES, CI_FILE_GROUP_EXCLUDES

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -1551,6 +1551,27 @@ def test_expected_output_pull_request_v2_7(
             id="Tests for all airflow core types except providers should run if "
             "any other than API/WWW/CLI/Operators file changed.",
         ),
+        pytest.param(
+            ("airflow/api_fastapi/core_api/openapi/v1-generated.yaml",),
+            {
+                "affected-providers-list-as-string": None,
+                "all-python-versions": "['3.9']",
+                "all-python-versions-list-as-string": "3.9",
+                "ci-image-build": "true",
+                "needs-helm-tests": "false",
+                "run-tests": "true",
+                "docs-build": "false",
+                "docs-list-as-string": None,
+                "upgrade-to-newer-dependencies": "false",
+                "skip-pre-commits": "check-provider-yaml-valid,flynt,identity,lint-helm-chart,"
+                "mypy-airflow,mypy-dev,mypy-docs,mypy-providers,mypy-task-sdk,ts-compile-format-lint-www",
+                "skip-provider-tests": "true",
+                "parallel-test-types-list-as-string": None,
+                "needs-mypy": "false",
+                "mypy-checks": "[]",
+            },
+            id="pre commit ts-compile-format-lint should not be ignored if openapi spec changed.",
+        ),
     ],
 )
 def test_expected_output_pull_request_target(


### PR DESCRIPTION
This PR highlighted an issue with the pre-commit selective checks, https://github.com/apache/airflow/pull/43521. diffs on the `v1-genereated.yaml` spec did not trigger the `ts-compile-lint-ui` hook that is supposed to run the front-end codegen.