### PR TITLE
Limit temporarily aiohttp to < 3.11.0

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -751,7 +751,7 @@
   },
   "http": {
     "deps": [
-      "aiohttp>=3.9.2",
+      "aiohttp>=3.9.2,<3.11.0",
       "apache-airflow>=2.8.0",
       "asgiref>=2.3.0",
       "requests-toolbelt>=0.4.0",

--- a/providers/src/airflow/providers/http/provider.yaml
+++ b/providers/src/airflow/providers/http/provider.yaml
@@ -67,7 +67,8 @@ dependencies:
   # release it as a requirement for airflow
   - requests>=2.27.0,<3
   - requests-toolbelt>=0.4.0
-  - aiohttp>=3.9.2
+  # Limit temporarily aiohttp to <3.11.0 because of https://github.com/aio-libs/aiohttp/issues/9866
+  - aiohttp>=3.9.2,<3.11.0
   - asgiref>=2.3.0
 
 integrations:


### PR DESCRIPTION
Because of aio-libs/aiohttp#9866 some tests are failing. This PR can be reverted when pnuckowski/aioresponses#262 is merged and released

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
