### PR TITLE
Correct type hinting for RPC API endpoint in EdgeWorker for FastAPI

### DIFF
--- a/providers/src/airflow/providers/edge/worker_api/routes/rpc_api.py
+++ b/providers/src/airflow/providers/edge/worker_api/routes/rpc_api.py
@@ -156,7 +156,7 @@ def json_rpc_version(body: JsonRpcRequest):
         ]
     ),
 )
-def rpcapi(body: JsonRpcRequest) -> dict | None:
+def rpcapi(body: JsonRpcRequest) -> Any | None:
     """Handle Edge Worker API calls as JSON-RPC."""
     log.debug("Got request for %s", body.method)
     methods_map = _initialize_method_map()


### PR DESCRIPTION
While testing the new FastAPI with Airflow 3 / main I saw that type hints broke RPC API for cases where Non-Dict values are returned by functions. Some functions called on internal API return scalar values or lists.