### PR TITLE
feat: automatically inject OL info into spark job in DataprocSubmitJobOperator

### DIFF
--- a/docs/apache-airflow-providers-openlineage/guides/user.rst
+++ b/docs/apache-airflow-providers-openlineage/guides/user.rst
@@ -414,6 +414,36 @@ which requires the DAG-level lineage to be enabled in some OpenLineage backend s
 Disabling DAG-level lineage while enabling task-level lineage might cause errors or inconsistencies.
 
 
+Passing parent job information to Spark jobs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+OpenLineage integration can automatically inject Airflow's information (namespace, job name, run id)
+into Spark application properties as parent job information
+(``spark.openlineage.parentJobNamespace``, ``spark.openlineage.parentJobName``, ``spark.openlineage.parentRunId``),
+for :ref:`supported Operators <supported_classes:openlineage>`.
+It allows Spark integration to automatically include ``parentRunFacet`` in application-level OpenLineage event,
+creating a parent-child relationship between tasks from different integrations.
+See `Scheduling from Airflow <https://openlineage.io/docs/integrations/spark/configuration/airflow>`_.
+
+.. warning::
+
+  If any of the above properties are manually specified in the Spark job configuration, the integration will refrain from injecting parent job properties to ensure that manually provided values are preserved.
+
+You can enable this automation by setting ``spark_inject_parent_job_info`` option to ``true`` in Airflow configuration.
+
+.. code-block:: ini
+
+    [openlineage]
+    transport = {"type": "http", "url": "http://example.com:5000", "endpoint": "api/v1/lineage"}
+    spark_inject_parent_job_info = true
+
+``AIRFLOW__OPENLINEAGE__SPARK_INJECT_PARENT_JOB_INFO`` environment variable is an equivalent.
+
+.. code-block:: ini
+
+  AIRFLOW__OPENLINEAGE__SPARK_INJECT_PARENT_JOB_INFO=true
+
+
 Troubleshooting
 ===============
 

--- a/docs/exts/templates/openlineage.rst.jinja2
+++ b/docs/exts/templates/openlineage.rst.jinja2
@@ -18,12 +18,23 @@
 #}
 Core operators
 ==============
-At the moment, two core operators supports OpenLineage. These operators function as a 'black box,'
+At the moment, two core operators support OpenLineage. These operators function as a 'black box,'
 capable of running any code, which might limit the extent of lineage extraction. To enhance the extraction
 of lineage information, operators can utilize the hooks listed below that support OpenLineage.
 
 - :class:`~airflow.providers.standard.operators.python.PythonOperator` (via :class:`airflow.providers.openlineage.extractors.python.PythonExtractor`)
 - :class:`~airflow.providers.standard.operators.bash.BashOperator` (via :class:`airflow.providers.openlineage.extractors.bash.BashExtractor`)
