### PR TITLE
AIP 72: Handling "deferrable" tasks in execution_api and task SDK

### DIFF
--- a/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
+++ b/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
@@ -18,9 +18,10 @@
 from __future__ import annotations
 
 import uuid
-from typing import Annotated, Literal, Union
+from datetime import timedelta
+from typing import Annotated, Any, Literal, Union
 
-from pydantic import Discriminator, Tag, WithJsonSchema
+from pydantic import Discriminator, Field, Tag, WithJsonSchema
 
 from airflow.api_fastapi.common.types import UtcDateTime
 from airflow.api_fastapi.core_api.base import BaseModel
@@ -60,6 +61,26 @@ class TITargetStatePayload(BaseModel):
     state: IntermediateTIState
 
 
+class TIDeferredStatePayload(BaseModel):
+    """Schema for updating TaskInstance to a deferred state."""
+
+    state: Annotated[
+        Literal[IntermediateTIState.DEFERRED],
+        # Specify a default in the schema, but not in code, so Pydantic marks it as required.
+        WithJsonSchema(
+            {
+                "type": "string",
+                "enum": [IntermediateTIState.DEFERRED],
+                "default": IntermediateTIState.DEFERRED,
+            }
+        ),
+    ]
+    classpath: str
+    trigger_kwargs: Annotated[dict[str, Any], Field(default_factory=dict)]
+    next_method: str
+    trigger_timeout: timedelta | None = None
+
+
 def ti_state_discriminator(v: dict[str, str] | BaseModel) -> str:
     """
     Determine the discriminator key for TaskInstance state transitions.
@@ -77,6 +98,8 @@ def ti_state_discriminator(v: dict[str, str] | BaseModel) -> str:
         return str(state)
     elif state in set(TerminalTIState):
         return "_terminal_"
+    elif state == TIState.DEFERRED:
+        return "deferred"
     return "_other_"
 
 
@@ -87,6 +110,7 @@ TIStateUpdate = Annotated[
         Annotated[TIEnterRunningPayload, Tag("running")],
         Annotated[TITerminalStatePayload, Tag("_terminal_")],
         Annotated[TITargetStatePayload, Tag("_other_")],
+        Annotated[TIDeferredStatePayload, Tag("deferred")],
     ],
     Discriminator(ti_state_discriminator),
 ]

--- a/task_sdk/src/airflow/sdk/api/client.py
+++ b/task_sdk/src/airflow/sdk/api/client.py
@@ -31,6 +31,7 @@ from airflow.sdk import __version__
 from airflow.sdk.api.datamodels._generated import (
     ConnectionResponse,
     TerminalTIState,
+    TIDeferredStatePayload,
     TIEnterRunningPayload,
     TIHeartbeatInfo,
     TITerminalStatePayload,
@@ -126,7 +127,11 @@ class TaskInstanceOperations:
         self.client.put(f"task-instances/{id}/heartbeat", content=body.model_dump_json())
 
     def defer(self, id: uuid.UUID, msg):
-        self.client.patch(f"task-instances/{id}/state", content=msg.model_dump_json())
+        """Tell the API server that this TI has been deferred."""
+        body = TIDeferredStatePayload(**msg.model_dump(exclude_unset=True))
+
+        # Create a deferred state payload from msg
+        self.client.patch(f"task-instances/{id}/state", content=body.model_dump_json())
 
 
 class ConnectionOperations:

--- a/task_sdk/src/airflow/sdk/api/client.py
+++ b/task_sdk/src/airflow/sdk/api/client.py
@@ -116,6 +116,7 @@ class TaskInstanceOperations:
 
     def finish(self, id: uuid.UUID, state: TerminalTIState, when: datetime):
         """Tell the API server that this TI has reached a terminal state."""
+        # TODO: handle the naming better. finish sounds wrong as "even" deferred is essentially finishing.
         body = TITerminalStatePayload(end_date=when, state=TerminalTIState(state))
 
         self.client.patch(f"task-instances/{id}/state", content=body.model_dump_json())
@@ -123,6 +124,9 @@ class TaskInstanceOperations:
     def heartbeat(self, id: uuid.UUID, pid: int):
         body = TIHeartbeatInfo(pid=pid, hostname=get_hostname())
         self.client.put(f"task-instances/{id}/heartbeat", content=body.model_dump_json())
+
+    def defer(self, id: uuid.UUID, msg):
+        self.client.patch(f"task-instances/{id}/state", content=msg.model_dump_json())
 
 
 class ConnectionOperations:

--- a/task_sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task_sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -21,7 +21,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from enum import Enum
 from typing import Annotated, Any, Literal
 from uuid import UUID
@@ -56,6 +56,18 @@ class IntermediateTIState(str, Enum):
     UP_FOR_RESCHEDULE = "up_for_reschedule"
     UPSTREAM_FAILED = "upstream_failed"
     DEFERRED = "deferred"
+
+
+class TIDeferredStatePayload(BaseModel):
+    """
+    Schema for updating TaskInstance to a deferred state.
+    """
+
+    state: Annotated[Literal["deferred"] | None, Field(title="State")] = "deferred"
+    classpath: Annotated[str, Field(title="Classpath")]
+    trigger_kwargs: Annotated[dict[str, Any] | None, Field(title="Trigger Kwargs")] = None
+    next_method: Annotated[str, Field(title="Next Method")]
+    trigger_timeout: Annotated[timedelta | None, Field(title="Trigger Timeout")] = None
 
 
 class TIEnterRunningPayload(BaseModel):

--- a/task_sdk/src/airflow/sdk/execution_time/comms.py
+++ b/task_sdk/src/airflow/sdk/execution_time/comms.py
@@ -51,6 +51,7 @@ from airflow.sdk.api.datamodels._generated import (
     ConnectionResponse,
     TaskInstance,
     TerminalTIState,
+    TIDeferredStatePayload,
     VariableResponse,
     XComResponse,
 )
@@ -103,6 +104,12 @@ class TaskState(BaseModel):
     type: Literal["TaskState"] = "TaskState"
 
 
+class DeferTask(TIDeferredStatePayload):
+    """Update a task instance state to deferred."""
+
+    type: Literal["DeferTask"] = "DeferTask"
+
+
 class GetXCom(BaseModel):
     key: str
     dag_id: str
@@ -123,6 +130,6 @@ class GetVariable(BaseModel):
 
 
 ToSupervisor = Annotated[
-    Union[TaskState, GetXCom, GetConnection, GetVariable],
+    Union[TaskState, GetXCom, GetConnection, GetVariable, DeferTask],
     Field(discriminator="type"),
 ]

--- a/task_sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task_sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -533,7 +533,7 @@ class WatchedSubprocess:
                 resp = xcom.model_dump_json(exclude_unset=True).encode()
             elif isinstance(msg, DeferTask):
                 self.final_state = IntermediateTIState.DEFERRED
-                self.client.task_instances.defer(self.ti_id, msg.model_dump_json(exclude_unset=True))
+                self.client.task_instances.defer(self.ti_id, msg)
                 resp = None
             else:
                 log.error("Unhandled request", msg=msg)

--- a/task_sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task_sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -43,8 +43,9 @@ import structlog
 from pydantic import TypeAdapter
 
 from airflow.sdk.api.client import Client
-from airflow.sdk.api.datamodels._generated import TaskInstance, TerminalTIState
+from airflow.sdk.api.datamodels._generated import IntermediateTIState, TaskInstance, TerminalTIState
 from airflow.sdk.execution_time.comms import (
+    DeferTask,
     GetConnection,
     GetVariable,
     GetXCom,
@@ -263,6 +264,7 @@ class WatchedSubprocess:
     _process: psutil.Process
     _exit_code: int | None = None
     _terminal_state: str | None = None
+    _final_state: str | None = None
 
     _last_heartbeat: float = 0
 
@@ -398,9 +400,10 @@ class WatchedSubprocess:
         # If it hasn't, assume it's failed
         self._exit_code = self._exit_code if self._exit_code is not None else 1
 
-        self.client.task_instances.finish(
-            id=self.ti_id, state=self.final_state, when=datetime.now(tz=timezone.utc)
-        )
+        if self.final_state in TerminalTIState:
+            self.client.task_instances.finish(
+                id=self.ti_id, state=self.final_state, when=datetime.now(tz=timezone.utc)
+            )
         return self._exit_code
 
     def _monitor_subprocess(self):
@@ -472,9 +475,19 @@ class WatchedSubprocess:
 
         Not valid before the process has finished.
         """
