### PR TITLE
AIP-84 Refactor Handling of Insert Duplicates

### DIFF
--- a/airflow/api_fastapi/common/exceptions.py
+++ b/airflow/api_fastapi/common/exceptions.py
@@ -18,12 +18,17 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar
+from enum import Enum
+from typing import Generic, NamedTuple, TypeVar
 
+import re2 as re
 from fastapi import HTTPException, Request, status
 from sqlalchemy.exc import IntegrityError
 
 T = TypeVar("T", bound=Exception)
+
+_ColumnsType = dict[str, str]
+# Key: column name, Value: column value
 
 
 class BaseErrorHandler(Generic[T], ABC):
@@ -38,25 +43,123 @@ class BaseErrorHandler(Generic[T], ABC):
         raise NotImplementedError
 
 
+class _DatabaseDialect(Enum):
+    SQLITE = "sqlite"
+    MYSQL = "mysql"
+    POSTGRESQL = "postgresql"
+
+
+def _get_columns_dict_from_params_statement(params: tuple, statement: str) -> _ColumnsType:
+    """Transform parameters and statement into a dictionary where the keys are column names, and the values are column values."""
+    column_names = statement.split("(")[1].split(")")[0].split(",")
+    column_names = [column_name.strip() for column_name in column_names]
+    return {column_name: param for column_name, param in zip(column_names, params)}
+
+
 class _UniqueConstraintErrorHandler(BaseErrorHandler[IntegrityError]):
     """Exception raised when trying to insert a duplicate value in a unique column."""
 
+    class UniqueConstraintViolationDetail(NamedTuple):
+        table_name: str | None = None
+        column_name: str | None = None
+        column_value: str | None = None
+        parsed_error: bool = False
+
     def __init__(self):
         super().__init__(IntegrityError)
-        self.unique_constraint_error_messages = [
-            "UNIQUE constraint failed",  # SQLite
-            "Duplicate entry",  # MySQL
-            "violates unique constraint",  # PostgreSQL
-        ]
+        self.response_error_format = (
+            "Unique constraint violation: {table_name} with {column_name}={column_value} already exists"
+        )
+        self.unique_constraint_error_messages: dict[str, str] = {
+            _DatabaseDialect.SQLITE: "UNIQUE constraint failed",
+            _DatabaseDialect.MYSQL: "Duplicate entry",
+            _DatabaseDialect.POSTGRESQL: "violates unique constraint",
+        }
+        self.dialect: _DatabaseDialect.value | None = None
 
     def exception_handler(self, request: Request, exc: IntegrityError):
         """Handle IntegrityError exception."""
-        exc_orig_str = str(exc.orig)
-        if any(error_msg in exc_orig_str for error_msg in self.unique_constraint_error_messages):
+        if self._is_dialect_matched(exc):
+            error_detail = self._parse_error_message(exc)
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
-                detail="Unique constraint violation",
+                detail=self.response_error_format.format(
+                    table_name=error_detail.table_name,
+                    column_name=error_detail.column_name,
+                    column_value=error_detail.column_value,
+                )
+                if not error_detail.parsed_error
+                else f"Unique constraint violation: {str(exc.orig)}",
             )
