### PR TITLE
Handle XCom value errors in FAB's XCom list view

### DIFF
--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -765,10 +765,8 @@ class AirflowFilterConverter(fab_sqlafilters.SQLAFilterConverter):
         ),
         # FAB will try to create filters for extendedjson fields even though we
         # exclude them from all UI, so we add this here to make it ignore them.
-        (
-            "is_extendedjson",
-            [],
-        ),
+        ("is_extendedjson", []),
+        ("is_json", []),
         *fab_sqlafilters.SQLAFilterConverter.conversion_table,
     )
 
@@ -830,6 +828,17 @@ class CustomSQLAInterface(SQLAInterface):
                 isinstance(obj, ExtendedJSON)
                 or isinstance(obj, types.TypeDecorator)
                 and isinstance(obj.impl, ExtendedJSON)
+            )
+        return False
+
+    def is_json(self, col_name):
+        """Check if it is a JSON type."""
+        from sqlalchemy import JSON
+
+        if col_name in self.list_columns:
+            obj = self.list_columns[col_name].type
+            return (
+                isinstance(obj, JSON) or isinstance(obj, types.TypeDecorator) and isinstance(obj.impl, JSON)
             )
         return False
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3879,6 +3879,8 @@ class XComModelView(AirflowModelView):
         permissions.ACTION_CAN_ACCESS_MENU,
     ]
 
+    add_exclude_columns = edit_exclude_columns = ["value"]
+
     search_columns = ["key", "timestamp", "dag_id", "task_id", "run_id", "logical_date"]
     list_columns = ["key", "value", "timestamp", "dag_id", "task_id", "run_id", "map_index", "logical_date"]
     base_order = ("dag_run_id", "desc")


### PR DESCRIPTION
This commit improved handling of JSON columns in FAB. While we are removing FAB for 3.0, this error was bothering me in breeze :)

- Added code to correctly identify JSON columns to not add FAB filter for it.
- Excluded the `value` column from add/edit operations in `XComModelView` as XCom values are not meant to be modified directly via the UI.

Errors:

```
root@b16e4907c2ca:/opt/airflow# airflow webserver
  ____________       _____________
 ____    |__( )_________  __/__  /________      __
____  /| |_  /__  ___/_  /_ __  /_  __ \_ | /| / /
___  ___ |  / _  /   _  __/ _  / / /_/ /_ |/ |/ /
 _/_/  |_/_/  /_/    /_/    /_/  \____/____/|__/
Running the Gunicorn Server with:
Workers: 4 sync
Host: 0.0.0.0:8080
Timeout: 120
Logfiles: - -
Access Logformat:
=================================================================
/usr/local/lib/python3.9/site-packages/flask_limiter/extension.py:333 UserWarning: Using the in-memory storage for tracking rate limits as no storage was explicitly specified. This is not recommended for production use. See: https://flask-limiter.readthedocs.io#configuring-a-storage-backend for documentation about configuring the storage backend.
[2024-11-22T01:22:43.225+0000] {filters.py:117} WARNING - Filter type not supported for column: value
[2024-11-22T01:22:43.225+0000] {filters.py:117} WARNING - Filter type not supported for column: value
[2024-11-22T01:22:43.226+0000] {filters.py:117} WARNING - Filter type not supported for column: value
[2024-11-22T01:22:43.226+0000] {filters.py:117} WARNING - Filter type not supported for column: value
[2024-11-22T01:22:43.226+0000] {forms.py:107} ERROR - Column value Type not supported
[2024-11-22T01:22:43.226+0000] {forms.py:107} ERROR - Column value Type not supported
[2024-11-22T01:22:43.226+0000] {forms.py:107} ERROR - Column value Type not supported
[2024-11-22T01:22:43.226+0000] {forms.py:107} ERROR - Column value Type not supported
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
