### PR TITLE
Edge worker connected state is sent to DB based on worker sate

### DIFF
--- a/providers/src/airflow/providers/edge/CHANGELOG.rst
+++ b/providers/src/airflow/providers/edge/CHANGELOG.rst
@@ -34,7 +34,6 @@ Misc
 
 * ``Edge worker state is sent as 0 to DB if offline or unknown.``
 
----------
 0.7.0pre0
 .........
 

--- a/providers/src/airflow/providers/edge/CHANGELOG.rst
+++ b/providers/src/airflow/providers/edge/CHANGELOG.rst
@@ -26,6 +26,15 @@
 
 Changelog
 ---------
+0.7.1pre0
+.........
+
+Misc
+~~~~
+
+* ``Edge worker state is sent as 0 to DB if offline or unknown.``
+
+---------
 0.7.0pre0
 .........
 

--- a/providers/src/airflow/providers/edge/__init__.py
+++ b/providers/src/airflow/providers/edge/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "0.7.0pre0"
+__version__ = "0.7.1pre0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.10.0"

--- a/providers/src/airflow/providers/edge/models/edge_worker.py
+++ b/providers/src/airflow/providers/edge/models/edge_worker.py
@@ -148,7 +148,6 @@ class EdgeWorker(BaseModel, LoggingMixin):
     def set_metrics(
         worker_name: str,
         state: EdgeWorkerState,
-        connected: bool,
         jobs_active: int,
         concurrency: int,
         free_concurrency: int,
@@ -156,7 +155,7 @@ class EdgeWorker(BaseModel, LoggingMixin):
     ) -> None:
         """Set metric of edge worker."""
         queues = queues if queues else []
-
+        connected = state not in (EdgeWorkerState.UNKNOWN, EdgeWorkerState.OFFLINE)
         Stats.gauge(f"edge_worker.state.{worker_name}", int(connected))
         Stats.gauge(
             "edge_worker.state",
@@ -189,7 +188,6 @@ class EdgeWorker(BaseModel, LoggingMixin):
         EdgeWorker.set_metrics(
             worker_name=worker_name,
             state=EdgeWorkerState.UNKNOWN,
-            connected=False,
             jobs_active=0,
             concurrency=0,
             free_concurrency=-1,
@@ -282,7 +280,6 @@ class EdgeWorker(BaseModel, LoggingMixin):
         EdgeWorker.set_metrics(
             worker_name=worker_name,
             state=state,
-            connected=True,
             jobs_active=jobs_active,
             concurrency=int(sysinfo["concurrency"]),
             free_concurrency=int(sysinfo["free_concurrency"]),

--- a/providers/src/airflow/providers/edge/provider.yaml
+++ b/providers/src/airflow/providers/edge/provider.yaml
@@ -27,7 +27,7 @@ source-date-epoch: 1729683247
 
 # note that those versions are maintained by release manager - do not update them manually
 versions:
-  - 0.7.0pre0
+  - 0.7.1pre0
 
 dependencies:
   - apache-airflow>=2.10.0


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
In the edge worker the set_state() method always sends the worker state by statsd as 1. So in case of graceful shut down, the worker state will remain 1 (connected).

This PR modifies the set_metrics method, so the worker is sent as connected if the worker state is not offline or unknown

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
