### PR TITLE
AIP-84 Refactor SortParm

### DIFF
--- a/airflow/api_fastapi/common/parameters.py
+++ b/airflow/api_fastapi/common/parameters.py
@@ -45,7 +45,6 @@ from airflow.models.asset import AssetEvent, AssetModel, DagScheduleAssetReferen
 from airflow.models.dag import DagModel, DagTag
 from airflow.models.dagrun import DagRun
 from airflow.models.dagwarning import DagWarning, DagWarningType
-from airflow.models.errors import ParseImportError
 from airflow.models.taskinstance import TaskInstance
 from airflow.typing_compat import Self
 from airflow.utils import timezone
@@ -219,7 +218,6 @@ class SortParam(BaseParam[str]):
     """Order result by the attribute."""
 
     attr_mapping = {
-        "import_error_id": ParseImportError.id,
         "dag_run_id": DagRun.run_id,
     }
 

--- a/airflow/api_fastapi/common/parameters.py
+++ b/airflow/api_fastapi/common/parameters.py
@@ -40,7 +40,7 @@ from sqlalchemy.inspection import inspect
 
 from airflow.api_connexion.endpoints.task_instance_endpoint import _convert_ti_states
 from airflow.jobs.job import Job
-from airflow.models import Base, Connection
+from airflow.models import Base
 from airflow.models.asset import AssetEvent, AssetModel, DagScheduleAssetReference, TaskOutletAssetReference
 from airflow.models.dag import DagModel, DagTag
 from airflow.models.dagrun import DagRun
@@ -221,7 +221,6 @@ class SortParam(BaseParam[str]):
     attr_mapping = {
         "last_run_state": DagRun.state,
         "last_run_start_date": DagRun.start_date,
-        "connection_id": Connection.conn_id,
         "import_error_id": ParseImportError.id,
         "dag_run_id": DagRun.run_id,
     }

--- a/airflow/api_fastapi/common/parameters.py
+++ b/airflow/api_fastapi/common/parameters.py
@@ -230,7 +230,7 @@ class SortParam(BaseParam[str]):
             raise ValueError(f"Cannot set 'skip_none' to False on a {type(self)}")
 
         if self.value is None:
-            return select
+            self.value = self.get_primary_key_string()
 
         lstriped_orderby = self.value.lstrip("-")
         column: Column | None = None

--- a/airflow/api_fastapi/common/parameters.py
+++ b/airflow/api_fastapi/common/parameters.py
@@ -226,7 +226,7 @@ class SortParam(BaseParam[str]):
     }
 
     def __init__(
-        self, allowed_attrs: list[str], model: Base, to_replace: dict[str, str] | None = None
+        self, allowed_attrs: list[str], model: Base, to_replace: dict[str, str | Column] | None = None
     ) -> None:
         super().__init__()
         self.allowed_attrs = allowed_attrs
@@ -241,19 +241,22 @@ class SortParam(BaseParam[str]):
             return select
 
         lstriped_orderby = self.value.lstrip("-")
+        column: Column | None = None
         if self.to_replace:
-            lstriped_orderby = self.to_replace.get(lstriped_orderby, lstriped_orderby)
+            replacement = self.to_replace.get(lstriped_orderby, lstriped_orderby)
+            if isinstance(replacement, str):
+                lstriped_orderby = replacement
+            else:
+                column = replacement
 
-        if self.allowed_attrs and lstriped_orderby not in self.allowed_attrs:
+        if (self.allowed_attrs and lstriped_orderby not in self.allowed_attrs) and column is None:
             raise HTTPException(
                 400,
                 f"Ordering with '{lstriped_orderby}' is disallowed or "
                 f"the attribute does not exist on the model",
             )
-
-        column: Column = self.attr_mapping.get(lstriped_orderby, None) or getattr(
-            self.model, lstriped_orderby
-        )
+        if column is None:
+            column = self.attr_mapping.get(lstriped_orderby, None) or getattr(self.model, lstriped_orderby)
 
         # MySQL does not support `nullslast`, and True/False ordering depends on the
         # database implementation.

--- a/airflow/api_fastapi/common/parameters.py
+++ b/airflow/api_fastapi/common/parameters.py
@@ -217,10 +217,6 @@ class _DagDisplayNamePatternSearch(_SearchParam):
 class SortParam(BaseParam[str]):
     """Order result by the attribute."""
 
