### PR TITLE
Add usedforsecurity for sha1 algorithm

### DIFF
--- a/airflow/models/dagcode.py
+++ b/airflow/models/dagcode.py
@@ -194,4 +194,9 @@ class DagCode(Base):
         import hashlib
 
         # Only 7 bytes because MySQL BigInteger can hold only 8 bytes (signed).
-        return struct.unpack(">Q", hashlib.sha1(full_filepath.encode("utf-8")).digest()[-8:])[0] >> 8
+        return (
+            struct.unpack(
+                ">Q", hashlib.sha1(full_filepath.encode("utf-8"), usedforsecurity=False).digest()[-8:]
+            )[0]
+            >> 8
+        )

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2456,7 +2456,8 @@ class TaskInstance(Base, LoggingMixin):
             # deterministic per task instance
             ti_hash = int(
                 hashlib.sha1(
-                    f"{self.dag_id}#{self.task_id}#{self.logical_date}#{self.try_number}".encode()
+                    f"{self.dag_id}#{self.task_id}#{self.logical_date}#{self.try_number}".encode(),
+                    usedforsecurity=False,
                 ).hexdigest(),
                 16,
             )

--- a/airflow/sensors/base.py
+++ b/airflow/sensors/base.py
@@ -365,7 +365,8 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
                 # Calculate the jitter
                 run_hash = int(
                     hashlib.sha1(
-                        f"{self.dag_id}#{self.task_id}#{started_at}#{estimated_poke_count}".encode()
+                        f"{self.dag_id}#{self.task_id}#{started_at}#{estimated_poke_count}".encode(),
+                        usedforsecurity=False,
                     ).hexdigest(),
                     16,
                 )
@@ -384,7 +385,9 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
         min_backoff = max(int(self.poke_interval * (2 ** (poke_count - 2))), 1)
 
         run_hash = int(
-            hashlib.sha1(f"{self.dag_id}#{self.task_id}#{started_at}#{poke_count}".encode()).hexdigest(),
+            hashlib.sha1(
+                f"{self.dag_id}#{self.task_id}#{started_at}#{poke_count}".encode(), usedforsecurity=False
+            ).hexdigest(),
             16,
         )
         modded_hash = min_backoff + run_hash % min_backoff

--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -356,7 +356,7 @@ def iter_airflow_imports(file_path: str) -> Generator[str, None, None]:
 def get_unique_dag_module_name(file_path: str) -> str:
     """Return a unique module name in the format unusual_prefix_{sha1 of module's file path}_{original module name}."""
     if isinstance(file_path, str):
-        path_hash = hashlib.sha1(file_path.encode("utf-8")).hexdigest()
+        path_hash = hashlib.sha1(file_path.encode("utf-8"), usedforsecurity=False).hexdigest()
         org_mod_name = re2.sub(r"[.-]", "_", Path(file_path).stem)
         return MODIFIED_DAG_MODULE_NAME.format(path_hash=path_hash, module_name=org_mod_name)
     raise ValueError("file_path should be a string to generate unique module name")


### PR DESCRIPTION
SHA1 is cryptographically weak and some restricted environments (FIPS compliant) are blocking weak algorithms. You can use them (as of Python 3.9) in those environments by specifically stating that the algorithm is not used for security.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
