### PR TITLE
AIP-72: Close sockets after sending start up msg

### DIFF
--- a/task_sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task_sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -347,12 +347,12 @@ class WatchedSubprocess:
             logs=read_logs,
         )
 
+        # Tell the task process what it needs to do!
+        proc._send_startup_message(ti, path, child_comms)
+
         # Close the remaining parent-end of the sockets we've passed to the child via fork. We still have the
         # other end of the pair open
         proc._close_unused_sockets(child_stdin, child_stdout, child_stderr, child_comms, child_logs)
-
-        # Tell the task process what it needs to do!
-        proc._send_startup_message(ti, path, child_comms)
         return proc
 
     def _register_pipe_readers(


### PR DESCRIPTION
We were closing `child_comms` socket before sending start-up msg which caused the startup msg to have fd of `-1` since it was closed. This resulted to the following to be `False` and hence there was no communication and it failed with `"NoneType' object has no attribute 'write"`.

https://github.com/apache/airflow/blob/55e419e95ab027d161cef95571300af9b2c81a0d/task_sdk/src/airflow/sdk/execution_time/task_runner.py#L95-L98

```
{'fd': -1, 'timestamp': datetime.datetime(2024, 11, 7, 12, 34, 56, 78901), 'logger': 'CommsDecoder', 'event': 'Received StartupDetails', 'level': 'info'},
```

Error was from following code block because `self.request_socket` was `None`:

https://github.com/apache/airflow/blob/55e419e95ab027d161cef95571300af9b2c81a0d/task_sdk/src/airflow/sdk/execution_time/task_runner.py#L101-L105

when sending it from

https://github.com/apache/airflow/blob/55e419e95ab027d161cef95571300af9b2c81a0d/task_sdk/src/airflow/sdk/execution_time/task_runner.py#L178
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