+
+Spark operators
+===============
+The OpenLineage integration can automatically inject information into Spark application properties when its being submitted from Airflow.
+The following is a list of supported operators along with the corresponding information that can be injected.
+
+apache-airflow-providers-google
+"""""""""""""""""""""""""""""""
+
+- :class:`~airflow.providers.google.cloud.operators.dataproc.DataprocSubmitJobOperator`
+    - Parent Job Information
 
 
 :class:`~airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -631,7 +631,7 @@
   "google": {
     "deps": [
       "PyOpenSSL>=23.0.0",
-      "apache-airflow-providers-common-compat>=1.2.1",
+      "apache-airflow-providers-common-compat>=1.3.0",
       "apache-airflow-providers-common-sql>=1.20.0",
       "apache-airflow>=2.9.0",
       "asgiref>=3.5.2",
@@ -973,7 +973,7 @@
   },
   "openlineage": {
     "deps": [
-      "apache-airflow-providers-common-compat>=1.2.1",
+      "apache-airflow-providers-common-compat>=1.3.0",
       "apache-airflow-providers-common-sql>=1.20.0",
       "apache-airflow>=2.9.0",
       "attrs>=22.2",

--- a/providers/src/airflow/providers/common/compat/openlineage/utils/spark.py
+++ b/providers/src/airflow/providers/common/compat/openlineage/utils/spark.py
@@ -1,0 +1,68 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+log = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from airflow.providers.openlineage.utils.spark import inject_parent_job_information_into_spark_properties
+else:
+    try:
+        from airflow.providers.openlineage.utils.spark import (
+            inject_parent_job_information_into_spark_properties,
+        )
+    except ImportError:
+        try:
+            from airflow.providers.openlineage.plugins.macros import (
+                lineage_job_name,
+                lineage_job_namespace,
+                lineage_run_id,
+            )
+        except ImportError:
+
+            def inject_parent_job_information_into_spark_properties(properties: dict, context) -> dict:
+                log.warning(
+                    "Could not import `airflow.providers.openlineage.plugins.macros`."
+                    "Skipping the injection of OpenLineage parent job information into Spark properties."
+                )
+                return properties
+
+        else:
+
+            def inject_parent_job_information_into_spark_properties(properties: dict, context) -> dict:
+                if any(str(key).startswith("spark.openlineage.parent") for key in properties):
+                    log.info(
+                        "Some OpenLineage properties with parent job information are already present "
+                        "in Spark properties. Skipping the injection of OpenLineage "
+                        "parent job information into Spark properties."
+                    )
+                    return properties
+
+                ti = context["ti"]
+                ol_parent_job_properties = {
+                    "spark.openlineage.parentJobNamespace": lineage_job_namespace(),
+                    "spark.openlineage.parentJobName": lineage_job_name(ti),
+                    "spark.openlineage.parentRunId": lineage_run_id(ti),
+                }
+                return {**properties, **ol_parent_job_properties}
+
+
+__all__ = ["inject_parent_job_information_into_spark_properties"]

--- a/providers/src/airflow/providers/google/provider.yaml
+++ b/providers/src/airflow/providers/google/provider.yaml
@@ -101,7 +101,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.9.0
-  - apache-airflow-providers-common-compat>=1.2.1
+  - apache-airflow-providers-common-compat>=1.3.0
   - apache-airflow-providers-common-sql>=1.20.0
   - asgiref>=3.5.2
   - dill>=0.2.3

--- a/providers/src/airflow/providers/openlineage/conf.py
+++ b/providers/src/airflow/providers/openlineage/conf.py
@@ -78,6 +78,12 @@ def selective_enable() -> bool:
 
 
 @cache
+def spark_inject_parent_job_info() -> bool:
+    """[openlineage] spark_inject_parent_job_info."""
+    return conf.getboolean(_CONFIG_SECTION, "spark_inject_parent_job_info", fallback="False")
+
+
+@cache
 def custom_extractors() -> set[str]:
     """[openlineage] extractors."""
     option = conf.get(_CONFIG_SECTION, "extractors", fallback="")

--- a/providers/src/airflow/providers/openlineage/provider.yaml
+++ b/providers/src/airflow/providers/openlineage/provider.yaml
@@ -53,7 +53,7 @@ versions:
 dependencies:
   - apache-airflow>=2.9.0
   - apache-airflow-providers-common-sql>=1.20.0
-  - apache-airflow-providers-common-compat>=1.2.1
+  - apache-airflow-providers-common-compat>=1.3.0
   - attrs>=22.2
   - openlineage-integration-common>=1.24.2
   - openlineage-python>=1.24.2
@@ -184,3 +184,11 @@ config:
         example: ~
         type: boolean
         version_added: 1.11.0
+      spark_inject_parent_job_info:
+        description: |
+          Automatically inject OpenLineage's parent job (namespace, job name, run id) information into Spark
+          application properties for supported Operators.
+        type: boolean
+        default: "False"
+        example: ~
+        version_added: 1.15.0

--- a/providers/src/airflow/providers/openlineage/utils/spark.py
+++ b/providers/src/airflow/providers/openlineage/utils/spark.py
@@ -1,0 +1,86 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from airflow.providers.openlineage.plugins.macros import (
+    lineage_job_name,
+    lineage_job_namespace,
+    lineage_run_id,
+)
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
+
+log = logging.getLogger(__name__)
+
+
+def _get_parent_job_information_as_spark_properties(context: Context) -> dict:
+    """
+    Retrieve parent job information as Spark properties.
+
+    Args:
+        context: The context containing task instance information.
+
+    Returns:
+        Spark properties with the parent job information.
+    """
+    ti = context["ti"]
+    return {
+        "spark.openlineage.parentJobNamespace": lineage_job_namespace(),
+        "spark.openlineage.parentJobName": lineage_job_name(ti),  # type: ignore[arg-type]
+        "spark.openlineage.parentRunId": lineage_run_id(ti),  # type: ignore[arg-type]
+    }
+
+
+def _is_parent_job_information_present_in_spark_properties(properties: dict) -> bool:
+    """
+    Check if any parent job information is present in Spark properties.
+
+    Args:
+        properties: Spark properties.
+
+    Returns:
+        True if parent job information is present, False otherwise.
+    """
+    return any(str(key).startswith("spark.openlineage.parent") for key in properties)
+
+
+def inject_parent_job_information_into_spark_properties(properties: dict, context: Context) -> dict:
+    """
+    Inject parent job information into Spark properties if not already present.
+
+    Args:
+        properties: Spark properties.
+        context: The context containing task instance information.
+
+    Returns:
+        Modified Spark properties with OpenLineage parent job information properties injected, if applicable.
+    """
+    if _is_parent_job_information_present_in_spark_properties(properties):
+        log.info(
+            "Some OpenLineage properties with parent job information are already present "
+            "in Spark properties. Skipping the injection of OpenLineage "
+            "parent job information into Spark properties."
+        )
+        return properties
+
+    ol_parent_job_properties = _get_parent_job_information_as_spark_properties(context)
+    return {**properties, **ol_parent_job_properties}

--- a/providers/tests/common/compat/openlineage/utils/test_spark.py
+++ b/providers/tests/common/compat/openlineage/utils/test_spark.py
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+
+def test_import():
+    from airflow.providers.common.compat.openlineage.utils.spark import (
+        inject_parent_job_information_into_spark_properties,
+    )
+
+    assert inject_parent_job_information_into_spark_properties is not None

--- a/providers/tests/google/cloud/operators/test_dataproc.py
+++ b/providers/tests/google/cloud/operators/test_dataproc.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import datetime as dt
 import inspect
 from unittest import mock
 from unittest.mock import MagicMock, Mock, call
@@ -1508,6 +1509,188 @@ class TestDataprocSubmitJobOperator(DataprocJobTestBase):
 
         op.execute(context=self.mock_context)
         assert not mock_defer.called
+
+    @mock.patch("airflow.providers.google.cloud.openlineage.utils._is_openlineage_provider_accessible")
+    @mock.patch(DATAPROC_PATH.format("DataprocHook"))
+    def test_execute_openlineage_parent_job_info_injection(self, mock_hook, mock_ol_accessible):
+        job_config = {
+            "placement": {"cluster_name": CLUSTER_NAME},
+            "pyspark_job": {
+                "main_python_file_uri": "gs://example/wordcount.py",
+                "properties": {
+                    "spark.sql.shuffle.partitions": "1",
+                    "spark.openlineage.transport.type": "console",
+                },
+            },
+        }
+        expected_config = {
+            "placement": {"cluster_name": CLUSTER_NAME},
+            "pyspark_job": {
+                "main_python_file_uri": "gs://example/wordcount.py",
+                "properties": {
+                    "spark.sql.shuffle.partitions": "1",
+                    "spark.openlineage.transport.type": "console",
+                    "spark.openlineage.parentJobName": "dag_id.task_id",
+                    "spark.openlineage.parentJobNamespace": "default",
+                    "spark.openlineage.parentRunId": "01931885-2800-7be7-aa8d-aaa15c337267",
+                },
+            },
+        }
+        context = {
+            "ti": MagicMock(
+                dag_id="dag_id",
+                task_id="task_id",
+                try_number=1,
+                map_index=1,
+                logical_date=dt.datetime(2024, 11, 11),
+            )
+        }
+
+        mock_ol_accessible.return_value = True
+
+        op = DataprocSubmitJobOperator(
+            task_id=TASK_ID,
+            region=GCP_REGION,
+            project_id=GCP_PROJECT,
+            request_id=REQUEST_ID,
+            retry=RETRY,
+            timeout=TIMEOUT,
+            metadata=METADATA,
+            job=job_config,
+            openlineage_inject_parent_job_info=True,
+        )
+        op.execute(context=context)
+
+        mock_hook.return_value.submit_job.assert_called_once_with(
+            project_id=GCP_PROJECT,
+            region=GCP_REGION,
+            job=expected_config,
+            request_id=REQUEST_ID,
+            retry=RETRY,
+            timeout=TIMEOUT,
+            metadata=METADATA,
+        )
+
+    @mock.patch("airflow.providers.google.cloud.openlineage.utils._is_openlineage_provider_accessible")
+    @mock.patch(DATAPROC_PATH.format("DataprocHook"))
+    def test_execute_openlineage_parent_job_info_injection_skipped_when_already_present(
+        self, mock_hook, mock_ol_accessible
+    ):
+        job_config = {
+            "placement": {"cluster_name": CLUSTER_NAME},
+            "pyspark_job": {
+                "main_python_file_uri": "gs://example/wordcount.py",
+                "properties": {
+                    "spark.sql.shuffle.partitions": "1",
+                    "spark.openlineage.parentJobNamespace": "default",
+                },
+            },
+        }
+
+        mock_ol_accessible.return_value = True
+
+        op = DataprocSubmitJobOperator(
+            task_id=TASK_ID,
+            region=GCP_REGION,
+            project_id=GCP_PROJECT,
+            request_id=REQUEST_ID,
+            retry=RETRY,
+            timeout=TIMEOUT,
+            metadata=METADATA,
+            job=job_config,
+            openlineage_inject_parent_job_info=True,
+        )
+        op.execute(context=self.mock_context)
+
+        mock_hook.return_value.submit_job.assert_called_once_with(
+            project_id=GCP_PROJECT,
+            region=GCP_REGION,
+            job=job_config,
+            request_id=REQUEST_ID,
+            retry=RETRY,
+            timeout=TIMEOUT,
+            metadata=METADATA,
+        )
+
+    @mock.patch("airflow.providers.google.cloud.openlineage.utils._is_openlineage_provider_accessible")
+    @mock.patch(DATAPROC_PATH.format("DataprocHook"))
+    def test_execute_openlineage_parent_job_info_injection_skipped_by_default_unless_enabled(
+        self, mock_hook, mock_ol_accessible
+    ):
+        job_config = {
+            "placement": {"cluster_name": CLUSTER_NAME},
+            "pyspark_job": {
+                "main_python_file_uri": "gs://example/wordcount.py",
+                "properties": {
+                    "spark.sql.shuffle.partitions": "1",
+                },
+            },
+        }
+
+        mock_ol_accessible.return_value = True
+
+        op = DataprocSubmitJobOperator(
+            task_id=TASK_ID,
+            region=GCP_REGION,
+            project_id=GCP_PROJECT,
+            request_id=REQUEST_ID,
+            retry=RETRY,
+            timeout=TIMEOUT,
+            metadata=METADATA,
+            job=job_config,
+            # not passing openlineage_inject_parent_job_info, should be False by default
+        )
+        op.execute(context=self.mock_context)
+
+        mock_hook.return_value.submit_job.assert_called_once_with(
+            project_id=GCP_PROJECT,
+            region=GCP_REGION,
+            job=job_config,
+            request_id=REQUEST_ID,
+            retry=RETRY,
+            timeout=TIMEOUT,
+            metadata=METADATA,
+        )
+
+    @mock.patch("airflow.providers.google.cloud.openlineage.utils._is_openlineage_provider_accessible")
+    @mock.patch(DATAPROC_PATH.format("DataprocHook"))
+    def test_execute_openlineage_parent_job_info_injection_skipped_when_ol_not_accessible(
+        self, mock_hook, mock_ol_accessible
+    ):
+        job_config = {
+            "placement": {"cluster_name": CLUSTER_NAME},
+            "pyspark_job": {
+                "main_python_file_uri": "gs://example/wordcount.py",
+                "properties": {
+                    "spark.sql.shuffle.partitions": "1",
+                },
+            },
+        }
+
+        mock_ol_accessible.return_value = False
+
+        op = DataprocSubmitJobOperator(
+            task_id=TASK_ID,
+            region=GCP_REGION,
+            project_id=GCP_PROJECT,
+            request_id=REQUEST_ID,
+            retry=RETRY,
+            timeout=TIMEOUT,
+            metadata=METADATA,
+            job=job_config,
+            openlineage_inject_parent_job_info=True,
+        )
+        op.execute(context=self.mock_context)
+
+        mock_hook.return_value.submit_job.assert_called_once_with(
+            project_id=GCP_PROJECT,
+            region=GCP_REGION,
+            job=job_config,
+            request_id=REQUEST_ID,
+            retry=RETRY,
+            timeout=TIMEOUT,
+            metadata=METADATA,
+        )
 
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_on_kill(self, mock_hook):

--- a/providers/tests/openlineage/test_conf.py
+++ b/providers/tests/openlineage/test_conf.py
@@ -36,6 +36,7 @@ from airflow.providers.openlineage.conf import (
     is_source_enabled,
     namespace,
     selective_enable,
+    spark_inject_parent_job_info,
     transport,
 )
 
@@ -61,6 +62,7 @@ _CONFIG_OPTION_SELECTIVE_ENABLE = "selective_enable"
 _CONFIG_OPTION_DAG_STATE_CHANGE_PROCESS_POOL_SIZE = "dag_state_change_process_pool_size"
 _CONFIG_OPTION_INCLUDE_FULL_TASK_INFO = "include_full_task_info"
 _CONFIG_OPTION_DEBUG_MODE = "debug_mode"
+_CONFIG_OPTION_SPARK_INJECT_PARENT_JOB_INFO = "spark_inject_parent_job_info"
 
 _BOOL_PARAMS = (
     ("1", True),
@@ -612,3 +614,30 @@ def test_debug_mode_invalid_value_raise_error(var_string):
 @conf_vars({(_CONFIG_SECTION, _CONFIG_OPTION_DEBUG_MODE): None})
 def test_debug_mode_do_not_fail_if_conf_option_missing():
     assert debug_mode() is False
+
+
+@pytest.mark.parametrize(
+    ("var_string", "expected"),
+    _BOOL_PARAMS,
+)
+def test_spark_inject_parent_job_info(var_string, expected):
+    with conf_vars({(_CONFIG_SECTION, _CONFIG_OPTION_SPARK_INJECT_PARENT_JOB_INFO): var_string}):
+        result = spark_inject_parent_job_info()
+        assert result is expected
+
+
+@conf_vars({(_CONFIG_SECTION, _CONFIG_OPTION_SPARK_INJECT_PARENT_JOB_INFO): "asdadawlaksnd"})
+def test_spark_inject_parent_job_info_not_working_for_random_string():
+    with pytest.raises(AirflowConfigException):
+        spark_inject_parent_job_info()
+
+
+@conf_vars({(_CONFIG_SECTION, _CONFIG_OPTION_SPARK_INJECT_PARENT_JOB_INFO): ""})
+def test_spark_inject_parent_job_info_empty_conf_option():
+    with pytest.raises(AirflowConfigException):
+        spark_inject_parent_job_info()
+
+
+@conf_vars({(_CONFIG_SECTION, _CONFIG_OPTION_SPARK_INJECT_PARENT_JOB_INFO): None})
+def test_spark_inject_parent_job_info_do_not_fail_if_conf_option_missing():
+    assert spark_inject_parent_job_info() is False

--- a/providers/tests/openlineage/utils/test_spark.py
+++ b/providers/tests/openlineage/utils/test_spark.py
@@ -1,0 +1,129 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import datetime as dt
+from unittest.mock import MagicMock
+
+import pytest
+
+from airflow.providers.openlineage.utils.spark import (
+    _get_parent_job_information_as_spark_properties,
+    _is_parent_job_information_present_in_spark_properties,
+    inject_parent_job_information_into_spark_properties,
+)
+
+EXAMPLE_CONTEXT = {
+    "ti": MagicMock(
+        dag_id="dag_id",
+        task_id="task_id",
+        try_number=1,
+        map_index=1,
+        logical_date=dt.datetime(2024, 11, 11),
+    )
+}
+EXAMPLE_PARENT_JOB_SPARK_PROPERTIES = {
+    "spark.openlineage.parentJobName": "dag_id.task_id",
+    "spark.openlineage.parentJobNamespace": "default",
+    "spark.openlineage.parentRunId": "01931885-2800-7be7-aa8d-aaa15c337267",
+}
+
+
+def test_get_parent_job_information_as_spark_properties():
+    result = _get_parent_job_information_as_spark_properties(EXAMPLE_CONTEXT)
+    assert result == EXAMPLE_PARENT_JOB_SPARK_PROPERTIES
+
+
+@pytest.mark.parametrize(
+    "properties, expected",
+    [
+        (
+            {"spark.openlineage.parentJobNamespace": "example_namespace"},
+            True,
+        ),
+        (
+            {"spark.openlineage.parentJobName": "some_job_name"},
+            True,
+        ),
+        (
+            {"spark.openlineage.parentRunId": "some_run_id"},
+            True,
+        ),
+        (
+            {"spark.openlineage.parentWhatever": "some_value", "some.other.property": "value"},
+            True,
+        ),
+        (
+            {"some.other.property": "value"},
+            False,
+        ),
+        (
+            {
+                "spark.openlineage.parentJobNamespace": "another_namespace",
+                "spark.openlineage.parentJobName": "another_job_name",
+                "spark.openlineage.parentRunId": "another_run_id",
+            },
+            True,
+        ),
+    ],
+)
+def test_is_parent_job_information_present_in_spark_properties(properties, expected):
+    assert _is_parent_job_information_present_in_spark_properties(properties) is expected
+
+
+@pytest.mark.parametrize(
+    "properties, should_inject",
+    [
+        (
+            {"spark.openlineage.parentJobNamespace": "example_namespace"},
+            False,
+        ),
+        (
+            {"spark.openlineage.parentJobName": "some_job_name"},
+            False,
+        ),
+        (
+            {"spark.openlineage.parentRunId": "some_run_id"},
+            False,
+        ),
+        (
+            {"spark.openlineage.parentWhatever": "some_value", "some.other.property": "value"},
+            False,
+        ),
+        (
+            {"some.other.property": "value"},
+            True,
+        ),
+        (
+            {},
+            True,
+        ),
+        (
+            {
+                "spark.openlineage.parentJobNamespace": "another_namespace",
+                "spark.openlineage.parentJobName": "another_job_name",
+                "spark.openlineage.parentRunId": "another_run_id",
+            },
+            False,
+        ),
+    ],
+)
+def test_inject_parent_job_information_into_spark_properties(properties, should_inject):
+    result = inject_parent_job_information_into_spark_properties(properties, EXAMPLE_CONTEXT)
+    expected = {**properties, **EXAMPLE_PARENT_JOB_SPARK_PROPERTIES} if should_inject else properties
+    assert result == expected


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
This PR introduces a completely new feature to OpenLineage integration. **It will NOT impact users that are not using OpenLineage or have not explicitly enabled this feature (False by default).**

## TLDR; 
When explicitly enabled by the user for supported operators, we will automatically inject parent job information into the Spark job properties. For example, when submitting a Spark job using the DataprocSubmitJobOperator, we will include details about the Airflow task that triggered it so that the OpenLineage Spark integration can include them in parentRunFacet.

## Why ?

To enable full pipeline visibility and track dependencies between jobs in OpenLineage, we utilize the parentRunFacet. This facet stores the identifier of the parent job that triggered the current job. This approach works across various integrations, f.e. you can pass Airflow’s job identifier to a Spark application if it was triggered by an Airflow operator. Currently, this process requires manual configuration by the user, such as leveraging [macros](https://airflow.apache.org/docs/apache-airflow-providers-openlineage/stable/macros.html):
```
DataprocSubmitJobOperator(
    task_id="my_task", 
    # ... 
    job={ 
        # ...
        "spark.openlineage.parentJobNamespace": "{{ macros.OpenLineageProviderPlugin.lineage_job_namespace() }}",
        "spark.openlineage.parentJobName": "{{ macros.OpenLineageProviderPlugin.lineage_job_name(task_instance) }}", 
        "spark.openlineage.parentRunId": "{{ macros.OpenLineageProviderPlugin.lineage_run_id(task_instance) }}"
    } 
)

