### PR TITLE
Fixing rendering of code block for newsfragment command

### DIFF
--- a/contributing-docs/16_contribution_workflow.rst
+++ b/contributing-docs/16_contribution_workflow.rst
@@ -201,6 +201,7 @@ Step 4: Prepare PR
      This can also be done by the following command.
 
 .. code-block:: bash
+
      uv tool run towncrier create --dir . --config newsfragments/config.toml --content "`cat newsfragments/template.significant.rst`"
 
 2. Rebase your fork, squash commits, and resolve all conflicts. See `How to rebase PR <#how-to-rebase-pr>`_

--- a/contributing-docs/16_contribution_workflow.rst
+++ b/contributing-docs/16_contribution_workflow.rst
@@ -200,9 +200,9 @@ Step 4: Prepare PR
      you should follow the template in ``newsfragments/template.significant.rst`` to include summary, body, change type and migrations rules needed.
      This can also be done by the following command.
 
-.. code-block:: bash
+     .. code-block:: bash
 
-     uv tool run towncrier create --dir . --config newsfragments/config.toml --content "`cat newsfragments/template.significant.rst`"
+        uv tool run towncrier create --dir . --config newsfragments/config.toml --content "`cat newsfragments/template.significant.rst`"
 
 2. Rebase your fork, squash commits, and resolve all conflicts. See `How to rebase PR <#how-to-rebase-pr>`_
    if you need help with rebasing your change. Remember to rebase often if your PR takes a lot of time to


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

https://github.com/apache/airflow/pull/44378/files introduced newsfragment templating 👏🏽
However, github wasnt able to render the command due to a missing line.

Before:
![image](https://github.com/user-attachments/assets/28e0ca86-856d-44dc-b733-2474393cf568)

After:
![image](https://github.com/user-attachments/assets/cd6ec958-40cf-412e-a332-fc2c8357f667)


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
