### PR TITLE
Add fail_on_file_not_exist option to SFTPToS3Operator

### DIFF
--- a/providers/src/airflow/providers/amazon/aws/transfers/sftp_to_s3.py
+++ b/providers/src/airflow/providers/amazon/aws/transfers/sftp_to_s3.py
@@ -94,9 +94,8 @@ class SFTPToS3Operator(BaseOperator):
         except FileNotFoundError:
             if self.fail_on_file_not_exist:
                 raise
-            else:
-                self.log.info("File %s not found on SFTP server. Skipping transfer.", self.sftp_path)
-                return
+            self.log.info("File %s not found on SFTP server. Skipping transfer.", self.sftp_path)
+            return
 
         if self.use_temp_file:
             with NamedTemporaryFile("w") as f:

--- a/providers/src/airflow/providers/amazon/aws/transfers/sftp_to_s3.py
+++ b/providers/src/airflow/providers/amazon/aws/transfers/sftp_to_s3.py
@@ -49,6 +49,8 @@ class SFTPToS3Operator(BaseOperator):
         uploading the file to S3.
     :param use_temp_file: If True, copies file first to local,
         if False streams file from SFTP to S3.
+    :param fail_on_file_not_exist: If True, operator fails when file does not exist,
+        if False, operator will not fail and skips transfer. Default is True.
     """
 
     template_fields: Sequence[str] = ("s3_key", "sftp_path", "s3_bucket")
@@ -62,6 +64,7 @@ class SFTPToS3Operator(BaseOperator):
         sftp_conn_id: str = "ssh_default",
         s3_conn_id: str = "aws_default",
         use_temp_file: bool = True,
+        fail_on_file_not_exist: bool = True,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -71,6 +74,7 @@ class SFTPToS3Operator(BaseOperator):
         self.s3_key = s3_key
         self.s3_conn_id = s3_conn_id
         self.use_temp_file = use_temp_file
+        self.fail_on_file_not_exist = fail_on_file_not_exist
 
     @staticmethod
     def get_s3_key(s3_key: str) -> str:
@@ -84,6 +88,15 @@ class SFTPToS3Operator(BaseOperator):
         s3_hook = S3Hook(self.s3_conn_id)
 
         sftp_client = ssh_hook.get_conn().open_sftp()
+
+        try:
+            sftp_client.stat(self.sftp_path)
+        except FileNotFoundError:
+            if self.fail_on_file_not_exist:
+                raise
+            else:
+                self.log.info("File %s not found on SFTP server. Skipping transfer.", self.sftp_path)
+                return
 
         if self.use_temp_file:
             with NamedTemporaryFile("w") as f:

--- a/providers/tests/amazon/aws/transfers/test_sftp_to_s3.py
+++ b/providers/tests/amazon/aws/transfers/test_sftp_to_s3.py
@@ -135,7 +135,7 @@ class TestSFTPToS3Operator:
                 SFTPToS3Operator(
                     s3_bucket=self.s3_bucket,
                     s3_key=self.s3_key,
-                    sftp_path=self.sftp_path,
+                    sftp_path="/tmp/wrong_path.txt",
                     sftp_conn_id=SFTP_CONN_ID,
                     s3_conn_id=S3_CONN_ID,
                     fail_on_file_not_exist=fail_on_file_not_exist,
@@ -154,5 +154,6 @@ class TestSFTPToS3Operator:
                 dag=self.dag,
             ).execute(None)
 
+        conn.delete_object(Bucket=self.s3_bucket, Key=self.s3_key)
         conn.delete_bucket(Bucket=self.s3_bucket)
         assert not s3_hook.check_for_bucket(self.s3_bucket)

--- a/providers/tests/amazon/aws/transfers/test_sftp_to_s3.py
+++ b/providers/tests/amazon/aws/transfers/test_sftp_to_s3.py
@@ -120,3 +120,39 @@ class TestSFTPToS3Operator:
         conn.delete_object(Bucket=self.s3_bucket, Key=self.s3_key)
         conn.delete_bucket(Bucket=self.s3_bucket)
         assert not s3_hook.check_for_bucket(self.s3_bucket)
+
+    @pytest.mark.parametrize("fail_on_file_not_exist", [True, False])
+    @mock_aws
+    @conf_vars({("core", "enable_xcom_pickling"): "True"})
+    def test_sftp_to_s3_fail_on_file_not_exist(self, fail_on_file_not_exist):
+        s3_hook = S3Hook(aws_conn_id=None)
+        conn = boto3.client("s3")
+        conn.create_bucket(Bucket=self.s3_bucket)
+        assert s3_hook.check_for_bucket(self.s3_bucket)
+
+        if fail_on_file_not_exist:
+            with pytest.raises(FileNotFoundError):
+                SFTPToS3Operator(
+                    s3_bucket=self.s3_bucket,
+                    s3_key=self.s3_key,
+                    sftp_path=self.sftp_path,
+                    sftp_conn_id=SFTP_CONN_ID,
+                    s3_conn_id=S3_CONN_ID,
+                    fail_on_file_not_exist=fail_on_file_not_exist,
+                    task_id="test_sftp_to_s3",
+                    dag=self.dag,
+                ).execute(None)
+        else:
+            SFTPToS3Operator(
+                s3_bucket=self.s3_bucket,
+                s3_key=self.s3_key,
+                sftp_path=self.sftp_path,
+                sftp_conn_id=SFTP_CONN_ID,
+                s3_conn_id=S3_CONN_ID,
+                fail_on_file_not_exist=fail_on_file_not_exist,
+                task_id="test_sftp_to_s3",
+                dag=self.dag,
+            ).execute(None)
+
+        conn.delete_bucket(Bucket=self.s3_bucket)
+        assert not s3_hook.check_for_bucket(self.s3_bucket)


### PR DESCRIPTION
Fixes: https://github.com/apache/airflow/issues/40576

I added `fail_on_file_not_exist` param to `SFTPToS3Operator` so that user can configure the parameter and operator will not fail in case of sftp file not exist.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).

----

Here's the test result ran in my local environment.
<img width="1718" alt="sftp_to_s3_test_local" src="https://github.com/user-attachments/assets/b10d30d8-7fd0-4a46-9697-3a2f1847ce8c">
you can see the dag does not fail with `fail_on_file_not_exist` but still shows logs that the file does not exist.

sftp_to_s3_dag.py
```python
from airflow import DAG
from airflow.providers.amazon.aws.transfers.sftp_to_s3 import SFTPToS3Operator
from datetime import datetime, timedelta

default_args = {
    "owner": "airflow",
    "retries": 1,
    "retry_delay": timedelta(minutes=1),
}

with DAG(
    dag_id="sftp_to_s3_example",
    default_args=default_args,
    description="Transfer a file from SFTP to S3",
    schedule_interval=None,
    start_date=datetime(2023, 1, 1),
    catchup=False,
    tags=["example", "sftp", "s3"],
) as dag:
    transfer_file = SFTPToS3Operator(
        task_id="transfer_file",
        sftp_conn_id="sftp_default",
        sftp_path="/Users/john/test.mv.dba", 
        s3_conn_id="aws_conn",
        s3_bucket="airflow",
        s3_key="test/test.mv.db",
        fail_on_file_not_exist=False,
    )
```
