### PR TITLE
Fix parsing of development dependencies for airflow version

### DIFF
--- a/scripts/in_container/install_devel_deps.py
+++ b/scripts/in_container/install_devel_deps.py
@@ -22,6 +22,7 @@ import json
 from pathlib import Path
 
 from in_container_utils import click, run_command
+from packaging.requirements import Requirement
 
 AIRFLOW_SOURCES_DIR = Path(__file__).resolve().parents[2]
 
@@ -46,7 +47,7 @@ def get_devel_deps_from_providers():
     devel_deps_from_providers = []
     deps = json.loads((AIRFLOW_SOURCES_DIR / "generated" / "provider_dependencies.json").read_text())
     for dep in deps:
-        devel_deps = [short_dep.split(">=")[0] for short_dep in deps[dep]["devel-deps"]]
+        devel_deps = [Requirement(short_dep).name for short_dep in deps[dep]["devel-deps"]]
         if devel_deps:
             devel_deps_from_providers.extend(devel_deps)
     return devel_deps_from_providers


### PR DESCRIPTION
The script to install development dependencies asumed development dependencies are always `>=` this might not be true in case we limit the depdencies to be < or provide other requirements for them.

This PR fixes it by using "packaging.requirements.Requirement" to parse the specifier, which should handle all cases nicely.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
