### PR TITLE
Core operator modules deprecations

### DIFF
--- a/airflow/hooks/__init__.py
+++ b/airflow/hooks/__init__.py
@@ -16,3 +16,20 @@
 # specific language governing permissions and limitations
 # under the License.
 # fmt:, off
+
+from __future__ import annotations
+
+from airflow.utils.deprecation_tools import add_deprecated_classes
+
+__deprecated_classes = {
+    "filesystem": {
+        "FSHook": "airflow.providers.standard.hooks.filesystem.FSHook",
+    },
+    "package_index": {
+        "PackageIndexHook": "airflow.providers.standard.hooks.package_index.PackageIndexHook",
+    },
+    "subprocess": {
+        "SubprocessHook": "airflow.providers.standard.hooks.subprocess.SubprocessHook",
+    },
+}
+add_deprecated_classes(__deprecated_classes, __name__)

--- a/airflow/operators/__init__.py
+++ b/airflow/operators/__init__.py
@@ -21,3 +21,33 @@ Operators.
 
 :sphinx-autoapi-skip:
 """
+
+from __future__ import annotations
+
+from airflow.utils.deprecation_tools import add_deprecated_classes
+
+__deprecated_classes = {
+    "python":{
+        "PythonOperator": "airflow.providers.standard.operators.python.PythonOperator",
+        "BranchPythonOperator": "airflow.providers.standard.operators.python.BranchPythonOperator",
+        "ShortCircuitOperator": "airflow.providers.standard.operators.python.ShortCircuitOperator",
+        "PythonVirtualenvOperator": "airflow.providers.standard.operators.python.PythonVirtualenvOperator",
+        "ExternalPythonOperator": "airflow.providers.standard.operators.python.ExternalPythonOperator",
+        "BranchExternalPythonOperator": "airflow.providers.standard.operators.python.BranchExternalPythonOperator",
+        "BranchPythonVirtualenvOperator": "airflow.providers.standard.operators.python.BranchPythonVirtualenvOperator",
+    },
+    "bash":{
+        "BashOperator": "airflow.providers.standard.operators.bash.BashOperator",
+    },
+    "datetime":{
+        "BranchDateTimeOperator": "airflow.providers.standard.operators.datetime.BranchDateTimeOperator",
+    },
+    "generic_transfer": {
+        "GenericTransfer": "airflow.providers.standard.operators.generic_transfer.GenericTransfer",
+    },
+    "weekday": {
+        "BranchDayOfWeekOperator": "airflow.providers.standard.operators.weekday.BranchDayOfWeekOperator",
+    },
+
+}
+add_deprecated_classes(__deprecated_classes, __name__)

--- a/airflow/sensors/__init__.py
+++ b/airflow/sensors/__init__.py
@@ -21,3 +21,32 @@ Sensors.
 
 :sphinx-autoapi-skip:
 """
+
+from __future__ import annotations
+
+from airflow.utils.deprecation_tools import add_deprecated_classes
+
+__deprecated_classes = {
+    "python":{
+        "PythonSensor": "airflow.providers.standard.sensors.python.PythonSensor",
+    },
+    "bash":{
+        "BashSensor": "airflow.providers.standard.sensor.bash.BashSensor",
+    },
+    "date_time":{
+        "DateTimeSensor": "airflow.providers.standard.sensors.date_time.DateTimeSensor",
+        "DateTimeSensorAsync": "airflow.providers.standard.sensors.date_time.DateTimeSensorAsync",
+    },
+    "time_sensor": {
+        "TimeSensor": "airflow.providers.standard.sensors.time.TimeSensor",
+        "TimeSensorAsync": "airflow.providers.standard.sensors.time.TimeSensorAsync",
+    },
+    "weekday": {
+        "DayOfWeekSensor": "airflow.providers.standard.sensors.weekday.DayOfWeekSensor",
+    },
+    "time_delta": {
+        "TimeDeltaSensor": "airflow.providers.standard.sensors.time_delta.TimeDeltaSensor",
+        "TimeDeltaSensorAsync": "airflow.providers.standard.sensors.time_delta.TimeDeltaSensorAsync",
+    }
+}
+add_deprecated_classes(__deprecated_classes, __name__)


### PR DESCRIPTION
Using pep 562 way to redirect modules.

There are issues when using metapath finder to redirect modules.

https://github.com/apache/airflow/pull/43610

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
