### PR TITLE
Swap internal RPC server for API server in the helm chart

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -590,122 +590,80 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- end }}
 {{- end }}
 
-{{/* Create the name of the webserver service account to use */}}
-{{- define "webserver.serviceAccountName" -}}
-  {{- if .Values.webserver.serviceAccount.create }}
-    {{- default (printf "%s-webserver" (include "airflow.serviceAccountName" .)) .Values.webserver.serviceAccount.name }}
+{{/* Helper to generate service account name respecting .Values.$section.serviceAccount flags */}}
+{{- define "_serviceAccountName" -}}
+  {{- $sa := get (get .Values .key) "serviceAccount" }}
+  {{- if $sa.create }}
+    {{- default (printf "%s-%s" (include "airflow.serviceAccountName" .) (default .key .nameSuffix )) $sa.name | quote }}
   {{- else }}
-    {{- default "default" .Values.webserver.serviceAccount.name }}
+    {{- default "default" $sa.name | quote }}
   {{- end }}
 {{- end }}
 
+{{/* Create the name of the webserver service account to use */}}
+{{- define "webserver.serviceAccountName" -}}
+  {{- include "_serviceAccountName" (merge (dict "key" "webserver") .) -}}
+{{- end }}
 
-{{/* Create the name of the RPC server service account to use */}}
-{{- define "rpcServer.serviceAccountName" -}}
-  {{- if .Values._rpcServer.serviceAccount.create }}
-    {{- default (printf "%s-rpc-server" (include "airflow.serviceAccountName" .)) .Values._rpcServer.serviceAccount.name }}
-  {{- else }}
-    {{- default "default" .Values._rpcServer.serviceAccount.name }}
-  {{- end }}
+
+{{/* Create the name of the API server service account to use */}}
+{{- define "apiServer.serviceAccountName" -}}
+  {{- include "_serviceAccountName" (merge (dict "key" "apiServer" "nameSuffix" "api-server" ) .) -}}
 {{- end }}
 
 {{/* Create the name of the redis service account to use */}}
 {{- define "redis.serviceAccountName" -}}
-  {{- if .Values.redis.serviceAccount.create }}
-    {{- default (printf "%s-redis" (include "airflow.serviceAccountName" .)) .Values.redis.serviceAccount.name }}
-  {{- else }}
-    {{- default "default" .Values.redis.serviceAccount.name }}
-  {{- end }}
+  {{- include "_serviceAccountName" (merge (dict "key" "redis") .) -}}
 {{- end }}
 
 {{/* Create the name of the flower service account to use */}}
 {{- define "flower.serviceAccountName" -}}
-  {{- if .Values.flower.serviceAccount.create }}
-    {{- default (printf "%s-flower" (include "airflow.serviceAccountName" .)) .Values.flower.serviceAccount.name }}
-  {{- else }}
-    {{- default "default" .Values.flower.serviceAccount.name }}
-  {{- end }}
+  {{- include "_serviceAccountName" (merge (dict "key" "flower") .) -}}
 {{- end }}
 
 {{/* Create the name of the scheduler service account to use */}}
 {{- define "scheduler.serviceAccountName" -}}
-  {{- if .Values.scheduler.serviceAccount.create }}
-    {{- default (printf "%s-scheduler" (include "airflow.serviceAccountName" .)) .Values.scheduler.serviceAccount.name }}
-  {{- else }}
-    {{- default "default" .Values.scheduler.serviceAccount.name }}
-  {{- end }}
+  {{- include "_serviceAccountName" (merge (dict "key" "scheduler") .) -}}
 {{- end }}
 
 {{/* Create the name of the StatsD service account to use */}}
 {{- define "statsd.serviceAccountName" -}}
-  {{- if .Values.statsd.serviceAccount.create }}
-    {{- default (printf "%s-statsd" (include "airflow.serviceAccountName" .)) .Values.statsd.serviceAccount.name }}
-  {{- else }}
-    {{- default "default" .Values.statsd.serviceAccount.name }}
-  {{- end }}
+  {{- include "_serviceAccountName" (merge (dict "key" "statsd") .) -}}
 {{- end }}
 
 {{/* Create the name of the create user job service account to use */}}
 {{- define "createUserJob.serviceAccountName" -}}
-  {{- if .Values.createUserJob.serviceAccount.create }}
-    {{- default (printf "%s-create-user-job" (include "airflow.serviceAccountName" .)) .Values.createUserJob.serviceAccount.name }}
-  {{- else }}
-    {{- default "default" .Values.createUserJob.serviceAccount.name }}
-  {{- end }}
+  {{- include "_serviceAccountName" (merge (dict "key" "createUserJob" "nameSuffix" "create-user-job") .) -}}
 {{- end }}
 
 {{/* Create the name of the migrate database job service account to use */}}
 {{- define "migrateDatabaseJob.serviceAccountName" -}}
-  {{- if .Values.migrateDatabaseJob.serviceAccount.create }}
-    {{- default (printf "%s-migrate-database-job" (include "airflow.serviceAccountName" .)) .Values.migrateDatabaseJob.serviceAccount.name }}
-  {{- else }}
-    {{- default "default" .Values.migrateDatabaseJob.serviceAccount.name }}
-  {{- end }}
+  {{- include "_serviceAccountName" (merge (dict "key" "migrateDatabaseJob" "nameSuffix" "migrate-database-job") .) -}}
 {{- end }}
 
 {{/* Create the name of the worker service account to use */}}
 {{- define "worker.serviceAccountName" -}}
-  {{- if .Values.workers.serviceAccount.create }}
-    {{- default (printf "%s-worker" (include "airflow.serviceAccountName" .)) .Values.workers.serviceAccount.name }}
-  {{- else }}
-    {{- default "default" .Values.workers.serviceAccount.name }}
-  {{- end }}
+  {{- include "_serviceAccountName" (merge (dict "key" "workers" "nameSuffix" "worker") .) -}}
 {{- end }}
 
 {{/* Create the name of the triggerer service account to use */}}
 {{- define "triggerer.serviceAccountName" -}}
-  {{- if .Values.triggerer.serviceAccount.create }}
-    {{- default (printf "%s-triggerer" (include "airflow.serviceAccountName" .)) .Values.triggerer.serviceAccount.name }}
-  {{- else }}
-    {{- default "default" .Values.triggerer.serviceAccount.name }}
-  {{- end }}
+  {{- include "_serviceAccountName" (merge (dict "key" "triggerer") .) -}}
 {{- end }}
 
 {{/* Create the name of the dag processor service account to use */}}
 {{- define "dagProcessor.serviceAccountName" -}}
-  {{- if .Values.dagProcessor.serviceAccount.create }}
-    {{- default (printf "%s-dag-processor" (include "airflow.serviceAccountName" .)) .Values.dagProcessor.serviceAccount.name }}
-  {{- else }}
-    {{- default "default" .Values.dagProcessor.serviceAccount.name }}
-  {{- end }}
+  {{- include "_serviceAccountName" (merge (dict "key" "dagProcessor" "nameSuffix" "dag-processor") .) -}}
 {{- end }}
 
 {{/* Create the name of the pgbouncer service account to use */}}
 {{- define "pgbouncer.serviceAccountName" -}}
