### PR TITLE
Fix: ensure `bool(check_query_exists)` returns `True` or `False`

### DIFF
--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -1557,7 +1557,9 @@ class LazySelectSequence(Sequence[T]):
         self._session = get_current_task_instance_session()
 
     def __bool__(self) -> bool:
-        return check_query_exists(self._select_asc, session=self._session)
+        if check := check_query_exists(self._select_asc, session=self._session) is not None:
+            return check
+        return False
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, collections.abc.Sequence):

--- a/tests/utils/test_db.py
+++ b/tests/utils/test_db.py
@@ -264,4 +264,4 @@ class TestDb:
         t = Table("t", MetaData(), Column("id", Integer, primary_key=True))
         lss = LazySelectSequence.from_select(select(t.c.id), order_by=[], session=MockSession())
 
-        assert not bool(lss)
+        assert bool(lss) is False


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #43977

<!-- Please keep an empty line above the dashes. -->
---

It is possible for `bool(check_query_exists)` to return `None`. This can break Xcom Jinja templates that retrieve null values from the airflow database using a `LazySelectSequence`