### PR TITLE
Revert "Remove `/webapp` prefix from new UI (#44227)"

### DIFF
--- a/airflow/api_fastapi/core_api/app.py
+++ b/airflow/api_fastapi/core_api/app.py
@@ -71,7 +71,7 @@ def init_views(app: FastAPI) -> None:
         name="webapp_static_folder",
     )
 
-    @app.get("/{rest_of_path:path}", response_class=HTMLResponse, include_in_schema=False)
+    @app.get("/webapp/{rest_of_path:path}", response_class=HTMLResponse, include_in_schema=False)
     def webapp(request: Request, rest_of_path: str):
         return templates.TemplateResponse("/index.html", {"request": request}, media_type="text/html")
 

--- a/airflow/ui/src/router.tsx
+++ b/airflow/ui/src/router.tsx
@@ -66,6 +66,6 @@ export const router = createBrowserRouter(
     },
   ],
   {
-    basename: "/",
+    basename: "/webapp",
   },
 );

--- a/airflow/ui/vite.config.ts
+++ b/airflow/ui/vite.config.ts
@@ -28,7 +28,9 @@ export default defineConfig({
     {
       name: "transform-url-src",
       transformIndexHtml: (html) =>
-        html.replace(`src="/assets/`, `src="/static/assets/`),
+        html
+          .replace(`src="/assets/`, `src="/static/assets/`)
+          .replace(`href="/`, `href="/webapp/`),
     },
   ],
   resolve: { alias: { openapi: "/openapi-gen", src: "/src" } },

--- a/airflow/www/templates/airflow/main.html
+++ b/airflow/www/templates/airflow/main.html
@@ -100,7 +100,7 @@
   {% if auth_manager.is_logged_in() %}
     {% call show_message(category='info', dismissible=true) %}
       <span>We have a new UI for Airflow 3.0</span>
-      <a href="http://localhost:29091/">Check it out now!</a>
+      <a href="http://localhost:29091/webapp">Check it out now!</a>
     {% endcall %}
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
This reverts commit 82e0157c7c252ad298d2018990d378def07d0077.

From #44227 - failing tests