### PR TITLE
[refactor] remove logical_date_field_name parametrization in TestPostDagRun.test_should_respond_200

### DIFF
--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -1079,7 +1079,6 @@ class TestGetDagRunBatchDateFilters(TestDagRunEndpoint):
 
 class TestPostDagRun(TestDagRunEndpoint):
     @time_machine.travel(timezone.utcnow(), tick=False)
-    @pytest.mark.parametrize("logical_date_field_name", ["logical_date"])
     @pytest.mark.parametrize(
         "dag_run_id, logical_date, note, data_interval_start, data_interval_end",
         [
@@ -1101,7 +1100,6 @@ class TestPostDagRun(TestDagRunEndpoint):
     def test_should_respond_200(
         self,
         session,
-        logical_date_field_name,
         dag_run_id,
         logical_date,
         note,
@@ -1117,7 +1115,7 @@ class TestPostDagRun(TestDagRunEndpoint):
 
         request_json = {}
         if logical_date is not None:
-            request_json[logical_date_field_name] = logical_date
+            request_json["logical_date"] = logical_date
         if dag_run_id is not None:
             request_json["dag_run_id"] = dag_run_id
         if data_interval_start is not None:


### PR DESCRIPTION
removing `logical_date_field_name` parametrization as `execution_date` has been removed and now, its just "logical_date"