### PR TITLE
rename run_id to dag_run_id in DagRun response

### DIFF
--- a/airflow/api_fastapi/core_api/datamodels/dag_run.py
+++ b/airflow/api_fastapi/core_api/datamodels/dag_run.py
@@ -51,7 +51,7 @@ class DAGRunClearBody(BaseModel):
 class DAGRunResponse(BaseModel):
     """DAG Run serializer for responses."""
 
-    dag_run_id: str | None = Field(alias="run_id")
+    dag_run_id: str | None = Field(validation_alias="run_id")
     dag_id: str
     logical_date: datetime | None
     queued_at: datetime | None

--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -5959,11 +5959,11 @@ components:
       description: Enum for DAG Run states when updating a DAG Run.
     DAGRunResponse:
       properties:
-        run_id:
+        dag_run_id:
           anyOf:
           - type: string
           - type: 'null'
-          title: Run Id
+          title: Dag Run Id
         dag_id:
           type: string
           title: Dag Id
@@ -6028,7 +6028,7 @@ components:
           title: Note
       type: object
       required:
-      - run_id
+      - dag_run_id
       - dag_id
       - logical_date
       - queued_at

--- a/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -1670,7 +1670,7 @@ export const $DAGRunPatchStates = {
 
 export const $DAGRunResponse = {
   properties: {
-    run_id: {
+    dag_run_id: {
       anyOf: [
         {
           type: "string",
@@ -1679,7 +1679,7 @@ export const $DAGRunResponse = {
           type: "null",
         },
       ],
-      title: "Run Id",
+      title: "Dag Run Id",
     },
     dag_id: {
       type: "string",
@@ -1800,7 +1800,7 @@ export const $DAGRunResponse = {
   },
   type: "object",
   required: [
-    "run_id",
+    "dag_run_id",
     "dag_id",
     "logical_date",
     "queued_at",

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -384,7 +384,7 @@ export type DAGRunPatchStates = "queued" | "success" | "failed";
  * DAG Run serializer for responses.
  */
 export type DAGRunResponse = {
-  run_id: string | null;
+  dag_run_id: string | null;
   dag_id: string;
   logical_date: string | null;
   queued_at: string | null;

--- a/airflow/ui/src/pages/DagsList/RecentRuns.tsx
+++ b/airflow/ui/src/pages/DagsList/RecentRuns.tsx
@@ -63,7 +63,7 @@ export const RecentRuns = ({
               <Text>Duration: {run.duration.toFixed(2)}s</Text>
             </Box>
           }
-          key={run.run_id}
+          key={run.dag_run_id}
           positioning={{
             offset: {
               crossAxis: 5,

--- a/tests/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/tests/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -147,7 +147,7 @@ class TestGetDagRun:
         assert response.status_code == 200
         body = response.json()
         assert body["dag_id"] == dag_id
-        assert body["run_id"] == run_id
+        assert body["dag_run_id"] == run_id
         assert body["state"] == state
         assert body["run_type"] == run_type
         assert body["triggered_by"] == triggered_by.value
@@ -168,7 +168,7 @@ class TestGetDagRuns:
     @staticmethod
     def get_dag_run_dict(run: DagRun):
         return {
-            "run_id": run.run_id,
+            "dag_run_id": run.run_id,
             "dag_id": run.dag_id,
             "logical_date": TestGetDagRuns.parse_datetime(run.logical_date),
             "queued_at": TestGetDagRuns.parse_datetime(run.queued_at),
@@ -194,7 +194,7 @@ class TestGetDagRuns:
         for each in body["dag_runs"]:
             run = (
                 session.query(DagRun)
-                .where(DagRun.dag_id == each["dag_id"], DagRun.run_id == each["run_id"])
+                .where(DagRun.dag_id == each["dag_id"], DagRun.run_id == each["dag_run_id"])
                 .one()
             )
             expected = self.get_dag_run_dict(run)
@@ -235,7 +235,7 @@ class TestGetDagRuns:
         assert response.status_code == 200
         body = response.json()
         assert body["total_entries"] == 2
-        assert [each["run_id"] for each in body["dag_runs"]] == expected_dag_id_order
+        assert [each["dag_run_id"] for each in body["dag_runs"]] == expected_dag_id_order
 
     @pytest.mark.parametrize(
         "query_params, expected_dag_id_order",
@@ -254,7 +254,7 @@ class TestGetDagRuns:
         assert response.status_code == 200
         body = response.json()
         assert body["total_entries"] == 2
-        assert [each["run_id"] for each in body["dag_runs"]] == expected_dag_id_order
+        assert [each["dag_run_id"] for each in body["dag_runs"]] == expected_dag_id_order
 
     @pytest.mark.parametrize(
         "query_params, expected_detail",
@@ -364,7 +364,7 @@ class TestGetDagRuns:
         response = test_client.get(f"/public/dags/{dag_id}/dagRuns", params=query_params)
         assert response.status_code == 200
         body = response.json()
-        assert [each["run_id"] for each in body["dag_runs"]] == expected_dag_id_list
+        assert [each["dag_run_id"] for each in body["dag_runs"]] == expected_dag_id_list
 
     def test_bad_filters(self, test_client):
         query_params = {
@@ -474,7 +474,7 @@ class TestPatchDagRun:
         assert response.status_code == 200
         body = response.json()
         assert body["dag_id"] == dag_id
-        assert body["run_id"] == run_id
+        assert body["dag_run_id"] == run_id
         assert body.get("state") == response_body.get("state")
         assert body.get("note") == response_body.get("note")
 
@@ -623,7 +623,7 @@ class TestClearDagRun:
         assert response.status_code == 200
         body = response.json()
         assert body["dag_id"] == DAG1_ID
-        assert body["run_id"] == DAG1_RUN1_ID
+        assert body["dag_run_id"] == DAG1_RUN1_ID
         assert body["state"] == "queued"
 
     @pytest.mark.parametrize(

--- a/tests/api_fastapi/core_api/routes/ui/test_dags.py
+++ b/tests/api_fastapi/core_api/routes/ui/test_dags.py
@@ -85,7 +85,7 @@ class TestRecentDagRuns(TestPublicDagEndpoint):
         assert response.status_code == 200
         body = response.json()
         required_dag_run_key = [
-            "run_id",
+            "dag_run_id",
             "dag_id",
             "state",
             "logical_date",


### PR DESCRIPTION
in my earlier [PR](https://github.com/apache/airflow/pull/42725/files#diff-a3a4378dfd0695c86020c63561b8d60020db031668608e8a644e272eaa5db047), I made a mistake by alias instead of validation_alias. which resulted in returning `run_id` instead of `dag_run_id` as per legacy implementation. This PR fixes it.