-  {{- if .Values.pgbouncer.serviceAccount.create }}
-    {{- default (printf "%s-pgbouncer" (include "airflow.serviceAccountName" .)) .Values.pgbouncer.serviceAccount.name }}
-  {{- else }}
-    {{- default "default" .Values.pgbouncer.serviceAccount.name }}
-  {{- end }}
+  {{- include "_serviceAccountName" (merge (dict "key" "pgbouncer") .) -}}
 {{- end }}
 
 {{/* Create the name of the cleanup service account to use */}}
 {{- define "cleanup.serviceAccountName" -}}
-  {{- if .Values.cleanup.serviceAccount.create }}
-    {{- default (printf "%s-cleanup" (include "airflow.serviceAccountName" .)) .Values.cleanup.serviceAccount.name }}
-  {{- else }}
-    {{- default "default" .Values.cleanup.serviceAccount.name }}
-  {{- end }}
+  {{- include "_serviceAccountName" (merge (dict "key" "cleanup") .) -}}
 {{- end }}
 
 {{- define "wait-for-migrations-command" -}}

--- a/chart/templates/api-server/api-server-deployment.yaml
+++ b/chart/templates/api-server/api-server-deployment.yaml
@@ -18,44 +18,43 @@
 */}}
 
 ################################
-## Airflow rpc-server Deployment
+## Airflow API Server Deployment
 #################################
-{{- if .Values._rpcServer.enabled }}
-{{- $nodeSelector := or .Values._rpcServer.nodeSelector .Values.nodeSelector }}
-{{- $affinity := or .Values._rpcServer.affinity .Values.affinity }}
-{{- $tolerations := or .Values._rpcServer.tolerations .Values.tolerations }}
-{{- $topologySpreadConstraints := or .Values._rpcServer.topologySpreadConstraints .Values.topologySpreadConstraints }}
-{{- $revisionHistoryLimit := or .Values._rpcServer.revisionHistoryLimit .Values.revisionHistoryLimit }}
-{{- $securityContext := include "airflowPodSecurityContext" (list . .Values._rpcServer) }}
-{{- $containerSecurityContext := include "containerSecurityContext" (list . .Values._rpcServer) }}
-{{- $containerSecurityContextWaitForMigrations := include "containerSecurityContext" (list . .Values._rpcServer.waitForMigrations) }}
-{{- $containerLifecycleHooks := or .Values._rpcServer.containerLifecycleHooks .Values.containerLifecycleHooks }}
+{{- if semverCompare ">=3.0.0" .Values.airflowVersion }}
+{{- $nodeSelector := or .Values.apiServer.nodeSelector .Values.nodeSelector }}
+{{- $affinity := or .Values.apiServer.affinity .Values.affinity }}
+{{- $tolerations := or .Values.apiServer.tolerations .Values.tolerations }}
+{{- $topologySpreadConstraints := or .Values.apiServer.topologySpreadConstraints .Values.topologySpreadConstraints }}
+{{- $revisionHistoryLimit := or .Values.apiServer.revisionHistoryLimit .Values.revisionHistoryLimit }}
+{{- $securityContext := include "airflowPodSecurityContext" (list . .Values.apiServer) }}
+{{- $containerSecurityContext := include "containerSecurityContext" (list . .Values.apiServer) }}
+{{- $containerSecurityContextWaitForMigrations := include "containerSecurityContext" (list . .Values.apiServer.waitForMigrations) }}
+{{- $containerLifecycleHooks := or .Values.apiServer.containerLifecycleHooks .Values.containerLifecycleHooks }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "airflow.fullname" . }}-rpc-server
+  name: {{ include "airflow.fullname" . }}-api-server
   labels:
     tier: airflow
-    component: rpc-server
+    component: api-server
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- if .Values._rpcServer.annotations }}
-  annotations: {{- toYaml .Values._rpcServer.annotations | nindent 4 }}
+  {{- if .Values.apiServer.annotations }}
+  annotations: {{- toYaml .Values.apiServer.annotations | nindent 4 }}
   {{- end }}
 spec:
-  replicas: {{ .Values._rpcServer.replicas }}
+  replicas: {{ .Values.apiServer.replicas }}
   {{- if $revisionHistoryLimit }}
   revisionHistoryLimit: {{ $revisionHistoryLimit }}
   {{- end }}
   strategy:
-    {{- if .Values._rpcServer.strategy }}
-    {{- toYaml .Values._rpcServer.strategy | nindent 4 }}
+    {{- if .Values.apiServer.strategy }}
+    {{- toYaml .Values.apiServer.strategy | nindent 4 }}
     {{- else }}
-    {{- if semverCompare ">=2.0.0" .Values.airflowVersion }}
     # Here we define the rolling update strategy
     # - maxSurge define how many pod we can add at a time
     # - maxUnavailable define how many pod can be unavailable
@@ -67,23 +66,20 @@ spec:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0
-    {{- else }}
-    type: Recreate
-    {{- end }}
     {{- end }}
   selector:
     matchLabels:
       tier: airflow
-      component: rpc-server
+      component: api-server
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
         tier: airflow
-        component: rpc-server
+        component: api-server
         release: {{ .Release.Name }}
-        {{- if or (.Values.labels) (.Values._rpcServer.labels) }}
-          {{- mustMerge .Values._rpcServer.labels .Values.labels | toYaml | nindent 8 }}
+        {{- if or (.Values.labels) (.Values.apiServer.labels) }}
+          {{- mustMerge .Values.apiServer.labels .Values.labels | toYaml | nindent 8 }}
         {{- end }}
       annotations:
         checksum/metadata-secret: {{ include (print $.Template.BasePath "/secrets/metadata-connection-secret.yaml") . | sha256sum }}
@@ -94,16 +90,16 @@ spec:
         {{- if .Values.airflowPodAnnotations }}
           {{- toYaml .Values.airflowPodAnnotations | nindent 8 }}
         {{- end }}
-        {{- if .Values._rpcServer.podAnnotations }}
-          {{- toYaml .Values._rpcServer.podAnnotations | nindent 8 }}
+        {{- if .Values.apiServer.podAnnotations }}
+          {{- toYaml .Values.apiServer.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values._rpcServer.hostAliases }}
-      hostAliases: {{- toYaml .Values._rpcServer.hostAliases | nindent 8 }}
+      {{- if .Values.apiServer.hostAliases }}
+      hostAliases: {{- toYaml .Values.apiServer.hostAliases | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "rpcServer.serviceAccountName" . }}
-      {{- if .Values._rpcServer.priorityClassName }}
-      priorityClassName: {{ .Values._rpcServer.priorityClassName }}
+      serviceAccountName: {{ include "apiServer.serviceAccountName" . }}
+      {{- if .Values.apiServer.priorityClassName }}
+      priorityClassName: {{ .Values.apiServer.priorityClassName }}
       {{- end }}
       {{- if .Values.schedulerName }}
       schedulerName: {{ .Values.schedulerName }}
