### PR TITLE
Add note about why we still have `black` config settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,8 @@ artifacts = [
 ]
 
 ## black settings ##
+# Used to format code examples inside .rst doc files
+# Needed until https://github.com/astral-sh/ruff/issues/8237 is available.
 [tool.black]
 line-length = 110
 target-version = ['py39', 'py310', 'py311', 'py312']


### PR DESCRIPTION
We mostly use ruff everywhere, but there is one use-case where black, or specifically `blacken-docs` is still needed.