+        if self._final_state:
+            return self._final_state
         if self._exit_code == 0:
             return self._terminal_state or TerminalTIState.SUCCESS
         return TerminalTIState.FAILED
+
+    @final_state.setter
+    def final_state(self, value):
+        """Setter for final_state for certain task instance stated present in IntermediateTIState."""
+        # TODO: Remove the setter and manage using the final_state property
+        # to be taken in a follow up
+        if value not in TerminalTIState:
+            self._final_state = value
 
     def __rich_repr__(self):
         yield "ti_id", self.ti_id
@@ -518,11 +531,16 @@ class WatchedSubprocess:
             elif isinstance(msg, GetXCom):
                 xcom = self.client.xcoms.get(msg.dag_id, msg.run_id, msg.task_id, msg.key, msg.map_index)
                 resp = xcom.model_dump_json(exclude_unset=True).encode()
+            elif isinstance(msg, DeferTask):
+                self.final_state = IntermediateTIState.DEFERRED
+                self.client.task_instances.defer(self.ti_id, msg.model_dump_json(exclude_unset=True))
+                resp = None
             else:
                 log.error("Unhandled request", msg=msg)
                 continue
 
-            self.stdin.write(resp + b"\n")
+            if resp:
+                self.stdin.write(resp + b"\n")
 
 
 # Sockets, even the `.makefile()` function don't correctly do line buffering on reading. If a chunk is read

