### PR TITLE
docs(newsfragment): these deprecated things are functions instead of arguments

### DIFF
--- a/newsfragments/41533.significant.rst
+++ b/newsfragments/41533.significant.rst
@@ -1,7 +1,7 @@
 **Breaking Change**
 
-The ``load_connections`` parameter has been removed from the ``local_file_system``.
-This parameter was previously deprecated in favor of ``load_connections_dict``.
+The ``load_connections`` function has been removed from the ``local_file_system``.
+This function was previously deprecated in favor of ``load_connections_dict``.
 
 If your code still uses ``load_connections``, you should update it to use ``load_connections_dict``
 instead to ensure compatibility with future Airflow versions.
@@ -12,8 +12,8 @@ Example update:
 
     connection_by_conn_id = local_filesystem.load_connections_dict(file_path="a.json")
 
-The ``get_connections`` parameter has been removed from the ``LocalFilesystemBackend`` class.
-This parameter was previously deprecated in favor of ``get_connection``.
+The ``get_connections`` function has been removed from the ``LocalFilesystemBackend`` class.
+This function was previously deprecated in favor of ``get_connection``.
 
 If your code still uses ``get_connections``, you should update it to use ``get_connection``
 instead to ensure compatibility with future Airflow versions.


### PR DESCRIPTION
## Why

the mentioned things are functions instead of arguments

## What
reword

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
