### PR TITLE
Use airflow config in new UI

### DIFF
--- a/airflow/ui/src/components/ConfirmationModal.tsx
+++ b/airflow/ui/src/components/ConfirmationModal.tsx
@@ -1,0 +1,66 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Button, type DialogBodyProps, Heading } from "@chakra-ui/react";
+
+import { Dialog } from "src/components/ui";
+
+type Props = {
+  readonly children?: DialogBodyProps["children"];
+  readonly description?: string;
+  readonly header: string;
+  readonly onConfirm: () => void;
+  readonly onOpenChange: (details: { open: boolean }) => void;
+  readonly open: boolean;
+};
+
+export const ConfirmationModal = ({
+  children,
+  header,
+  onConfirm,
+  onOpenChange,
+  open,
+}: Props) => (
+  <Dialog.Root onOpenChange={onOpenChange} open={open}>
+    <Dialog.Content backdrop>
+      <Dialog.Header>
+        <Heading>{header}</Heading>
+      </Dialog.Header>
+
+      <Dialog.CloseTrigger />
+
+      <Dialog.Body>{children}</Dialog.Body>
+      <Dialog.Footer>
+        <Dialog.ActionTrigger asChild>
+          <Button onClick={() => onOpenChange({ open })} variant="outline">
+            Cancel
+          </Button>
+        </Dialog.ActionTrigger>
+        <Button
+          colorPalette="blue"
+          onClick={() => {
+            onConfirm();
+            onOpenChange({ open });
+          }}
+        >
+          Confirm
+        </Button>
+      </Dialog.Footer>
+    </Dialog.Content>
+  </Dialog.Root>
+);

