### PR TITLE
Remove AIP-44 from models/dagrun

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -85,9 +85,6 @@ if TYPE_CHECKING:
 
     from airflow.models.dag import DAG
     from airflow.models.operator import Operator
-    from airflow.serialization.pydantic.dag_run import DagRunPydantic
-    from airflow.serialization.pydantic.taskinstance import TaskInstancePydantic
-    from airflow.serialization.pydantic.tasklog import LogTemplatePydantic
     from airflow.typing_compat import Literal
     from airflow.utils.types import ArgNotSet
 
@@ -716,7 +713,7 @@ class DagRun(Base, LoggingMixin):
         session: Session = NEW_SESSION,
         *,
         map_index: int = -1,
-    ) -> TI | TaskInstancePydantic | None:
+    ) -> TI | None:
         """
         Return the task instance specified by task_id for this dag run.
 
@@ -739,7 +736,7 @@ class DagRun(Base, LoggingMixin):
         task_id: str,
         session: Session = NEW_SESSION,
         map_index: int = -1,
-    ) -> TI | TaskInstancePydantic | None:
+    ) -> TI | None:
         """
         Return the task instance specified by task_id for this dag run.
 
@@ -766,7 +763,7 @@ class DagRun(Base, LoggingMixin):
     @staticmethod
     @provide_session
     def get_previous_dagrun(
-        dag_run: DagRun | DagRunPydantic, state: DagRunState | None = None, session: Session = NEW_SESSION
+        dag_run: DagRun, state: DagRunState | None = None, session: Session = NEW_SESSION
     ) -> DagRun | None:
         """
         Return the previous DagRun, if there is one.
@@ -1700,14 +1697,12 @@ class DagRun(Base, LoggingMixin):
         return count
 
     @provide_session
-    def get_log_template(self, *, session: Session = NEW_SESSION) -> LogTemplate | LogTemplatePydantic:
+    def get_log_template(self, *, session: Session = NEW_SESSION) -> LogTemplate:
         return DagRun._get_log_template(log_template_id=self.log_template_id, session=session)
 
     @staticmethod
     @provide_session
-    def _get_log_template(
-        log_template_id: int | None, session: Session = NEW_SESSION
-    ) -> LogTemplate | LogTemplatePydantic:
+    def _get_log_template(log_template_id: int | None, session: Session = NEW_SESSION) -> LogTemplate:
         template: LogTemplate | None
         if log_template_id is None:  # DagRun created before LogTemplate introduction.
             template = session.scalar(select(LogTemplate).order_by(LogTemplate.id).limit(1))

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -52,7 +52,6 @@ from sqlalchemy.sql.functions import coalesce
 from sqlalchemy_utils import UUIDType
 
 from airflow import settings
-from airflow.api_internal.internal_api_call import internal_api_call
 from airflow.callbacks.callback_requests import DagCallbackRequest
 from airflow.configuration import conf as airflow_conf
 from airflow.exceptions import AirflowException, TaskNotFound
@@ -611,7 +610,6 @@ class DagRun(Base, LoggingMixin):
         return DagRunType(run_type).generate_run_id(logical_date)
 
     @staticmethod
-    @internal_api_call
     @provide_session
     def fetch_task_instances(
         dag_id: str | None = None,
@@ -648,7 +646,6 @@ class DagRun(Base, LoggingMixin):
             tis = tis.where(TI.task_id.in_(task_ids))
         return session.scalars(tis).all()
 
-    @internal_api_call
     def _check_last_n_dagruns_failed(self, dag_id, max_consecutive_failed_dag_runs, session):
         """Check if last N dags failed."""
         dag_runs = (
@@ -735,7 +732,6 @@ class DagRun(Base, LoggingMixin):
         )
 
     @staticmethod
-    @internal_api_call
     @provide_session
     def fetch_task_instance(
         dag_id: str,
@@ -768,7 +764,6 @@ class DagRun(Base, LoggingMixin):
         return self.dag
 
     @staticmethod
-    @internal_api_call
     @provide_session
     def get_previous_dagrun(
         dag_run: DagRun | DagRunPydantic, state: DagRunState | None = None, session: Session = NEW_SESSION
@@ -789,7 +784,6 @@ class DagRun(Base, LoggingMixin):
         return session.scalar(select(DagRun).where(*filters).order_by(DagRun.logical_date.desc()).limit(1))
 
     @staticmethod
-    @internal_api_call
     @provide_session
     def get_previous_scheduled_dagrun(
         dag_run_id: int,
@@ -1710,7 +1704,6 @@ class DagRun(Base, LoggingMixin):
         return DagRun._get_log_template(log_template_id=self.log_template_id, session=session)
 
     @staticmethod
-    @internal_api_call
     @provide_session
     def _get_log_template(
         log_template_id: int | None, session: Session = NEW_SESSION

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1257,7 +1257,7 @@ def _record_task_map_for_downstreams(
 
 def _get_previous_dagrun(
     *,
-    task_instance: TaskInstance | TaskInstancePydantic,
+    task_instance: TaskInstance,
     state: DagRunState | None = None,
     session: Session | None = None,
 ) -> DagRun | None:

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1257,7 +1257,7 @@ def _record_task_map_for_downstreams(
 
 def _get_previous_dagrun(
     *,
-    task_instance: TaskInstance,
+    task_instance: TaskInstance | TaskInstancePydantic,
     state: DagRunState | None = None,
     session: Session | None = None,
 ) -> DagRun | None:

--- a/airflow/serialization/pydantic/taskinstance.py
+++ b/airflow/serialization/pydantic/taskinstance.py
@@ -220,7 +220,7 @@ class TaskInstancePydantic(BaseModelPydantic, LoggingMixin):
             session=session,
         )
 
-    def get_dagrun(self, session: Session | None = None) -> DagRunPydantic:
+    def get_dagrun(self, session: Session | None = None) -> DagRun:
         """
         Return the DagRun for this TaskInstance.
 


### PR DESCRIPTION
related to #44436

 

- [x] ./airflow/models/dagrun.py: fetch_task_instances
- [x]  ./airflow/models/dagrun.py: _check_last_n_dagruns_failed
- [x]  ./airflow/models/dagrun.py: fetch_task_instance
- [x]  ./airflow/models/dagrun.py: get_previous_dagrun
- [x]  ./airflow/models/dagrun.py: get_previous_scheduled_dagrun
- [x]  ./airflow/models/dagrun.py: _get_log_template