### PR TITLE
AIP-84 Refactor test cases with `datetime_zulu_format`

### DIFF
--- a/tests/api_fastapi/core_api/routes/public/test_assets.py
+++ b/tests/api_fastapi/core_api/routes/public/test_assets.py
@@ -40,7 +40,7 @@ from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.asserts import assert_queries_count
 from tests_common.test_utils.db import clear_db_assets, clear_db_runs
-from tests_common.test_utils.format_datetime import datetime_zulu_format_without_ms
+from tests_common.test_utils.format_datetime import from_datetime_to_zulu_without_ms
 
 DEFAULT_DATE = datetime(2020, 6, 11, 18, 0, 0, tzinfo=timezone.utc)
 
@@ -211,7 +211,7 @@ class TestGetAssets(TestAssets):
         response = test_client.get("/public/assets")
         assert response.status_code == 200
         response_data = response.json()
-        tz_datetime_format = datetime_zulu_format_without_ms(DEFAULT_DATE)
+        tz_datetime_format = from_datetime_to_zulu_without_ms(DEFAULT_DATE)
         assert response_data == {
             "assets": [
                 {
@@ -391,15 +391,15 @@ class TestGetAssetEvents(TestAssets):
                         {
                             "run_id": "source_run_id_1",
                             "dag_id": "source_dag_id",
-                            "logical_date": datetime_zulu_format_without_ms(DEFAULT_DATE),
-                            "start_date": datetime_zulu_format_without_ms(DEFAULT_DATE),
-                            "end_date": datetime_zulu_format_without_ms(DEFAULT_DATE),
+                            "logical_date": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
+                            "start_date": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
+                            "end_date": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
                             "state": "success",
-                            "data_interval_start": datetime_zulu_format_without_ms(DEFAULT_DATE),
-                            "data_interval_end": datetime_zulu_format_without_ms(DEFAULT_DATE),
+                            "data_interval_start": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
+                            "data_interval_end": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
                         }
                     ],
-                    "timestamp": datetime_zulu_format_without_ms(DEFAULT_DATE),
+                    "timestamp": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
                 },
                 {
                     "id": 2,
@@ -414,15 +414,15 @@ class TestGetAssetEvents(TestAssets):
                         {
                             "run_id": "source_run_id_2",
                             "dag_id": "source_dag_id",
-                            "logical_date": datetime_zulu_format_without_ms(DEFAULT_DATE),
-                            "start_date": datetime_zulu_format_without_ms(DEFAULT_DATE),
-                            "end_date": datetime_zulu_format_without_ms(DEFAULT_DATE),
+                            "logical_date": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
+                            "start_date": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
+                            "end_date": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
                             "state": "success",
-                            "data_interval_start": datetime_zulu_format_without_ms(DEFAULT_DATE),
-                            "data_interval_end": datetime_zulu_format_without_ms(DEFAULT_DATE),
+                            "data_interval_start": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
+                            "data_interval_end": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
                         }
                     ],
-                    "timestamp": datetime_zulu_format_without_ms(DEFAULT_DATE),
+                    "timestamp": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
                 },
             ],
             "total_entries": 2,
@@ -503,15 +503,15 @@ class TestGetAssetEvents(TestAssets):
                         {
                             "run_id": "source_run_id_1",
                             "dag_id": "source_dag_id",
-                            "logical_date": datetime_zulu_format_without_ms(DEFAULT_DATE),
-                            "start_date": datetime_zulu_format_without_ms(DEFAULT_DATE),
-                            "end_date": datetime_zulu_format_without_ms(DEFAULT_DATE),
+                            "logical_date": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
+                            "start_date": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
+                            "end_date": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
                             "state": "success",
-                            "data_interval_start": datetime_zulu_format_without_ms(DEFAULT_DATE),
-                            "data_interval_end": datetime_zulu_format_without_ms(DEFAULT_DATE),
+                            "data_interval_start": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
+                            "data_interval_end": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
                         }
                     ],
