### PR TITLE
Remove references to logical date in new UI

### DIFF
--- a/airflow/ui/src/components/DagRunInfo.tsx
+++ b/airflow/ui/src/components/DagRunInfo.tsx
@@ -26,7 +26,6 @@ type Props = {
   readonly dataIntervalEnd?: string | null;
   readonly dataIntervalStart?: string | null;
   readonly endDate?: string | null;
-  readonly logicalDate?: string | null;
   readonly nextDagrunCreateAfter?: string | null;
   readonly startDate?: string | null;
 };
@@ -35,7 +34,6 @@ const DagRunInfo = ({
   dataIntervalEnd,
   dataIntervalStart,
   endDate,
-  logicalDate,
   nextDagrunCreateAfter,
   startDate,
 }: Props) =>
@@ -53,9 +51,6 @@ const DagRunInfo = ({
             <Text>
               Run After: <Time datetime={nextDagrunCreateAfter} />
             </Text>
-          ) : undefined}
-          {Boolean(logicalDate) ? (
-            <Text>Logical Date: {logicalDate}</Text>
           ) : undefined}
           {Boolean(startDate) ? (
             <Text>Start Date: {startDate}</Text>

--- a/airflow/ui/src/pages/DagsList/Dag/Header.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Header.tsx
@@ -80,7 +80,6 @@ export const Header = ({
               dataIntervalEnd={latestRun.data_interval_end}
               dataIntervalStart={latestRun.data_interval_start}
               endDate={latestRun.end_date}
-              logicalDate={latestRun.logical_date}
               startDate={latestRun.start_date}
             />
           ) : undefined}

--- a/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -93,7 +93,6 @@ export const DagCard = ({ dag }: Props) => {
               dataIntervalEnd={latestRun.data_interval_end}
               dataIntervalStart={latestRun.data_interval_start}
               endDate={latestRun.end_date}
-              logicalDate={latestRun.logical_date}
               startDate={latestRun.start_date}
             />
           ) : undefined}

--- a/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -107,7 +107,6 @@ const columns: Array<ColumnDef<DAGWithLatestDagRunsResponse>> = [
           dataIntervalEnd={original.latest_dag_runs[0].data_interval_end}
           dataIntervalStart={original.latest_dag_runs[0].data_interval_start}
           endDate={original.latest_dag_runs[0].end_date}
-          logicalDate={original.latest_dag_runs[0].logical_date}
           startDate={original.latest_dag_runs[0].start_date}
         />
       ) : undefined,

--- a/airflow/ui/src/pages/DagsList/LatestRun.tsx
+++ b/airflow/ui/src/pages/DagsList/LatestRun.tsx
@@ -29,7 +29,7 @@ type Props = {
 export const LatestRun = ({ latestRun }: Props) =>
   latestRun ? (
     <HStack fontSize="sm">
-      <Time datetime={latestRun.logical_date} />
+      <Time datetime={latestRun.start_date} />
       <Box
         bg={stateColor[latestRun.state]}
         borderRadius="50%"

--- a/airflow/ui/src/pages/DagsList/RecentRuns.tsx
+++ b/airflow/ui/src/pages/DagsList/RecentRuns.tsx
@@ -58,7 +58,7 @@ export const RecentRuns = ({
             <Box>
               <Text>State: {run.state}</Text>
               <Text>
-                Logical Date: <Time datetime={run.logical_date} />
+                Start Date: <Time datetime={run.start_date} />
               </Text>
               <Text>Duration: {run.duration.toFixed(2)}s</Text>
             </Box>


### PR DESCRIPTION
We should avoid using logical date for display in the UI.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
