### PR TITLE
Simplify asset decorator implementation

### DIFF
--- a/task_sdk/src/airflow/sdk/definitions/asset/__init__.py
+++ b/task_sdk/src/airflow/sdk/definitions/asset/__init__.py
@@ -300,6 +300,15 @@ class Asset(os.PathLike, BaseAsset):
     def __fspath__(self) -> str:
         return self.uri
 
+    def __eq__(self, other: Any) -> bool:
+        # The Asset class can be subclassed, and we don't want fields added by a
+        # subclass to break equality. This explicitly filters out only fields
+        # defined by the Asset class for comparison.
+        if not isinstance(other, Asset):
+            return NotImplemented
+        f = attrs.filters.include(*attrs.fields_dict(Asset))
+        return attrs.asdict(self, filter=f) == attrs.asdict(other, filter=f)
+
     @property
     def normalized_uri(self) -> str | None:
         """

--- a/task_sdk/src/airflow/sdk/definitions/asset/decorators.py
+++ b/task_sdk/src/airflow/sdk/definitions/asset/decorators.py
@@ -18,23 +18,19 @@
 from __future__ import annotations
 
 import inspect
-from collections.abc import Iterator, Mapping
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-)
+from typing import TYPE_CHECKING, Any, Callable
 
 import attrs
 
-from airflow.models.asset import _fetch_active_assets_by_name
-from airflow.models.dag import DAG, ScheduleArg
 from airflow.providers.standard.operators.python import PythonOperator
 from airflow.sdk.definitions.asset import Asset, AssetRef
 from airflow.utils.session import create_session
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator, Mapping
+
     from airflow.io.path import ObjectStoragePath
+    from airflow.models.dag import ScheduleArg
     from airflow.triggers.base import BaseTrigger
 
 
@@ -58,7 +54,8 @@ class _AssetMainOperator(PythonOperator):
             yield key, value
 
     def determine_kwargs(self, context: Mapping[str, Any]) -> Mapping[str, Any]:
-        active_assets: dict[str, Asset] = {}
+        from airflow.models.asset import _fetch_active_assets_by_name
+
         asset_names = [asset_ref.name for asset_ref in self.inlets if isinstance(asset_ref, AssetRef)]
         if "self" in inspect.signature(self.python_callable).parameters:
             asset_names.append(self._definition_name)
@@ -66,6 +63,8 @@ class _AssetMainOperator(PythonOperator):
         if asset_names:
             with create_session() as session:
                 active_assets = _fetch_active_assets_by_name(asset_names, session)
+        else:
+            active_assets = {}
         return dict(self._iter_kwargs(context, active_assets))
 
 
@@ -81,37 +80,21 @@ class AssetDefinition(Asset):
     schedule: ScheduleArg
 
     def __attrs_post_init__(self) -> None:
-        parameters = inspect.signature(self.function).parameters
+        from airflow.models.dag import DAG
 
         with DAG(dag_id=self.name, schedule=self.schedule, auto_register=True):
             _AssetMainOperator(
                 task_id="__main__",
                 inlets=[
                     AssetRef(name=inlet_asset_name)
-                    for inlet_asset_name in parameters
+                    for inlet_asset_name in inspect.signature(self.function).parameters
                     if inlet_asset_name not in ("self", "context")
                 ],
-                outlets=[self.to_asset()],
+                outlets=[self],
                 python_callable=self.function,
                 definition_name=self.name,
                 uri=self.uri,
             )
-
-    def to_asset(self) -> Asset:
-        return Asset(
-            name=self.name,
-            uri=self.uri,
-            group=self.group,
-            extra=self.extra,
-        )
-
-    def serialize(self):
-        return {
-            "uri": self.uri,
-            "name": self.name,
-            "group": self.group,
-            "extra": self.extra,
-        }
 
 
 @attrs.define(kw_only=True)
@@ -125,6 +108,9 @@ class asset:
     watchers: list[BaseTrigger] = attrs.field(factory=list)
 
     def __call__(self, f: Callable) -> AssetDefinition:
+        if self.schedule is not None:
+            raise NotImplementedError("asset scheduling not implemented yet")
+
         if (name := f.__name__) != f.__qualname__:
             raise ValueError("nested function not supported")
 

--- a/task_sdk/src/airflow/sdk/definitions/asset/decorators.py
+++ b/task_sdk/src/airflow/sdk/definitions/asset/decorators.py
@@ -103,7 +103,7 @@ class asset:
 
     schedule: ScheduleArg
     uri: str | ObjectStoragePath | None = None
-    group: str = ""
+    group: str = Asset.asset_type
     extra: dict[str, Any] = attrs.field(factory=dict)
     watchers: list[BaseTrigger] = attrs.field(factory=list)
 

--- a/task_sdk/tests/defintions/test_asset_decorators.py
+++ b/task_sdk/tests/defintions/test_asset_decorators.py
@@ -135,7 +135,7 @@ class TestAssetDefinition:
                 AssetRef(name="inlet_asset_1"),
                 AssetRef(name="inlet_asset_2"),
             ],
-            outlets=[asset_definition.to_asset()],
+            outlets=[asset_definition],
             python_callable=ANY,
             definition_name="example_asset_func",
             uri="s3://bucket/object",


### PR DESCRIPTION
Since AssetDefinition subclasses Asset, we don't really need the to_asset() method, but can just pass self in.

I also moved some imports around to reduce module loading at import time.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
