### PR TITLE
Make Edge API retries configurable

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -528,7 +528,8 @@
   "edge": {
     "deps": [
       "apache-airflow>=2.10.0",
-      "pydantic>=2.10.2"
+      "pydantic>=2.10.2",
+      "retryhttp>=1.2.0"
     ],
     "devel-deps": [],
     "plugins": [

--- a/providers/src/airflow/providers/edge/CHANGELOG.rst
+++ b/providers/src/airflow/providers/edge/CHANGELOG.rst
@@ -31,7 +31,7 @@ Changelog
 .........
 
 * ``Make API retries configurable via ENV. Connection loss is sustained for 5min by default.``
-* ``Align retry handling logic and tooling with Task SDK.``
+* ``Align retry handling logic and tooling with Task SDK, via retryhttp.``
 
 Misc
 ~~~~

--- a/providers/src/airflow/providers/edge/CHANGELOG.rst
+++ b/providers/src/airflow/providers/edge/CHANGELOG.rst
@@ -31,6 +31,7 @@ Changelog
 .........
 
 * ``Make API retries configurable via ENV. Connection loss is sustained for 5min by default.``
+* ``Align retry handling logic and tooling with Task SDK.``
 
 Misc
 ~~~~

--- a/providers/src/airflow/providers/edge/CHANGELOG.rst
+++ b/providers/src/airflow/providers/edge/CHANGELOG.rst
@@ -27,6 +27,14 @@
 Changelog
 ---------
 
+0.9.7pre0
+.........
+
+* ``Make API retries configurable via ENV. Connection loss is sustained for 5min by default.``
+
+Misc
+~~~~
+
 0.9.6pre0
 .........
 

--- a/providers/src/airflow/providers/edge/__init__.py
+++ b/providers/src/airflow/providers/edge/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "0.9.6pre0"
+__version__ = "0.9.7pre0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.10.0"

--- a/providers/src/airflow/providers/edge/cli/api_client.py
+++ b/providers/src/airflow/providers/edge/cli/api_client.py
@@ -26,9 +26,8 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import quote, urljoin
 
 import requests
-import tenacity
-from requests.exceptions import ConnectionError
-from urllib3.exceptions import NewConnectionError
+from retryhttp import retry, wait_retry_after
+from tenacity import before_log, wait_random_exponential
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
@@ -50,36 +49,28 @@ logger = logging.getLogger(__name__)
 
 # Hidden config options for Edge Worker how retries on HTTP requests should be handled
 # Note: Given defaults make attempts after 1, 3, 7, 15, 31seconds, 1:03, 2:07, 3:37 and fails after 5:07min
-AIRFLOW__EDGE__API_RETRIES = int(os.getenv("AIRFLOW__EDGE__API_RETRIES", 10))
-AIRFLOW__EDGE__API_RETRY_WAIT_MIN = int(os.getenv("AIRFLOW__EDGE__API_RETRY_WAIT_MIN", 1))
-AIRFLOW__EDGE__API_RETRY_WAIT_MAX = int(os.getenv("AIRFLOW__EDGE__API_RETRY_WAIT_MAX", 90))
+# So far there is no other config facility in Task SDK we use ENV for the moment
+# TODO: Consider these env variables jointly in task sdk together with task_sdk/src/airflow/sdk/api/client.py
+API_RETRIES = int(os.getenv("AIRFLOW__EDGE__API_RETRIES", os.getenv("AIRFLOW__WORKERS__API_RETRIES", 10)))
+API_RETRY_WAIT_MIN = float(
+    os.getenv("AIRFLOW__EDGE__API_RETRY_WAIT_MIN", os.getenv("AIRFLOW__WORKERS__API_RETRY_WAIT_MIN", 1.0))
+)
+API_RETRY_WAIT_MAX = float(
+    os.getenv("AIRFLOW__EDGE__API_RETRY_WAIT_MAX", os.getenv("AIRFLOW__WORKERS__API_RETRY_WAIT_MAX", 90.0))
+)
 
 
-def _is_retryable_exception(exception: BaseException) -> bool:
-    """
-    Evaluate which exception types to retry.
-
-    This is especially demanded for cases where an application gateway or Kubernetes ingress can
-    not find a running instance of a webserver hosting the API (HTTP 502+504) or when the
-    HTTP request fails in general on network level.
-
-    Note that we want to fail on other general errors on the webserver not to send bad requests in an endless loop.
-    """
-    retryable_status_codes = (HTTPStatus.BAD_GATEWAY, HTTPStatus.GATEWAY_TIMEOUT)
-    return (
-        isinstance(exception, AirflowException)
-        and exception.status_code in retryable_status_codes
-        or isinstance(exception, (ConnectionError, NewConnectionError))
-    )
+_default_wait = wait_random_exponential(min=API_RETRY_WAIT_MIN, max=API_RETRY_WAIT_MAX)
 
 
-@tenacity.retry(
-    stop=tenacity.stop_after_attempt(AIRFLOW__EDGE__API_RETRIES),
-    wait=tenacity.wait_exponential(
-        min=AIRFLOW__EDGE__API_RETRY_WAIT_MIN, max=AIRFLOW__EDGE__API_RETRY_WAIT_MAX
-    ),
-    retry=tenacity.retry_if_exception(_is_retryable_exception),
-    before_sleep=tenacity.before_log(logger, logging.WARNING),
+@retry(
+    reraise=True,
+    max_attempt_number=API_RETRIES,
+    wait_server_errors=_default_wait,
+    wait_network_errors=_default_wait,
+    wait_timeouts=_default_wait,
+    wait_rate_limited=wait_retry_after(fallback=_default_wait),  # No infinite timeout on HTTP 429
+    before_sleep=before_log(logger, logging.WARNING),
 )
 def _make_generic_request(method: str, rest_path: str, data: str | None = None) -> Any:
     signer = jwt_signer()

--- a/providers/src/airflow/providers/edge/cli/api_client.py
+++ b/providers/src/airflow/providers/edge/cli/api_client.py
@@ -30,7 +30,6 @@ from retryhttp import retry, wait_retry_after
 from tenacity import before_log, wait_random_exponential
 
 from airflow.configuration import conf
-from airflow.exceptions import AirflowException
 from airflow.providers.edge.worker_api.auth import jwt_signer
 from airflow.providers.edge.worker_api.datamodels import (
     EdgeJobFetched,
@@ -82,14 +81,9 @@ def _make_generic_request(method: str, rest_path: str, data: str | None = None) 
     }
     api_endpoint = urljoin(api_url, rest_path)
     response = requests.request(method, url=api_endpoint, data=data, headers=headers)
+    response.raise_for_status()
     if response.status_code == HTTPStatus.NO_CONTENT:
         return None
-    if response.status_code != HTTPStatus.OK:
-        raise AirflowException(
-            f"Got {response.status_code}:{response.reason} when sending "
-            f"the internal api request: {response.text}",
-            HTTPStatus(response.status_code),
-        )
     return json.loads(response.content)
 
 

--- a/providers/src/airflow/providers/edge/provider.yaml
+++ b/providers/src/airflow/providers/edge/provider.yaml
@@ -32,6 +32,7 @@ versions:
 dependencies:
   - apache-airflow>=2.10.0
   - pydantic>=2.10.2
+  - retryhttp>=1.2.0
 
 plugins:
   - name: edge_executor

--- a/providers/src/airflow/providers/edge/provider.yaml
+++ b/providers/src/airflow/providers/edge/provider.yaml
@@ -27,7 +27,7 @@ source-date-epoch: 1729683247
 
 # note that those versions are maintained by release manager - do not update them manually
 versions:
-  - 0.9.6pre0
+  - 0.9.7pre0
 
 dependencies:
   - apache-airflow>=2.10.0

--- a/providers/tests/edge/cli/test_api_client.py
+++ b/providers/tests/edge/cli/test_api_client.py
@@ -1,0 +1,88 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from http import HTTPStatus
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from requests import HTTPError
+from requests.exceptions import ConnectTimeout
+from requests_mock import ANY
+
+from airflow.providers.edge.cli.api_client import _make_generic_request
+
+from tests_common.test_utils.config import conf_vars
+
+if TYPE_CHECKING:
+    from requests_mock import Mocker as RequestsMocker
+
+MOCK_ENDPOINT = "https://invalid-api-test-endpoint"
+
+
+class TestApiClient:
+    @conf_vars({("edge", "api_url"): MOCK_ENDPOINT})
+    def test_make_generic_request_success(self, requests_mock: RequestsMocker):
+        requests_mock.get(
+            ANY,
+            [
+                {"json": {"test": "ok"}},
+                {"status_code": HTTPStatus.NO_CONTENT},
+            ],
+        )
+
+        result1 = _make_generic_request("GET", f"{MOCK_ENDPOINT}/dummy_service", "test")
+        result2 = _make_generic_request("GET", f"{MOCK_ENDPOINT}/service_no_content", "test")
+
+        assert result1 == {"test": "ok"}
+        assert result2 is None
+        assert requests_mock.call_count == 2
+
+    @patch("time.sleep", return_value=None)
+    @conf_vars({("edge", "api_url"): MOCK_ENDPOINT})
+    def test_make_generic_request_retry(self, mock_sleep, requests_mock: RequestsMocker):
+        requests_mock.get(
+            ANY,
+            [
+                *[{"status_code": HTTPStatus.SERVICE_UNAVAILABLE}] * 3,
+                {"exc": ConnectTimeout},
+                {"json": {"test": 42}},
+            ],
+        )
+
+        result = _make_generic_request("GET", f"{MOCK_ENDPOINT}/flaky_service", "test")
+
+        assert result == {"test": 42}
+        assert requests_mock.call_count == 5
+
+    @patch("time.sleep", return_value=None)
+    @conf_vars({("edge", "api_url"): MOCK_ENDPOINT})
+    def test_make_generic_request_unrecoverable_error(self, mock_sleep, requests_mock: RequestsMocker):
+        requests_mock.get(
+            ANY,
+            [
+                *[{"status_code": HTTPStatus.INTERNAL_SERVER_ERROR}] * 11,
+                {"json": {"test": "uups"}},
+            ],
+        )
+
+        with pytest.raises(HTTPError) as err:
+            _make_generic_request("GET", f"{MOCK_ENDPOINT}/broken_service", "test")
+
+        assert err.value.response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+        assert requests_mock.call_count == 10

--- a/providers/tests/edge/cli/test_edge_command.py
+++ b/providers/tests/edge/cli/test_edge_command.py
@@ -25,7 +25,7 @@ from unittest.mock import call, patch
 
 import pytest
 import time_machine
-from requests import HTTPError
+from requests import HTTPError, Response
 
 from airflow.providers.edge.cli.edge_command import _EdgeWorkerCli, _Job, _write_pid_to_pidfile
 from airflow.providers.edge.models.edge_worker import EdgeWorkerState, EdgeWorkerVersionException
@@ -282,22 +282,20 @@ class TestEdgeWorkerCli:
 
     @patch("airflow.providers.edge.cli.edge_command.worker_register")
     def test_start_missing_apiserver(self, mock_register_worker, worker_with_job: _EdgeWorkerCli):
-        class MockResponse:
-            status_code = 404
-
+        mock_response = Response()
+        mock_response.status_code = 404
         mock_register_worker.side_effect = HTTPError(
-            "Something with 404:NOT FOUND means API is not active", response=MockResponse()
+            "Something with 404:NOT FOUND means API is not active", response=mock_response
         )
         with pytest.raises(SystemExit, match=r"API endpoint is not ready"):
             worker_with_job.start()
 
     @patch("airflow.providers.edge.cli.edge_command.worker_register")
     def test_start_server_error(self, mock_register_worker, worker_with_job: _EdgeWorkerCli):
-        class MockResponse:
-            status_code = 500
-
+        mock_response = Response()
+        mock_response.status_code = 500
         mock_register_worker.side_effect = HTTPError(
-            "Something other error not FourhundretFour", response=MockResponse()
+            "Something other error not FourhundretFour", response=mock_response
         )
         with pytest.raises(SystemExit, match=r"Something other"):
             worker_with_job.start()


### PR DESCRIPTION
In https://github.com/apache/airflow/pull/44311#discussion_r1862825630 @kaxil, @potiuk and me had a bit of discussion. As promised to come back with this, this PR implements (as promised) a way to make the retries in Edge worker configurable.

But it is also opening the box of debates because:

- Do we want to add a new config? (Some people start screaming?)
    - (My position: Sensible default and make it configurable)
- Should we really retry 10 times?
    - (My position: 10 attempts was the former default in internal API, in a small prod outage I can say at least this is good such that tasks do not fail in small webserver outages or connection interrupts. We see daily flakiness on our WAN. As Zombie threshold is at 300s per default retrying more than 5min might not be needed. But also we should faster on small glitches... so the exponential back-off is good. I tested with the parameters below and I think for waiting 5min max it is reasonable to test 10 times in between before fail.
- Oh, why specific in Edge? (I saw multiple occasions in retries in different places in the repo. But also moving to TaskSDK I think we also should consider making this more common - at least Edge API retries from far away should be matching to the calls that are made to TaskSDK!)
    - (My position: I'd favor to make such setting common in Edge API and at least TaskSDK calls)

@ashb would also call for your opinion.

And if needed - but I assume it can be made within this PR - we could also call for an open [DISCUSS] or loop-in other stakeholders. Le me know.

UPDATE 28.12.2024: Updated after merge of https://github.com/apache/airflow/pull/45121