### PR TITLE
Ignore requests RetryError in k8s tests

### DIFF
--- a/kubernetes_tests/test_base.py
+++ b/kubernetes_tests/test_base.py
@@ -29,6 +29,7 @@ import re2
 import requests
 import requests.exceptions
 from requests.adapters import HTTPAdapter
+from requests.exceptions import RetryError
 from urllib3.exceptions import MaxRetryError
 from urllib3.util.retry import Retry
 
@@ -234,7 +235,7 @@ class BaseK8STest:
                 result = self.session.patch(patch_string, json={"is_paused": False})
                 if result.status_code == 200:
                     break
-            except MaxRetryError:
+            except (MaxRetryError, RetryError):
                 pass
 
             time.sleep(30)

--- a/kubernetes_tests/test_base.py
+++ b/kubernetes_tests/test_base.py
@@ -229,7 +229,7 @@ class BaseK8STest:
         result = {}
         # This loop retries until the DAG parser finishes with max_attempts and the DAG is available for execution.
         # Keep the try/catch block, as the session object has a default retry configuration.
-        # If a MaxRetryError is raised, it can be safely ignored, indicating that the DAG is not yet parsed.
+        # If a MaxRetryError, RetryError is raised, it can be safely ignored, indicating that the DAG is not yet parsed.
         while max_attempts:
             try:
                 result = self.session.patch(patch_string, json={"is_paused": False})


### PR DESCRIPTION
We have max_attempts to loop until the DAG successfully parses. Additionally, there is a retry configuration in place, so it might fail before reaching the max_attempts. RetryError exceptions can be safely ignored in this case.


https://github.com/apache/airflow/actions/runs/11868315063/job/33077761184#step:10:1494
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
