### PR TITLE
Bump min version of sqlparse to 0.5.1

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -421,7 +421,7 @@
     "deps": [
       "apache-airflow>=2.8.0",
       "more-itertools>=9.0.0",
-      "sqlparse>=0.4.2"
+      "sqlparse>=0.5.1"
     ],
     "devel-deps": [],
     "plugins": [],

--- a/providers/src/airflow/providers/common/sql/provider.yaml
+++ b/providers/src/airflow/providers/common/sql/provider.yaml
@@ -64,7 +64,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.8.0
-  - sqlparse>=0.4.2
+  - sqlparse>=0.5.1
   - more-itertools>=9.0.0
 
 additional-extras:


### PR DESCRIPTION
We are going to bump it anyway to unblock https://github.com/apache/airflow/pull/41916 so raised PR to expedite things