### PR TITLE
AIP-81 Add Insert Multiple Pools API

### DIFF
--- a/airflow/api_fastapi/app.py
+++ b/airflow/api_fastapi/app.py
@@ -22,7 +22,13 @@ from contextlib import AsyncExitStack, asynccontextmanager
 from fastapi import FastAPI
 from starlette.routing import Mount
 
-from airflow.api_fastapi.core_api.app import init_config, init_dag_bag, init_plugins, init_views
+from airflow.api_fastapi.core_api.app import (
+    init_config,
+    init_dag_bag,
+    init_error_handlers,
+    init_plugins,
+    init_views,
+)
 from airflow.api_fastapi.execution_api.app import create_task_execution_api_app
 from airflow.auth.managers.base_auth_manager import BaseAuthManager
 from airflow.configuration import conf
@@ -61,6 +67,7 @@ def create_app(apps: str = "all") -> FastAPI:
         init_dag_bag(app)
         init_views(app)
         init_plugins(app)
+        init_error_handlers(app)
         init_auth_manager()
 
     if "execution" in apps_list or "all" in apps_list:

--- a/airflow/api_fastapi/common/exceptions.py
+++ b/airflow/api_fastapi/common/exceptions.py
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Generic, TypeVar
+
+from fastapi import HTTPException, Request, status
+from sqlalchemy.exc import IntegrityError
+
+T = TypeVar("T")
+
+
+class BaseErrorHandler(Generic[T], ABC):
+    """Base class for error handlers."""
+
+    def __init__(self, exception_cls: T) -> None:
+        self.exception_cls = exception_cls
+
+    @abstractmethod
+    def exception_handler(self, request: Request, exc: T):
+        """exception_handler method."""
+        raise NotImplementedError
+
+
+class _UniqueConstraintErrorHandler(BaseErrorHandler[IntegrityError]):
+    """Exception raised when trying to insert a duplicate value in a unique column."""
+
+    def __init__(self):
+        super().__init__(IntegrityError)
+        self.unique_constraint_error_messages = [
+            "UNIQUE constraint failed",  # SQLite
+            "Duplicate entry",  # MySQL
+            "violates unique constraint",  # PostgreSQL
+        ]
+
+    def exception_handler(self, request: Request, exc: IntegrityError):
+        """Handle IntegrityError exception."""
+        exc_orig_str = str(exc.orig)
+        if any(error_msg in exc_orig_str for error_msg in self.unique_constraint_error_messages):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Unique constraint violation",
+            )
+
+
+DatabaseErrorHandlers = [
+    _UniqueConstraintErrorHandler(),
+]

--- a/airflow/api_fastapi/common/exceptions.py
+++ b/airflow/api_fastapi/common/exceptions.py
@@ -23,7 +23,7 @@ from typing import Generic, TypeVar
 from fastapi import HTTPException, Request, status
 from sqlalchemy.exc import IntegrityError
 
-T = TypeVar("T")
+T = TypeVar("T", bound=Exception)
 
 
 class BaseErrorHandler(Generic[T], ABC):

--- a/airflow/api_fastapi/core_api/app.py
+++ b/airflow/api_fastapi/core_api/app.py
@@ -120,3 +120,11 @@ def init_config(app: FastAPI) -> None:
     app.add_middleware(GZipMiddleware, minimum_size=1024, compresslevel=5)
 
     app.state.secret_key = conf.get("webserver", "secret_key")
+
+
+def init_error_handlers(app: FastAPI) -> None:
+    from airflow.api_fastapi.common.exceptions import DatabaseErrorHandlers
+
+    # register database error handlers
+    for handler in DatabaseErrorHandlers:
+        app.add_exception_handler(handler.exception_cls, handler.exception_handler)

--- a/airflow/api_fastapi/core_api/datamodels/pools.py
+++ b/airflow/api_fastapi/core_api/datamodels/pools.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from typing import Annotated, Callable
 
-from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, field_validator
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
 
 
 def _call_function(function: Callable[[], int]) -> int:
@@ -81,16 +81,3 @@ class PoolPostBulkBody(BaseModel):
     """Pools serializer for post bodies."""
 
     pools: list[PoolPostBody]
-
-    @field_validator("pools", mode="after")
-    def validate_pools(cls, v: list[PoolPostBody]) -> list[PoolPostBody]:
-        pool_set = set()
-        duplicates = []
-        for pool in v:
-            if pool.pool in pool_set:
-                duplicates.append(pool.pool)
-            else:
-                pool_set.add(pool.pool)
-        if duplicates:
-            raise ValueError(f"Pool name should be unique, found duplicates: {duplicates}")
-        return v

