### PR TITLE
Pass cluster context into load_kube_config_from_dict

### DIFF
--- a/providers/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/providers/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -754,7 +754,7 @@ class AsyncKubernetesHook(KubernetesHook):
         if self.config_dict:
             self.log.debug(LOADING_KUBE_CONFIG_FILE_RESOURCE.format("config dictionary"))
             self._is_in_cluster = False
-            await async_config.load_kube_config_from_dict(self.config_dict)
+            await async_config.load_kube_config_from_dict(self.config_dict, context=cluster_context)
             return async_client.ApiClient()
 
         if kubeconfig is not None:

--- a/providers/tests/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/providers/tests/cncf/kubernetes/hooks/test_kubernetes.py
@@ -876,10 +876,7 @@ class TestAsyncKubernetesHook:
         assert not incluster_config.called
         assert hook._is_in_cluster is False
         kube_config_loader.assert_called_once_with(
-            config_dict={"a": "b"},
-            config_base_path=None,
-            active_context=None,
-            temp_file_path=None
+            config_dict={"a": "b"}, config_base_path=None, active_context=None, temp_file_path=None
         )
 
     @pytest.mark.asyncio
@@ -899,10 +896,7 @@ class TestAsyncKubernetesHook:
         assert not incluster_config.called
         assert hook._is_in_cluster is False
         kube_config_loader.assert_called_once_with(
-            config_dict={"a": "b"},
-            config_base_path=None,
-            active_context=cluster_context,
-            temp_file_path=None
+            config_dict={"a": "b"}, config_base_path=None, active_context=cluster_context, temp_file_path=None
         )
 
     @pytest.mark.asyncio

--- a/providers/tests/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/providers/tests/cncf/kubernetes/hooks/test_kubernetes.py
@@ -875,7 +875,35 @@ class TestAsyncKubernetesHook:
         await hook._load_config()
         assert not incluster_config.called
         assert hook._is_in_cluster is False
-        kube_config_loader.assert_called_once()
+        kube_config_loader.assert_called_once_with(
+            config_dict={"a": "b"},
+            config_base_path=None,
+            active_context=None,
+            temp_file_path=None
+        )
+
+    @pytest.mark.asyncio
+    @mock.patch(INCLUSTER_CONFIG_LOADER)
+    @mock.patch(KUBE_CONFIG_MERGER)
+    async def test_load_config_with_config_dict_and_cluster_context(
+        self, kube_config_merger, incluster_config, kube_config_loader
+    ):
+        cluster_context = "some_kubernetes_cluster"
+        hook = AsyncKubernetesHook(
+            conn_id=None,
+            in_cluster=False,
+            config_dict={"a": "b"},
+            cluster_context=cluster_context,
+        )
+        await hook._load_config()
+        assert not incluster_config.called
+        assert hook._is_in_cluster is False
+        kube_config_loader.assert_called_once_with(
+            config_dict={"a": "b"},
+            config_base_path=None,
+            active_context=cluster_context,
+            temp_file_path=None
+        )
 
     @pytest.mark.asyncio
     @mock.patch(INCLUSTER_CONFIG_LOADER)


### PR DESCRIPTION
The cluster_context passed into AsyncKubernetesHook is not passed through when load_kube_config_from_dict is called. This causes failures if you are running a KubernetesPodOperator task with deferrable=True and a cluster context that’s different to the default.

Ensuring the cluster_context is passed into the load_kube_config_from_dict method ensures the correct context is used for API calls
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
