### PR TITLE
Use UI config

### DIFF
--- a/airflow/ui/src/components/DataTable/useTableUrlState.ts
+++ b/airflow/ui/src/components/DataTable/useTableUrlState.ts
@@ -27,9 +27,7 @@ import type { TableState } from "./types";
 export const useTableURLState = (defaultState?: Partial<TableState>) => {
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const configPageSize = useConfig("page_size");
-  const pageSize =
-    typeof configPageSize === "string" ? parseInt(configPageSize, 10) : 50;
+  const pageSize = useConfig("page_size") as number;
 
   const defaultTableState = {
     pagination: {

--- a/airflow/ui/src/components/DataTable/useTableUrlState.ts
+++ b/airflow/ui/src/components/DataTable/useTableUrlState.ts
@@ -27,7 +27,7 @@ import type { TableState } from "./types";
 export const useTableURLState = (defaultState?: Partial<TableState>) => {
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const configPageSize = useConfig("webserver", "page_size");
+  const configPageSize = useConfig("page_size");
   const pageSize =
     typeof configPageSize === "string" ? parseInt(configPageSize, 10) : 50;
 

--- a/airflow/ui/src/components/TogglePause.tsx
+++ b/airflow/ui/src/components/TogglePause.tsx
@@ -60,8 +60,9 @@ export const TogglePause = ({
     onSuccess,
   });
 
-  const showConfirmation =
-    useConfig("require_confirmation_dag_change") === "True";
+  const showConfirmation = Boolean(
+    useConfig("require_confirmation_dag_change"),
+  );
 
   const onToggle = useCallback(() => {
     mutate({

--- a/airflow/ui/src/components/TogglePause.tsx
+++ b/airflow/ui/src/components/TogglePause.tsx
@@ -61,7 +61,7 @@ export const TogglePause = ({
   });
 
   const showConfirmation =
-    useConfig("webserver", "require_confirmation_dag_change") === "True";
+    useConfig("require_confirmation_dag_change") === "True";
 
   const onToggle = useCallback(() => {
     mutate({

--- a/airflow/ui/src/context/timezone/TimezoneProvider.tsx
+++ b/airflow/ui/src/context/timezone/TimezoneProvider.tsx
@@ -33,7 +33,7 @@ export const TimezoneContext = createContext<TimezoneContextType | undefined>(
 const TIMEZONE_KEY = "timezone";
 
 export const TimezoneProvider = ({ children }: PropsWithChildren) => {
-  const defaultUITimezone = useConfig("webserver", "default_ui_timezone");
+  const defaultUITimezone = useConfig("default_ui_timezone");
 
   const [selectedTimezone, setSelectedTimezone] = useLocalStorage(
     TIMEZONE_KEY,

--- a/airflow/ui/src/layouts/BaseLayout.tsx
+++ b/airflow/ui/src/layouts/BaseLayout.tsx
@@ -25,7 +25,7 @@ import { useConfig } from "src/queries/useConfig";
 import { Nav } from "./Nav";
 
 export const BaseLayout = ({ children }: PropsWithChildren) => {
-  const instanceName = useConfig("webserver", "instance_name");
+  const instanceName = useConfig("instance_name");
   // const instanceNameHasMarkup =
   //   webserverConfig?.options.find(
   //     ({ key }) => key === "instance_name_has_markup",

--- a/airflow/ui/src/layouts/Nav/DocsButton.tsx
+++ b/airflow/ui/src/layouts/Nav/DocsButton.tsx
@@ -40,7 +40,7 @@ const links = [
 ];
 
 export const DocsButton = () => {
-  const showAPIDocs = useConfig("webserver", "enable_swagger_ui") === "True";
+  const showAPIDocs = useConfig("enable_swagger_ui") === "True";
 
   return (
     <Menu.Root positioning={{ placement: "right" }}>

--- a/airflow/ui/src/layouts/Nav/DocsButton.tsx
+++ b/airflow/ui/src/layouts/Nav/DocsButton.tsx
@@ -40,7 +40,7 @@ const links = [
 ];
 
 export const DocsButton = () => {
-  const showAPIDocs = useConfig("enable_swagger_ui") === "True";
+  const showAPIDocs = Boolean(useConfig("enable_swagger_ui"));
 
   return (
     <Menu.Root positioning={{ placement: "right" }}>

--- a/airflow/ui/src/pages/DagsList/Dag/Code/Code.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Code/Code.tsx
@@ -60,7 +60,7 @@ export const Code = () => {
     dagId: dagId ?? "",
   });
 
-  const defaultWrap = useConfig("webserver", "default_wrap") === "True";
+  const defaultWrap = useConfig("default_wrap") === "True";
 
   const [wrap, setWrap] = useState(defaultWrap);
 

--- a/airflow/ui/src/pages/DagsList/Dag/Code/Code.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Code/Code.tsx
@@ -60,7 +60,7 @@ export const Code = () => {
     dagId: dagId ?? "",
   });
 
-  const defaultWrap = useConfig("default_wrap") === "True";
+  const defaultWrap = Boolean(useConfig("default_wrap"));
 
   const [wrap, setWrap] = useState(defaultWrap);
 

--- a/airflow/ui/src/pages/DagsList/DagsFilters.tsx
+++ b/airflow/ui/src/pages/DagsList/DagsFilters.tsx
@@ -70,9 +70,10 @@ export const DagsFilters = () => {
     orderBy: "name",
   });
 
-  const hidePausedDagsByDefault = useConfig("hide_paused_dags_by_default");
-  const defaultShowPaused =
-    hidePausedDagsByDefault === "True" ? "false" : "all";
+  const hidePausedDagsByDefault = Boolean(
+    useConfig("hide_paused_dags_by_default"),
+  );
+  const defaultShowPaused = hidePausedDagsByDefault ? "false" : "all";
 
   const { setTableURLState, tableURLState } = useTableURLState();
   const { pagination, sorting } = tableURLState;

--- a/airflow/ui/src/pages/DagsList/DagsFilters.tsx
+++ b/airflow/ui/src/pages/DagsList/DagsFilters.tsx
@@ -70,10 +70,7 @@ export const DagsFilters = () => {
     orderBy: "name",
   });
 
-  const hidePausedDagsByDefault = useConfig(
-    "webserver",
-    "hide_paused_dags_by_default",
-  );
+  const hidePausedDagsByDefault = useConfig("hide_paused_dags_by_default");
   const defaultShowPaused =
     hidePausedDagsByDefault === "True" ? "false" : "all";
 

--- a/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -159,9 +159,10 @@ export const DagsList = () => {
     "card",
   );
 
-  const hidePausedDagsByDefault = useConfig("hide_paused_dags_by_default");
-  const defaultShowPaused =
-    hidePausedDagsByDefault === "True" ? false : undefined;
+  const hidePausedDagsByDefault = Boolean(
+    useConfig("hide_paused_dags_by_default"),
+  );
+  const defaultShowPaused = hidePausedDagsByDefault ? false : undefined;
 
   const showPaused = searchParams.get(PAUSED_PARAM);
 

--- a/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -159,10 +159,7 @@ export const DagsList = () => {
     "card",
   );
 
-  const hidePausedDagsByDefault = useConfig(
-    "webserver",
-    "hide_paused_dags_by_default",
-  );
+  const hidePausedDagsByDefault = useConfig("hide_paused_dags_by_default");
   const defaultShowPaused =
     hidePausedDagsByDefault === "True" ? false : undefined;
 

--- a/airflow/ui/src/pages/Dashboard/Health/Health.tsx
+++ b/airflow/ui/src/pages/Dashboard/Health/Health.tsx
@@ -29,7 +29,7 @@ export const Health = () => {
   const { data, error, isLoading } = useMonitorServiceGetHealth();
 
   const isStandaloneDagProcessor =
-    useConfig("scheduler", "standalone_dag_processor") === "True";
+    useConfig("standalone_dag_processor") === "True";
 
   return (
     <Box>

--- a/airflow/ui/src/pages/Dashboard/Health/Health.tsx
+++ b/airflow/ui/src/pages/Dashboard/Health/Health.tsx
@@ -21,15 +21,11 @@ import { MdOutlineHealthAndSafety } from "react-icons/md";
 
 import { useMonitorServiceGetHealth } from "openapi/queries";
 import { ErrorAlert } from "src/components/ErrorAlert";
-import { useConfig } from "src/queries/useConfig";
 
 import { HealthTag } from "./HealthTag";
 
 export const Health = () => {
   const { data, error, isLoading } = useMonitorServiceGetHealth();
-
-  const isStandaloneDagProcessor =
-    useConfig("standalone_dag_processor") === "True";
 
   return (
     <Box>
@@ -58,14 +54,15 @@ export const Health = () => {
           status={data?.triggerer.status}
           title="Triggerer"
         />
-        {isStandaloneDagProcessor ? (
+        {/* TODO: Update this to match the API when we move the config check to the API level */}
+        {data?.dag_processor.status === undefined ? undefined : (
           <HealthTag
             isLoading={isLoading}
-            latestHeartbeat={data?.dag_processor.latest_dag_processor_heartbeat}
-            status={data?.dag_processor.status}
+            latestHeartbeat={data.dag_processor.latest_dag_processor_heartbeat}
+            status={data.dag_processor.status}
             title="Dag Processor"
           />
-        ) : undefined}
+        )}
       </HStack>
     </Box>
   );

--- a/airflow/ui/src/queries/useConfig.tsx
+++ b/airflow/ui/src/queries/useConfig.tsx
@@ -19,8 +19,8 @@
 import { useConfigServiceGetConfigs } from "openapi/queries";
 import type { ConfigResponse } from "openapi/requests/types.gen";
 
-export const useConfig = (configKey: string) => {
+export const useConfig = (configKey: keyof ConfigResponse) => {
   const { data: config } = useConfigServiceGetConfigs();
 
-  return config?.[configKey as keyof ConfigResponse];
+  return config?.[configKey];
 };

--- a/airflow/ui/src/queries/useConfig.tsx
+++ b/airflow/ui/src/queries/useConfig.tsx
@@ -16,17 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useConfigServiceGetConfig } from "openapi/queries";
+import { useConfigServiceGetConfigs } from "openapi/queries";
+import type { ConfigResponse } from "openapi/requests/types.gen";
 
-export const useConfig = (sectionName: string, configKey: string) => {
-  // TODO: replace with a ui/config endpoint which will always return what the UI need to render
-  const { data: config } = useConfigServiceGetConfig({
-    accept: "application/json",
-  });
+export const useConfig = (configKey: string) => {
+  const { data: config } = useConfigServiceGetConfigs();
 
-  const configSection = config?.sections.find(
-    (section) => section.name === sectionName,
-  );
-
-  return configSection?.options.find(({ key }) => key === configKey)?.value;
+  return config?.[configKey as keyof ConfigResponse];
 };


### PR DESCRIPTION
Swap the UI to use the `ui/config` endpoint that will always be enabled and has better type checks.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
