### PR TITLE
AIP-84 Rename Monitor Schema to DataModel

### DIFF
--- a/airflow/api_fastapi/core_api/datamodels/monitor.py
+++ b/airflow/api_fastapi/core_api/datamodels/monitor.py
@@ -19,34 +19,34 @@ from __future__ import annotations
 from airflow.api_fastapi.core_api.base import BaseModel
 
 
-class BaseInfoSchema(BaseModel):
-    """Base status field for metadatabase and scheduler."""
+class BaseInfoResponse(BaseModel):
+    """Base info serializer for responses."""
 
     status: str | None
 
 
-class SchedulerInfoSchema(BaseInfoSchema):
-    """Schema for Scheduler info."""
+class SchedulerInfoResponse(BaseInfoResponse):
+    """Scheduler info serializer for responses."""
 
     latest_scheduler_heartbeat: str | None
 
 
-class TriggererInfoSchema(BaseInfoSchema):
-    """Schema for Triggerer info."""
+class TriggererInfoResponse(BaseInfoResponse):
+    """Triggerer info serializer for responses."""
 
     latest_triggerer_heartbeat: str | None
 
 
-class DagProcessorInfoSchema(BaseInfoSchema):
-    """Schema for DagProcessor info."""
+class DagProcessorInfoResponse(BaseInfoResponse):
+    """DagProcessor info serializer for responses."""
 
     latest_dag_processor_heartbeat: str | None
 
 
-class HealthInfoSchema(BaseModel):
-    """Schema for the Health endpoint."""
+class HealthInfoResponse(BaseModel):
+    """Health serializer for responses."""
 
-    metadatabase: BaseInfoSchema
-    scheduler: SchedulerInfoSchema
-    triggerer: TriggererInfoSchema
-    dag_processor: DagProcessorInfoSchema | None = None
+    metadatabase: BaseInfoResponse
+    scheduler: SchedulerInfoResponse
+    triggerer: TriggererInfoResponse
+    dag_processor: DagProcessorInfoResponse | None = None

--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -5670,7 +5670,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HealthInfoSchema'
+                $ref: '#/components/schemas/HealthInfoResponse'
   /public/version:
     get:
       tags:
@@ -5995,7 +5995,7 @@ components:
       - updated_at
       title: BackfillResponse
       description: Base serializer for Backfill.
-    BaseInfoSchema:
+    BaseInfoResponse:
       properties:
         status:
           anyOf:
@@ -6005,8 +6005,8 @@ components:
       type: object
       required:
       - status
-      title: BaseInfoSchema
-      description: Base status field for metadatabase and scheduler.
+      title: BaseInfoResponse
+      description: Base info serializer for responses.
     ClearTaskInstancesBody:
       properties:
         dry_run:
@@ -7204,7 +7204,7 @@ components:
       - file_token
       title: DAGWithLatestDagRunsResponse
       description: DAG with latest dag runs response serializer.
-    DagProcessorInfoSchema:
+    DagProcessorInfoResponse:
       properties:
         status:
           anyOf:
@@ -7220,8 +7220,8 @@ components:
       required:
       - status
       - latest_dag_processor_heartbeat
-      title: DagProcessorInfoSchema
-      description: Schema for DagProcessor info.
+      title: DagProcessorInfoResponse
+      description: DagProcessor info serializer for responses.
     DagRunAssetReference:
       properties:
         run_id:
@@ -7577,25 +7577,25 @@ components:
           title: Detail
       type: object
       title: HTTPValidationError
-    HealthInfoSchema:
+    HealthInfoResponse:
       properties:
         metadatabase:
-          $ref: '#/components/schemas/BaseInfoSchema'
+          $ref: '#/components/schemas/BaseInfoResponse'
         scheduler:
-          $ref: '#/components/schemas/SchedulerInfoSchema'
+          $ref: '#/components/schemas/SchedulerInfoResponse'
         triggerer:
-          $ref: '#/components/schemas/TriggererInfoSchema'
+          $ref: '#/components/schemas/TriggererInfoResponse'
         dag_processor:
           anyOf:
-          - $ref: '#/components/schemas/DagProcessorInfoSchema'
+          - $ref: '#/components/schemas/DagProcessorInfoResponse'
           - type: 'null'
       type: object
       required:
       - metadatabase
       - scheduler
       - triggerer
-      title: HealthInfoSchema
-      description: Schema for the Health endpoint.
+      title: HealthInfoResponse
+      description: Health serializer for responses.
     HistoricalMetricDataResponse:
       properties:
         dag_run_types:
@@ -8139,7 +8139,7 @@ components:
 
 
         :meta private:'
-    SchedulerInfoSchema:
+    SchedulerInfoResponse:
       properties:
         status:
           anyOf:
@@ -8155,8 +8155,8 @@ components:
       required:
       - status
       - latest_scheduler_heartbeat
-      title: SchedulerInfoSchema
-      description: Schema for Scheduler info.
+      title: SchedulerInfoResponse
+      description: Scheduler info serializer for responses.
     TaskCollectionResponse:
       properties:
         tasks:
