### PR TITLE
BaseExecutor allows executors to consumer task_instance parameters

### DIFF
--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -400,7 +400,7 @@ class BaseExecutor(LoggingMixin):
                 span.set_attribute("queue", str(queue))
                 span.set_attribute("executor_config", str(executor_config))
                 del self.queued_tasks[key]
-                self.run(ti=task_instance, command=command, queue=queue, executor_config=executor_config)
+                self.execute(ti=task_instance, command=command, queue=queue, executor_config=executor_config)
                 self.running.add(key)
 
     def change_state(
@@ -506,7 +506,7 @@ class BaseExecutor(LoggingMixin):
 
         return cleared_events
 
-    def run(
+    def execute(
         self,
         ti: TaskInstance,
         command: CommandType,
@@ -514,7 +514,7 @@ class BaseExecutor(LoggingMixin):
         executor_config: Any | None = None,
     ) -> None:  # pragma: no cover
         """
-        Run task instance command.
+        Execute the command.
 
         :param ti: task instance to run
         :param command: Command to run
@@ -522,7 +522,7 @@ class BaseExecutor(LoggingMixin):
         :param executor_config: Configuration passed to the executor.
         """
         warnings.warn(
-            f"Old execute_async function is used. Please update your executor: {type(self).__name__} to use new run function with updated interface.",
+            f"Old execute_async function is used. Please update your executor: {type(self).__name__} to use new execute function with updated interface.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import logging
 import sys
+import warnings
 from collections import defaultdict, deque
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Tuple
@@ -399,7 +400,7 @@ class BaseExecutor(LoggingMixin):
                 span.set_attribute("queue", str(queue))
                 span.set_attribute("executor_config", str(executor_config))
                 del self.queued_tasks[key]
-                self.execute_async(key=key, command=command, queue=queue, executor_config=executor_config)
+                self.run(ti=task_instance, command=command, queue=queue, executor_config=executor_config)
                 self.running.add(key)
 
     def change_state(
@@ -504,6 +505,28 @@ class BaseExecutor(LoggingMixin):
                     cleared_events[ti_key] = self.event_buffer.pop(ti_key)
 
         return cleared_events
+
+    def run(
+        self,
+        ti: TaskInstance,
+        command: CommandType,
+        queue: str | None = None,
+        executor_config: Any | None = None,
+    ) -> None:  # pragma: no cover
+        """
+        Run task instance command.
+
+        :param ti: task instance to run
+        :param command: Command to run
+        :param queue: name of the queue
+        :param executor_config: Configuration passed to the executor.
+        """
+        warnings.warn(
+            f"Old execute_async function is used. Please update your executor: {type(self).__name__} to use new run function with updated interface.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.execute_async(key=ti.key, command=command, queue=queue, executor_config=executor_config)
 
     def execute_async(
         self,


### PR DESCRIPTION
# Description

During implementation of the slot handling in the Edge provider package (see https://github.com/apache/airflow/pull/43737) a discussion about how to enable executors to use additional information was started. This PR tackles the idea on extend the execute_async function with task_instance to allow executor consuming all the task_instance parameters. With this it is pretty simple to change a the interface and the executer can decide with task_instance parameters he wants to use to implement task specific behaviors.

This PR shows a possible solution how to tackle option 2 of discussion in this PR https://github.com/apache/airflow/pull/43737. Will also create a devlist discussion about this.

# Details about changes

* Add execute function into BaseExecutor which has task_instance as parameter.
* New execute function calls old execute_async function to keep not updated Executors running.
* Add deprecation warning for Executor which use the old execute_async function.