### PR TITLE
feat: add OpenLineage support for BigQueryToBigQueryOperator

### DIFF
--- a/providers/src/airflow/providers/google/cloud/openlineage/utils.py
+++ b/providers/src/airflow/providers/google/cloud/openlineage/utils.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from airflow.providers.common.compat.openlineage.facet import Dataset
 
 from airflow.providers.common.compat.openlineage.facet import (
+    BaseFacet,
     ColumnLineageDatasetFacet,
     DocumentationDatasetFacet,
     Fields,
@@ -41,50 +42,82 @@ BIGQUERY_NAMESPACE = "bigquery"
 BIGQUERY_URI = "bigquery"
 
 
-def get_facets_from_bq_table(table: Table) -> dict[Any, Any]:
+def get_facets_from_bq_table(table: Table) -> dict[str, BaseFacet]:
     """Get facets from BigQuery table object."""
-    facets = {
-        "schema": SchemaDatasetFacet(
+    facets: dict[str, BaseFacet] = {}
+    if table.schema:
+        facets["schema"] = SchemaDatasetFacet(
             fields=[
                 SchemaDatasetFacetFields(
-                    name=field.name, type=field.field_type, description=field.description
+                    name=schema_field.name, type=schema_field.field_type, description=schema_field.description
                 )
-                for field in table.schema
+                for schema_field in table.schema
             ]
-        ),
-        "documentation": DocumentationDatasetFacet(description=table.description or ""),
-    }
+        )
+    if table.description:
+        facets["documentation"] = DocumentationDatasetFacet(description=table.description)
 
     return facets
 
 
 def get_identity_column_lineage_facet(
-    field_names: list[str],
+    dest_field_names: list[str],
     input_datasets: list[Dataset],
-) -> ColumnLineageDatasetFacet:
+) -> dict[str, ColumnLineageDatasetFacet]:
     """
-    Get column lineage facet.
+    Get column lineage facet for identity transformations.
 
-    Simple lineage will be created, where each source column corresponds to single destination column
-    in each input dataset and there are no transformations made.
+    This function generates a simple column lineage facet, where each destination column
+    consists of source columns of the same name from all input datasets that have that column.
+    The lineage assumes there are no transformations applied, meaning the columns retain their
+    identity between the source and destination datasets.
+
+    Args:
+        dest_field_names: A list of destination column names for which lineage should be determined.
+        input_datasets: A list of input datasets with schema facets.
+
+    Returns:
+        A dictionary containing a single key, `columnLineage`, mapped to a `ColumnLineageDatasetFacet`.
+         If no column lineage can be determined, an empty dictionary is returned - see Notes below.
+
+    Notes:
+        - If any input dataset lacks a schema facet, the function immediately returns an empty dictionary.
+        - If any field in the source dataset's schema is not present in the destination table,
+          the function returns an empty dictionary. The destination table can contain extra fields, but all
+          source columns should be present in the destination table.
+        - If none of the destination columns can be matched to input dataset columns, an empty
+          dictionary is returned.
+        - Extra columns in the destination table that do not exist in the input datasets are ignored and
+          skipped in the lineage facet, as they cannot be traced back to a source column.
+        - The function assumes there are no transformations applied, meaning the columns retain their
+          identity between the source and destination datasets.
     """
