### PR TITLE
Version Dags when the python_callable name changes

### DIFF
--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -1285,8 +1285,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 setattr(op, "operator_extra_links", list(op_extra_links_from_plugin.values()))
 
         for k, v in encoded_op.items():
-            # python_callable_name only serves to detect function name
-            # changes
+            # python_callable_name only serves to detect function name changes
             if k == "python_callable_name":
                 continue
             if k in ("_outlets", "_inlets"):

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -1161,6 +1161,12 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
         """Serialize operator into a JSON object."""
         serialize_op = cls.serialize_to_json(op, cls._decorated_fields)
 
+        # Detect if there's a change in python callable name
+        python_callable = getattr(op, "python_callable", None)
+        if python_callable:
+            callable_name = python_callable.__name__
+            serialize_op["python_callable_name"] = callable_name
+
         serialize_op["task_type"] = getattr(op, "task_type", type(op).__name__)
         serialize_op["_task_module"] = getattr(op, "_task_module", type(op).__module__)
         if op.operator_name != serialize_op["task_type"]:
@@ -1279,6 +1285,10 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 setattr(op, "operator_extra_links", list(op_extra_links_from_plugin.values()))
 
         for k, v in encoded_op.items():
+            # python_callable_name only serves to detect function name
+            # changes
+            if k == "python_callable_name":
+                continue
             if k in ("_outlets", "_inlets"):
                 # `_outlets` -> `outlets`
                 k = k[1:]

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -1164,7 +1164,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
         # Detect if there's a change in python callable name
         python_callable = getattr(op, "python_callable", None)
         if python_callable:
-            callable_name = python_callable.__name__
+            callable_name = qualname(python_callable)
             serialize_op["python_callable_name"] = callable_name
 
         serialize_op["task_type"] = getattr(op, "task_type", type(op).__name__)

--- a/tests/models/test_serialized_dag.py
+++ b/tests/models/test_serialized_dag.py
@@ -27,12 +27,15 @@ from sqlalchemy import func, select
 
 import airflow.example_dags as example_dags_module
 from airflow.assets import Asset
+from airflow.decorators import task as task_decorator
 from airflow.models.dag import DAG
+from airflow.models.dag_version import DagVersion
 from airflow.models.dagbag import DagBag
 from airflow.models.dagcode import DagCode
 from airflow.models.serialized_dag import SerializedDagModel as SDM
 from airflow.operators.empty import EmptyOperator
 from airflow.providers.standard.operators.bash import BashOperator
+from airflow.providers.standard.operators.python import PythonOperator
 from airflow.serialization.serialized_objects import SerializedDAG
 from airflow.settings import json
 from airflow.utils.hashlib_wrapper import md5
@@ -92,6 +95,39 @@ class TestSerializedDagModel:
                 assert result.dag_version.dag_code.fileloc == dag.fileloc
                 # Verifies JSON schema.
                 SerializedDAG.validate_schema(result.data)
+
+    def test_write_dag_when_python_callable_name_changes(self, dag_maker, session):
+        def my_callable():
+            pass
+
+        with dag_maker("dag1") as dag:
+            PythonOperator(task_id="task1", python_callable=my_callable)
+        dag.sync_to_db()
+        SDM.write_dag(dag)
+        with dag_maker("dag1") as dag:
+            PythonOperator(task_id="task1", python_callable=lambda x: None)
+        SDM.write_dag(dag)
+        assert len(session.query(DagVersion).all()) == 2
+
+        with dag_maker("dag2") as dag:
+
+            @task_decorator
+            def my_callable():
+                pass
+
+            my_callable()
+        dag.sync_to_db()
+        SDM.write_dag(dag)
+        with dag_maker("dag2") as dag:
+
+            @task_decorator
+            def my_callable2():
+                pass
+
+            my_callable2()
+        SDM.write_dag(dag)
+
+        assert len(session.query(DagVersion).all()) == 4
 
     @pytest.mark.skip_if_database_isolation_mode  # Does not work in db isolation mode
     def test_serialized_dag_is_updated_if_dag_is_changed(self):

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -2631,6 +2631,7 @@ def test_taskflow_expand_serde():
         "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"},
         "_disallow_kwargs_override": False,
         "_expand_input_attr": "op_kwargs_expand_input",
+        "python_callable_name": "x",
         "start_trigger_args": None,
         "start_from_trigger": False,
     }
@@ -2702,6 +2703,7 @@ def test_taskflow_expand_kwargs_serde(strict):
         "_task_module": "airflow.decorators.python",
         "task_type": "_PythonDecoratedOperator",
         "_operator_name": "@task",
+        "python_callable_name": "x",
         "start_trigger_args": None,
         "start_from_trigger": False,
         "downstream_task_ids": [],

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -78,6 +78,7 @@ from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
 from airflow.timetables.simple import NullTimetable, OnceTimetable
 from airflow.triggers.base import StartTriggerArgs
 from airflow.utils import timezone
+from airflow.utils.module_loading import qualname
 from airflow.utils.operator_resources import Resources
 from airflow.utils.task_group import TaskGroup
 from airflow.utils.xcom import XCOM_RETURN_KEY
@@ -2631,7 +2632,7 @@ def test_taskflow_expand_serde():
         "template_fields_renderers": {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"},
         "_disallow_kwargs_override": False,
         "_expand_input_attr": "op_kwargs_expand_input",
-        "python_callable_name": "x",
+        "python_callable_name": qualname(x),
         "start_trigger_args": None,
         "start_from_trigger": False,
     }
@@ -2703,7 +2704,7 @@ def test_taskflow_expand_kwargs_serde(strict):
         "_task_module": "airflow.decorators.python",
         "task_type": "_PythonDecoratedOperator",
         "_operator_name": "@task",
-        "python_callable_name": "x",
+        "python_callable_name": qualname(x),
         "start_trigger_args": None,
         "start_from_trigger": False,
         "downstream_task_ids": [],


### PR DESCRIPTION
We currently version DAGs when the serialized DAGs changes. Some code changes don't lead to versioning of the DAG, and we prefer not to version through code changes.

This change will allow the python callable name change to trigger versioning. A code change, but this is the max we want to go in versioning from code changes