--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -3322,9 +3322,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPExceptionResponse'
-        '400':
-          description: Validation error
-          example: {}
         '409':
           description: Conflict
           content:

--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -3278,6 +3278,59 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPExceptionResponse'
           description: Forbidden
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Conflict
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /public/pools/bulk:
+    post:
+      tags:
+      - Pool
+      summary: Post Pools
+      description: Create multiple pools.
+      operationId: post_pools
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PoolPostBulkBody'
+        required: true
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PoolCollectionResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+        '400':
+          description: Validation error
+          example: {}
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
         '422':
           description: Validation Error
           content:
@@ -6544,6 +6597,7 @@ components:
       properties:
         name:
           type: string
+          maxLength: 256
           title: Name
         slots:
           type: integer
@@ -6563,6 +6617,18 @@ components:
       - slots
       title: PoolPostBody
       description: Pool serializer for post bodies.
+    PoolPostBulkBody:
+      properties:
+        pools:
+          items:
+            $ref: '#/components/schemas/PoolPostBody'
+          type: array
+          title: Pools
+      type: object
+      required:
+      - pools
+      title: PoolPostBulkBody
+      description: Pools serializer for post bodies.
     PoolResponse:
       properties:
         name:

--- a/airflow/api_fastapi/core_api/routes/public/pools.py
+++ b/airflow/api_fastapi/core_api/routes/public/pools.py
@@ -163,7 +163,7 @@ def patch_pool(
     status_code=status.HTTP_201_CREATED,
     responses=create_openapi_http_exception_doc(
         [status.HTTP_409_CONFLICT]
-    ),  # handle by global exception handler
+    ),  # handled by global exception handler
 )
 def post_pool(
     body: PoolPostBody,
@@ -181,7 +181,7 @@ def post_pool(
     status_code=status.HTTP_201_CREATED,
     responses=create_openapi_http_exception_doc(
         [
-            status.HTTP_409_CONFLICT,  # handle by global exception handler
+            status.HTTP_409_CONFLICT,  # handled by global exception handler
         ]
     ),
 )

--- a/airflow/api_fastapi/core_api/routes/public/pools.py
+++ b/airflow/api_fastapi/core_api/routes/public/pools.py
@@ -32,6 +32,7 @@ from airflow.api_fastapi.core_api.datamodels.pools import (
     PoolCollectionResponse,
     PoolPatchBody,
     PoolPostBody,
+    PoolPostBulkBody,
     PoolResponse,
 )
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
@@ -160,14 +161,55 @@ def patch_pool(
 @pools_router.post(
     "",
     status_code=status.HTTP_201_CREATED,
+    responses=create_openapi_http_exception_doc([status.HTTP_409_CONFLICT]),
 )
 def post_pool(
     post_body: PoolPostBody,
     session: Annotated[Session, Depends(get_session)],
 ) -> PoolResponse:
     """Create a Pool."""
+    pool = session.scalar(select(Pool).where(Pool.pool == post_body.pool))
+    if pool is not None:
+        raise HTTPException(status.HTTP_409_CONFLICT, f"Pool with name: `{post_body.pool}` already exists")
     pool = Pool(**post_body.model_dump())
 
     session.add(pool)
 
     return PoolResponse.model_validate(pool, from_attributes=True)
+
+
+@pools_router.post(
+    "/bulk",
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        status.HTTP_400_BAD_REQUEST: {"description": "Validation error", "example": {}},
+        **create_openapi_http_exception_doc(
+            [
+                status.HTTP_401_UNAUTHORIZED,
+                status.HTTP_403_FORBIDDEN,
+                status.HTTP_409_CONFLICT,
+            ]
+        ),
+    },
+)
+def post_pools(
+    post_bulk_body: PoolPostBulkBody,
+    session: Annotated[Session, Depends(get_session)],
+) -> PoolCollectionResponse:
+    """Create multiple pools."""
+    # Check if any of the pools already exists
+    pools_names = [pool.pool for pool in post_bulk_body.pools]
+    existing_pools = session.scalars(select(Pool.pool).where(Pool.pool.in_(pools_names))).all()
+    if existing_pools:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            detail=f"Pools with names: `{existing_pools}` already exist",
+        )
+
+    pools = [Pool(**post_body.model_dump()) for post_body in post_bulk_body.pools]
+    session.add_all(pools)
+
+    return PoolCollectionResponse(
+        pools=[PoolResponse.model_validate(pool, from_attributes=True) for pool in pools],
+        total_entries=len(pools),
+    )

