### PR TITLE
Remove AIP-44 from models/xcom_arg

### DIFF
--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -25,7 +25,6 @@ from typing import TYPE_CHECKING, Any, Callable, Union, overload
 
 from sqlalchemy import func, or_, select
 
-from airflow.api_internal.internal_api_call import internal_api_call
 from airflow.exceptions import AirflowException, XComNotFound
 from airflow.models import MappedOperator, TaskInstance
 from airflow.models.abstractoperator import AbstractOperator
@@ -232,7 +231,6 @@ class XComArg(ResolveMixin, DependencyMixin):
         SetupTeardownContext.set_work_task_roots_and_leaves()
 
 
-@internal_api_call
 @provide_session
 def _get_task_map_length(
     *,


### PR DESCRIPTION
related: https://github.com/apache/airflow/issues/44436
 - [x] ./airflow/models/xcom_arg.py: _get_task_map_length

### Note

The Edge Worker also depends on the `_get_task_map_length` function, so I leave it starting with `_` instead of rejoining it with the `get_task_map_length` method.
