### PR TITLE
Make task output "unbuffered" so output is captured straight away

### DIFF
--- a/task_sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task_sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -149,8 +149,9 @@ def _reopen_std_io_handles(child_stdin, child_stdout, child_stderr):
                 fd = sock.fileno()
             else:
                 raise
-
-        setattr(sys, handle_name, os.fdopen(fd, mode))
+        # We can't open text mode fully unbuffered (python throws an exception if we try), but we can make it line buffered with `buffering=1`
+        handle = os.fdopen(fd, mode, buffering=1)
+        setattr(sys, handle_name, handle)
 
 
 def _fork_main(


### PR DESCRIPTION
Without this change a dag like this:

```
@task()
def hello():
    print("hello")
    time.sleep(300)
    print("goodbye")
```

would not show the output for "hello" until after the sleep!

This is analogouys to setting PYTHONUNBUFFERED environment variable when
running something like `python script.py | cat` etc.
