### PR TITLE
[edge] Clean up of dead tasks in edge_jobs table 

### DIFF
--- a/providers/src/airflow/providers/edge/CHANGELOG.rst
+++ b/providers/src/airflow/providers/edge/CHANGELOG.rst
@@ -27,6 +27,14 @@
 Changelog
 ---------
 
+0.6.1pre0
+.........
+
+Misc
+~~~~
+
+* ``Update jobs or edge workers who have been killed to clean up job table.``
+
 0.6.0pre0
 .........
 

--- a/providers/src/airflow/providers/edge/__init__.py
+++ b/providers/src/airflow/providers/edge/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "0.6.0pre0"
+__version__ = "0.6.1pre0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.10.0"

--- a/providers/src/airflow/providers/edge/executors/edge_executor.py
+++ b/providers/src/airflow/providers/edge/executors/edge_executor.py
@@ -196,11 +196,10 @@ class EdgeExecutor(BaseExecutor):
     def sync(self, session: Session = NEW_SESSION) -> None:
         """Sync will get called periodically by the heartbeat method."""
         with Stats.timer("edge_executor.sync.duration"):
-            if (
-                self._purge_jobs(session)
-                or self._check_worker_liveness(session)
-                or self._update_orphaned_jobs(session)
-            ):
+            orphaned = self._update_orphaned_jobs(session)
+            purged = self._purge_jobs(session)
+            liveness = self._check_worker_liveness(session)
+            if purged or liveness or orphaned:
                 session.commit()
 
     def end(self) -> None:

--- a/providers/src/airflow/providers/edge/executors/edge_executor.py
+++ b/providers/src/airflow/providers/edge/executors/edge_executor.py
@@ -26,7 +26,7 @@ from airflow.cli.cli_config import GroupCommand
 from airflow.configuration import conf
 from airflow.executors.base_executor import BaseExecutor
 from airflow.models.abstractoperator import DEFAULT_QUEUE
-from airflow.models.taskinstance import TaskInstanceState
+from airflow.models.taskinstance import TaskInstance, TaskInstanceState
 from airflow.providers.edge.cli.edge_command import EDGE_COMMANDS
 from airflow.providers.edge.models.edge_job import EdgeJobModel
 from airflow.providers.edge.models.edge_logs import EdgeLogsModel
@@ -42,7 +42,6 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
     from airflow.executors.base_executor import CommandType
-    from airflow.models.taskinstance import TaskInstance
     from airflow.models.taskinstancekey import TaskInstanceKey
 
 PARALLELISM: int = conf.getint("core", "PARALLELISM")
@@ -108,6 +107,30 @@ class EdgeExecutor(BaseExecutor):
 
         return changed
 
+    def _update_orphaned_jobs(self, session: Session) -> bool:
+        """Update status ob jobs when workers die and don't update anymore."""
+        heartbeat_interval: int = conf.getint("scheduler", "scheduler_zombie_task_threshold")
+        lifeless_jobs: list[EdgeJobModel] = (
+            session.query(EdgeJobModel)
+            .filter(
+                EdgeJobModel.state == TaskInstanceState.RUNNING,
+                EdgeJobModel.last_update < (timezone.utcnow() - timedelta(seconds=heartbeat_interval)),
+            )
+            .all()
+        )
+
+        for job in lifeless_jobs:
+            ti = TaskInstance.get_task_instance(
+                dag_id=job.dag_id,
+                run_id=job.run_id,
+                task_id=job.task_id,
+                map_index=job.map_index,
+                session=session,
+            )
+            job.state = ti.state if ti else TaskInstanceState.REMOVED
+
+        return bool(lifeless_jobs)
+
     def _purge_jobs(self, session: Session) -> bool:
         """Clean finished jobs."""
         purged_marker = False
@@ -117,7 +140,12 @@ class EdgeExecutor(BaseExecutor):
             session.query(EdgeJobModel)
             .filter(
                 EdgeJobModel.state.in_(
-                    [TaskInstanceState.RUNNING, TaskInstanceState.SUCCESS, TaskInstanceState.FAILED]
+                    [
+                        TaskInstanceState.RUNNING,
+                        TaskInstanceState.SUCCESS,
+                        TaskInstanceState.FAILED,
+                        TaskInstanceState.REMOVED,
+                    ]
                 )
             )
             .all()
@@ -145,7 +173,7 @@ class EdgeExecutor(BaseExecutor):
                 job.state == TaskInstanceState.SUCCESS
                 and job.last_update_t < (datetime.now() - timedelta(minutes=job_success_purge)).timestamp()
             ) or (
-                job.state == TaskInstanceState.FAILED
+                job.state in (TaskInstanceState.FAILED, TaskInstanceState.REMOVED)
                 and job.last_update_t < (datetime.now() - timedelta(minutes=job_fail_purge)).timestamp()
             ):
                 if job.key in self.last_reported_state:
@@ -168,7 +196,11 @@ class EdgeExecutor(BaseExecutor):
     def sync(self, session: Session = NEW_SESSION) -> None:
         """Sync will get called periodically by the heartbeat method."""
         with Stats.timer("edge_executor.sync.duration"):
