### PR TITLE
docs(newsfragment): add template for significant newsfragments

### DIFF
--- a/.github/workflows/news-fragment.yml
+++ b/.github/workflows/news-fragment.yml
@@ -36,7 +36,7 @@ jobs:
           # needs a non-shallow clone.
           fetch-depth: 0
 
-      - name: Check news fragment
+      - name: Check news fragment existence
         run: >
           python -m pip install --upgrade uv &&
           uv tool run towncrier check
@@ -52,3 +52,26 @@ jobs:
           &&
           false
           ; }
+
+      - name: Check news fragment contains change types
+        run: >
+          change_types=(
+            'DAG changes'
+            'Config changes'
+            'API changes'
+            'CLI changes'
+            'Behaviour changes'
+            'Plugin changes'
+            'Dependency change'
+          )
+          news_fragment_content=`git diff origin/${{ github.base_ref }} newsfragments/*.significant.rst`
+
+          for type in "${change_types[@]}"; do
+            if [[ $news_fragment_content != *"$type"* ]]; then
+              printf "\033[1;33mMissing change type '$type' in significant newsfragment for PR labeled with
+              'airflow3.0:breaking'.\nCheck
+              https://github.com/apache/airflow/blob/main/contributing-docs/16_contribution_workflow.rst
+              for guidance.\033[m\n"
+              exit 1
+            fi
+          done

--- a/contributing-docs/16_contribution_workflow.rst
+++ b/contributing-docs/16_contribution_workflow.rst
@@ -196,7 +196,12 @@ Step 4: Prepare PR
      and place in either `newsfragments <https://github.com/apache/airflow/blob/main/newsfragments>`__ for core newsfragments,
      or `chart/newsfragments <https://github.com/apache/airflow/blob/main/chart/newsfragments>`__ for helm chart newsfragments.
 
-     In general newsfragments must be one line.  For newsfragment type ``significant``, you may include summary and body separated by a blank line, similar to ``git`` commit messages.
+     In general newsfragments must be one line.  For newsfragment type ``significant``,
+     you should follow the template in ``newsfragments/template.significant.rst`` to include summary, body, change type and migrations rules needed.
+     This can also be done by the following command.
+
+.. code-block:: bash
+     uv tool run towncrier create --dir . --config newsfragments/config.toml --content "`cat newsfragments/template.significant.rst`"
 
 2. Rebase your fork, squash commits, and resolve all conflicts. See `How to rebase PR <#how-to-rebase-pr>`_
    if you need help with rebasing your change. Remember to rebase often if your PR takes a lot of time to

--- a/newsfragments/template.significant.rst
+++ b/newsfragments/template.significant.rst
@@ -1,0 +1,19 @@
+.. Write a short and imperative summary of this changes
+
+.. Provide additional contextual information
+
+.. Check the type of change that applies to this change
+
+* Types of change
+
+  * [ ] DAG changes
+  * [ ] Config changes
+  * [ ] API changes
+  * [ ] CLI changes
+  * [ ] Behaviour changes
+  * [ ] Plugin changes
+  * [ ] Dependency change
+
+.. List the migration rules needed for this change (see https://github.com/apache/airflow/issues/41641)
+
+* Migrations rules needed


### PR DESCRIPTION
Closes: #44374

## Why
make updating https://github.com/apache/airflow/issues/41641 and https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+3+breaking+changes easier

## What
Add a template and a command line to generate a file based on the description to the doc

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
