### PR TITLE
Resolve circular import issue related to task sdk

### DIFF
--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -75,7 +75,7 @@ if TYPE_CHECKING:
         OperatorExpandKwargsArgument,
     )
     from airflow.models.mappedoperator import ValidationSource
-    from airflow.sdk import DAG
+    from airflow.sdk.definitions.dag import DAG
     from airflow.utils.context import Context
     from airflow.utils.task_group import TaskGroup
 

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -50,7 +50,8 @@ if TYPE_CHECKING:
     from airflow.models.dag import DAG as SchedulerDAG
     from airflow.models.mappedoperator import MappedOperator
     from airflow.models.taskinstance import TaskInstance
-    from airflow.sdk import DAG, BaseOperator
+    from airflow.sdk.definitions.baseoperator import BaseOperator
+    from airflow.sdk.definitions.dag import DAG
     from airflow.sdk.definitions.node import DAGNode
     from airflow.task.priority_strategy import PriorityWeightStrategy
     from airflow.triggers.base import StartTriggerArgs
@@ -460,7 +461,7 @@ class AbstractOperator(Templater, TaskSDKAbstractOperator):
 
         from airflow.models.mappedoperator import MappedOperator
         from airflow.models.taskinstance import TaskInstance
-        from airflow.sdk import BaseOperator
+        from airflow.sdk.definitions.baseoperator import BaseOperator
         from airflow.settings import task_instance_mutation_hook
 
         if not isinstance(self, (BaseOperator, MappedOperator)):

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -74,14 +74,15 @@ from airflow.models.base import _sentinel
 from airflow.models.mappedoperator import OperatorPartial, validate_mapping_kwargs
 from airflow.models.taskinstance import TaskInstance, clear_task_instances
 from airflow.models.taskmixin import DependencyMixin
-
-# Keeping this file at all is a temp thing as we migrate the repo to the task sdk as the base, but to keep
-# main working and useful for others to develop against we use the TaskSDK here but keep this file around
-from airflow.sdk import DAG, BaseOperator as TaskSDKBaseOperator, EdgeModifier as TaskSDKEdgeModifier
 from airflow.sdk.definitions.baseoperator import (
     BaseOperatorMeta as TaskSDKBaseOperatorMeta,
     get_merged_defaults,
 )
+
+# Keeping this file at all is a temp thing as we migrate the repo to the task sdk as the base, but to keep
+# main working and useful for others to develop against we use the TaskSDK here but keep this file around
+from airflow.sdk.definitions.dag import DAG, BaseOperator as TaskSDKBaseOperator
+from airflow.sdk.definitions.edges import EdgeModifier as TaskSDKEdgeModifier
 from airflow.serialization.enums import DagAttributeTypes
 from airflow.ti_deps.deps.mapped_task_upstream_dep import MappedTaskUpstreamDep
 from airflow.ti_deps.deps.not_in_retry_period_dep import NotInRetryPeriodDep

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -94,7 +94,7 @@ from airflow.models.taskinstance import (
     clear_task_instances,
 )
 from airflow.models.tasklog import LogTemplate
-from airflow.sdk import DAG as TaskSDKDag, dag as task_sdk_dag_decorator
+from airflow.sdk.definitions.dag import DAG as TaskSDKDag, dag as task_sdk_dag_decorator
 from airflow.secrets.local_filesystem import LocalFilesystemBackend
 from airflow.security import permissions
 from airflow.settings import json

--- a/airflow/models/param.py
+++ b/airflow/models/param.py
@@ -29,7 +29,7 @@ from airflow.utils.types import NOTSET, ArgNotSet
 if TYPE_CHECKING:
     from airflow.models.dagrun import DagRun
     from airflow.models.operator import Operator
-    from airflow.sdk import DAG
+    from airflow.sdk.definitions.dag import DAG
     from airflow.serialization.pydantic.dag_run import DagRunPydantic
     from airflow.utils.context import Context
 

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -163,7 +163,7 @@ if TYPE_CHECKING:
     from airflow.models.dag import DAG as SchedulerDAG, DagModel
     from airflow.models.dagrun import DagRun
     from airflow.models.operator import Operator
