### PR TITLE
AIP-84 update List  Task Instances  route

### DIFF
--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -3286,7 +3286,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /public/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/:
+  /public/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances:
     get:
       tags:
       - Task Instance

--- a/airflow/api_fastapi/core_api/routes/public/task_instances.py
+++ b/airflow/api_fastapi/core_api/routes/public/task_instances.py
@@ -262,7 +262,7 @@ def get_mapped_task_instance(
 
 
 @task_instances_router.get(
-    "/",
+    "",
     responses=create_openapi_http_exception_doc([status.HTTP_404_NOT_FOUND]),
 )
 def get_task_instances(

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -1821,7 +1821,7 @@ export class TaskInstanceService {
   ): CancelablePromise<GetTaskInstancesResponse> {
     return __request(OpenAPI, {
       method: "GET",
-      url: "/public/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/",
+      url: "/public/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances",
       path: {
         dag_id: data.dagId,
         dag_run_id: data.dagRunId,

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -2961,7 +2961,7 @@ export type $OpenApiTs = {
       };
     };
   };
-  "/public/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/": {
+  "/public/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances": {
     get: {
       req: GetTaskInstancesData;
       res: {


### PR DESCRIPTION
Currently, the route is `/public/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/` 

When running tests, I noticed a redirect:

```
(Pdb) test_client.get("/public/dags/~/dagRuns/~/taskInstances")
[2024-11-19T10:43:57.544+0530] {_client.py:1026} INFO - HTTP Request: GET http://testserver/public/dags/~/dagRuns/~/taskInstances "HTTP/1.1 307 Temporary Redirect"
[2024-11-19T10:43:57.561+0530] {_client.py:1026} INFO - HTTP Request: GET http://testserver/public/dags/~/dagRuns/~/taskInstances/ "HTTP/1.1 200 OK"
```