+
+    def _is_dialect_matched(self, exc: IntegrityError) -> bool:
+        """Check if the exception matches the unique constraint error message for any dialect."""
+        exc_orig_str = str(exc.orig)
+        for dialect, error_msg in self.unique_constraint_error_messages.items():
+            if error_msg in exc_orig_str:
+                self.dialect = dialect
+                return True
+        return False
+
+    def _parse_error_message(self, exc: IntegrityError) -> UniqueConstraintViolationDetail:
+        """Parse the error message to extract the table name, column name and value."""
+        str_exc_orig = str(exc.orig)
+        table_name: None | str = None
+        error_column_name: None | str = None
+        column_value: None | str = None
+
+        if self.dialect is _DatabaseDialect.SQLITE:
+            # 'UNIQUE constraint failed: {table_name}.{column_name}'
+            table_name, error_column_name = str_exc_orig.split(":")[1].split(".")
+            table_name = table_name.strip()
+            error_column_name = error_column_name.strip()
+            column_value = _get_columns_dict_from_params_statement(exc.params, exc.statement)[
+                error_column_name
+            ]
+
+        if self.dialect is _DatabaseDialect.MYSQL:
+            # "Duplicate entry '{column_value}' for key '{table_name}.{table_name}_{column_name}_uq'"
+            pattern = re.compile(
+                r"Duplicate entry '(?P<column_value>.*)' for key '(?P<table_name>.*)\.(?P<constraint_name>.*)'"
+            )
+            match = pattern.search(str_exc_orig)
+            constraint_name = None
+            if match:
+                table_name = match.group("table_name")
+                column_value = match.group("column_value")
+                constraint_name = match.group("constraint_name")
+            # extract column_name from the constraint name
+            column_pattern = re.compile(rf"{table_name}_(?P<column_name>.*)_uq")
+            match = column_pattern.search(constraint_name)
+            if match:
+                error_column_name = match.group("column_name")
+
+        if self.dialect is _DatabaseDialect.POSTGRESQL:
+            # 'duplicate key value violates unique constraint "{table_name}_{column_name}_uq"\nDETAIL:  Key (column_name)=(column_value) already exists.\n'
+            # use regex to extract KEY (column_name)=(column_value)
+            column_pattern = re.compile(
+                r"Key \((?P<column_name>.*)\)=\((?P<column_value>.*)\) already exists"
+            )
+            match = column_pattern.search(str_exc_orig)
+            if match:
+                error_column_name = match.group("column_name")
+                column_value = match.group("column_value")
+            # extract table_name from the constraint name
+            table_pattern = re.compile(rf"\"([a-zA-Z0-9_]+)_{re.escape(error_column_name)}_uq\"")
+            match = table_pattern.search(str_exc_orig)
+            if match:
+                table_name = match.group(1)
+
+        if table_name is None or error_column_name is None or column_value is None:
+            return self.UniqueConstraintViolationDetail(
+                parsed_error=True,
+            )
+
+        return self.UniqueConstraintViolationDetail(
+            table_name=table_name,
+            column_name=error_column_name,
+            column_value=column_value,
+        )
 
 
 DatabaseErrorHandlers = [

--- a/airflow/api_fastapi/common/exceptions.py
+++ b/airflow/api_fastapi/common/exceptions.py
@@ -46,13 +46,16 @@ class BaseErrorHandler(Generic[T], ABC):
 class _DatabaseDialect(Enum):
     SQLITE = "sqlite"
     MYSQL = "mysql"
-    POSTGRESQL = "postgresql"
+    POSTGRES = "postgres"
 
 
 def _get_columns_dict_from_params_statement(params: tuple, statement: str) -> _ColumnsType:
     """Transform parameters and statement into a dictionary where the keys are column names, and the values are column values."""
+    if not params or not statement:
+        return {}
     column_names = statement.split("(")[1].split(")")[0].split(",")
-    column_names = [column_name.strip() for column_name in column_names]
+    # replace ",',` and space with empty string
+    column_names = [re.sub(r"[\"'` ]", "", column_name) for column_name in column_names]
     return {column_name: param for column_name, param in zip(column_names, params)}
 
 
@@ -60,21 +63,21 @@ class _UniqueConstraintErrorHandler(BaseErrorHandler[IntegrityError]):
     """Exception raised when trying to insert a duplicate value in a unique column."""
 
     class UniqueConstraintViolationDetail(NamedTuple):
-        table_name: str | None = None
-        column_name: str | None = None
-        column_value: str | None = None
-        parsed_error: bool = False
+        table_name: str | None
+        error_columns: list[tuple[str, str]]
+        parsed_error: bool
+
+    response_error_format = (
+        "Unique constraint violation: {table_name} with {error_column_pairs} already exists"
+    )
+    unique_constraint_error_prefix_dict: dict[_DatabaseDialect, str] = {
+        _DatabaseDialect.SQLITE: "UNIQUE constraint failed",
+        _DatabaseDialect.MYSQL: "Duplicate entry",
+        _DatabaseDialect.POSTGRES: "violates unique constraint",
+    }
 
     def __init__(self):
         super().__init__(IntegrityError)
-        self.response_error_format = (
-            "Unique constraint violation: {table_name} with {column_name}={column_value} already exists"
-        )
-        self.unique_constraint_error_messages: dict[str, str] = {
-            _DatabaseDialect.SQLITE: "UNIQUE constraint failed",
-            _DatabaseDialect.MYSQL: "Duplicate entry",
-            _DatabaseDialect.POSTGRESQL: "violates unique constraint",
-        }
         self.dialect: _DatabaseDialect.value | None = None
 
     def exception_handler(self, request: Request, exc: IntegrityError):
@@ -85,17 +88,21 @@ class _UniqueConstraintErrorHandler(BaseErrorHandler[IntegrityError]):
                 status_code=status.HTTP_409_CONFLICT,
                 detail=self.response_error_format.format(
                     table_name=error_detail.table_name,
-                    column_name=error_detail.column_name,
-                    column_value=error_detail.column_value,
+                    error_column_pairs=", ".join(
+                        [
+                            f"{column_name}={column_value}"
+                            for column_name, column_value in error_detail.error_columns
+                        ]
+                    ),
                 )
-                if not error_detail.parsed_error
+                if not error_detail.parsed_error and error_detail.table_name is not None
                 else f"Unique constraint violation: {str(exc.orig)}",
             )
 
     def _is_dialect_matched(self, exc: IntegrityError) -> bool:
         """Check if the exception matches the unique constraint error message for any dialect."""
         exc_orig_str = str(exc.orig)
-        for dialect, error_msg in self.unique_constraint_error_messages.items():
+        for dialect, error_msg in self.unique_constraint_error_prefix_dict.items():
             if error_msg in exc_orig_str:
                 self.dialect = dialect
                 return True
@@ -105,60 +112,89 @@ class _UniqueConstraintErrorHandler(BaseErrorHandler[IntegrityError]):
         """Parse the error message to extract the table name, column name and value."""
         str_exc_orig = str(exc.orig)
         table_name: None | str = None
-        error_column_name: None | str = None
-        column_value: None | str = None
+        error_columns: list[tuple[str, str]] = []
 
         if self.dialect is _DatabaseDialect.SQLITE:
             # 'UNIQUE constraint failed: {table_name}.{column_name}'
-            table_name, error_column_name = str_exc_orig.split(":")[1].split(".")
-            table_name = table_name.strip()
-            error_column_name = error_column_name.strip()
-            column_value = _get_columns_dict_from_params_statement(exc.params, exc.statement)[
-                error_column_name
-            ]
+            # Can be multiple columns in the unique constraint:
+            # 'UNIQUE constraint failed: {table_name}.{column_name}, {table_name}.{column_name}, ...'
+            matches = re.findall(r"([a-zA-Z0-9_]+)\.([a-zA-Z0-9_]+)", str_exc_orig)
+            if not matches:
+                return self.UniqueConstraintViolationDetail(
+                    table_name=None,
+                    error_columns=error_columns,
+                    parsed_error=True,
+                )
+            columns_dict = _get_columns_dict_from_params_statement(exc.params, str(exc.statement))
+            for match in matches:
+                if table_name is None:
+                    table_name = match[0]
+                column_name = match[1]
+                error_columns.append((column_name, columns_dict[column_name]))
 
         if self.dialect is _DatabaseDialect.MYSQL:
             # "Duplicate entry '{column_value}' for key '{table_name}.{table_name}_{column_name}_uq'"