-                    "timestamp": datetime_zulu_format_without_ms(DEFAULT_DATE),
+                    "timestamp": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
                 },
                 {
                     "id": 2,
@@ -526,15 +526,15 @@ class TestGetAssetEvents(TestAssets):
                         {
                             "run_id": "source_run_id_2",
                             "dag_id": "source_dag_id",
-                            "logical_date": datetime_zulu_format_without_ms(DEFAULT_DATE),
-                            "start_date": datetime_zulu_format_without_ms(DEFAULT_DATE),
-                            "end_date": datetime_zulu_format_without_ms(DEFAULT_DATE),
+                            "logical_date": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
+                            "start_date": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
+                            "end_date": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
                             "state": "success",
-                            "data_interval_start": datetime_zulu_format_without_ms(DEFAULT_DATE),
-                            "data_interval_end": datetime_zulu_format_without_ms(DEFAULT_DATE),
+                            "data_interval_start": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
+                            "data_interval_end": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
                         }
                     ],
-                    "timestamp": datetime_zulu_format_without_ms(DEFAULT_DATE),
+                    "timestamp": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
                 },
             ],
             "total_entries": 2,
@@ -555,7 +555,7 @@ class TestGetAssetEndpoint(TestAssets):
     def test_should_respond_200(self, test_client, url, session):
         self.create_assets(num=1)
         assert session.query(AssetModel).count() == 1
