### PR TITLE
BUG Update `initialise_virtualenv.py` to use `uv sync`

### DIFF
--- a/scripts/tools/initialize_virtualenv.py
+++ b/scripts/tools/initialize_virtualenv.py
@@ -168,7 +168,7 @@ def main():
     env["AIRFLOW__DATABASE__SQL_ALCHEMY_POOL_ENABLED"] = "False"
     env["AIRFLOW__CORE__DAGS_FOLDER"] = f"{airflow_sources}/empty"
     env["AIRFLOW__CORE__PLUGINS_FOLDER"] = f"{airflow_sources}/empty"
-    subprocess.run(["airflow", "db", "reset", "--yes"], env=env)
+    subprocess.run(["uv", "run", "airflow", "db", "reset", "--yes"], env=env)
 
     print("\nResetting AIRFLOW sqlite unit test database...")
     env = os.environ.copy()
@@ -177,7 +177,7 @@ def main():
     env["AIRFLOW__DATABASE__SQL_ALCHEMY_POOL_ENABLED"] = "False"
     env["AIRFLOW__CORE__DAGS_FOLDER"] = f"{airflow_sources}/empty"
     env["AIRFLOW__CORE__PLUGINS_FOLDER"] = f"{airflow_sources}/empty"
-    subprocess.run(["airflow", "db", "reset", "--yes"], env=env)
+    subprocess.run(["uv", "run", "airflow", "db", "reset", "--yes"], env=env)
 
     print("\nInitialization of environment complete! Go ahead and develop Airflow!")
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #44078

`uv` is the recommended tool for installing `airflow` and other dependecies. I updated the `./scripts/tool/initialise_virtualenv.py` file to use `uv sync` instead of `pip unstall`



<!-- Please keep an empty line above the dashes. -->