+            # Can be multiple columns in the unique constraint:
+            # "Duplicate entry '{column_value}-{column_value2}' for key '{table_name}.{table_name}_{column_name}_{column_name2}_uq'"
             pattern = re.compile(
-                r"Duplicate entry '(?P<column_value>.*)' for key '(?P<table_name>.*)\.(?P<constraint_name>.*)'"
+                r"Duplicate entry '(?P<column_values>.*)' for key '(?P<table_name>.*)\.(?P<constraint_name>.*)'"
             )
             match = pattern.search(str_exc_orig)
-            constraint_name = None
-            if match:
-                table_name = match.group("table_name")
-                column_value = match.group("column_value")
-                constraint_name = match.group("constraint_name")
-            # extract column_name from the constraint name
-            column_pattern = re.compile(rf"{table_name}_(?P<column_name>.*)_uq")
-            match = column_pattern.search(constraint_name)
-            if match:
-                error_column_name = match.group("column_name")
+            if not match:
+                return self.UniqueConstraintViolationDetail(
+                    table_name=None,
+                    error_columns=error_columns,
+                    parsed_error=True,
+                )
+            table_name = match.group("table_name")
+            column_values = match.group("column_values").split("-")
+            # since unique constraint suffix naming is not consistent, we can't extract column_name from the constraint name
+            # try extracting column_name from the column_values
+            columns_dict = _get_columns_dict_from_params_statement(exc.params, str(exc.statement))
+            column_keys = [key for key, value in columns_dict.items() if value in column_values]
+            # this could be wrong if column_value contains '-' or there are same values in multiple columns
+            if len(column_keys) != len(column_values):
+                return self.UniqueConstraintViolationDetail(
+                    parsed_error=True,
+                )
+            error_columns = list(zip(column_keys, column_values))
 
-        if self.dialect is _DatabaseDialect.POSTGRESQL:
+        if self.dialect is _DatabaseDialect.POSTGRES:
             # 'duplicate key value violates unique constraint "{table_name}_{column_name}_uq"\nDETAIL:  Key (column_name)=(column_value) already exists.\n'
-            # use regex to extract KEY (column_name)=(column_value)
+            # Can be multiple columns in the unique constraint:
+            # "{table_name}_{column_name}_{column_name2}_uq"\nDETAIL:  Key (column_name, column_name2)=(column_value, column_value2) already exists.\n'
+            # Use regex to extract KEY (column_name)=(column_value)
             column_pattern = re.compile(
-                r"Key \((?P<column_name>.*)\)=\((?P<column_value>.*)\) already exists"
+                r"Key \((?P<column_keys>.*)\)=\((?P<column_values>.*)\) already exists"
             )
-            match = column_pattern.search(str_exc_orig)
-            if match:
-                error_column_name = match.group("column_name")
-                column_value = match.group("column_value")
-            # extract table_name from the constraint name
-            table_pattern = re.compile(rf"\"([a-zA-Z0-9_]+)_{re.escape(error_column_name)}_uq\"")
+            matches = column_pattern.search(str_exc_orig)
+            if not matches:
+                return self.UniqueConstraintViolationDetail(
+                    table_name=None,
+                    error_columns=error_columns,
+                    parsed_error=True,
+                )
+            column_keys = matches.group("column_keys").split(", ")
+            column_values = matches.group("column_values").split(", ")
+            error_columns = list(zip(column_keys, column_values))
+            # extract table_name from the unique constraint name
+            joined_column_keys = "_".join(sorted(column_keys))
+            table_pattern = re.compile(rf"\"([a-zA-Z0-9_]+)_{re.escape(joined_column_keys)}.*\"")
             match = table_pattern.search(str_exc_orig)
             if match:
                 table_name = match.group(1)
 
-        if table_name is None or error_column_name is None or column_value is None:
+        if table_name is None or not error_columns:
             return self.UniqueConstraintViolationDetail(
+                table_name=None,
+                error_columns=error_columns,
                 parsed_error=True,
             )
 
         return self.UniqueConstraintViolationDetail(
             table_name=table_name,
-            column_name=error_column_name,
-            column_value=column_value,
+            error_columns=error_columns,
+            parsed_error=False,
         )
 
 

--- a/airflow/api_fastapi/common/exceptions.py
+++ b/airflow/api_fastapi/common/exceptions.py
@@ -19,16 +19,12 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Generic, NamedTuple, TypeVar
+from typing import Generic, TypeVar
 
-import re2 as re
 from fastapi import HTTPException, Request, status
 from sqlalchemy.exc import IntegrityError
 
 T = TypeVar("T", bound=Exception)
-
-_ColumnsType = dict[str, str]
-# Key: column name, Value: column value
 
 
 class BaseErrorHandler(Generic[T], ABC):
@@ -49,27 +45,9 @@ class _DatabaseDialect(Enum):
     POSTGRES = "postgres"
 
 
-def _get_columns_dict_from_params_statement(params: tuple, statement: str) -> _ColumnsType:
-    """Transform parameters and statement into a dictionary where the keys are column names, and the values are column values."""
-    if not params or not statement:
-        return {}
-    column_names = statement.split("(")[1].split(")")[0].split(",")
-    # replace ",',` and space with empty string
-    column_names = [re.sub(r"[\"'` ]", "", column_name) for column_name in column_names]
-    return {column_name: param for column_name, param in zip(column_names, params)}
-
-
 class _UniqueConstraintErrorHandler(BaseErrorHandler[IntegrityError]):
     """Exception raised when trying to insert a duplicate value in a unique column."""
 
