### PR TITLE
Add queued_at to fastapi dag run response

### DIFF
--- a/airflow/api_fastapi/core_api/datamodels/dag_run.py
+++ b/airflow/api_fastapi/core_api/datamodels/dag_run.py
@@ -47,6 +47,7 @@ class DAGRunResponse(BaseModel):
     dag_run_id: str | None = Field(alias="run_id")
     dag_id: str
     logical_date: datetime | None
+    queued_at: datetime | None
     start_date: datetime | None
     end_date: datetime | None
     data_interval_start: datetime | None

--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -4172,6 +4172,12 @@ components:
             format: date-time
           - type: 'null'
           title: Logical Date
+        queued_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Queued At
         start_date:
           anyOf:
           - type: string
@@ -4224,6 +4230,7 @@ components:
       - run_id
       - dag_id
       - logical_date
+      - queued_at
       - start_date
       - end_date
       - data_interval_start

--- a/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -1262,6 +1262,18 @@ export const $DAGRunResponse = {
       ],
       title: "Logical Date",
     },
+    queued_at: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Queued At",
+    },
     start_date: {
       anyOf: [
         {
@@ -1356,6 +1368,7 @@ export const $DAGRunResponse = {
     "run_id",
     "dag_id",
     "logical_date",
+    "queued_at",
     "start_date",
     "end_date",
     "data_interval_start",

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -267,6 +267,7 @@ export type DAGRunResponse = {
   run_id: string | null;
   dag_id: string;
   logical_date: string | null;
+  queued_at: string | null;
   start_date: string | null;
   end_date: string | null;
   data_interval_start: string | null;


### PR DESCRIPTION
Our dag run datamodel was missing `queued_at`

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
