### PR TITLE
Add 'airflow assets list'

### DIFF
--- a/airflow/api_fastapi/core_api/datamodels/assets.py
+++ b/airflow/api_fastapi/core_api/datamodels/assets.py
@@ -53,7 +53,9 @@ class AssetResponse(BaseModel):
     """Asset serializer for responses."""
 
     id: int
+    name: str
     uri: str
+    group: str
     extra: dict | None = None
     created_at: datetime
     updated_at: datetime

--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -5737,9 +5737,15 @@ components:
         id:
           type: integer
           title: Id
+        name:
+          type: string
+          title: Name
         uri:
           type: string
           title: Uri
+        group:
+          type: string
+          title: Group
         extra:
           anyOf:
           - type: object
@@ -5771,7 +5777,9 @@ components:
       type: object
       required:
       - id
+      - name
       - uri
+      - group
       - created_at
       - updated_at
       - consuming_dags

--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -974,6 +974,13 @@ ARG_DAG_LIST_COLUMNS = Arg(
     default=("dag_id", "fileloc", "owners", "is_paused"),
 )
 
+ARG_ASSET_LIST_COLUMNS = Arg(
+    ("--columns",),
+    type=string_list_type,
+    help="List of columns to render. (default: ['name', 'uri', 'group', 'extra'])",
+    default=("name", "uri", "group", "extra"),
+)
+
 ALTERNATIVE_CONN_SPECS_ARGS = [
     ARG_CONN_TYPE,
     ARG_CONN_DESCRIPTION,
@@ -1009,6 +1016,14 @@ class GroupCommand(NamedTuple):
 
 CLICommand = Union[ActionCommand, GroupCommand]
 
+ASSETS_COMMANDS = (
+    ActionCommand(
+        name="list",
+        help="List assets",
+        func=lazy_load_command("airflow.cli.commands.asset_command.asset_list"),
+        args=(ARG_OUTPUT, ARG_VERBOSE, ARG_ASSET_LIST_COLUMNS),
+    ),
+)
 BACKFILL_COMMANDS = (
     ActionCommand(
         name="create",
@@ -1855,6 +1870,11 @@ core_commands: list[CLICommand] = [
         name="tasks",
         help="Manage tasks",
         subcommands=TASKS_COMMANDS,
+    ),
+    GroupCommand(
+        name="assets",
+        help="Manage assets",
+        subcommands=ASSETS_COMMANDS,
     ),
     GroupCommand(
         name="pools",

--- a/airflow/cli/commands/asset_command.py
+++ b/airflow/cli/commands/asset_command.py
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import logging
+import typing
+
+from sqlalchemy import select
+
+from airflow.api_fastapi.core_api.datamodels.assets import AssetResponse
+from airflow.cli.simple_table import AirflowConsole
+from airflow.models.asset import AssetModel
+from airflow.utils import cli as cli_utils
+from airflow.utils.session import NEW_SESSION, provide_session
+
+if typing.TYPE_CHECKING:
+    from typing import Any
+
+    from sqlalchemy.orm import Session
+
+log = logging.getLogger(__name__)
+
+
+@cli_utils.action_cli
+@provide_session
+def asset_list(args, *, session: Session = NEW_SESSION) -> None:
+    """Display assets in the command line."""
+    assets = session.scalars(select(AssetModel).order_by(AssetModel.name))
+
+    def detail_mapper(asset: AssetModel) -> dict[str, Any]:
+        model = AssetResponse.model_validate(asset)
+        return model.model_dump(include=args.columns)
+
+    AirflowConsole().print_as(
+        data=assets,
+        output=args.output,
+        mapper=detail_mapper,
+    )

--- a/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -240,9 +240,17 @@ export const $AssetResponse = {
       type: "integer",
       title: "Id",
     },
+    name: {
+      type: "string",
+      title: "Name",
+    },
     uri: {
       type: "string",
       title: "Uri",
+    },
+    group: {
+      type: "string",
+      title: "Group",
     },
     extra: {
       anyOf: [
@@ -290,7 +298,9 @@ export const $AssetResponse = {
   type: "object",
   required: [
     "id",
+    "name",
     "uri",
+    "group",
     "created_at",
     "updated_at",
     "consuming_dags",

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -68,7 +68,9 @@ export type AssetEventResponse = {
  */
 export type AssetResponse = {
   id: number;
+  name: string;
   uri: string;
+  group: string;
   extra?: {
     [key: string]: unknown;
   } | null;

--- a/tests/api_fastapi/core_api/routes/public/test_assets.py
+++ b/tests/api_fastapi/core_api/routes/public/test_assets.py
@@ -48,7 +48,9 @@ def _create_assets(session, num: int = 2) -> None:
     assets = [
         AssetModel(
             id=i,
+            name=f"simple{i}",
             uri=f"s3://bucket/key/{i}",
+            group="asset",
             extra={"foo": "bar"},
             created_at=timezone.parse(default_time),
             updated_at=timezone.parse(default_time),
@@ -64,7 +66,9 @@ def _create_assets_with_sensitive_extra(session, num: int = 2) -> None:
     assets = [
         AssetModel(
             id=i,
+            name=f"sensitive{i}",
             uri=f"s3://bucket/key/{i}",
+            group="asset",
             extra={"password": "bar"},
             created_at=timezone.parse(default_time),
             updated_at=timezone.parse(default_time),
@@ -219,7 +223,9 @@ class TestGetAssets(TestAssets):
             "assets": [
                 {
                     "id": 1,
+                    "name": "simple1",
                     "uri": "s3://bucket/key/1",
+                    "group": "asset",
                     "extra": {"foo": "bar"},
                     "created_at": tz_datetime_format,
                     "updated_at": tz_datetime_format,
@@ -229,7 +235,9 @@ class TestGetAssets(TestAssets):
                 },
                 {
                     "id": 2,
+                    "name": "simple2",
                     "uri": "s3://bucket/key/2",
+                    "group": "asset",
                     "extra": {"foo": "bar"},
                     "created_at": tz_datetime_format,
                     "updated_at": tz_datetime_format,
@@ -566,7 +574,9 @@ class TestGetAssetEndpoint(TestAssets):
         assert response.status_code == 200
         assert response.json() == {
             "id": 1,
+            "name": "simple1",
             "uri": "s3://bucket/key/1",
+            "group": "asset",
             "extra": {"foo": "bar"},
             "created_at": tz_datetime_format,
             "updated_at": tz_datetime_format,
@@ -594,7 +604,9 @@ class TestGetAssetEndpoint(TestAssets):
         assert response.status_code == 200
         assert response.json() == {
             "id": 1,
+            "name": "sensitive1",
             "uri": "s3://bucket/key/1",
+            "group": "asset",
             "extra": {"password": "***"},
             "created_at": tz_datetime_format,
             "updated_at": tz_datetime_format,

--- a/tests/cli/commands/test_asset_command.py
+++ b/tests/cli/commands/test_asset_command.py
@@ -1,0 +1,65 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import typing
+
+import pytest
+
+from airflow.cli import cli_parser
+from airflow.cli.commands import asset_command
+from airflow.models.dagbag import DagBag
+
+from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.db import clear_db_dags
+
+if typing.TYPE_CHECKING:
+    from argparse import ArgumentParser
+
+pytestmark = [pytest.mark.db_test]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def prepare_examples():
+    DagBag(include_examples=True).sync_to_db()
+    yield
+    clear_db_dags()
+
+
+@pytest.fixture(scope="module")
+def parser() -> ArgumentParser:
+    return cli_parser.get_parser()
+
+
+@conf_vars({("core", "load_examples"): "true"})
+def test_cli_assets_list(parser: ArgumentParser) -> None:
+    args = parser.parse_args(["assets", "list", "--output=json"])
+    with contextlib.redirect_stdout(io.StringIO()) as temp_stdout:
+        asset_command.asset_list(args)
+
+    asset_list = json.loads(temp_stdout.getvalue())
+    assert len(asset_list) > 0
+    assert "name" in asset_list[0]
+    assert "uri" in asset_list[0]
+    assert "group" in asset_list[0]
+    assert "extra" in asset_list[0]
+    assert any(asset["uri"] == "s3://dag1/output_1.txt" for asset in asset_list)


### PR DESCRIPTION
First one for #42317. The idea is pretty straightfoward.

Existing CLIs mostly use the Marshmallow models (from Connexion), but I opted to use the Pydantic models (for FastAPI) instead. I assume we’ll change those at some point anyway?

I also added the two fields added to Asset recently to the model. This would affect the endpoints, so we’ll see what happens…