### PR TITLE
Fix so tests run in local docker for devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,5 +26,6 @@
     // for users who use non-standard git config patterns
     // https://github.com/microsoft/vscode-remote-release/issues/2084#issuecomment-989756268
     "initializeCommand": "cd \"${localWorkspaceFolder}\" && git config --local user.email \"$(git config user.email)\" && git config --local user.name \"$(git config user.name)\"",
+    "postCreateCommand": "./scripts/ci/docker-compose/link-workspaces-on-local-docker.sh",
     "overrideCommand": true
 }

--- a/.devcontainer/mysql/devcontainer.json
+++ b/.devcontainer/mysql/devcontainer.json
@@ -27,5 +27,6 @@
     // for users who use non-standard git config patterns
     // https://github.com/microsoft/vscode-remote-release/issues/2084#issuecomment-989756268
     "initializeCommand": "cd \"${localWorkspaceFolder}\" && git config --local user.email \"$(git config user.email)\" && git config --local user.name \"$(git config user.name)\"",
+    "postCreateCommand": "./scripts/ci/docker-compose/link-workspaces-on-local-docker.sh",
     "overrideCommand": true
 }

--- a/.devcontainer/postgres/devcontainer.json
+++ b/.devcontainer/postgres/devcontainer.json
@@ -27,5 +27,6 @@
     // for users who use non-standard git config patterns
     // https://github.com/microsoft/vscode-remote-release/issues/2084#issuecomment-989756268
     "initializeCommand": "cd \"${localWorkspaceFolder}\" && git config --local user.email \"$(git config user.email)\" && git config --local user.name \"$(git config user.name)\"",
+    "postCreateCommand": "./scripts/ci/docker-compose/link-workspaces-on-local-docker.sh",
     "overrideCommand": true
 }

--- a/scripts/ci/docker-compose/devcontainer.yml
+++ b/scripts/ci/docker-compose/devcontainer.yml
@@ -32,7 +32,7 @@ services:
       # Pass docker to inside of the container so that Kind and Moto tests can use it.
       - /var/run/docker.sock:/var/run/docker.sock
       - /dev/urandom:/dev/random  # Required to get non-blocking entropy source
-      # Mount the cloned repo from codspaces docker host into the container,
+      # Mount the cloned repo from codespaces docker host into the container,
       # this will keep /workspaces/airflow and /opt/airflow in sync.
       - ../../../.:/opt/airflow
       # - /var/lib/docker/codespacemount/workspace/airflow:/opt/airflow

--- a/scripts/ci/docker-compose/link-workspaces-on-local-docker.sh
+++ b/scripts/ci/docker-compose/link-workspaces-on-local-docker.sh
@@ -1,5 +1,22 @@
 #!/bin/sh
- 
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 if [ ! -d /workspaces ] ; then
   # Running in docker so create missing link from /opt/airflow to /workspaces/airflow
   #

--- a/scripts/ci/docker-compose/link-workspaces-on-local-docker.sh
+++ b/scripts/ci/docker-compose/link-workspaces-on-local-docker.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+ 
+if [ ! -d /workspaces ] ; then
+  # Running in docker so create missing link from /opt/airflow to /workspaces/airflow
+  #
+  # This is created automatically when running in codespaces so we need to replicate it
+  # in the local docker environment
+  mkdir /workspaces && ln -s /opt/airflow /workspaces/airflow
+fi


### PR DESCRIPTION
Tests worked in github devcontainers, but not in local docker instances. This change ensures the expected /workspaces/airflow contains a link to the code so the tests can run. 

Possibly this is an X-Y problem where I fixed X, the test, but where really we should fix Y where Y is that the location is hardcoded to a place that isn't always populated.
