### PR TITLE
Improve ability to see and clear dags list filters

### DIFF
--- a/airflow/ui/src/components/DagRunInfo.tsx
+++ b/airflow/ui/src/components/DagRunInfo.tsx
@@ -16,13 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { VStack, Text, Box, HStack } from "@chakra-ui/react";
+import { VStack, Text, HStack } from "@chakra-ui/react";
 import dayjs from "dayjs";
 
 import type { DAGRunResponse } from "openapi/requests/types.gen";
 import Time from "src/components/Time";
 import { Tooltip } from "src/components/ui";
 import { stateColor } from "src/utils/stateColor";
+
+import { StateCircle } from "./StateCircle";
 
 type Props = {
   readonly dataIntervalEnd?: string | null;
@@ -81,13 +83,7 @@ const DagRunInfo = ({
         <Time datetime={dataIntervalStart} showTooltip={false} />
         {state === undefined ? undefined : (
           <>
-            <Box
-              bg={stateColor[state]}
-              borderRadius="50%"
-              height={2}
-              minW={2}
-              width={2}
-            />
+            <StateCircle state={state} />
             <Text color={stateColor[state]}>{state}</Text>
           </>
         )}

--- a/airflow/ui/src/components/DataTable/ToggleTableDisplay.tsx
+++ b/airflow/ui/src/components/DataTable/ToggleTableDisplay.tsx
@@ -29,21 +29,29 @@ type Props = {
 export const ToggleTableDisplay = ({ display, setDisplay }: Props) => (
   <HStack colorPalette="blue" gap={1} pb={2}>
     <IconButton
+      _hover={{ bg: "colorPalette.subtle" }}
       aria-label="Show card view"
+      bg={display === "card" ? "colorPalette.muted" : "bg"}
+      borderColor="colorPalette.fg"
+      borderWidth={1}
+      color="colorPalette.fg"
       height={8}
       minWidth={8}
       onClick={() => setDisplay("card")}
-      variant={display === "table" ? "outline" : "solid"}
       width={8}
     >
       <FiGrid />
     </IconButton>
     <IconButton
+      _hover={{ bg: "colorPalette.subtle" }}
       aria-label="Show table view"
+      bg={display === "table" ? "colorPalette.muted" : "bg"}
+      borderColor="colorPalette.fg"
+      borderWidth={1}
+      color="colorPalette.fg"
       height={8}
       minWidth={8}
       onClick={() => setDisplay("table")}
-      variant={display === "card" ? "outline" : "solid"}
       width={8}
     >
       <FiAlignJustify />

--- a/airflow/ui/src/components/SearchBar.tsx
+++ b/airflow/ui/src/components/SearchBar.tsx
@@ -53,11 +53,13 @@ export const SearchBar = ({
   return (
     <InputGroup
       {...groupProps}
+      colorPalette="blue"
       endElement={
         <>
           {Boolean(value) ? (
             <CloseButton
               aria-label="Clear search"
+              colorPalette="gray"
               data-testid="clear-search"
               onClick={() => {
                 setValue("");
@@ -67,7 +69,6 @@ export const SearchBar = ({
             />
           ) : undefined}
           <Button
-            colorPalette="blue"
             fontWeight="normal"
             height="1.75rem"
             variant="ghost"

--- a/airflow/ui/src/components/StateCircle.tsx
+++ b/airflow/ui/src/components/StateCircle.tsx
@@ -16,30 +16,23 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Button, type ButtonProps } from "@chakra-ui/react";
+import { Box, type BoxProps } from "@chakra-ui/react";
 
-type QuickFilterButtonProps = {
-  readonly isActive: boolean;
-} & ButtonProps;
+import type { TaskInstanceState } from "openapi/requests/types.gen";
+import { stateColor } from "src/utils/stateColor";
 
-export const QuickFilterButton = ({
-  children,
-  isActive,
+export const StateCircle = ({
+  state,
   ...rest
-}: QuickFilterButtonProps) => (
-  <Button
-    _hover={{ bg: "colorPalette.subtle" }}
-    bg={isActive ? "colorPalette.muted" : undefined}
-    borderColor="colorPalette.fg"
-    borderRadius={20}
-    borderWidth={1}
-    color="colorPalette.fg"
-    colorPalette="blue"
-    fontWeight="normal"
-    size="sm"
-    variant={isActive ? "solid" : "outline"}
+}: {
+  readonly state: TaskInstanceState;
+} & BoxProps) => (
+  <Box
     {...rest}
-  >
-    {children}
-  </Button>
+    bg={stateColor[state]}
+    borderRadius="50%"
+    h={2}
+    maxW={2}
+    w={2}
+  />
 );

--- a/airflow/ui/src/components/TriggerDag/TriggerDAGIconButton.tsx
+++ b/airflow/ui/src/components/TriggerDag/TriggerDAGIconButton.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Button } from "@chakra-ui/react";
+import { Box, IconButton } from "@chakra-ui/react";
 import { useDisclosure } from "@chakra-ui/react";
 import { FiPlay } from "react-icons/fi";
 
@@ -33,9 +33,15 @@ const TriggerDAGIconButton: React.FC<Props> = ({ dag }) => {
 
   return (
     <Box>
-      <Button onClick={onOpen} variant="ghost">
+      <IconButton
+        aria-label={`Trigger ${dag.dag_display_name}`}
+        colorPalette="blue"
+        onClick={onOpen}
+        size="sm"
+        variant="ghost"
+      >
         <FiPlay />
-      </Button>
+      </IconButton>
 
       <TriggerDAGModal
         dagDisplayName={dag.dag_display_name}

--- a/airflow/ui/src/components/TriggerDag/TriggerDAGIconButton.tsx
+++ b/airflow/ui/src/components/TriggerDag/TriggerDAGIconButton.tsx
@@ -37,7 +37,7 @@ const TriggerDAGIconButton: React.FC<Props> = ({ dag }) => {
         aria-label={`Trigger ${dag.dag_display_name}`}
         colorPalette="blue"
         onClick={onOpen}
-        size="sm"
+        size="xs"
         variant="ghost"
       >
         <FiPlay />

--- a/airflow/ui/src/components/ui/Select/Trigger.tsx
+++ b/airflow/ui/src/components/ui/Select/Trigger.tsx
@@ -21,32 +21,40 @@ import { forwardRef } from "react";
 
 import { CloseButton } from "../CloseButton";
 
-type TriggerProps = {
+type Props = {
   clearable?: boolean;
+  isActive?: boolean;
 } & ChakraSelect.ControlProps;
 
-export const Trigger = forwardRef<HTMLButtonElement, TriggerProps>(
-  (props, ref) => {
-    const { children, clearable, ...rest } = props;
+export const Trigger = forwardRef<HTMLButtonElement, Props>((props, ref) => {
+  const { children, clearable, isActive, ...rest } = props;
 
-    return (
-      <ChakraSelect.Control {...rest}>
-        <ChakraSelect.Trigger ref={ref}>{children}</ChakraSelect.Trigger>
-        <ChakraSelect.IndicatorGroup>
-          {clearable ? (
-            <ChakraSelect.ClearTrigger asChild>
-              <CloseButton
-                focusRingWidth="2px"
-                focusVisibleRing="inside"
-                pointerEvents="auto"
-                size="xs"
-                variant="plain"
-              />
-            </ChakraSelect.ClearTrigger>
-          ) : undefined}
-          <ChakraSelect.Indicator />
-        </ChakraSelect.IndicatorGroup>
-      </ChakraSelect.Control>
-    );
-  },
-);
+  return (
+    <ChakraSelect.Control {...rest}>
+      <ChakraSelect.Trigger
+        bg={isActive ? "colorPalette.solid" : undefined}
+        borderColor={isActive ? "colorPalette.solid" : "colorPalette.muted"}
+        color={isActive ? "colorPalette.contrast" : undefined}
+        ref={ref}
+      >
+        {children}
+      </ChakraSelect.Trigger>
+      <ChakraSelect.IndicatorGroup>
+        {clearable ? (
+          <ChakraSelect.ClearTrigger asChild>
+            <CloseButton
+              focusRingWidth="2px"
+              focusVisibleRing="inside"
+              pointerEvents="auto"
+              size="xs"
+              variant="plain"
+            />
+          </ChakraSelect.ClearTrigger>
+        ) : undefined}
+        <ChakraSelect.Indicator
+          color={isActive ? "colorPalette.contrast" : undefined}
+        />
+      </ChakraSelect.IndicatorGroup>
+    </ChakraSelect.Control>
+  );
+});

--- a/airflow/ui/src/components/ui/Select/Trigger.tsx
+++ b/airflow/ui/src/components/ui/Select/Trigger.tsx
@@ -31,14 +31,7 @@ export const Trigger = forwardRef<HTMLButtonElement, Props>((props, ref) => {
 
   return (
     <ChakraSelect.Control {...rest}>
-      <ChakraSelect.Trigger
-        bg={isActive ? "colorPalette.solid" : undefined}
-        borderColor={isActive ? "colorPalette.solid" : "colorPalette.muted"}
-        color={isActive ? "colorPalette.contrast" : undefined}
-        ref={ref}
-      >
-        {children}
-      </ChakraSelect.Trigger>
+      <ChakraSelect.Trigger ref={ref}>{children}</ChakraSelect.Trigger>
       <ChakraSelect.IndicatorGroup>
         {clearable ? (
           <ChakraSelect.ClearTrigger asChild>
@@ -51,9 +44,7 @@ export const Trigger = forwardRef<HTMLButtonElement, Props>((props, ref) => {
             />
           </ChakraSelect.ClearTrigger>
         ) : undefined}
-        <ChakraSelect.Indicator
-          color={isActive ? "colorPalette.contrast" : undefined}
-        />
+        <ChakraSelect.Indicator />
       </ChakraSelect.IndicatorGroup>
     </ChakraSelect.Control>
   );

--- a/airflow/ui/src/pages/DagsList/DagsFilters.tsx
+++ b/airflow/ui/src/pages/DagsList/DagsFilters.tsx
@@ -32,11 +32,13 @@ import { useSearchParams } from "react-router-dom";
 import { useDagServiceGetDagTags } from "openapi/queries";
 import { useTableURLState } from "src/components/DataTable/useTableUrlState";
 import { QuickFilterButton } from "src/components/QuickFilterButton";
+import { StateCircle } from "src/components/StateCircle";
 import { Select } from "src/components/ui";
 import {
   SearchParamsKeys,
   type SearchParamsKeysType,
 } from "src/constants/searchParams";
+import { pluralize } from "src/utils";
 
 const {
   LAST_DAG_RUN_STATE: LAST_DAG_RUN_STATE_PARAM,
@@ -128,36 +130,51 @@ export const DagsFilters = () => {
     setSearchParams(searchParams);
   };
 
+  let filterCount = 0;
+
+  if (state !== null) {
+    filterCount += 1;
+  }
+  if (showPaused !== null) {
+    filterCount += 1;
+  }
+  if (selectedTags.length > 0) {
+    filterCount += 1;
+  }
+
   return (
     <HStack justifyContent="space-between">
       <HStack gap={4}>
         <HStack>
           <QuickFilterButton
-            active={isAll}
+            isActive={isAll}
             onClick={handleStateChange}
             value="all"
           >
             All
           </QuickFilterButton>
           <QuickFilterButton
-            active={isFailed}
+            isActive={isFailed}
             onClick={handleStateChange}
             value="failed"
           >
+            <StateCircle state="failed" />
             Failed
           </QuickFilterButton>
           <QuickFilterButton
-            active={isRunning}
+            isActive={isRunning}
             onClick={handleStateChange}
             value="running"
           >
+            <StateCircle state="running" />
             Running
           </QuickFilterButton>
           <QuickFilterButton
-            active={isSuccess}
+            isActive={isSuccess}
             onClick={handleStateChange}
             value="success"
           >
+            <StateCircle state="success" />
             Success
           </QuickFilterButton>
         </HStack>
@@ -183,8 +200,7 @@ export const DagsFilters = () => {
             chakraStyles={{
               clearIndicator: (provided) => ({
                 ...provided,
-                color:
-                  selectedTags.length > 0 ? "colorPalette.contrast" : undefined,
+                color: "gray.fg",
               }),
               container: (provided) => ({
                 ...provided,
@@ -192,19 +208,7 @@ export const DagsFilters = () => {
               }),
               control: (provided) => ({
                 ...provided,
-                bg: selectedTags.length > 0 ? "colorPalette.solid" : undefined,
-                borderColor:
-                  selectedTags.length > 0
-                    ? "colorPalette.solid"
-                    : "colorPalette.muted",
-                color:
-                  selectedTags.length > 0 ? "colorPalette.contrast" : undefined,
                 colorPalette: "blue",
-              }),
-              downChevron: (provided) => ({
-                ...provided,
-                color:
-                  selectedTags.length > 0 ? "colorPalette.contrast" : undefined,
               }),
               menu: (provided) => ({
                 ...provided,
@@ -230,9 +234,9 @@ export const DagsFilters = () => {
         </Field.Root>
       </HStack>
       <Box>
-        {(state !== null || showPaused !== null || selectedTags.length > 0) && (
+        {filterCount > 0 && (
           <Button onClick={onClearFilters} size="sm" variant="outline">
-            <LuX /> Clear filters
+            <LuX /> Reset {pluralize("filter", filterCount)}
           </Button>
         )}
       </Box>

--- a/airflow/ui/src/pages/DagsList/DagsFilters.tsx
+++ b/airflow/ui/src/pages/DagsList/DagsFilters.tsx
@@ -18,14 +18,15 @@
  */
 import {
   Box,
+  Button,
   createListCollection,
   Field,
   HStack,
   type SelectValueChangeDetails,
 } from "@chakra-ui/react";
-import { Select as ReactSelect } from "chakra-react-select";
-import type { MultiValue } from "chakra-react-select";
+import { Select as ReactSelect, type MultiValue } from "chakra-react-select";
 import { useCallback } from "react";
+import { LuX } from "react-icons/lu";
 import { useSearchParams } from "react-router-dom";
 
 import { useDagServiceGetDagTags } from "openapi/queries";
@@ -119,6 +120,14 @@ export const DagsFilters = () => {
     [searchParams, setSearchParams],
   );
 
+  const onClearFilters = () => {
+    searchParams.delete(PAUSED_PARAM);
+    searchParams.delete(LAST_DAG_RUN_STATE_PARAM);
+    searchParams.delete(TAGS_PARAM);
+
+    setSearchParams(searchParams);
+  };
+
   return (
     <HStack justifyContent="space-between">
       <HStack gap={4}>
@@ -157,7 +166,7 @@ export const DagsFilters = () => {
           onValueChange={handlePausedChange}
           value={showPaused === null ? ["All"] : [showPaused]}
         >
-          <Select.Trigger>
+          <Select.Trigger colorPalette="blue" isActive={Boolean(showPaused)}>
             <Select.ValueText width={20} />
           </Select.Trigger>
           <Select.Content>
@@ -168,15 +177,34 @@ export const DagsFilters = () => {
             ))}
           </Select.Content>
         </Select.Root>
-      </HStack>
-      <Box>
         <Field.Root>
           <ReactSelect
             aria-label="Filter Dags by tag"
             chakraStyles={{
+              clearIndicator: (provided) => ({
+                ...provided,
+                color:
+                  selectedTags.length > 0 ? "colorPalette.contrast" : undefined,
+              }),
               container: (provided) => ({
                 ...provided,
                 minWidth: 64,
+              }),
+              control: (provided) => ({
+                ...provided,
+                bg: selectedTags.length > 0 ? "colorPalette.solid" : undefined,
+                borderColor:
+                  selectedTags.length > 0
+                    ? "colorPalette.solid"
+                    : "colorPalette.muted",
+                color:
+                  selectedTags.length > 0 ? "colorPalette.contrast" : undefined,
+                colorPalette: "blue",
+              }),
+              downChevron: (provided) => ({
+                ...provided,
+                color:
+                  selectedTags.length > 0 ? "colorPalette.contrast" : undefined,
               }),
               menu: (provided) => ({
                 ...provided,
@@ -187,10 +215,12 @@ export const DagsFilters = () => {
             isMulti
             noOptionsMessage={() => "No tags found"}
             onChange={handleSelectTagsChange}
-            options={data?.tags.map((tag) => ({
-              label: tag,
-              value: tag,
-            }))}
+            options={
+              data?.tags.map((tag) => ({
+                label: tag,
+                value: tag,
+              })) ?? []
+            }
             placeholder="Filter by tag"
             value={selectedTags.map((tag) => ({
               label: tag,
@@ -198,6 +228,13 @@ export const DagsFilters = () => {
             }))}
           />
         </Field.Root>
+      </HStack>
+      <Box>
+        {(state !== null || showPaused !== null || selectedTags.length > 0) && (
+          <Button onClick={onClearFilters} size="sm" variant="outline">
+            <LuX /> Clear filters
+          </Button>
+        )}
       </Box>
     </HStack>
   );

--- a/airflow/ui/src/utils/advancedSelectStyles.ts
+++ b/airflow/ui/src/utils/advancedSelectStyles.ts
@@ -1,0 +1,18 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */


### PR DESCRIPTION
Make it easier to use filters on the dags list.

- Create a StateCircle component to render the state across the UI
- Reduce visual impact of toggle table/card and filtering by dag run state
- Add a "Reset X Filters" to reset everything at once
- Also added blue color scheme to the trigger button to better indicate that its an action

<img width="1259" alt="Screenshot 2024-11-13 at 5 30 05 PM" src="https://github.com/user-attachments/assets/406b84c9-86e0-4f09-aeac-61d1fb89eb99">
<img width="632" alt="Screenshot 2024-11-13 at 5 29 56 PM" src="https://github.com/user-attachments/assets/5c77d5f7-3ce8-49a3-97e3-81e65632d2dc">


---

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