-    class UniqueConstraintViolationDetail(NamedTuple):
-        table_name: str | None
-        error_columns: list[tuple[str, str]]
-        parsed_error: bool
-
-    response_error_format = (
-        "Unique constraint violation: {table_name} with {error_column_pairs} already exists"
-    )
     unique_constraint_error_prefix_dict: dict[_DatabaseDialect, str] = {
         _DatabaseDialect.SQLITE: "UNIQUE constraint failed",
         _DatabaseDialect.MYSQL: "Duplicate entry",
@@ -83,20 +61,13 @@ class _UniqueConstraintErrorHandler(BaseErrorHandler[IntegrityError]):
     def exception_handler(self, request: Request, exc: IntegrityError):
         """Handle IntegrityError exception."""
         if self._is_dialect_matched(exc):
-            error_detail = self._parse_error_message(exc)
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
-                detail=self.response_error_format.format(
-                    table_name=error_detail.table_name,
-                    error_column_pairs=", ".join(
-                        [
-                            f"{column_name}={column_value}"
-                            for column_name, column_value in error_detail.error_columns
-                        ]
-                    ),
-                )
-                if not error_detail.parsed_error and error_detail.table_name is not None
-                else f"Unique constraint violation: {str(exc.orig)}",
+                detail={
+                    "reason": "Unique constraint violation",
+                    "statement": str(exc.statement),
+                    "orig_error": str(exc.orig),
+                },
             )
 
     def _is_dialect_matched(self, exc: IntegrityError) -> bool:
@@ -107,95 +78,6 @@ class _UniqueConstraintErrorHandler(BaseErrorHandler[IntegrityError]):
                 self.dialect = dialect
                 return True
         return False
