### PR TITLE
remove "/" at end from FastAPI endpoints routes

### DIFF
--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -2018,7 +2018,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /public/dags/:
+  /public/dags:
     get:
       tags:
       - DAG
@@ -2577,7 +2577,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /public/eventLogs/:
+  /public/eventLogs:
     get:
       tags:
       - Event Log
@@ -2772,7 +2772,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /public/importErrors/:
+  /public/importErrors:
     get:
       tags:
       - Import Error
@@ -2828,7 +2828,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /public/plugins/:
+  /public/plugins:
     get:
       tags:
       - Plugin
@@ -3033,7 +3033,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /public/pools/:
+  /public/pools:
     get:
       tags:
       - Pool
@@ -3132,7 +3132,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /public/providers/:
+  /public/providers:
     get:
       tags:
       - Provider
@@ -3961,7 +3961,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /public/dags/{dag_id}/tasks/:
+  /public/dags/{dag_id}/tasks:
     get:
       tags:
       - Task
@@ -4226,7 +4226,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /public/variables/:
+  /public/variables:
     get:
       tags:
       - Variable
@@ -4426,7 +4426,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HealthInfoSchema'
-  /public/version/:
+  /public/version:
     get:
       tags:
       - Version

--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -768,7 +768,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /public/backfills/:
+  /public/backfills:
     get:
       tags:
       - Backfill
@@ -1219,7 +1219,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /public/connections/:
+  /public/connections:
     get:
       tags:
       - Connection
@@ -1736,7 +1736,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /public/dagStats/:
+  /public/dagStats:
     get:
       tags:
       - DagStats

