### PR TITLE
spark-submit: replace `principle` by `principal`

### DIFF
--- a/providers/src/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/providers/src/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -520,7 +520,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         """Resolve kerberos principal."""
         # todo: remove try/exception when min airflow version is 3.0
         try:
-            from airflow.security.kerberos import get_kerberos_principal
+            from airflow.security.kerberos import get_kerberos_principal   # type: ignore[attr-defined]
         except ImportError:
             from airflow.security.kerberos import (
                 get_kerberos_principle as get_kerberos_principal,  # type: ignore[attr-defined]

--- a/providers/src/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/providers/src/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -521,7 +521,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         # todo: remove try/exception when min airflow version is 3.0
         try:
             from airflow.security.kerberos import get_kerberos_principal
-        except ModuleNotFoundError:
+        except ImportError:
             from airflow.security.kerberos import get_kerberos_principle as get_kerberos_principal
 
         return get_kerberos_principal(principal)

--- a/providers/src/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/providers/src/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -518,9 +518,13 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
 
     def _resolve_kerberos_principal(self, principal: str | None) -> str:
         """Resolve kerberos principal."""
-        from airflow.security.kerberos import get_kerberos_principle
+        # todo: remove try/exception when min airflow version is 3.0
+        try:
+            from airflow.security.kerberos import get_kerberos_principal
+        except ModuleNotFoundError:
+            from airflow.security.kerberos import get_kerberos_principle as get_kerberos_principal
 
-        return get_kerberos_principle(principal)
+        return get_kerberos_principal(principal)
 
     def submit(self, application: str = "", **kwargs: Any) -> None:
         """

--- a/providers/src/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/providers/src/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -520,7 +520,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         """Resolve kerberos principal."""
         # todo: remove try/exception when min airflow version is 3.0
         try:
-            from airflow.security.kerberos import get_kerberos_principal   # type: ignore[attr-defined]
+            from airflow.security.kerberos import get_kerberos_principal  # type: ignore[attr-defined]
         except ImportError:
             from airflow.security.kerberos import (
                 get_kerberos_principle as get_kerberos_principal,  # type: ignore[attr-defined]

--- a/providers/src/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/providers/src/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -522,7 +522,9 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         try:
             from airflow.security.kerberos import get_kerberos_principal
         except ImportError:
-            from airflow.security.kerberos import get_kerberos_principle as get_kerberos_principal # type: ignore[attr-defined]
+            from airflow.security.kerberos import (
+                get_kerberos_principle as get_kerberos_principal,  # type: ignore[attr-defined]
+            )
 
         return get_kerberos_principal(principal)
 

--- a/providers/src/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/providers/src/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -522,7 +522,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         try:
             from airflow.security.kerberos import get_kerberos_principal
         except ImportError:
-            from airflow.security.kerberos import get_kerberos_principle as get_kerberos_principal
+            from airflow.security.kerberos import get_kerberos_principle as get_kerberos_principal # type: ignore[attr-defined]
 
         return get_kerberos_principal(principal)
 

--- a/providers/tests/apache/spark/hooks/test_spark_submit.py
+++ b/providers/tests/apache/spark/hooks/test_spark_submit.py
@@ -230,11 +230,11 @@ class TestSparkSubmitHook:
 
     @patch("airflow.configuration.conf.get_mandatory_value")
     def test_resolve_spark_submit_env_vars_use_krb5ccache_missing_principal(self, mock_get_madantory_value):
-        mock_principle = "airflow"
-        mock_get_madantory_value.return_value = mock_principle
+        mock_principal = "airflow"
+        mock_get_madantory_value.return_value = mock_principal
         hook = SparkSubmitHook(conn_id="spark_yarn_cluster", principal=None, use_krb5ccache=True)
         mock_get_madantory_value.assert_called_with("kerberos", "principal")
-        assert hook._principal == mock_principle
+        assert hook._principal == mock_principal
 
     def test_resolve_spark_submit_env_vars_use_krb5ccache_missing_KRB5CCNAME_env(self):
         hook = SparkSubmitHook(


### PR DESCRIPTION
This is related to #43679, in which the `airflow.security.kerberos.get_kerberos_principle` function was renamed `get_kerberos_principle`.

In this patch, we introduce a `try/except` block around this import, getting ready to deprecate the typo-ed function in Airflow 3.0.

We also fix a innocuous typo in a unit test.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