-
-    def _parse_error_message(self, exc: IntegrityError) -> UniqueConstraintViolationDetail:
-        """Parse the error message to extract the table name, column name and value."""
-        str_exc_orig = str(exc.orig)
-        table_name: None | str = None
-        error_columns: list[tuple[str, str]] = []
-
-        if self.dialect is _DatabaseDialect.SQLITE:
-            # 'UNIQUE constraint failed: {table_name}.{column_name}'
-            # Can be multiple columns in the unique constraint:
-            # 'UNIQUE constraint failed: {table_name}.{column_name}, {table_name}.{column_name}, ...'
-            matches = re.findall(r"([a-zA-Z0-9_]+)\.([a-zA-Z0-9_]+)", str_exc_orig)
-            if not matches:
-                return self.UniqueConstraintViolationDetail(
-                    table_name=None,
-                    error_columns=error_columns,
-                    parsed_error=True,
-                )
-            columns_dict = _get_columns_dict_from_params_statement(exc.params, str(exc.statement))
-            for match in matches:
-                if table_name is None:
-                    table_name = match[0]
-                column_name = match[1]
-                error_columns.append((column_name, columns_dict[column_name]))
-
-        if self.dialect is _DatabaseDialect.MYSQL:
-            # "Duplicate entry '{column_value}' for key '{table_name}.{table_name}_{column_name}_uq'"
-            # Can be multiple columns in the unique constraint:
-            # "Duplicate entry '{column_value}-{column_value2}' for key '{table_name}.{table_name}_{column_name}_{column_name2}_uq'"
-            pattern = re.compile(
-                r"Duplicate entry '(?P<column_values>.*)' for key '(?P<table_name>.*)\.(?P<constraint_name>.*)'"
-            )
-            match = pattern.search(str_exc_orig)
-            if not match:
-                return self.UniqueConstraintViolationDetail(
-                    table_name=None,
-                    error_columns=error_columns,
-                    parsed_error=True,
-                )
-            table_name = match.group("table_name")
-            column_values = match.group("column_values").split("-")
-            # since unique constraint suffix naming is not consistent, we can't extract column_name from the constraint name
-            # try extracting column_name from the column_values
-            columns_dict = _get_columns_dict_from_params_statement(exc.params, str(exc.statement))
-            column_keys = [key for key, value in columns_dict.items() if value in column_values]
-            # this could be wrong if column_value contains '-' or there are same values in multiple columns
-            if len(column_keys) != len(column_values):
-                return self.UniqueConstraintViolationDetail(
-                    parsed_error=True,
-                )
-            error_columns = list(zip(column_keys, column_values))
-
-        if self.dialect is _DatabaseDialect.POSTGRES:
-            # 'duplicate key value violates unique constraint "{table_name}_{column_name}_uq"\nDETAIL:  Key (column_name)=(column_value) already exists.\n'
-            # Can be multiple columns in the unique constraint:
-            # "{table_name}_{column_name}_{column_name2}_uq"\nDETAIL:  Key (column_name, column_name2)=(column_value, column_value2) already exists.\n'
-            # Use regex to extract KEY (column_name)=(column_value)
-            column_pattern = re.compile(
-                r"Key \((?P<column_keys>.*)\)=\((?P<column_values>.*)\) already exists"
-            )
-            matches = column_pattern.search(str_exc_orig)
-            if not matches:
-                return self.UniqueConstraintViolationDetail(
-                    table_name=None,
-                    error_columns=error_columns,
-                    parsed_error=True,
-                )
-            column_keys = matches.group("column_keys").split(", ")
-            column_values = matches.group("column_values").split(", ")
-            error_columns = list(zip(column_keys, column_values))
-            # extract table_name from the unique constraint name
-            joined_column_keys = "_".join(sorted(column_keys))
-            table_pattern = re.compile(rf"\"([a-zA-Z0-9_]+)_{re.escape(joined_column_keys)}.*\"")
-            match = table_pattern.search(str_exc_orig)
-            if match:
-                table_name = match.group(1)
-
-        if table_name is None or not error_columns:
-            return self.UniqueConstraintViolationDetail(
-                table_name=None,
-                error_columns=error_columns,
-                parsed_error=True,
-            )
-
-        return self.UniqueConstraintViolationDetail(
-            table_name=table_name,
-            error_columns=error_columns,
-            parsed_error=False,
-        )
 
 
 DatabaseErrorHandlers = [

--- a/airflow/api_fastapi/core_api/routes/public/connections.py
+++ b/airflow/api_fastapi/core_api/routes/public/connections.py
@@ -121,7 +121,9 @@ def get_connections(
 @connections_router.post(
     "",
     status_code=status.HTTP_201_CREATED,
-    responses=create_openapi_http_exception_doc([status.HTTP_409_CONFLICT]),
+    responses=create_openapi_http_exception_doc(
+        [status.HTTP_409_CONFLICT]
+    ),  # handled by global exception handler
 )
 def post_connection(
     post_body: ConnectionBody,

--- a/tests/api_fastapi/common/__init__.py
+++ b/tests/api_fastapi/common/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/api_fastapi/common/test_exceptions.py
+++ b/tests/api_fastapi/common/test_exceptions.py
@@ -1,0 +1,120 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException, status
+from sqlalchemy.exc import IntegrityError
+
+from airflow.api_fastapi.common.exceptions import _DatabaseDialect, _UniqueConstraintErrorHandler
+from airflow.configuration import conf
+from airflow.models import Pool, Variable
+from airflow.utils.session import provide_session
+
+from tests_common.test_utils.db import clear_db_connections, clear_db_pools
+
+pytestmark = pytest.mark.db_test
+
+CURRENT_DATABASE_DIALECT = conf.get_mandatory_value("database", "sql_alchemy_conn").lower()
+TEST_POOL = "test_pool"
+TEST_VARIABLE_KEY = "test_key"
+EXPECTED_EXCEPTION_POOL = HTTPException(
+    status_code=status.HTTP_409_CONFLICT,
+    detail="Unique constraint violation: slot_pool with pool=test_pool already exists",
+)
+
+EXPECTED_EXCEPTION_VARIABLE = HTTPException(
+    status_code=status.HTTP_409_CONFLICT,
+    detail="Unique constraint violation: variable with key=test_key already exists",
+)
+
+# Take Pool and Variable tables as test cases
+TEST_CASES_TABLES = [
+    "Pool",
+    "Variable",
+]
+TEST_CASES_EXCEPTIONS = [
+    EXPECTED_EXCEPTION_POOL,
+    EXPECTED_EXCEPTION_VARIABLE,
+]
+TEST_CASE_DB_DIALECTS_SKIP = [
+    {
+        "condition": CURRENT_DATABASE_DIALECT.startswith(_DatabaseDialect.MYSQL.value)
+        or CURRENT_DATABASE_DIALECT.startswith(_DatabaseDialect.POSTGRESQL.value),
+        "reason": f"Test for {_DatabaseDialect.SQLITE.value} only",
+    },
+    {
+        "condition": CURRENT_DATABASE_DIALECT.startswith(_DatabaseDialect.SQLITE.value)
+        or CURRENT_DATABASE_DIALECT.startswith(_DatabaseDialect.POSTGRESQL.value),
+        "reason": f"Test for {_DatabaseDialect.MYSQL.value} only",
+    },
+    {
+        "condition": CURRENT_DATABASE_DIALECT.startswith(_DatabaseDialect.SQLITE.value)
+        or CURRENT_DATABASE_DIALECT.startswith(_DatabaseDialect.MYSQL.value),
+        "reason": f"Test for {_DatabaseDialect.POSTGRESQL.value} only",
+    },
+]
+
+
+def generate_test_cases_parametrize():
+    """Generate cross product of test cases for parametrize."""
+    test_cases = []
+    for table, expected_exception in zip(TEST_CASES_TABLES, TEST_CASES_EXCEPTIONS):
+        for test_case in TEST_CASE_DB_DIALECTS_SKIP:
+            test_cases.append(
+                pytest.param(
+                    table,
+                    expected_exception,
+                    id=f"{test_case['reason']} - Inserting duplicate entry in {table}",
+                    marks=pytest.mark.skipif(**test_case),
+                )
+            )
+    return test_cases
+
+
+class TestUniqueConstraintErrorHandler:
+    unique_constraint_error_handler = _UniqueConstraintErrorHandler()
+
+    @pytest.fixture(autouse=True)
+    def setup(self) -> None:
+        clear_db_connections(add_default_connections_back=False)
+        clear_db_pools()
+
+    def teardown_method(self) -> None:
+        clear_db_connections()
+        clear_db_pools()
+
+    @pytest.mark.parametrize(
+        "table, expected_exception",
+        generate_test_cases_parametrize(),
+    )
+    @provide_session
+    def test_handle_unique_constraint_error(self, session, table, expected_exception) -> None:
+        if table == "Pool":
+            session.add(Pool(pool=TEST_POOL, slots=1, description="test pool", include_deferred=False))
+            session.add(Pool(pool=TEST_POOL, slots=1, description="test pool", include_deferred=False))
+        elif table == "Variable":
+            session.add(Variable(key=TEST_VARIABLE_KEY, val="test_val"))
+            session.add(Variable(key=TEST_VARIABLE_KEY, val="test_val"))
+
+        with pytest.raises(IntegrityError) as exeinfo_integrity_error:
+            session.commit()
+
+        with pytest.raises(HTTPException) as exeinfo_response_error:
+            self.unique_constraint_error_handler.exception_handler(None, exeinfo_integrity_error.value)  # type: ignore
+
+        assert str(exeinfo_response_error.value) == str(expected_exception)

--- a/tests/api_fastapi/common/test_exceptions.py
+++ b/tests/api_fastapi/common/test_exceptions.py
@@ -22,10 +22,11 @@ from sqlalchemy.exc import IntegrityError
 
 from airflow.api_fastapi.common.exceptions import _DatabaseDialect, _UniqueConstraintErrorHandler
 from airflow.configuration import conf
-from airflow.models import Pool, Variable
+from airflow.models import DagRun, Pool, Variable
 from airflow.utils.session import provide_session
+from airflow.utils.state import DagRunState
 
-from tests_common.test_utils.db import clear_db_connections, clear_db_pools
+from tests_common.test_utils.db import clear_db_connections, clear_db_dags, clear_db_pools, clear_db_runs
 
 pytestmark = pytest.mark.db_test
 
@@ -41,49 +42,54 @@ EXPECTED_EXCEPTION_VARIABLE = HTTPException(
     status_code=status.HTTP_409_CONFLICT,
     detail="Unique constraint violation: variable with key=test_key already exists",
 )
-
-# Take Pool and Variable tables as test cases
-TEST_CASES_TABLES = [
-    "Pool",
-    "Variable",
-]
-TEST_CASES_EXCEPTIONS = [
-    EXPECTED_EXCEPTION_POOL,
-    EXPECTED_EXCEPTION_VARIABLE,
-]
-TEST_CASE_DB_DIALECTS_SKIP = [
+EXPECTED_EXCEPTION_DAG_RUN = HTTPException(
+    status_code=status.HTTP_409_CONFLICT,
+    detail="Unique constraint violation: dag_run with dag_id=test_dag_id, run_id=test_run_id already exists",
+)
+PYTEST_MARKS_DB_DIALECT = [
     {
         "condition": CURRENT_DATABASE_DIALECT.startswith(_DatabaseDialect.MYSQL.value)
-        or CURRENT_DATABASE_DIALECT.startswith(_DatabaseDialect.POSTGRESQL.value),
+        or CURRENT_DATABASE_DIALECT.startswith(_DatabaseDialect.POSTGRES.value),
         "reason": f"Test for {_DatabaseDialect.SQLITE.value} only",
     },
     {
         "condition": CURRENT_DATABASE_DIALECT.startswith(_DatabaseDialect.SQLITE.value)
-        or CURRENT_DATABASE_DIALECT.startswith(_DatabaseDialect.POSTGRESQL.value),
+        or CURRENT_DATABASE_DIALECT.startswith(_DatabaseDialect.POSTGRES.value),
         "reason": f"Test for {_DatabaseDialect.MYSQL.value} only",
     },
     {
         "condition": CURRENT_DATABASE_DIALECT.startswith(_DatabaseDialect.SQLITE.value)
         or CURRENT_DATABASE_DIALECT.startswith(_DatabaseDialect.MYSQL.value),
-        "reason": f"Test for {_DatabaseDialect.POSTGRESQL.value} only",
+        "reason": f"Test for {_DatabaseDialect.POSTGRES.value} only",
     },
 ]
 
 
-def generate_test_cases_parametrize():
-    """Generate cross product of test cases for parametrize."""
-    test_cases = []
-    for table, expected_exception in zip(TEST_CASES_TABLES, TEST_CASES_EXCEPTIONS):
-        for test_case in TEST_CASE_DB_DIALECTS_SKIP:
-            test_cases.append(
+def generate_test_cases_parametrize(test_cases: list[str], expected_exceptions: list[HTTPException]):
+    """Generate cross product of test cases for parametrize with different database dialects."""
+    generated_test_cases = []
+    for test_case, expected_exception in zip(test_cases, expected_exceptions):
+        for mark in PYTEST_MARKS_DB_DIALECT:
+            generated_test_cases.append(
                 pytest.param(
-                    table,
+                    test_case,
                     expected_exception,
-                    id=f"{test_case['reason']} - Inserting duplicate entry in {table}",
-                    marks=pytest.mark.skipif(**test_case),
+                    id=f"{mark['reason']} - {test_case}",
+                    marks=pytest.mark.skipif(**mark),  # type: ignore
                 )
             )
-    return test_cases
+    return generated_test_cases
+
+
+def get_unique_constraint_error_prefix():
+    """Get unique constraint error prefix based on current database dialect."""
+    if CURRENT_DATABASE_DIALECT.startswith(_DatabaseDialect.SQLITE.value):
+        return _UniqueConstraintErrorHandler.unique_constraint_error_prefix_dict[_DatabaseDialect.SQLITE]
+    if CURRENT_DATABASE_DIALECT.startswith(_DatabaseDialect.MYSQL.value):
+        return _UniqueConstraintErrorHandler.unique_constraint_error_prefix_dict[_DatabaseDialect.MYSQL]
+    if CURRENT_DATABASE_DIALECT.startswith(_DatabaseDialect.POSTGRES.value):
+        return _UniqueConstraintErrorHandler.unique_constraint_error_prefix_dict[_DatabaseDialect.POSTGRES]
+    return ""
 
 
 class TestUniqueConstraintErrorHandler:
@@ -93,17 +99,28 @@ class TestUniqueConstraintErrorHandler:
     def setup(self) -> None:
         clear_db_connections(add_default_connections_back=False)
         clear_db_pools()
+        clear_db_runs()
+        clear_db_dags()
 
     def teardown_method(self) -> None:
         clear_db_connections()
         clear_db_pools()
+        clear_db_runs()
+        clear_db_dags()
 
     @pytest.mark.parametrize(
         "table, expected_exception",
-        generate_test_cases_parametrize(),
+        generate_test_cases_parametrize(
+            ["Pool", "Variable"],
+            [
+                EXPECTED_EXCEPTION_POOL,
+                EXPECTED_EXCEPTION_VARIABLE,
+            ],
+        ),
     )
     @provide_session
-    def test_handle_unique_constraint_error(self, session, table, expected_exception) -> None:
+    def test_handle_single_column_unique_constraint_error(self, session, table, expected_exception) -> None:
+        # Take Pool and Variable tables as test cases
         if table == "Pool":
             session.add(Pool(pool=TEST_POOL, slots=1, description="test pool", include_deferred=False))
             session.add(Pool(pool=TEST_POOL, slots=1, description="test pool", include_deferred=False))
@@ -116,5 +133,68 @@ class TestUniqueConstraintErrorHandler:
 
         with pytest.raises(HTTPException) as exeinfo_response_error:
             self.unique_constraint_error_handler.exception_handler(None, exeinfo_integrity_error.value)  # type: ignore
+
+        assert str(exeinfo_response_error.value) == str(expected_exception)
+
+    @pytest.mark.parametrize(
+        "table, expected_exception",
+        generate_test_cases_parametrize(
+            ["DagRun"],
+            [EXPECTED_EXCEPTION_DAG_RUN],
+        ),
+    )
+    @provide_session
+    def test_handle_multiple_columns_unique_constraint_error(
+        self, session, table, expected_exception
+    ) -> None:
+        if table == "DagRun":
+            session.add(
+                DagRun(
+                    dag_id="test_dag_id", run_id="test_run_id", run_type="manual", state=DagRunState.RUNNING
+                )
+            )
+            session.add(
+                DagRun(
+                    dag_id="test_dag_id", run_id="test_run_id", run_type="manual", state=DagRunState.RUNNING
+                )
+            )
+
+        with pytest.raises(IntegrityError) as exeinfo_integrity_error:
+            session.commit()
+
+        with pytest.raises(HTTPException) as exeinfo_response_error:
+            self.unique_constraint_error_handler.exception_handler(None, exeinfo_integrity_error.value)  # type: ignore
+
+        assert str(exeinfo_response_error.value) == str(expected_exception)
+
+    @pytest.mark.parametrize(
+        "mock_error_orig, expected_exception",
+        generate_test_cases_parametrize(
+            [
+                f"{get_unique_constraint_error_prefix()} This is a string that will cause parse error in exception handler",
+                f"{get_unique_constraint_error_prefix()} This_is_another_string_that_will_cause_parse_error_in_exception_handler",
+            ],
+            [
+                HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail=f"Unique constraint violation: {get_unique_constraint_error_prefix()} This is a string that will cause parse error in exception handler",
+                ),
+                HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail=f"Unique constraint violation: {get_unique_constraint_error_prefix()} This_is_another_string_that_will_cause_parse_error_in_exception_handler",
+                ),
+            ],
+        ),
+    )
+    def test_handle_error_parsing_message_unique_constraint_error(
+        self, mock_error_orig, expected_exception
+    ) -> None:
+        mock_integrity_error = IntegrityError(
+            statement="mock statement",
+            params={},
+            orig=Exception(mock_error_orig),
+        )
+        with pytest.raises(HTTPException) as exeinfo_response_error:
+            self.unique_constraint_error_handler.exception_handler(None, mock_integrity_error)  # type: ignore
 
         assert str(exeinfo_response_error.value) == str(expected_exception)

--- a/tests/api_fastapi/core_api/routes/public/test_connections.py
+++ b/tests/api_fastapi/core_api/routes/public/test_connections.py
@@ -247,7 +247,7 @@ class TestPostConnection(TestConnectionEndpoint):
         response = test_client.post("/public/connections", json=body)
         assert response.status_code == 409
         assert response.json() == {
-            "detail": "Unique constraint violation",
+            "detail": "Unique constraint violation: connection with conn_id=test_connection_id already exists",
         }
 
     @pytest.mark.enable_redact
@@ -397,7 +397,7 @@ class TestPostConnections(TestConnectionEndpoint):
         response = test_client.post("/public/connections/bulk", json=body)
         assert response.status_code == 409
         assert response.json() == {
-            "detail": "Unique constraint violation",
+            "detail": "Unique constraint violation: connection with conn_id=test_connection_id already exists",
         }
 
     @pytest.mark.enable_redact

--- a/tests/api_fastapi/core_api/routes/public/test_connections.py
+++ b/tests/api_fastapi/core_api/routes/public/test_connections.py
@@ -246,9 +246,9 @@ class TestPostConnection(TestConnectionEndpoint):
         # Another request
         response = test_client.post("/public/connections", json=body)
         assert response.status_code == 409
-        assert response.json() == {
-            "detail": "Unique constraint violation: connection with conn_id=test_connection_id already exists",
-        }
+        response_json = response.json()
+        assert "detail" in response_json
+        assert list(response_json["detail"].keys()) == ["reason", "statement", "orig_error"]
 
     @pytest.mark.enable_redact
     @pytest.mark.parametrize(
@@ -396,9 +396,9 @@ class TestPostConnections(TestConnectionEndpoint):
         # Another request
         response = test_client.post("/public/connections/bulk", json=body)
         assert response.status_code == 409
-        assert response.json() == {
-            "detail": "Unique constraint violation: connection with conn_id=test_connection_id already exists",
-        }
+        response_json = response.json()
+        assert "detail" in response_json
+        assert list(response_json["detail"].keys()) == ["reason", "statement", "orig_error"]
 
     @pytest.mark.enable_redact
     @pytest.mark.parametrize(
@@ -649,7 +649,6 @@ class TestPatchConnection(TestConnectionEndpoint):
         self.create_connection()
         response = test_client.patch(f"/public/connections/{TEST_CONN_ID}", json=body)
         assert response.status_code == 400
-        print(response.json())
         assert response.json() == {
             "detail": "The connection_id in the request body does not match the URL parameter",
         }

--- a/tests/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/tests/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -1353,4 +1353,7 @@ class TestTriggerDagRun:
     def test_response_409(self, test_client):
         response = test_client.post(f"/public/dags/{DAG1_ID}/dagRuns", json={"dag_run_id": DAG1_RUN1_ID})
         assert response.status_code == 409
-        assert response.json()["detail"] == "Unique constraint violation"
+        assert (
+            response.json()["detail"]
+            == "Unique constraint violation: dag_run with dag_id=test_dag1, run_id=dag_run_1 already exists"
+        )

--- a/tests/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/tests/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -1353,7 +1353,6 @@ class TestTriggerDagRun:
     def test_response_409(self, test_client):
         response = test_client.post(f"/public/dags/{DAG1_ID}/dagRuns", json={"dag_run_id": DAG1_RUN1_ID})
         assert response.status_code == 409
-        assert (
-            response.json()["detail"]
-            == "Unique constraint violation: dag_run with dag_id=test_dag1, run_id=dag_run_1 already exists"
-        )
+        response_json = response.json()
+        assert "detail" in response_json
+        assert list(response_json["detail"].keys()) == ["reason", "statement", "orig_error"]

--- a/tests/api_fastapi/core_api/routes/public/test_pools.py
+++ b/tests/api_fastapi/core_api/routes/public/test_pools.py
@@ -349,7 +349,7 @@ class TestPostPool(TestPoolsEndpoint):
                     "deferred_slots": 0,
                 },
                 409,
-                {"detail": "Unique constraint violation"},
+                {"detail": "Unique constraint violation: slot_pool with pool=my_pool already exists"},
             ),
         ],
     )
@@ -425,7 +425,7 @@ class TestPostPools(TestPoolsEndpoint):
                     ]
                 },
                 409,
