### PR TITLE
Fix special tests in the new workflow structure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,6 +501,7 @@ jobs:
       excluded-providers-as-string: ${{ needs.build-info.outputs.excluded-providers-as-string }}
       canary-run: ${{ needs.build-info.outputs.canary-run }}
       upgrade-to-newer-dependencies: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
+      include-success-outputs: ${{ needs.build-info.outputs.include-success-outputs }}
       debug-resources: ${{ needs.build-info.outputs.debug-resources }}
 
   tests-integration-system:

--- a/.github/workflows/special-tests.yml
+++ b/.github/workflows/special-tests.yml
@@ -68,6 +68,10 @@ on:  # yamllint disable-line rule:truthy
         description: "Whether to upgrade to newer dependencies or not (true/false)"
         required: true
         type: string
+      include-success-outputs:
+        description: "Whether to include success outputs or not (true/false)"
+        required: true
+        type: string
       debug-resources:
         description: "Whether to debug resources or not (true/false)"
         required: true
@@ -85,7 +89,7 @@ jobs:
       downgrade-sqlalchemy: "true"
       test-name: "MinSQLAlchemy-Postgres"
       test-scope: "DB"
-      test-groups: ${{ needs.build-info.outputs.test-groups }}
+      test-groups: ${{ inputs.test-groups }}
       backend: "postgres"
       image-tag: ${{ inputs.image-tag }}
       python-versions: "['${{ inputs.default-python-version }}']"
@@ -109,7 +113,7 @@ jobs:
       upgrade-boto: "true"
       test-name: "LatestBoto-Postgres"
       test-scope: "All"
-      test-groups: ${{ needs.build-info.outputs.test-groups }}
+      test-groups: ${{ inputs.test-groups }}
       backend: "postgres"
       image-tag: ${{ inputs.image-tag }}
       python-versions: "['${{ inputs.default-python-version }}']"
@@ -118,7 +122,7 @@ jobs:
       excludes: "[]"
       core-test-types-list-as-string: ${{ inputs.core-test-types-list-as-string }}
       providers-test-types-list-as-string: ${{ inputs.providers-test-types-list-as-string }}
-      include-success-outputs: ${{ needs.build-info.outputs.include-success-outputs }}
+      include-success-outputs: ${{ inputs.include-success-outputs }}
       run-coverage: ${{ inputs.run-coverage }}
       debug-resources: ${{ inputs.debug-resources }}
 
@@ -134,7 +138,7 @@ jobs:
       downgrade-pendulum: "true"
       test-name: "Pendulum2-Postgres"
       test-scope: "All"
-      test-groups: ${{ needs.build-info.outputs.test-groups }}
+      test-groups: ${{ inputs.test-groups }}
       backend: "postgres"
       image-tag: ${{ inputs.image-tag }}
       python-versions: "['${{ inputs.default-python-version }}']"
@@ -143,7 +147,7 @@ jobs:
       excludes: "[]"
       core-test-types-list-as-string: ${{ inputs.core-test-types-list-as-string }}
       providers-test-types-list-as-string: ${{ inputs.providers-test-types-list-as-string }}
-      include-success-outputs: ${{ needs.build-info.outputs.include-success-outputs }}
+      include-success-outputs: ${{ inputs.include-success-outputs }}
       run-coverage: ${{ inputs.run-coverage }}
       debug-resources: ${{ inputs.debug-resources }}
 
@@ -159,7 +163,7 @@ jobs:
       enable-aip-44: "false"
       test-name: "InProgressDisabled-Postgres"
       test-scope: "All"
-      test-groups: ${{ needs.build-info.outputs.test-groups }}
+      test-groups: ${{ inputs.test-groups }}
       backend: "postgres"
       image-tag: ${{ inputs.image-tag }}
       python-versions: "['${{ inputs.default-python-version }}']"
@@ -168,7 +172,7 @@ jobs:
       excludes: "[]"
       core-test-types-list-as-string: ${{ inputs.core-test-types-list-as-string }}
       providers-test-types-list-as-string: ${{ inputs.providers-test-types-list-as-string }}
-      include-success-outputs: ${{ needs.build-info.outputs.include-success-outputs }}
+      include-success-outputs: ${{ inputs.include-success-outputs }}
       run-coverage: ${{ inputs.run-coverage }}
       debug-resources: ${{ inputs.debug-resources }}
 
@@ -183,7 +187,7 @@ jobs:
       runs-on-as-json-default: ${{ inputs.runs-on-as-json-default }}
       test-name: "Postgres"
       test-scope: "Quarantined"
-      test-groups: ${{ needs.build-info.outputs.test-groups }}
+      test-groups: ${{ inputs.test-groups }}
       backend: "postgres"
       image-tag: ${{ inputs.image-tag }}
       python-versions: "['${{ inputs.default-python-version }}']"
@@ -192,7 +196,7 @@ jobs:
       excludes: "[]"
       core-test-types-list-as-string: ${{ inputs.core-test-types-list-as-string }}
       providers-test-types-list-as-string: ${{ inputs.providers-test-types-list-as-string }}
-      include-success-outputs: ${{ needs.build-info.outputs.include-success-outputs }}
+      include-success-outputs: ${{ inputs.include-success-outputs }}
       run-coverage: ${{ inputs.run-coverage }}
       debug-resources: ${{ inputs.debug-resources }}
 
@@ -207,7 +211,7 @@ jobs:
       runs-on-as-json-default: ${{ inputs.runs-on-as-json-default }}
       test-name: "Postgres"
       test-scope: "ARM collection"
-      test-groups: ${{ needs.build-info.outputs.test-groups }}
+      test-groups: ${{ inputs.test-groups }}
       backend: "postgres"
       image-tag: ${{ inputs.image-tag }}
       python-versions: "['${{ inputs.default-python-version }}']"
@@ -216,7 +220,7 @@ jobs:
       excludes: "[]"
       core-test-types-list-as-string: ${{ inputs.core-test-types-list-as-string }}
       providers-test-types-list-as-string: ${{ inputs.providers-test-types-list-as-string }}
-      include-success-outputs: ${{ needs.build-info.outputs.include-success-outputs }}
+      include-success-outputs: ${{ inputs.include-success-outputs }}
       run-coverage: ${{ inputs.run-coverage }}
       debug-resources: ${{ inputs.debug-resources }}
 
@@ -231,7 +235,7 @@ jobs:
       runs-on-as-json-default: ${{ inputs.runs-on-as-json-default }}
       test-name: "SystemTest"
       test-scope: "System"
-      test-groups: ${{ needs.build-info.outputs.test-groups }}
+      test-groups: ${{ inputs.test-groups }}
       backend: "postgres"
       image-tag: ${{ inputs.image-tag }}
       python-versions: "['${{ inputs.default-python-version }}']"
@@ -240,6 +244,6 @@ jobs:
       excludes: "[]"
       core-test-types-list-as-string: ${{ inputs.core-test-types-list-as-string }}
       providers-test-types-list-as-string: ${{ inputs.providers-test-types-list-as-string }}
-      include-success-outputs: ${{ needs.build-info.outputs.include-success-outputs }}
+      include-success-outputs: ${{ inputs.include-success-outputs }}
       run-coverage: ${{ inputs.run-coverage }}
       debug-resources: ${{ inputs.debug-resources }}


### PR DESCRIPTION
When #43979 there was a typo where inputs passed as test-groups were not passed to unit tests in "special-tests" case - because the "needs.build-info.outputs" were used instead.

Unfortunately this is not caught by GitHub parsing the workflows, it will only signal it by having annotations of errors on the affected actions - missing needs.build-info entries are simply replaced by empty string.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
