### PR TITLE
AIP-84 Fix: Allow Null Values for end_date Field in Dashboard Endpint in FastAPI

### DIFF
--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -50,9 +50,11 @@ paths:
           title: Start Date
       - name: end_date
         in: query
-        required: true
+        required: false
         schema:
-          type: string
+          anyOf:
+          - type: string
+          - type: 'null'
           title: End Date
       responses:
         '200':

--- a/airflow/api_fastapi/core_api/routes/ui/dashboard.py
+++ b/airflow/api_fastapi/core_api/routes/ui/dashboard.py
@@ -46,7 +46,7 @@ dashboard_router = AirflowRouter(tags=["Dashboard"])
 def historical_metrics(
     session: Annotated[Session, Depends(get_session)],
     start_date: DateTimeQuery,
-    end_date: OptionalDateTimeQuery | None = None,
+    end_date: OptionalDateTimeQuery = None,
 ) -> HistoricalMetricDataResponse:
     """Return cluster activity historical metrics."""
     current_time = timezone.utcnow()

--- a/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow/ui/openapi-gen/queries/common.ts
@@ -165,7 +165,7 @@ export const UseDashboardServiceHistoricalMetricsKeyFn = (
     endDate,
     startDate,
   }: {
-    endDate: string;
+    endDate?: string;
     startDate: string;
   },
   queryKey?: Array<unknown>,

--- a/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -206,7 +206,7 @@ export const prefetchUseDashboardServiceHistoricalMetrics = (
     endDate,
     startDate,
   }: {
-    endDate: string;
+    endDate?: string;
     startDate: string;
   },
 ) =>

--- a/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow/ui/openapi-gen/queries/queries.ts
@@ -264,7 +264,7 @@ export const useDashboardServiceHistoricalMetrics = <
     endDate,
     startDate,
   }: {
-    endDate: string;
+    endDate?: string;
     startDate: string;
   },
   queryKey?: TQueryKey,