--- a/task_sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task_sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -30,7 +30,7 @@ from pydantic import ConfigDict, TypeAdapter
 
 from airflow.sdk.api.datamodels._generated import TaskInstance
 from airflow.sdk.definitions.baseoperator import BaseOperator
-from airflow.sdk.execution_time.comms import StartupDetails, ToSupervisor, ToTask
+from airflow.sdk.execution_time.comms import DeferTask, StartupDetails, ToSupervisor, ToTask
 
 if TYPE_CHECKING:
     from structlog.typing import FilteringBoundLogger as Logger
@@ -159,8 +159,19 @@ def run(ti: RuntimeTaskInstance, log: Logger):
         # TODO next_method to support resuming from deferred
         # TODO: Get a real context object
         ti.task.execute({"task_instance": ti})  # type: ignore[attr-defined]
-    except TaskDeferred:
-        ...
+    except TaskDeferred as defer:
+        classpath, trigger_kwargs = defer.trigger.serialize()
+        next_method = defer.method_name
+        timeout = defer.timeout
+        msg = DeferTask(
+            state="deferred",
+            classpath=classpath,
+            trigger_kwargs=trigger_kwargs,
+            next_method=next_method,
+            trigger_timeout=timeout,
+        )
+        global SUPERVISOR_COMMS
+        SUPERVISOR_COMMS.send_request(msg=msg, log=log)
     except AirflowSkipException:
         ...
     except AirflowRescheduleException:

--- a/task_sdk/tests/dags/super_basic_deferred_run.py
+++ b/task_sdk/tests/dags/super_basic_deferred_run.py
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import datetime
+
+from airflow.providers.standard.sensors.date_time import DateTimeSensorAsync
+from airflow.sdk.definitions.dag import dag
+from airflow.utils import timezone
+
+
+@dag()
+def super_basic_deferred_run():
+    DateTimeSensorAsync(
+        task_id="async",
+        target_time=str(timezone.utcnow() + datetime.timedelta(seconds=3)),
+        poke_interval=60,
+        timeout=600,
+    )
+
+
+super_basic_deferred_run()