@@ -9024,7 +9024,7 @@ components:
       - triggerer_id
       title: TriggerResponse
       description: Trigger serializer for responses.
-    TriggererInfoSchema:
+    TriggererInfoResponse:
       properties:
         status:
           anyOf:
@@ -9040,8 +9040,8 @@ components:
       required:
       - status
       - latest_triggerer_heartbeat
-      title: TriggererInfoSchema
-      description: Schema for Triggerer info.
+      title: TriggererInfoResponse
+      description: Triggerer info serializer for responses.
     ValidationError:
       properties:
         loc:

--- a/airflow/api_fastapi/core_api/routes/public/monitor.py
+++ b/airflow/api_fastapi/core_api/routes/public/monitor.py
@@ -19,12 +19,12 @@ from __future__ import annotations
 
 from airflow.api.common.airflow_health import get_airflow_health
 from airflow.api_fastapi.common.router import AirflowRouter
-from airflow.api_fastapi.core_api.datamodels.monitor import HealthInfoSchema
+from airflow.api_fastapi.core_api.datamodels.monitor import HealthInfoResponse
 
 monitor_router = AirflowRouter(tags=["Monitor"], prefix="/monitor")
 
 
-@monitor_router.get("/health", response_model=HealthInfoSchema, response_model_exclude_unset=True)
+@monitor_router.get("/health", response_model=HealthInfoResponse, response_model_exclude_unset=True)
 def get_health():
     airflow_health_status = get_airflow_health()
-    return HealthInfoSchema.model_validate(airflow_health_status)
+    return HealthInfoResponse.model_validate(airflow_health_status)

--- a/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -2142,7 +2142,7 @@ export const prefetchUseVariableServiceGetVariables = (
   });
 /**
  * Get Health
- * @returns HealthInfoSchema Successful Response
+ * @returns HealthInfoResponse Successful Response
  * @throws ApiError
  */
 export const prefetchUseMonitorServiceGetHealth = (queryClient: QueryClient) =>

--- a/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow/ui/openapi-gen/queries/queries.ts
@@ -2533,7 +2533,7 @@ export const useVariableServiceGetVariables = <
   });
 /**
  * Get Health
- * @returns HealthInfoSchema Successful Response
+ * @returns HealthInfoResponse Successful Response
  * @throws ApiError
  */
 export const useMonitorServiceGetHealth = <

--- a/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow/ui/openapi-gen/queries/suspense.ts
@@ -2509,7 +2509,7 @@ export const useVariableServiceGetVariablesSuspense = <
   });
 /**
  * Get Health
- * @returns HealthInfoSchema Successful Response
+ * @returns HealthInfoResponse Successful Response
  * @throws ApiError
  */
 export const useMonitorServiceGetHealthSuspense = <

--- a/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -449,7 +449,7 @@ export const $BackfillResponse = {
   description: "Base serializer for Backfill.",
 } as const;
 
