### PR TITLE
AIP-84 Fix sqlite in non tests environment

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -484,7 +484,7 @@ def configure_orm(disable_connection_pool=False, pool_class=None):
     else:
         connect_args = {}
 
-    if os.environ.get("AIRFLOW__CORE__UNIT_TEST_MODE") == "True" and SQL_ALCHEMY_CONN.startswith("sqlite"):
+    if SQL_ALCHEMY_CONN.startswith("sqlite"):
         # FastAPI runs sync endpoints in a separate thread. SQLite does not allow
         # to use objects created in another threads by default. Allowing that in test
         # to so the `test` thread and the tested endpoints can use common objects.


### PR DESCRIPTION
We actually need that in **tests** but also **outside of tests.** (breeze, standalone).

I didn't know that but FastAPI can use multiple threads to handle the same requests. (Some part are processed by one thread, some other by another thread, for instance for dependency resolutions).

Running breeze with sqlite currently yields errors without this change.

More information in FastAPI documentation:
https://fastapi.tiangolo.com/tutorial/sql-databases/#create-an-engine