### PR TITLE
Add copy-pasteable cherry-picker command if it fails to cherry-pick

### DIFF
--- a/dev/backport/update_backport_status.py
+++ b/dev/backport/update_backport_status.py
@@ -52,7 +52,23 @@ def get_failure_comment(branch: str, commit_sha_url: str, commit_sha: str):
                 <td>{branch}</td>
                 <td><a href="{commit_sha_url}"><img src='{commit_shield_url}' alt='Commit Link'></a></td>
             </tr>
-        </table>"""
+        </table>
+
+        You can attempt to backport this manually by running:
+
+        ```bash
+        cherry_picker {commit_sha[:7]} {branch}
+        ```
+
+        This should apply the commit to the {branch} branch and leave the commit in conflict state marking
+        the files that need manual conflict resolution.
+
+        After you have resolved the conflicts, you can continue the backport process by running:
+
+        ```bash
+        cherry_picker --continue
+        ```
+"""
     return comment
 
 


### PR DESCRIPTION
When cherry-picker fails to backport a PR it adds a message to the PR explaining the failure and linking to the commit. This PR also adds a copy&pasteable cherry-picker command that the maintainer should run to retry it locally. It also explains what maintainer should do after solving the conflicts.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
