### PR TITLE
fix test_long_stalled_task_is_killed_by_listener_overtime_if_ol_timeout_long_enough

### DIFF
--- a/providers/tests/openlineage/plugins/test_execution.py
+++ b/providers/tests/openlineage/plugins/test_execution.py
@@ -167,7 +167,6 @@ with tempfile.TemporaryDirectory(prefix="venv") as tmp_dir:
             assert has_value_in_events(events, ["inputs", "name"], "on-start")
             assert not has_value_in_events(events, ["inputs", "name"], "on-complete")
 
-        @pytest.mark.quarantined
         @conf_vars(
             {
                 ("openlineage", "transport"): f'{{"type": "file", "log_file_path": "{listener_path}"}}',
@@ -176,7 +175,9 @@ with tempfile.TemporaryDirectory(prefix="venv") as tmp_dir:
             }
         )
         @pytest.mark.db_test
-        def test_long_stalled_task_is_killed_by_listener_overtime_if_ol_timeout_long_enough(self):
+        def test_success_overtime_kills_tasks(self):
+            # This test checks whether LocalTaskJobRunner kills OL listener which take
+            # longer time than permitted by core.task_success_overtime setting
             dirpath = Path(tmp_dir)
             if dirpath.exists():
                 shutil.rmtree(dirpath)
@@ -203,7 +204,7 @@ with tempfile.TemporaryDirectory(prefix="venv") as tmp_dir:
                 task=task,
                 run_id="test_long_stalled_task_is_killed_by_listener_overtime_if_ol_timeout_long_enough",
             )
-            job = Job(id="1", dag_id=ti.dag_id)
+            job = Job(dag_id=ti.dag_id)
             job_runner = LocalTaskJobRunner(job=job, task_instance=ti, ignore_ti_state=True)
             job_runner._execute()
 


### PR DESCRIPTION
...and rename it to `test_success_overtime_kills_tasks`.

It was failing because heartbeat was failing due to primary key duplication:

```
WARNING  airflow.jobs.local_task_job_runner.LocalTaskJobRunner:local_task_job_runner.py:215 Heartbeat failed with Exception: (psycopg2.errors.UniqueViolation) duplicate key value violates unique constraint "job_pkey"
DETAIL:  Key (id)=(1) already exists.

[SQL: INSERT INTO job (id, dag_id, state, job_type, start_date, end_date, latest_heartbeat, executor_class, hostname, unixname) VALUES (%(id)s, %(dag_id)s, %(state)s, %(job_type)s, %(start_date)s, %(end_date)s, %(latest_heartbeat)s, %(executor_class)s, %(hostname)s, %(unixname)s)]
[parameters: ({'id': '1', 'dag_id': 'test_openlineage_execution', 'state': None, 'job_type': 'LocalTaskJob', 'start_date': datetime.datetime(2024, 12, 1, 15, 43, 57, 356380, tzinfo=Timezone('UTC')), 'end_date': None, 'latest_heartbeat': datetime.datetime(2024, 12, 1, 15, 44, 2, 585608, tzinfo=Timezone('UTC')), 'executor_class': None, 'hostname': '3b984b754931', 'unixname': 'root'}, {'id': '1', 'dag_id': 'test_openlineage_execution', 'state': None, 'job_type': 'LocalTaskJob', 'start_date': datetime.datetime(2024, 12, 1, 15, 43, 57, 356380, tzinfo=Timezone('UTC')), 'end_date': None, 'latest_heartbeat': datetime.datetime(2024, 12, 1, 15, 44, 2, 585608, tzinfo=Timezone('UTC')), 'executor_class': None, 'hostname': '3b984b754931', 'unixname': 'root'})]
(Background on this error at: https://sqlalche.me/e/14/gkpj)
```

Removing id when passing job fixes that issue. 