-    attr_mapping = {
-        "dag_run_id": DagRun.run_id,
-    }
-
     def __init__(
         self, allowed_attrs: list[str], model: Base, to_replace: dict[str, str | Column] | None = None
     ) -> None:
@@ -252,7 +248,7 @@ class SortParam(BaseParam[str]):
                 f"the attribute does not exist on the model",
             )
         if column is None:
-            column = self.attr_mapping.get(lstriped_orderby, None) or getattr(self.model, lstriped_orderby)
+            column = getattr(self.model, lstriped_orderby)
 
         # MySQL does not support `nullslast`, and True/False ordering depends on the
         # database implementation.

--- a/airflow/api_fastapi/common/parameters.py
+++ b/airflow/api_fastapi/common/parameters.py
@@ -219,8 +219,6 @@ class SortParam(BaseParam[str]):
     """Order result by the attribute."""
 
     attr_mapping = {
-        "last_run_state": DagRun.state,
-        "last_run_start_date": DagRun.start_date,
         "import_error_id": ParseImportError.id,
         "dag_run_id": DagRun.run_id,
     }

--- a/airflow/api_fastapi/core_api/routes/public/connections.py
+++ b/airflow/api_fastapi/core_api/routes/public/connections.py
@@ -92,7 +92,9 @@ def get_connections(
         SortParam,
         Depends(
             SortParam(
-                ["connection_id", "conn_type", "description", "host", "port", "id"], Connection
+                ["conn_id", "conn_type", "description", "host", "port", "id"],
+                Connection,
+                {"connection_id": "conn_id"},
             ).dynamic_depends()
         ),
     ],

--- a/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -334,7 +334,7 @@ def get_list_dag_runs_batch(
             "state",
             "dag_id",
             "logical_date",
-            "dag_run_id",
+            "run_id",
             "start_date",
             "end_date",
             "updated_at",
@@ -342,6 +342,7 @@ def get_list_dag_runs_batch(
             "conf",
         ],
         DagRun,
+        {"dag_run_id": "run_id"},
     ).set_value(body.order_by)
 
     base_query = select(DagRun)

--- a/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -259,8 +259,8 @@ def get_dag_runs(
                     "id",
                     "state",
                     "dag_id",
+                    "run_id",
                     "logical_date",
-                    "dag_run_id",
                     "start_date",
                     "end_date",
                     "updated_at",
@@ -268,6 +268,7 @@ def get_dag_runs(
                     "conf",
                 ],
                 DagRun,
+                {"dag_run_id": "run_id"},
             ).dynamic_depends(default="id")
         ),
     ],

--- a/airflow/api_fastapi/core_api/routes/public/dags.py
+++ b/airflow/api_fastapi/core_api/routes/public/dags.py
@@ -54,6 +54,7 @@ from airflow.api_fastapi.core_api.datamodels.dags import (
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
 from airflow.exceptions import AirflowException, DagNotFound
 from airflow.models import DAG, DagModel, DagTag
+from airflow.models.dagrun import DagRun
 
 dags_router = AirflowRouter(tags=["DAG"], prefix="/dags")
 
@@ -73,8 +74,9 @@ def get_dags(
         SortParam,
         Depends(
             SortParam(
-                ["dag_id", "dag_display_name", "next_dagrun", "last_run_state", "last_run_start_date"],
+                ["dag_id", "dag_display_name", "next_dagrun", "state", "start_date"],
                 DagModel,
+                {"last_run_state": DagRun.state, "last_run_start_date": DagRun.start_date},
             ).dynamic_depends()
         ),
     ],

--- a/airflow/api_fastapi/core_api/routes/public/import_error.py
+++ b/airflow/api_fastapi/core_api/routes/public/import_error.py
@@ -73,12 +73,12 @@ def get_import_errors(
             SortParam(
                 [
                     "id",
-                    "import_error_id",
                     "timestamp",
                     "filename",
                     "stacktrace",
                 ],
                 ParseImportError,
+                {"import_error_id": "id"},
             ).dynamic_depends()
         ),
     ],


### PR DESCRIPTION
Related: https://github.com/apache/airflow/pull/42959#issuecomment-2422749143  

### Refactor `SortParam`  

Leverage the `to_replace` functionality introduced in https://github.com/apache/airflow/pull/43793 and allow the `Column` type to be used in the `to_replace` dictionary.  
This change enables the complete removal of `attr_mapping` from `SortParam`, as most instances of `SortParam` do not require `attr_mapping`. 
