### PR TITLE
Move tests `bootstrap_dagbag` into test utils

### DIFF
--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -1225,19 +1225,6 @@ def resetdb(session: Session = NEW_SESSION, skip_init: bool = False):
 
 
 @provide_session
-def bootstrap_dagbag(session: Session = NEW_SESSION):
-    from airflow.models.dag import DAG
-    from airflow.models.dagbag import DagBag
-
-    dagbag = DagBag()
-    # Save DAGs in the ORM
-    dagbag.sync_to_db(session=session)
-
-    # Deactivate the unknown ones
-    DAG.deactivate_unknown_dags(dagbag.dags.keys(), session=session)
-
-
-@provide_session
 def downgrade(*, to_revision, from_revision=None, show_sql_only=False, session: Session = NEW_SESSION):
     """
     Downgrade the airflow metastore schema to a prior version.

--- a/tests_common/test_utils/db.py
+++ b/tests_common/test_utils/db.py
@@ -54,6 +54,19 @@ from tests_common.test_utils.compat import (
 )
 
 
+def _bootstrap_dagbag():
+    from airflow.models.dag import DAG
+    from airflow.models.dagbag import DagBag
+
+    with create_session() as session:
+        dagbag = DagBag()
+        # Save DAGs in the ORM
+        dagbag.sync_to_db(session=session)
+
+        # Deactivate the unknown ones
+        DAG.deactivate_unknown_dags(dagbag.dags.keys(), session=session)
+
+
 def initial_db_init():
     from flask import Flask
 
@@ -63,7 +76,7 @@ def initial_db_init():
     from airflow.www.extensions.init_auth_manager import get_auth_manager
 
     db.resetdb()
-    db.bootstrap_dagbag()
+    _bootstrap_dagbag()
     # minimal app to add roles
     flask_app = Flask(__name__)
     flask_app.config["SQLALCHEMY_DATABASE_URI"] = conf.get("database", "SQL_ALCHEMY_CONN")


### PR DESCRIPTION
This is only used during testing, so I've moved into the testing utils.
The normal db utils aren't public, so this isn't a breaking change.

