### PR TITLE
Replace `breeze testing tests` command in a few places remaining

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1080,7 +1080,7 @@ function check_run_tests() {
     if [[ ${REMOVE_ARM_PACKAGES:="false"} == "true" ]]; then
         # Test what happens if we do not have ARM packages installed.
         # This is useful to see if pytest collection works without ARM packages which is important
-        # for the MacOS M1 users running tests in their ARM machines with `breeze testing tests` command
+        # for the MacOS M1 users running tests in their ARM machines with `breeze testing *-tests` command
         python "${IN_CONTAINER_DIR}/remove_arm_packages.py"
     fi
 

--- a/contributing-docs/05_pull_requests.rst
+++ b/contributing-docs/05_pull_requests.rst
@@ -88,7 +88,8 @@ these guidelines:
     to the changed code (for example for ``airflow/cli/cli_parser.py`` changes you have tests in
     ``tests/cli/test_cli_parser.py``). However there are a number of cases where the tests that should run
     are placed elsewhere - you can either run tests for the whole ``TEST_TYPE`` that is relevant (see
-    ``breeze testing tests --help`` output for available test types) or you can run all tests, or eventually
+    ``breeze testing core-tests --help`` or ``breeze testing providers-tests --help`` output for
+    available test types for each of the testing commands) or you can run all tests, or eventually
     you can push your code to PR and see results of the tests in the CI.
 
 -   You can use any supported python version to run the tests, but the best is to check

--- a/dev/breeze/doc/03_developer_tasks.rst
+++ b/dev/breeze/doc/03_developer_tasks.rst
@@ -419,7 +419,7 @@ are several reasons why you might want to do that.
 
 Breeze uses docker images heavily and those images are rebuild periodically and might leave dangling, unused
 images in docker cache. This might cause extra disk usage. Also running various docker compose commands
-(for example running tests with ``breeze testing tests``) might create additional docker networks that might
+(for example running tests with ``breeze testing core-tests``) might create additional docker networks that might
 prevent new networks from being created. Those networks are not removed automatically by docker-compose.
 Also Breeze uses it's own cache to keep information about all images.
 

--- a/dev/breeze/doc/05_test_commands.rst
+++ b/dev/breeze/doc/05_test_commands.rst
@@ -106,9 +106,9 @@ For example this will run API and WWW tests in parallel:
 
 .. code-block:: bash
 
-    breeze testing tests --parallel-test-types "API WWW" --run-in-parallel
+    breeze testing core-tests --parallel-test-types "API WWW" --run-in-parallel
 
-Here is the detailed set of options for the ``breeze testing tests`` command.
+Here is the detailed set of options for the ``breeze testing core-tests`` command.
 
 .. image:: ./images/output_testing_core-tests.svg
   :target: https://raw.githubusercontent.com/apache/airflow/main/dev/breeze/images/output_testing_core-tests.svg
@@ -143,11 +143,11 @@ You can also run parallel tests with ``--run-in-parallel`` flag - by default it 
 in parallel, but you can specify the test type that you want to run with space separated list of test
 types passed to ``--parallel-test-types`` flag.
 
-For example this will run API and WWW tests in parallel:
+For example this will run ``amazon`` and ``google`` tests in parallel:
 
 .. code-block:: bash
 
-    breeze testing tests --parallel-test-types "Providers[amazon] Providers[google]" --run-in-parallel
+    breeze testing providers-tests --parallel-test-types "Providers[amazon] Providers[google]" --run-in-parallel
 
 Here is the detailed set of options for the ``breeze testing providers-test`` command.
 

--- a/scripts/docker/entrypoint_ci.sh
+++ b/scripts/docker/entrypoint_ci.sh
@@ -316,7 +316,7 @@ function check_run_tests() {
     if [[ ${REMOVE_ARM_PACKAGES:="false"} == "true" ]]; then
         # Test what happens if we do not have ARM packages installed.
         # This is useful to see if pytest collection works without ARM packages which is important
-        # for the MacOS M1 users running tests in their ARM machines with `breeze testing tests` command
+        # for the MacOS M1 users running tests in their ARM machines with `breeze testing *-tests` command
         python "${IN_CONTAINER_DIR}/remove_arm_packages.py"
     fi
 


### PR DESCRIPTION
Follow up after #43979 to remove a few remaining places where old `breeze testing tests` command was used.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