-            if self._purge_jobs(session) or self._check_worker_liveness(session):
+            if (
+                self._purge_jobs(session)
+                or self._check_worker_liveness(session)
+                or self._update_orphaned_jobs(session)
+            ):
                 session.commit()
 
     def end(self) -> None:

--- a/providers/src/airflow/providers/edge/provider.yaml
+++ b/providers/src/airflow/providers/edge/provider.yaml
@@ -27,7 +27,7 @@ source-date-epoch: 1729683247
 
 # note that those versions are maintained by release manager - do not update them manually
 versions:
-  - 0.6.0pre0
+  - 0.6.1pre0
 
 dependencies:
   - apache-airflow>=2.10.0

--- a/providers/tests/edge/executors/test_edge_executor.py
+++ b/providers/tests/edge/executors/test_edge_executor.py
@@ -66,29 +66,20 @@ class TestEdgeExecutor:
         assert jobs[0].run_id == "test_run"
         assert jobs[0].task_id == "test_task"
 
-    @patch("airflow.providers.edge.executors.edge_executor.EdgeExecutor.running_state")
-    @patch("airflow.providers.edge.executors.edge_executor.EdgeExecutor.success")
-    @patch("airflow.providers.edge.executors.edge_executor.EdgeExecutor.fail")
-    def test_sync(self, mock_fail, mock_success, mock_running_state):
+    def test_sync_orphaned_tasks(self):
         executor = EdgeExecutor()
 
-        def remove_from_running(key: TaskInstanceKey):
-            executor.running.remove(key)
+        delta_to_purge = timedelta(minutes=conf.getint("edge", "job_fail_purge") + 1)
+        delta_to_orphaned = timedelta(seconds=conf.getint("scheduler", "scheduler_zombie_task_threshold") + 1)
 
-        mock_success.side_effect = remove_from_running
-        mock_fail.side_effect = remove_from_running
-
-        smaler_job_failed_purge = timedelta(minutes=conf.getint("edge", "job_fail_purge") + 1)
-
-        # Prepare some data
         with create_session() as session:
             for task_id, state, last_update in [
                 (
                     "started_running_orphaned",
                     TaskInstanceState.RUNNING,
-                    timezone.utcnow() - smaler_job_failed_purge,
+                    timezone.utcnow() - delta_to_orphaned,
                 ),
-                ("started_removed", TaskInstanceState.REMOVED, timezone.utcnow() - smaler_job_failed_purge),
+                ("started_removed", TaskInstanceState.REMOVED, timezone.utcnow() - delta_to_purge),
             ]:
                 session.add(
                     EdgeJobModel(
@@ -109,14 +100,30 @@ class TestEdgeExecutor:
 
         with create_session() as session:
             jobs = session.query(EdgeJobModel).all()
-            assert len(jobs) == 0
+            assert len(jobs) == 1
+            assert jobs[0].task_id == "started_running_orphaned"
+            assert jobs[0].task_id == "started_running_orphaned"
+
+    @patch("airflow.providers.edge.executors.edge_executor.EdgeExecutor.running_state")
+    @patch("airflow.providers.edge.executors.edge_executor.EdgeExecutor.success")
+    @patch("airflow.providers.edge.executors.edge_executor.EdgeExecutor.fail")
+    def test_sync(self, mock_fail, mock_success, mock_running_state):
+        executor = EdgeExecutor()
+
+        def remove_from_running(key: TaskInstanceKey):
+            executor.running.remove(key)
+
+        mock_success.side_effect = remove_from_running
+        mock_fail.side_effect = remove_from_running
+
+        delta_to_purge = timedelta(minutes=conf.getint("edge", "job_fail_purge") + 1)
 
         # Prepare some data
         with create_session() as session:
             for task_id, state, last_update in [
                 ("started_running", TaskInstanceState.RUNNING, timezone.utcnow()),
-                ("started_success", TaskInstanceState.SUCCESS, timezone.utcnow() - smaler_job_failed_purge),
-                ("started_failed", TaskInstanceState.FAILED, timezone.utcnow() - smaler_job_failed_purge),
+                ("started_success", TaskInstanceState.SUCCESS, timezone.utcnow() - delta_to_purge),
+                ("started_failed", TaskInstanceState.FAILED, timezone.utcnow() - delta_to_purge),
             ]:
                 session.add(
                     EdgeJobModel(


### PR DESCRIPTION
# Description

This PR fixes the issue with dead edge jobs stay in edge_job table. If worker died or was not able to update the state of a job, the task will stay forever in the table. To fix this the job last_update will be checked with the SCHEDULER_ZOMBIE_TASK_THRESHOLD time to detect zombie task and state will be set to REMOVED. A job in state REMOVED will be deleted after job_fail_purge time archived

# Details about changes
* Detect orphaned tasks after SCHEDULER_ZOMBIE_TASK_THRESHOLD 
* Add REMOVED  job state
* Remove REMOVED state jobs after job_fail_purge  time.
* Adapt unit test