### PR TITLE
Use `S3CopyObjectOperator` in `example_comprehend_document_classifier`

### DIFF
--- a/providers/src/airflow/providers/amazon/aws/hooks/s3.py
+++ b/providers/src/airflow/providers/amazon/aws/hooks/s3.py
@@ -1297,6 +1297,7 @@ class S3Hook(AwsBaseHook):
         dest_bucket_name: str | None = None,
         source_version_id: str | None = None,
         acl_policy: str | None = None,
+        meta_data_directive: str | None = None,
         **kwargs,
     ) -> None:
         """
@@ -1326,10 +1327,14 @@ class S3Hook(AwsBaseHook):
         :param source_version_id: Version ID of the source object (OPTIONAL)
         :param acl_policy: The string to specify the canned ACL policy for the
             object to be copied which is private by default.
+        :param meta_data_directive: Whether to `COPY` the metadata from the source object or `REPLACE` it
+            with metadata that's provided in the request.
         """
         acl_policy = acl_policy or "private"
         if acl_policy != NO_ACL:
             kwargs["ACL"] = acl_policy
+        if meta_data_directive:
+            kwargs["MetadataDirective"] = meta_data_directive
 
         dest_bucket_name, dest_bucket_key = self.get_s3_bucket_key(
             dest_bucket_name, dest_bucket_key, "dest_bucket_name", "dest_bucket_key"

--- a/providers/src/airflow/providers/amazon/aws/operators/s3.py
+++ b/providers/src/airflow/providers/amazon/aws/operators/s3.py
@@ -282,6 +282,8 @@ class S3CopyObjectOperator(BaseOperator):
                  CA cert bundle than the one used by botocore.
     :param acl_policy: String specifying the canned ACL policy for the file being
         uploaded to the S3 bucket.
+    :param meta_data_directive: Whether to `COPY` the metadata from the source object or `REPLACE` it with
+        metadata that's provided in the request.
     """
 
     template_fields: Sequence[str] = (
@@ -302,6 +304,7 @@ class S3CopyObjectOperator(BaseOperator):
         aws_conn_id: str | None = "aws_default",
         verify: str | bool | None = None,
         acl_policy: str | None = None,
+        meta_data_directive: str | None = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -314,6 +317,7 @@ class S3CopyObjectOperator(BaseOperator):
         self.aws_conn_id = aws_conn_id
         self.verify = verify
         self.acl_policy = acl_policy
+        self.meta_data_directive = meta_data_directive
 
     def execute(self, context: Context):
         s3_hook = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
@@ -324,6 +328,7 @@ class S3CopyObjectOperator(BaseOperator):
             self.dest_bucket_name,
             self.source_version_id,
             self.acl_policy,
+            self.meta_data_directive,
         )
 
     def get_openlineage_facets_on_start(self):


### PR DESCRIPTION
Today, the system test `example_comprehend_document_classifier` downloads 10 times the same file from Github and save it in s3. As a consequence, Github might block you access and return a 403. Let's be nice with Github and download it once and then copy it from s3 to s3

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