--- a/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow/ui/openapi-gen/queries/suspense.ts
@@ -246,7 +246,7 @@ export const useDashboardServiceHistoricalMetricsSuspense = <
     endDate,
     startDate,
   }: {
-    endDate: string;
+    endDate?: string;
     startDate: string;
   },
   queryKey?: TQueryKey,

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1084,7 +1084,7 @@ export type DeleteAssetQueuedEventsData = {
 export type DeleteAssetQueuedEventsResponse = void;
 
 export type HistoricalMetricsData = {
-  endDate: string;
+  endDate?: string | null;
   startDate: string;
 };
 

--- a/tests/api_fastapi/core_api/routes/ui/test_dashboard.py
+++ b/tests/api_fastapi/core_api/routes/ui/test_dashboard.py
@@ -148,7 +148,7 @@ class TestHistoricalMetricsDataEndpoint:
                 },
             ),
             (
-                {"start_date": "2023-02-02T00:00", "end_date": None},
+                {"start_date": "2023-02-02T00:00"},
                 {
                     "dag_run_states": {"failed": 1, "queued": 0, "running": 1, "success": 0},
                     "dag_run_types": {"backfill": 0, "asset_triggered": 1, "manual": 0, "scheduled": 1},
@@ -176,15 +176,3 @@ class TestHistoricalMetricsDataEndpoint:
         response = test_client.get("/ui/dashboard/historical_metrics_data", params=params)
         assert response.status_code == 200
         assert response.json() == expected
-
-    @pytest.mark.parametrize(
-        "params",
-        [
-            {"start_date": None, "end_date": "2023-08-02T00:00"},
-        ],
-    )
-    @pytest.mark.usefixtures("freeze_time_for_dagruns", "make_dag_runs")
-    def test_historical_metrics_data_start_date_none(self, test_client, params):
-        response = test_client.get("/ui/dashboard/historical_metrics_data", params=params)
-        assert response.status_code == 400
-        assert response.json() == {"detail": "start_date parameter is required in the request"}

--- a/tests/api_fastapi/core_api/routes/ui/test_dashboard.py
+++ b/tests/api_fastapi/core_api/routes/ui/test_dashboard.py
@@ -100,53 +100,91 @@ def make_dag_runs(dag_maker, session, time_machine):
 
 
 class TestHistoricalMetricsDataEndpoint:
+    @pytest.mark.parametrize(
+        "params, expected",
+        [
+            (
+                {"start_date": "2023-01-01T00:00", "end_date": "2023-08-02T00:00"},
+                {
+                    "dag_run_states": {"failed": 1, "queued": 0, "running": 1, "success": 1},
+                    "dag_run_types": {"backfill": 0, "asset_triggered": 1, "manual": 0, "scheduled": 2},
+                    "task_instance_states": {
+                        "deferred": 0,
+                        "failed": 2,
+                        "no_status": 2,
+                        "queued": 0,
+                        "removed": 0,
+                        "restarting": 0,
+                        "running": 0,
+                        "scheduled": 0,
+                        "skipped": 0,
+                        "success": 2,
+                        "up_for_reschedule": 0,
+                        "up_for_retry": 0,
+                        "upstream_failed": 0,
+                    },
+                },
+            ),
+            (
+                {"start_date": "2023-02-02T00:00", "end_date": "2023-06-02T00:00"},
+                {
+                    "dag_run_states": {"failed": 1, "queued": 0, "running": 0, "success": 0},
+                    "dag_run_types": {"backfill": 0, "asset_triggered": 1, "manual": 0, "scheduled": 0},
+                    "task_instance_states": {
+                        "deferred": 0,
+                        "failed": 2,
+                        "no_status": 0,
+                        "queued": 0,
+                        "removed": 0,
+                        "restarting": 0,
+                        "running": 0,
+                        "scheduled": 0,
+                        "skipped": 0,
+                        "success": 0,
+                        "up_for_reschedule": 0,
+                        "up_for_retry": 0,
+                        "upstream_failed": 0,
+                    },
+                },
+            ),
+            (
+                {"start_date": "2023-02-02T00:00", "end_date": None},
+                {
+                    "dag_run_states": {"failed": 1, "queued": 0, "running": 1, "success": 0},
+                    "dag_run_types": {"backfill": 0, "asset_triggered": 1, "manual": 0, "scheduled": 1},
+                    "task_instance_states": {
+                        "deferred": 0,
+                        "failed": 2,
+                        "no_status": 2,
+                        "queued": 0,
+                        "removed": 0,
+                        "restarting": 0,
+                        "running": 0,
+                        "scheduled": 0,
+                        "skipped": 0,
+                        "success": 0,
+                        "up_for_reschedule": 0,
+                        "up_for_retry": 0,
+                        "upstream_failed": 0,
+                    },
+                },
+            ),
+        ],
+    )
     @pytest.mark.usefixtures("freeze_time_for_dagruns", "make_dag_runs")
-    def test_historical_metrics_data(self, test_client, time_machine):
-        params = {"start_date": "2023-01-01T00:00", "end_date": "2023-08-02T00:00"}
+    def test_historical_metrics_data(self, test_client, params, expected):
         response = test_client.get("/ui/dashboard/historical_metrics_data", params=params)
-
         assert response.status_code == 200
-        assert response.json() == {
-            "dag_run_states": {"failed": 1, "queued": 0, "running": 1, "success": 1},
-            "dag_run_types": {"backfill": 0, "asset_triggered": 1, "manual": 0, "scheduled": 2},
-            "task_instance_states": {
-                "deferred": 0,
-                "failed": 2,
-                "no_status": 2,
-                "queued": 0,
-                "removed": 0,
-                "restarting": 0,
-                "running": 0,
-                "scheduled": 0,
-                "skipped": 0,
-                "success": 2,
-                "up_for_reschedule": 0,
-                "up_for_retry": 0,
-                "upstream_failed": 0,
-            },
-        }
+        assert response.json() == expected
 
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {"start_date": None, "end_date": "2023-08-02T00:00"},
+        ],
+    )
     @pytest.mark.usefixtures("freeze_time_for_dagruns", "make_dag_runs")
-    def test_historical_metrics_data_date_filters(self, test_client):
-        params = {"start_date": "2023-02-02T00:00", "end_date": "2023-06-02T00:00"}
+    def test_historical_metrics_data_start_date_none(self, test_client, params):
         response = test_client.get("/ui/dashboard/historical_metrics_data", params=params)
-        assert response.status_code == 200
-        assert response.json() == {
-            "dag_run_states": {"failed": 1, "queued": 0, "running": 0, "success": 0},
-            "dag_run_types": {"backfill": 0, "asset_triggered": 1, "manual": 0, "scheduled": 0},
-            "task_instance_states": {
-                "deferred": 0,
-                "failed": 2,
-                "no_status": 0,
-                "queued": 0,
-                "removed": 0,
-                "restarting": 0,
-                "running": 0,
-                "scheduled": 0,
-                "skipped": 0,
-                "success": 0,
-                "up_for_reschedule": 0,
-                "up_for_retry": 0,
-                "upstream_failed": 0,
-            },
-        }
+        assert response.status_code == 400
+        assert response.json() == {"detail": "start_date parameter is required in the request"}


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
related: #43846

- Allow `safe_date_time` to return `None` if the input is `None`
- Handle `None` in queries/endpoints 
- Simplify unit tests

I have created a separate PR because write permissions don't allow me to push to the existing PR.
cc: @bbovenzi @pierrejeambrun @tirkarthi 

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