--- a/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow/ui/openapi-gen/queries/common.ts
@@ -1330,6 +1330,9 @@ export type DagRunServiceClearDagRunMutationResult = Awaited<
 export type PoolServicePostPoolMutationResult = Awaited<
   ReturnType<typeof PoolService.postPool>
 >;
+export type PoolServicePostPoolsMutationResult = Awaited<
+  ReturnType<typeof PoolService.postPools>
+>;
 export type TaskInstanceServiceGetTaskInstancesBatchMutationResult = Awaited<
   ReturnType<typeof TaskInstanceService.getTaskInstancesBatch>
 >;

--- a/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow/ui/openapi-gen/queries/queries.ts
@@ -41,6 +41,7 @@ import {
   DagWarningType,
   PoolPatchBody,
   PoolPostBody,
+  PoolPostBulkBody,
   TaskInstancesBatchBody,
   VariableBody,
 } from "../requests/types.gen";
@@ -2361,6 +2362,43 @@ export const usePoolServicePostPool = <
   >({
     mutationFn: ({ requestBody }) =>
       PoolService.postPool({ requestBody }) as unknown as Promise<TData>,
+    ...options,
+  });
+/**
+ * Post Pools
+ * Create multiple pools.
+ * @param data The data for the request.
+ * @param data.requestBody
+ * @returns PoolCollectionResponse Successful Response
+ * @throws ApiError
+ */
+export const usePoolServicePostPools = <
+  TData = Common.PoolServicePostPoolsMutationResult,
+  TError = unknown,
+  TContext = unknown,
+>(
+  options?: Omit<
+    UseMutationOptions<
+      TData,
+      TError,
+      {
+        requestBody: PoolPostBulkBody;
+      },
+      TContext
+    >,
+    "mutationFn"
+  >,
+) =>
+  useMutation<
+    TData,
+    TError,
+    {
+      requestBody: PoolPostBulkBody;
+    },
+    TContext
+  >({
+    mutationFn: ({ requestBody }) =>
+      PoolService.postPools({ requestBody }) as unknown as Promise<TData>,
     ...options,
   });
 /**

--- a/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -2848,6 +2848,7 @@ export const $PoolPostBody = {
   properties: {
     name: {
       type: "string",
+      maxLength: 256,
       title: "Name",
     },
     slots: {
@@ -2875,6 +2876,22 @@ export const $PoolPostBody = {
   required: ["name", "slots"],
   title: "PoolPostBody",
   description: "Pool serializer for post bodies.",
+} as const;
+
+export const $PoolPostBulkBody = {
+  properties: {
+    pools: {
+      items: {
+        $ref: "#/components/schemas/PoolPostBody",
+      },
+      type: "array",
+      title: "Pools",
+    },
+  },
+  type: "object",
+  required: ["pools"],
+  title: "PoolPostBulkBody",
+  description: "Pools serializer for post bodies.",
 } as const;
 
 export const $PoolResponse = {

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -109,6 +109,8 @@ import type {
   GetPoolsResponse,
   PostPoolData,
   PostPoolResponse,
+  PostPoolsData,
+  PostPoolsResponse,
   GetProvidersData,
   GetProvidersResponse,
   GetTaskInstanceData,
@@ -1790,6 +1792,33 @@ export class PoolService {
       errors: {
         401: "Unauthorized",
         403: "Forbidden",
+        409: "Conflict",
+        422: "Validation Error",
+      },
+    });
+  }
+
+  /**
+   * Post Pools
+   * Create multiple pools.
+   * @param data The data for the request.
+   * @param data.requestBody
+   * @returns PoolCollectionResponse Successful Response
+   * @throws ApiError
+   */
+  public static postPools(
+    data: PostPoolsData,
+  ): CancelablePromise<PostPoolsResponse> {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/public/pools/bulk",
+      body: data.requestBody,
+      mediaType: "application/json",
+      errors: {
+        400: "Validation error",
+        401: "Unauthorized",
+        403: "Forbidden",
+        409: "Conflict",
         422: "Validation Error",
       },
     });

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -1815,7 +1815,6 @@ export class PoolService {
       body: data.requestBody,
       mediaType: "application/json",
       errors: {
-        400: "Validation error",
         401: "Unauthorized",
         403: "Forbidden",
         409: "Conflict",

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -3140,10 +3140,6 @@ export type $OpenApiTs = {
          */
         201: PoolCollectionResponse;
         /**
-         * Validation error
-         */
-        400: unknown;
-        /**
          * Unauthorized
          */
         401: HTTPExceptionResponse;

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -713,6 +713,13 @@ export type PoolPostBody = {
 };
 
 /**
+ * Pools serializer for post bodies.
+ */
+export type PoolPostBulkBody = {
+  pools: Array<PoolPostBody>;
+};
+
+/**
  * Pool serializer for responses.
  */
 export type PoolResponse = {
@@ -1509,6 +1516,12 @@ export type PostPoolData = {
 };
 
 export type PostPoolResponse = PoolResponse;
+
+export type PostPoolsData = {
+  requestBody: PoolPostBulkBody;
+};
+
+export type PostPoolsResponse = PoolCollectionResponse;
 
 export type GetProvidersData = {
   limit?: number;
@@ -3107,6 +3120,41 @@ export type $OpenApiTs = {
          * Forbidden
          */
         403: HTTPExceptionResponse;
+        /**
+         * Conflict
+         */
+        409: HTTPExceptionResponse;
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError;
+      };
+    };
+  };
+  "/public/pools/bulk": {
+    post: {
+      req: PostPoolsData;
+      res: {
+        /**
+         * Successful Response
+         */
+        201: PoolCollectionResponse;
+        /**
+         * Validation error
+         */
+        400: unknown;
+        /**
+         * Unauthorized
+         */
+        401: HTTPExceptionResponse;
+        /**
+         * Forbidden
+         */
+        403: HTTPExceptionResponse;
+        /**
+         * Conflict
+         */
+        409: HTTPExceptionResponse;
         /**
          * Validation Error
          */

--- a/tests/api_fastapi/core_api/routes/public/test_pools.py
+++ b/tests/api_fastapi/core_api/routes/public/test_pools.py
@@ -364,7 +364,7 @@ class TestPostPool(TestPoolsEndpoint):
                     "deferred_slots": 0,
                 },
                 409,
-                {"detail": "Pool with name: `my_pool` already exists"},
+                {"detail": "Unique constraint violation"},
             ),
         ],
     )

--- a/tests/api_fastapi/core_api/routes/public/test_pools.py
+++ b/tests/api_fastapi/core_api/routes/public/test_pools.py
@@ -71,7 +71,6 @@ class TestPoolsEndpoint:
         response = test_client.post("/public/pools/", json=body)
         assert response.status_code == expected_status_code
 
-        body = response.json()
         assert response.json() == expected_response
         if check_count:
             assert session.query(Pool).count() == n_pools + 1
@@ -464,16 +463,8 @@ class TestPostPools(TestPoolsEndpoint):
                         {"name": "my_pool", "slots": 12},
                     ]
                 },