```
Understanding how various Airflow operators configure Spark allows us to automatically inject parent job information.

## Controlling the Behavior

We provide users with a flexible control mechanism to manage this injection, combining per-operator enablement with a global fallback configuration. This design is inspired by the `deferrable` argument in Airflow.

```python
ol_inject_parent_job_info: bool = conf.getboolean(
    "openlineage", "spark_inject_parent_job_info", fallback=False
)
```
Each supported operator will include an argument like `ol_inject_parent_job_info`, which defaults to the global configuration value of `openlineage.spark_inject_parent_job_info`. This approach allows users to:

1. Control behavior on a per-job basis by explicitly setting the argument.
2. Rely on a consistent default configuration for all jobs if the argument is not set.

This design ensures both flexibility and ease of use, enabling users to fine-tune their workflows while minimizing repetitive configuration. I am aware that adding an OpenLineage-related argument to the operator will affect all users, even those not using OpenLineage, but since it defaults to False and can be ignored, I hope this will not pose any issues.

## How?
The implementation is divided into three parts for better organization and clarity:

1. **Operator's Code (including the `execute` method):**  
   Contains minimal logic to avoid overwhelming users who are not actively working with OpenLineage.

2. **Google's Provider OpenLineage Utils File:**  
   Handles the logic for accessing Spark properties specific to a given operator or job.

3. **OpenLineage Provider's Utils:**  
   Responsible for creating / extracting all necessary information in a format compatible with the OpenLineage Spark integration. We are also performing modifications to the Spark properties here.

For some operators parts 1 and 2 may be in the operator's code. In general, the specific operator / provider will know how to get the spark properties and the OL will know what to inject and do the injection itself.

## Next steps
1. **Expand Operator Coverage:**  
   Increase support for additional operators by extending the parent job information injection to cover more cases.

2. **Automate Transport Configuration:**  
   Implement similar automation for transport configurations, starting with HTTP, to streamline the integration process.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
