### PR TITLE
Remove mypy errors from semantic merge problems due to Internal API removal

### DIFF
--- a/providers/src/airflow/providers/edge/models/edge_logs.py
+++ b/providers/src/airflow/providers/edge/models/edge_logs.py
@@ -144,6 +144,7 @@ class EdgeLogs(BaseModel, LoggingMixin):
         )
         if TYPE_CHECKING:
             assert ti
+            assert isinstance(ti, TaskInstance)
         base_log_folder = conf.get("logging", "base_log_folder", fallback="NOT AVAILABLE")
         return Path(base_log_folder, FileTaskHandler(base_log_folder)._render_filename(ti, task.try_number))
 

--- a/providers/src/airflow/providers/edge/worker_api/routes/_v2_routes.py
+++ b/providers/src/airflow/providers/edge/worker_api/routes/_v2_routes.py
@@ -49,7 +49,7 @@ def _initialize_method_map() -> dict[str, Callable]:
     #       for compatibility with Airflow 2.10-line.
     #       Methods are potentially not existing more on main branch for Airflow 3.
     from airflow.api.common.trigger_dag import trigger_dag
-    from airflow.cli.commands.task_command import _get_ti_db_access
+    from airflow.cli.commands.task_command import _get_ti_db_access  # type: ignore[attr-defined]
     from airflow.dag_processing.manager import DagFileProcessorManager
     from airflow.dag_processing.processor import DagFileProcessor
 
@@ -82,7 +82,7 @@ def _initialize_method_map() -> dict[str, Callable]:
     from airflow.providers.edge.models.edge_worker import EdgeWorker
     from airflow.secrets.metastore import MetastoreBackend
     from airflow.sensors.base import _orig_start_date
-    from airflow.utils.cli_action_loggers import _default_action_log_internal
+    from airflow.utils.cli_action_loggers import _default_action_log_internal  # type: ignore[attr-defined]
     from airflow.utils.log.file_task_handler import FileTaskHandler
 
     functions: list[Callable] = [
@@ -118,7 +118,7 @@ def _initialize_method_map() -> dict[str, Callable]:
         DagWarning.purge_inactive_dag_warnings,
         expand_alias_to_datasets,
         DatasetManager.register_dataset_change,
-        FileTaskHandler._render_filename_db_access,
+        FileTaskHandler._render_filename_db_access,  # type: ignore[attr-defined]
         Job._add_to_db,
         Job._fetch_from_db,
         Job._kill,

--- a/providers/src/airflow/providers/edge/worker_api/routes/logs.py
+++ b/providers/src/airflow/providers/edge/worker_api/routes/logs.py
@@ -55,6 +55,7 @@ def _logfile_path(task: TaskInstanceKey, session=NEW_SESSION) -> str:
     )
     if TYPE_CHECKING:
         assert ti
+        assert isinstance(ti, TaskInstance)
     return FileTaskHandler(".")._render_filename(ti, task.try_number)
 
 


### PR DESCRIPTION
I found more mypy errors on main due to parallel removal of AIP-44 internal API calls. This time (again) cause by me merging a PR that was checked in parallel and generated semantic check problems ... it was https://github.com/apache/airflow/pull/44330

Hope to get rid of this state when PR #44434 is merged, but this also was not building and is not fully reviewed.