### PR TITLE
fix google datacatalog operator tests

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -655,7 +655,7 @@
       "google-cloud-build>=3.22.0",
       "google-cloud-compute>=1.10.0",
       "google-cloud-container>=2.17.4",
-      "google-cloud-datacatalog>=3.11.1",
+      "google-cloud-datacatalog>=3.23.0",
       "google-cloud-dataflow-client>=0.8.6",
       "google-cloud-dataform>=0.5.0",
       "google-cloud-dataplex>=1.10.0",

--- a/providers/src/airflow/providers/google/provider.yaml
+++ b/providers/src/airflow/providers/google/provider.yaml
@@ -125,7 +125,7 @@ dependencies:
   - google-cloud-build>=3.22.0
   - google-cloud-compute>=1.10.0
   - google-cloud-container>=2.17.4
-  - google-cloud-datacatalog>=3.11.1
+  - google-cloud-datacatalog>=3.23.0
   - google-cloud-dataflow-client>=0.8.6
   - google-cloud-dataform>=0.5.0
   - google-cloud-dataplex>=1.10.0

--- a/providers/tests/google/cloud/operators/test_datacatalog.py
+++ b/providers/tests/google/cloud/operators/test_datacatalog.py
@@ -102,9 +102,20 @@ TEST_ENTRY_DICT: dict = {
     "name": TEST_ENTRY_PATH,
 }
 TEST_ENTRY_GROUP: EntryGroup = EntryGroup(name=TEST_ENTRY_GROUP_PATH)
-TEST_ENTRY_GROUP_DICT: dict = {"description": "", "display_name": "", "name": TEST_ENTRY_GROUP_PATH}
+TEST_ENTRY_GROUP_DICT: dict = {
+    "description": "",
+    "display_name": "",
+    "name": TEST_ENTRY_GROUP_PATH,
+    "transferred_to_dataplex": False,
+}
 TEST_TAG: Tag = Tag(name=TEST_TAG_PATH)
-TEST_TAG_DICT: dict = {"fields": {}, "name": TEST_TAG_PATH, "template": "", "template_display_name": ""}
+TEST_TAG_DICT: dict = {
+    "fields": {},
+    "name": TEST_TAG_PATH,
+    "template": "",
+    "template_display_name": "",
+    "dataplex_transfer_status": 0,
+}
 TEST_TAG_TEMPLATE: TagTemplate = TagTemplate(name=TEST_TAG_TEMPLATE_PATH)
 TEST_TAG_TEMPLATE_DICT: dict = {
     "display_name": "",
@@ -172,6 +183,7 @@ class TestCloudDataCatalogCreateEntryOperator:
                 "project_id": TEST_PROJECT_ID,
             },
         )
+
         assert TEST_ENTRY_DICT == result
 
     @mock.patch("airflow.providers.google.cloud.operators.datacatalog.CloudDataCatalogHook")


### PR DESCRIPTION
GCP has released new version of google-cloud-datacatalog, it seems added extra attributes.

https://github.com/apache/airflow/actions/runs/11965065908/job/33364323283#step:11:5147
https://cloud.google.com/python/docs/reference/datacatalog/latest/changelog

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
