### PR TITLE
Add source_tag to PineconeHook

### DIFF
--- a/providers/src/airflow/providers/pinecone/hooks/pinecone.py
+++ b/providers/src/airflow/providers/pinecone/hooks/pinecone.py
@@ -118,7 +118,12 @@ class PineconeHook(BaseHook):
         enable_curl_debug = extras.get("debug_curl")
         if enable_curl_debug:
             os.environ["PINECONE_DEBUG_CURL"] = "true"
-        return Pinecone(api_key=self.api_key, host=pinecone_host, project_id=pinecone_project_id)
+        return Pinecone(
+            api_key=self.api_key,
+            host=pinecone_host,
+            project_id=pinecone_project_id,
+            source_tag="apache_airflow",
+        )
 
     @cached_property
     def conn(self) -> Connection:


### PR DESCRIPTION
The Pinecone partners team asked if it would be possible to add an [attribution tag](https://docs.pinecone.io/integrations/build-integration/attribute-usage-to-your-integration) to the provider to track how much SDK usage they get through it.