### PR TITLE
refactor(trigger_rule): remove deprecated NONE_FAILED_OR_SKIPPED

### DIFF
--- a/airflow/utils/trigger_rule.py
+++ b/airflow/utils/trigger_rule.py
@@ -31,7 +31,6 @@ class TriggerRule(str, Enum):
     ONE_FAILED = "one_failed"
     ONE_DONE = "one_done"
     NONE_FAILED = "none_failed"
-    NONE_FAILED_OR_SKIPPED = "none_failed_or_skipped"
     NONE_SKIPPED = "none_skipped"
     ALWAYS = "always"
     NONE_FAILED_MIN_ONE_SUCCESS = "none_failed_min_one_success"

--- a/newsfragments/44475.significant.rst
+++ b/newsfragments/44475.significant.rst
@@ -1,0 +1,21 @@
+Remove ``TriggerRule.NONE_FAILED_OR_SKIPPED``
+
+.. Provide additional contextual information
+
+.. Check the type of change that applies to this change
+
+* Types of change
+
+  * [x] DAG changes
+  * [ ] Config changes
+  * [ ] API changes
+  * [ ] CLI changes
+  * [ ] Behaviour changes
+  * [ ] Plugin changes
+  * [ ] Dependency change
+
+.. List the migration rules needed for this change (see https://github.com/apache/airflow/issues/41641)
+
+* Migrations rules needed
+
+  * Remove attribute ``TriggerRule.NONE_FAILED_OR_SKIPPED``

--- a/tests/utils/test_trigger_rule.py
+++ b/tests/utils/test_trigger_rule.py
@@ -36,7 +36,7 @@ class TestTriggerRule:
         assert TriggerRule.is_valid(TriggerRule.ALWAYS)
         assert TriggerRule.is_valid(TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS)
         assert TriggerRule.is_valid(TriggerRule.ALL_DONE_SETUP_SUCCESS)
-        assert len(TriggerRule.all_triggers()) == 13
+        assert len(TriggerRule.all_triggers()) == 12
 
         with pytest.raises(ValueError):
             TriggerRule("NOT_EXIST_TRIGGER_RULE")

--- a/tests/utils/test_trigger_rule.py
+++ b/tests/utils/test_trigger_rule.py
@@ -32,7 +32,6 @@ class TestTriggerRule:
         assert TriggerRule.is_valid(TriggerRule.ONE_FAILED)
         assert TriggerRule.is_valid(TriggerRule.ONE_DONE)
         assert TriggerRule.is_valid(TriggerRule.NONE_FAILED)
-        assert TriggerRule.is_valid(TriggerRule.NONE_FAILED_OR_SKIPPED)
         assert TriggerRule.is_valid(TriggerRule.NONE_SKIPPED)
         assert TriggerRule.is_valid(TriggerRule.ALWAYS)
         assert TriggerRule.is_valid(TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS)


### PR DESCRIPTION
## Why
as stated in https://github.com/apache/airflow/blob/b882246702ccb040243db803c08d2097d67283a5/RELEASE_NOTES.rst?plain=1#L4935, this should be removed

## What
remove deprecated `TriggerRule.NONE_FAILED_OR_SKIPPED`
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