@@ -118,7 +114,7 @@ spec:
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
-                  component: rpc-server
+                  component: api-server
               topologyKey: kubernetes.io/hostname
             weight: 100
         {{- end }}
@@ -131,9 +127,9 @@ spec:
         - name: {{ template "registry_secret" . }}
       {{- end }}
       initContainers:
-        {{- if .Values._rpcServer.waitForMigrations.enabled }}
+        {{- if .Values.apiServer.waitForMigrations.enabled }}
         - name: wait-for-airflow-migrations
-          resources: {{- toYaml .Values._rpcServer.resources | nindent 12 }}
+          resources: {{- toYaml .Values.apiServer.resources | nindent 12 }}
           image: {{ template "airflow_image_for_migrations" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           securityContext: {{ $containerSecurityContextWaitForMigrations | nindent 12 }}
@@ -142,36 +138,36 @@ spec:
             {{- if .Values.volumeMounts }}
               {{- toYaml .Values.volumeMounts | nindent 12 }}
             {{- end }}
-            {{- if .Values._rpcServer.extraVolumeMounts }}
-              {{- tpl (toYaml .Values._rpcServer.extraVolumeMounts) . | nindent 12 }}
+            {{- if .Values.apiServer.extraVolumeMounts }}
+              {{- tpl (toYaml .Values.apiServer.extraVolumeMounts) . | nindent 12 }}
             {{- end }}
           args: {{- include "wait-for-migrations-command" . | indent 10 }}
           envFrom: {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 10 }}
           env:
             {{- include "custom_airflow_environment" . | indent 10 }}
             {{- include "standard_airflow_environment" . | indent 10 }}
-            {{- if .Values._rpcServer.waitForMigrations.env }}
-              {{- tpl (toYaml .Values._rpcServer.waitForMigrations.env) $ | nindent 12 }}
+            {{- if .Values.apiServer.waitForMigrations.env }}
+              {{- tpl (toYaml .Values.apiServer.waitForMigrations.env) $ | nindent 12 }}
             {{- end }}
         {{- end }}
-        {{- if .Values._rpcServer.extraInitContainers }}
-          {{- toYaml .Values._rpcServer.extraInitContainers | nindent 8 }}
+        {{- if .Values.apiServer.extraInitContainers }}
+          {{- toYaml .Values.apiServer.extraInitContainers | nindent 8 }}
         {{- end }}
       containers:
-        - name: rpc-server
+        - name: api-server
           image: {{ template "airflow_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           securityContext: {{ $containerSecurityContext | nindent 12 }}
           {{- if $containerLifecycleHooks  }}
           lifecycle: {{- tpl (toYaml $containerLifecycleHooks) . | nindent 12 }}
           {{- end }}
-          {{- if .Values._rpcServer.command }}
-          command: {{ tpl (toYaml .Values._rpcServer.command) . | nindent 12 }}
+          {{- if .Values.apiServer.command }}
+          command: {{ tpl (toYaml .Values.apiServer.command) . | nindent 12 }}
           {{- end }}
-          {{- if .Values._rpcServer.args }}
-          args: {{- tpl (toYaml .Values._rpcServer.args) . | nindent 12 }}
+          {{- if .Values.apiServer.args }}
+          args: {{- tpl (toYaml .Values.apiServer.args) . | nindent 12 }}
           {{- end }}
-          resources: {{- toYaml .Values._rpcServer.resources | nindent 12 }}
+          resources: {{- toYaml .Values.apiServer.resources | nindent 12 }}
           volumeMounts:
             {{- include "airflow_config_mount" . | nindent 12 }}
             {{- if .Values.logs.persistence.enabled }}
@@ -181,63 +177,48 @@ spec:
             {{- if .Values.volumeMounts }}
               {{- toYaml .Values.volumeMounts | nindent 12 }}
             {{- end }}
-            {{- if .Values._rpcServer.extraVolumeMounts }}
-              {{- tpl (toYaml .Values._rpcServer.extraVolumeMounts) . | nindent 12 }}
+            {{- if .Values.apiServer.extraVolumeMounts }}
+              {{- tpl (toYaml .Values.apiServer.extraVolumeMounts) . | nindent 12 }}
             {{- end }}
           ports:
-            - name: rpc-server
-              containerPort: {{ .Values.ports._rpcServer }}
+            - name: api-server
+              containerPort: {{ .Values.ports.apiServer }}
           livenessProbe:
             httpGet:
-              path: {{ if .Values.config.core.internal_api_url }}{{- with urlParse (tpl .Values.config.core.internal_api_url .) }}{{ .path }}{{ end }}{{ end }}/internal_api/v1/health
-              port: {{ .Values.ports._rpcServer }}
-              {{- if .Values.config.core.internal_api_url}}
-              httpHeaders:
-                - name: Host
-                  value: {{ regexReplaceAll ":\\d+$" (urlParse (tpl .Values.config.core.internal_api_url .)).host  "" }}
-              {{- end }}
-              scheme: {{ .Values._rpcServer.livenessProbe.scheme | default "http" }}
-            initialDelaySeconds: {{ .Values._rpcServer.livenessProbe.initialDelaySeconds }}
-            timeoutSeconds: {{ .Values._rpcServer.livenessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values._rpcServer.livenessProbe.failureThreshold }}
-            periodSeconds: {{ .Values._rpcServer.livenessProbe.periodSeconds }}
+              path: /public/version
+              port: {{ .Values.ports.apiServer }}
+              scheme: {{ .Values.apiServer.livenessProbe.scheme | default "http" }}
+            initialDelaySeconds: {{ .Values.apiServer.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.apiServer.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.apiServer.livenessProbe.failureThreshold }}
+            periodSeconds: {{ .Values.apiServer.livenessProbe.periodSeconds }}
           readinessProbe:
             httpGet:
-              path: {{ if .Values.config.core.internal_api_url }}{{- with urlParse (tpl .Values.config.core.internal_api_url .) }}{{ .path }}{{ end }}{{ end }}/internal_api/v1/health
-              port: {{ .Values.ports._rpcServer }}
-              {{- if .Values.config.core.internal_api_url }}
-              httpHeaders:
-                - name: Host
-                  value: {{ regexReplaceAll ":\\d+$" (urlParse (tpl .Values.config.core.internal_api_url .)).host  "" }}
-              {{- end }}
-              scheme: {{ .Values._rpcServer.readinessProbe.scheme | default "http" }}
-            initialDelaySeconds: {{ .Values._rpcServer.readinessProbe.initialDelaySeconds }}
-            timeoutSeconds: {{ .Values._rpcServer.readinessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values._rpcServer.readinessProbe.failureThreshold }}
-            periodSeconds: {{ .Values._rpcServer.readinessProbe.periodSeconds }}
+              path: /public/version
+              port: {{ .Values.ports.apiServer }}
+              scheme: {{ .Values.apiServer.readinessProbe.scheme | default "http" }}
+            initialDelaySeconds: {{ .Values.apiServer.readinessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.apiServer.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.apiServer.readinessProbe.failureThreshold }}
+            periodSeconds: {{ .Values.apiServer.readinessProbe.periodSeconds }}
           startupProbe:
             httpGet:
-              path: {{ if .Values.config.core.internal_api_url }}{{- with urlParse (tpl .Values.config.core.internal_api_url .) }}{{ .path }}{{ end }}{{ end }}/internal_api/v1/health
-              port: {{ .Values.ports._rpcServer }}
-              {{- if .Values.config.core.internal_api_url}}
-              httpHeaders:
-                - name: Host
-                  value: {{ regexReplaceAll ":\\d+$" (urlParse (tpl .Values.config.core.internal_api_url .)).host  "" }}
-              {{- end }}
-              scheme: {{ .Values._rpcServer.startupProbe.scheme | default "http" }}
-            timeoutSeconds: {{ .Values._rpcServer.startupProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values._rpcServer.startupProbe.failureThreshold }}
-            periodSeconds: {{ .Values._rpcServer.startupProbe.periodSeconds }}
+              path: /public/version
+              port: {{ .Values.ports.apiServer }}
+              scheme: {{ .Values.apiServer.startupProbe.scheme | default "http" }}
+            timeoutSeconds: {{ .Values.apiServer.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.apiServer.startupProbe.failureThreshold }}
+            periodSeconds: {{ .Values.apiServer.startupProbe.periodSeconds }}
           envFrom: {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 10 }}
           env:
             {{- include "custom_airflow_environment" . | indent 10 }}
             {{- include "standard_airflow_environment" . | indent 10 }}
-            {{- include "container_extra_envs" (list . .Values._rpcServer.env) | indent 10 }}
+            {{- include "container_extra_envs" (list . .Values.apiServer.env) | indent 10 }}
         {{- if and (.Values.dags.gitSync.enabled) (not .Values.dags.persistence.enabled) (semverCompare "<2.0.0" .Values.airflowVersion) }}
           {{- include "git_sync_container" . | nindent 8 }}
         {{- end }}
-        {{- if .Values._rpcServer.extraContainers }}
-          {{- tpl (toYaml .Values._rpcServer.extraContainers) . | nindent 8 }}
+        {{- if .Values.apiServer.extraContainers }}
+          {{- tpl (toYaml .Values.apiServer.extraContainers) . | nindent 8 }}
         {{- end }}
       volumes:
         - name: config
@@ -253,7 +234,7 @@ spec:
         {{- if .Values.volumes }}
           {{- toYaml .Values.volumes | nindent 8 }}
         {{- end }}
-        {{- if .Values._rpcServer.extraVolumes }}
-          {{- tpl (toYaml .Values._rpcServer.extraVolumes) . | nindent 8 }}
+        {{- if .Values.apiServer.extraVolumes }}
+          {{- tpl (toYaml .Values.apiServer.extraVolumes) . | nindent 8 }}
         {{- end }}
 {{- end }}

--- a/chart/templates/api-server/api-server-networkpolicy.yaml
+++ b/chart/templates/api-server/api-server-networkpolicy.yaml
@@ -18,42 +18,41 @@
 */}}
 
 ################################
