### PR TITLE
Migrate public endpoint Set Task Instances State to FastAPI

### DIFF
--- a/airflow/api_connexion/endpoints/task_instance_endpoint.py
+++ b/airflow/api_connexion/endpoints/task_instance_endpoint.py
@@ -500,6 +500,7 @@ def post_clear_task_instances(*, dag_id: str, session: Session = NEW_SESSION) ->
     )
 
 
+@mark_fastapi_migration_done
 @security.requires_access_dag("PUT", DagAccessEntity.TASK_INSTANCE)
 @action_logging
 @provide_session

--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -4181,6 +4181,63 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /public/dags/{dag_id}/updateTaskInstancesState:
+    put:
+      tags:
+      - Task Instance
+      summary: Set Task Instances State
+      description: Set a state of task instances.
+      operationId: set_task_instances_state
+      parameters:
+      - name: dag_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Dag Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetTaskInstancesStateBody'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskInstanceReferenceCollectionResponse'
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Unauthorized
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Forbidden
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Bad Request
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Not Found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /public/dags/{dag_id}/tasks:
     get:
       tags:
@@ -6709,6 +6766,44 @@ components:
       - latest_scheduler_heartbeat
       title: SchedulerInfoSchema
       description: Schema for Scheduler info.
+    SetTaskInstancesStateBody:
+      properties:
+        dry_run:
+          type: boolean
+          title: Dry Run
+          default: true
+        task_id:
+          type: string
+          title: Task Id
+        dag_run_id:
+          type: string
+          title: Dag Run Id
+        include_upstream:
+          type: boolean
+          title: Include Upstream
+        include_downstream:
+          type: boolean
+          title: Include Downstream
+        include_future:
+          type: boolean
+          title: Include Future
+        include_past:
+          type: boolean
+          title: Include Past
+        new_state:
+          type: string
+          title: New State
+      type: object
+      required:
+      - task_id
+      - dag_run_id
+      - include_upstream
+      - include_downstream
+      - include_future
+      - include_past
+      - new_state
+      title: SetTaskInstancesStateBody
+      description: Request body for Set Task Instances State endpoint.
     TaskCollectionResponse:
       properties:
         tasks:
@@ -6887,6 +6982,41 @@ components:
       - executor_config
       title: TaskInstanceHistoryResponse
       description: TaskInstanceHistory serializer for responses.
+    TaskInstanceReferenceCollectionResponse:
+      properties:
+        task_instances:
+          items:
+            $ref: '#/components/schemas/TaskInstanceReferenceResponse'
+          type: array
+          title: Task Instances
+      type: object
+      required:
+      - task_instances
+      title: TaskInstanceReferenceCollectionResponse
+      description: Task Instance Reference collection serializer for responses.
+    TaskInstanceReferenceResponse:
+      properties:
+        task_id:
+          type: string
+          title: Task Id
+        dag_run_id:
+          type: string
+          title: Dag Run Id
+        dag_id:
+          type: string
+          title: Dag Id
+        logical_date:
+          type: string
+          format: date-time
+          title: Logical Date
+      type: object
+      required:
+      - task_id
+      - dag_run_id
+      - dag_id
+      - logical_date
+      title: TaskInstanceReferenceResponse
+      description: Task Instance Reference serializer for responses.
     TaskInstanceResponse:
       properties:
         id:

