### PR TITLE
Fix link to events page

### DIFF
--- a/airflow/ui/src/layouts/Nav/BrowseButton.tsx
+++ b/airflow/ui/src/layouts/Nav/BrowseButton.tsx
@@ -16,8 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Link } from "@chakra-ui/react";
 import { FiGlobe } from "react-icons/fi";
+import { Link } from "react-router-dom";
 
 import { Menu } from "src/components/ui";
 
@@ -25,7 +25,7 @@ import { NavButton } from "./NavButton";
 
 const links = [
   {
-    href: `/webapp/events`,
+    href: "/events",
     title: "Events",
   },
 ];
@@ -38,7 +38,7 @@ export const BrowseButton = () => (
     <Menu.Content>
       {links.map((link) => (
         <Menu.Item asChild key={link.title} value={link.title}>
-          <Link aria-label={link.title} href={link.href}>
+          <Link aria-label={link.title} to={link.href}>
             {link.title}
           </Link>
         </Menu.Item>


### PR DESCRIPTION
Clicking on Browse->Events caused a weird page flicker. That is because we were using the wrong `Link` component. We should use the one from react-router-dom which plays better with the UIs navigation.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
