### PR TITLE
[edge] Fixed UnicodeDecodeError during log file upload of Edge worker

### DIFF
--- a/providers/src/airflow/providers/edge/CHANGELOG.rst
+++ b/providers/src/airflow/providers/edge/CHANGELOG.rst
@@ -27,6 +27,14 @@
 Changelog
 ---------
 
+0.5.5pre0
+.........
+
+Misc
+~~~~
+
+* ``Fixed reading none UTF-8 signs in log file.``
+
 0.5.4pre0
 .........
 
@@ -35,7 +43,6 @@ Misc
 
 * ``Fix SIGINT handling of child processes. Ensure graceful shutdown when SIGINT in received (not killing working tasks).``
 * ``Fix SIGTERM handling of child processes. Ensure all childs are terminated on SIGTERM.``
-
 
 0.5.3pre0
 .........

--- a/providers/src/airflow/providers/edge/__init__.py
+++ b/providers/src/airflow/providers/edge/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "0.5.4pre0"
+__version__ = "0.5.5pre0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.10.0"

--- a/providers/src/airflow/providers/edge/cli/edge_command.py
+++ b/providers/src/airflow/providers/edge/cli/edge_command.py
@@ -248,19 +248,23 @@ class _EdgeWorkerCli:
                     logger.error("Job failed: %s", job.edge_job)
                     EdgeJob.set_state(job.edge_job.key, TaskInstanceState.FAILED)
             if job.logfile.exists() and job.logfile.stat().st_size > job.logsize:
-                with job.logfile.open("r") as logfile:
+                with job.logfile.open("rb") as logfile:
                     push_log_chunk_size = conf.getint("edge", "push_log_chunk_size")
                     logfile.seek(job.logsize, os.SEEK_SET)
+                    read_data = logfile.read()
+                    job.logsize += len(read_data)
+                    log_data = read_data.decode("utf-8", "backslashreplace")
                     while True:
-                        logdata = logfile.read(push_log_chunk_size)
-                        if not logdata:
+                        chunk_data = log_data[:push_log_chunk_size]
+                        log_data = log_data[push_log_chunk_size:]
+                        if not chunk_data:
                             break
+
                         EdgeLogs.push_logs(
                             task=job.edge_job.key,
                             log_chunk_time=datetime.now(),
-                            log_chunk_data=logdata,
+                            log_chunk_data=chunk_data,
                         )
-                        job.logsize += len(logdata)
 
     def heartbeat(self) -> None:
         """Report liveness state of worker to central site with stats."""

--- a/providers/src/airflow/providers/edge/cli/edge_command.py
+++ b/providers/src/airflow/providers/edge/cli/edge_command.py
@@ -253,7 +253,8 @@ class _EdgeWorkerCli:
                     logfile.seek(job.logsize, os.SEEK_SET)
                     read_data = logfile.read()
                     job.logsize += len(read_data)
-                    log_data = read_data.decode("utf-8", "backslashreplace")
+                    # backslashreplace to keep not decoded characters and not raising exception
+                    log_data = read_data.decode(errors="backslashreplace")
                     while True:
                         chunk_data = log_data[:push_log_chunk_size]
                         log_data = log_data[push_log_chunk_size:]

--- a/providers/src/airflow/providers/edge/provider.yaml
+++ b/providers/src/airflow/providers/edge/provider.yaml
@@ -27,7 +27,7 @@ source-date-epoch: 1729683247
 
 # note that those versions are maintained by release manager - do not update them manually
 versions:
-  - 0.5.4pre0
+  - 0.5.5pre0
 
 dependencies:
   - apache-airflow>=2.10.0


### PR DESCRIPTION
# Description

Edge worker runs into UnicodeDecodeError exception during log file upload. The Worker reads log file as string and counts number of string characters to seek into the file during uploading next log file part. This can result in mismatch between number of bytes and number of string characters if log file contains none UTF-8 characters. So during upload of next log file part worker can jump between 2 bytes of none utf-8 characters and crashes. Edge worker now uses read bytes to calc place to seek into and decode string as UTF-8 to handle none UTF-8 charaters.

# Details about changes

* Worker reads log file as byte string to calc number of read bytes to seek in.
* Worker decode byte string to UTF-8
* Changed unit tests to test none UTF-8 log file.