--- a/airflow/api_fastapi/core_api/routes/public/task_instances.py
+++ b/airflow/api_fastapi/core_api/routes/public/task_instances.py
@@ -504,21 +504,19 @@ def set_task_instances_state(
 
     task_id = body.task_id
     task = dag.task_dict.get(task_id)
-
     if not task:
         error_message = f"Task ID {task_id} not found"
         raise HTTPException(status.HTTP_404_NOT_FOUND, error_message)
+
     run_id = body.dag_run_id
+    error_message = f"Task instance not found for task '{task_id}' on DAG run with ID '{run_id}'"
     if not run_id:
-        error_message = f"Task instance not found for task {task_id} on DAG run with ID {run_id}"
         raise HTTPException(status.HTTP_404_NOT_FOUND, error_message)
 
     select_stmt = select(TI).where(
         TI.dag_id == dag_id, TI.task_id == task_id, TI.run_id == run_id, TI.map_index == -1
     )
-
     if run_id and not session.scalars(select_stmt).one_or_none():
-        error_message = f"Task instance not found for task {task_id} on DAG run with ID {run_id}"
         raise HTTPException(status.HTTP_404_NOT_FOUND, error_message)
 
     tis = dag.set_task_instance_state(

--- a/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow/ui/openapi-gen/queries/common.ts
@@ -1345,6 +1345,9 @@ export type BackfillServiceUnpauseBackfillMutationResult = Awaited<
 export type BackfillServiceCancelBackfillMutationResult = Awaited<
   ReturnType<typeof BackfillService.cancelBackfill>
 >;
+export type TaskInstanceServiceSetTaskInstancesStateMutationResult = Awaited<
+  ReturnType<typeof TaskInstanceService.setTaskInstancesState>
+>;
 export type ConnectionServicePatchConnectionMutationResult = Awaited<
   ReturnType<typeof ConnectionService.patchConnection>
 >;

--- a/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow/ui/openapi-gen/queries/queries.ts
@@ -41,6 +41,7 @@ import {
   DagWarningType,
   PoolPatchBody,
   PoolPostBody,
+  SetTaskInstancesStateBody,
   TaskInstancesBatchBody,
   VariableBody,
 } from "../requests/types.gen";
@@ -2560,6 +2561,49 @@ export const useBackfillServiceCancelBackfill = <
     mutationFn: ({ backfillId }) =>
       BackfillService.cancelBackfill({
         backfillId,
+      }) as unknown as Promise<TData>,
+    ...options,
+  });
+/**
+ * Set Task Instances State
+ * Set a state of task instances.
+ * @param data The data for the request.
+ * @param data.dagId
+ * @param data.requestBody
+ * @returns TaskInstanceReferenceCollectionResponse Successful Response
+ * @throws ApiError
+ */
+export const useTaskInstanceServiceSetTaskInstancesState = <
+  TData = Common.TaskInstanceServiceSetTaskInstancesStateMutationResult,
+  TError = unknown,
+  TContext = unknown,
+>(
+  options?: Omit<
+    UseMutationOptions<
+      TData,
+      TError,
+      {
+        dagId: string;
+        requestBody: SetTaskInstancesStateBody;
+      },
+      TContext
+    >,
+    "mutationFn"
+  >,
+) =>
+  useMutation<
+    TData,
+    TError,
+    {
+      dagId: string;
+      requestBody: SetTaskInstancesStateBody;
+    },
+    TContext
+  >({
+    mutationFn: ({ dagId, requestBody }) =>
+      TaskInstanceService.setTaskInstancesState({
+        dagId,
+        requestBody,
       }) as unknown as Promise<TData>,
     ...options,
   });

--- a/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -3067,6 +3067,56 @@ export const $SchedulerInfoSchema = {
   description: "Schema for Scheduler info.",
 } as const;
 