-    if field_names and not input_datasets:
-        raise ValueError("When providing `field_names` You must provide at least one `input_dataset`.")
+    fields_sources: dict[str, list[Dataset]] = {}
+    for ds in input_datasets:
+        if not ds.facets or "schema" not in ds.facets:
+            return {}
+        for schema_field in ds.facets["schema"].fields:  # type: ignore[attr-defined]
+            if schema_field.name not in dest_field_names:
+                return {}
+            fields_sources[schema_field.name] = fields_sources.get(schema_field.name, []) + [ds]
+
+    if not fields_sources:
+        return {}
 
     column_lineage_facet = ColumnLineageDatasetFacet(
         fields={
-            field: Fields(
+            field_name: Fields(
                 inputFields=[
-                    InputField(namespace=dataset.namespace, name=dataset.name, field=field)
-                    for dataset in input_datasets
+                    InputField(namespace=dataset.namespace, name=dataset.name, field=field_name)
+                    for dataset in source_datasets
                 ],
                 transformationType="IDENTITY",
                 transformationDescription="identical",
             )
-            for field in field_names
+            for field_name, source_datasets in fields_sources.items()
         }
     )
-    return column_lineage_facet
+    return {"columnLineage": column_lineage_facet}
 
 
 @define

--- a/providers/src/airflow/providers/google/cloud/transfers/bigquery_to_bigquery.py
+++ b/providers/src/airflow/providers/google/cloud/transfers/bigquery_to_bigquery.py
@@ -110,6 +110,7 @@ class BigQueryToBigQueryOperator(BaseOperator):
         self.location = location
         self.impersonation_chain = impersonation_chain
         self.hook: BigQueryHook | None = None
+        self._job_conf: dict = {}
 
     def _prepare_job_configuration(self):
         self.source_project_dataset_tables = (
@@ -154,39 +155,94 @@ class BigQueryToBigQueryOperator(BaseOperator):
 
         return configuration
 
-    def _submit_job(
-        self,
-        hook: BigQueryHook,
-        configuration: dict,
-    ) -> str:
-        job = hook.insert_job(configuration=configuration, project_id=hook.project_id)
-        return job.job_id
-
     def execute(self, context: Context) -> None:
         self.log.info(
             "Executing copy of %s into: %s",
             self.source_project_dataset_tables,
             self.destination_project_dataset_table,
         )
-        hook = BigQueryHook(
+        self.hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
             location=self.location,
             impersonation_chain=self.impersonation_chain,
         )
-        self.hook = hook
 
-        if not hook.project_id:
+        if not self.hook.project_id:
             raise ValueError("The project_id should be set")
 
         configuration = self._prepare_job_configuration()
-        job_id = self._submit_job(hook=hook, configuration=configuration)
+        self._job_conf = self.hook.insert_job(
+            configuration=configuration, project_id=self.hook.project_id
+        ).to_api_repr()
 
-        job = hook.get_job(job_id=job_id, location=self.location).to_api_repr()
-        conf = job["configuration"]["copy"]["destinationTable"]
+        dest_table_info = self._job_conf["configuration"]["copy"]["destinationTable"]
         BigQueryTableLink.persist(
             context=context,
             task_instance=self,
-            dataset_id=conf["datasetId"],
-            project_id=conf["projectId"],
-            table_id=conf["tableId"],
+            dataset_id=dest_table_info["datasetId"],
+            project_id=dest_table_info["projectId"],
+            table_id=dest_table_info["tableId"],
         )
+
+    def get_openlineage_facets_on_complete(self, task_instance):
+        """Implement on_complete as we will include final BQ job id."""
+        from airflow.providers.common.compat.openlineage.facet import (
+            Dataset,
+            ExternalQueryRunFacet,
+        )
+        from airflow.providers.google.cloud.openlineage.utils import (
+            BIGQUERY_NAMESPACE,
+            get_facets_from_bq_table,
+            get_identity_column_lineage_facet,
+        )
+        from airflow.providers.openlineage.extractors import OperatorLineage
+
+        if not self.hook:
+            self.hook = BigQueryHook(
+                gcp_conn_id=self.gcp_conn_id,
+                location=self.location,
+                impersonation_chain=self.impersonation_chain,
+            )
+
+        if not self._job_conf:
+            self.log.debug("OpenLineage could not find BQ job configuration.")
+            return OperatorLineage()
+
+        bq_job_id = self._job_conf["jobReference"]["jobId"]
+        source_tables_info = self._job_conf["configuration"]["copy"]["sourceTables"]
+        dest_table_info = self._job_conf["configuration"]["copy"]["destinationTable"]
+
+        run_facets = {
+            "externalQuery": ExternalQueryRunFacet(externalQueryId=bq_job_id, source="bigquery"),
+        }
+
+        input_datasets = []
+        for in_table_info in source_tables_info:
+            table_id = ".".join(
+                (in_table_info["projectId"], in_table_info["datasetId"], in_table_info["tableId"])
+            )
+            table_object = self.hook.get_client().get_table(table_id)
+            input_datasets.append(
+                Dataset(
+                    namespace=BIGQUERY_NAMESPACE, name=table_id, facets=get_facets_from_bq_table(table_object)
+                )
+            )
+
+        out_table_id = ".".join(
+            (dest_table_info["projectId"], dest_table_info["datasetId"], dest_table_info["tableId"])
+        )
+        out_table_object = self.hook.get_client().get_table(out_table_id)
+        output_dataset_facets = {
+            **get_facets_from_bq_table(out_table_object),
+            **get_identity_column_lineage_facet(
+                dest_field_names=[field.name for field in out_table_object.schema],
+                input_datasets=input_datasets,
+            ),
+        }
+        output_dataset = Dataset(
+            namespace=BIGQUERY_NAMESPACE,
+            name=out_table_id,
+            facets=output_dataset_facets,
+        )
+
+        return OperatorLineage(inputs=input_datasets, outputs=[output_dataset], run_facets=run_facets)

--- a/providers/tests/google/cloud/transfers/test_bigquery_to_bigquery.py
+++ b/providers/tests/google/cloud/transfers/test_bigquery_to_bigquery.py
@@ -19,16 +19,29 @@ from __future__ import annotations
 
 from unittest import mock
 
+from google.cloud.bigquery import Table
+
+from airflow.providers.common.compat.openlineage.facet import (
+    ColumnLineageDatasetFacet,
+    Dataset,
+    DocumentationDatasetFacet,
+    ExternalQueryRunFacet,
+    Fields,
+    InputField,
+    SchemaDatasetFacet,
+    SchemaDatasetFacetFields,
+)
 from airflow.providers.google.cloud.transfers.bigquery_to_bigquery import BigQueryToBigQueryOperator
 
 BQ_HOOK_PATH = "airflow.providers.google.cloud.transfers.bigquery_to_bigquery.BigQueryHook"
-TASK_ID = "test-bq-create-table-operator"
+TASK_ID = "test-bq-to-bq-operator"
 TEST_GCP_PROJECT_ID = "test-project"
 TEST_DATASET = "test-dataset"
 TEST_TABLE_ID = "test-table-id"
 
-SOURCE_PROJECT_DATASET_TABLES = f"{TEST_GCP_PROJECT_ID}.{TEST_DATASET}.{TEST_TABLE_ID}"
-DESTINATION_PROJECT_DATASET_TABLE = f"{TEST_GCP_PROJECT_ID}.{TEST_DATASET + '_new'}.{TEST_TABLE_ID}"
+SOURCE_PROJECT_DATASET_TABLE = f"{TEST_GCP_PROJECT_ID}.{TEST_DATASET}.{TEST_TABLE_ID}"
+SOURCE_PROJECT_DATASET_TABLE2 = f"{TEST_GCP_PROJECT_ID}.{TEST_DATASET}.{TEST_TABLE_ID}-2"
+DESTINATION_PROJECT_DATASET_TABLE = f"{TEST_GCP_PROJECT_ID}.{TEST_DATASET}_new.{TEST_TABLE_ID}"
 WRITE_DISPOSITION = "WRITE_EMPTY"
 CREATE_DISPOSITION = "CREATE_IF_NEEDED"
 LABELS = {"k1": "v1"}
@@ -36,11 +49,17 @@ ENCRYPTION_CONFIGURATION = {"key": "kk"}
 
 
 def split_tablename_side_effect(*args, **kwargs):
-    if kwargs["table_input"] == SOURCE_PROJECT_DATASET_TABLES:
+    if kwargs["table_input"] == SOURCE_PROJECT_DATASET_TABLE:
         return (
             TEST_GCP_PROJECT_ID,
             TEST_DATASET,
             TEST_TABLE_ID,
+        )
+    elif kwargs["table_input"] == SOURCE_PROJECT_DATASET_TABLE2:
+        return (
+            TEST_GCP_PROJECT_ID,
+            TEST_DATASET,
+            TEST_TABLE_ID + "-2",
         )
     elif kwargs["table_input"] == DESTINATION_PROJECT_DATASET_TABLE:
         return (
@@ -55,7 +74,7 @@ class TestBigQueryToBigQueryOperator:
     def test_execute_without_location_should_execute_successfully(self, mock_hook):
         operator = BigQueryToBigQueryOperator(
             task_id=TASK_ID,
-            source_project_dataset_tables=SOURCE_PROJECT_DATASET_TABLES,
+            source_project_dataset_tables=SOURCE_PROJECT_DATASET_TABLE,
             destination_project_dataset_table=DESTINATION_PROJECT_DATASET_TABLE,
             write_disposition=WRITE_DISPOSITION,
             create_disposition=CREATE_DISPOSITION,
@@ -95,7 +114,7 @@ class TestBigQueryToBigQueryOperator:
 
         operator = BigQueryToBigQueryOperator(
             task_id=TASK_ID,
-            source_project_dataset_tables=SOURCE_PROJECT_DATASET_TABLES,
+            source_project_dataset_tables=SOURCE_PROJECT_DATASET_TABLE,
             destination_project_dataset_table=DESTINATION_PROJECT_DATASET_TABLE,
             write_disposition=WRITE_DISPOSITION,
             create_disposition=CREATE_DISPOSITION,
@@ -106,7 +125,304 @@ class TestBigQueryToBigQueryOperator:
 
         mock_hook.return_value.split_tablename.side_effect = split_tablename_side_effect
         operator.execute(context=mock.MagicMock())
-        mock_hook.return_value.get_job.assert_called_once_with(
-            job_id=mock_hook.return_value.insert_job.return_value.job_id,
+        mock_hook.return_value.insert_job.assert_called_once_with(
+            configuration={
+                "copy": {
+                    "createDisposition": CREATE_DISPOSITION,
+                    "destinationEncryptionConfiguration": ENCRYPTION_CONFIGURATION,
+                    "destinationTable": {
+                        "datasetId": TEST_DATASET + "_new",
+                        "projectId": TEST_GCP_PROJECT_ID,
+                        "tableId": TEST_TABLE_ID,
+                    },
+                    "sourceTables": [
+                        {
+                            "datasetId": TEST_DATASET,
+                            "projectId": TEST_GCP_PROJECT_ID,
+                            "tableId": TEST_TABLE_ID,
+                        },
+                    ],
+                    "writeDisposition": WRITE_DISPOSITION,
+                },
+                "labels": LABELS,
+            },
+            project_id=mock_hook.return_value.project_id,
+        )
+
+    @mock.patch(BQ_HOOK_PATH)
+    def test_get_openlineage_facets_on_complete_single_source_table(self, mock_hook):
+        location = "us-central1"
+
+        operator = BigQueryToBigQueryOperator(
+            task_id=TASK_ID,
+            source_project_dataset_tables=SOURCE_PROJECT_DATASET_TABLE,
+            destination_project_dataset_table=DESTINATION_PROJECT_DATASET_TABLE,
+            write_disposition=WRITE_DISPOSITION,
+            create_disposition=CREATE_DISPOSITION,
+            labels=LABELS,
+            encryption_configuration=ENCRYPTION_CONFIGURATION,
             location=location,
+        )
+
+        source_table_api_repr = {
+            "tableReference": {
+                "projectId": TEST_GCP_PROJECT_ID,
+                "datasetId": TEST_DATASET,
+                "tableId": TEST_TABLE_ID,
+            },
+            "description": "Table description.",
+            "schema": {
+                "fields": [
+                    {"name": "field1", "type": "STRING"},
+                    {"name": "field2", "type": "INTEGER"},
+                ]
+            },
+        }
+        dest_table_api_repr = {**source_table_api_repr}
+        dest_table_api_repr["tableReference"]["datasetId"] = TEST_DATASET + "_new"
+        mock_table_data = {
+            SOURCE_PROJECT_DATASET_TABLE: Table.from_api_repr(source_table_api_repr),
+            DESTINATION_PROJECT_DATASET_TABLE: Table.from_api_repr(dest_table_api_repr),
+        }
+
+        mock_hook.return_value.insert_job.return_value.to_api_repr.return_value = {
+            "jobReference": {
+                "projectId": TEST_GCP_PROJECT_ID,
+                "jobId": "actual_job_id",
+                "location": location,
+            },
+            "configuration": {
+                "copy": {
+                    "sourceTables": [
+                        {
+                            "projectId": TEST_GCP_PROJECT_ID,
+                            "datasetId": TEST_DATASET,
+                            "tableId": TEST_TABLE_ID,
+                        },
+                    ],
+                    "destinationTable": {
+                        "projectId": TEST_GCP_PROJECT_ID,
+                        "datasetId": TEST_DATASET + "_new",
+                        "tableId": TEST_TABLE_ID,
+                    },
+                }
+            },
+        }
+        mock_hook.return_value.split_tablename.side_effect = split_tablename_side_effect
+        mock_hook.return_value.get_client.return_value.get_table.side_effect = (
+            lambda table_id: mock_table_data[table_id]
+        )
+
+        operator.execute(context=mock.MagicMock())
+        result = operator.get_openlineage_facets_on_complete(None)
+
+        assert result.job_facets == {}
+        assert result.run_facets == {
+            "externalQuery": ExternalQueryRunFacet(externalQueryId="actual_job_id", source="bigquery")
+        }
+        assert len(result.inputs) == 1
+        assert result.inputs[0] == Dataset(
+            namespace="bigquery",
+            name=SOURCE_PROJECT_DATASET_TABLE,
+            facets={
+                "schema": SchemaDatasetFacet(
+                    fields=[
+                        SchemaDatasetFacetFields(name="field1", type="STRING"),
+                        SchemaDatasetFacetFields(name="field2", type="INTEGER"),
+                    ]
+                ),
+                "documentation": DocumentationDatasetFacet("Table description."),
+            },
+        )
+        assert len(result.outputs) == 1
+        assert result.outputs[0] == Dataset(
+            namespace="bigquery",
+            name=DESTINATION_PROJECT_DATASET_TABLE,
+            facets={
+                "schema": SchemaDatasetFacet(
+                    fields=[
+                        SchemaDatasetFacetFields(name="field1", type="STRING"),
+                        SchemaDatasetFacetFields(name="field2", type="INTEGER"),
+                    ]
+                ),
+                "documentation": DocumentationDatasetFacet("Table description."),
+                "columnLineage": ColumnLineageDatasetFacet(
+                    fields={
+                        "field1": Fields(
+                            inputFields=[
+                                InputField(
+                                    namespace="bigquery",
+                                    name=SOURCE_PROJECT_DATASET_TABLE,
+                                    field="field1",
+                                    transformations=[],
+                                )
+                            ],
+                            transformationDescription="identical",
+                            transformationType="IDENTITY",
+                        ),
+                        "field2": Fields(
+                            inputFields=[
+                                InputField(
+                                    namespace="bigquery",
+                                    name=SOURCE_PROJECT_DATASET_TABLE,
+                                    field="field2",
+                                    transformations=[],
+                                )
+                            ],
+                            transformationDescription="identical",
+                            transformationType="IDENTITY",
+                        ),
+                    },
+                    dataset=[],
+                ),
+            },
+        )
+
+    @mock.patch(BQ_HOOK_PATH)
+    def test_get_openlineage_facets_on_complete_multiple_source_tables(self, mock_hook):
+        location = "us-central1"
+
+        operator = BigQueryToBigQueryOperator(
+            task_id=TASK_ID,
+            source_project_dataset_tables=[
+                SOURCE_PROJECT_DATASET_TABLE,
+                SOURCE_PROJECT_DATASET_TABLE2,
+            ],
+            destination_project_dataset_table=DESTINATION_PROJECT_DATASET_TABLE,
+            write_disposition=WRITE_DISPOSITION,
+            create_disposition=CREATE_DISPOSITION,
+            labels=LABELS,
+            encryption_configuration=ENCRYPTION_CONFIGURATION,
+            location=location,
+        )
+
+        source_table_repr = {
+            "tableReference": {
+                "projectId": TEST_GCP_PROJECT_ID,
+                "datasetId": TEST_DATASET,
+                "tableId": TEST_TABLE_ID,
+            },
+            "schema": {
+                "fields": [
+                    {"name": "field1", "type": "STRING"},
+                ]
+            },
+        }
+        source_table_repr2 = {**source_table_repr}
+        source_table_repr2["tableReference"]["tableId"] = TEST_TABLE_ID + "-2"
+        dest_table_api_repr = {
+            "tableReference": {
+                "projectId": TEST_GCP_PROJECT_ID,
+                "datasetId": TEST_DATASET + "_new",
+                "tableId": TEST_TABLE_ID,
+            },
+            "schema": {
+                "fields": [
+                    {"name": "field1", "type": "STRING"},
+                    {"name": "field2", "type": "INTEGER"},
+                ]
+            },
+        }
+        mock_table_data = {
+            SOURCE_PROJECT_DATASET_TABLE: Table.from_api_repr(source_table_repr),
+            SOURCE_PROJECT_DATASET_TABLE2: Table.from_api_repr(source_table_repr2),
+            DESTINATION_PROJECT_DATASET_TABLE: Table.from_api_repr(dest_table_api_repr),
+        }
+
+        mock_hook.return_value.insert_job.return_value.to_api_repr.return_value = {
+            "jobReference": {
+                "projectId": TEST_GCP_PROJECT_ID,
+                "jobId": "actual_job_id",
+                "location": location,
+            },
+            "configuration": {
+                "copy": {
+                    "sourceTables": [
+                        {
+                            "projectId": TEST_GCP_PROJECT_ID,
+                            "datasetId": TEST_DATASET,
+                            "tableId": TEST_TABLE_ID,
+                        },
+                        {
+                            "projectId": TEST_GCP_PROJECT_ID,
+                            "datasetId": TEST_DATASET,
+                            "tableId": TEST_TABLE_ID + "-2",
+                        },
+                    ],
+                    "destinationTable": {
+                        "projectId": TEST_GCP_PROJECT_ID,
+                        "datasetId": TEST_DATASET + "_new",
+                        "tableId": TEST_TABLE_ID,
+                    },
+                }
+            },
+        }
+        mock_hook.return_value.split_tablename.side_effect = split_tablename_side_effect
+        mock_hook.return_value.get_client.return_value.get_table.side_effect = (
+            lambda table_id: mock_table_data[table_id]
+        )
+        operator.execute(context=mock.MagicMock())
+        result = operator.get_openlineage_facets_on_complete(None)
+        assert result.job_facets == {}
+        assert result.run_facets == {
+            "externalQuery": ExternalQueryRunFacet(externalQueryId="actual_job_id", source="bigquery")
+        }
+        assert len(result.inputs) == 2
+        assert result.inputs[0] == Dataset(
+            namespace="bigquery",
+            name=SOURCE_PROJECT_DATASET_TABLE,
+            facets={
+                "schema": SchemaDatasetFacet(
+                    fields=[
+                        SchemaDatasetFacetFields(name="field1", type="STRING"),
+                    ]
+                )
+            },
+        )
+        assert result.inputs[1] == Dataset(
+            namespace="bigquery",
+            name=SOURCE_PROJECT_DATASET_TABLE2,
+            facets={
+                "schema": SchemaDatasetFacet(
+                    fields=[
+                        SchemaDatasetFacetFields(name="field1", type="STRING"),
+                    ]
+                )
+            },
+        )
+        assert len(result.outputs) == 1
+        assert result.outputs[0] == Dataset(
+            namespace="bigquery",
+            name=DESTINATION_PROJECT_DATASET_TABLE,
+            facets={
+                "schema": SchemaDatasetFacet(
+                    fields=[
+                        SchemaDatasetFacetFields(name="field1", type="STRING"),
+                        SchemaDatasetFacetFields(name="field2", type="INTEGER"),
+                    ]
+                ),
+                "columnLineage": ColumnLineageDatasetFacet(
+                    fields={
+                        "field1": Fields(
+                            inputFields=[
+                                InputField(
+                                    namespace="bigquery",
+                                    name=SOURCE_PROJECT_DATASET_TABLE,
+                                    field="field1",
+                                    transformations=[],
+                                ),
+                                InputField(
+                                    namespace="bigquery",
+                                    name=SOURCE_PROJECT_DATASET_TABLE2,
+                                    field="field1",
+                                    transformations=[],
+                                ),
+                            ],
+                            transformationDescription="identical",
+                            transformationType="IDENTITY",
+                        )
+                    },
+                    dataset=[],
+                ),
+            },
         )

--- a/providers/tests/google/cloud/transfers/test_bigquery_to_gcs.py
+++ b/providers/tests/google/cloud/transfers/test_bigquery_to_gcs.py
@@ -299,11 +299,6 @@ class TestBigQueryToGCSOperator:
     def test_get_openlineage_facets_on_complete_bq_dataset_empty_table(self, mock_hook):
         source_project_dataset_table = f"{PROJECT_ID}.{TEST_DATASET}.{TEST_TABLE_ID}"
 
-        expected_input_dataset_facets = {
-            "schema": SchemaDatasetFacet(fields=[]),
-            "documentation": DocumentationDatasetFacet(description=""),
-        }
-
         mock_hook.return_value.split_tablename.return_value = (PROJECT_ID, TEST_DATASET, TEST_TABLE_ID)
         mock_hook.return_value.get_client.return_value.get_table.return_value = TEST_EMPTY_TABLE
 
@@ -320,7 +315,7 @@ class TestBigQueryToGCSOperator:
         assert lineage.inputs[0] == Dataset(
             namespace="bigquery",
             name=source_project_dataset_table,
-            facets=expected_input_dataset_facets,
+            facets={},
         )
 
     @mock.patch("airflow.providers.google.cloud.transfers.bigquery_to_gcs.BigQueryHook")
@@ -329,16 +324,6 @@ class TestBigQueryToGCSOperator:
         destination_cloud_storage_uris = [f"gs://{TEST_BUCKET}/{TEST_FOLDER}/{TEST_OBJECT_NO_WILDCARD}"]
         real_job_id = "123456_hash"
         bq_namespace = "bigquery"
-
-        expected_input_facets = {
-            "schema": SchemaDatasetFacet(fields=[]),
-            "documentation": DocumentationDatasetFacet(description=""),
-        }
-
-        expected_output_facets = {
-            "schema": SchemaDatasetFacet(fields=[]),
-            "columnLineage": ColumnLineageDatasetFacet(fields={}),
-        }
 
         mock_hook.return_value.split_tablename.return_value = (PROJECT_ID, TEST_DATASET, TEST_TABLE_ID)
         mock_hook.return_value.insert_job.return_value = MagicMock(job_id=real_job_id, error_result=False)
@@ -357,12 +342,12 @@ class TestBigQueryToGCSOperator:
         assert len(lineage.inputs) == 1
         assert len(lineage.outputs) == 1
         assert lineage.inputs[0] == Dataset(
-            namespace=bq_namespace, name=source_project_dataset_table, facets=expected_input_facets
+            namespace=bq_namespace, name=source_project_dataset_table, facets={}
         )
         assert lineage.outputs[0] == Dataset(
             namespace=f"gs://{TEST_BUCKET}",
             name=f"{TEST_FOLDER}/{TEST_OBJECT_NO_WILDCARD}",
-            facets=expected_output_facets,
+            facets={},
         )
         assert lineage.run_facets == {
             "externalQuery": ExternalQueryRunFacet(externalQueryId=real_job_id, source=bq_namespace)

--- a/providers/tests/google/cloud/transfers/test_gcs_to_bigquery.py
+++ b/providers/tests/google/cloud/transfers/test_gcs_to_bigquery.py
@@ -1439,12 +1439,6 @@ class TestGCSToBigQueryOperator:
         hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
         hook.return_value.get_client.return_value.get_table.return_value = TEST_EMPTY_TABLE
 
-        expected_output_dataset_facets = {
-            "schema": SchemaDatasetFacet(fields=[]),
-            "documentation": DocumentationDatasetFacet(description=""),
-            "columnLineage": ColumnLineageDatasetFacet(fields={}),
-        }
-
         operator = GCSToBigQueryOperator(
             project_id=JOB_PROJECT_ID,
             task_id=TASK_ID,
@@ -1461,18 +1455,17 @@ class TestGCSToBigQueryOperator:
         assert lineage.outputs[0] == Dataset(
             namespace="bigquery",
             name=TEST_EXPLICIT_DEST,
-            facets=expected_output_dataset_facets,
+            facets={},
         )
         assert lineage.inputs[0] == Dataset(
             namespace=f"gs://{TEST_BUCKET}",
             name=TEST_OBJECT_NO_WILDCARD,
-            facets={"schema": SchemaDatasetFacet(fields=[])},
+            facets={},
         )
         assert lineage.inputs[1] == Dataset(
             namespace=f"gs://{TEST_BUCKET}",
             name="/",
             facets={
-                "schema": SchemaDatasetFacet(fields=[]),
                 "symlink": SymlinksDatasetFacet(
                     identifiers=[
                         Identifier(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
This PR adds OpenLineage support for BigQueryToBigQueryOperator.

Within the operator itself, i removed the additional call to BQ API that got the job configuration as it's already returned by method that's submitting job - I adjusted the code to take advantage of that. The configuration returned is also saved as instance attribute for later use of OpenLineage method.

In the same time, I'm modifying two **internal** OpenLineage utils function:

- `get_facets_from_bq_table` now do not return facets instead of returning empty facets when there is no schema or description for bq table
- `get_identity_column_lineage_facet` is now checking if the source columns included in column lineage facet are actually in the schema of source datasets. It's now possible to generate this facet when source tables contain subset of columns of a destination table, which can be a case f.e. in BQ to BQ copy.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
