### PR TITLE
Replace var names `select`, `base_select`, `base_query` with `query`

### DIFF
--- a/airflow/api_fastapi/common/db/common.py
+++ b/airflow/api_fastapi/common/db/common.py
@@ -55,19 +55,15 @@ def get_session() -> Session:
         yield session
 
 
-def apply_filters_to_select(
-    *,
-    base_select: Select,
-    filters: Sequence[BaseParam | None] | None = None,
-) -> Select:
+def apply_filters_to_select(*, query: Select, filters: Sequence[BaseParam | None] | None = None) -> Select:
     if filters is None:
-        return base_select
+        return query
     for f in filters:
         if f is None:
             continue
-        base_select = f.to_orm(base_select)
+        query = f.to_orm(query)
 
-    return base_select
+    return query
 
 
 async def get_async_session() -> AsyncSession:
@@ -147,7 +143,7 @@ async def paginated_select_async(
 @overload
 def paginated_select(
     *,
-    select: Select,
+    query: Select,
     filters: Sequence[BaseParam] | None = None,
     order_by: BaseParam | None = None,
     offset: BaseParam | None = None,
@@ -160,7 +156,7 @@ def paginated_select(
 @overload
 def paginated_select(
     *,
-    select: Select,
+    query: Select,
     filters: Sequence[BaseParam] | None = None,
     order_by: BaseParam | None = None,
     offset: BaseParam | None = None,
@@ -173,7 +169,7 @@ def paginated_select(
 @provide_session
 def paginated_select(
     *,
-    select: Select,
+    query: Select,
     filters: Sequence[BaseParam] | None = None,
     order_by: BaseParam | None = None,
     offset: BaseParam | None = None,
@@ -181,20 +177,20 @@ def paginated_select(
     session: Session = NEW_SESSION,
     return_total_entries: bool = True,
 ) -> tuple[Select, int | None]:
-    base_select = apply_filters_to_select(
-        base_select=select,
+    query = apply_filters_to_select(
+        query=query,
         filters=filters,
     )
 
     total_entries = None
     if return_total_entries:
-        total_entries = get_query_count(base_select, session=session)
+        total_entries = get_query_count(query, session=session)
 
     # TODO: Re-enable when permissions are handled. Readable / writable entities,
     # for instance:
     # readable_dags = get_auth_manager().get_permitted_dag_ids(user=g.user)
     # dags_select = dags_select.where(DagModel.dag_id.in_(readable_dags))
 
-    base_select = apply_filters_to_select(base_select=base_select, filters=[order_by, offset, limit])
+    query = apply_filters_to_select(query=query, filters=[order_by, offset, limit])
 
-    return base_select, total_entries
+    return query, total_entries

--- a/airflow/api_fastapi/common/db/common.py
+++ b/airflow/api_fastapi/common/db/common.py
@@ -119,7 +119,7 @@ async def paginated_select_async(
     return_total_entries: bool = True,
 ) -> tuple[Select, int | None]:
     query = apply_filters_to_select(
-        base_select=query,
+        query=query,
         filters=filters,
     )
 
@@ -133,7 +133,7 @@ async def paginated_select_async(
     # dags_select = dags_select.where(DagModel.dag_id.in_(readable_dags))
 
     query = apply_filters_to_select(
-        base_select=query,
+        query=query,
         filters=[order_by, offset, limit],
     )
 

--- a/airflow/api_fastapi/core_api/routes/public/assets.py
+++ b/airflow/api_fastapi/core_api/routes/public/assets.py
@@ -95,7 +95,7 @@ def get_assets(
 ) -> AssetCollectionResponse:
     """Get assets."""
     assets_select, total_entries = paginated_select(
-        select=select(AssetModel),
+        query=select(AssetModel),
         filters=[uri_pattern, dag_ids],
         order_by=order_by,
         offset=offset,
@@ -145,7 +145,7 @@ def get_asset_events(
 ) -> AssetEventCollectionResponse:
     """Get asset events."""
     assets_event_select, total_entries = paginated_select(
-        select=select(AssetEvent),
+        query=select(AssetEvent),
         filters=[asset_id, source_dag_id, source_task_id, source_run_id, source_map_index],
         order_by=order_by,
         offset=offset,
@@ -210,7 +210,7 @@ def get_asset_queued_events(
         .where(*where_clause)
     )
 
-    dag_asset_queued_events_select, total_entries = paginated_select(select=query)
+    dag_asset_queued_events_select, total_entries = paginated_select(query=query)
     adrqs = session.execute(dag_asset_queued_events_select).all()
 
     if not adrqs:
@@ -269,7 +269,7 @@ def get_dag_asset_queued_events(
         .where(*where_clause)
     )
 
-    dag_asset_queued_events_select, total_entries = paginated_select(select=query)
+    dag_asset_queued_events_select, total_entries = paginated_select(query=query)
     adrqs = session.execute(dag_asset_queued_events_select).all()
     if not adrqs:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"Queue event with dag_id: `{dag_id}` was not found")

--- a/airflow/api_fastapi/core_api/routes/public/assets.py
+++ b/airflow/api_fastapi/core_api/routes/public/assets.py
@@ -95,7 +95,7 @@ def get_assets(
 ) -> AssetCollectionResponse:
     """Get assets."""
     assets_select, total_entries = paginated_select(
-        query=select(AssetModel),
+        statement=select(AssetModel),
         filters=[uri_pattern, dag_ids],
         order_by=order_by,
         offset=offset,
@@ -145,7 +145,7 @@ def get_asset_events(
 ) -> AssetEventCollectionResponse:
     """Get asset events."""
     assets_event_select, total_entries = paginated_select(
-        query=select(AssetEvent),
+        statement=select(AssetEvent),
         filters=[asset_id, source_dag_id, source_task_id, source_run_id, source_map_index],
         order_by=order_by,
         offset=offset,
@@ -210,7 +210,7 @@ def get_asset_queued_events(
         .where(*where_clause)
     )
 
-    dag_asset_queued_events_select, total_entries = paginated_select(query=query)
+    dag_asset_queued_events_select, total_entries = paginated_select(statement=query)
     adrqs = session.execute(dag_asset_queued_events_select).all()
 
     if not adrqs:
@@ -269,7 +269,7 @@ def get_dag_asset_queued_events(
         .where(*where_clause)
     )
 
-    dag_asset_queued_events_select, total_entries = paginated_select(query=query)
+    dag_asset_queued_events_select, total_entries = paginated_select(statement=query)
     adrqs = session.execute(dag_asset_queued_events_select).all()
     if not adrqs:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"Queue event with dag_id: `{dag_id}` was not found")

--- a/airflow/api_fastapi/core_api/routes/public/backfills.py
+++ b/airflow/api_fastapi/core_api/routes/public/backfills.py
@@ -61,7 +61,7 @@ async def list_backfills(
     session: Annotated[AsyncSession, Depends(get_async_session)],
 ) -> BackfillCollectionResponse:
     select_stmt, total_entries = await paginated_select_async(
-        query=select(Backfill).where(Backfill.dag_id == dag_id),
+        statement=select(Backfill).where(Backfill.dag_id == dag_id),
         order_by=order_by,
         offset=offset,
         limit=limit,

--- a/airflow/api_fastapi/core_api/routes/public/connections.py
+++ b/airflow/api_fastapi/core_api/routes/public/connections.py
@@ -100,7 +100,7 @@ def get_connections(
 ) -> ConnectionCollectionResponse:
     """Get all connection entries."""
     connection_select, total_entries = paginated_select(
-        select=select(Connection),
+        query=select(Connection),
         order_by=order_by,
         offset=offset,
         limit=limit,

--- a/airflow/api_fastapi/core_api/routes/public/connections.py
+++ b/airflow/api_fastapi/core_api/routes/public/connections.py
@@ -100,7 +100,7 @@ def get_connections(
 ) -> ConnectionCollectionResponse:
     """Get all connection entries."""
     connection_select, total_entries = paginated_select(
-        query=select(Connection),
+        statement=select(Connection),
         order_by=order_by,
         offset=offset,
         limit=limit,

--- a/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -284,7 +284,7 @@ def get_dag_runs(
         query = query.filter(DagRun.dag_id == dag_id)
 
     dag_run_select, total_entries = paginated_select(
-        query=query,
+        statement=query,
         filters=[logical_date, start_date_range, end_date_range, update_at_range, state],
         order_by=order_by,
         offset=offset,

--- a/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -274,17 +274,17 @@ def get_dag_runs(
 
     This endpoint allows specifying `~` as the dag_id to retrieve Dag Runs for all DAGs.
     """
-    base_query = select(DagRun)
+    query = select(DagRun)
 
     if dag_id != "~":
         dag: DAG = request.app.state.dag_bag.get_dag(dag_id)
         if not dag:
             raise HTTPException(status.HTTP_404_NOT_FOUND, f"The DAG with dag_id: `{dag_id}` was not found")
 
-        base_query = base_query.filter(DagRun.dag_id == dag_id)
+        query = query.filter(DagRun.dag_id == dag_id)
 
     dag_run_select, total_entries = paginated_select(
-        select=base_query,
+        query=query,
         filters=[logical_date, start_date_range, end_date_range, update_at_range, state],
         order_by=order_by,
         offset=offset,

--- a/airflow/api_fastapi/core_api/routes/public/dag_stats.py
+++ b/airflow/api_fastapi/core_api/routes/public/dag_stats.py
@@ -55,7 +55,7 @@ def get_dag_stats(
 ) -> DagStatsCollectionResponse:
     """Get Dag statistics."""
     dagruns_select, _ = paginated_select(
-        select=dagruns_select_with_state_count,
+        query=dagruns_select_with_state_count,
         filters=[dag_ids],
         session=session,
         return_total_entries=False,

--- a/airflow/api_fastapi/core_api/routes/public/dag_stats.py
+++ b/airflow/api_fastapi/core_api/routes/public/dag_stats.py
@@ -55,7 +55,7 @@ def get_dag_stats(
 ) -> DagStatsCollectionResponse:
     """Get Dag statistics."""
     dagruns_select, _ = paginated_select(
-        query=dagruns_select_with_state_count,
+        statement=dagruns_select_with_state_count,
         filters=[dag_ids],
         session=session,
         return_total_entries=False,

--- a/airflow/api_fastapi/core_api/routes/public/dag_warning.py
+++ b/airflow/api_fastapi/core_api/routes/public/dag_warning.py
@@ -59,7 +59,7 @@ def list_dag_warnings(
 ) -> DAGWarningCollectionResponse:
     """Get a list of DAG warnings."""
     dag_warnings_select, total_entries = paginated_select(
-        select=select(DagWarning),
+        query=select(DagWarning),
         filters=[warning_type, dag_id],
         order_by=order_by,
         offset=offset,

--- a/airflow/api_fastapi/core_api/routes/public/dag_warning.py
+++ b/airflow/api_fastapi/core_api/routes/public/dag_warning.py
@@ -59,7 +59,7 @@ def list_dag_warnings(
 ) -> DAGWarningCollectionResponse:
     """Get a list of DAG warnings."""
     dag_warnings_select, total_entries = paginated_select(
-        query=select(DagWarning),
+        statement=select(DagWarning),
         filters=[warning_type, dag_id],
         order_by=order_by,
         offset=offset,

--- a/airflow/api_fastapi/core_api/routes/public/dags.py
+++ b/airflow/api_fastapi/core_api/routes/public/dags.py
@@ -82,7 +82,7 @@ def get_dags(
 ) -> DAGCollectionResponse:
     """Get all DAGs."""
     dags_select, total_entries = paginated_select(
-        query=dags_select_with_latest_dag_run,
+        statement=dags_select_with_latest_dag_run,
         filters=[
             only_active,
             paused,
@@ -127,7 +127,7 @@ def get_dag_tags(
     """Get all DAG tags."""
     query = select(DagTag.name).group_by(DagTag.name)
     dag_tags_select, total_entries = paginated_select(
-        query=query,
+        statement=query,
         filters=[tag_name_pattern],
         order_by=order_by,
         offset=offset,
@@ -263,7 +263,7 @@ def patch_dags(
         update_mask = ["is_paused"]
 
     dags_select, total_entries = paginated_select(
-        query=dags_select_with_latest_dag_run,
+        statement=dags_select_with_latest_dag_run,
         filters=[only_active, paused, dag_id_pattern, tags, owners, last_dag_run_state],
         order_by=None,
         offset=offset,

--- a/airflow/api_fastapi/core_api/routes/public/dags.py
+++ b/airflow/api_fastapi/core_api/routes/public/dags.py
@@ -82,7 +82,7 @@ def get_dags(
 ) -> DAGCollectionResponse:
     """Get all DAGs."""
     dags_select, total_entries = paginated_select(
-        select=dags_select_with_latest_dag_run,
+        query=dags_select_with_latest_dag_run,
         filters=[
             only_active,
             paused,
@@ -125,9 +125,9 @@ def get_dag_tags(
     session: Annotated[Session, Depends(get_session)],
 ) -> DAGTagCollectionResponse:
     """Get all DAG tags."""
-    base_select = select(DagTag.name).group_by(DagTag.name)
+    query = select(DagTag.name).group_by(DagTag.name)
     dag_tags_select, total_entries = paginated_select(
-        select=base_select,
+        query=query,
         filters=[tag_name_pattern],
         order_by=order_by,
         offset=offset,
@@ -263,7 +263,7 @@ def patch_dags(
         update_mask = ["is_paused"]
 
     dags_select, total_entries = paginated_select(
-        select=dags_select_with_latest_dag_run,
+        query=dags_select_with_latest_dag_run,
         filters=[only_active, paused, dag_id_pattern, tags, owners, last_dag_run_state],
         order_by=None,
         offset=offset,

--- a/airflow/api_fastapi/core_api/routes/public/event_logs.py
+++ b/airflow/api_fastapi/core_api/routes/public/event_logs.py
@@ -122,7 +122,7 @@ def get_event_logs(
     if after is not None:
         query = query.where(Log.dttm > after)
     event_logs_select, total_entries = paginated_select(
-        query=query,
+        statement=query,
         order_by=order_by,
         offset=offset,
         limit=limit,

--- a/airflow/api_fastapi/core_api/routes/public/event_logs.py
+++ b/airflow/api_fastapi/core_api/routes/public/event_logs.py
@@ -97,32 +97,32 @@ def get_event_logs(
     after: datetime | None = None,
 ) -> EventLogCollectionResponse:
     """Get all Event Logs."""
-    base_select = select(Log).group_by(Log.id)
+    query = select(Log).group_by(Log.id)
     # TODO: Refactor using the `FilterParam` class in commit `574b72e41cc5ed175a2bbf4356522589b836bb11`
     if dag_id is not None:
-        base_select = base_select.where(Log.dag_id == dag_id)
+        query = query.where(Log.dag_id == dag_id)
     if task_id is not None:
-        base_select = base_select.where(Log.task_id == task_id)
+        query = query.where(Log.task_id == task_id)
     if run_id is not None:
-        base_select = base_select.where(Log.run_id == run_id)
+        query = query.where(Log.run_id == run_id)
     if map_index is not None:
-        base_select = base_select.where(Log.map_index == map_index)
+        query = query.where(Log.map_index == map_index)
     if try_number is not None:
-        base_select = base_select.where(Log.try_number == try_number)
+        query = query.where(Log.try_number == try_number)
     if owner is not None:
-        base_select = base_select.where(Log.owner == owner)
+        query = query.where(Log.owner == owner)
     if event is not None:
-        base_select = base_select.where(Log.event == event)
+        query = query.where(Log.event == event)
     if excluded_events is not None:
-        base_select = base_select.where(Log.event.notin_(excluded_events))
+        query = query.where(Log.event.notin_(excluded_events))
     if included_events is not None:
-        base_select = base_select.where(Log.event.in_(included_events))
+        query = query.where(Log.event.in_(included_events))
     if before is not None:
-        base_select = base_select.where(Log.dttm < before)
+        query = query.where(Log.dttm < before)
     if after is not None:
-        base_select = base_select.where(Log.dttm > after)
+        query = query.where(Log.dttm > after)
     event_logs_select, total_entries = paginated_select(
-        select=base_select,
+        query=query,
         order_by=order_by,
         offset=offset,
         limit=limit,

--- a/airflow/api_fastapi/core_api/routes/public/import_error.py
+++ b/airflow/api_fastapi/core_api/routes/public/import_error.py
@@ -86,7 +86,7 @@ def get_import_errors(
 ) -> ImportErrorCollectionResponse:
     """Get all import errors."""
     import_errors_select, total_entries = paginated_select(
-        query=select(ParseImportError),
+        statement=select(ParseImportError),
         order_by=order_by,
         offset=offset,
         limit=limit,

--- a/airflow/api_fastapi/core_api/routes/public/import_error.py
+++ b/airflow/api_fastapi/core_api/routes/public/import_error.py
@@ -86,7 +86,7 @@ def get_import_errors(
 ) -> ImportErrorCollectionResponse:
     """Get all import errors."""
     import_errors_select, total_entries = paginated_select(
-        select=select(ParseImportError),
+        query=select(ParseImportError),
         order_by=order_by,
         offset=offset,
         limit=limit,

--- a/airflow/api_fastapi/core_api/routes/public/job.py
+++ b/airflow/api_fastapi/core_api/routes/public/job.py
@@ -96,7 +96,7 @@ def get_jobs(
     # TODO: Refactor using the `FilterParam` class in commit `574b72e41cc5ed175a2bbf4356522589b836bb11`
 
     jobs_select, total_entries = paginated_select(
-        select=base_select,
+        statement=base_select,
         filters=[
             start_date_range,
             end_date_range,

--- a/airflow/api_fastapi/core_api/routes/public/pools.py
+++ b/airflow/api_fastapi/core_api/routes/public/pools.py
@@ -96,7 +96,7 @@ def get_pools(
 ) -> PoolCollectionResponse:
     """Get all pools entries."""
     pools_select, total_entries = paginated_select(
-        select=select(Pool),
+        query=select(Pool),
         order_by=order_by,
         offset=offset,
         limit=limit,

--- a/airflow/api_fastapi/core_api/routes/public/pools.py
+++ b/airflow/api_fastapi/core_api/routes/public/pools.py
@@ -96,7 +96,7 @@ def get_pools(
 ) -> PoolCollectionResponse:
     """Get all pools entries."""
     pools_select, total_entries = paginated_select(
-        query=select(Pool),
+        statement=select(Pool),
         order_by=order_by,
         offset=offset,
         limit=limit,

--- a/airflow/api_fastapi/core_api/routes/public/task_instances.py
+++ b/airflow/api_fastapi/core_api/routes/public/task_instances.py
@@ -133,13 +133,13 @@ def get_mapped_task_instances(
     session: Annotated[Session, Depends(get_session)],
 ) -> TaskInstanceCollectionResponse:
     """Get list of mapped task instances."""
-    base_query = (
+    query = (
         select(TI)
         .where(TI.dag_id == dag_id, TI.run_id == dag_run_id, TI.task_id == task_id, TI.map_index >= 0)
         .join(TI.dag_run)
     )
     # 0 can mean a mapped TI that expanded to an empty list, so it is not an automatic 404
-    unfiltered_total_count = get_query_count(base_query, session=session)
+    unfiltered_total_count = get_query_count(query, session=session)
     if unfiltered_total_count == 0:
         dag = request.app.state.dag_bag.get_dag(dag_id)
         if not dag:
@@ -155,7 +155,7 @@ def get_mapped_task_instances(
             raise HTTPException(status.HTTP_404_NOT_FOUND, error_message)
 
     task_instance_select, total_entries = paginated_select(
-        select=base_query,
+        query=query,
         filters=[
             logical_date_range,
             start_date_range,
@@ -299,13 +299,13 @@ def get_task_instances(
     This endpoint allows specifying `~` as the dag_id, dag_run_id to retrieve Task Instances for all DAGs
     and DAG runs.
     """
-    base_query = select(TI).join(TI.dag_run)
+    query = select(TI).join(TI.dag_run)
 
     if dag_id != "~":
         dag = request.app.state.dag_bag.get_dag(dag_id)
         if not dag:
             raise HTTPException(status.HTTP_404_NOT_FOUND, f"DAG with dag_id: `{dag_id}` was not found")
-        base_query = base_query.where(TI.dag_id == dag_id)
+        query = query.where(TI.dag_id == dag_id)
 
     if dag_run_id != "~":
         dag_run = session.scalar(select(DagRun).filter_by(run_id=dag_run_id))
@@ -314,10 +314,10 @@ def get_task_instances(
                 status.HTTP_404_NOT_FOUND,
                 f"DagRun with run_id: `{dag_run_id}` was not found",
             )
-        base_query = base_query.where(TI.run_id == dag_run_id)
+        query = query.where(TI.run_id == dag_run_id)
 
     task_instance_select, total_entries = paginated_select(
-        select=base_query,
+        query=query,
         filters=[
             logical_date,
             start_date_range,
@@ -384,9 +384,9 @@ def get_task_instances_batch(
         TI,
     ).set_value(body.order_by)
 
-    base_query = select(TI).join(TI.dag_run)
+    query = select(TI).join(TI.dag_run)
     task_instance_select, total_entries = paginated_select(
-        select=base_query,
+        query=query,
         filters=[
             dag_ids,
             dag_run_ids,

--- a/airflow/api_fastapi/core_api/routes/public/task_instances.py
+++ b/airflow/api_fastapi/core_api/routes/public/task_instances.py
@@ -155,7 +155,7 @@ def get_mapped_task_instances(
             raise HTTPException(status.HTTP_404_NOT_FOUND, error_message)
 
     task_instance_select, total_entries = paginated_select(
-        query=query,
+        statement=query,
         filters=[
             logical_date_range,
             start_date_range,
@@ -317,7 +317,7 @@ def get_task_instances(
         query = query.where(TI.run_id == dag_run_id)
 
     task_instance_select, total_entries = paginated_select(
-        query=query,
+        statement=query,
         filters=[
             logical_date,
             start_date_range,
@@ -386,7 +386,7 @@ def get_task_instances_batch(
 
     query = select(TI).join(TI.dag_run)
     task_instance_select, total_entries = paginated_select(
-        query=query,
+        statement=query,
         filters=[
             dag_ids,
             dag_run_ids,

--- a/airflow/api_fastapi/core_api/routes/public/variables.py
+++ b/airflow/api_fastapi/core_api/routes/public/variables.py
@@ -90,7 +90,7 @@ def get_variables(
 ) -> VariableCollectionResponse:
     """Get all Variables entries."""
     variable_select, total_entries = paginated_select(
-        query=select(Variable),
+        statement=select(Variable),
         order_by=order_by,
         offset=offset,
         limit=limit,

--- a/airflow/api_fastapi/core_api/routes/public/variables.py
+++ b/airflow/api_fastapi/core_api/routes/public/variables.py
@@ -90,7 +90,7 @@ def get_variables(
 ) -> VariableCollectionResponse:
     """Get all Variables entries."""
     variable_select, total_entries = paginated_select(
-        select=select(Variable),
+        query=select(Variable),
         order_by=order_by,
         offset=offset,
         limit=limit,

--- a/airflow/api_fastapi/core_api/routes/ui/dags.py
+++ b/airflow/api_fastapi/core_api/routes/ui/dags.py
@@ -103,7 +103,7 @@ def recent_dag_runs(
         .order_by(recent_runs_subquery.c.logical_date.desc())
     )
     dags_with_recent_dag_runs_select_filter, _ = paginated_select(
-        select=dags_with_recent_dag_runs_select,
+        query=dags_with_recent_dag_runs_select,
         filters=[
             only_active,
             paused,

--- a/airflow/api_fastapi/core_api/routes/ui/dags.py
+++ b/airflow/api_fastapi/core_api/routes/ui/dags.py
@@ -103,7 +103,7 @@ def recent_dag_runs(
         .order_by(recent_runs_subquery.c.logical_date.desc())
     )
     dags_with_recent_dag_runs_select_filter, _ = paginated_select(
-        query=dags_with_recent_dag_runs_select,
+        statement=dags_with_recent_dag_runs_select,
         filters=[
             only_active,
             paused,

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -1448,7 +1448,7 @@ def get_query_count(query_stmt: Select, *, session: Session) -> int:
     return session.scalar(count_stmt)
 
 
-async def get_query_count_async(query: Select, *, session: AsyncSession) -> int:
+async def get_query_count_async(statement: Select, *, session: AsyncSession) -> int:
     """
     Get count of a query.
 
@@ -1459,7 +1459,7 @@ async def get_query_count_async(query: Select, *, session: AsyncSession) -> int:
 
     :meta private:
     """
-    count_stmt = select(func.count()).select_from(query.order_by(None).subquery())
+    count_stmt = select(func.count()).select_from(statement.order_by(None).subquery())
     return await session.scalar(count_stmt)
 
 


### PR DESCRIPTION
Previosly it was `base_select` then recently renamed to `select`.  `select` is not a great choice because it collides with the sqlalchemy function.  Query is a better name.

Also best to remove the "base" part of it because we tend to mutate it, making it not a "base" of anything.