-## Airflow rpc-server Service
+## Airflow API server NetworkPolicy
 #################################
-{{- if .Values._rpcServer.enabled }}
-apiVersion: v1
-kind: Service
+{{- if semverCompare ">=3.0.0" .Values.airflowVersion }}
+{{- if .Values.networkPolicies.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
 metadata:
-  name: {{ include "airflow.fullname" . }}-rpc-server
+  name: {{ include "airflow.fullname" . }}-api-server-policy
   labels:
     tier: airflow
-    component: rpc-server
+    component: airflow-api-server-policy
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    {{- if or (.Values.labels) (.Values._rpcServer.labels) }}
-      {{- mustMerge .Values._rpcServer.labels .Values.labels | toYaml | nindent 4 }}
+    {{- if or (.Values.labels) (.Values.apiServer.labels) }}
+      {{- mustMerge .Values.apiServer.labels .Values.labels | toYaml | nindent 4 }}
     {{- end }}
-  {{- with .Values._rpcServer.service.annotations }}
-  annotations: {{- toYaml . | nindent 4 }}
-  {{- end }}
 spec:
-  type: {{ .Values._rpcServer.service.type }}
-  selector:
-    tier: airflow
-    component: rpc-server
-    release: {{ .Release.Name }}
-  ports:
-  {{ range .Values._rpcServer.service.ports }}
-    -
-      {{- range $key, $val := . }}
-      {{ $key }}: {{ tpl (toString $val) $ }}
+  podSelector:
+    matchLabels:
+      tier: airflow
+      component: api-server
+      release: {{ .Release.Name }}
+  policyTypes:
+    - Ingress
+  {{- if .Values.apiServer.networkPolicy.ingress.from }}
+  ingress:
+    - from: {{- toYaml .Values.apiServer.networkPolicy.ingress.from | nindent 6 }}
+      ports:
+      {{ range .Values.apiServer.networkPolicy.ingress.ports }}
+        -
+          {{- range $key, $val := . }}
+          {{ $key }}: {{ tpl (toString $val) $ }}
+          {{- end }}
       {{- end }}
   {{- end }}
-  {{- if .Values._rpcServer.service.loadBalancerIP }}
-  loadBalancerIP: {{ .Values._rpcServer.service.loadBalancerIP }}
-  {{- end }}
-  {{- if .Values._rpcServer.service.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges: {{- toYaml .Values._rpcServer.service.loadBalancerSourceRanges | nindent 4 }}
-  {{- end }}
+{{- end }}
 {{- end }}

--- a/chart/templates/api-server/api-server-poddisruptionbudget.yaml
+++ b/chart/templates/api-server/api-server-poddisruptionbudget.yaml
@@ -18,29 +18,29 @@
 */}}
 
 ################################
-## Airflow rpc-server PodDisruptionBudget
+## Airflow api-server PodDisruptionBudget
 #################################
-{{- if .Values._rpcServer.enabled }}
-{{- if .Values._rpcServer.podDisruptionBudget.enabled }}
+{{- if semverCompare ">=3.0.0" .Values.airflowVersion }}
+{{- if .Values.apiServer.podDisruptionBudget.enabled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "airflow.fullname" . }}-rpc-server-pdb
+  name: {{ include "airflow.fullname" . }}-api-server-pdb
   labels:
     tier: airflow
-    component: rpc-server
+    component: api-server
     release: {{ .Release.Name }}
     chart: {{ .Chart.Name }}
     heritage: {{ .Release.Service }}
-    {{- if or (.Values.labels) (.Values._rpcServer.labels) }}
-      {{- mustMerge .Values._rpcServer.labels .Values.labels | toYaml | nindent 4 }}
+    {{- if or (.Values.labels) (.Values.apiServer.labels) }}
+      {{- mustMerge .Values.apiServer.labels .Values.labels | toYaml | nindent 4 }}
     {{- end }}
 spec:
   selector:
     matchLabels:
       tier: airflow
-      component: rpc-server
+      component: api-server
       release: {{ .Release.Name }}
-  {{- toYaml .Values._rpcServer.podDisruptionBudget.config | nindent 2 }}
+  {{- toYaml .Values.apiServer.podDisruptionBudget.config | nindent 2 }}
 {{- end }}
 {{- end }}

--- a/chart/templates/api-server/api-server-service.yaml
+++ b/chart/templates/api-server/api-server-service.yaml
@@ -18,41 +18,42 @@
 */}}
 
 ################################
