### PR TITLE
Update dag reserialize command

### DIFF
--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -967,13 +967,6 @@ ARG_CAPACITY = Arg(
     help="The maximum number of triggers that a Triggerer will run at one time.",
 )
 
-# reserialize
-ARG_CLEAR_HISTORY = Arg(
-    ("--clear-history",),
-    action="store_true",
-    help="If passed, DAGs history will be cleared.",
-)
-
 ARG_DAG_LIST_COLUMNS = Arg(
     ("--columns",),
     type=string_list_type,
@@ -1243,15 +1236,15 @@ DAGS_COMMANDS = (
     ),
     ActionCommand(
         name="reserialize",
-        help="Reserialize all DAGs by parsing the DagBag files",
+        help="Re-version DAGs by parsing the DagBag files",
         description=(
-            "Drop all serialized dags from the metadata DB. This will cause all DAGs to be reserialized "
-            "from the DagBag folder. This can be helpful if your serialized DAGs get out of sync with the "
-            "version of Airflow that you are running."
+            "Manually initiate re-versioning of DAGs. Airflow will detect any changes in "
+            "your DAG's structure and re-version those that have been modified. This can be "
+            "particularly useful if your serialized DAGs become out of sync with the Airflow "
+            "version you are using."
         ),
         func=lazy_load_command("airflow.cli.commands.dag_command.dag_reserialize"),
         args=(
-            ARG_CLEAR_HISTORY,
             ARG_SUBDIR,
             ARG_VERBOSE,
         ),

--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -968,10 +968,10 @@ ARG_CAPACITY = Arg(
 )
 
 # reserialize
-ARG_CLEAR_ONLY = Arg(
-    ("--clear-only",),
+ARG_CLEAR_HISTORY = Arg(
+    ("--clear-history",),
     action="store_true",
-    help="If passed, serialized DAGs will be cleared but not reserialized.",
+    help="If passed, DAGs history will be cleared.",
 )
 
 ARG_DAG_LIST_COLUMNS = Arg(
@@ -1251,10 +1251,9 @@ DAGS_COMMANDS = (
         ),
         func=lazy_load_command("airflow.cli.commands.dag_command.dag_reserialize"),
         args=(
-            ARG_CLEAR_ONLY,
+            ARG_CLEAR_HISTORY,
             ARG_SUBDIR,
             ARG_VERBOSE,
-            ARG_YES,
         ),
     ),
 )

--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -1254,6 +1254,7 @@ DAGS_COMMANDS = (
             ARG_CLEAR_ONLY,
             ARG_SUBDIR,
             ARG_VERBOSE,
+            ARG_YES,
         ),
     ),
 )

