### PR TITLE
Pass last_dag_run_state to recent dagruns API to fetch only dags with given state for the latest dagrun.

### DIFF
--- a/airflow/ui/src/queries/useDags.tsx
+++ b/airflow/ui/src/queries/useDags.tsx
@@ -49,7 +49,7 @@ export const useDags = (
     queryOptions,
   );
 
-  const { lastDagRunState, orderBy, ...runsParams } = searchParams;
+  const { orderBy, ...runsParams } = searchParams;
   const {
     data: runsData,
     error: runsError,


### PR DESCRIPTION
I noticed while debugging https://github.com/apache/airflow/issues/43882 the recent dagruns endpoint supports passing `last_dag_run_state` which makes it efficient to fetch only the dag with given `last_dag_run_state` as latest dagrun and corresponding dagruns for the dag. Else all dags of all states are returned and filtered in the frontend.