### PR TITLE
AIP-84 Migrate private graph_data endpoint

### DIFF
--- a/airflow/api_fastapi/core_api/datamodels/ui/graph.py
+++ b/airflow/api_fastapi/core_api/datamodels/ui/graph.py
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import Literal
+
+from airflow.api_fastapi.core_api.base import BaseModel
+
+
+class EdgeResponse(BaseModel):
+    """Edge serializer for responses."""
+
+    is_setup_teardown: bool | None = None
+    label: str | None = None
+    source_id: str
+    target_id: str
+
+
+class NodeValueResponse(BaseModel):
+    """Graph Node Value responses."""
+
+    isMapped: bool | None = None
+    label: str | None = None
+    labelStyle: str | None = None
+    style: str | None = None
+    tooltip: str | None = None
+    rx: int
+    ry: int
+    clusterLabelPos: str | None = None
+    setupTeardownType: Literal["setup", "teardown"] | None = None
+
+
+class NodeResponse(BaseModel):
+    """Node serializer for responses."""
+
+    children: list[NodeResponse] | None = None
+    id: str | None
+    value: NodeValueResponse
+
+
+class GraphDataResponse(BaseModel):
+    """Graph Data serializer for responses."""
+
+    edges: list[EdgeResponse]
+    nodes: NodeResponse
+    arrange: Literal["BT", "LR", "RL", "TB"]

--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -34,47 +34,26 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /ui/dashboard/historical_metrics_data:
+  /ui/config:
     get:
       tags:
-      - Dashboard
-      summary: Historical Metrics
-      description: Return cluster activity historical metrics.
-      operationId: historical_metrics
-      parameters:
-      - name: start_date
-        in: query
-        required: true
-        schema:
-          type: string
-          title: Start Date
-      - name: end_date
-        in: query
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: End Date
+      - Config
+      summary: Get Configs
+      description: Get configs for UI.
+      operationId: get_configs
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HistoricalMetricDataResponse'
-        '400':
+                $ref: '#/components/schemas/ConfigResponse'
+        '404':
+          description: Not Found
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPExceptionResponse'
-          description: Bad Request
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
   /ui/dags/recent_dag_runs:
     get:
       tags:
@@ -174,26 +153,102 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /ui/config:
+  /ui/dashboard/historical_metrics_data:
     get:
       tags:
-      - Config
-      summary: Get Configs
-      description: Get configs for UI.
-      operationId: get_configs
+      - Dashboard
+      summary: Historical Metrics
+      description: Return cluster activity historical metrics.
+      operationId: historical_metrics
+      parameters:
+      - name: start_date
+        in: query
+        required: true
+        schema:
+          type: string
+          title: Start Date
+      - name: end_date
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: End Date
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ConfigResponse'
-        '404':
-          description: Not Found
+                $ref: '#/components/schemas/HistoricalMetricDataResponse'
+        '400':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Bad Request
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /ui/graph_data:
+    get:
+      tags:
+      - Graph
+      summary: Graph Data
+      description: Get Graph Data.
+      operationId: graph_data
+      parameters:
+      - name: dag_id
+        in: query
+        required: true
+        schema:
+          type: string
+          title: Dag Id
+      - name: root
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Root
+      - name: filter_upstream
+        in: query
+        required: false
+        schema:
+          type: boolean
+          default: false
+          title: Filter Upstream
+      - name: filter_downstream
+        in: query
+        required: false
+        schema:
+          type: boolean
+          default: false
+          title: Filter Downstream
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GraphDataResponse'
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Bad Request
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /public/assets:
     get:
       tags:
@@ -7296,6 +7351,30 @@ components:
         This is the set of allowable values for the ``warning_type`` field
 
         in the DagWarning model.'
+    EdgeResponse:
+      properties:
+        is_setup_teardown:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Is Setup Teardown
+        label:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Label
+        source_id:
+          type: string
+          title: Source Id
+        target_id:
+          type: string
+          title: Target Id
+      type: object
+      required:
+      - source_id
+      - target_id
+      title: EdgeResponse
+      description: Edge serializer for responses.
     EventLogCollectionResponse:
       properties:
         event_logs:
@@ -7407,6 +7486,30 @@ components:
       - name
       title: FastAPIAppResponse
       description: Serializer for Plugin FastAPI App responses.
+    GraphDataResponse:
+      properties:
+        edges:
+          items:
+            $ref: '#/components/schemas/EdgeResponse'
+          type: array
+          title: Edges
+        nodes:
+          $ref: '#/components/schemas/NodeResponse'
+        arrange:
+          type: string
+          enum:
+          - BT
+          - LR
+          - RL
+          - TB
+          title: Arrange
+      type: object
+      required:
+      - edges
+      - nodes
+      - arrange
+      title: GraphDataResponse
+      description: Graph Data serializer for responses.
     HTTPExceptionResponse:
       properties:
         detail:
@@ -7584,6 +7687,80 @@ components:
       - unixname
       title: JobResponse
       description: Job serializer for responses.
+    NodeResponse:
+      properties:
+        children:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/NodeResponse'
+            type: array
+          - type: 'null'
+          title: Children
+        id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Id
+        value:
+          $ref: '#/components/schemas/NodeValueResponse'
+      type: object
+      required:
+      - id
+      - value
+      title: NodeResponse
+      description: Node serializer for responses.
+    NodeValueResponse:
+      properties:
+        isMapped:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Ismapped
+        label:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Label
+        labelStyle:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Labelstyle
+        style:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Style
+        tooltip:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Tooltip
+        rx:
+          type: integer
+          title: Rx
+        ry:
+          type: integer
+          title: Ry
+        clusterLabelPos:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Clusterlabelpos
+        setupTeardownType:
+          anyOf:
+          - type: string
+            enum:
+            - setup
+            - teardown
+          - type: 'null'
+          title: Setupteardowntype
+      type: object
+      required:
+      - rx
+      - ry
+      title: NodeValueResponse
+      description: Graph Node Value responses.
     PatchTaskInstanceBody:
       properties:
         dry_run:

--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -194,7 +194,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /ui/graph_data:
+  /ui/graph/graph_data:
     get:
       tags:
       - Graph
@@ -216,20 +216,20 @@ paths:
           - type: string
           - type: 'null'
           title: Root
-      - name: filter_upstream
+      - name: include_upstream
         in: query
         required: false
         schema:
           type: boolean
           default: false
-          title: Filter Upstream
-      - name: filter_downstream
+          title: Include Upstream
+      - name: include_downstream
         in: query
         required: false
         schema:
           type: boolean
           default: false
-          title: Filter Downstream
+          title: Include Downstream
       responses:
         '200':
           description: Successful Response

--- a/airflow/api_fastapi/core_api/routes/ui/__init__.py
+++ b/airflow/api_fastapi/core_api/routes/ui/__init__.py
@@ -21,10 +21,12 @@ from airflow.api_fastapi.core_api.routes.ui.assets import assets_router
 from airflow.api_fastapi.core_api.routes.ui.config import config_router
 from airflow.api_fastapi.core_api.routes.ui.dags import dags_router
 from airflow.api_fastapi.core_api.routes.ui.dashboard import dashboard_router
+from airflow.api_fastapi.core_api.routes.ui.graph import graph_data_router
 
 ui_router = AirflowRouter(prefix="/ui")
 
 ui_router.include_router(assets_router)
-ui_router.include_router(dashboard_router)
-ui_router.include_router(dags_router)
 ui_router.include_router(config_router)
+ui_router.include_router(dags_router)
+ui_router.include_router(dashboard_router)
+ui_router.include_router(graph_data_router)

--- a/airflow/api_fastapi/core_api/routes/ui/dashboard.py
+++ b/airflow/api_fastapi/core_api/routes/ui/dashboard.py
@@ -35,11 +35,11 @@ from airflow.api_fastapi.common.db.common import get_session
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.utils import timezone
 
-dashboard_router = AirflowRouter(tags=["Dashboard"])
+dashboard_router = AirflowRouter(tags=["Dashboard"], prefix="/dashboard")
 
 
 @dashboard_router.get(
-    "/dashboard/historical_metrics_data",
+    "/historical_metrics_data",
     include_in_schema=False,
     responses=create_openapi_http_exception_doc([status.HTTP_400_BAD_REQUEST]),
 )