--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -1236,10 +1236,9 @@ DAGS_COMMANDS = (
     ),
     ActionCommand(
         name="reserialize",
-        help="Re-version DAGs by parsing the DagBag files",
+        help="Reserialize DAGs by parsing the DagBag files",
         description=(
-            "Manually initiate re-versioning of DAGs. Airflow will detect any changes in "
-            "your DAG's structure and re-version those that have been modified. This can be "
+            "Reserialize DAGs in the metadata DB. This can be "
             "particularly useful if your serialized DAGs become out of sync with the Airflow "
             "version you are using."
         ),

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -538,12 +538,8 @@ def dag_test(args, dag: DAG | None = None, session: Session = NEW_SESSION) -> No
 @provide_session
 def dag_reserialize(args, session: Session = NEW_SESSION) -> None:
     """Serialize a DAG instance."""
-    if not (
-        args.yes or input("This will clean out all DAG versioning history. Proceed? (y/n)").upper() == "Y"
-    ):
-        raise SystemExit("Cancelled")
-    session.execute(delete(DagVersion).execution_options(synchronize_session=False))
+    if args.clear_history:
+        session.execute(delete(DagVersion).execution_options(synchronize_session=False))
 
-    if not args.clear_only:
-        dagbag = DagBag(process_subdir(args.subdir))
-        dagbag.sync_to_db(session=session)
+    dagbag = DagBag(process_subdir(args.subdir))
+    dagbag.sync_to_db(session=session)

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -28,7 +28,7 @@ import sys
 from typing import TYPE_CHECKING
 
 import re2
-from sqlalchemy import delete, select
+from sqlalchemy import select
 
 from airflow.api.client import get_current_api_client
 from airflow.api_connexion.schemas.dag_schema import dag_schema
@@ -36,7 +36,6 @@ from airflow.cli.simple_table import AirflowConsole
 from airflow.exceptions import AirflowException
 from airflow.jobs.job import Job
 from airflow.models import DagBag, DagModel, DagRun, TaskInstance
-from airflow.models.dag_version import DagVersion
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.utils import cli as cli_utils, timezone
 from airflow.utils.cli import get_dag, process_subdir, suppress_logs_and_warning
@@ -538,8 +537,5 @@ def dag_test(args, dag: DAG | None = None, session: Session = NEW_SESSION) -> No
 @provide_session
 def dag_reserialize(args, session: Session = NEW_SESSION) -> None:
     """Serialize a DAG instance."""
-    if args.clear_history:
-        session.execute(delete(DagVersion).execution_options(synchronize_session=False))
-
     dagbag = DagBag(process_subdir(args.subdir))
     dagbag.sync_to_db(session=session)

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -41,7 +41,6 @@ from typing import (
 import attrs
 from sqlalchemy import (
     Table,
-    delete,
     exc,
     func,
     inspect,
@@ -924,9 +923,7 @@ def check_and_run_migrations():
 
 def _reserialize_dags(*, session: Session) -> None:
     from airflow.models.dagbag import DagBag
-    from airflow.models.serialized_dag import SerializedDagModel
 
-    session.execute(delete(SerializedDagModel).execution_options(synchronize_session=False))
     dagbag = DagBag(collect_dags=False)
     dagbag.collect_dags(only_if_updated=False)
     dagbag.sync_to_db(session=session)

--- a/newsfragments/43949.significant.rst
+++ b/newsfragments/43949.significant.rst
@@ -1,4 +1,4 @@
 The ``--clear-only`` option of ``airflow dags reserialize`` command is now removed.
 
 The ``--clear-only`` option was added to clear the serialized DAGs without reserializing them.
-This option is now removed as it is no longer needed. The command is now only for re-versioning DAGs.
+This option is now removed as it is no longer needed. The command is now only for reserializing DAGs.

--- a/newsfragments/43949.significant.rst
+++ b/newsfragments/43949.significant.rst
@@ -1,0 +1,5 @@
+The ``--clear-only`` option of ``airflow dags reserialize`` command is now removed.
+
+The ``--clear-only`` option was added to clear the serialized DAGs without reserializing them.
+This option is now removed as it is no longer needed. By default, the command only reserializes dags. If you want
+to clear dags serialization history, you can use the ``--clear-history`` option.

--- a/newsfragments/43949.significant.rst
+++ b/newsfragments/43949.significant.rst
@@ -1,5 +1,4 @@
 The ``--clear-only`` option of ``airflow dags reserialize`` command is now removed.
 
 The ``--clear-only`` option was added to clear the serialized DAGs without reserializing them.
-This option is now removed as it is no longer needed. By default, the command only reserializes dags. If you want
-to clear dags serialization history, you can use the ``--clear-history`` option.
+This option is now removed as it is no longer needed. The command is now only for re-versioning DAGs.

--- a/newsfragments/43949.significant.rst
+++ b/newsfragments/43949.significant.rst
@@ -1,4 +1,5 @@
 The ``--clear-only`` option of ``airflow dags reserialize`` command is now removed.
 
 The ``--clear-only`` option was added to clear the serialized DAGs without reserializing them.
-This option is now removed as it is no longer needed. The command is now only for reserializing DAGs.
+This option has been removed as it is no longer needed. We have implemented DAG versioning and can
+no longer delete serialized dag without going through ``airflow db-clean`` command. This command is now only for reserializing DAGs.

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -99,16 +99,6 @@ class TestCliDags:
         dag_version_after_command = session.query(DagVersion).all()
         assert len(dag_version_after_command)
 
-        # Serialize the dag with clear history
-        dag_command.dag_reserialize(self.parser.parse_args(["dags", "reserialize", "--clear-history"]))
-
-        # Check serialized DAGs are back
-        dagv = session.query(DagVersion).all()
-        assert len(dagv)
-        serialized_dags_after_reserialize = session.query(SerializedDagModel).all()
-        assert len(serialized_dags_after_reserialize) >= 40  # Serialized DAGs back
-        assert len(dagv) == len(serialized_dags_after_reserialize)
-
     def test_reserialize_should_support_subdir_argument(self, session):
         # Run clear of serialized dags
         session.query(DagVersion).delete()

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -79,34 +79,30 @@ class TestCliDags:
     def setup_method(self):
         clear_db_runs()  # clean-up all dag run before start each test
 
-    def test_reserialize(self):
+    def test_reserialize(self, session):
         # Assert that there are serialized Dags
-        with create_session() as session:
-            serialized_dags_before_command = session.query(SerializedDagModel).all()
+        serialized_dags_before_command = session.query(SerializedDagModel).all()
         assert len(serialized_dags_before_command)  # There are serialized DAGs to delete
 
         # Run clear of serialized dags
-        dag_command.dag_reserialize(self.parser.parse_args(["dags", "reserialize", "--clear-only"]))
+        dag_command.dag_reserialize(self.parser.parse_args(["dags", "reserialize", "--clear-only", "--yes"]))
         # Assert no serialized Dags
-        with create_session() as session:
-            serialized_dags_after_clear = session.query(SerializedDagModel).all()
+        serialized_dags_after_clear = session.query(SerializedDagModel).all()
         assert not len(serialized_dags_after_clear)
 
         # Serialize manually
-        dag_command.dag_reserialize(self.parser.parse_args(["dags", "reserialize"]))
+        dag_command.dag_reserialize(self.parser.parse_args(["dags", "reserialize", "--yes"]))
 
         # Check serialized DAGs are back
-        with create_session() as session:
-            serialized_dags_after_reserialize = session.query(SerializedDagModel).all()
+        serialized_dags_after_reserialize = session.query(SerializedDagModel).all()
         assert len(serialized_dags_after_reserialize) >= 40  # Serialized DAGs back
 
-    def test_reserialize_should_support_subdir_argument(self):
+    def test_reserialize_should_support_subdir_argument(self, session):
         # Run clear of serialized dags
-        dag_command.dag_reserialize(self.parser.parse_args(["dags", "reserialize", "--clear-only"]))
+        dag_command.dag_reserialize(self.parser.parse_args(["dags", "reserialize", "--clear-only", "--yes"]))
 
         # Assert no serialized Dags
-        with create_session() as session:
-            serialized_dags_after_clear = session.query(SerializedDagModel).all()
+        serialized_dags_after_clear = session.query(SerializedDagModel).all()
         assert len(serialized_dags_after_clear) == 0
 
         # Serialize manually
@@ -117,11 +113,12 @@ class TestCliDags:
         with mock.patch(
             "airflow.cli.commands.dag_command.DagBag.__init__.__defaults__", tuple(dagbag_default)
         ):
-            dag_command.dag_reserialize(self.parser.parse_args(["dags", "reserialize", "--subdir", dag_path]))
+            dag_command.dag_reserialize(
+                self.parser.parse_args(["dags", "reserialize", "--subdir", dag_path, "--yes"])
+            )
 
         # Check serialized DAG are back
-        with create_session() as session:
-            serialized_dags_after_reserialize = session.query(SerializedDagModel).all()
+        serialized_dags_after_reserialize = session.query(SerializedDagModel).all()
         assert len(serialized_dags_after_reserialize) == 1  # Serialized DAG back
 
     def test_show_dag_dependencies_print(self):


### PR DESCRIPTION
Now that we have versioning, users must specify that they want to delete history before we do it in `airflow dags reserialize` command.

serialize dags are no longer deleted as part of this command. Users should use airflow db-clean command

Also updated the _reserialize function at DB upgrade so that it doesn't delete the serializedDag since that won't be necessary.

