### PR TITLE
Fix Google Cloud Datacatalog test

### DIFF
--- a/providers/tests/google/cloud/operators/test_datacatalog.py
+++ b/providers/tests/google/cloud/operators/test_datacatalog.py
@@ -370,7 +370,7 @@ class TestCloudDataCatalogCreateTagTemplateOperator:
                 "project_id": TEST_PROJECT_ID,
             },
         )
-        assert TEST_TAG_TEMPLATE_DICT == result
+        assert {**result, **TEST_TAG_TEMPLATE_DICT} == result
 
 
 class TestCloudDataCatalogCreateTagTemplateFieldOperator:
@@ -418,7 +418,7 @@ class TestCloudDataCatalogCreateTagTemplateFieldOperator:
                 "project_id": TEST_PROJECT_ID,
             },
         )
-        assert TEST_TAG_TEMPLATE_FIELD_DICT == result
+        assert {**result, **TEST_TAG_TEMPLATE_FIELD_DICT} == result
 
 
 class TestCloudDataCatalogDeleteEntryOperator:


### PR DESCRIPTION
This field (`dataplex_transfer_status`) got added in https://github.com/googleapis/google-cloud-python/pull/13277 as part of `google-cloud-datacatalog==3.22.0`

Example failure: https://github.com/apache/airflow/actions/runs/11842030744/job/33000167393?pr=44036

```
=========================== short test summary info ============================
FAILED providers/tests/google/cloud/operators/test_datacatalog.py::TestCloudDataCatalogCreateTagTemplateOperator::test_assert_valid_hook_call - AssertionError: assert equals failed
  {                                {                               
                                     'dataplex_transfer_status': 0 
                                   ,                               
    'display_name': '',              'display_name': '',           
    'fields': {},                    'fields': {},                 
    'is_publicly_readable': False    'is_publicly_readable': False 
  ,                                ,                               
    'name': 'projects/example_id/    'name': 'projects/example_id/ 
  locations/en-west-3/tagTemplate  locations/en-west-3/tagTemplate 
  s/test-tag-template-id',         s/test-tag-template-id',        
  }                                }
====== 1 failed, 4200 passed, 79 skipped, 1 warning in 261.02s (0:04:21) =======

```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