--- a/airflow/api_fastapi/core_api/routes/ui/graph.py
+++ b/airflow/api_fastapi/core_api/routes/ui/graph.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 from airflow.api_fastapi.common.db.common import get_session
 from airflow.api_fastapi.common.router import AirflowRouter
 
-graph_data_router = AirflowRouter(tags=["Graph"])
+graph_data_router = AirflowRouter(tags=["Graph"], prefix="/graph")
 
 
 @graph_data_router.get(
@@ -44,14 +44,14 @@ def graph_data(
     dag_id: str,
     request: Request,
     root: str | None = None,
-    filter_upstream: bool = False,
-    filter_downstream: bool = False,
+    include_upstream: bool = False,
+    include_downstream: bool = False,
 ) -> GraphDataResponse:
     """Get Graph Data."""
     dag = request.app.state.dag_bag.get_dag(dag_id)
     if root:
         dag = dag.partial_subset(
-            task_ids_or_regex=root, include_upstream=filter_upstream, include_downstream=filter_downstream
+            task_ids_or_regex=root, include_upstream=include_upstream, include_downstream=include_downstream
         )
 
     nodes = task_group_to_dict(dag.task_group)
@@ -63,6 +63,4 @@ def graph_data(
         "edges": edges,
     }
 
-    print(data)
-
-    return GraphDataResponse.model_validate(data)
+    return GraphDataResponse(**data)

--- a/airflow/api_fastapi/core_api/routes/ui/graph.py
+++ b/airflow/api_fastapi/core_api/routes/ui/graph.py
@@ -1,0 +1,68 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated
+
+from fastapi import Depends, Request, status
+from sqlalchemy.orm import Session
+
+from airflow.api_fastapi.core_api.datamodels.ui.graph import GraphDataResponse
+from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
+from airflow.utils.dag_edges import dag_edges
+from airflow.utils.task_group import task_group_to_dict
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+from airflow.api_fastapi.common.db.common import get_session
+from airflow.api_fastapi.common.router import AirflowRouter
+
+graph_data_router = AirflowRouter(tags=["Graph"])
+
+
+@graph_data_router.get(
+    "/graph_data",
+    include_in_schema=False,
+    responses=create_openapi_http_exception_doc([status.HTTP_400_BAD_REQUEST]),
+)
+def graph_data(
+    session: Annotated[Session, Depends(get_session)],
+    dag_id: str,
+    request: Request,
+    root: str | None = None,
+    filter_upstream: bool = False,
+    filter_downstream: bool = False,
+) -> GraphDataResponse:
+    """Get Graph Data."""
+    dag = request.app.state.dag_bag.get_dag(dag_id)
+    if root:
+        dag = dag.partial_subset(
+            task_ids_or_regex=root, include_upstream=filter_upstream, include_downstream=filter_downstream
+        )
+
+    nodes = task_group_to_dict(dag.task_group)
+    edges = dag_edges(dag)
+
+    data = {
+        "arrange": dag.orientation,
+        "nodes": nodes,
+        "edges": edges,
+    }
+
+    print(data)
+
+    return GraphDataResponse.model_validate(data)

--- a/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow/ui/openapi-gen/queries/common.ts
@@ -15,6 +15,7 @@ import {
   DashboardService,
   EventLogService,
   ExtraLinksService,
+  GraphService,
   ImportErrorService,
   JobService,
   MonitorService,
@@ -200,78 +201,6 @@ export const UseAssetServiceGetDagAssetQueuedEventKeyFn = (
   useAssetServiceGetDagAssetQueuedEventKey,
   ...(queryKey ?? [{ before, dagId, uri }]),
 ];
-export type DashboardServiceHistoricalMetricsDefaultResponse = Awaited<
-  ReturnType<typeof DashboardService.historicalMetrics>
->;
-export type DashboardServiceHistoricalMetricsQueryResult<
-  TData = DashboardServiceHistoricalMetricsDefaultResponse,
-  TError = unknown,
-> = UseQueryResult<TData, TError>;
-export const useDashboardServiceHistoricalMetricsKey =
-  "DashboardServiceHistoricalMetrics";
-export const UseDashboardServiceHistoricalMetricsKeyFn = (
-  {
-    endDate,
-    startDate,
-  }: {
-    endDate?: string;
-    startDate: string;
-  },
-  queryKey?: Array<unknown>,
-) => [
-  useDashboardServiceHistoricalMetricsKey,
-  ...(queryKey ?? [{ endDate, startDate }]),
-];
-export type DagsServiceRecentDagRunsDefaultResponse = Awaited<
-  ReturnType<typeof DagsService.recentDagRuns>
->;
-export type DagsServiceRecentDagRunsQueryResult<
-  TData = DagsServiceRecentDagRunsDefaultResponse,
-  TError = unknown,
-> = UseQueryResult<TData, TError>;
-export const useDagsServiceRecentDagRunsKey = "DagsServiceRecentDagRuns";
-export const UseDagsServiceRecentDagRunsKeyFn = (
-  {
-    dagDisplayNamePattern,
-    dagIdPattern,
-    dagRunsLimit,
-    lastDagRunState,
-    limit,
-    offset,
-    onlyActive,
-    owners,
-    paused,
-    tags,
-  }: {
-    dagDisplayNamePattern?: string;
-    dagIdPattern?: string;
-    dagRunsLimit?: number;
-    lastDagRunState?: DagRunState;
-    limit?: number;
-    offset?: number;
-    onlyActive?: boolean;
-    owners?: string[];
-    paused?: boolean;
-    tags?: string[];
-  } = {},
-  queryKey?: Array<unknown>,
-) => [
-  useDagsServiceRecentDagRunsKey,
-  ...(queryKey ?? [
-    {
-      dagDisplayNamePattern,
-      dagIdPattern,
-      dagRunsLimit,
-      lastDagRunState,
-      limit,
-      offset,
-      onlyActive,
-      owners,
-      paused,
-      tags,
-    },
-  ]),
-];
 export type ConfigServiceGetConfigsDefaultResponse = Awaited<
   ReturnType<typeof ConfigService.getConfigs>
 >;
@@ -324,6 +253,103 @@ export const UseConfigServiceGetConfigValueKeyFn = (
 ) => [
   useConfigServiceGetConfigValueKey,
   ...(queryKey ?? [{ accept, option, section }]),
+];
+export type DagsServiceRecentDagRunsDefaultResponse = Awaited<
+  ReturnType<typeof DagsService.recentDagRuns>
+>;
+export type DagsServiceRecentDagRunsQueryResult<
+  TData = DagsServiceRecentDagRunsDefaultResponse,
+  TError = unknown,
+> = UseQueryResult<TData, TError>;
+export const useDagsServiceRecentDagRunsKey = "DagsServiceRecentDagRuns";
+export const UseDagsServiceRecentDagRunsKeyFn = (
+  {
+    dagDisplayNamePattern,
+    dagIdPattern,
+    dagRunsLimit,
+    lastDagRunState,
+    limit,
+    offset,
+    onlyActive,
+    owners,
+    paused,
+    tags,
+  }: {
+    dagDisplayNamePattern?: string;
+    dagIdPattern?: string;
+    dagRunsLimit?: number;
+    lastDagRunState?: DagRunState;
+    limit?: number;
+    offset?: number;
+    onlyActive?: boolean;
+    owners?: string[];
+    paused?: boolean;
+    tags?: string[];
+  } = {},
+  queryKey?: Array<unknown>,
+) => [
+  useDagsServiceRecentDagRunsKey,
+  ...(queryKey ?? [
+    {
+      dagDisplayNamePattern,
+      dagIdPattern,
+      dagRunsLimit,
+      lastDagRunState,
+      limit,
+      offset,
+      onlyActive,
+      owners,
+      paused,
+      tags,
+    },
+  ]),
+];
+export type DashboardServiceHistoricalMetricsDefaultResponse = Awaited<
+  ReturnType<typeof DashboardService.historicalMetrics>
+>;
+export type DashboardServiceHistoricalMetricsQueryResult<
+  TData = DashboardServiceHistoricalMetricsDefaultResponse,
+  TError = unknown,
+> = UseQueryResult<TData, TError>;
+export const useDashboardServiceHistoricalMetricsKey =
+  "DashboardServiceHistoricalMetrics";
+export const UseDashboardServiceHistoricalMetricsKeyFn = (
+  {
+    endDate,
+    startDate,
+  }: {
+    endDate?: string;
+    startDate: string;
+  },
+  queryKey?: Array<unknown>,
+) => [
+  useDashboardServiceHistoricalMetricsKey,
+  ...(queryKey ?? [{ endDate, startDate }]),
+];
+export type GraphServiceGraphDataDefaultResponse = Awaited<
+  ReturnType<typeof GraphService.graphData>
+>;
+export type GraphServiceGraphDataQueryResult<
+  TData = GraphServiceGraphDataDefaultResponse,
+  TError = unknown,
+> = UseQueryResult<TData, TError>;
+export const useGraphServiceGraphDataKey = "GraphServiceGraphData";
+export const UseGraphServiceGraphDataKeyFn = (
+  {
+    dagId,
+    filterDownstream,
+    filterUpstream,
+    root,
+  }: {
+    dagId: string;
+    filterDownstream?: boolean;
+    filterUpstream?: boolean;
+    root?: string;
+  },
+  queryKey?: Array<unknown>,
+) => [
+  useGraphServiceGraphDataKey,
+  ...(queryKey ?? [{ dagId, filterDownstream, filterUpstream, root }]),
 ];
 export type BackfillServiceListBackfillsDefaultResponse = Awaited<
   ReturnType<typeof BackfillService.listBackfills>

--- a/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow/ui/openapi-gen/queries/common.ts
@@ -337,19 +337,19 @@ export const useGraphServiceGraphDataKey = "GraphServiceGraphData";
 export const UseGraphServiceGraphDataKeyFn = (
   {
     dagId,
-    filterDownstream,
-    filterUpstream,
+    includeDownstream,
+    includeUpstream,
     root,
   }: {
     dagId: string;
-    filterDownstream?: boolean;
-    filterUpstream?: boolean;
+    includeDownstream?: boolean;
+    includeUpstream?: boolean;
     root?: string;
   },
   queryKey?: Array<unknown>,
 ) => [
   useGraphServiceGraphDataKey,
-  ...(queryKey ?? [{ dagId, filterDownstream, filterUpstream, root }]),
+  ...(queryKey ?? [{ dagId, includeDownstream, includeUpstream, root }]),
 ];
 export type BackfillServiceListBackfillsDefaultResponse = Awaited<
   ReturnType<typeof BackfillService.listBackfills>

--- a/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -412,8 +412,8 @@ export const prefetchUseDashboardServiceHistoricalMetrics = (
  * @param data The data for the request.
  * @param data.dagId
  * @param data.root
- * @param data.filterUpstream
- * @param data.filterDownstream
+ * @param data.includeUpstream
+ * @param data.includeDownstream
  * @returns GraphDataResponse Successful Response
  * @throws ApiError
  */
@@ -421,25 +421,30 @@ export const prefetchUseGraphServiceGraphData = (
   queryClient: QueryClient,
   {
     dagId,
-    filterDownstream,
-    filterUpstream,
+    includeDownstream,
+    includeUpstream,
     root,
   }: {
     dagId: string;
-    filterDownstream?: boolean;
-    filterUpstream?: boolean;
+    includeDownstream?: boolean;
+    includeUpstream?: boolean;
     root?: string;
   },
 ) =>
   queryClient.prefetchQuery({
     queryKey: Common.UseGraphServiceGraphDataKeyFn({
       dagId,
-      filterDownstream,
-      filterUpstream,
+      includeDownstream,
+      includeUpstream,
       root,
     }),
     queryFn: () =>
-      GraphService.graphData({ dagId, filterDownstream, filterUpstream, root }),
+      GraphService.graphData({
+        dagId,
+        includeDownstream,
+        includeUpstream,
+        root,
+      }),
   });
 /**
  * List Backfills

--- a/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -15,6 +15,7 @@ import {
   DashboardService,
   EventLogService,
   ExtraLinksService,
+  GraphService,
   ImportErrorService,
   JobService,
   MonitorService,
@@ -248,30 +249,66 @@ export const prefetchUseAssetServiceGetDagAssetQueuedEvent = (
     queryFn: () => AssetService.getDagAssetQueuedEvent({ before, dagId, uri }),
   });
 /**
- * Historical Metrics
- * Return cluster activity historical metrics.
- * @param data The data for the request.
- * @param data.startDate
- * @param data.endDate
- * @returns HistoricalMetricDataResponse Successful Response
+ * Get Configs
+ * Get configs for UI.
+ * @returns ConfigResponse Successful Response
  * @throws ApiError
  */
-export const prefetchUseDashboardServiceHistoricalMetrics = (
+export const prefetchUseConfigServiceGetConfigs = (queryClient: QueryClient) =>
+  queryClient.prefetchQuery({
+    queryKey: Common.UseConfigServiceGetConfigsKeyFn(),
+    queryFn: () => ConfigService.getConfigs(),
+  });
+/**
+ * Get Config
+ * @param data The data for the request.
+ * @param data.section
+ * @param data.accept
+ * @returns Config Successful Response
+ * @throws ApiError
+ */
+export const prefetchUseConfigServiceGetConfig = (
   queryClient: QueryClient,
   {
-    endDate,
-    startDate,
+    accept,
+    section,
   }: {
-    endDate?: string;
-    startDate: string;
+    accept?: "application/json" | "text/plain" | "*/*";
+    section?: string;
+  } = {},
+) =>
+  queryClient.prefetchQuery({
+    queryKey: Common.UseConfigServiceGetConfigKeyFn({ accept, section }),
+    queryFn: () => ConfigService.getConfig({ accept, section }),
+  });
+/**
+ * Get Config Value
+ * @param data The data for the request.
+ * @param data.section
+ * @param data.option
+ * @param data.accept
+ * @returns Config Successful Response
+ * @throws ApiError
+ */
+export const prefetchUseConfigServiceGetConfigValue = (
+  queryClient: QueryClient,
+  {
+    accept,
+    option,
+    section,
+  }: {
+    accept?: "application/json" | "text/plain" | "*/*";
+    option: string;
+    section: string;
   },
 ) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseDashboardServiceHistoricalMetricsKeyFn({
-      endDate,
-      startDate,
+    queryKey: Common.UseConfigServiceGetConfigValueKeyFn({
+      accept,
+      option,
+      section,
     }),
-    queryFn: () => DashboardService.historicalMetrics({ endDate, startDate }),
+    queryFn: () => ConfigService.getConfigValue({ accept, option, section }),
   });
 /**
  * Recent Dag Runs
@@ -344,66 +381,65 @@ export const prefetchUseDagsServiceRecentDagRuns = (
       }),
   });
 /**
- * Get Configs
- * Get configs for UI.
- * @returns ConfigResponse Successful Response
- * @throws ApiError
- */
-export const prefetchUseConfigServiceGetConfigs = (queryClient: QueryClient) =>
-  queryClient.prefetchQuery({
-    queryKey: Common.UseConfigServiceGetConfigsKeyFn(),
-    queryFn: () => ConfigService.getConfigs(),
-  });
-/**
- * Get Config
+ * Historical Metrics
+ * Return cluster activity historical metrics.
  * @param data The data for the request.
- * @param data.section
- * @param data.accept
- * @returns Config Successful Response
+ * @param data.startDate
+ * @param data.endDate
+ * @returns HistoricalMetricDataResponse Successful Response
  * @throws ApiError
  */
-export const prefetchUseConfigServiceGetConfig = (
+export const prefetchUseDashboardServiceHistoricalMetrics = (
   queryClient: QueryClient,
   {
-    accept,
-    section,
+    endDate,
+    startDate,
   }: {
-    accept?: "application/json" | "text/plain" | "*/*";
-    section?: string;
-  } = {},
-) =>
-  queryClient.prefetchQuery({
-    queryKey: Common.UseConfigServiceGetConfigKeyFn({ accept, section }),
-    queryFn: () => ConfigService.getConfig({ accept, section }),
-  });
-/**
- * Get Config Value
- * @param data The data for the request.
- * @param data.section
- * @param data.option
- * @param data.accept
- * @returns Config Successful Response
- * @throws ApiError
- */
-export const prefetchUseConfigServiceGetConfigValue = (
-  queryClient: QueryClient,
-  {
-    accept,
-    option,
-    section,
-  }: {
-    accept?: "application/json" | "text/plain" | "*/*";
-    option: string;
-    section: string;
+    endDate?: string;
+    startDate: string;
   },
 ) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseConfigServiceGetConfigValueKeyFn({
-      accept,
-      option,
-      section,
+    queryKey: Common.UseDashboardServiceHistoricalMetricsKeyFn({
+      endDate,
+      startDate,
     }),
-    queryFn: () => ConfigService.getConfigValue({ accept, option, section }),
+    queryFn: () => DashboardService.historicalMetrics({ endDate, startDate }),
+  });
+/**
+ * Graph Data
+ * Get Graph Data.
+ * @param data The data for the request.
+ * @param data.dagId
+ * @param data.root
+ * @param data.filterUpstream
+ * @param data.filterDownstream
+ * @returns GraphDataResponse Successful Response
+ * @throws ApiError
+ */
+export const prefetchUseGraphServiceGraphData = (
+  queryClient: QueryClient,
+  {
+    dagId,
+    filterDownstream,
+    filterUpstream,
+    root,
+  }: {
+    dagId: string;
+    filterDownstream?: boolean;
+    filterUpstream?: boolean;
+    root?: string;
+  },
+) =>
+  queryClient.prefetchQuery({
+    queryKey: Common.UseGraphServiceGraphDataKeyFn({
+      dagId,
+      filterDownstream,
+      filterUpstream,
+      root,
+    }),
+    queryFn: () =>
+      GraphService.graphData({ dagId, filterDownstream, filterUpstream, root }),
   });
 /**
  * List Backfills

--- a/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow/ui/openapi-gen/queries/queries.ts
@@ -20,6 +20,7 @@ import {
   DashboardService,
   EventLogService,
   ExtraLinksService,
+  GraphService,
   ImportErrorService,
   JobService,
   MonitorService,
@@ -323,118 +324,6 @@ export const useAssetServiceGetDagAssetQueuedEvent = <
     ...options,
   });
 /**
- * Historical Metrics
- * Return cluster activity historical metrics.
- * @param data The data for the request.
- * @param data.startDate
- * @param data.endDate
- * @returns HistoricalMetricDataResponse Successful Response
- * @throws ApiError
- */
-export const useDashboardServiceHistoricalMetrics = <
-  TData = Common.DashboardServiceHistoricalMetricsDefaultResponse,
-  TError = unknown,
-  TQueryKey extends Array<unknown> = unknown[],
->(
-  {
-    endDate,
-    startDate,
-  }: {
-    endDate?: string;
-    startDate: string;
-  },
-  queryKey?: TQueryKey,
-  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
-) =>
-  useQuery<TData, TError>({
-    queryKey: Common.UseDashboardServiceHistoricalMetricsKeyFn(
-      { endDate, startDate },
-      queryKey,
-    ),
-    queryFn: () =>
-      DashboardService.historicalMetrics({ endDate, startDate }) as TData,
-    ...options,
-  });
-/**
- * Recent Dag Runs
- * Get recent DAG runs.
- * @param data The data for the request.
- * @param data.dagRunsLimit
- * @param data.limit
- * @param data.offset
- * @param data.tags
- * @param data.owners
- * @param data.dagIdPattern
- * @param data.dagDisplayNamePattern
- * @param data.onlyActive
- * @param data.paused
- * @param data.lastDagRunState
- * @returns DAGWithLatestDagRunsCollectionResponse Successful Response
- * @throws ApiError
- */
-export const useDagsServiceRecentDagRuns = <
-  TData = Common.DagsServiceRecentDagRunsDefaultResponse,
-  TError = unknown,
-  TQueryKey extends Array<unknown> = unknown[],
->(
-  {
-    dagDisplayNamePattern,
-    dagIdPattern,
-    dagRunsLimit,
-    lastDagRunState,
-    limit,
-    offset,
-    onlyActive,
-    owners,
-    paused,
-    tags,
-  }: {
-    dagDisplayNamePattern?: string;
-    dagIdPattern?: string;
-    dagRunsLimit?: number;
-    lastDagRunState?: DagRunState;
-    limit?: number;
-    offset?: number;
-    onlyActive?: boolean;
-    owners?: string[];
-    paused?: boolean;
-    tags?: string[];
-  } = {},
-  queryKey?: TQueryKey,
-  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
-) =>
-  useQuery<TData, TError>({
-    queryKey: Common.UseDagsServiceRecentDagRunsKeyFn(
-      {
-        dagDisplayNamePattern,
-        dagIdPattern,
-        dagRunsLimit,
-        lastDagRunState,
-        limit,
-        offset,
-        onlyActive,
-        owners,
-        paused,
-        tags,
-      },
-      queryKey,
-    ),
-    queryFn: () =>
-      DagsService.recentDagRuns({
-        dagDisplayNamePattern,
-        dagIdPattern,
-        dagRunsLimit,
-        lastDagRunState,
-        limit,
-        offset,
-        onlyActive,
-        owners,
-        paused,
-        tags,
-      }) as TData,
-    ...options,
-  });
-/**
  * Get Configs
  * Get configs for UI.
  * @returns ConfigResponse Successful Response
@@ -517,6 +406,162 @@ export const useConfigServiceGetConfigValue = <
     ),
     queryFn: () =>
       ConfigService.getConfigValue({ accept, option, section }) as TData,
+    ...options,
+  });
+/**
+ * Recent Dag Runs
+ * Get recent DAG runs.
+ * @param data The data for the request.
+ * @param data.dagRunsLimit
+ * @param data.limit
+ * @param data.offset
+ * @param data.tags
+ * @param data.owners
+ * @param data.dagIdPattern
+ * @param data.dagDisplayNamePattern
+ * @param data.onlyActive
+ * @param data.paused
+ * @param data.lastDagRunState
+ * @returns DAGWithLatestDagRunsCollectionResponse Successful Response
+ * @throws ApiError
+ */
+export const useDagsServiceRecentDagRuns = <
+  TData = Common.DagsServiceRecentDagRunsDefaultResponse,
+  TError = unknown,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  {
+    dagDisplayNamePattern,
+    dagIdPattern,
+    dagRunsLimit,
+    lastDagRunState,
+    limit,
+    offset,
+    onlyActive,
+    owners,
+    paused,
+    tags,
+  }: {
+    dagDisplayNamePattern?: string;
+    dagIdPattern?: string;
+    dagRunsLimit?: number;
+    lastDagRunState?: DagRunState;
+    limit?: number;
+    offset?: number;
+    onlyActive?: boolean;
+    owners?: string[];
+    paused?: boolean;
+    tags?: string[];
+  } = {},
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
+) =>
+  useQuery<TData, TError>({
+    queryKey: Common.UseDagsServiceRecentDagRunsKeyFn(
+      {
+        dagDisplayNamePattern,
+        dagIdPattern,
+        dagRunsLimit,
+        lastDagRunState,
+        limit,
+        offset,
+        onlyActive,
+        owners,
+        paused,
+        tags,
+      },
+      queryKey,
+    ),
+    queryFn: () =>
+      DagsService.recentDagRuns({
+        dagDisplayNamePattern,
+        dagIdPattern,
+        dagRunsLimit,
+        lastDagRunState,
+        limit,
+        offset,
+        onlyActive,
+        owners,
+        paused,
+        tags,
+      }) as TData,
+    ...options,
+  });
+/**
+ * Historical Metrics
+ * Return cluster activity historical metrics.
+ * @param data The data for the request.
+ * @param data.startDate
+ * @param data.endDate
+ * @returns HistoricalMetricDataResponse Successful Response
+ * @throws ApiError
+ */
+export const useDashboardServiceHistoricalMetrics = <
+  TData = Common.DashboardServiceHistoricalMetricsDefaultResponse,
+  TError = unknown,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  {
+    endDate,
+    startDate,
+  }: {
+    endDate?: string;
+    startDate: string;
+  },
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
+) =>
+  useQuery<TData, TError>({
+    queryKey: Common.UseDashboardServiceHistoricalMetricsKeyFn(
+      { endDate, startDate },
+      queryKey,
+    ),
+    queryFn: () =>
+      DashboardService.historicalMetrics({ endDate, startDate }) as TData,
+    ...options,
+  });
+/**
+ * Graph Data
+ * Get Graph Data.
+ * @param data The data for the request.
+ * @param data.dagId
+ * @param data.root
+ * @param data.filterUpstream
+ * @param data.filterDownstream
+ * @returns GraphDataResponse Successful Response
+ * @throws ApiError
+ */
+export const useGraphServiceGraphData = <
+  TData = Common.GraphServiceGraphDataDefaultResponse,
+  TError = unknown,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  {
+    dagId,
+    filterDownstream,
+    filterUpstream,
+    root,
+  }: {
+    dagId: string;
+    filterDownstream?: boolean;
+    filterUpstream?: boolean;
+    root?: string;
+  },
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
+) =>
+  useQuery<TData, TError>({
+    queryKey: Common.UseGraphServiceGraphDataKeyFn(
+      { dagId, filterDownstream, filterUpstream, root },
+      queryKey,
+    ),
+    queryFn: () =>
+      GraphService.graphData({
+        dagId,
+        filterDownstream,
+        filterUpstream,
+        root,
+      }) as TData,
     ...options,
   });
 /**

--- a/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow/ui/openapi-gen/queries/queries.ts
@@ -526,8 +526,8 @@ export const useDashboardServiceHistoricalMetrics = <
  * @param data The data for the request.
  * @param data.dagId
  * @param data.root
- * @param data.filterUpstream
- * @param data.filterDownstream
+ * @param data.includeUpstream
+ * @param data.includeDownstream
  * @returns GraphDataResponse Successful Response
  * @throws ApiError
  */
@@ -538,13 +538,13 @@ export const useGraphServiceGraphData = <
 >(
   {
     dagId,
-    filterDownstream,
-    filterUpstream,
+    includeDownstream,
+    includeUpstream,
     root,
   }: {
     dagId: string;
-    filterDownstream?: boolean;
-    filterUpstream?: boolean;
+    includeDownstream?: boolean;
+    includeUpstream?: boolean;
     root?: string;
   },
   queryKey?: TQueryKey,
@@ -552,14 +552,14 @@ export const useGraphServiceGraphData = <
 ) =>
   useQuery<TData, TError>({
     queryKey: Common.UseGraphServiceGraphDataKeyFn(
-      { dagId, filterDownstream, filterUpstream, root },
+      { dagId, includeDownstream, includeUpstream, root },
       queryKey,
     ),
     queryFn: () =>
       GraphService.graphData({
         dagId,
-        filterDownstream,
-        filterUpstream,
+        includeDownstream,
+        includeUpstream,
         root,
       }) as TData,
     ...options,

--- a/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow/ui/openapi-gen/queries/suspense.ts
@@ -503,8 +503,8 @@ export const useDashboardServiceHistoricalMetricsSuspense = <
  * @param data The data for the request.
  * @param data.dagId
  * @param data.root
- * @param data.filterUpstream
- * @param data.filterDownstream
+ * @param data.includeUpstream
+ * @param data.includeDownstream
  * @returns GraphDataResponse Successful Response
  * @throws ApiError
  */
@@ -515,13 +515,13 @@ export const useGraphServiceGraphDataSuspense = <
 >(
   {
     dagId,
-    filterDownstream,
-    filterUpstream,
+    includeDownstream,
+    includeUpstream,
     root,
   }: {
     dagId: string;
-    filterDownstream?: boolean;
-    filterUpstream?: boolean;
+    includeDownstream?: boolean;
+    includeUpstream?: boolean;
     root?: string;
   },
   queryKey?: TQueryKey,
@@ -529,14 +529,14 @@ export const useGraphServiceGraphDataSuspense = <
 ) =>
   useSuspenseQuery<TData, TError>({
     queryKey: Common.UseGraphServiceGraphDataKeyFn(
-      { dagId, filterDownstream, filterUpstream, root },
+      { dagId, includeDownstream, includeUpstream, root },
       queryKey,
     ),
     queryFn: () =>
       GraphService.graphData({
         dagId,
-        filterDownstream,
-        filterUpstream,
+        includeDownstream,
+        includeUpstream,
         root,
       }) as TData,
     ...options,

--- a/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow/ui/openapi-gen/queries/suspense.ts
@@ -15,6 +15,7 @@ import {
   DashboardService,
   EventLogService,
   ExtraLinksService,
+  GraphService,
   ImportErrorService,
   JobService,
   MonitorService,
@@ -300,118 +301,6 @@ export const useAssetServiceGetDagAssetQueuedEventSuspense = <
     ...options,
   });
 /**
- * Historical Metrics
- * Return cluster activity historical metrics.
- * @param data The data for the request.
- * @param data.startDate
- * @param data.endDate
- * @returns HistoricalMetricDataResponse Successful Response
- * @throws ApiError
- */
-export const useDashboardServiceHistoricalMetricsSuspense = <
-  TData = Common.DashboardServiceHistoricalMetricsDefaultResponse,
-  TError = unknown,
-  TQueryKey extends Array<unknown> = unknown[],
->(
-  {
-    endDate,
-    startDate,
-  }: {
-    endDate?: string;
-    startDate: string;
-  },
-  queryKey?: TQueryKey,
-  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
-) =>
-  useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseDashboardServiceHistoricalMetricsKeyFn(
-      { endDate, startDate },
-      queryKey,
-    ),
-    queryFn: () =>
-      DashboardService.historicalMetrics({ endDate, startDate }) as TData,
-    ...options,
-  });
-/**
- * Recent Dag Runs
- * Get recent DAG runs.
- * @param data The data for the request.
- * @param data.dagRunsLimit
- * @param data.limit
- * @param data.offset
- * @param data.tags
- * @param data.owners
- * @param data.dagIdPattern
- * @param data.dagDisplayNamePattern
- * @param data.onlyActive
- * @param data.paused
- * @param data.lastDagRunState
- * @returns DAGWithLatestDagRunsCollectionResponse Successful Response
- * @throws ApiError
- */
-export const useDagsServiceRecentDagRunsSuspense = <
-  TData = Common.DagsServiceRecentDagRunsDefaultResponse,
-  TError = unknown,
-  TQueryKey extends Array<unknown> = unknown[],
->(
-  {
-    dagDisplayNamePattern,
-    dagIdPattern,
-    dagRunsLimit,
-    lastDagRunState,
-    limit,
-    offset,
-    onlyActive,
-    owners,
-    paused,
-    tags,
-  }: {
-    dagDisplayNamePattern?: string;
-    dagIdPattern?: string;
-    dagRunsLimit?: number;
-    lastDagRunState?: DagRunState;
-    limit?: number;
-    offset?: number;
-    onlyActive?: boolean;
-    owners?: string[];
-    paused?: boolean;
-    tags?: string[];
-  } = {},
-  queryKey?: TQueryKey,
-  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
-) =>
-  useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseDagsServiceRecentDagRunsKeyFn(
-      {
-        dagDisplayNamePattern,
-        dagIdPattern,
-        dagRunsLimit,
-        lastDagRunState,
-        limit,
-        offset,
-        onlyActive,
-        owners,
-        paused,
-        tags,
-      },
-      queryKey,
-    ),
-    queryFn: () =>
-      DagsService.recentDagRuns({
-        dagDisplayNamePattern,
-        dagIdPattern,
-        dagRunsLimit,
-        lastDagRunState,
-        limit,
-        offset,
-        onlyActive,
-        owners,
-        paused,
-        tags,
-      }) as TData,
-    ...options,
-  });
-/**
  * Get Configs
  * Get configs for UI.
  * @returns ConfigResponse Successful Response
@@ -494,6 +383,162 @@ export const useConfigServiceGetConfigValueSuspense = <
     ),
     queryFn: () =>
       ConfigService.getConfigValue({ accept, option, section }) as TData,
+    ...options,
+  });
+/**
+ * Recent Dag Runs
+ * Get recent DAG runs.
+ * @param data The data for the request.
+ * @param data.dagRunsLimit
+ * @param data.limit
+ * @param data.offset
+ * @param data.tags
+ * @param data.owners
+ * @param data.dagIdPattern
+ * @param data.dagDisplayNamePattern
+ * @param data.onlyActive
+ * @param data.paused
+ * @param data.lastDagRunState
+ * @returns DAGWithLatestDagRunsCollectionResponse Successful Response
+ * @throws ApiError
+ */
+export const useDagsServiceRecentDagRunsSuspense = <
+  TData = Common.DagsServiceRecentDagRunsDefaultResponse,
+  TError = unknown,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  {
+    dagDisplayNamePattern,
+    dagIdPattern,
+    dagRunsLimit,
+    lastDagRunState,
+    limit,
+    offset,
+    onlyActive,
+    owners,
+    paused,
+    tags,
+  }: {
+    dagDisplayNamePattern?: string;
+    dagIdPattern?: string;
+    dagRunsLimit?: number;
+    lastDagRunState?: DagRunState;
+    limit?: number;
+    offset?: number;
+    onlyActive?: boolean;
+    owners?: string[];
+    paused?: boolean;
+    tags?: string[];
+  } = {},
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
+) =>
+  useSuspenseQuery<TData, TError>({
+    queryKey: Common.UseDagsServiceRecentDagRunsKeyFn(
+      {
+        dagDisplayNamePattern,
+        dagIdPattern,
+        dagRunsLimit,
+        lastDagRunState,
+        limit,
+        offset,
+        onlyActive,
+        owners,
+        paused,
+        tags,
+      },
+      queryKey,
+    ),
+    queryFn: () =>
+      DagsService.recentDagRuns({
+        dagDisplayNamePattern,
+        dagIdPattern,
+        dagRunsLimit,
+        lastDagRunState,
+        limit,
+        offset,
+        onlyActive,
+        owners,
+        paused,
+        tags,
+      }) as TData,
+    ...options,
+  });
+/**
+ * Historical Metrics
+ * Return cluster activity historical metrics.
+ * @param data The data for the request.
+ * @param data.startDate
+ * @param data.endDate
+ * @returns HistoricalMetricDataResponse Successful Response
+ * @throws ApiError
+ */
+export const useDashboardServiceHistoricalMetricsSuspense = <
+  TData = Common.DashboardServiceHistoricalMetricsDefaultResponse,
+  TError = unknown,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  {
+    endDate,
+    startDate,
+  }: {
+    endDate?: string;
+    startDate: string;
+  },
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
+) =>
+  useSuspenseQuery<TData, TError>({
+    queryKey: Common.UseDashboardServiceHistoricalMetricsKeyFn(
+      { endDate, startDate },
+      queryKey,
+    ),
+    queryFn: () =>
+      DashboardService.historicalMetrics({ endDate, startDate }) as TData,
+    ...options,
+  });
+/**
+ * Graph Data
+ * Get Graph Data.
+ * @param data The data for the request.
+ * @param data.dagId
+ * @param data.root
+ * @param data.filterUpstream
+ * @param data.filterDownstream
+ * @returns GraphDataResponse Successful Response
+ * @throws ApiError
+ */
+export const useGraphServiceGraphDataSuspense = <
+  TData = Common.GraphServiceGraphDataDefaultResponse,
+  TError = unknown,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  {
+    dagId,
+    filterDownstream,
+    filterUpstream,
+    root,
+  }: {
+    dagId: string;
+    filterDownstream?: boolean;
+    filterUpstream?: boolean;
+    root?: string;
+  },
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
+) =>
+  useSuspenseQuery<TData, TError>({
+    queryKey: Common.UseGraphServiceGraphDataKeyFn(
+      { dagId, filterDownstream, filterUpstream, root },
+      queryKey,
+    ),
+    queryFn: () =>
+      GraphService.graphData({
+        dagId,
+        filterDownstream,
+        filterUpstream,
+        root,
+      }) as TData,
     ...options,
   });
 /**

--- a/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -2596,6 +2596,45 @@ This is the set of allowable values for the \`\`warning_type\`\` field
 in the DagWarning model.`,
 } as const;
 
+export const $EdgeResponse = {
+  properties: {
+    is_setup_teardown: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Is Setup Teardown",
+    },
+    label: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Label",
+    },
+    source_id: {
+      type: "string",
+      title: "Source Id",
+    },
+    target_id: {
+      type: "string",
+      title: "Target Id",
+    },
+  },
+  type: "object",
+  required: ["source_id", "target_id"],
+  title: "EdgeResponse",
+  description: "Edge serializer for responses.",
+} as const;
+
 export const $EventLogCollectionResponse = {
   properties: {
     event_logs: {
@@ -2775,6 +2814,30 @@ export const $FastAPIAppResponse = {
   required: ["app", "url_prefix", "name"],
   title: "FastAPIAppResponse",
   description: "Serializer for Plugin FastAPI App responses.",
+} as const;
+
+export const $GraphDataResponse = {
+  properties: {
+    edges: {
+      items: {
+        $ref: "#/components/schemas/EdgeResponse",
+      },
+      type: "array",
+      title: "Edges",
+    },
+    nodes: {
+      $ref: "#/components/schemas/NodeResponse",
+    },
+    arrange: {
+      type: "string",
+      enum: ["BT", "LR", "RL", "TB"],
+      title: "Arrange",
+    },
+  },
+  type: "object",
+  required: ["edges", "nodes", "arrange"],
+  title: "GraphDataResponse",
+  description: "Graph Data serializer for responses.",
 } as const;
 
 export const $HTTPExceptionResponse = {
@@ -3041,6 +3104,138 @@ export const $JobResponse = {
   ],
   title: "JobResponse",
   description: "Job serializer for responses.",
+} as const;
+
+export const $NodeResponse = {
+  properties: {
+    children: {
+      anyOf: [
+        {
+          items: {
+            $ref: "#/components/schemas/NodeResponse",
+          },
+          type: "array",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Children",
+    },
+    id: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Id",
+    },
+    value: {
+      $ref: "#/components/schemas/NodeValueResponse",
+    },
+  },
+  type: "object",
+  required: ["id", "value"],
+  title: "NodeResponse",
+  description: "Node serializer for responses.",
+} as const;
+
+export const $NodeValueResponse = {
+  properties: {
+    isMapped: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Ismapped",
+    },
+    label: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Label",
+    },
+    labelStyle: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Labelstyle",
+    },
+    style: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Style",
+    },
+    tooltip: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Tooltip",
+    },
+    rx: {
+      type: "integer",
+      title: "Rx",
+    },
+    ry: {
+      type: "integer",
+      title: "Ry",
+    },
+    clusterLabelPos: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Clusterlabelpos",
+    },
+    setupTeardownType: {
+      anyOf: [
+        {
+          type: "string",
+          enum: ["setup", "teardown"],
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Setupteardowntype",
+    },
+  },
+  type: "object",
+  required: ["rx", "ry"],
+  title: "NodeValueResponse",
+  description: "Graph Node Value responses.",
 } as const;
 
 export const $PatchTaskInstanceBody = {

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -25,15 +25,17 @@ import type {
   GetDagAssetQueuedEventResponse,
   DeleteDagAssetQueuedEventData,
   DeleteDagAssetQueuedEventResponse,
-  HistoricalMetricsData,
-  HistoricalMetricsResponse,
-  RecentDagRunsData,
-  RecentDagRunsResponse,
   GetConfigsResponse,
   GetConfigData,
   GetConfigResponse,
   GetConfigValueData,
   GetConfigValueResponse,
+  RecentDagRunsData,
+  RecentDagRunsResponse,
+  HistoricalMetricsData,
+  HistoricalMetricsResponse,
+  GraphDataData,
+  GraphDataResponse2,
   ListBackfillsData,
   ListBackfillsResponse,
   CreateBackfillData,
@@ -508,77 +510,6 @@ export class AssetService {
   }
 }
 
-export class DashboardService {
-  /**
-   * Historical Metrics
-   * Return cluster activity historical metrics.
-   * @param data The data for the request.
-   * @param data.startDate
-   * @param data.endDate
-   * @returns HistoricalMetricDataResponse Successful Response
-   * @throws ApiError
-   */
-  public static historicalMetrics(
-    data: HistoricalMetricsData,
-  ): CancelablePromise<HistoricalMetricsResponse> {
-    return __request(OpenAPI, {
-      method: "GET",
-      url: "/ui/dashboard/historical_metrics_data",
-      query: {
-        start_date: data.startDate,
-        end_date: data.endDate,
-      },
-      errors: {
-        400: "Bad Request",
-        422: "Validation Error",
-      },
-    });
-  }
-}
-
-export class DagsService {
-  /**
-   * Recent Dag Runs
-   * Get recent DAG runs.
-   * @param data The data for the request.
-   * @param data.dagRunsLimit
-   * @param data.limit
-   * @param data.offset
-   * @param data.tags
-   * @param data.owners
-   * @param data.dagIdPattern
-   * @param data.dagDisplayNamePattern
-   * @param data.onlyActive
-   * @param data.paused
-   * @param data.lastDagRunState
-   * @returns DAGWithLatestDagRunsCollectionResponse Successful Response
-   * @throws ApiError
-   */
-  public static recentDagRuns(
-    data: RecentDagRunsData = {},
-  ): CancelablePromise<RecentDagRunsResponse> {
-    return __request(OpenAPI, {
-      method: "GET",
-      url: "/ui/dags/recent_dag_runs",
-      query: {
-        dag_runs_limit: data.dagRunsLimit,
-        limit: data.limit,
-        offset: data.offset,
-        tags: data.tags,
-        owners: data.owners,
-        dag_id_pattern: data.dagIdPattern,
-        dag_display_name_pattern: data.dagDisplayNamePattern,
-        only_active: data.onlyActive,
-        paused: data.paused,
-        last_dag_run_state: data.lastDagRunState,
-      },
-      errors: {
-        422: "Validation Error",
-      },
-    });
-  }
-}
-
 export class ConfigService {
   /**
    * Get Configs
@@ -653,6 +584,109 @@ export class ConfigService {
         403: "Forbidden",
         404: "Not Found",
         406: "Not Acceptable",
+        422: "Validation Error",
+      },
+    });
+  }
+}
+
+export class DagsService {
+  /**
+   * Recent Dag Runs
+   * Get recent DAG runs.
+   * @param data The data for the request.
+   * @param data.dagRunsLimit
+   * @param data.limit
+   * @param data.offset
+   * @param data.tags
+   * @param data.owners
+   * @param data.dagIdPattern
+   * @param data.dagDisplayNamePattern
+   * @param data.onlyActive
+   * @param data.paused
+   * @param data.lastDagRunState
+   * @returns DAGWithLatestDagRunsCollectionResponse Successful Response
+   * @throws ApiError
+   */
+  public static recentDagRuns(
+    data: RecentDagRunsData = {},
+  ): CancelablePromise<RecentDagRunsResponse> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/ui/dags/recent_dag_runs",
+      query: {
+        dag_runs_limit: data.dagRunsLimit,
+        limit: data.limit,
+        offset: data.offset,
+        tags: data.tags,
+        owners: data.owners,
+        dag_id_pattern: data.dagIdPattern,
+        dag_display_name_pattern: data.dagDisplayNamePattern,
+        only_active: data.onlyActive,
+        paused: data.paused,
+        last_dag_run_state: data.lastDagRunState,
+      },
+      errors: {
+        422: "Validation Error",
+      },
+    });
+  }
+}
+
+export class DashboardService {
+  /**
+   * Historical Metrics
+   * Return cluster activity historical metrics.
+   * @param data The data for the request.
+   * @param data.startDate
+   * @param data.endDate
+   * @returns HistoricalMetricDataResponse Successful Response
+   * @throws ApiError
+   */
+  public static historicalMetrics(
+    data: HistoricalMetricsData,
+  ): CancelablePromise<HistoricalMetricsResponse> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/ui/dashboard/historical_metrics_data",
+      query: {
+        start_date: data.startDate,
+        end_date: data.endDate,
+      },
+      errors: {
+        400: "Bad Request",
+        422: "Validation Error",
+      },
+    });
+  }
+}
+
+export class GraphService {
+  /**
+   * Graph Data
+   * Get Graph Data.
+   * @param data The data for the request.
+   * @param data.dagId
+   * @param data.root
+   * @param data.filterUpstream
+   * @param data.filterDownstream
+   * @returns GraphDataResponse Successful Response
+   * @throws ApiError
+   */
+  public static graphData(
+    data: GraphDataData,
+  ): CancelablePromise<GraphDataResponse2> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/ui/graph_data",
+      query: {
+        dag_id: data.dagId,
+        root: data.root,
+        filter_upstream: data.filterUpstream,
+        filter_downstream: data.filterDownstream,
+      },
+      errors: {
+        400: "Bad Request",
         422: "Validation Error",
       },
     });

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -668,8 +668,8 @@ export class GraphService {
    * @param data The data for the request.
    * @param data.dagId
    * @param data.root
-   * @param data.filterUpstream
-   * @param data.filterDownstream
+   * @param data.includeUpstream
+   * @param data.includeDownstream
    * @returns GraphDataResponse Successful Response
    * @throws ApiError
    */
@@ -678,12 +678,12 @@ export class GraphService {
   ): CancelablePromise<GraphDataResponse2> {
     return __request(OpenAPI, {
       method: "GET",
-      url: "/ui/graph_data",
+      url: "/ui/graph/graph_data",
       query: {
         dag_id: data.dagId,
         root: data.root,
-        filter_upstream: data.filterUpstream,
-        filter_downstream: data.filterDownstream,
+        include_upstream: data.includeUpstream,
+        include_downstream: data.includeDownstream,
       },
       errors: {
         400: "Bad Request",

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -621,6 +621,16 @@ export type DagTagPydantic = {
 export type DagWarningType = "asset conflict" | "non-existent pool";
 
 /**
+ * Edge serializer for responses.
+ */
+export type EdgeResponse = {
+  is_setup_teardown?: boolean | null;
+  label?: string | null;
+  source_id: string;
+  target_id: string;
+};
+
+/**
  * Event Log Collection Response.
  */
 export type EventLogCollectionResponse = {
@@ -661,6 +671,17 @@ export type FastAPIAppResponse = {
   name: string;
   [key: string]: unknown | string;
 };
+
+/**
+ * Graph Data serializer for responses.
+ */
+export type GraphDataResponse = {
+  edges: Array<EdgeResponse>;
+  nodes: NodeResponse;
+  arrange: "BT" | "LR" | "RL" | "TB";
+};
+
+export type arrange = "BT" | "LR" | "RL" | "TB";
 
 /**
  * HTTPException Model used for error response.
@@ -736,6 +757,30 @@ export type JobResponse = {
   executor_class: string | null;
   hostname: string | null;
   unixname: string | null;
+};
+
+/**
+ * Node serializer for responses.
+ */
+export type NodeResponse = {
+  children?: Array<NodeResponse> | null;
+  id: string | null;
+  value: NodeValueResponse;
+};
+
+/**
+ * Graph Node Value responses.
+ */
+export type NodeValueResponse = {
+  isMapped?: boolean | null;
+  label?: string | null;
+  labelStyle?: string | null;
+  style?: string | null;
+  tooltip?: string | null;
+  rx: number;
+  ry: number;
+  clusterLabelPos?: string | null;
+  setupTeardownType?: "setup" | "teardown" | null;
 };
 
 /**
@@ -1333,28 +1378,6 @@ export type DeleteDagAssetQueuedEventData = {
 
 export type DeleteDagAssetQueuedEventResponse = void;
 
-export type HistoricalMetricsData = {
-  endDate?: string | null;
-  startDate: string;
-};
-
-export type HistoricalMetricsResponse = HistoricalMetricDataResponse;
-
-export type RecentDagRunsData = {
-  dagDisplayNamePattern?: string | null;
-  dagIdPattern?: string | null;
-  dagRunsLimit?: number;
-  lastDagRunState?: DagRunState | null;
-  limit?: number;
-  offset?: number;
-  onlyActive?: boolean;
-  owners?: Array<string>;
-  paused?: boolean | null;
-  tags?: Array<string>;
-};
-
-export type RecentDagRunsResponse = DAGWithLatestDagRunsCollectionResponse;
-
 export type GetConfigsResponse = ConfigResponse;
 
 export type GetConfigData = {
@@ -1371,6 +1394,37 @@ export type GetConfigValueData = {
 };
 
 export type GetConfigValueResponse = Config;
+
+export type RecentDagRunsData = {
+  dagDisplayNamePattern?: string | null;
+  dagIdPattern?: string | null;
+  dagRunsLimit?: number;
+  lastDagRunState?: DagRunState | null;
+  limit?: number;
+  offset?: number;
+  onlyActive?: boolean;
+  owners?: Array<string>;
+  paused?: boolean | null;
+  tags?: Array<string>;
+};
+
+export type RecentDagRunsResponse = DAGWithLatestDagRunsCollectionResponse;
+
+export type HistoricalMetricsData = {
+  endDate?: string | null;
+  startDate: string;
+};
+
+export type HistoricalMetricsResponse = HistoricalMetricDataResponse;
+
+export type GraphDataData = {
+  dagId: string;
+  filterDownstream?: boolean;
+  filterUpstream?: boolean;
+  root?: string | null;
+};
+
+export type GraphDataResponse2 = GraphDataResponse;
 
 export type ListBackfillsData = {
   dagId: string;
@@ -2272,40 +2326,6 @@ export type $OpenApiTs = {
       };
     };
   };
-  "/ui/dashboard/historical_metrics_data": {
-    get: {
-      req: HistoricalMetricsData;
-      res: {
-        /**
-         * Successful Response
-         */
-        200: HistoricalMetricDataResponse;
-        /**
-         * Bad Request
-         */
-        400: HTTPExceptionResponse;
-        /**
-         * Validation Error
-         */
-        422: HTTPValidationError;
-      };
-    };
-  };
-  "/ui/dags/recent_dag_runs": {
-    get: {
-      req: RecentDagRunsData;
-      res: {
-        /**
-         * Successful Response
-         */
-        200: DAGWithLatestDagRunsCollectionResponse;
-        /**
-         * Validation Error
-         */
-        422: HTTPValidationError;
-      };
-    };
-  };
   "/ui/config": {
     get: {
       res: {
@@ -2375,6 +2395,59 @@ export type $OpenApiTs = {
          * Not Acceptable
          */
         406: HTTPExceptionResponse;
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError;
+      };
+    };
+  };
+  "/ui/dags/recent_dag_runs": {
+    get: {
+      req: RecentDagRunsData;
+      res: {
+        /**
+         * Successful Response
+         */
+        200: DAGWithLatestDagRunsCollectionResponse;
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError;
+      };
+    };
+  };
+  "/ui/dashboard/historical_metrics_data": {
+    get: {
+      req: HistoricalMetricsData;
+      res: {
+        /**
+         * Successful Response
+         */
+        200: HistoricalMetricDataResponse;
+        /**
+         * Bad Request
+         */
+        400: HTTPExceptionResponse;
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError;
+      };
+    };
+  };
+  "/ui/graph_data": {
+    get: {
+      req: GraphDataData;
+      res: {
+        /**
+         * Successful Response
+         */
+        200: GraphDataResponse;
+        /**
+         * Bad Request
+         */
+        400: HTTPExceptionResponse;
         /**
          * Validation Error
          */

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1419,8 +1419,8 @@ export type HistoricalMetricsResponse = HistoricalMetricDataResponse;
 
 export type GraphDataData = {
   dagId: string;
-  filterDownstream?: boolean;
-  filterUpstream?: boolean;
+  includeDownstream?: boolean;
+  includeUpstream?: boolean;
   root?: string | null;
 };
 
@@ -2436,7 +2436,7 @@ export type $OpenApiTs = {
       };
     };
   };
-  "/ui/graph_data": {
+  "/ui/graph/graph_data": {
     get: {
       req: GraphDataData;
       res: {

--- a/tests/api_fastapi/core_api/routes/ui/test_graph.py
+++ b/tests/api_fastapi/core_api/routes/ui/test_graph.py
@@ -1,0 +1,198 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pendulum
+import pytest
+
+from airflow.models import DagBag
+from airflow.operators.empty import EmptyOperator
+
+from tests_common.test_utils.db import clear_db_runs
+
+pytestmark = pytest.mark.db_test
+
+DAG_ID = "test_dag_id"
+
+
+@pytest.fixture(autouse=True, scope="module")
+def examples_dag_bag():
+    # Speed up: We don't want example dags for this module
+
+    return DagBag(include_examples=False, read_dags_from_db=True)
+
+
+@pytest.fixture(autouse=True)
+def clean():
+    clear_db_runs()
+    yield
+    clear_db_runs()
+
+
+@pytest.fixture
+def make_dag(dag_maker, session, time_machine):
+    with dag_maker(
+        dag_id=DAG_ID,
+        serialized=True,
+        session=session,
+        start_date=pendulum.DateTime(2023, 2, 1, 0, 0, 0, tzinfo=pendulum.UTC),
+    ):
+        EmptyOperator(task_id="task_1") >> EmptyOperator(task_id="task_2")
+
+    dag_maker.dagbag.sync_to_db()
+
+
+class TestGraphDataEndpoint:
+    @pytest.mark.parametrize(
+        "params, expected",
+        [
+            (
+                {"dag_id": DAG_ID},
+                {
+                    "arrange": "LR",
+                    "edges": [
+                        {
+                            "is_setup_teardown": None,
+                            "label": None,
+                            "source_id": "task_1",
+                            "target_id": "task_2",
+                        },
+                    ],
+                    "nodes": {
+                        "children": [
+                            {
+                                "children": None,
+                                "id": "task_1",
+                                "value": {
+                                    "clusterLabelPos": None,
+                                    "isMapped": None,
+                                    "label": "task_1",
+                                    "labelStyle": "fill:#000;",
+                                    "rx": 5,
+                                    "ry": 5,
+                                    "setupTeardownType": None,
+                                    "style": "fill:#e8f7e4;",
+                                    "tooltip": None,
+                                },
+                            },
+                            {
+                                "children": None,
+                                "id": "task_2",
+                                "value": {
+                                    "clusterLabelPos": None,
+                                    "isMapped": None,
+                                    "label": "task_2",
+                                    "labelStyle": "fill:#000;",
+                                    "rx": 5,
+                                    "ry": 5,
+                                    "setupTeardownType": None,
+                                    "style": "fill:#e8f7e4;",
+                                    "tooltip": None,
+                                },
+                            },
+                        ],
+                        "id": None,
+                        "value": {
+                            "clusterLabelPos": "top",
+                            "isMapped": False,
+                            "label": None,
+                            "labelStyle": "fill:#000;",
+                            "rx": 5,
+                            "ry": 5,
+                            "setupTeardownType": None,
+                            "style": "fill:CornflowerBlue",
+                            "tooltip": "",
+                        },
+                    },
+                },
+            ),
+            (
+                {
+                    "dag_id": DAG_ID,
+                    "root": "unknown_task",
+                },
+                {
+                    "arrange": "LR",
+                    "edges": [],
+                    "nodes": {
+                        "children": [],
+                        "id": None,
+                        "value": {
+                            "clusterLabelPos": "top",
+                            "isMapped": False,
+                            "label": None,
+                            "labelStyle": "fill:#000;",
+                            "rx": 5,
+                            "ry": 5,
+                            "setupTeardownType": None,
+                            "style": "fill:CornflowerBlue",
+                            "tooltip": "",
+                        },
+                    },
+                },
+            ),
+            (
+                {
+                    "dag_id": DAG_ID,
+                    "root": "task_1",
+                    "filter_upstream": False,
+                    "filter_downstream": False,
+                },
+                {
+                    "arrange": "LR",
+                    "edges": [],
+                    "nodes": {
+                        "children": [
+                            {
+                                "children": None,
+                                "id": "task_1",
+                                "value": {
+                                    "clusterLabelPos": None,
+                                    "isMapped": None,
+                                    "label": "task_1",
+                                    "labelStyle": "fill:#000;",
+                                    "rx": 5,
+                                    "ry": 5,
+                                    "setupTeardownType": None,
+                                    "style": "fill:#e8f7e4;",
+                                    "tooltip": None,
+                                },
+                            },
+                        ],
+                        "id": None,
+                        "value": {
+                            "clusterLabelPos": "top",
+                            "isMapped": False,
+                            "label": None,
+                            "labelStyle": "fill:#000;",
+                            "rx": 5,
+                            "ry": 5,
+                            "setupTeardownType": None,
+                            "style": "fill:CornflowerBlue",
+                            "tooltip": "",
+                        },
+                    },
+                },
+            ),
+        ],
+    )
+    @pytest.mark.usefixtures("make_dag")
+    def test_historical_metrics_data(self, test_client, params, expected):
+        response = test_client.get("/ui/graph/graph_data", params=params)
+        assert response.status_code == 200
+        assert response.json() == expected


### PR DESCRIPTION
Related to: https://github.com/apache/airflow/issues/42366

Subpart of: https://github.com/apache/airflow/issues/42367

Rough implementation of the `graph_data` in the FastAPI API. (same interface except that all fields are always returned, nothing is omitted like in the original implementation).

Then I will follow up with an update of the data model to return what is expected in https://github.com/apache/airflow/issues/42367

> Renaming to `Structure` will happen on the following PR.