-export const $BaseInfoSchema = {
+export const $BaseInfoResponse = {
   properties: {
     status: {
       anyOf: [
@@ -465,8 +465,8 @@ export const $BaseInfoSchema = {
   },
   type: "object",
   required: ["status"],
-  title: "BaseInfoSchema",
-  description: "Base status field for metadatabase and scheduler.",
+  title: "BaseInfoResponse",
+  description: "Base info serializer for responses.",
 } as const;
 
 export const $ClearTaskInstancesBody = {
@@ -2362,7 +2362,7 @@ export const $DAGWithLatestDagRunsResponse = {
   description: "DAG with latest dag runs response serializer.",
 } as const;
 
-export const $DagProcessorInfoSchema = {
+export const $DagProcessorInfoResponse = {
   properties: {
     status: {
       anyOf: [
@@ -2389,8 +2389,8 @@ export const $DagProcessorInfoSchema = {
   },
   type: "object",
   required: ["status", "latest_dag_processor_heartbeat"],
-  title: "DagProcessorInfoSchema",
-  description: "Schema for DagProcessor info.",
+  title: "DagProcessorInfoResponse",
+  description: "DagProcessor info serializer for responses.",
 } as const;
 
 export const $DagRunAssetReference = {
@@ -2874,21 +2874,21 @@ export const $HTTPValidationError = {
   title: "HTTPValidationError",
 } as const;
 
-export const $HealthInfoSchema = {
+export const $HealthInfoResponse = {
   properties: {
     metadatabase: {
-      $ref: "#/components/schemas/BaseInfoSchema",
+      $ref: "#/components/schemas/BaseInfoResponse",
     },
     scheduler: {
-      $ref: "#/components/schemas/SchedulerInfoSchema",
+      $ref: "#/components/schemas/SchedulerInfoResponse",
     },
     triggerer: {
-      $ref: "#/components/schemas/TriggererInfoSchema",
+      $ref: "#/components/schemas/TriggererInfoResponse",
     },
     dag_processor: {
       anyOf: [
         {
-          $ref: "#/components/schemas/DagProcessorInfoSchema",
+          $ref: "#/components/schemas/DagProcessorInfoResponse",
         },
         {
           type: "null",
@@ -2898,8 +2898,8 @@ export const $HealthInfoSchema = {
   },
   type: "object",
   required: ["metadatabase", "scheduler", "triggerer"],
-  title: "HealthInfoSchema",
-  description: "Schema for the Health endpoint.",
+  title: "HealthInfoResponse",
+  description: "Health serializer for responses.",
 } as const;
 
 export const $HistoricalMetricDataResponse = {
@@ -3702,7 +3702,7 @@ export const $ReprocessBehavior = {
 :meta private:`,
 } as const;
 
-export const $SchedulerInfoSchema = {
+export const $SchedulerInfoResponse = {
   properties: {
     status: {
       anyOf: [
@@ -3729,8 +3729,8 @@ export const $SchedulerInfoSchema = {
   },
   type: "object",
   required: ["status", "latest_scheduler_heartbeat"],
-  title: "SchedulerInfoSchema",
-  description: "Schema for Scheduler info.",
+  title: "SchedulerInfoResponse",
+  description: "Scheduler info serializer for responses.",
 } as const;
 
 export const $TaskCollectionResponse = {
@@ -5159,7 +5159,7 @@ export const $TriggerResponse = {
   description: "Trigger serializer for responses.",
 } as const;
 
-export const $TriggererInfoSchema = {
+export const $TriggererInfoResponse = {
   properties: {
     status: {
       anyOf: [
@@ -5186,8 +5186,8 @@ export const $TriggererInfoSchema = {
   },
   type: "object",
   required: ["status", "latest_triggerer_heartbeat"],
-  title: "TriggererInfoSchema",
-  description: "Schema for Triggerer info.",
+  title: "TriggererInfoResponse",
+  description: "Triggerer info serializer for responses.",
 } as const;
 
 export const $ValidationError = {

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -2997,7 +2997,7 @@ export class DagParsingService {
 export class MonitorService {
   /**
    * Get Health
-   * @returns HealthInfoSchema Successful Response
+   * @returns HealthInfoResponse Successful Response
    * @throws ApiError
    */
   public static getHealth(): CancelablePromise<GetHealthResponse> {

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -124,9 +124,9 @@ export type BackfillResponse = {
 };
 
 /**
- * Base status field for metadatabase and scheduler.
+ * Base info serializer for responses.
  */
-export type BaseInfoSchema = {
+export type BaseInfoResponse = {
   status: string | null;
 };
 
@@ -519,9 +519,9 @@ export type DAGWithLatestDagRunsResponse = {
 };
 
 /**
- * Schema for DagProcessor info.
+ * DagProcessor info serializer for responses.
  */
-export type DagProcessorInfoSchema = {
+export type DagProcessorInfoResponse = {
   status: string | null;
   latest_dag_processor_heartbeat: string | null;
 };
@@ -699,13 +699,13 @@ export type HTTPValidationError = {
 };
 
 /**
- * Schema for the Health endpoint.
+ * Health serializer for responses.
  */
-export type HealthInfoSchema = {
-  metadatabase: BaseInfoSchema;
-  scheduler: SchedulerInfoSchema;
-  triggerer: TriggererInfoSchema;
-  dag_processor?: DagProcessorInfoSchema | null;
+export type HealthInfoResponse = {
+  metadatabase: BaseInfoResponse;
+  scheduler: SchedulerInfoResponse;
+  triggerer: TriggererInfoResponse;
+  dag_processor?: DagProcessorInfoResponse | null;
 };
 
 /**
@@ -915,9 +915,9 @@ export type QueuedEventResponse = {
 export type ReprocessBehavior = "failed" | "completed" | "none";
 
 /**
- * Schema for Scheduler info.
+ * Scheduler info serializer for responses.
  */
-export type SchedulerInfoSchema = {
+export type SchedulerInfoResponse = {
   status: string | null;
   latest_scheduler_heartbeat: string | null;
 };
@@ -1198,9 +1198,9 @@ export type TriggerResponse = {
 };
 
 /**
- * Schema for Triggerer info.
+ * Triggerer info serializer for responses.
  */
-export type TriggererInfoSchema = {
+export type TriggererInfoResponse = {
   status: string | null;
   latest_triggerer_heartbeat: string | null;
 };
@@ -2040,7 +2040,7 @@ export type ReparseDagFileData = {
 
 export type ReparseDagFileResponse = null;
 
-export type GetHealthResponse = HealthInfoSchema;
+export type GetHealthResponse = HealthInfoResponse;
 
 export type GetVersionResponse = VersionInfo;
 
@@ -4354,7 +4354,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: HealthInfoSchema;
+        200: HealthInfoResponse;
       };
     };
   };


### PR DESCRIPTION
"Schema" is a remnant from marshmallow. Harmonized the data models name of the `monitor` module to be more consistent with other FastAPI data models naming convention.