### PR TITLE
fix mypy failure due to termcolor upgrade

### DIFF
--- a/airflow/cli/commands/standalone_command.py
+++ b/airflow/cli/commands/standalone_command.py
@@ -143,14 +143,14 @@ class StandaloneCommand:
 
         You can pass multiple lines to output if you wish; it will be split for you.
         """
-        color: Color = {
+        color: dict[str, Color] = {
             "fastapi-api": "magenta",
             "webserver": "green",
             "scheduler": "blue",
             "triggerer": "cyan",
             "standalone": "white",
-        }.get(name, "white")
-        colorised_name = colored(f"{name:10}", color)
+        }
+        colorised_name = colored(f"{name:10}", color.get(name, "white"))
         for line in output.splitlines():
             print(f"{colorised_name} | {line.strip()}")
 

--- a/airflow/cli/commands/standalone_command.py
+++ b/airflow/cli/commands/standalone_command.py
@@ -37,6 +37,8 @@ from airflow.utils import db
 from airflow.utils.providers_configuration_loader import providers_configuration_loaded
 
 if TYPE_CHECKING:
+    from termcolor.termcolor import Color
+
     from airflow.jobs.base_job_runner import BaseJobRunner
 
 
@@ -141,7 +143,7 @@ class StandaloneCommand:
 
         You can pass multiple lines to output if you wish; it will be split for you.
         """
-        color = {
+        color: Color = {
             "fastapi-api": "magenta",
             "webserver": "green",
             "scheduler": "blue",


### PR DESCRIPTION
[PR](https://github.com/apache/airflow/actions/runs/11989299333/job/33425681929?pr=44312) 
 static check failed with following error

```

airflow/cli/commands/standalone_command.py:151: error: Argument 2 to "colored"
has incompatible type "str"; expected
"Optional[Literal['black', 'grey', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'light_grey', 'dark_grey', 'light_red', 'light_green', 'light_yellow', 'light_blue', 'light_magenta', 'light_cyan', 'white']]"
 [arg-type]
            colorised_name = colored(f"{name:10}", color)
```

This fixes it