-        tz_datetime_format = datetime_zulu_format_without_ms(DEFAULT_DATE)
+        tz_datetime_format = from_datetime_to_zulu_without_ms(DEFAULT_DATE)
         with assert_queries_count(6):
             response = test_client.get(
                 f"/public/assets/{url}",
@@ -583,7 +583,7 @@ class TestGetAssetEndpoint(TestAssets):
     @pytest.mark.enable_redact
     def test_should_mask_sensitive_extra(self, test_client, session):
         self.create_assets_with_sensitive_extra()
-        tz_datetime_format = datetime_zulu_format_without_ms(DEFAULT_DATE)
+        tz_datetime_format = from_datetime_to_zulu_without_ms(DEFAULT_DATE)
         uri = "s3://bucket/key/1"
         response = test_client.get(
             f"/public/assets/{uri}",
@@ -626,7 +626,7 @@ class TestGetDagAssetQueuedEvents(TestQueuedEventEndpoint):
         assert response.json() == {
             "queued_events": [
                 {
-                    "created_at": datetime_zulu_format_without_ms(DEFAULT_DATE),
+                    "created_at": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
                     "uri": "s3://bucket/key/1",
                     "dag_id": "dag",
                 }
@@ -706,7 +706,7 @@ class TestPostAssetEvents(TestAssets):
             "source_run_id": None,
             "source_map_index": -1,
             "created_dagruns": [],
-            "timestamp": datetime_zulu_format_without_ms(DEFAULT_DATE),
+            "timestamp": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
         }
 
     def test_invalid_attr_not_allowed(self, test_client, session):
@@ -733,7 +733,7 @@ class TestPostAssetEvents(TestAssets):
             "source_run_id": None,
             "source_map_index": -1,
             "created_dagruns": [],
-            "timestamp": datetime_zulu_format_without_ms(DEFAULT_DATE),
+            "timestamp": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
         }
 
 
@@ -754,7 +754,7 @@ class TestGetAssetQueuedEvents(TestQueuedEventEndpoint):
         assert response.json() == {
             "queued_events": [
                 {
-                    "created_at": datetime_zulu_format_without_ms(DEFAULT_DATE),
+                    "created_at": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
                     "uri": "s3://bucket/key/1",
                     "dag_id": "dag",
                 }

--- a/tests/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/tests/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -482,21 +482,19 @@ class TestGetDagRuns:
 
 class TestListDagRunsBatch:
     @staticmethod
-    def parse_datetime(datetime_str):
-        return datetime_str.isoformat().replace("+00:00", "Z") if datetime_str else None
-
-    @staticmethod
     def get_dag_run_dict(run: DagRun):
         return {
             "dag_run_id": run.run_id,
             "dag_id": run.dag_id,
-            "logical_date": TestGetDagRuns.parse_datetime(run.logical_date),
-            "queued_at": TestGetDagRuns.parse_datetime(run.queued_at),
-            "start_date": TestGetDagRuns.parse_datetime(run.start_date),
-            "end_date": TestGetDagRuns.parse_datetime(run.end_date),
-            "data_interval_start": TestGetDagRuns.parse_datetime(run.data_interval_start),
-            "data_interval_end": TestGetDagRuns.parse_datetime(run.data_interval_end),
-            "last_scheduling_decision": TestGetDagRuns.parse_datetime(run.last_scheduling_decision),
+            "logical_date": from_datetime_to_zulu_without_ms(run.logical_date),
+            "queued_at": from_datetime_to_zulu_without_ms(run.queued_at) if run.queued_at else None,
+            "start_date": from_datetime_to_zulu_without_ms(run.start_date),
+            "end_date": from_datetime_to_zulu(run.end_date),
+            "data_interval_start": from_datetime_to_zulu_without_ms(run.data_interval_start),
+            "data_interval_end": from_datetime_to_zulu_without_ms(run.data_interval_end),
+            "last_scheduling_decision": from_datetime_to_zulu_without_ms(run.last_scheduling_decision)
+            if run.last_scheduling_decision
+            else None,
             "run_type": run.run_type,
             "state": run.state,
             "external_trigger": run.external_trigger,

--- a/tests/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/tests/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -39,7 +39,7 @@ from tests_common.test_utils.db import (
     clear_db_runs,
     clear_db_serialized_dags,
 )
-from tests_common.test_utils.format_datetime import datetime_zulu_format, datetime_zulu_format_without_ms
+from tests_common.test_utils.format_datetime import from_datetime_to_zulu, from_datetime_to_zulu_without_ms
 
 pytestmark = pytest.mark.db_test
 
@@ -198,13 +198,13 @@ class TestGetDagRuns:
         return {
             "dag_run_id": run.run_id,
             "dag_id": run.dag_id,
-            "logical_date": datetime_zulu_format_without_ms(run.logical_date),
-            "queued_at": datetime_zulu_format(run.queued_at) if run.queued_at else None,
-            "start_date": datetime_zulu_format_without_ms(run.start_date),
-            "end_date": datetime_zulu_format(run.end_date),
-            "data_interval_start": datetime_zulu_format_without_ms(run.data_interval_start),
-            "data_interval_end": datetime_zulu_format_without_ms(run.data_interval_end),
-            "last_scheduling_decision": datetime_zulu_format(run.last_scheduling_decision)
+            "logical_date": from_datetime_to_zulu_without_ms(run.logical_date),
+            "queued_at": from_datetime_to_zulu(run.queued_at) if run.queued_at else None,
+            "start_date": from_datetime_to_zulu_without_ms(run.start_date),
+            "end_date": from_datetime_to_zulu(run.end_date),
+            "data_interval_start": from_datetime_to_zulu_without_ms(run.data_interval_start),
+            "data_interval_end": from_datetime_to_zulu_without_ms(run.data_interval_end),
+            "last_scheduling_decision": from_datetime_to_zulu(run.last_scheduling_decision)
             if run.last_scheduling_decision
             else None,
             "run_type": run.run_type,
@@ -975,7 +975,7 @@ class TestGetDagRunAssetTriggerEvents:
         expected_response = {
             "asset_events": [
                 {
-                    "timestamp": datetime_zulu_format(event.timestamp),
+                    "timestamp": from_datetime_to_zulu(event.timestamp),
                     "asset_id": asset1_id,
                     "uri": asset1.uri,
                     "extra": {},
@@ -988,11 +988,11 @@ class TestGetDagRunAssetTriggerEvents:
                         {
                             "dag_id": "TEST_DAG_ID",
                             "run_id": "TEST_DAG_RUN_ID",
-                            "data_interval_end": datetime_zulu_format_without_ms(dr.data_interval_end),
-                            "data_interval_start": datetime_zulu_format_without_ms(dr.data_interval_start),
+                            "data_interval_end": from_datetime_to_zulu_without_ms(dr.data_interval_end),
+                            "data_interval_start": from_datetime_to_zulu_without_ms(dr.data_interval_start),
                             "end_date": None,
-                            "logical_date": datetime_zulu_format_without_ms(dr.logical_date),
-                            "start_date": datetime_zulu_format_without_ms(dr.start_date),
+                            "logical_date": from_datetime_to_zulu_without_ms(dr.logical_date),
+                            "start_date": from_datetime_to_zulu_without_ms(dr.start_date),
                             "state": "running",
                         }
                     ],

--- a/tests/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/tests/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -39,6 +39,7 @@ from tests_common.test_utils.db import (
     clear_db_runs,
     clear_db_serialized_dags,
 )
+from tests_common.test_utils.format_datetime import datetime_zulu_format, datetime_zulu_format_without_ms
 
 pytestmark = pytest.mark.db_test
 
@@ -193,21 +194,19 @@ class TestGetDagRun:
 
 class TestGetDagRuns:
     @staticmethod
-    def parse_datetime(datetime_str):
-        return datetime_str.isoformat().replace("+00:00", "Z") if datetime_str else None
-
-    @staticmethod
     def get_dag_run_dict(run: DagRun):
         return {
             "dag_run_id": run.run_id,
             "dag_id": run.dag_id,
-            "logical_date": TestGetDagRuns.parse_datetime(run.logical_date),
-            "queued_at": TestGetDagRuns.parse_datetime(run.queued_at),
-            "start_date": TestGetDagRuns.parse_datetime(run.start_date),
-            "end_date": TestGetDagRuns.parse_datetime(run.end_date),
-            "data_interval_start": TestGetDagRuns.parse_datetime(run.data_interval_start),
-            "data_interval_end": TestGetDagRuns.parse_datetime(run.data_interval_end),
-            "last_scheduling_decision": TestGetDagRuns.parse_datetime(run.last_scheduling_decision),
+            "logical_date": datetime_zulu_format_without_ms(run.logical_date),
+            "queued_at": datetime_zulu_format(run.queued_at) if run.queued_at else None,
+            "start_date": datetime_zulu_format_without_ms(run.start_date),
+            "end_date": datetime_zulu_format(run.end_date),
+            "data_interval_start": datetime_zulu_format_without_ms(run.data_interval_start),
+            "data_interval_end": datetime_zulu_format_without_ms(run.data_interval_end),
+            "last_scheduling_decision": datetime_zulu_format(run.last_scheduling_decision)
+            if run.last_scheduling_decision
+            else None,
             "run_type": run.run_type,
             "state": run.state,
             "external_trigger": run.external_trigger,
@@ -976,7 +975,7 @@ class TestGetDagRunAssetTriggerEvents:
         expected_response = {
             "asset_events": [
                 {
-                    "timestamp": event.timestamp.isoformat().replace("+00:00", "Z"),
+                    "timestamp": datetime_zulu_format(event.timestamp),
                     "asset_id": asset1_id,
                     "uri": asset1.uri,
                     "extra": {},
@@ -989,11 +988,11 @@ class TestGetDagRunAssetTriggerEvents:
                         {
                             "dag_id": "TEST_DAG_ID",
                             "run_id": "TEST_DAG_RUN_ID",
-                            "data_interval_end": dr.data_interval_end.isoformat().replace("+00:00", "Z"),
-                            "data_interval_start": dr.data_interval_start.isoformat().replace("+00:00", "Z"),
+                            "data_interval_end": datetime_zulu_format_without_ms(dr.data_interval_end),
+                            "data_interval_start": datetime_zulu_format_without_ms(dr.data_interval_start),
                             "end_date": None,
-                            "logical_date": dr.logical_date.isoformat().replace("+00:00", "Z"),
-                            "start_date": dr.start_date.isoformat().replace("+00:00", "Z"),
+                            "logical_date": datetime_zulu_format_without_ms(dr.logical_date),
+                            "start_date": datetime_zulu_format_without_ms(dr.start_date),
                             "state": "running",
                         }
                     ],

--- a/tests/api_fastapi/core_api/routes/public/test_event_logs.py
+++ b/tests/api_fastapi/core_api/routes/public/test_event_logs.py
@@ -24,7 +24,7 @@ from airflow.models.log import Log
 from airflow.utils.session import provide_session
 
 from tests_common.test_utils.db import clear_db_logs, clear_db_runs
-from tests_common.test_utils.format_datetime import datetime_zulu_format, datetime_zulu_format_without_ms
+from tests_common.test_utils.format_datetime import from_datetime_to_zulu, from_datetime_to_zulu_without_ms
 
 pytestmark = pytest.mark.db_test
 
@@ -161,14 +161,14 @@ class TestGetEventLog(TestEventLogsEndpoint):
 
         expected_json = {
             "event_log_id": event_log_id,
-            "when": datetime_zulu_format(event_log.dttm) if event_log.dttm else None,
+            "when": from_datetime_to_zulu(event_log.dttm) if event_log.dttm else None,
             "dag_id": expected_body.get("dag_id"),
             "task_id": expected_body.get("task_id"),
             "run_id": expected_body.get("run_id"),
             "map_index": event_log.map_index,
             "try_number": event_log.try_number,
             "event": expected_body.get("event"),
-            "logical_date": datetime_zulu_format_without_ms(event_log.logical_date)
+            "logical_date": from_datetime_to_zulu_without_ms(event_log.logical_date)
             if event_log.logical_date
             else None,
             "owner": expected_body.get("owner"),

--- a/tests/api_fastapi/core_api/routes/public/test_import_error.py
+++ b/tests/api_fastapi/core_api/routes/public/test_import_error.py
@@ -24,7 +24,7 @@ from airflow.models.errors import ParseImportError
 from airflow.utils.session import provide_session
 
 from tests_common.test_utils.db import clear_db_import_errors
-from tests_common.test_utils.format_datetime import datetime_zulu_format_without_ms
+from tests_common.test_utils.format_datetime import from_datetime_to_zulu_without_ms
 
 pytestmark = pytest.mark.db_test
 
@@ -116,7 +116,7 @@ class TestGetImportError(TestImportErrorEndpoint):
             return
         expected_json = {
             "import_error_id": import_error_id,
-            "timestamp": datetime_zulu_format_without_ms(expected_body["timestamp"]),
+            "timestamp": from_datetime_to_zulu_without_ms(expected_body["timestamp"]),
             "filename": expected_body["filename"],
             "stack_trace": expected_body["stack_trace"],
         }

--- a/tests/api_fastapi/core_api/routes/public/test_job.py
+++ b/tests/api_fastapi/core_api/routes/public/test_job.py
@@ -26,7 +26,7 @@ from airflow.utils.session import provide_session
 from airflow.utils.state import JobState, State
 
 from tests_common.test_utils.db import clear_db_jobs
-from tests_common.test_utils.format_datetime import datetime_zulu_format
+from tests_common.test_utils.format_datetime import from_datetime_to_zulu
 
 pytestmark = pytest.mark.db_test
 
@@ -155,9 +155,9 @@ class TestGetJobs(TestJobEndpoint):
                 "dag_id": None,
                 "state": "running",
                 "job_type": "SchedulerJob",
-                "start_date": datetime_zulu_format(self.scheduler_jobs[idx].start_date),
+                "start_date": from_datetime_to_zulu(self.scheduler_jobs[idx].start_date),
                 "end_date": None,
-                "latest_heartbeat": datetime_zulu_format(self.scheduler_jobs[idx].latest_heartbeat),
+                "latest_heartbeat": from_datetime_to_zulu(self.scheduler_jobs[idx].latest_heartbeat),
                 "executor_class": None,
                 "hostname": self.scheduler_jobs[idx].hostname,
                 "unixname": self.scheduler_jobs[idx].unixname,

--- a/tests_common/test_utils/format_datetime.py
+++ b/tests_common/test_utils/format_datetime.py
@@ -19,11 +19,11 @@ from __future__ import annotations
 from datetime import datetime
 
 
-def datetime_zulu_format(dt: datetime) -> str:
+def from_datetime_to_zulu(dt: datetime) -> str:
     """Format a datetime object to a string in Zulu time."""
     return dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
 
-def datetime_zulu_format_without_ms(dt: datetime) -> str:
+def from_datetime_to_zulu_without_ms(dt: datetime) -> str:
     """Format a datetime object to a string in Zulu time without milliseconds."""
     return dt.strftime("%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
related: https://github.com/apache/airflow/pull/43859#issuecomment-2493093935

Refactor test cases using the `datetime_zulu_format` utility instead of manual replacements.  
This change depends on https://github.com/apache/airflow/pull/43859 being merged.

### Refactored Test Cases  
- **In this PR**:  
  - `test_assets`  
  - `test_dag_run`  

- **In https://github.com/apache/airflow/pull/43859**:  
  - `test_event_logs`  
  - `test_import_error`  