--- a/airflow/ui/src/components/DataTable/useTableUrlState.ts
+++ b/airflow/ui/src/components/DataTable/useTableUrlState.ts
@@ -19,19 +19,25 @@
 import { useCallback, useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
 
+import { useConfig } from "src/queries/useConfig";
+
 import { searchParamsToState, stateToSearchParams } from "./searchParams";
 import type { TableState } from "./types";
 
-export const defaultTableState = {
-  pagination: {
-    pageIndex: 0,
-    pageSize: 50,
-  },
-  sorting: [],
-} as const satisfies TableState;
-
 export const useTableURLState = (defaultState?: Partial<TableState>) => {
   const [searchParams, setSearchParams] = useSearchParams();
+
+  const configPageSize = useConfig("webserver", "page_size");
+  const pageSize =
+    typeof configPageSize === "string" ? parseInt(configPageSize, 10) : 50;
+
+  const defaultTableState = {
+    pagination: {
+      pageIndex: 0,
+      pageSize,
+    },
+    sorting: [],
+  } as const satisfies TableState;
 
   const handleStateChange = useCallback(
     (state: TableState) => {
@@ -39,7 +45,7 @@ export const useTableURLState = (defaultState?: Partial<TableState>) => {
         replace: true,
       });
     },
-    [setSearchParams],
+    [setSearchParams, defaultTableState],
   );
 
   const tableURLState = useMemo(
@@ -48,7 +54,7 @@ export const useTableURLState = (defaultState?: Partial<TableState>) => {
         ...defaultTableState,
         ...defaultState,
       }),
-    [searchParams, defaultState],
+    [searchParams, defaultState, defaultTableState],
   );
 
   return {

--- a/airflow/ui/src/components/TogglePause.tsx
+++ b/airflow/ui/src/components/TogglePause.tsx
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { useDisclosure } from "@chakra-ui/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 
@@ -24,16 +25,26 @@ import {
   useDagServiceGetDagsKey,
   useDagServicePatchDag,
 } from "openapi/queries";
+import { useConfig } from "src/queries/useConfig";
 
+import { ConfirmationModal } from "./ConfirmationModal";
 import { Switch } from "./ui";
 
 type Props = {
+  readonly dagDisplayName?: string;
   readonly dagId: string;
   readonly isPaused: boolean;
+  readonly skipConfirm?: boolean;
 };
 
-export const TogglePause = ({ dagId, isPaused }: Props) => {
+export const TogglePause = ({
+  dagDisplayName,
+  dagId,
+  isPaused,
+  skipConfirm,
+}: Props) => {
   const queryClient = useQueryClient();
+  const { onClose, onOpen, open } = useDisclosure();
 
   const onSuccess = async () => {
     await queryClient.invalidateQueries({
@@ -49,7 +60,10 @@ export const TogglePause = ({ dagId, isPaused }: Props) => {
     onSuccess,
   });
 
-  const onChange = useCallback(() => {
+  const showConfirmation =
+    useConfig("webserver", "require_confirmation_dag_change") === "True";
+
+  const onToggle = useCallback(() => {
     mutate({
       dagId,
       requestBody: {
@@ -58,12 +72,28 @@ export const TogglePause = ({ dagId, isPaused }: Props) => {
     });
   }, [dagId, isPaused, mutate]);
 
+  const onChange = () => {
+    if (showConfirmation && skipConfirm !== true) {
+      onOpen();
+    } else {
+      onToggle();
+    }
+  };
+
   return (
-    <Switch
-      checked={!isPaused}
-      colorPalette="blue"
-      onCheckedChange={onChange}
-      size="sm"
-    />
+    <>
+      <Switch
+        checked={!isPaused}
+        colorPalette="blue"
+        onCheckedChange={onChange}
+        size="sm"
+      />
+      <ConfirmationModal
+        header={`${isPaused ? "Unpause" : "Pause"} ${dagDisplayName ?? dagId}?`}
+        onConfirm={onToggle}
+        onOpenChange={onClose}
+        open={open}
+      />
+    </>
   );
 };

--- a/airflow/ui/src/components/TriggerDag/TriggerDAGModal.tsx
+++ b/airflow/ui/src/components/TriggerDag/TriggerDAGModal.tsx
@@ -75,7 +75,11 @@ const TriggerDAGModal: React.FC<TriggerDAGModalProps> = ({
           <VStack align="start" gap={4}>
             <Heading size="xl">
               Trigger DAG - {dagDisplayName}{" "}
-              <TogglePause dagId={dagParams.dagId} isPaused={isPaused} />
+              <TogglePause
+                dagId={dagParams.dagId}
+                isPaused={isPaused}
+                skipConfirm
+              />
             </Heading>
             {isPaused ? (
               <Alert status="warning" title="Paused DAG">

--- a/airflow/ui/src/constants/sortParams.ts
+++ b/airflow/ui/src/constants/sortParams.ts
@@ -18,7 +18,7 @@
  */
 import { createListCollection } from "@chakra-ui/react/collection";
 
-export const DagSortOptions = createListCollection({
+export const dagSortOptions = createListCollection({
   items: [
     { label: "Sort by Display Name (A-Z)", value: "dag_display_name" },
     { label: "Sort by Display Name (Z-A)", value: "-dag_display_name" },

--- a/airflow/ui/src/context/timezone/TimezoneProvider.tsx
+++ b/airflow/ui/src/context/timezone/TimezoneProvider.tsx
@@ -19,6 +19,8 @@
 import { createContext, useMemo, type PropsWithChildren } from "react";
 import { useLocalStorage } from "usehooks-ts";
 
+import { useConfig } from "src/queries/useConfig";
+
 export type TimezoneContextType = {
   selectedTimezone: string;
   setSelectedTimezone: (timezone: string) => void;
@@ -31,9 +33,11 @@ export const TimezoneContext = createContext<TimezoneContextType | undefined>(
 const TIMEZONE_KEY = "timezone";
 
 export const TimezoneProvider = ({ children }: PropsWithChildren) => {
+  const defaultUITimezone = useConfig("webserver", "default_ui_timezone");
+
   const [selectedTimezone, setSelectedTimezone] = useLocalStorage(
     TIMEZONE_KEY,
-    "UTC",
+    typeof defaultUITimezone === "string" ? defaultUITimezone : "UTC",
   );
 
   const value = useMemo<TimezoneContextType>(

--- a/airflow/ui/src/layouts/Nav/DocsButton.tsx
+++ b/airflow/ui/src/layouts/Nav/DocsButton.tsx
@@ -20,6 +20,7 @@ import { Link } from "@chakra-ui/react";
 import { FiBookOpen } from "react-icons/fi";
 
 import { Menu } from "src/components/ui";
+import { useConfig } from "src/queries/useConfig";
 
 import { NavButton } from "./NavButton";
 
@@ -33,29 +34,35 @@ const links = [
     title: "GitHub Repo",
   },
   {
-    href: `/docs`,
+    href: "/docs",
     title: "REST API Reference",
   },
 ];
 
-export const DocsButton = () => (
-  <Menu.Root positioning={{ placement: "right" }}>
-    <Menu.Trigger asChild>
-      <NavButton icon={<FiBookOpen size="1.75rem" />} title="Docs" />
-    </Menu.Trigger>
-    <Menu.Content>
-      {links.map((link) => (
-        <Menu.Item asChild key={link.title} value={link.title}>
-          <Link
-            aria-label={link.title}
-            href={link.href}
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            {link.title}
-          </Link>
-        </Menu.Item>
-      ))}
-    </Menu.Content>
-  </Menu.Root>
-);
+export const DocsButton = () => {
+  const showAPIDocs = useConfig("webserver", "enable_swagger_ui") === "True";
+
+  return (
+    <Menu.Root positioning={{ placement: "right" }}>
+      <Menu.Trigger asChild>
+        <NavButton icon={<FiBookOpen size="1.75rem" />} title="Docs" />
+      </Menu.Trigger>
+      <Menu.Content>
+        {links
+          .filter((link) => !(!showAPIDocs && link.href === "/docs"))
+          .map((link) => (
+            <Menu.Item asChild key={link.title} value={link.title}>
+              <Link
+                aria-label={link.title}
+                href={link.href}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                {link.title}
+              </Link>
+            </Menu.Item>
+          ))}
+      </Menu.Content>
+    </Menu.Root>
+  );
+};

--- a/airflow/ui/src/pages/DagsList/Dag/Code/Code.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Code/Code.tsx
@@ -37,6 +37,7 @@ import { ErrorAlert } from "src/components/ErrorAlert";
 import Time from "src/components/Time";
 import { ProgressBar } from "src/components/ui";
 import { useColorMode } from "src/context/colorMode";
+import { useConfig } from "src/queries/useConfig";
 
 SyntaxHighlighter.registerLanguage("python", python);
 
@@ -59,8 +60,9 @@ export const Code = () => {
     dagId: dagId ?? "",
   });
 
-  // TODO: get default_wrap from config
-  const [wrap, setWrap] = useState(false);
+  const defaultWrap = useConfig("webserver", "default_wrap") === "True";
+
+  const [wrap, setWrap] = useState(defaultWrap);
 
   const toggleWrap = () => setWrap(!wrap);
   const { colorMode } = useColorMode();

--- a/airflow/ui/src/pages/DagsList/Dag/Header.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Header.tsx
@@ -52,7 +52,11 @@ export const Header = ({
           <DagIcon height={8} width={8} />
           <Heading size="lg">{dag?.dag_display_name ?? dagId}</Heading>
           {dag !== undefined && (
-            <TogglePause dagId={dag.dag_id} isPaused={dag.is_paused} />
+            <TogglePause
+              dagDisplayName={dag.dag_display_name}
+              dagId={dag.dag_id}
+              isPaused={dag.is_paused}
+            />
           )}
         </HStack>
         <Flex>{dag ? <TriggerDAGTextButton dag={dag} /> : undefined}</Flex>

--- a/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -73,7 +73,11 @@ export const DagCard = ({ dag }: Props) => {
           <DagTags tags={dag.tags} />
         </HStack>
         <HStack>
-          <TogglePause dagId={dag.dag_id} isPaused={dag.is_paused} />
+          <TogglePause
+            dagDisplayName={dag.dag_display_name}
+            dagId={dag.dag_id}
+            isPaused={dag.is_paused}
+          />
           <TriggerDAGIconButton dag={dag} />
         </HStack>
       </Flex>

--- a/airflow/ui/src/pages/DagsList/DagsFilters.tsx
+++ b/airflow/ui/src/pages/DagsList/DagsFilters.tsx
@@ -38,6 +38,7 @@ import {
   SearchParamsKeys,
   type SearchParamsKeysType,
 } from "src/constants/searchParams";
+import { useConfig } from "src/queries/useConfig";
 import { pluralize } from "src/utils";
 
 const {
@@ -48,7 +49,7 @@ const {
 
 const enabledOptions = createListCollection({
   items: [
-    { label: "All", value: "All" },
+    { label: "All", value: "all" },
     { label: "Enabled", value: "false" },
     { label: "Disabled", value: "true" },
   ],
@@ -69,6 +70,13 @@ export const DagsFilters = () => {
     orderBy: "name",
   });
 
+  const hidePausedDagsByDefault = useConfig(
+    "webserver",
+    "hide_paused_dags_by_default",
+  );
+  const defaultShowPaused =
+    hidePausedDagsByDefault === "True" ? "false" : "all";
+
   const { setTableURLState, tableURLState } = useTableURLState();
   const { pagination, sorting } = tableURLState;
 
@@ -76,7 +84,7 @@ export const DagsFilters = () => {
     ({ value }: SelectValueChangeDetails<string>) => {
       const [val] = value;
 
-      if (val === "All" || val === undefined) {
+      if (val === undefined) {
         searchParams.delete(PAUSED_PARAM);
       } else {
         searchParams.set(PAUSED_PARAM, val);
@@ -181,7 +189,7 @@ export const DagsFilters = () => {
         <Select.Root
           collection={enabledOptions}
           onValueChange={handlePausedChange}
-          value={showPaused === null ? ["All"] : [showPaused]}
+          value={[showPaused ?? defaultShowPaused]}
         >
           <Select.Trigger colorPalette="blue" isActive={Boolean(showPaused)}>
             <Select.ValueText width={20} />

--- a/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -43,12 +43,11 @@ import { ErrorAlert } from "src/components/ErrorAlert";
 import { SearchBar } from "src/components/SearchBar";
 import { TogglePause } from "src/components/TogglePause";
 import TriggerDAGIconButton from "src/components/TriggerDag/TriggerDAGIconButton";
-import { Select } from "src/components/ui";
 import {
   SearchParamsKeys,
   type SearchParamsKeysType,
 } from "src/constants/searchParams";
-import { DagSortOptions as sortOptions } from "src/constants/sortParams";
+import { useConfig } from "src/queries/useConfig";
 import { useDags } from "src/queries/useDags";
 import { pluralize } from "src/utils";
 
@@ -56,12 +55,17 @@ import { DagCard } from "./DagCard";
 import { DagTags } from "./DagTags";
 import { DagsFilters } from "./DagsFilters";
 import { Schedule } from "./Schedule";
+import { SortSelect } from "./SortSelect";
 
 const columns: Array<ColumnDef<DAGWithLatestDagRunsResponse>> = [
   {
     accessorKey: "is_paused",
     cell: ({ row: { original } }) => (
-      <TogglePause dagId={original.dag_id} isPaused={original.is_paused} />
+      <TogglePause
+        dagDisplayName={original.dag_display_name}
+        dagId={original.dag_id}
+        isPaused={original.is_paused}
+      />
     ),
     enableSorting: false,
     header: "",
@@ -155,7 +159,15 @@ export const DagsList = () => {
     "card",
   );
 
+  const hidePausedDagsByDefault = useConfig(
+    "webserver",
+    "hide_paused_dags_by_default",
+  );
+  const defaultShowPaused =
+    hidePausedDagsByDefault === "True" ? false : undefined;
+
   const showPaused = searchParams.get(PAUSED_PARAM);
+
   const lastDagRunState = searchParams.get(
     LAST_DAG_RUN_STATE_PARAM,
   ) as DagRunState;
@@ -167,7 +179,6 @@ export const DagsList = () => {
     searchParams.get(NAME_PATTERN_PARAM) ?? undefined,
   );
 
-  // TODO: update API to accept multiple orderBy params
   const [sort] = sorting;
   const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : undefined;
 
@@ -185,6 +196,16 @@ export const DagsList = () => {
     setDagDisplayNamePattern(value);
   };
 
+  let paused = defaultShowPaused;
+
+  if (showPaused === "all") {
+    paused = undefined;
+  } else if (showPaused === "true") {
+    paused = true;
+  } else if (showPaused === "false") {
+    paused = false;
+  }
+
   const { data, error, isFetching, isLoading } = useDags({
     dagDisplayNamePattern: Boolean(dagDisplayNamePattern)
       ? `%${dagDisplayNamePattern}%`
@@ -194,7 +215,7 @@ export const DagsList = () => {
     offset: pagination.pageIndex * pagination.pageSize,
     onlyActive: true,
     orderBy,
-    paused: showPaused === null ? undefined : showPaused === "true",
+    paused,
     tags: selectedTags,
   });
 
@@ -225,27 +246,8 @@ export const DagsList = () => {
             {pluralize("Dag", data.total_entries)}
           </Heading>
           {display === "card" ? (
-            <Select.Root
-              collection={sortOptions}
-              data-testid="sort-by-select"
-              onValueChange={handleSortChange}
-              value={orderBy === undefined ? undefined : [orderBy]}
-              width="310px"
-            >
-              <Select.Trigger>
-                <Select.ValueText placeholder="Sort by" />
-              </Select.Trigger>
-              <Select.Content>
-                {sortOptions.items.map((option) => (
-                  <Select.Item item={option} key={option.value}>
-                    {option.label}
-                  </Select.Item>
-                ))}
-              </Select.Content>
-            </Select.Root>
-          ) : (
-            false
-          )}
+            <SortSelect handleSortChange={handleSortChange} orderBy={orderBy} />
+          ) : undefined}
         </HStack>
       </VStack>
       <ToggleTableDisplay display={display} setDisplay={setDisplay} />

--- a/airflow/ui/src/pages/DagsList/SortSelect.tsx
+++ b/airflow/ui/src/pages/DagsList/SortSelect.tsx
@@ -1,0 +1,50 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import type { SelectValueChangeDetails } from "@chakra-ui/react";
+
+import { Select } from "src/components/ui";
+import { dagSortOptions } from "src/constants/sortParams";
+
+type Props = {
+  readonly handleSortChange: ({
+    value,
+  }: SelectValueChangeDetails<Array<string>>) => void;
+  readonly orderBy?: string;
+};
+
+export const SortSelect = ({ handleSortChange, orderBy }: Props) => (
+  <Select.Root
+    collection={dagSortOptions}
+    data-testid="sort-by-select"
+    onValueChange={handleSortChange}
+    value={orderBy === undefined ? undefined : [orderBy]}
+    width="310px"
+  >
+    <Select.Trigger>
+      <Select.ValueText placeholder="Sort by" />
+    </Select.Trigger>
+    <Select.Content>
+      {dagSortOptions.items.map((option) => (
+        <Select.Item item={option} key={option.value}>
+          {option.label}
+        </Select.Item>
+      ))}
+    </Select.Content>
+  </Select.Root>
+);

--- a/airflow/ui/src/pages/Dashboard/Health/Health.tsx
+++ b/airflow/ui/src/pages/Dashboard/Health/Health.tsx
@@ -21,11 +21,15 @@ import { MdOutlineHealthAndSafety } from "react-icons/md";
 
 import { useMonitorServiceGetHealth } from "openapi/queries";
 import { ErrorAlert } from "src/components/ErrorAlert";
+import { useConfig } from "src/queries/useConfig";
 
 import { HealthTag } from "./HealthTag";
 
 export const Health = () => {
   const { data, error, isLoading } = useMonitorServiceGetHealth();
+
+  const isStandaloneDagProcessor =
+    useConfig("scheduler", "standalone_dag_processor") === "True";
 
   return (
     <Box>
@@ -54,13 +58,14 @@ export const Health = () => {
           status={data?.triggerer.status}
           title="Triggerer"
         />
-        {/* TODO add is_standalone to API to determine when to render this */}
-        <HealthTag
-          isLoading={isLoading}
-          latestHeartbeat={data?.dag_processor.latest_dag_processor_heartbeat}
-          status={data?.dag_processor.status}
-          title="Dag Processor"
-        />
+        {isStandaloneDagProcessor ? (
+          <HealthTag
+            isLoading={isLoading}
+            latestHeartbeat={data?.dag_processor.latest_dag_processor_heartbeat}
+            status={data?.dag_processor.status}
+            title="Dag Processor"
+          />
+        ) : undefined}
       </HStack>
     </Box>
   );

--- a/airflow/ui/src/queries/useConfig.tsx
+++ b/airflow/ui/src/queries/useConfig.tsx
@@ -16,31 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Flex } from "@chakra-ui/react";
-import type { PropsWithChildren } from "react";
-import { Outlet } from "react-router-dom";
+import { useConfigServiceGetConfig } from "openapi/queries";
 
-import { useConfig } from "src/queries/useConfig";
+export const useConfig = (sectionName: string, configKey: string) => {
+  // TODO: replace with a ui/config endpoitn which will always return what the UI need to render
+  const { data: config } = useConfigServiceGetConfig({
+    accept: "application/json",
+  });
 
-import { Nav } from "./Nav";
-
-export const BaseLayout = ({ children }: PropsWithChildren) => {
-  const instanceName = useConfig("webserver", "instance_name");
-  // const instanceNameHasMarkup =
-  //   webserverConfig?.options.find(
-  //     ({ key }) => key === "instance_name_has_markup",
-  //   )?.value === "True";
-
-  if (typeof instanceName === "string") {
-    document.title = instanceName;
-  }
-
-  return (
-    <>
-      <Nav />
-      <Flex flexFlow="column" height="100%" ml={20} p={3}>
-        {children ?? <Outlet />}
-      </Flex>
-    </>
+  const configSection = config?.sections.find(
+    (section) => section.name === sectionName,
   );
+
+  return configSection?.options.find(({ key }) => key === configKey)?.value;
 };

--- a/airflow/ui/src/queries/useConfig.tsx
+++ b/airflow/ui/src/queries/useConfig.tsx
@@ -19,7 +19,7 @@
 import { useConfigServiceGetConfig } from "openapi/queries";
 
 export const useConfig = (sectionName: string, configKey: string) => {
-  // TODO: replace with a ui/config endpoitn which will always return what the UI need to render
+  // TODO: replace with a ui/config endpoint which will always return what the UI need to render
   const { data: config } = useConfigServiceGetConfig({
     accept: "application/json",
   });


### PR DESCRIPTION
Use the new public/config api endpoint to make sure the UI uses config values. The public endpoint can we switched off. So later on we should migrate this to a dedicated `ui/config` endpoint.

Also, I didn't get around to `show_trigger_form_if_no_params` since we may also need API changes to make that work.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