-                {"detail": "Unique constraint violation"},
+                {"detail": "Unique constraint violation: slot_pool with pool=pool1 already exists"},
             ),
             (
                 {
@@ -435,7 +435,7 @@ class TestPostPools(TestPoolsEndpoint):
                     ]
                 },
                 409,
-                {"detail": "Unique constraint violation"},
+                {"detail": "Unique constraint violation: slot_pool with pool=pool1 already exists"},
             ),
             (
                 {
@@ -445,7 +445,7 @@ class TestPostPools(TestPoolsEndpoint):
                     ]
                 },
                 409,
-                {"detail": "Unique constraint violation"},
+                {"detail": "Unique constraint violation: slot_pool with pool=my_pool already exists"},
             ),
         ],
     )

--- a/tests/api_fastapi/core_api/routes/public/test_pools.py
+++ b/tests/api_fastapi/core_api/routes/public/test_pools.py
@@ -349,7 +349,7 @@ class TestPostPool(TestPoolsEndpoint):
                     "deferred_slots": 0,
                 },
                 409,
-                {"detail": "Unique constraint violation: slot_pool with pool=my_pool already exists"},
+                None,
             ),
         ],
     )
@@ -371,7 +371,13 @@ class TestPostPool(TestPoolsEndpoint):
         assert session.query(Pool).count() == n_pools + 1
         response = test_client.post("/public/pools", json=body)
         assert response.status_code == second_expected_status_code
