### PR TITLE
Fix Pydantic model in Airflow 2.10 back-compat tests for Edge

### DIFF
--- a/providers/src/airflow/providers/edge/worker_api/datamodels.py
+++ b/providers/src/airflow/providers/edge/worker_api/datamodels.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Dict, Optional
 
 from pydantic import BaseModel
 
@@ -28,5 +28,5 @@ class JsonRpcRequest(BaseModel):
     """Fully qualified python module method name that is called via JSON RPC."""
     jsonrpc: str
     """JSON RPC version."""
-    params: dict[str, Any] | None = None
+    params: Optional[Dict[str, Any]] = None  # noqa: UP006, UP007 - prevent pytest failing in back-compat
     """Parameters passed to the method."""


### PR DESCRIPTION
Fixes broken canary test. See:
https://github.com/apache/airflow/actions/runs/11872681950/job/33086780319

After fixing the one problem there was also a error appearing in collection of non-db tests for this PR. Therefore needed to adjust pytests which are known not to be working in Airflow 3. DIFF looks large but it is actually just 200 lines indented. Difference is just an IF and re-formatting. Hiding white-space changes help as
![image](https://github.com/user-attachments/assets/005393b0-0726-43d8-a375-2e4052fe3783)


```
==================================== ERRORS ====================================
___ ERROR collecting providers/tests/edge/worker_api/routes/test_rpc_api.py ____
/usr/local/lib/python3.9/site-packages/pydantic/_internal/_typing_extra.py:303: in _eval_type_backport
    return _eval_type(value, globalns, localns, type_params)
/usr/local/lib/python3.9/site-packages/pydantic/_internal/_typing_extra.py:332: in _eval_type
    return typing._eval_type(  # type: ignore
/usr/local/lib/python3.9/typing.py:292: in _eval_type
    return t._evaluate(globalns, localns, recursive_guard)
/usr/local/lib/python3.9/typing.py:554: in _evaluate
    eval(self.__forward_code__, globalns, localns),
<string>:1: in <module>
    ???
E   TypeError: unsupported operand type(s) for |: 'types.GenericAlias' and 'NoneType'

The above exception was the direct cause of the following exception:
providers/tests/edge/worker_api/routes/test_rpc_api.py:37: in <module>
    from airflow.providers.edge.worker_api.routes.rpc_api import _initialize_method_map
/usr/local/lib/python3.9/site-packages/airflow/providers/edge/worker_api/routes/rpc_api.py:40: in <module>
    from airflow.providers.edge.worker_api.datamodels import JsonRpcRequest
/usr/local/lib/python3.9/site-packages/airflow/providers/edge/worker_api/datamodels.py:24: in <module>
    class JsonRpcRequest(BaseModel):
/usr/local/lib/python3.9/site-packages/pydantic/_internal/_model_construction.py:219: in __new__
    set_model_fields(cls, bases, config_wrapper, types_namespace)
/usr/local/lib/python3.9/site-packages/pydantic/_internal/_model_construction.py:512: in set_model_fields
    fields, class_vars = collect_model_fields(cls, bases, config_wrapper, types_namespace, typevars_map=typevars_map)
/usr/local/lib/python3.9/site-packages/pydantic/_internal/_fields.py:105: in collect_model_fields
    type_hints = get_cls_type_hints_lenient(cls, types_namespace)
/usr/local/lib/python3.9/site-packages/pydantic/_internal/_typing_extra.py:245: in get_cls_type_hints_lenient
    hints[name] = eval_type_lenient(value, globalns, localns)
/usr/local/lib/python3.9/site-packages/pydantic/_internal/_typing_extra.py:257: in eval_type_lenient
    return eval_type_backport(value, globalns, localns)
/usr/local/lib/python3.9/site-packages/pydantic/_internal/_typing_extra.py:279: in eval_type_backport
    return _eval_type_backport(value, globalns, localns, type_params)
/usr/local/lib/python3.9/site-packages/pydantic/_internal/_typing_extra.py:311: in _eval_type_backport
    raise TypeError(
E   TypeError: Unable to evaluate type annotation 'dict[str, Any] | None'. If you are making use of the new typing syntax (unions using `|` since Python 3.10 or builtins subscripting since Python 3.9), you should either replace the use of new syntax with the existing `typing` constructs or install the `eval_type_backport` package.
- generated xml file: /files/test_result-providers_-amazon_google_stand-sqlite.xml -
```