--- a/task_sdk/tests/execution_time/test_task_runner.py
+++ b/task_sdk/tests/execution_time/test_task_runner.py
@@ -29,6 +29,7 @@ from airflow.sdk import DAG, BaseOperator
 from airflow.sdk.api.datamodels._generated import TaskInstance
 from airflow.sdk.execution_time.comms import StartupDetails
 from airflow.sdk.execution_time.task_runner import CommsDecoder, parse, run
+from airflow.utils import timezone
 
 
 class TestCommsDecoder:
@@ -86,3 +87,41 @@ def test_run_basic(test_dags_dir: Path):
 
     ti = parse(what)
     run(ti, log=mock.MagicMock())
+
+
+def test_run_deferred_basic(test_dags_dir: Path):
+    """Test running a basic task."""
+    from datetime import datetime
+
+    mock_utcnow = mock.MagicMock(return_value=timezone.datetime(2024, 11, 22, 0, 0, 0))
+    with (
+        mock.patch(
+            "airflow.sdk.execution_time.task_runner.SUPERVISOR_COMMS", create=True
+        ) as mock_supervisor_comms,
+        mock.patch("airflow.utils.timezone.utcnow", mock_utcnow),
+    ):
+        what = StartupDetails(
+            ti=TaskInstance(
+                id=uuid7(), task_id="async", dag_id="super_basic_deferred_run", run_id="c", try_number=1
+            ),
+            file=str(test_dags_dir / "super_basic_deferred_run.py"),
+            requests_fd=0,
+        )
+
+        ti = parse(what)
+        run(ti, log=mock.MagicMock())
+
+        # send_request will only be called when the TaskDeferred exception is raised
+        assert mock_supervisor_comms.send_request.called
+
+        call_params = mock_supervisor_comms.send_request.call_args_list[0][1]["msg"]
+        assert call_params
+        assert call_params.state == "deferred"
+        assert call_params.classpath == "airflow.providers.standard.triggers.temporal.DateTimeTrigger"
+        assert call_params.trigger_kwargs == {
+            "end_from_trigger": False,
+            "moment": datetime(2024, 11, 22, 0, 0, 3, tzinfo=timezone.utc),
+        }
+        assert call_params.next_method == "execute_complete"
+        assert call_params.trigger_timeout is None
+        assert call_params.type == "DeferTask"

--- a/task_sdk/tests/execution_time/test_task_runner.py
+++ b/task_sdk/tests/execution_time/test_task_runner.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import uuid
+from datetime import timedelta
 from pathlib import Path
 from socket import socketpair
 from unittest import mock
@@ -27,7 +28,7 @@ from uuid6 import uuid7
 
 from airflow.sdk import DAG, BaseOperator
 from airflow.sdk.api.datamodels._generated import TaskInstance
-from airflow.sdk.execution_time.comms import StartupDetails
+from airflow.sdk.execution_time.comms import DeferTask, StartupDetails
 from airflow.sdk.execution_time.task_runner import CommsDecoder, parse, run
 from airflow.utils import timezone
 
@@ -89,39 +90,38 @@ def test_run_basic(test_dags_dir: Path):
     run(ti, log=mock.MagicMock())
 
 
-def test_run_deferred_basic(test_dags_dir: Path):
-    """Test running a basic task."""
-    from datetime import datetime
+def test_run_deferred_basic(test_dags_dir: Path, time_machine):
+    """Test that a task can transition to a deferred state."""
+    what = StartupDetails(
+        ti=TaskInstance(
+            id=uuid7(), task_id="async", dag_id="super_basic_deferred_run", run_id="c", try_number=1
+        ),
+        file=str(test_dags_dir / "super_basic_deferred_run.py"),
+        requests_fd=0,
+    )
 