-        assert response.json() == second_expected_response
+        if second_expected_status_code == 201:
+            assert response.json() == second_expected_response
+        else:
+            response_json = response.json()
+            assert "detail" in response_json
+            assert list(response_json["detail"].keys()) == ["reason", "statement", "orig_error"]
+
         assert session.query(Pool).count() == n_pools + 1
 
 
@@ -425,7 +431,7 @@ class TestPostPools(TestPoolsEndpoint):
                     ]
                 },
                 409,
-                {"detail": "Unique constraint violation: slot_pool with pool=pool1 already exists"},
+                None,
             ),
             (
                 {
@@ -435,7 +441,7 @@ class TestPostPools(TestPoolsEndpoint):
                     ]
                 },
                 409,
-                {"detail": "Unique constraint violation: slot_pool with pool=pool1 already exists"},
+                None,
             ),
             (
                 {
@@ -445,7 +451,7 @@ class TestPostPools(TestPoolsEndpoint):
                     ]
                 },
                 409,
-                {"detail": "Unique constraint violation: slot_pool with pool=my_pool already exists"},
+                None,
             ),
         ],
     )
@@ -454,8 +460,11 @@ class TestPostPools(TestPoolsEndpoint):
         n_pools = session.query(Pool).count()
         response = test_client.post("/public/pools/bulk", json=body)
         assert response.status_code == expected_status_code
-        assert response.json() == expected_response
         if expected_status_code == 201:
+            response.json() == expected_response
             assert session.query(Pool).count() == n_pools + 2
         else:
+            response_json = response.json()
+            assert "detail" in response_json
+            assert list(response_json["detail"].keys()) == ["reason", "statement", "orig_error"]
             assert session.query(Pool).count() == n_pools


### PR DESCRIPTION
related: https://github.com/apache/airflow/pull/44121#issuecomment-2493193823

It seems that only the Post Connection endpoint has an extra query to handle duplicate entries. Other `409_CONFLICT` cases don't handle inserting duplicate entries on unique constraint columns.  





