### PR TITLE
Allow dropping `_xcom_archive` table via CLI

### DIFF
--- a/airflow/utils/db_cleanup.py
+++ b/airflow/utils/db_cleanup.py
@@ -53,6 +53,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 ARCHIVE_TABLE_PREFIX = "_airflow_deleted__"
+# Archived tables created by the DB migrations
+ARCHIVED_TABLES_FROM_DB_MIGRATIONS = [
+    "_xcom_archive"  # Table created by the migration AF 2 -> 3.0.0 when the XComs had pickled values
+]
 
 
 @dataclass
@@ -116,6 +120,7 @@ config_list: list[_TableConfig] = [
     _TableConfig(table_name="task_instance_history", recency_column_name="start_date"),
     _TableConfig(table_name="task_reschedule", recency_column_name="start_date"),
     _TableConfig(table_name="xcom", recency_column_name="timestamp"),
+    _TableConfig(table_name="_xcom_archive", recency_column_name="timestamp"),
     _TableConfig(table_name="callback_request", recency_column_name="created_at"),
     _TableConfig(table_name="celery_taskmeta", recency_column_name="date_done"),
     _TableConfig(table_name="celery_tasksetmeta", recency_column_name="date_done"),
@@ -380,13 +385,20 @@ def _effective_table_names(*, table_names: list[str] | None) -> tuple[set[str], 
 
 def _get_archived_table_names(table_names: list[str] | None, session: Session) -> list[str]:
     inspector = inspect(session.bind)
-    db_table_names = [x for x in inspector.get_table_names() if x.startswith(ARCHIVE_TABLE_PREFIX)]
+    db_table_names = [
+        x
+        for x in inspector.get_table_names()
+        if x.startswith(ARCHIVE_TABLE_PREFIX) or x in ARCHIVED_TABLES_FROM_DB_MIGRATIONS
+    ]
     effective_table_names, _ = _effective_table_names(table_names=table_names)
     # Filter out tables that don't start with the archive prefix
     archived_table_names = [
         table_name
         for table_name in db_table_names
-        if any("__" + x + "__" in table_name for x in effective_table_names)
+        if (
+            any("__" + x + "__" in table_name for x in effective_table_names)
+            or table_name in ARCHIVED_TABLES_FROM_DB_MIGRATIONS
+        )
     ]
     return archived_table_names
 

--- a/airflow/utils/db_cleanup.py
+++ b/airflow/utils/db_cleanup.py
@@ -53,9 +53,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 ARCHIVE_TABLE_PREFIX = "_airflow_deleted__"
-# Archived tables created by the DB migrations
+# Archived tables created by DB migrations
 ARCHIVED_TABLES_FROM_DB_MIGRATIONS = [
-    "_xcom_archive"  # Table created by the migration AF 2 -> 3.0.0 when the XComs had pickled values
+    "_xcom_archive"  # Table created by the AF 2 -> 3.0.0 migration when the XComs had pickled values
 ]
 
 

--- a/newsfragments/aip-72.significant.rst
+++ b/newsfragments/aip-72.significant.rst
@@ -30,4 +30,8 @@ As part of this change the following breaking changes have occurred:
 
   The ``value`` field in the XCom table has been changed to a ``JSON`` type via DB migration. The XCom records that
   contains pickled data are archived in the ``_xcom_archive`` table. You can safely drop this table if you don't need
-  the data anymore.
+  the data anymore. To drop the table, you can use the following command or manually drop the table from the database.
+
+  .. code-block:: bash
+
+      airflow db drop-archived -t "_xcom_archive"


### PR DESCRIPTION
This tables was created to not cause data loss (in https://github.com/apache/airflow/pull/44166) when upgrading from AF 2 to AF 3 if a user had pickled values in XCom table.

- Introduced `ARCHIVED_TABLES_FROM_DB_MIGRATIONS` to track tables created during database migrations, such as `_xcom_archive`.
- Added `_xcom_archive` to the db cleanup `config_list` for handling its records based on `timestamp`.
- Add support in `airflow db drop-archived` to drop `_xcom_archive`.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