-    mock_utcnow = mock.MagicMock(return_value=timezone.datetime(2024, 11, 22, 0, 0, 0))
-    with (
-        mock.patch(
-            "airflow.sdk.execution_time.task_runner.SUPERVISOR_COMMS", create=True
-        ) as mock_supervisor_comms,
-        mock.patch("airflow.utils.timezone.utcnow", mock_utcnow),
-    ):
-        what = StartupDetails(
-            ti=TaskInstance(
-                id=uuid7(), task_id="async", dag_id="super_basic_deferred_run", run_id="c", try_number=1
-            ),
-            file=str(test_dags_dir / "super_basic_deferred_run.py"),
-            requests_fd=0,
-        )
+    # Use the time machine to set the current time
+    instant = timezone.datetime(2024, 11, 22)
+    time_machine.move_to(instant, tick=False)
 
+    # Expected DeferTask
+    expected_defer_task = DeferTask(
+        state="deferred",
+        classpath="airflow.providers.standard.triggers.temporal.DateTimeTrigger",
+        trigger_kwargs={
+            "end_from_trigger": False,
+            "moment": instant + timedelta(seconds=3),
+        },
+        next_method="execute_complete",
+        trigger_timeout=None,
+    )
+
+    # Run the task
+    with mock.patch(
+        "airflow.sdk.execution_time.task_runner.SUPERVISOR_COMMS", create=True
+    ) as mock_supervisor_comms:
         ti = parse(what)
         run(ti, log=mock.MagicMock())
 
         # send_request will only be called when the TaskDeferred exception is raised
-        assert mock_supervisor_comms.send_request.called
-
-        call_params = mock_supervisor_comms.send_request.call_args_list[0][1]["msg"]
-        assert call_params
-        assert call_params.state == "deferred"
-        assert call_params.classpath == "airflow.providers.standard.triggers.temporal.DateTimeTrigger"
-        assert call_params.trigger_kwargs == {
-            "end_from_trigger": False,
-            "moment": datetime(2024, 11, 22, 0, 0, 3, tzinfo=timezone.utc),
-        }
-        assert call_params.next_method == "execute_complete"
-        assert call_params.trigger_timeout is None
-        assert call_params.type == "DeferTask"
+        mock_supervisor_comms.send_request.assert_called_once_with(msg=expected_defer_task, log=mock.ANY)

--- a/tests/api_fastapi/execution_api/routes/test_task_instances.py
+++ b/tests/api_fastapi/execution_api/routes/test_task_instances.py
@@ -17,12 +17,14 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from unittest import mock
 
 import pytest
 from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
 
+from airflow.models import Trigger
 from airflow.models.taskinstance import TaskInstance
 from airflow.utils import timezone
 from airflow.utils.state import State, TaskInstanceState
@@ -195,6 +197,50 @@ class TestTIUpdateState:
             response = client.patch(f"/execution/task-instances/{ti.id}/state", json=payload)
             assert response.status_code == 500
             assert response.json()["detail"] == "Database error occurred"
+
+    def test_ti_update_state_to_deferred(self, client, session, create_task_instance):
+        """
+        Test that tests if the transition to deferred state is handled correctly.
+        """
+
+        ti = create_task_instance(
+            task_id="test_ti_update_state_to_deferred",
+            state=State.RUNNING,
+            session=session,
+        )
+        session.commit()
+
+        mock_utcnow = mock.MagicMock(return_value=timezone.datetime(2024, 11, 22, 0, 0, 0))
+
+        with mock.patch("airflow.utils.timezone.utcnow", mock_utcnow):
+            payload = {
+                "state": "deferred",
+                "trigger_kwargs": {"key": "value"},
+                "classpath": "my-classpath",
+                "next_method": "execute_callback",
+                "trigger_timeout": "P1D",
+            }
+
+            response = client.patch(f"/execution/task-instances/{ti.id}/state", json=payload)
+
+            assert response.status_code == 204
+            assert response.text == ""
+
+            session.expire_all()
+
+            tis = session.query(TaskInstance).all()
+            assert len(tis) == 1
+
+            assert tis[0].state == TaskInstanceState.DEFERRED
+            assert tis[0].next_method == "execute_callback"
+            assert tis[0].next_kwargs == {"key": "value"}
+            assert tis[0].trigger_timeout == datetime(2024, 11, 23, 0, 0)
+
+            t = session.query(Trigger).all()
+            assert len(t) == 1
+            assert t[0].created_date == datetime(2024, 11, 22, 0, 0, tzinfo=timezone.utc)
+            assert t[0].classpath == "my-classpath"
+            assert t[0].kwargs == {"key": "value"}
 
 
 class TestTIHealthEndpoint:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #44137

