### PR TITLE
Bump Ruff to 0.8.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -360,7 +360,7 @@ repos:
         types_or: [python, pyi]
         args: [--fix]
         require_serial: true
-        additional_dependencies: ["ruff==0.7.3"]
+        additional_dependencies: ["ruff==0.8.0"]
         exclude: ^.*/.*_vendor/|^tests/dags/test_imports.py|^performance/tests/test_.*.py
       - id: ruff-format
         name: Run 'ruff format'
@@ -370,7 +370,7 @@ repos:
         types_or: [python, pyi]
         args: []
         require_serial: true
-        additional_dependencies: ["ruff==0.7.3"]
+        additional_dependencies: ["ruff==0.8.0"]
         exclude: ^.*/.*_vendor/|^tests/dags/test_imports.py$
       - id: replace-bad-characters
         name: Replace bad characters

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -116,7 +116,7 @@ if TYPE_CHECKING:
 
 # Todo: AIP-44: Once we get rid of AIP-44 we can remove this. But without this here pydantic fails to resolve
 # types for serialization
-from airflow.utils.task_group import TaskGroup  # noqa: TCH001
+from airflow.utils.task_group import TaskGroup  # noqa: TC001
 
 TaskPreExecuteHook = Callable[[Context], None]
 TaskPostExecuteHook = Callable[[Context, Any], None]

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -110,9 +110,9 @@ if TYPE_CHECKING:
 
     HAS_KUBERNETES: bool
     try:
-        from kubernetes.client import models as k8s  # noqa: TCH004
+        from kubernetes.client import models as k8s  # noqa: TC004
 
-        from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator  # noqa: TCH004
+        from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator  # noqa: TC004
     except ImportError:
         pass
 

--- a/dev/breeze/src/airflow_breeze/utils/console.py
+++ b/dev/breeze/src/airflow_breeze/utils/console.py
@@ -83,7 +83,7 @@ class Output(NamedTuple):
 
     @property
     def file(self) -> TextIO:
-        return open(self.file_name, "a+t")
+        return open(self.file_name, "a+")
 
     @property
     def escaped_title(self) -> str:

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -248,7 +248,7 @@ DEVEL_EXTRAS: dict[str, list[str]] = {
     ],
     "devel-static-checks": [
         "black>=23.12.0",
-        "ruff==0.7.3",
+        "ruff==0.8.0",
         "yamllint>=1.33.0",
     ],
     "devel-tests": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,7 +216,7 @@ extend-select = [
     "UP", # Pyupgrade
     "ASYNC", # subset of flake8-async rules
     "ISC",  # Checks for implicit literal string concatenation (auto-fixable)
-    "TCH", # Rules around TYPE_CHECKING blocks
+    "TC", # Rules around TYPE_CHECKING blocks
     "G", # flake8-logging-format rules
     "LOG", # flake8-logging rules, most of them autofixable
     "PT", # flake8-pytest-style rules
@@ -260,8 +260,7 @@ ignore = [
     "D203",
     "D212", # Conflicts with D213.  Both can not be enabled.
     "E731", # Do not assign a lambda expression, use a def
-    "TCH003", # Do not move imports from stdlib to TYPE_CHECKING block
-    "PT004", # Fixture does not return anything, add leading underscore
+    "TC003", # Do not move imports from stdlib to TYPE_CHECKING block
     "PT006", # Wrong type of names in @pytest.mark.parametrize
     "PT007", # Wrong type of values in @pytest.mark.parametrize
     "PT013", # silly rule prohibiting e.g. `from pytest import param`
@@ -313,8 +312,8 @@ section-order = [
 testing = ["dev", "providers.tests", "task_sdk.tests", "tests_common", "tests"]
 
 [tool.ruff.lint.extend-per-file-ignores]
-"airflow/__init__.py" = ["F401", "TCH004", "I002"]
-"airflow/models/__init__.py" = ["F401", "TCH004"]
+"airflow/__init__.py" = ["F401", "TC004", "I002"]
+"airflow/models/__init__.py" = ["F401", "TC004"]
 "airflow/models/sqla_models.py" = ["F401"]
 "providers/src/airflow/providers/__init__.py" = ["I002"]
 "providers/src/airflow/__init__.py" = ["I002"]
@@ -326,12 +325,12 @@ testing = ["dev", "providers.tests", "task_sdk.tests", "tests_common", "tests"]
 # The Pydantic representations of SqlAlchemy Models are not parsed well with Pydantic
 # when __future__.annotations is used so we need to skip them from upgrading
 # Pydantic also require models to be imported during execution
-"airflow/serialization/pydantic/*.py" = ["I002", "UP007", "TCH001"]
+"airflow/serialization/pydantic/*.py" = ["I002", "UP007", "TC001"]
 
 # Failing to detect types and functions used in `Annotated[...]` syntax as required at runtime.
 # Annotated is central for FastAPI dependency injection, skipping rules for FastAPI folders.
-"airflow/api_fastapi/*" = ["TCH001", "TCH002"]
-"tests/api_fastapi/*" = ["TCH001", "TCH002"]
+"airflow/api_fastapi/*" = ["TC001", "TC002"]
+"tests/api_fastapi/*" = ["T001", "TC002"]
 
 # Ignore pydoc style from these
 "*.pyi" = ["D"]

--- a/task_sdk/pyproject.toml
+++ b/task_sdk/pyproject.toml
@@ -62,11 +62,11 @@ namespace-packages = ["src/airflow"]
 # Pycharm barfs if this "stub" file has future imports
 "src/airflow/__init__.py" = ["I002"]
 
-"src/airflow/sdk/__init__.py" = ["TCH004"]
+"src/airflow/sdk/__init__.py" = ["TC004"]
 
 # msgspec needs types for annotations to be defined, even with future
 # annotations, so disable the "type check only import" for these files
-"src/airflow/sdk/api/datamodels/*.py" = ["TCH001"]
+"src/airflow/sdk/api/datamodels/*.py" = ["TC001"]
 
 # Only the public API should _require_ docstrings on classes
 "!src/airflow/sdk/definitions/*" = ["D101"]


### PR DESCRIPTION
[pypi.org/project/ruff/0.8.0](https://pypi.org/project/ruff/0.8.0/)

Hi! I just released Ruff 0.8.0. This release removes a few rules that had been deprecated for a few releases, so Ruff 0.8.0 would have started emitting warnings when linting trio due to the fact that you have some of these now-removed rules explicitly ignored in your Ruff config.

This PR gets rid of the removed rules from your Ruff config. There's also some additional changes made here; let me know if any of them are undesirable, and I can revert them:
- The `flake8-type-checking` rules have been recoded from `TCH` to `TC`; I updated `noqa` comments and configuration settings related to these so that they use the new error codes
- `dev/breeze/src/airflow_breeze/utils/console.py` was changed slightly due to autofix for UP015, which has been improved in the latest release

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
