### PR TITLE
AIP-84 Fix default ordering when directly using SortParam

### DIFF
--- a/airflow/api_fastapi/common/parameters.py
+++ b/airflow/api_fastapi/common/parameters.py
@@ -239,7 +239,7 @@ class SortParam(BaseParam[str]):
             raise ValueError(f"Cannot set 'skip_none' to False on a {type(self)}")
 
         if self.value is None:
-            return select
+            self.value = self.get_primary_key_string()
 
         lstriped_orderby = self.value.lstrip("-")
         if self.to_replace:


### PR DESCRIPTION
This should fix the flakiness observed in main.

When no order is specified (i.e None), this should use the primary key as the default sorting. (Exactly what we do to fill the query parameter default value, but in some cases we use the SortParam outside of the FastAPI dependency system, bypassing the `dynamic_depends` function). 