-                422,
-                {
-                    "detail": [
-                        {
-                            "loc": ["body", "pools"],
-                            "msg": "Value error, Pool name should be unique, found duplicates: ['my_pool']",
-                            "type": "value_error",
-                        }
-                    ]
-                },
+                409,
+                {},
             ),
         ],
     )
@@ -485,11 +476,7 @@ class TestPostPools(TestPoolsEndpoint):
         response_json = response.json()
         if expected_status_code == 201:
             assert response_json == expected_response
-        elif expected_status_code == 422:
-            assert response_json["detail"][0]["loc"] == expected_response["detail"][0]["loc"]
-            assert response_json["detail"][0]["msg"] == expected_response["detail"][0]["msg"]
-            assert response_json["detail"][0]["type"] == expected_response["detail"][0]["type"]
-        if expected_status_code == 201:
             assert session.query(Pool).count() == n_pools + 2
         else:
+            # since different database backend return different error messages, we just check the status code
             assert session.query(Pool).count() == n_pools


### PR DESCRIPTION
closes: #43896
related: #43657

### Fix: Add `max_length=256` for `PoolPostBody.pool`  

The model defined in https://github.com/apache/airflow/blob/main/airflow/models/pool.py#L54 enforces a string length constraint on `Pool.pool`. To maintain consistency, this constraint should also be validated at the router level.  

### Refactor: Handle Duplicate Cases in `Insert Pool`  

The `Insert Pool` (single insert) functionality should account for cases where a duplicate pool name is provided, as `Pool.pool` is defined with a `unique` constraint.  

### Feat: Add Insert Multiple Pools API  

A new API endpoint for inserting multiple pools has been introduced as `/pools/bulk`. Alternative names such as `/pools/batch` or `/pools/multiple` were considered. Feedback on which name best describes the endpoint is welcome.  