-## Airflow rpc-server NetworkPolicy
+## Airflow api-server Service
 #################################
-{{- if .Values._rpcServer.enabled }}
-{{- if .Values.networkPolicies.enabled }}
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
+{{- if semverCompare ">=3.0.0" .Values.airflowVersion }}
+apiVersion: v1
+kind: Service
 metadata:
-  name: {{ include "airflow.fullname" . }}-rpc-server-policy
+  name: {{ include "airflow.fullname" . }}-api-server
   labels:
     tier: airflow
-    component: airflow-rpc-server-policy
+    component: api-server
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    {{- if or (.Values.labels) (.Values._rpcServer.labels) }}
-      {{- mustMerge .Values._rpcServer.labels .Values.labels | toYaml | nindent 4 }}
+    {{- if or (.Values.labels) (.Values.apiServer.labels) }}
+      {{- mustMerge .Values.apiServer.labels .Values.labels | toYaml | nindent 4 }}
     {{- end }}
+  {{- with .Values.apiServer.service.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  podSelector:
-    matchLabels:
-      tier: airflow
-      component: rpc-server
-      release: {{ .Release.Name }}
-  policyTypes:
-    - Ingress
-  {{- if .Values._rpcServer.networkPolicy.ingress.from }}
-  ingress:
-    - from: {{- toYaml .Values._rpcServer.networkPolicy.ingress.from | nindent 6 }}
-      ports:
-      {{ range .Values._rpcServer.networkPolicy.ingress.ports }}
-        -
-          {{- range $key, $val := . }}
-          {{ $key }}: {{ tpl (toString $val) $ }}
-          {{- end }}
+  type: {{ .Values.apiServer.service.type }}
+  selector:
+    tier: airflow
+    component: api-server
+    release: {{ .Release.Name }}
+  ports:
+  {{ range .Values.apiServer.service.ports }}
+    -
+      {{- range $key, $val := . }}
+      {{ $key }}: {{ tpl (toString $val) $ }}
       {{- end }}
   {{- end }}
-{{- end }}
+  {{- if .Values.apiServer.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.apiServer.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.apiServer.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- toYaml .Values.apiServer.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/chart/templates/api-server/api-server-serviceaccount.yaml
+++ b/chart/templates/api-server/api-server-serviceaccount.yaml
@@ -18,24 +18,24 @@
 */}}
 
 ######################################
-## Airflow rpc-server ServiceAccount
+## Airflow api-server ServiceAccount
 ######################################
-{{- if and .Values._rpcServer.enabled .Values._rpcServer.serviceAccount.create }}
+{{- if and .Values.apiServer.serviceAccount.create (semverCompare ">=3.0.0" .Values.airflowVersion) }}
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: {{ .Values._rpcServer.serviceAccount.automountServiceAccountToken }}
+automountServiceAccountToken: {{ .Values.apiServer.serviceAccount.automountServiceAccountToken }}
 metadata:
-  name: {{ include "rpcServer.serviceAccountName" . }}
+  name: {{ include "apiServer.serviceAccountName" . }}
   labels:
     tier: airflow
-    component: rpc-server
+    component: api-server
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    {{- if or (.Values.labels) (.Values._rpcServer.labels) }}
-      {{- mustMerge .Values._rpcServer.labels .Values.labels | toYaml | nindent 4 }}
+    {{- if or (.Values.labels) (.Values.apiServer.labels) }}
+      {{- mustMerge .Values.apiServer.labels .Values.labels | toYaml | nindent 4 }}
     {{- end }}
-  {{- with .Values._rpcServer.serviceAccount.annotations }}
+  {{- with .Values.apiServer.serviceAccount.annotations }}
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/chart/templates/configmaps/configmap.yaml
+++ b/chart/templates/configmaps/configmap.yaml
@@ -38,6 +38,13 @@ metadata:
   {{- end }}
 {{- $Global := . }}
 data:
+  {{/*- Set a default for workers.execution_api_server_url pointing to the api-server service if it's not set -*/}}
+  {{- if semverCompare ">=3.0.0" .Values.airflowVersion -}}
+    {{- $config := merge .Values.config ( dict  "workers" dict )}}
+    {{- if not (hasKey $config.workers "execution_api_server_url") -}}
+      {{- $_ := set $config.workers "execution_api_server_url" (printf "http://%s-api-server:%d/execution/" (include "airflow.fullname" .) (int .Values.ports.apiServer))  -}}
+    {{- end -}}
+  {{- end -}}
   # These are system-specified config overrides.
   airflow.cfg: |-
     {{- range $section, $settings := .Values.config }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -9,7 +9,7 @@
         "Ports",
         "Database",
         "PgBouncer",
-        "RPC Server",
+        "API Server",
         "Scheduler",
         "Webserver",
         "Workers",
@@ -4668,19 +4668,14 @@
                 }
             }
         },