+export const $SetTaskInstancesStateBody = {
+  properties: {
+    dry_run: {
+      type: "boolean",
+      title: "Dry Run",
+      default: true,
+    },
+    task_id: {
+      type: "string",
+      title: "Task Id",
+    },
+    dag_run_id: {
+      type: "string",
+      title: "Dag Run Id",
+    },
+    include_upstream: {
+      type: "boolean",
+      title: "Include Upstream",
+    },
+    include_downstream: {
+      type: "boolean",
+      title: "Include Downstream",
+    },
+    include_future: {
+      type: "boolean",
+      title: "Include Future",
+    },
+    include_past: {
+      type: "boolean",
+      title: "Include Past",
+    },
+    new_state: {
+      type: "string",
+      title: "New State",
+    },
+  },
+  type: "object",
+  required: [
+    "task_id",
+    "dag_run_id",
+    "include_upstream",
+    "include_downstream",
+    "include_future",
+    "include_past",
+    "new_state",
+  ],
+  title: "SetTaskInstancesStateBody",
+  description: "Request body for Set Task Instances State endpoint.",
+} as const;
+
 export const $TaskCollectionResponse = {
   properties: {
     tasks: {
@@ -3345,6 +3395,48 @@ export const $TaskInstanceHistoryResponse = {
   ],
   title: "TaskInstanceHistoryResponse",
   description: "TaskInstanceHistory serializer for responses.",
+} as const;
+
+export const $TaskInstanceReferenceCollectionResponse = {
+  properties: {
+    task_instances: {
+      items: {
+        $ref: "#/components/schemas/TaskInstanceReferenceResponse",
+      },
+      type: "array",
+      title: "Task Instances",
+    },
+  },
+  type: "object",
+  required: ["task_instances"],
+  title: "TaskInstanceReferenceCollectionResponse",
+  description: "Task Instance Reference collection serializer for responses.",
+} as const;
+
+export const $TaskInstanceReferenceResponse = {
+  properties: {
+    task_id: {
+      type: "string",
+      title: "Task Id",
+    },
+    dag_run_id: {
+      type: "string",
+      title: "Dag Run Id",
+    },
+    dag_id: {
+      type: "string",
+      title: "Dag Id",
+    },
+    logical_date: {
+      type: "string",
+      format: "date-time",
+      title: "Logical Date",
+    },
+  },
+  type: "object",
+  required: ["task_id", "dag_run_id", "dag_id", "logical_date"],
+  title: "TaskInstanceReferenceResponse",
+  description: "Task Instance Reference serializer for responses.",
 } as const;
 
 export const $TaskInstanceResponse = {

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -129,6 +129,8 @@ import type {
   GetTaskInstanceTryDetailsResponse,
   GetMappedTaskInstanceTryDetailsData,
   GetMappedTaskInstanceTryDetailsResponse,
+  SetTaskInstancesStateData,
+  SetTaskInstancesStateResponse,
   GetTasksData,
   GetTasksResponse,
   GetTaskData,
@@ -2179,6 +2181,36 @@ export class TaskInstanceService {
         map_index: data.mapIndex,
       },
       errors: {
+        401: "Unauthorized",
+        403: "Forbidden",
+        404: "Not Found",
+        422: "Validation Error",
+      },
+    });
+  }
+
+  /**
+   * Set Task Instances State
+   * Set a state of task instances.
+   * @param data The data for the request.
+   * @param data.dagId
+   * @param data.requestBody
+   * @returns TaskInstanceReferenceCollectionResponse Successful Response
+   * @throws ApiError
+   */
+  public static setTaskInstancesState(
+    data: SetTaskInstancesStateData,
+  ): CancelablePromise<SetTaskInstancesStateResponse> {
+    return __request(OpenAPI, {
+      method: "PUT",
+      url: "/public/dags/{dag_id}/updateTaskInstancesState",
+      path: {
+        dag_id: data.dagId,
+      },
+      body: data.requestBody,
+      mediaType: "application/json",
+      errors: {
+        400: "Bad Request",
         401: "Unauthorized",
         403: "Forbidden",
         404: "Not Found",

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -778,6 +778,20 @@ export type SchedulerInfoSchema = {
 };
 
 /**
+ * Request body for Set Task Instances State endpoint.
+ */
+export type SetTaskInstancesStateBody = {
+  dry_run?: boolean;
+  task_id: string;
+  dag_run_id: string;
+  include_upstream: boolean;
+  include_downstream: boolean;
+  include_future: boolean;
+  include_past: boolean;
+  new_state: string;
+};
+
+/**
  * Task collection serializer for responses.
  */
 export type TaskCollectionResponse = {
@@ -834,6 +848,23 @@ export type TaskInstanceHistoryResponse = {
   pid: number | null;
   executor: string | null;
   executor_config: string;
+};
+
+/**
+ * Task Instance Reference collection serializer for responses.
+ */
+export type TaskInstanceReferenceCollectionResponse = {
+  task_instances: Array<TaskInstanceReferenceResponse>;
+};
+
+/**
+ * Task Instance Reference serializer for responses.
+ */
+export type TaskInstanceReferenceResponse = {
+  task_id: string;
+  dag_run_id: string;
+  dag_id: string;
+  logical_date: string;
 };
 
 /**
@@ -1631,6 +1662,14 @@ export type GetMappedTaskInstanceTryDetailsData = {
 
 export type GetMappedTaskInstanceTryDetailsResponse =
   TaskInstanceHistoryResponse;
+
+export type SetTaskInstancesStateData = {
+  dagId: string;
+  requestBody: SetTaskInstancesStateBody;
+};
+
+export type SetTaskInstancesStateResponse =
+  TaskInstanceReferenceCollectionResponse;
 
 export type GetTasksData = {
   dagId: string;
@@ -3361,6 +3400,37 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: TaskInstanceHistoryResponse;
+        /**
+         * Unauthorized
+         */
+        401: HTTPExceptionResponse;
+        /**
+         * Forbidden
+         */
+        403: HTTPExceptionResponse;
+        /**
+         * Not Found
+         */
+        404: HTTPExceptionResponse;
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError;
+      };
+    };
+  };
+  "/public/dags/{dag_id}/updateTaskInstancesState": {
+    put: {
+      req: SetTaskInstancesStateData;
+      res: {
+        /**
+         * Successful Response
+         */
+        200: TaskInstanceReferenceCollectionResponse;
+        /**
+         * Bad Request
+         */
+        400: HTTPExceptionResponse;
         /**
          * Unauthorized
          */


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/43752
related: https://github.com/apache/airflow/issues/42370

This migrates the Set Task Instances State API from `api_connexion` to `api_fastapi`.