### PR TITLE
AIP84: Transform assets/queuedEvent to assets/queuedEvents

### DIFF
--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -397,7 +397,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /public/assets/queuedEvent/{uri}:
+  /public/assets/queuedEvents/{uri}:
     get:
       tags:
       - Asset
@@ -543,7 +543,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /public/dags/{dag_id}/assets/queuedEvent:
+  /public/dags/{dag_id}/assets/queuedEvents:
     get:
       tags:
       - Asset
@@ -649,7 +649,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /public/dags/{dag_id}/assets/queuedEvent/{uri}:
+  /public/dags/{dag_id}/assets/queuedEvents/{uri}:
     get:
       tags:
       - Asset

--- a/airflow/api_fastapi/core_api/routes/public/assets.py
+++ b/airflow/api_fastapi/core_api/routes/public/assets.py
@@ -190,7 +190,7 @@ def create_asset_event(
 
 
 @assets_router.get(
-    "/assets/queuedEvent/{uri:path}",
+    "/assets/queuedEvents/{uri:path}",
     responses=create_openapi_http_exception_doc(
         [
             status.HTTP_404_NOT_FOUND,
@@ -253,7 +253,7 @@ def get_asset(
 
 
 @assets_router.get(
-    "/dags/{dag_id}/assets/queuedEvent",
+    "/dags/{dag_id}/assets/queuedEvents",
     responses=create_openapi_http_exception_doc(
         [
             status.HTTP_404_NOT_FOUND,
@@ -297,7 +297,7 @@ def get_dag_asset_queued_events(
 
 
 @assets_router.get(
-    "/dags/{dag_id}/assets/queuedEvent/{uri:path}",
+    "/dags/{dag_id}/assets/queuedEvents/{uri:path}",
     responses=create_openapi_http_exception_doc(
         [
             status.HTTP_404_NOT_FOUND,
@@ -328,7 +328,7 @@ def get_dag_asset_queued_event(
 
 
 @assets_router.delete(
-    "/assets/queuedEvent/{uri:path}",
+    "/assets/queuedEvents/{uri:path}",
     status_code=status.HTTP_204_NO_CONTENT,
     responses=create_openapi_http_exception_doc(
         [
@@ -350,7 +350,7 @@ def delete_asset_queued_events(
 
 
 @assets_router.delete(
-    "/dags/{dag_id}/assets/queuedEvent",
+    "/dags/{dag_id}/assets/queuedEvents",
     status_code=status.HTTP_204_NO_CONTENT,
     responses=create_openapi_http_exception_doc(
         [
@@ -374,7 +374,7 @@ def delete_dag_asset_queued_events(
 
 
 @assets_router.delete(
-    "/dags/{dag_id}/assets/queuedEvent/{uri:path}",
+    "/dags/{dag_id}/assets/queuedEvents/{uri:path}",
     status_code=status.HTTP_204_NO_CONTENT,
     responses=create_openapi_http_exception_doc(
         [

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -277,7 +277,7 @@ export class AssetService {
   ): CancelablePromise<GetAssetQueuedEventsResponse> {
     return __request(OpenAPI, {
       method: "GET",
-      url: "/public/assets/queuedEvent/{uri}",
+      url: "/public/assets/queuedEvents/{uri}",
       path: {
         uri: data.uri,
       },
@@ -307,7 +307,7 @@ export class AssetService {
   ): CancelablePromise<DeleteAssetQueuedEventsResponse> {
     return __request(OpenAPI, {
       method: "DELETE",
-      url: "/public/assets/queuedEvent/{uri}",
+      url: "/public/assets/queuedEvents/{uri}",
       path: {
         uri: data.uri,
       },
@@ -363,7 +363,7 @@ export class AssetService {
   ): CancelablePromise<GetDagAssetQueuedEventsResponse> {
     return __request(OpenAPI, {
       method: "GET",
-      url: "/public/dags/{dag_id}/assets/queuedEvent",
+      url: "/public/dags/{dag_id}/assets/queuedEvents",
       path: {
         dag_id: data.dagId,
       },
@@ -392,7 +392,7 @@ export class AssetService {
   ): CancelablePromise<DeleteDagAssetQueuedEventsResponse> {
     return __request(OpenAPI, {
       method: "DELETE",
-      url: "/public/dags/{dag_id}/assets/queuedEvent",
+      url: "/public/dags/{dag_id}/assets/queuedEvents",
       path: {
         dag_id: data.dagId,
       },
@@ -424,7 +424,7 @@ export class AssetService {
   ): CancelablePromise<GetDagAssetQueuedEventResponse> {
     return __request(OpenAPI, {
       method: "GET",
-      url: "/public/dags/{dag_id}/assets/queuedEvent/{uri}",
+      url: "/public/dags/{dag_id}/assets/queuedEvents/{uri}",
       path: {
         dag_id: data.dagId,
         uri: data.uri,
@@ -456,7 +456,7 @@ export class AssetService {
   ): CancelablePromise<DeleteDagAssetQueuedEventResponse> {
     return __request(OpenAPI, {
       method: "DELETE",
-      url: "/public/dags/{dag_id}/assets/queuedEvent/{uri}",
+      url: "/public/dags/{dag_id}/assets/queuedEvents/{uri}",
       path: {
         dag_id: data.dagId,
         uri: data.uri,

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1718,7 +1718,7 @@ export type $OpenApiTs = {
       };
     };
   };
-  "/public/assets/queuedEvent/{uri}": {
+  "/public/assets/queuedEvents/{uri}": {
     get: {
       req: GetAssetQueuedEventsData;
       res: {
@@ -1797,7 +1797,7 @@ export type $OpenApiTs = {
       };
     };
   };
-  "/public/dags/{dag_id}/assets/queuedEvent": {
+  "/public/dags/{dag_id}/assets/queuedEvents": {
     get: {
       req: GetDagAssetQueuedEventsData;
       res: {
@@ -1853,7 +1853,7 @@ export type $OpenApiTs = {
       };
     };
   };
-  "/public/dags/{dag_id}/assets/queuedEvent/{uri}": {
+  "/public/dags/{dag_id}/assets/queuedEvents/{uri}": {
     get: {
       req: GetDagAssetQueuedEventData;
       res: {

--- a/tests/api_fastapi/core_api/routes/public/test_assets.py
+++ b/tests/api_fastapi/core_api/routes/public/test_assets.py
@@ -622,7 +622,7 @@ class TestGetDagAssetQueuedEvents(TestQueuedEventEndpoint):
         self._create_asset_dag_run_queues(dag_id, asset_id, session)
 
         response = test_client.get(
-            f"/public/dags/{dag_id}/assets/queuedEvent",
+            f"/public/dags/{dag_id}/assets/queuedEvents",
         )
 
         assert response.status_code == 200
@@ -641,7 +641,7 @@ class TestGetDagAssetQueuedEvents(TestQueuedEventEndpoint):
         dag_id = "not_exists"
 
         response = test_client.get(
-            f"/public/dags/{dag_id}/assets/queuedEvent",
+            f"/public/dags/{dag_id}/assets/queuedEvents",
         )
 
         assert response.status_code == 404
@@ -660,7 +660,7 @@ class TestDeleteDagDatasetQueuedEvents(TestQueuedEventEndpoint):
         assert len(adrqs) == 1
 
         response = test_client.delete(
-            f"/public/dags/{dag_id}/assets/queuedEvent",
+            f"/public/dags/{dag_id}/assets/queuedEvents",
         )
 
         assert response.status_code == 204
@@ -671,7 +671,7 @@ class TestDeleteDagDatasetQueuedEvents(TestQueuedEventEndpoint):
         dag_id = "not_exists"
 
         response = test_client.delete(
-            f"/public/dags/{dag_id}/assets/queuedEvent",
+            f"/public/dags/{dag_id}/assets/queuedEvents",
         )
 
         assert response.status_code == 404
@@ -685,7 +685,7 @@ class TestDeleteDagDatasetQueuedEvents(TestQueuedEventEndpoint):
         assert len(adrqs) == 0
 
         response = test_client.delete(
-            f"/public/dags/{dag_id}/assets/queuedEvent",
+            f"/public/dags/{dag_id}/assets/queuedEvents",
         )
 
         assert response.status_code == 404
@@ -751,7 +751,7 @@ class TestGetAssetQueuedEvents(TestQueuedEventEndpoint):
         self._create_asset_dag_run_queues(dag_id, asset_id, session)
 
         response = test_client.get(
-            f"/public/assets/queuedEvent/{uri}",
+            f"/public/assets/queuedEvents/{uri}",
         )
         assert response.status_code == 200
         assert response.json() == {
@@ -769,7 +769,7 @@ class TestGetAssetQueuedEvents(TestQueuedEventEndpoint):
         uri = "not_exists"
 
         response = test_client.get(
-            f"/public/assets/queuedEvent/{uri}",
+            f"/public/assets/queuedEvents/{uri}",
         )
 
         assert response.status_code == 404
@@ -787,7 +787,7 @@ class TestDeleteAssetQueuedEvents(TestQueuedEventEndpoint):
         self._create_asset_dag_run_queues(dag_id, asset_id, session)
 
         response = test_client.delete(
-            f"/public/assets/queuedEvent/{uri}",
+            f"/public/assets/queuedEvents/{uri}",
         )
         assert response.status_code == 204
         assert session.query(AssetDagRunQueue).filter_by(asset_id=1).first() is None
@@ -796,7 +796,7 @@ class TestDeleteAssetQueuedEvents(TestQueuedEventEndpoint):
         uri = "not_exists"
 
         response = test_client.delete(
-            f"/public/assets/queuedEvent/{uri}",
+            f"/public/assets/queuedEvents/{uri}",
         )
 
         assert response.status_code == 404
@@ -816,7 +816,7 @@ class TestDeleteDagAssetQueuedEvent(TestQueuedEventEndpoint):
         assert len(adrq) == 1
 
         response = test_client.delete(
-            f"/public/dags/{dag_id}/assets/queuedEvent/{asset_uri}",
+            f"/public/dags/{dag_id}/assets/queuedEvents/{asset_uri}",
         )
 
         assert response.status_code == 204
@@ -828,7 +828,7 @@ class TestDeleteDagAssetQueuedEvent(TestQueuedEventEndpoint):
         asset_uri = "not_exists"
 
         response = test_client.delete(
-            f"/public/dags/{dag_id}/assets/queuedEvent/{asset_uri}",
+            f"/public/dags/{dag_id}/assets/queuedEvents/{asset_uri}",
         )
 
         assert response.status_code == 404


### PR DESCRIPTION
Transform all assets/queuedEvent into assets/queudEvents so that they are consistent with other routes as we have for assets/events.
Closes: https://github.com/apache/airflow/issues/44193
<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
