### PR TITLE
Convert the LocalExecutor to run tasks using new Task SDK supervisor code

### DIFF
--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -300,6 +300,8 @@ def _run_task_by_executor(args, dag: DAG, ti: TaskInstance) -> None:
 
     This can result in the task being started by another host if the executor implementation does.
     """
+    from airflow.executors.base_executor import BaseExecutor
+
     if ti.executor:
         executor = ExecutorLoader.load_executor(ti.executor)
     else:
@@ -307,17 +309,25 @@ def _run_task_by_executor(args, dag: DAG, ti: TaskInstance) -> None:
     executor.job_id = None
     executor.start()
     print("Sending to executor.")
-    executor.queue_task_instance(
-        ti,
-        mark_success=args.mark_success,
-        ignore_all_deps=args.ignore_all_dependencies,
-        ignore_depends_on_past=should_ignore_depends_on_past(args),
-        wait_for_past_depends_before_skipping=(args.depends_on_past == "wait"),
-        ignore_task_deps=args.ignore_dependencies,
-        ignore_ti_state=args.force,
-        pool=args.pool,
-    )
-    executor.heartbeat()
+
+    # TODO: Task-SDK: this is temporary while we migrate the other executors over
+    if executor.queue_workload.__func__ is not BaseExecutor.queue_workload:  # type: ignore[attr-defined]
+        from airflow.executors import workloads
+
+        workload = workloads.ExecuteTask.make(ti, dag_path=dag.relative_fileloc)
+        executor.queue_workload(workload)
+    else:
+        executor.queue_task_instance(
+            ti,
+            mark_success=args.mark_success,
+            ignore_all_deps=args.ignore_all_dependencies,
+            ignore_depends_on_past=should_ignore_depends_on_past(args),
+            wait_for_past_depends_before_skipping=(args.depends_on_past == "wait"),
+            ignore_task_deps=args.ignore_dependencies,
+            ignore_ti_state=args.force,
+            pool=args.pool,
+        )
+        executor.heartbeat()
     executor.end()
 
 

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -908,7 +908,7 @@ logging:
       is_template: true
       default: "dag_id={{ ti.dag_id }}/run_id={{ ti.run_id }}/task_id={{ ti.task_id }}/\
                {%% if ti.map_index >= 0 %%}map_index={{ ti.map_index }}/{%% endif %%}\
-               attempt={{ try_number }}.log"
+               attempt={{ try_number|default(ti.try_number) }}.log"
     log_processor_filename_template:
       description: |
         Formatting for how airflow generates file names for log

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
     from airflow.callbacks.base_callback_sink import BaseCallbackSink
     from airflow.callbacks.callback_requests import CallbackRequest
     from airflow.cli.cli_config import GroupCommand
+    from airflow.executors import workloads
     from airflow.executors.executor_utils import ExecutorName
     from airflow.models.taskinstance import TaskInstance
     from airflow.models.taskinstancekey import TaskInstanceKey
@@ -169,6 +170,9 @@ class BaseExecutor(LoggingMixin):
             self.queued_tasks[task_instance.key] = (command, priority, queue, task_instance)
         else:
             self.log.error("could not queue task %s", task_instance.key)
+
+    def queue_workload(self, workload: workloads.All) -> None:
+        raise ValueError(f"Un-handled workload kind {type(workload).__name__!r} in {type(self).__name__}")
 
     def queue_task_instance(
         self,
@@ -409,6 +413,9 @@ class BaseExecutor(LoggingMixin):
                 self.execute_async(key=key, command=command, queue=queue, executor_config=executor_config)
                 self.running.add(key)
 
+    # TODO: This should not be using `TaskInstanceState` here, this is just "did the process complete, or did
+    # it die". It is possible for the task itself to finish with success, but the state of the task to be set
+    # to FAILED. By using TaskInstanceState enum here it confuses matters!
     def change_state(
         self, key: TaskInstanceKey, state: TaskInstanceState, info=None, remove_running=True
     ) -> None:

--- a/airflow/executors/workloads.py
+++ b/airflow/executors/workloads.py
@@ -1,0 +1,98 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import os
+import uuid
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal, Union
+
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from airflow.models.taskinstance import TaskInstance as TIModel
+    from airflow.models.taskinstancekey import TaskInstanceKey
+
+
+__all__ = [
+    "All",
+    "ExecuteTask",
+]
+
+
+class BaseActivity(BaseModel):
+    token: str
+    """The identity token for this workload"""
+
+
+class TaskInstance(BaseModel):
+    """Schema for TaskInstance with minimal required fields needed for Executors and Task SDK."""
+
+    id: uuid.UUID
+
+    task_id: str
+    dag_id: str
+    run_id: str
+    try_number: int
+    map_index: int | None = None
+
+    # TODO: Task-SDK: Can we replace TastInstanceKey with just the uuid across the codebase?
+    @property
+    def key(self) -> TaskInstanceKey:
+        from airflow.models.taskinstancekey import TaskInstanceKey
+
+        return TaskInstanceKey(
+            dag_id=self.dag_id,
+            task_id=self.task_id,
+            run_id=self.run_id,
+            try_number=self.try_number,
+            map_index=-1 if self.map_index is None else self.map_index,
+        )
+
+
+class ExecuteTask(BaseActivity):
+    """Execute the given Task."""
+
+    ti: TaskInstance
+    """The TaskInstance to execute"""
+    dag_path: os.PathLike[str]
+    """The filepath where the DAG can be found (likely prefixed with `DAG_FOLDER/`)"""
+
+    log_path: str | None
+    """The rendered relative log filename template the task logs should be written to"""
+
+    kind: Literal["ExecuteTask"] = Field(init=False, default="ExecuteTask")
+
+    @classmethod
+    def make(cls, ti: TIModel, dag_path: Path | None = None) -> ExecuteTask:
+        from pathlib import Path
+
+        from airflow.utils.helpers import log_filename_template_renderer
+
+        ser_ti = TaskInstance.model_validate(ti, from_attributes=True)
+
+        dag_path = dag_path or Path(ti.dag_run.dag_model.relative_fileloc)
+
+        if dag_path and not dag_path.is_absolute():
+            # TODO: What about multiple dag sub folders
+            dag_path = "DAGS_FOLDER" / dag_path
+
+        fname = log_filename_template_renderer()(ti=ti)
+        return cls(ti=ser_ti, dag_path=dag_path, token="", log_path=fname)
+
+
+All = Union[ExecuteTask]

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -23,7 +23,7 @@ import re
 import signal
 from collections.abc import Generator, Iterable, Mapping, MutableMapping
 from datetime import datetime
-from functools import reduce
+from functools import cache, reduce
 from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast
 
 from lazy_object_proxy import Proxy
@@ -171,7 +171,7 @@ def as_flattened_list(iterable: Iterable[Iterable[T]]) -> list[T]:
     return [e for i in iterable for e in i]
 
 
-def parse_template_string(template_string: str) -> tuple[str | None, jinja2.Template | None]:
+def parse_template_string(template_string: str) -> tuple[str, None] | tuple[None, jinja2.Template]:
     """Parse Jinja template string."""
     import jinja2
 
@@ -179,6 +179,27 @@ def parse_template_string(template_string: str) -> tuple[str | None, jinja2.Temp
         return None, jinja2.Template(template_string)
     else:
         return template_string, None
+
+
+@cache
+def log_filename_template_renderer() -> Callable[..., str]:
+    template = conf.get("logging", "log_filename_template")
+
+    if "{{" in template:
+        import jinja2
+
+        return jinja2.Template(template).render
+    else:
+
+        def f_str_format(ti: TaskInstance, try_number: int | None = None):
+            return template.format(
+                dag_id=ti.dag_id,
+                task_id=ti.task_id,
+                logical_date=ti.logical_date.isoformat(),
+                try_number=try_number or ti.try_number,
+            )
+
+        return f_str_format
 
 
 def render_log_filename(ti: TaskInstance, try_number, filename_template) -> str:

--- a/task_sdk/pyproject.toml
+++ b/task_sdk/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "attrs>=24.2.0",
     "google-re2>=1.1.20240702",
     "httpx>=0.27.0",
+    "jinja2>=3.1.4",
     "methodtools>=0.4.7",
     "msgspec>=0.18.6",
     "psutil>=6.1.0",

--- a/task_sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task_sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -54,9 +54,8 @@ from airflow.sdk.execution_time.comms import (
 )
 
 if TYPE_CHECKING:
-    from structlog.typing import FilteringBoundLogger
+    from structlog.typing import FilteringBoundLogger, WrappedLogger
 
-    from airflow.sdk.api.datamodels.activities import ExecuteTaskActivity
 
 __all__ = ["WatchedSubprocess", "supervise"]
 
@@ -282,6 +281,7 @@ class WatchedSubprocess:
         ti: TaskInstance,
         client: Client,
         target: Callable[[], None] = _subprocess_main,
+        logger: FilteringBoundLogger | None = None,
     ) -> WatchedSubprocess:
         """Fork and start a new subprocess to execute the given task."""
         # Create socketpairs/"pipes" to connect to the stdin and out from the subprocess
@@ -296,6 +296,13 @@ class WatchedSubprocess:
         pid = os.fork()
         if pid == 0:
             # Parent ends of the sockets are closed by the OS as they are set as non-inheritable
+
+            # Python GC should delete these for us, but lets make double sure that we don't keep anything
+            # around in the forked processes, especially things that might involve open files or sockets!
+            del path
+            del client
+            del ti
+            del logger
 
             # Run the child entrypoint
             _fork_main(child_stdin, child_stdout, child_stderr, child_logs.fileno(), target)
@@ -319,8 +326,13 @@ class WatchedSubprocess:
             proc.kill(signal.SIGKILL)
             raise
 
+        logger = logger or cast("FilteringBoundLogger", structlog.get_logger(logger_name="task").bind())
         proc._register_pipe_readers(
-            stdout=read_stdout, stderr=read_stderr, requests=read_msgs, logs=read_logs
+            logger=logger,
+            stdout=read_stdout,
+            stderr=read_stderr,
+            requests=read_msgs,
+            logs=read_logs,
         )
 
         # Close the remaining parent-end of the sockets we've passed to the child via fork. We still have the
@@ -331,15 +343,14 @@ class WatchedSubprocess:
         proc._send_startup_message(ti, path, child_comms)
         return proc
 
-    def _register_pipe_readers(self, stdout: socket, stderr: socket, requests: socket, logs: socket):
+    def _register_pipe_readers(
+        self, logger: FilteringBoundLogger, stdout: socket, stderr: socket, requests: socket, logs: socket
+    ):
         """Register handlers for subprocess communication channels."""
         # self.selector is a way of registering a handler/callback to be called when the given IO channel has
         # activity to read on (https://www.man7.org/linux/man-pages/man2/select.2.html etc, but better
         # alternatives are used automatically) -- this is a way of having "event-based" code, but without
         # needing full async, to read and process output from each socket as it is received.
-
-        # TODO: Use logging providers to handle the chunked upload for us
-        logger: FilteringBoundLogger = structlog.get_logger(logger_name="task").bind()
 
         self.selector.register(stdout, selectors.EVENT_READ, self._create_socket_handler(logger, "stdout"))
         self.selector.register(
@@ -369,7 +380,7 @@ class WatchedSubprocess:
 
     def _send_startup_message(self, ti: TaskInstance, path: str | os.PathLike[str], child_comms: socket):
         """Send startup message to the subprocess."""
-        msg = StartupDetails(
+        msg = StartupDetails.model_construct(
             ti=ti,
             file=str(path),
             requests_fd=child_comms.fileno(),
@@ -630,25 +641,57 @@ def forward_to_log(target_log: FilteringBoundLogger, level: int) -> Generator[No
             target_log.log(level, msg)
 
 
-def supervise(activity: ExecuteTaskActivity, server: str | None = None, dry_run: bool = False) -> int:
+def supervise(
+    *,
+    ti: TaskInstance,
+    dag_path: str | os.PathLike[str],
+    token: str,
+    server: str | None = None,
+    dry_run: bool = False,
+    log_path: str | None = None,
+) -> int:
     """
     Run a single task execution to completion.
 
     Returns the exit code of the process
     """
     # One or the other
-    if (server == "") ^ dry_run:
+    if (not server) ^ dry_run:
         raise ValueError(f"Can only specify one of {server=} or {dry_run=}")
 
-    if not activity.path:
-        raise ValueError("path filed of activity missing")
+    if not dag_path:
+        raise ValueError("dag_path is required")
+
+    if (str_path := os.fspath(dag_path)).startswith("DAGS_FOLDER/"):
+        from airflow.settings import DAGS_FOLDER
+
+        dag_path = str_path.replace("DAGS_FOLDER/", DAGS_FOLDER + "/", 1)
 
     limits = httpx.Limits(max_keepalive_connections=1, max_connections=10)
-    client = Client(base_url=server or "", limits=limits, dry_run=dry_run, token=activity.token)
+    client = Client(base_url=server or "", limits=limits, dry_run=dry_run, token=token)
 
     start = time.monotonic()
 
-    process = WatchedSubprocess.start(activity.path, activity.ti, client=client)
+    # TODO: Use logging providers to handle the chunked upload for us etc.
+    logger: FilteringBoundLogger | None = None
+    if log_path:
+        # If we are told to write logs to a file, redirect the task logger to it.
+        from airflow.sdk.log import init_log_file, logging_processors
+
+        try:
+            log_file = init_log_file(log_path)
+        except OSError as e:
+            log.warning("OSError while changing ownership of the log file. ", e)
+
+        pretty_logs = False
+        if pretty_logs:
+            underlying_logger: WrappedLogger = structlog.WriteLogger(log_file.open("w", buffering=1))
+        else:
+            underlying_logger = structlog.BytesLogger(log_file.open("wb"))
+        processors = logging_processors(enable_pretty_log=pretty_logs)[0]
+        logger = structlog.wrap_logger(underlying_logger, processors=processors, logger_name="task").bind()
+
+    process = WatchedSubprocess.start(dag_path, ti, client=client, logger=logger)
 
     exit_code = process.wait()
     end = time.monotonic()

--- a/task_sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task_sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -127,6 +127,10 @@ def startup() -> tuple[RuntimeTaskInstance, Logger]:
     msg = SUPERVISOR_COMMS.get_message()
 
     if isinstance(msg, StartupDetails):
+        from setproctitle import setproctitle
+
+        setproctitle(f"airflow worker -- {msg.ti.id}")
+
         log = structlog.get_logger(logger_name="task")
         # TODO: set the "magic loop" context vars for parsing
         ti = parse(msg)

--- a/task_sdk/tests/execution_time/test_supervisor.py
+++ b/task_sdk/tests/execution_time/test_supervisor.py
@@ -36,7 +36,6 @@ from uuid6 import uuid7
 from airflow.sdk.api import client as sdk_client
 from airflow.sdk.api.client import ServerResponseError
 from airflow.sdk.api.datamodels._generated import TaskInstance
-from airflow.sdk.api.datamodels.activities import ExecuteTaskActivity
 from airflow.sdk.execution_time.comms import (
     ConnectionResult,
     DeferTask,
@@ -249,19 +248,15 @@ class TestWatchedSubprocess:
         time_machine.move_to(instant, tick=False)
 
         dagfile_path = test_dags_dir / "super_basic_run.py"
-        task_activity = ExecuteTaskActivity(
-            ti=TaskInstance(
-                id=uuid7(),
-                task_id="hello",
-                dag_id="super_basic_run",
-                run_id="c",
-                try_number=1,
-            ),
-            path=dagfile_path,
-            token="",
+        ti = TaskInstance(
+            id=uuid7(),
+            task_id="hello",
+            dag_id="super_basic_run",
+            run_id="c",
+            try_number=1,
         )
         # Assert Exit Code is 0
-        assert supervise(activity=task_activity, server="", dry_run=True) == 0
+        assert supervise(ti=ti, dag_path=dagfile_path, token="", server="", dry_run=True) == 0
 
         # We should have a log from the task!
         assert {

--- a/tests/executors/test_local_executor.py
+++ b/tests/executors/test_local_executor.py
@@ -17,17 +17,15 @@
 # under the License.
 from __future__ import annotations
 
-import datetime
 import multiprocessing
 import os
-import subprocess
 from unittest import mock
 
 import pytest
 from kgb import spy_on
+from uuid6 import uuid7
 
-from airflow import settings
-from airflow.exceptions import AirflowException
+from airflow.executors import workloads
 from airflow.executors.local_executor import LocalExecutor
 from airflow.utils.state import State
 
@@ -52,43 +50,43 @@ class TestLocalExecutor:
     def test_serve_logs_default_value(self):
         assert LocalExecutor.serve_logs
 
-    @mock.patch("airflow.executors.local_executor.subprocess.check_call")
-    @mock.patch("airflow.cli.commands.task_command.task_run")
-    def _test_execute(self, mock_run, mock_check_call, parallelism=1):
-        success_command = ["airflow", "tasks", "run", "success", "some_parameter", "2020-10-07"]
-        fail_command = ["airflow", "tasks", "run", "failure", "task_id", "2020-10-07"]
+    @mock.patch("airflow.sdk.execution_time.supervisor.supervise")
+    def _test_execute(self, mock_supervise, parallelism=1):
+        success_tis = [
+            workloads.TaskInstance(
+                id=uuid7(),
+                task_id=f"success_{i}",
+                dag_id="mydag",
+                run_id="run1",
+                try_number=1,
+                state="queued",
+            )
+            for i in range(self.TEST_SUCCESS_COMMANDS)
+        ]
+        fail_ti = success_tis[0].model_copy(update={"id": uuid7(), "task_id": "failure"})
 
         # We just mock both styles here, only one will be hit though
-        def fake_execute_command(command, close_fds=True):
-            if command != success_command:
-                raise subprocess.CalledProcessError(returncode=1, cmd=command)
-            else:
-                return 0
+        def fake_supervise(ti, **kwargs):
+            if ti.id == fail_ti.id:
+                raise RuntimeError("fake failure")
+            return 0
 
-        def fake_task_run(args):
-            if args.dag_id != "success":
-                raise AirflowException("Simulate failed task")
-
-        mock_check_call.side_effect = fake_execute_command
-        mock_run.side_effect = fake_task_run
+        mock_supervise.side_effect = fake_supervise
 
         executor = LocalExecutor(parallelism=parallelism)
         executor.start()
 
-        success_key = "success {}"
         assert executor.result_queue.empty()
 
         with spy_on(executor._spawn_worker) as spawn_worker:
-            run_id = "manual_" + datetime.datetime.now().isoformat()
-            for i in range(self.TEST_SUCCESS_COMMANDS):
-                key_id, command = success_key.format(i), success_command
-                key = key_id, "fake_ti", run_id, 0
-                executor.running.add(key)
-                executor.execute_async(key=key, command=command)
+            for ti in success_tis:
+                executor.queue_workload(
+                    workloads.ExecuteTask(token="", ti=ti, dag_path="some/path", log_path=None)
+                )
 
-            fail_key = "fail", "fake_ti", run_id, 0
-            executor.running.add(fail_key)
-            executor.execute_async(key=fail_key, command=fail_command)
+            executor.queue_workload(
+                workloads.ExecuteTask(token="", ti=fail_ti, dag_path="some/path", log_path=None)
+            )
 
             executor.end()
 
@@ -100,24 +98,19 @@ class TestLocalExecutor:
         assert len(executor.running) == 0
         assert executor._unread_messages.value == 0
 
-        for i in range(self.TEST_SUCCESS_COMMANDS):
-            key_id = success_key.format(i)
-            key = key_id, "fake_ti", run_id, 0
-            assert executor.event_buffer[key][0] == State.SUCCESS
-        assert executor.event_buffer[fail_key][0] == State.FAILED
+        for ti in success_tis:
+            assert executor.event_buffer[ti.key][0] == State.SUCCESS
+        assert executor.event_buffer[fail_ti.key][0] == State.FAILED
 
     @skip_spawn_mp_start
     @pytest.mark.parametrize(
-        ("parallelism", "fork_or_subproc"),
+        ("parallelism",),
         [
-            pytest.param(0, True, id="unlimited_subprocess"),
-            pytest.param(2, True, id="limited_subprocess"),
-            pytest.param(0, False, id="unlimited_fork"),
-            pytest.param(2, False, id="limited_fork"),
+            pytest.param(0, id="unlimited"),
+            pytest.param(2, id="limited"),
         ],
     )
-    def test_execution(self, parallelism: int, fork_or_subproc: bool, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.setattr(settings, "EXECUTE_TASKS_NEW_PYTHON_INTERPRETER", fork_or_subproc)
+    def test_execution(self, parallelism: int):
         self._test_execute(parallelism=parallelism)
 
     @mock.patch("airflow.executors.local_executor.LocalExecutor.sync")

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -181,6 +181,12 @@ class TestSchedulerJob:
         default_executor.name = ExecutorName(alias="default_exec", module_path="default.exec.module.path")
         second_executor = mock.MagicMock(name="SeconadaryExecutor", slots_available=8, slots_occupied=0)
         second_executor.name = ExecutorName(alias="secondary_exec", module_path="secondary.exec.module.path")
+
+        # TODO: Task-SDK Make it look like a bound method. Needed until we remove the old queue_command
+        # interface from executors
+        default_executor.queue_workload.__func__ = BaseExecutor.queue_workload
+        second_executor.queue_workload.__func__ = BaseExecutor.queue_workload
+
         with mock.patch("airflow.jobs.job.Job.executors", new_callable=PropertyMock) as executors_mock:
             executors_mock.return_value = [default_executor, second_executor]
             yield [default_executor, second_executor]


### PR DESCRIPTION
This also lays the groundwork for a more general purpose "workload" execution
system, make a single interface for executors to run tasks and callbacks.

Also in this PR we set up the supervise function to send Task logs to a file,
and handle the task log template rendering in the scheduler before queueing
the workload.

Additionally we don't pass the activity directly to `supervise()` but instead
the properties/fields of it to reduce the coupling between SDK and Executor.
(More separation will appear in PRs over the next few weeks.)

The big change of note here is that rather than sending an airflow command
line to execute (`["airflow", "tasks", "run", ...]`) and going back in via the
CLI parser we go directly to a special purpose function. Much simpler.

It doesn't remove any of the old behaviour (CeleryExecutor still uses
LocalTaskJob via the CLI parser etc.), nor does anything currently send
callback requests via this new workload mechanism.

The `airflow.executors.workloads` module currently needs to be shared between
the Scheduler (or more specifically the Executor) and the "worker" side of
things. In the future these will be separate python dists and this module will
need to live somewhere else.

Right now we check the if `executor.queue_workload` is different from the
BaseExecutor version (which just raises an error right now) to see which
executors support this new version. That check will be removed as soon as all
the in-tree executors have been migrated.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
