### PR TITLE
Fix the Show Down text

### DIFF
--- a/providers/src/airflow/providers/edge/cli/edge_command.py
+++ b/providers/src/airflow/providers/edge/cli/edge_command.py
@@ -156,7 +156,7 @@ class _EdgeWorkerCli:
 
     @staticmethod
     def signal_handler(sig, frame):
-        logger.info("Request to show down Edge Worker received, waiting for jobs to complete.")
+        logger.info("Request to shut down Edge Worker received, waiting for jobs to complete.")
         _EdgeWorkerCli.drain = True
 
     def shutdown_handler(self, sig, frame):

--- a/providers/src/airflow/providers/edge/models/edge_worker.py
+++ b/providers/src/airflow/providers/edge/models/edge_worker.py
@@ -62,7 +62,7 @@ class EdgeWorkerState(str, Enum):
     TERMINATING = "terminating"
     """Edge Worker is completing work and stopping."""
     OFFLINE = "offline"
-    """Edge Worker was show down."""
+    """Edge Worker was shut down."""
     UNKNOWN = "unknown"
     """No heartbeat signal from worker for some time, Edge Worker probably down."""
 


### PR DESCRIPTION
I needed to smile a bit when I was re-working the API and realized that the edge worker is involved in a "show down". Nice typo. But "Shut down" is correct.