### PR TITLE
Allow 'dag_version' table to be deleted by db clean command

### DIFF
--- a/airflow/utils/db_cleanup.py
+++ b/airflow/utils/db_cleanup.py
@@ -125,6 +125,7 @@ config_list: list[_TableConfig] = [
     _TableConfig(table_name="celery_taskmeta", recency_column_name="date_done"),
     _TableConfig(table_name="celery_tasksetmeta", recency_column_name="date_done"),
     _TableConfig(table_name="trigger", recency_column_name="created_date"),
+    _TableConfig(table_name="dag_version", recency_column_name="created_at"),
 ]
 
 if conf.get("webserver", "session_backend") == "database":

--- a/tests/utils/test_db_cleanup.py
+++ b/tests/utils/test_db_cleanup.py
@@ -352,7 +352,6 @@ class TestDBCleanup:
             "rendered_task_instance_fields",  # foreign key with TI
             "dag_priority_parsing_request",  # Records are purged once per DAG Processing loop, not a
             # significant source of data.
-            "dag_version",  # self-maintaining
         }
 
         from airflow.utils.db_cleanup import config_dict


### PR DESCRIPTION
Deleting a dag would cascade delete dag_version table along with serialized_dag model and dagcode. However, we should be able to delete dag_version directly. I didn't add dag_code or serdag model because it won't make sense to have an existing dag_version without a corresponding dagcode and serdag