-        "_rpcServer": {
-            "description": "Airflow RPC server settings (AIP-44). Experimental / for dev purpose only.",
+        "apiServer": {
+            "description": "Airflow API server settings.",
             "type": "object",
-            "x-docsSection": "RPC Server",
+            "x-docsSection": "API Server",
             "additionalProperties": false,
             "properties": {
-                "enabled": {
-                    "description": "Enable RPC server",
-                    "type": "boolean",
-                    "default": false
-                },
                 "configMapAnnotations": {
-                    "description": "Extra annotations to apply to the RPC server configmap.",
+                    "description": "Extra annotations to apply to the API server configmap.",
                     "type": "object",
                     "default": {},
                     "additionalProperties": {
@@ -4688,7 +4683,7 @@
                     }
                 },
                 "hostAliases": {
-                    "description": "HostAliases for the RPC server pod.",
+                    "description": "HostAliases for the API server pod.",
                     "items": {
                         "$ref": "#/definitions/io.k8s.api.core.v1.HostAlias"
                     },
@@ -4710,7 +4705,7 @@
                     ]
                 },
                 "allowPodLogReading": {
-                    "description": "Allow RPC server to read k8s pod logs. Useful when you don't have an external log store.",
+                    "description": "Allow API server to read k8s pod logs. Useful when you don't have an external log store.",
                     "type": "boolean",
                     "default": true
                 },
@@ -4720,27 +4715,27 @@
                     "additionalProperties": false,
                     "properties": {
                         "initialDelaySeconds": {
-                            "description": "RPC server Liveness probe initial delay.",
+                            "description": "API server Liveness probe initial delay.",
                             "type": "integer",
                             "default": 15
                         },
                         "timeoutSeconds": {
-                            "description": "RPC server Liveness probe timeout seconds.",
+                            "description": "API server Liveness probe timeout seconds.",
                             "type": "integer",
                             "default": 5
                         },
                         "failureThreshold": {
-                            "description": "RPC server Liveness probe failure threshold.",
+                            "description": "API server Liveness probe failure threshold.",
                             "type": "integer",
                             "default": 5
                         },
                         "periodSeconds": {
-                            "description": "RPC server Liveness probe period seconds.",
+                            "description": "API server Liveness probe period seconds.",
                             "type": "integer",
                             "default": 10
                         },
                         "scheme": {
-                            "description": "RPC server Liveness probe scheme.",
+                            "description": "API server Liveness probe scheme.",
                             "type": "string",
                             "default": "HTTP"
                         }
@@ -4752,27 +4747,27 @@
                     "additionalProperties": false,
                     "properties": {
                         "initialDelaySeconds": {
-                            "description": "RPC server Readiness probe initial delay.",
+                            "description": "API server Readiness probe initial delay.",
                             "type": "integer",
                             "default": 15
                         },
                         "timeoutSeconds": {
-                            "description": "RPC server Readiness probe timeout seconds.",
+                            "description": "API server Readiness probe timeout seconds.",
                             "type": "integer",
                             "default": 5
                         },
                         "failureThreshold": {
-                            "description": "RPC server Readiness probe failure threshold.",
+                            "description": "API server Readiness probe failure threshold.",
                             "type": "integer",
                             "default": 5
                         },
                         "periodSeconds": {
-                            "description": "RPC server Readiness probe period seconds.",
+                            "description": "API server Readiness probe period seconds.",
                             "type": "integer",
                             "default": 10
                         },
                         "scheme": {
-                            "description": "RPC server Readiness probe scheme.",
+                            "description": "API server Readiness probe scheme.",
                             "type": "string",
                             "default": "HTTP"
                         }
@@ -4784,29 +4779,29 @@
                     "additionalProperties": false,
                     "properties": {
                         "timeoutSeconds": {
-                            "description": "RPC server Startup probe timeout seconds.",
+                            "description": "API server Startup probe timeout seconds.",
                             "type": "integer",
                             "default": 20
                         },
                         "failureThreshold": {
-                            "description": "RPC server Startup probe failure threshold.",
+                            "description": "API server Startup probe failure threshold.",
                             "type": "integer",
                             "default": 6
                         },
                         "periodSeconds": {
-                            "description": "RPC server Startup probe period seconds.",
+                            "description": "API server Startup probe period seconds.",
                             "type": "integer",
                             "default": 10
                         },
                         "scheme": {
-                            "description": "RPC server Startup probe scheme.",
+                            "description": "API server Startup probe scheme.",
                             "type": "string",
                             "default": "HTTP"
                         }
                     }
                 },
                 "replicas": {
-                    "description": "How many Airflow RPC server replicas should run.",
+                    "description": "How many Airflow API server replicas should run.",
                     "type": "integer",
                     "default": 1
                 },
@@ -4820,7 +4815,7 @@
                     "x-docsSection": null
                 },
                 "command": {
-                    "description": "Command to use when running the Airflow RPC server (templated).",
+                    "description": "Command to use when running the Airflow API server (templated).",
                     "type": [
                         "array",
                         "null"
@@ -4828,12 +4823,10 @@
                     "items": {
                         "type": "string"
                     },
-                    "default": [
-                        "bash"
-                    ]
+                    "default": null
                 },
                 "args": {
-                    "description": "Args to use when running the Airflow RPC server (templated).",
+                    "description": "Args to use when running the Airflow API server (templated).",
                     "type": [
                         "array",
                         "null"
@@ -4842,8 +4835,9 @@
                         "type": "string"
                     },
                     "default": [
+                        "bash",
                         "-c",
-                        "exec airflow internal-api"
+                        "exec airflow fastapi-api"
                     ]
                 },
                 "strategy": {
@@ -4877,7 +4871,7 @@
                             "default": null
                         },
                         "annotations": {
-                            "description": "Annotations to add to the RPC server Kubernetes ServiceAccount.",
+                            "description": "Annotations to add to the API server Kubernetes ServiceAccount.",
                             "type": "object",
                             "default": {},
                             "additionalProperties": {
@@ -4887,7 +4881,7 @@
                     }
                 },
                 "podDisruptionBudget": {
-                    "description": "RPC server pod disruption budget.",
+                    "description": "API server pod disruption budget.",
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
@@ -4902,7 +4896,7 @@
                             "additionalProperties": false,
                             "properties": {
                                 "maxUnavailable": {
-                                    "description": "Max unavailable pods for RPC server.",
+                                    "description": "Max unavailable pods for API server.",
                                     "type": [
                                         "integer",
                                         "string"
@@ -4910,7 +4904,7 @@
                                     "default": 1
                                 },
                                 "minAvailable": {
-                                    "description": "Min available pods for RPC server.",
+                                    "description": "Min available pods for API server.",
                                     "type": [
                                         "integer",
                                         "string"
@@ -4921,27 +4915,18 @@
                         }
                     }
                 },
-                "extraNetworkPolicies": {
-                    "description": "Additional NetworkPolicies as needed (Deprecated - renamed to `RPC server.networkPolicy.ingress.from`).",
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicyPeer"
-                    },
-                    "default": []
-                },
                 "networkPolicy": {
-                    "description": "RPC server NetworkPolicy configuration",
+                    "description": "API server NetworkPolicy configuration",
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
                         "ingress": {
-                            "description": "RPC server NetworkPolicyingress configuration",
+                            "description": "API server NetworkPolicyingress configuration",
                             "type": "object",
                             "additionalProperties": false,
                             "properties": {
                                 "from": {
-                                    "description": "Peers for RPC server NetworkPolicyingress.",
+                                    "description": "Peers for API server NetworkPolicyingress.",
                                     "type": "array",
                                     "default": [],
                                     "items": {
@@ -4949,19 +4934,19 @@
                                     }
                                 },
                                 "ports": {
-                                    "description": "Ports for RPC server NetworkPolicyingress (if `from` is set).",
+                                    "description": "Ports for API server NetworkPolicyingress (if `from` is set).",
                                     "type": "array",
                                     "items": {
                                         "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicyPort"
                                     },
                                     "default": [
                                         {
-                                            "port": "{{ .Values.ports._rpcServer }}"
+                                            "port": "{{ .Values.ports.apiServer }}"
                                         }
                                     ],
                                     "examples": [
                                         {
-                                            "port": 9080
+                                            "port": 9091
                                         }
                                     ]
                                 }
@@ -4970,7 +4955,7 @@
                     }
                 },
                 "containerLifecycleHooks": {
-                    "description": "Container Lifecycle Hooks definition for the RPC server. If not set, the values from global `containerLifecycleHooks` will be used.",
+                    "description": "Container Lifecycle Hooks definition for the API server. If not set, the values from global `containerLifecycleHooks` will be used.",
                     "type": "object",
                     "$ref": "#/definitions/io.k8s.api.core.v1.Lifecycle",
                     "default": {},
@@ -4999,12 +4984,12 @@
                     ]
                 },
                 "securityContexts": {
-                    "description": "Security context definition for the RPC server. If not set, the values from global `securityContexts` will be used.",
+                    "description": "Security context definition for the API server. If not set, the values from global `securityContexts` will be used.",
                     "type": "object",
                     "x-docsSection": "Kubernetes",
                     "properties": {
                         "pod": {
-                            "description": "Pod security context definition for the RPC server.",
+                            "description": "Pod security context definition for the API server.",
                             "type": "object",
                             "$ref": "#/definitions/io.k8s.api.core.v1.PodSecurityContext",
                             "default": {},
@@ -5018,7 +5003,7 @@
                             ]
                         },
                         "container": {
-                            "description": "Container security context definition for the RPC server.",
+                            "description": "Container security context definition for the API server.",
                             "type": "object",
                             "$ref": "#/definitions/io.k8s.api.core.v1.SecurityContext",
                             "default": {},
@@ -5037,7 +5022,7 @@
                     }
                 },
                 "resources": {
-                    "description": "Resources for RPC server pods.",
+                    "description": "Resources for API server pods.",
                     "type": "object",
                     "default": {},
                     "examples": [
@@ -5098,7 +5083,7 @@
                     }
                 },
                 "extraContainers": {
-                    "description": "Launch additional containers into RPC server.",
+                    "description": "Launch additional containers into API server.",
                     "type": "array",
                     "default": [],
                     "items": {
@@ -5106,7 +5091,7 @@
                     }
                 },
                 "extraInitContainers": {
-                    "description": "Add additional init containers into RPC server.",
+                    "description": "Add additional init containers into API server.",
                     "type": "array",
                     "default": [],
                     "items": {
@@ -5114,7 +5099,7 @@
                     }
                 },
                 "extraVolumes": {
-                    "description": "Mount additional volumes into RPC server.",
+                    "description": "Mount additional volumes into API server.",
                     "type": "array",
                     "default": [],
                     "items": {
@@ -5122,49 +5107,25 @@
                     }
                 },
                 "extraVolumeMounts": {
-                    "description": "Mount additional volumes into RPC server.",
+                    "description": "Mount additional volumes into API server.",
                     "type": "array",
                     "default": [],
                     "items": {
                         "$ref": "#/definitions/io.k8s.api.core.v1.VolumeMount"
                     }
                 },
-                "RPC serverConfig": {
-                    "description": "This string (can be templated) will be mounted into the Airflow RPC server as a custom `RPC server_config.py`. You can bake a `RPC server_config.py` in to your image instead or specify a configmap containing the RPC server_config.py.",
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "x-docsSection": "Common",
-                    "default": null,
-                    "examples": [
-                        "from airflow import configuration as conf\n\n# The SQLAlchemy connection string.\nSQLALCHEMY_DATABASE_URI = conf.get('database', 'SQL_ALCHEMY_CONN')\n\n# Flask-WTF flag for CSRF\nCSRF_ENABLED = True"
-                    ]
-                },
-                "RPC serverConfigConfigMapName": {
-                    "description": "The configmap name containing the RPC server_config.py.",
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "x-docsSection": "Common",
-                    "default": null,
-                    "examples": [
-                        "my-RPC server-configmap"
-                    ]
-                },
                 "service": {
-                    "description": "RPC server Service configuration.",
+                    "description": "API server Service configuration.",
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
                         "type": {
-                            "description": "RPC server Service type.",
+                            "description": "API server Service type.",
                             "type": "string",
                             "default": "ClusterIP"
                         },
                         "annotations": {
-                            "description": "Annotations for the RPC server Service.",
+                            "description": "Annotations for the API server Service.",
                             "type": "object",
                             "default": {},
                             "additionalProperties": {
@@ -5172,7 +5133,7 @@
                             }
                         },
                         "ports": {
-                            "description": "Ports for the RPC server Service.",
+                            "description": "Ports for the API server Service.",
                             "type": "array",
                             "items": {
                                 "type": "object",
@@ -5206,15 +5167,15 @@
                             },
                             "default": [
                                 {
-                                    "name": "rpc-server",
-                                    "port": "{{ .Values.ports._rpcServer }}"
+                                    "name": "api-server",
+                                    "port": "{{ .Values.ports.apiServer }}"
                                 }
                             ],
                             "examples": [
                                 {
-                                    "name": "rpc-server",
-                                    "port": 9080,
-                                    "targetPort": "rpc-server"
+                                    "name": "api-server",
+                                    "port": 9091,
+                                    "targetPort": "api-server"
                                 },
                                 {
                                     "name": "only_sidecar",
@@ -5224,7 +5185,7 @@
                             ]
                         },
                         "loadBalancerIP": {
-                            "description": "RPC server Service loadBalancerIP.",
+                            "description": "API server Service loadBalancerIP.",
                             "type": [
                                 "string",
                                 "null"
@@ -5232,7 +5193,7 @@
                             "default": null
                         },
                         "loadBalancerSourceRanges": {
-                            "description": "RPC server Service ``loadBalancerSourceRanges``.",
+                            "description": "API server Service ``loadBalancerSourceRanges``.",
                             "type": "array",
                             "items": {
                                 "type": "string"
@@ -5245,7 +5206,7 @@
                     }
                 },
                 "nodeSelector": {
-                    "description": "Select certain nodes for RPC server pods.",
+                    "description": "Select certain nodes for API server pods.",
                     "type": "object",
                     "default": {},
                     "additionalProperties": {
@@ -5253,7 +5214,7 @@
                     }
                 },
                 "priorityClassName": {
-                    "description": "Specify priority for RPC server pods.",
+                    "description": "Specify priority for API server pods.",
                     "type": [
                         "string",
                         "null"
@@ -5261,13 +5222,13 @@
                     "default": null
                 },
                 "affinity": {
-                    "description": "Specify scheduling constraints for RPC server pods.",
+                    "description": "Specify scheduling constraints for API server pods.",
                     "type": "object",
                     "default": "See values.yaml",
                     "$ref": "#/definitions/io.k8s.api.core.v1.Affinity"
                 },
                 "tolerations": {
-                    "description": "Specify Tolerations for RPC server pods.",
+                    "description": "Specify Tolerations for API server pods.",
                     "type": "array",
                     "default": [],
                     "items": {
@@ -5276,7 +5237,7 @@
                     }
                 },
                 "topologySpreadConstraints": {
-                    "description": "Specify topology spread constraints for RPC server pods.",
+                    "description": "Specify topology spread constraints for API server pods.",
                     "type": "array",
                     "default": [],
                     "x-docsSection": "Kubernetes",
@@ -5286,7 +5247,7 @@
                     }
                 },
                 "annotations": {
-                    "description": "Annotations to add to the RPC server deployment",
+                    "description": "Annotations to add to the API server deployment",
                     "type": "object",
                     "default": {},
                     "additionalProperties": {
@@ -5294,7 +5255,7 @@
                     }
                 },
                 "podAnnotations": {
-                    "description": "Annotations to add to the RPC server pods.",
+                    "description": "Annotations to add to the API server pods.",
                     "type": "object",
                     "default": {},
                     "additionalProperties": {
@@ -5302,7 +5263,7 @@
                     }
                 },
                 "labels": {
-                    "description": "Labels to add to the RPC server objects and pods.",
+                    "description": "Labels to add to the API server objects and pods.",
                     "type": "object",
                     "default": {},
                     "additionalProperties": {
@@ -5367,7 +5328,7 @@
                     }
                 },
                 "env": {
-                    "description": "Add additional env vars to RPC server.",
+                    "description": "Add additional env vars to API server.",
                     "type": "array",
                     "default": [],
                     "items": {
@@ -8099,10 +8060,10 @@
                     "type": "integer",
                     "default": 8080
                 },
-                "_rpcServer": {
-                    "description": "RPC server port (AIP-44). Experimental / dev purpose only.",
+                "apiServer": {
+                    "description": "API server port.",
                     "type": "integer",
-                    "default": 9080
+                    "default": 9091
                 },
                 "workerLogs": {
                     "description": "Worker logs port.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1243,18 +1243,15 @@ migrateDatabaseJob:
   applyCustomEnv: true
   env: []
 
-# rpcServer support is experimental / dev purpose only and will later be renamed
-_rpcServer:
-  enabled: false
+apiServer:
 
   # Labels specific to workers objects and pods
   labels: {}
 
-  # Command to use when running the Airflow rpc server (templated).
-  command:
-    - "bash"
-  # Args to use when running the Airflow rpc server (templated).
-  args: ["-c", "exec airflow internal-api"]
+  # Command to use when running the Airflow API server (templated).
+  command: ~
+  # Args to use when running the Airflow API server (templated).
+  args: ["bash", "-c", "exec airflow fastapi-api"]
   env: []
   serviceAccount:
     # default value is true
@@ -1273,8 +1270,8 @@ _rpcServer:
     ## service annotations
     annotations: {}
     ports:
-      - name: rpc-server
-        port: "{{ .Values.ports._rpcServer }}"
+      - name: api-server
+        port: "{{ .Values.ports.apiServer }}"
 
     loadBalancerIP: ~
     ## Limit load balancer source ips to list of CIDRs
@@ -1307,15 +1304,13 @@ _rpcServer:
   # Launch additional containers into the flower pods.
   extraContainers: []
 
-  # Additional network policies as needed (Deprecated - renamed to `webserver.networkPolicy.ingress.from`)
-  extraNetworkPolicies: []
   networkPolicy:
     ingress:
       # Peers for webserver NetworkPolicy ingress
       from: []
       # Ports for webserver NetworkPolicy ingress (if `from` is set)
       ports:
-        - port: "{{ .Values.ports._rpcServer }}"
+        - port: "{{ .Values.ports.apiServer }}"
 
   resources: {}
   #   limits:
@@ -1339,8 +1334,6 @@ _rpcServer:
     periodSeconds: 10
     scheme: HTTP
 
-  # Wait for at most 1 minute (6*10s) for the RPC server container to startup.
-  # livenessProbe kicks in after the first successful startupProbe
   startupProbe:
     timeoutSeconds: 20
     failureThreshold: 6
@@ -2491,8 +2484,7 @@ ports:
   statsdScrape: 9102
   pgbouncer: 6543
   pgbouncerScrape: 9127
-  # rpcServer support is experimental / dev purpose only and will later be renamed
-  _rpcServer: 9080
+  apiServer: 9091
 
 # Define any ResourceQuotas for namespace
 quotas: {}

--- a/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
@@ -998,7 +998,6 @@ def _deploy_helm_chart(
         get_console(output=output).print(f"[info]Copied chart sources to {tmp_chart_path}")
         kubectl_context = get_kubectl_cluster_name(python=python, kubernetes_version=kubernetes_version)
         params = BuildProdParams(python=python)
-        airflow_kubernetes_image_name = params.airflow_image_kubernetes
         helm_command = [
             "helm",
             "upgrade" if upgrade else "install",
@@ -1011,13 +1010,13 @@ def _deploy_helm_chart(
             "--namespace",
             HELM_AIRFLOW_NAMESPACE,
             "--set",
-            f"defaultAirflowRepository={airflow_kubernetes_image_name}",
+            f"defaultAirflowRepository={params.airflow_image_kubernetes}",
             "--set",
             "defaultAirflowTag=latest",
             "-v",
             "1",
             "--set",
-            f"images.airflow.repository={airflow_kubernetes_image_name}",
+            f"images.airflow.repository={params.airflow_image_kubernetes}",
             "--set",
             "images.airflow.tag=latest",
             "-v",
@@ -1028,6 +1027,8 @@ def _deploy_helm_chart(
             "config.logging.logging_level=DEBUG",
             "--set",
             f"executor={executor}",
+            "--set",
+            f"airflowVersion={params.airflow_semver_version}",
         ]
         if multi_namespace_mode:
             helm_command.extend(["--set", "multiNamespaceMode=true"])

--- a/dev/breeze/src/airflow_breeze/params/build_prod_params.py
+++ b/dev/breeze/src/airflow_breeze/params/build_prod_params.py
@@ -64,6 +64,18 @@ class BuildProdParams(CommonBuildParams):
             return self._get_version_with_suffix()
 
     @property
+    def airflow_semver_version(self) -> str:
+        """The airflow version in SemVer compatible form"""
+        from packaging.version import Version
+
+        pyVer = Version(self.airflow_version)
+
+        ver = pyVer.base_version
+        # if (dev := pyVer.dev) is not None:
+        #     ver += f"-dev.{dev}"
+        return ver
+
+    @property
     def image_type(self) -> str:
         return "PROD"
 

--- a/kubernetes_tests/test_base.py
+++ b/kubernetes_tests/test_base.py
@@ -183,6 +183,10 @@ class BaseK8STest:
 
                 if state == expected_final_state:
                     break
+                if state in {"failed", "upstream_failed", "removed"}:
+                    # If the TI is in failed state (and that's not the state we want) there's no point
+                    # continuing to poll, it won't change
+                    break
                 self._describe_resources(namespace="airflow")
                 self._describe_resources(namespace="default")
                 tries += 1
@@ -214,6 +218,9 @@ class BaseK8STest:
             print(f"Attempt {tries}: Current state of dag is {state}")
 
             if state == expected_final_state:
+                break
+            if state == "failed":
+                # If the DR is in failed state there's no point continuing to poll!
                 break
             self._describe_resources("airflow")
             self._describe_resources("default")

--- a/kubernetes_tests/test_other_executors.py
+++ b/kubernetes_tests/test_other_executors.py
@@ -54,6 +54,10 @@ class TestCeleryAndLocalExecutor(BaseK8STest):
             timeout=300,
         )
 
+    @pytest.mark.xfail(
+        EXECUTOR == "LocalExecutor",
+        reason="https://github.com/apache/airflow/issues/44481 needs to be implemented",
+    )
     def test_integration_run_dag_with_scheduler_failure(self):
         dag_id = "example_xcom"
 


### PR DESCRIPTION
Previously the PRC server was possible to disable/enable, where as now the new
api-server is a required component in Airflow 3.0+

This also does a little bit of drive-by refactoring of the helper templates
for service account name generation

I'm not 100% sure what "default" version is the tests, so maybe me adding a parameterization for "3.0.0" is not right. I also don't know what version we set it the kube/helm tests we run against main etc. 

Part of https://github.com/apache/airflow/issues/44436 (and needed to fix main after #44427 was merged)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