--- a/airflow/api_fastapi/core_api/routes/public/backfills.py
+++ b/airflow/api_fastapi/core_api/routes/public/backfills.py
@@ -47,7 +47,7 @@ backfills_router = AirflowRouter(tags=["Backfill"], prefix="/backfills")
 
 
 @backfills_router.get(
-    path="/",
+    path="",
 )
 def list_backfills(
     dag_id: str,
@@ -176,7 +176,7 @@ def cancel_backfill(backfill_id, session: Annotated[Session, Depends(get_session
 
 
 @backfills_router.post(
-    path="/",
+    path="",
     responses=create_openapi_http_exception_doc(
         [
             status.HTTP_404_NOT_FOUND,

--- a/airflow/api_fastapi/core_api/routes/public/connections.py
+++ b/airflow/api_fastapi/core_api/routes/public/connections.py
@@ -82,7 +82,7 @@ def get_connection(
 
 
 @connections_router.get(
-    "/",
+    "",
     responses=create_openapi_http_exception_doc([status.HTTP_404_NOT_FOUND]),
 )
 def get_connections(
@@ -119,7 +119,7 @@ def get_connections(
 
 
 @connections_router.post(
-    "/",
+    "",
     status_code=status.HTTP_201_CREATED,
     responses=create_openapi_http_exception_doc([status.HTTP_409_CONFLICT]),
 )

--- a/airflow/api_fastapi/core_api/routes/public/dag_stats.py
+++ b/airflow/api_fastapi/core_api/routes/public/dag_stats.py
@@ -41,7 +41,7 @@ dag_stats_router = AirflowRouter(tags=["DagStats"], prefix="/dagStats")
 
 
 @dag_stats_router.get(
-    "/",
+    "",
     responses=create_openapi_http_exception_doc(
         [
             status.HTTP_400_BAD_REQUEST,

--- a/airflow/api_fastapi/core_api/routes/public/dags.py
+++ b/airflow/api_fastapi/core_api/routes/public/dags.py
@@ -58,7 +58,7 @@ from airflow.models import DAG, DagModel, DagTag
 dags_router = AirflowRouter(tags=["DAG"], prefix="/dags")
 
 
-@dags_router.get("/")
+@dags_router.get("")
 def get_dags(
     limit: QueryLimit,
     offset: QueryOffset,
@@ -223,7 +223,7 @@ def patch_dag(
 
 
 @dags_router.patch(
-    "/",
+    "",
     responses=create_openapi_http_exception_doc(
         [
             status.HTTP_400_BAD_REQUEST,

--- a/airflow/api_fastapi/core_api/routes/public/event_logs.py
+++ b/airflow/api_fastapi/core_api/routes/public/event_logs.py
@@ -61,7 +61,7 @@ def get_event_log(
 
 
 @event_logs_router.get(
-    "/",
+    "",
 )
 def get_event_logs(
     limit: QueryLimit,

--- a/airflow/api_fastapi/core_api/routes/public/import_error.py
+++ b/airflow/api_fastapi/core_api/routes/public/import_error.py
@@ -65,7 +65,7 @@ def get_import_error(
 
 
 @import_error_router.get(
-    "/",
+    "",
 )
 def get_import_errors(
     limit: QueryLimit,

--- a/airflow/api_fastapi/core_api/routes/public/plugins.py
+++ b/airflow/api_fastapi/core_api/routes/public/plugins.py
@@ -25,7 +25,7 @@ from airflow.plugins_manager import get_plugin_info
 plugins_router = AirflowRouter(tags=["Plugin"], prefix="/plugins")
 
 
-@plugins_router.get("/")
+@plugins_router.get("")
 def get_plugins(
     limit: QueryLimit,
     offset: QueryOffset,

--- a/airflow/api_fastapi/core_api/routes/public/pools.py
+++ b/airflow/api_fastapi/core_api/routes/public/pools.py
@@ -81,7 +81,7 @@ def get_pool(
 
 
 @pools_router.get(
-    "/",
+    "",
     responses=create_openapi_http_exception_doc(
         [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND]
     ),
@@ -163,7 +163,7 @@ def patch_pool(
 
 
 @pools_router.post(
-    "/",
+    "",
     status_code=status.HTTP_201_CREATED,
     responses=create_openapi_http_exception_doc([status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]),
 )

--- a/airflow/api_fastapi/core_api/routes/public/providers.py
+++ b/airflow/api_fastapi/core_api/routes/public/providers.py
@@ -39,7 +39,7 @@ def _provider_mapper(provider: ProviderInfo) -> ProviderResponse:
     )
 
 
-@providers_router.get("/")
+@providers_router.get("")
 def get_providers(
     limit: QueryLimit,
     offset: QueryOffset,

--- a/airflow/api_fastapi/core_api/routes/public/tasks.py
+++ b/airflow/api_fastapi/core_api/routes/public/tasks.py
@@ -31,7 +31,7 @@ tasks_router = AirflowRouter(tags=["Task"], prefix="/dags/{dag_id}/tasks")
 
 
 @tasks_router.get(
-    "/",
+    "",
     responses=create_openapi_http_exception_doc(
         [
             status.HTTP_400_BAD_REQUEST,

--- a/airflow/api_fastapi/core_api/routes/public/variables.py
+++ b/airflow/api_fastapi/core_api/routes/public/variables.py
@@ -72,7 +72,7 @@ def get_variable(
 
 
 @variables_router.get(
-    "/",
+    "",
 )
 def get_variables(
     limit: QueryLimit,
@@ -144,7 +144,7 @@ def patch_variable(
 
 
 @variables_router.post(
-    "/",
+    "",
     status_code=status.HTTP_201_CREATED,
 )
 def post_variable(

--- a/airflow/api_fastapi/core_api/routes/public/version.py
+++ b/airflow/api_fastapi/core_api/routes/public/version.py
@@ -25,7 +25,7 @@ from airflow.utils.platform import get_airflow_git_version
 version_router = AirflowRouter(tags=["Version"], prefix="/version")
 
 
-@version_router.get("/")
+@version_router.get("")
 def get_version() -> VersionInfo:
     """Get version information."""
     airflow_version = airflow.__version__

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -566,7 +566,7 @@ export class BackfillService {
   ): CancelablePromise<ListBackfillsResponse> {
     return __request(OpenAPI, {
       method: "GET",
-      url: "/public/backfills/",
+      url: "/public/backfills",
       query: {
         dag_id: data.dagId,
         limit: data.limit,
@@ -593,7 +593,7 @@ export class BackfillService {
   ): CancelablePromise<CreateBackfillResponse> {
     return __request(OpenAPI, {
       method: "POST",
-      url: "/public/backfills/",
+      url: "/public/backfills",
       body: data.requestBody,
       mediaType: "application/json",
       errors: {
@@ -812,7 +812,7 @@ export class ConnectionService {
   ): CancelablePromise<GetConnectionsResponse> {
     return __request(OpenAPI, {
       method: "GET",
-      url: "/public/connections/",
+      url: "/public/connections",
       query: {
         limit: data.limit,
         offset: data.offset,
@@ -840,7 +840,7 @@ export class ConnectionService {
   ): CancelablePromise<PostConnectionResponse> {
     return __request(OpenAPI, {
       method: "POST",
-      url: "/public/connections/",
+      url: "/public/connections",
       body: data.requestBody,
       mediaType: "application/json",
       errors: {
@@ -1085,7 +1085,7 @@ export class DagStatsService {
   ): CancelablePromise<GetDagStatsResponse> {
     return __request(OpenAPI, {
       method: "GET",
-      url: "/public/dagStats/",
+      url: "/public/dagStats",
       query: {
         dag_ids: data.dagIds,
       },

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -1222,7 +1222,7 @@ export class DagService {
   ): CancelablePromise<GetDagsResponse> {
     return __request(OpenAPI, {
       method: "GET",
-      url: "/public/dags/",
+      url: "/public/dags",
       query: {
         limit: data.limit,
         offset: data.offset,
@@ -1265,7 +1265,7 @@ export class DagService {
   ): CancelablePromise<PatchDagsResponse> {
     return __request(OpenAPI, {
       method: "PATCH",
-      url: "/public/dags/",
+      url: "/public/dags",
       query: {
         update_mask: data.updateMask,
         limit: data.limit,
@@ -1486,7 +1486,7 @@ export class EventLogService {
   ): CancelablePromise<GetEventLogsResponse> {
     return __request(OpenAPI, {
       method: "GET",
-      url: "/public/eventLogs/",
+      url: "/public/eventLogs",
       query: {
         dag_id: data.dagId,
         task_id: data.taskId,
@@ -1554,7 +1554,7 @@ export class ImportErrorService {
   ): CancelablePromise<GetImportErrorsResponse> {
     return __request(OpenAPI, {
       method: "GET",
-      url: "/public/importErrors/",
+      url: "/public/importErrors",
       query: {
         limit: data.limit,
         offset: data.offset,
@@ -1583,7 +1583,7 @@ export class PluginService {
   ): CancelablePromise<GetPluginsResponse> {
     return __request(OpenAPI, {
       method: "GET",
-      url: "/public/plugins/",
+      url: "/public/plugins",
       query: {
         limit: data.limit,
         offset: data.offset,
@@ -1698,7 +1698,7 @@ export class PoolService {
   ): CancelablePromise<GetPoolsResponse> {
     return __request(OpenAPI, {
       method: "GET",
-      url: "/public/pools/",
+      url: "/public/pools",
       query: {
         limit: data.limit,
         offset: data.offset,
@@ -1726,7 +1726,7 @@ export class PoolService {
   ): CancelablePromise<PostPoolResponse> {
     return __request(OpenAPI, {
       method: "POST",
-      url: "/public/pools/",
+      url: "/public/pools",
       body: data.requestBody,
       mediaType: "application/json",
       errors: {
@@ -1753,7 +1753,7 @@ export class ProviderService {
   ): CancelablePromise<GetProvidersResponse> {
     return __request(OpenAPI, {
       method: "GET",
-      url: "/public/providers/",
+      url: "/public/providers",
       query: {
         limit: data.limit,
         offset: data.offset,
@@ -2112,7 +2112,7 @@ export class TaskService {
   ): CancelablePromise<GetTasksResponse> {
     return __request(OpenAPI, {
       method: "GET",
-      url: "/public/dags/{dag_id}/tasks/",
+      url: "/public/dags/{dag_id}/tasks",
       path: {
         dag_id: data.dagId,
       },
@@ -2259,7 +2259,7 @@ export class VariableService {
   ): CancelablePromise<GetVariablesResponse> {
     return __request(OpenAPI, {
       method: "GET",
-      url: "/public/variables/",
+      url: "/public/variables",
       query: {
         limit: data.limit,
         offset: data.offset,
@@ -2286,7 +2286,7 @@ export class VariableService {
   ): CancelablePromise<PostVariableResponse> {
     return __request(OpenAPI, {
       method: "POST",
-      url: "/public/variables/",
+      url: "/public/variables",
       body: data.requestBody,
       mediaType: "application/json",
       errors: {
@@ -2365,7 +2365,7 @@ export class VersionService {
   public static getVersion(): CancelablePromise<GetVersionResponse> {
     return __request(OpenAPI, {
       method: "GET",
-      url: "/public/version/",
+      url: "/public/version",
     });
   }
 }

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1981,7 +1981,7 @@ export type $OpenApiTs = {
       };
     };
   };
-  "/public/backfills/": {
+  "/public/backfills": {
     get: {
       req: ListBackfillsData;
       res: {
@@ -2234,7 +2234,7 @@ export type $OpenApiTs = {
       };
     };
   };
-  "/public/connections/": {
+  "/public/connections": {
     get: {
       req: GetConnectionsData;
       res: {
@@ -2483,7 +2483,7 @@ export type $OpenApiTs = {
       };
     };
   };
-  "/public/dagStats/": {
+  "/public/dagStats": {
     get: {
       req: GetDagStatsData;
       res: {

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -2599,7 +2599,7 @@ export type $OpenApiTs = {
       };
     };
   };
-  "/public/dags/": {
+  "/public/dags": {
     get: {
       req: GetDagsData;
       res: {
@@ -2821,7 +2821,7 @@ export type $OpenApiTs = {
       };
     };
   };
-  "/public/eventLogs/": {
+  "/public/eventLogs": {
     get: {
       req: GetEventLogsData;
       res: {
@@ -2871,7 +2871,7 @@ export type $OpenApiTs = {
       };
     };
   };
-  "/public/importErrors/": {
+  "/public/importErrors": {
     get: {
       req: GetImportErrorsData;
       res: {
@@ -2894,7 +2894,7 @@ export type $OpenApiTs = {
       };
     };
   };
-  "/public/plugins/": {
+  "/public/plugins": {
     get: {
       req: GetPluginsData;
       res: {
@@ -3002,7 +3002,7 @@ export type $OpenApiTs = {
       };
     };
   };
-  "/public/pools/": {
+  "/public/pools": {
     get: {
       req: GetPoolsData;
       res: {
@@ -3050,7 +3050,7 @@ export type $OpenApiTs = {
       };
     };
   };
-  "/public/providers/": {
+  "/public/providers": {
     get: {
       req: GetProvidersData;
       res: {
@@ -3289,7 +3289,7 @@ export type $OpenApiTs = {
       };
     };
   };
-  "/public/dags/{dag_id}/tasks/": {
+  "/public/dags/{dag_id}/tasks": {
     get: {
       req: GetTasksData;
       res: {
@@ -3432,7 +3432,7 @@ export type $OpenApiTs = {
       };
     };
   };
-  "/public/variables/": {
+  "/public/variables": {
     get: {
       req: GetVariablesData;
       res: {
@@ -3517,7 +3517,7 @@ export type $OpenApiTs = {
       };
     };
   };
-  "/public/version/": {
+  "/public/version": {
     get: {
       res: {
         /**


### PR DESCRIPTION
Removing trailing "/" from routes to be inline with legacy endpoints

related to #42370

