### PR TITLE
Repair internal API on main for Edge Worker / RPC API

### DIFF
--- a/airflow/api_internal/endpoints/rpc_api_endpoint.py
+++ b/airflow/api_internal/endpoints/rpc_api_endpoint.py
@@ -73,6 +73,7 @@ def initialize_method_map() -> dict[str, Callable]:
         _handle_failure,
         _handle_reschedule,
         _update_rtif,
+        _update_ti_heartbeat,
         _xcom_pull,
     )
     from airflow.secrets.metastore import MetastoreBackend
@@ -86,6 +87,7 @@ def initialize_method_map() -> dict[str, Callable]:
         _get_ti_db_access,
         _get_task_map_length,
         _update_rtif,
+        _update_ti_heartbeat,
         _orig_start_date,
         _handle_failure,
         _handle_reschedule,
@@ -144,6 +146,7 @@ def initialize_method_map() -> dict[str, Callable]:
         TaskInstance._set_state,
         TaskInstance.save_to_db,
         TaskInstance._clear_xcom_data,
+        TaskInstance._register_asset_changes_int,
         Trigger.from_object,
         Trigger.bulk_fetch,
         Trigger.clean_unused,

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2796,20 +2796,33 @@ class TaskInstance(Base, LoggingMixin):
             session=session,
         )
 
-    def _register_asset_changes(self, *, events: OutletEventAccessors, session: Session) -> None:
+    def _register_asset_changes(
+        self, *, events: OutletEventAccessors, session: Session | None = None
+    ) -> None:
+        if session:
+            TaskInstance._register_asset_changes_int(ti=self, events=events, session=session)
+        else:
+            TaskInstance._register_asset_changes_int(ti=self, events=events)
+
+    @staticmethod
+    @internal_api_call
+    @provide_session
+    def _register_asset_changes_int(
+        ti: TaskInstance, *, events: OutletEventAccessors, session: Session = NEW_SESSION
+    ) -> None:
         if TYPE_CHECKING:
-            assert self.task
+            assert ti.task
 
         # One task only triggers one asset event for each asset with the same extra.
         # This tuple[asset uri, extra] to sets alias names mapping is used to find whether
         # there're assets with same uri but different extra that we need to emit more than one asset events.
         asset_alias_names: dict[tuple[str, frozenset], set[str]] = defaultdict(set)
-        for obj in self.task.outlets or []:
-            self.log.debug("outlet obj %s", obj)
+        for obj in ti.task.outlets or []:
+            ti.log.debug("outlet obj %s", obj)
             # Lineage can have other types of objects besides assets
             if isinstance(obj, Asset):
                 asset_manager.register_asset_change(
-                    task_instance=self,
+                    task_instance=ti,
                     asset=obj,
                     extra=events[obj].extra,
                     session=session,
@@ -2832,18 +2845,18 @@ class TaskInstance(Base, LoggingMixin):
                 (asset_obj.uri, asset_obj)
                 for asset_obj in asset_manager.create_assets(missing_assets, session=session)
             )
-            self.log.warning("Created new assets for alias reference: %s", missing_assets)
+            ti.log.warning("Created new assets for alias reference: %s", missing_assets)
             session.flush()  # Needed because we need the id for fk.
 
         for (uri, extra_items), alias_names in asset_alias_names.items():
             asset_obj = asset_models[uri]
-            self.log.info(
+            ti.log.info(
                 'Creating event for %r through aliases "%s"',
                 asset_obj,
                 ", ".join(alias_names),
             )
             asset_manager.register_asset_change(
-                task_instance=self,
+                task_instance=ti,
                 asset=asset_obj,
                 aliases=[AssetAlias(name=name) for name in alias_names],
                 extra=dict(extra_items),

--- a/airflow/serialization/pydantic/dag_run.py
+++ b/airflow/serialization/pydantic/dag_run.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import TYPE_CHECKING, Iterable, List, Optional
+from uuid import UUID
 
 from pydantic import BaseModel as BaseModelPydantic, ConfigDict
 
@@ -52,7 +53,7 @@ class DagRunPydantic(BaseModelPydantic):
     data_interval_start: Optional[datetime]
     data_interval_end: Optional[datetime]
     last_scheduling_decision: Optional[datetime]
-    dag_version_id: Optional[int]
+    dag_version_id: Optional[UUID]
     updated_at: Optional[datetime]
     dag: Optional[PydanticDag]
     consumed_asset_events: List[AssetEventPydantic]  # noqa: UP006

--- a/airflow/serialization/pydantic/taskinstance.py
+++ b/airflow/serialization/pydantic/taskinstance.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import TYPE_CHECKING, Annotated, Any, Iterable, Optional
+from uuid import UUID
 
 from pydantic import (
     BaseModel as BaseModelPydantic,
@@ -116,6 +117,7 @@ class TaskInstancePydantic(BaseModelPydantic, LoggingMixin):
     trigger_timeout: Optional[datetime]
     next_method: Optional[str]
     next_kwargs: Optional[dict]
+    dag_version_id: Optional[UUID]
     run_as_user: Optional[str]
     task: Optional[PydanticOperator]
     test_mode: bool

--- a/tests/assets/test_manager.py
+++ b/tests/assets/test_manager.py
@@ -92,6 +92,7 @@ def mock_task_instance():
         trigger_timeout=datetime.now(),
         next_method="bla",
         next_kwargs=None,
+        dag_version_id=None,
         run_as_user=None,
         task=None,
         test_mode=False,


### PR DESCRIPTION
While I was testing the new FastAPI for EdgeWorker in #43865 I realized that the model changes on main broke the EdgeWorker for current Airflow 3.

While the internal API will never get to Airflow 3... still the "broken window" is something that needs repair... until AIP-72 is not available... to further test EdgeWorker on main.

This PR corrects a few glitches introduced by changes:
- Field `dag_version_id` as UUID was missed in Pydantic models
- Funcion `_update_ti_heartbeat` was missed in internal API spec
- Function `_register_asset_changes_int` was missed in internal API in general after it was added, fails remotely

P.S.: Time to have AIP-72 working to remove the internal API...