-    from airflow.sdk import DAG
+    from airflow.sdk.definitions.dag import DAG
     from airflow.serialization.pydantic.asset import AssetEventPydantic
     from airflow.serialization.pydantic.dag import DagModelPydantic
     from airflow.serialization.pydantic.taskinstance import TaskInstancePydantic

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -42,7 +42,8 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
     from airflow.models.operator import Operator
-    from airflow.sdk import DAG, BaseOperator
+    from airflow.sdk.definitions.baseoperator import BaseOperator
+    from airflow.sdk.definitions.dag import DAG
     from airflow.utils.context import Context
     from airflow.utils.edgemodifier import EdgeModifier
 

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -60,7 +60,7 @@ from airflow.models.taskinstancekey import TaskInstanceKey
 from airflow.models.tasklog import LogTemplate
 from airflow.models.xcom_arg import XComArg, deserialize_xcom_arg, serialize_xcom_arg
 from airflow.providers_manager import ProvidersManager
-from airflow.sdk import BaseOperator as TaskSDKBaseOperator
+from airflow.sdk.definitions.baseoperator import BaseOperator as TaskSDKBaseOperator
 from airflow.serialization.dag_dependency import DagDependency
 from airflow.serialization.enums import DagAttributeTypes as DAT, Encoding
 from airflow.serialization.helpers import serialize_template_field

--- a/airflow/template/templater.py
+++ b/airflow/template/templater.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     import jinja2
 
     from airflow.models.operator import Operator
-    from airflow.sdk import DAG
+    from airflow.sdk.definitions.dag import DAG
     from airflow.utils.context import Context
 
 

--- a/airflow/utils/edgemodifier.py
+++ b/airflow/utils/edgemodifier.py
@@ -23,7 +23,7 @@ import airflow.sdk
 if TYPE_CHECKING:
     from airflow.typing_compat import TypeAlias
 
-EdgeModifier: TypeAlias = airflow.sdk.EdgeModifier
+EdgeModifier: TypeAlias = airflow.sdk.definitions.edges.EdgeModifier
 
 
 # Factory functions

--- a/task_sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task_sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -28,8 +28,8 @@ import attrs
 import structlog
 from pydantic import ConfigDict, TypeAdapter
 
-from airflow.sdk import BaseOperator
 from airflow.sdk.api.datamodels._generated import TaskInstance
+from airflow.sdk.definitions.baseoperator import BaseOperator
 from airflow.sdk.execution_time.comms import StartupDetails, ToSupervisor, ToTask
 
 if TYPE_CHECKING:

--- a/task_sdk/tests/dags/super_basic.py
+++ b/task_sdk/tests/dags/super_basic.py
@@ -17,7 +17,8 @@
 
 from __future__ import annotations
 
-from airflow.sdk import BaseOperator, dag
+from airflow.sdk.definitions.baseoperator import BaseOperator
+from airflow.sdk.definitions.dag import dag
 
 
 @dag()

--- a/task_sdk/tests/defintions/test_dag.py
+++ b/task_sdk/tests/defintions/test_dag.py
@@ -221,7 +221,7 @@ class TestDag:
         assert "t3" not in partial.task_group.used_group_ids
 
     def test_partial_subset_taskgroup_join_ids(self):
-        from airflow.sdk import TaskGroup
+        from airflow.sdk.definitions.taskgroup import TaskGroup
 
         with DAG("test_dag", schedule=None, start_date=DEFAULT_DATE) as dag:
             start = BaseOperator(task_id="start")


### PR DESCRIPTION
When building official prod image locally and trying to run a task with it, I got circular import error.

This PR shows how to resolve it.  But it may not be "the right way".  For that I defer to @ashb and @kaxil.

Please don't merge this unless they approve.

Note that, with these changes, you can still import the "normal" way from dag files.  E.g. the below now works fine.  Just the internal code had to import from the actual full paths.

<img width="802" alt="image" src="https://github.com/user-attachments/assets/a7abb906-1e2a-41ac-96d2-a19953148d42">


