### PR TITLE
Add `otel_headers` to OTel logic

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1174,6 +1174,13 @@ metrics:
       type: string
       example: ~
       default: "8889"
+    otel_headers:
+      description: |
+        Headers to be added to the traces.
+      version_added: 2.10.0
+      type: string
+      example: 'Authorization="Bearer token",Potato="Tomato"'
+      default: ""
     otel_prefix:
       description: |
         The prefix for the Airflow metrics.
@@ -1239,6 +1246,13 @@ traces:
       type: string
       example: ~
       default: "8889"
+    otel_headers:
+      description: |
+        Headers to be added to the traces.
+      version_added: 2.10.0
+      type: string
+      example: 'Authorization="Bearer token",Potato="Tomato"'
+      default: ""
     otel_service:
       description: |
         The default service name of traces.

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1177,7 +1177,7 @@ metrics:
     otel_headers:
       description: |
         Headers to be added to the traces.
-      version_added: 2.10.0
+      version_added: 3.0.0
       type: string
       example: 'Authorization="Bearer token",Potato="Tomato"'
       default: ""
@@ -1249,7 +1249,7 @@ traces:
     otel_headers:
       description: |
         Headers to be added to the traces.
-      version_added: 2.10.0
+      version_added: 3.0.0
       type: string
       example: 'Authorization="Bearer token",Potato="Tomato"'
       default: ""

--- a/airflow/metrics/otel_logger.py
+++ b/airflow/metrics/otel_logger.py
@@ -392,6 +392,9 @@ class MetricsMap:
 def get_otel_logger(cls) -> SafeOtelLogger:
     host = conf.get("metrics", "otel_host")  # ex: "breeze-otel-collector"
     port = conf.getint("metrics", "otel_port")  # ex: 4318
+    headers = dict([
+        header.split('=', 1) for header in conf.getlist("traces", "otel_headers")
+    ])
     prefix = conf.get("metrics", "otel_prefix")  # ex: "airflow"
     ssl_active = conf.getboolean("metrics", "otel_ssl_active")
     # PeriodicExportingMetricReader will default to an interval of 60000 millis.
@@ -409,7 +412,7 @@ def get_otel_logger(cls) -> SafeOtelLogger:
         PeriodicExportingMetricReader(
             OTLPMetricExporter(
                 endpoint=endpoint,
-                headers={"Content-Type": "application/json"},
+                headers={"Content-Type": "application/json", **headers},
             ),
             export_interval_millis=interval,
         )

--- a/airflow/traces/otel_tracer.py
+++ b/airflow/traces/otel_tracer.py
@@ -269,6 +269,9 @@ def get_otel_tracer(cls) -> OtelTrace:
     """Get OTEL tracer from airflow configuration."""
     host = conf.get("traces", "otel_host")
     port = conf.getint("traces", "otel_port")
+    headers = dict([
+        header.split('=', 1) for header in conf.getlist("traces", "otel_headers")
+    ])
     ssl_active = conf.getboolean("traces", "otel_ssl_active")
     tag_string = cls.get_constant_tags()
 
@@ -276,7 +279,10 @@ def get_otel_tracer(cls) -> OtelTrace:
     endpoint = f"{protocol}://{host}:{port}/v1/traces"
     log.info("[OTLPSpanExporter] Connecting to OpenTelemetry Collector at %s", endpoint)
     return OtelTrace(
-        span_exporter=OTLPSpanExporter(endpoint=endpoint, headers={"Content-Type": "application/json"}),
+        span_exporter=OTLPSpanExporter(
+            endpoint=endpoint,
+            headers={"Content-Type": "application/json", **headers}
+        ),
         tag_string=tag_string,
     )
 


### PR DESCRIPTION
Does anyone know why just doing `export OTEL_EXPORTER_OTLP_HEADERS='Authorization=your-write-token'` on the terminal, before running airflow isn't enough? Airflow ignores environment variables?