### PR TITLE
Fix failing mypy check on `main`

### DIFF
--- a/providers/src/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/providers/src/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -519,14 +519,14 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
     def _resolve_kerberos_principal(self, principal: str | None) -> str:
         """Resolve kerberos principal."""
         # todo: remove try/exception when min airflow version is 3.0
-        try:
-            from airflow.security.kerberos import get_kerberos_principal  # type: ignore[attr-defined]
-        except ImportError:
-            from airflow.security.kerberos import (
-                get_kerberos_principle as get_kerberos_principal,  # type: ignore[attr-defined]
-            )
+        from airflow.security import kerberos
 
-        return get_kerberos_principal(principal)
+        try:
+            func = kerberos.get_kerberos_principal
+        except AttributeError:
+            # Fallback for older versions of Airflow
+            func = kerberos.get_kerberos_principle  # type: ignore[attr-defined]
+        return func(principal)
 
     def submit(self, application: str = "", **kwargs: Any) -> None:
         """


### PR DESCRIPTION
Failure on main:

```
providers/src/airflow/providers/apache/spark/hooks/spark_submit.py:525: error:
Module "airflow.security.kerberos" has no attribute "get_kerberos_principle";
maybe "get_kerberos_principal"?  [attr-defined]
                from airflow.security.kerberos import (
                ^
providers/src/airflow/providers/apache/spark/hooks/spark_submit.py:525: error:
Name "get_kerberos_principal" already defined (possibly by an import)
[no-redef]
                from airflow.security.kerberos import (
                ^
Found 2 errors in 1 file (checked 3337 source files)
Error 1 returned
```

Example: https://github.com/apache/airflow/actions/runs/11916279945/job/33209076757

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
