### PR TITLE
Refactor implementation to get OTel tracer

### DIFF
--- a/airflow/traces/tracer.py
+++ b/airflow/traces/tracer.py
@@ -17,9 +17,9 @@
 # under the License.
 from __future__ import annotations
 
-import inspect
 import logging
 import socket
+from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable
 
 from airflow.configuration import conf
@@ -44,20 +44,15 @@ def gen_links_from_kv_list(list):
 
 def add_span(func):
     """Decorate a function with span."""
+    func_name = func.__name__
+    qual_name = func.__qualname__
+    module_name = func.__module__
+    component = qual_name.rsplit(".", 1)[0] if "." in qual_name else module_name
 
+    @wraps(func)
     def wrapper(*args, **kwargs):
-        func_name = func.__name__
-        qual_name = func.__qualname__
-        module_name = func.__module__
-        if "." in qual_name:
-            component = f"{qual_name.rsplit('.', 1)[0]}"
-        else:
-            component = module_name
         with Trace.start_span(span_name=func_name, component=component):
-            if len(inspect.signature(func).parameters) > 0:
-                return func(*args, **kwargs)
-            else:
-                return func()
+            return func(*args, **kwargs)
 
     return wrapper
 
@@ -65,8 +60,7 @@ def add_span(func):
 class EmptyContext:
     """If no Tracer is configured, EmptyContext is used as a fallback."""
 
-    def __init__(self):
-        self.trace_id = 1
+    trace_id = 1
 
 
 class EmptySpan:
@@ -243,41 +237,55 @@ class EmptyTrace:
         return EMPTY_SPAN
 
 
-class _Trace(type):
-    factory: Callable
+class _TraceMeta(type):
+    factory: Callable[[], Tracer] | None = None
     instance: Tracer | EmptyTrace | None = None
 
-    def __getattr__(cls, name: str) -> str:
+    def __getattr__(cls, name: str):
+        if not cls.factory:
+            # Lazy initialization of the factory
+            cls.configure_factory()
         if not cls.instance:
-            try:
-                cls.instance = cls.factory()
-            except (socket.gaierror, ImportError) as e:
-                log.error("Could not configure Trace: %s, using EmptyTrace instead.", e)
-                cls.instance = EmptyTrace()
+            cls._initialize_instance()
         return getattr(cls.instance, name)
 
-    def __init__(cls, *args, **kwargs) -> None:
-        super().__init__(cls)
-        if not hasattr(cls.__class__, "factory"):
-            if conf.has_option("traces", "otel_on") and conf.getboolean("traces", "otel_on"):
-                from airflow.traces import otel_tracer
+    def _initialize_instance(cls):
+        """Initialize the trace instance."""
+        try:
+            cls.instance = cls.factory()
+        except (socket.gaierror, ImportError) as e:
+            log.error("Could not configure Trace: %s. Using EmptyTrace instead.", e)
+            cls.instance = EmptyTrace()
 
-                cls.__class__.factory = otel_tracer.get_otel_tracer
-            else:
-                cls.__class__.factory = EmptyTrace
+    def __call__(cls, *args, **kwargs):
+        """Ensure the class behaves as a singleton."""
+        if not cls.instance:
+            cls._initialize_instance()
+        return cls.instance
+
+    @classmethod
+    def configure_factory(cls):
+        """Configure the trace factory based on settings."""
+        if conf.has_option("traces", "otel_on") and conf.getboolean("traces", "otel_on"):
+            from airflow.traces import otel_tracer
+
+            cls.factory = otel_tracer.get_otel_tracer
+        else:
+            # EmptyTrace is a class and not inherently callable.
+            # Using a lambda ensures it can be invoked as a callable factory.
+            # staticmethod ensures the lambda is treated as a standalone function
+            # and avoids passing `cls` as an implicit argument.
+            cls.factory = staticmethod(lambda: EmptyTrace())
 
     @classmethod
     def get_constant_tags(cls) -> str | None:
         """Get constant tags to add to all traces."""
-        tags_in_string = conf.get("traces", "tags", fallback=None)
-        if not tags_in_string:
-            return None
-        return tags_in_string
+        return conf.get("traces", "tags", fallback=None)
 
 
 if TYPE_CHECKING:
     Trace: EmptyTrace
 else:
 
-    class Trace(metaclass=_Trace):
+    class Trace(metaclass=_TraceMeta):
         """Empty class for Trace - we use metaclass to inject the right one."""


### PR DESCRIPTION
Previous implementation had redundant logic in add_span for parameter inspection:

```python
with Trace.start_span(span_name=func_name, component=component):
    if len(inspect.signature(func).parameters) > 0:
        return func(*args, **kwargs)
    else:
        return func()
```

`_Trace` Metaclass was using `__init__` and few more Python-related changes -- check inline comments.

related issue: https://github.com/apache/airflow/issues/43789

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
