### PR TITLE
Fix error propagation in new tests

### DIFF
--- a/scripts/ci/testing/run_breeze_command_with_retries.sh
+++ b/scripts/ci/testing/run_breeze_command_with_retries.sh
@@ -28,6 +28,7 @@ for i in $(seq 1 "$NUMBER_OF_ATTEMPT") ; do
     breeze down
     set +e
     if breeze "$@"; then
+        set -e
         exit 0
     else
         echo

--- a/scripts/ci/testing/run_unit_tests.sh
+++ b/scripts/ci/testing/run_unit_tests.sh
@@ -31,68 +31,98 @@ TEST_SCOPE=${2}
 
 function core_tests() {
     echo "${COLOR_BLUE}Running core tests${COLOR_RESET}"
+    set +e
     if [[ "${TEST_SCOPE}" == "DB" ]]; then
         set -x
         breeze testing core-tests --run-in-parallel --run-db-tests-only
+        RESULT=$?
         set +x
     elif [[ "${TEST_SCOPE}" == "Non-DB" ]]; then
         set -x
         breeze testing core-tests --use-xdist --skip-db-tests --no-db-cleanup --backend none
+        RESULT=$?
         set +x
     elif [[ "${TEST_SCOPE}" == "All" ]]; then
         set -x
         breeze testing core-tests --run-in-parallel
+        RESULT=$?
         set +x
     elif [[ "${TEST_SCOPE}" == "Quarantined" ]]; then
         set -x
-        breeze testing core-tests --test-type "All-Quarantined"
+        breeze testing core-tests --test-type "All-Quarantined" || true
+        RESULT=$?
         set +x
     elif [[ "${TEST_SCOPE}" == "ARM collection" ]]; then
         set -x
         breeze testing core-tests --collect-only --remove-arm-packages --test-type "All"
+        RESULT=$?
         set +x
     elif [[  "${TEST_SCOPE}" == "System" ]]; then
         set -x
         breeze testing system-tests tests/system/example_empty.py
+        RESULT=$?
         set +x
     else
         echo "Unknown test scope: ${TEST_SCOPE}"
+        set -e
         exit 1
     fi
-    echo "${COLOR_BLUE}Core tests completed${COLOR_RESET}"
+    set -e
+    if [[ ${RESULT} != "0" ]]; then
+        echo
+        echo "${COLOR_RED}The ${TEST_GROUP} test ${TEST_SCOPE} failed! Giving up${COLOR_RESET}"
+        echo
+        exit "${RESULT}"
+    fi
+    echo "${COLOR_GREEN}Core tests completed successfully${COLOR_RESET}"
 }
 
 function providers_tests() {
     echo "${COLOR_BLUE}Running providers tests${COLOR_RESET}"
+    set +e
     if [[ "${TEST_SCOPE}" == "DB" ]]; then
         set -x
         breeze testing providers-tests --run-in-parallel --run-db-tests-only
+        RESULT=$?
         set +x
     elif [[ "${TEST_SCOPE}" == "Non-DB" ]]; then
         set -x
         breeze testing providers-tests --use-xdist --skip-db-tests --no-db-cleanup --backend none
+        RESULT=$?
         set +x
     elif [[ "${TEST_SCOPE}" == "All" ]]; then
         set -x
         breeze testing providers-tests --run-in-parallel
+        RESULT=$?
         set +x
     elif [[ "${TEST_SCOPE}" == "Quarantined" ]]; then
         set -x
-        breeze testing providers-tests --test-type "All-Quarantined"
+        breeze testing providers-tests --test-type "All-Quarantined" || true
+        RESULT=$?
         set +x
     elif [[ "${TEST_SCOPE}" == "ARM collection" ]]; then
         set -x
         breeze testing providers-tests --collect-only --remove-arm-packages --test-type "All"
+        RESULT=$?
         set +x
     elif [[  "${TEST_SCOPE}" == "System" ]]; then
         set -x
         breeze testing system-tests providers/tests/system/example_empty.py
+        RESULT=$?
         set +x
     else
         echo "Unknown test scope: ${TEST_SCOPE}"
+        set -e
         exit 1
     fi
-    echo "${COLOR_BLUE}Providers tests completed${COLOR_RESET}"
+    set -e
+    if [[ ${RESULT} != "0" ]]; then
+        echo
+        echo "${COLOR_RED}The ${TEST_GROUP} test ${TEST_SCOPE} failed! Giving up${COLOR_RESET}"
+        echo
+        exit "${RESULT}"
+    fi
+    echo "${COLOR_GREEB}Providers tests completed successfully${COLOR_RESET}"
 }
 
 


### PR DESCRIPTION
The #43979 introduced unit_tests.sh script that did not properly propagate error codes (no -e/+e setting).

This PR fixes it - also fixes an edge case where the -e setting is not restored in run breeze commmand script.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
