### PR TITLE
feat(dataset): allow "airflow.dataset.metadata.Metadata" import for backward compat

### DIFF
--- a/airflow/datasets/metadata.py
+++ b/airflow/datasets/metadata.py
@@ -15,26 +15,19 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# We do not use "from __future__ import annotations" here because it is not supported
-# by Pycharm when we want to make sure all imports in airflow work from namespace packages
-# Adding it automatically is excluded in pyproject.toml via I002 ruff rule exclusion
-
-# Make `airflow` a namespace package, supporting installing
-# airflow.providers.* in different locations (i.e. one in site, and one in user
-# lib.)  This is required by some IDEs to resolve the import paths.
 from __future__ import annotations
 
 import warnings
 
-from airflow.sdk.definitions.asset import AssetAlias as DatasetAlias, Dataset
+from airflow.sdk.definitions.asset.metadata import Metadata
 
 # TODO: Remove this module in Airflow 3.2
 
 warnings.warn(
     "Import from the airflow.dataset module is deprecated and "
-    "will be removed in the Airflow 3.2. Please import it from 'airflow.sdk.definitions.asset'.",
+    "will be removed in the Airflow 3.2. Please import it from 'airflow.sdk.definitions.asset.metadata'.",
     DeprecationWarning,
     stacklevel=2,
 )
 
-__all__ = ["Dataset", "DatasetAlias"]
+__all__ = ["Metadata"]

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -40,6 +40,15 @@ import pytest
                 "will be removed in the Airflow 3.2. Please import it from 'airflow.sdk.definitions.asset'."
             ),
         ),
+        (
+            "airflow.datasets.metadata",
+            "Metadata",
+            (
+                "Import from the airflow.dataset module is deprecated and "
+                "will be removed in the Airflow 3.2. Please import it from "
+                "'airflow.sdk.definitions.asset.metadata'."
+            ),
+        ),
     ),
 )
 def test_backward_compat_import_before_airflow_3_2(module_path, attr_name, warning_message):


### PR DESCRIPTION
## Why
As we already have `airflow.dataset.Dataset` and `airflow.dataset.DatasetAlias` for backward compat, it makes sense to allow `airflow.dataset.metadata.Metadata` till airflow 3.2.

## What

allow importing `airflow.dataset.metadata.Metadata`

close: #44411

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
