### PR TITLE
Make host/port configurable for Snowflake connections

### DIFF
--- a/docs/apache-airflow-providers-snowflake/connections/snowflake.rst
+++ b/docs/apache-airflow-providers-snowflake/connections/snowflake.rst
@@ -62,6 +62,8 @@ Extra (optional)
     * ``private_key_content``: Specify the content of the private key file.
     * ``session_parameters``: Specify `session level parameters <https://docs.snowflake.com/en/user-guide/python-connector-example.html#setting-session-parameters>`_.
     * ``insecure_mode``: Turn off OCSP certificate checks. For details, see: `How To: Turn Off OCSP Checking in Snowflake Client Drivers - Snowflake Community <https://community.snowflake.com/s/article/How-to-turn-off-OCSP-checking-in-Snowflake-client-drivers>`_.
+    * ``host``: Target Snowflake hostname to connect to (e.g., for local testing with LocalStack).
+    * ``port``: Target Snowflake port to connect to (e.g., for local testing with LocalStack).
 
 URI format example
 ^^^^^^^^^^^^^^^^^^

--- a/providers/src/airflow/providers/snowflake/hooks/snowflake.py
+++ b/providers/src/airflow/providers/snowflake/hooks/snowflake.py
@@ -279,6 +279,14 @@ class SnowflakeHook(DbApiHook):
             conn_config.pop("login", None)
             conn_config.pop("password", None)
 
+        # configure custom target hostname and port, if specified
+        snowflake_host = extra_dict.get("host")
+        snowflake_port = extra_dict.get("port")
+        if snowflake_host:
+            conn_config["host"] = snowflake_host
+        if snowflake_port:
+            conn_config["port"] = snowflake_port
+
         return conn_config
 
     def get_uri(self) -> str:


### PR DESCRIPTION
First of all - thanks so much for building Airflow, it is an absolutely awesome platform! 🙌 🚀 

This PR extends the functionality of `SnowflakeHook` to make the host/port configurable for Snowflake connections. This facilitates testing against non-standard Snowflake endpoints, for example when testing against [LocalStack](https://www.localstack.cloud/localstack-for-snowflake) (a local cloud emulator).

A similar PR has been created against the Astronomer Cosmos repo some time ago (see https://github.com/astronomer/astronomer-cosmos/pull/1063), and our users have now requested to use the standard Airflow Snowflake connector with LocalStack Snowflake as well.

The PR also updates the documentation for the Snowflake connector, but it does not contain any tests at this point. If adding a test is required, then any pointers or guidance would be appreciated. 👍 

## Testing

Tested this locally against the LocalStack Snowflake emulator - with a connection config like this:

<img width="1009" alt="image" src="https://github.com/user-attachments/assets/0977470c-234f-4cd2-8aff-736b3fc82124">

... and a simple DAG like this:
```
from airflow import DAG
from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator

conn_id = "snowflake_local"

dag = DAG(
    'snowflake_test',
    default_args={'snowflake_conn_id': conn_id},
    tags=['example'],
    catchup=False,
)

snowflake_op_sql_str = SnowflakeOperator(
    task_id='query1',
    dag=dag,
    sql="SELECT CURRENT_ACCOUNT()",
)
```

... the DAG executes successfully, and outputs:
<img width="862" alt="image" src="https://github.com/user-attachments/assets/66ca0cf1-a1ee-45ad-affb-4bddf18e2faf">


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
