### PR TITLE
Fix edge in rare conditions that task state can not be reported as cleaned in parallel

### DIFF
--- a/providers/src/airflow/providers/edge/CHANGELOG.rst
+++ b/providers/src/airflow/providers/edge/CHANGELOG.rst
@@ -27,6 +27,14 @@
 Changelog
 ---------
 
+0.6.2pre0
+.........
+
+Misc
+~~~~
+
+* ``Fix race that reporting status fails if the task has been cleaned in parallel.``
+
 0.6.1pre0
 .........
 

--- a/providers/src/airflow/providers/edge/__init__.py
+++ b/providers/src/airflow/providers/edge/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "0.6.1pre0"
+__version__ = "0.6.2pre0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.10.0"

--- a/providers/src/airflow/providers/edge/models/edge_job.py
+++ b/providers/src/airflow/providers/edge/models/edge_job.py
@@ -172,9 +172,10 @@ class EdgeJob(BaseModel, LoggingMixin):
             EdgeJobModel.try_number == task.try_number,
         )
         job: EdgeJobModel = session.scalar(query)
-        job.state = state
-        job.last_update = timezone.utcnow()
-        session.commit()
+        if job:
+            job.state = state
+            job.last_update = timezone.utcnow()
+            session.commit()
 
     def __hash__(self):
         return f"{self.dag_id}|{self.task_id}|{self.run_id}|{self.map_index}|{self.try_number}".__hash__()

--- a/providers/src/airflow/providers/edge/provider.yaml
+++ b/providers/src/airflow/providers/edge/provider.yaml
@@ -27,7 +27,7 @@ source-date-epoch: 1729683247
 
 # note that those versions are maintained by release manager - do not update them manually
 versions:
-  - 0.6.1pre0
+  - 0.6.2pre0
 
 dependencies:
   - apache-airflow>=2.10.0


### PR DESCRIPTION
With 0.6.1 a cleanup of orphan tasks has been added. I have seen a race in my testing that if the task is already acknowledged and the purging is running ... and in parallel the edge worker attempts to report state that the task/job is gone.
This small fix prevents the failure when the task is gone in the central table already,