### PR TITLE
AIP-38 Fix 401 and 403 handling

### DIFF
--- a/airflow/ui/src/main.tsx
+++ b/airflow/ui/src/main.tsx
@@ -47,11 +47,13 @@ const queryClient = new QueryClient({
 axios.interceptors.response.use(
   (response) => response,
   (error: AxiosError) => {
-    if (error.response?.status === 403 || error.response?.status === 401) {
+    if (error.response?.status === 401) {
       const params = new URLSearchParams();
 
       params.set("next", globalThis.location.href);
-      globalThis.location.replace(`/login?${params.toString()}`);
+      globalThis.location.replace(
+        `${import.meta.env.VITE_LEGACY_API_URL}/login?${params.toString()}`,
+      );
     }
 
     return Promise.reject(error);


### PR DESCRIPTION
Small improvements:
- Redirection URL is changed to use the legacy `login` endpoint for now. At the moment the new API does not expose any `/login` route, and the current redirection will cause a plain `404`. (We can swap that back later when the new login endpoint is implemented)

- Do not handle 403. Permissions errors mean that the user is authenticated and recognized, he just does not have permission to do that. In that case redirecting him to `/login` does not serve any purpose as the user is already authenticated. We should instead handle the `403` and display an appropriate message to the User.