This PR is trying to port the "deferral" logic from airflow 2 to the airflow 3 (execution api + task sdk)

## Summary of changes:

### Server side changes (execution api):
1. Handling `TIDeferredStatePayload` in `ti_update_state` -> covered by unit test: `test_ti_update_state_to_deferred`
      a. Didn't piggy back on `ti.defer_task()` as it extracts the trigger out of `TaskDeferred` exception. It is much more expensive to send across multiple models like `TaskInstance`, `TaskDeferred`, `Trigger` instead of just the required minimal properties
      b. `returning` and not proceeding with query execution as we already do it above https://github.com/apache/airflow/pull/44241/files#diff-d44a72566870079ee943e24bac2af74fb84c426c54d210561a251549a7078ed7L129
2. Defining a datamodel for TIDeferredStatePayload and adding it to the discriminator: ti_state_discriminator

### Client side changes (task sdk):

#### HTTP client:
Added a new function defer that sends a patch request to the `task-instances/{id}/state execution` api with payload: `PatchTIToDeferred`

#### Comms:
Defining a new data model to send a request to patch ti as "deferred" from task runner to supervisor: `PatchTIToDeferred`  (Added to ToSupervisor)

#### Supervisor:
1. Adding a new class property as `_final_state` to support `@property` `final_state` which is final state of a TI
      a. Added a setter to set values for this final state for cases like deferred so that the finish is not called for tasks those aren't in terminal stage: https://github.com/apache/airflow/pull/44241/files#diff-c2651fdee1a25e091e2a9d4f937f8032ca3d289d0de76f38ed88aee5df0f880dL392-L394
2. Deferred tasks first enter the "wait" in supervisor and then mark themselves as deferred by setting up a trigger. So skipping `finish()` when `final_state` is not `TerminalTIState` 
3. Extended `handle_requests` to receive requests from task runner and forwarding the message to http client to call defer

#### TaskRunner:
Task runner executes: ti.task.execute and raises `TaskDeferred` for deferral. This sends a request to supervisor using `SUPERVISOR_COMMS`


## How was this tested?
1. The end to end flow isn't available as of now, but I have tried to cover up the ground using unit tests
2. New case under `test_handle_requests` covers the supervisor + client side of things along with a mock of the message from task runner
3. `test_ti_update_state_to_deferred` covers the scenario for execution API
4. Added an integration test for task runner component:
- It creates a DAG that raises the deferral exception:
![image](https://github.com/user-attachments/assets/871fdfd1-034d-4b66-a25a-0981a47f860c)
- `test_run_deferred_basic` tests if the DAG raised a task exception and sent the right message across the SUPERVISOR_COMMS or not.


## Additional sanity tests
### Testing the "task runner" entries and exits (client side)

1. Wrote a async operator DAG:
![image](https://github.com/user-attachments/assets/425ec4e8-3695-4695-894b-d21c84d47ff1)

2. Breakpoint inside task_runner.py#run

3. Validated the exception entrypoint with all the variables to be set as required by running the test: `test_run_basic`
![image](https://github.com/user-attachments/assets/afdaa611-7350-45b5-9d4b-282a7a71d5dc)


### Testing the DB state in the server side (execution API)
1. Used the test: `test_ti_update_state_to_deferred`

2. Debugger inside `ti_update_state` method

3. Validated the `TaskDeferred` and related logic
![image](https://github.com/user-attachments/assets/9fb7d632-4bc1-439c-a0b8-7143a751e01a)

5. Checked state of the DB on execution
![image](https://github.com/user-attachments/assets/6fbde3e2-734b-43c2-8a02-464f401760b7)

![image](https://github.com/user-attachments/assets/5249dae5-cb81-45a2-a761-ff2437c6fed5)



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
