### PR TITLE
Remove Provider Deprecations in SSH

### DIFF
--- a/providers/src/airflow/providers/ssh/CHANGELOG.rst
+++ b/providers/src/airflow/providers/ssh/CHANGELOG.rst
@@ -27,6 +27,26 @@
 Changelog
 ---------
 
+4.0.0
+......
+
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+.. warning::
+  All deprecated classes, parameters and features have been removed from the SSH provider package.
+  The following breaking changes were introduced:
+
+  * Hooks
+     * Remove attribute ``timeout`` from ``airflow.providers.ssh.hooks.ssh.SSHHook``. Use parameter ``conn_timeout`` instead.
+     * The contextmanager of ``SSHHook`` is deprecated. Please use ``get_conn()`` as a contextmanager instead.
+     * ``SSHHook.create_tunnel()`` is deprecated, Please use ``get_tunnel()`` instead.
+       But please note that the order of the parameters have changed.
+  * operators
+     * The deprecated ``get_hook()`` method is removed in ``airflow.providers.ssh.operators.ssh.SSHOperator``. Please use ``hook`` attribute instead.
+     * Deprecated ``exec_ssh_client_command()`` method on SSHOperator is removed, call ``ssh_hook.exec_ssh_client_command()`` instead
+
 3.14.0
 ......
 

--- a/providers/src/airflow/providers/ssh/CHANGELOG.rst
+++ b/providers/src/airflow/providers/ssh/CHANGELOG.rst
@@ -40,7 +40,7 @@ Breaking changes
 
   * Hooks
      * Remove attribute ``timeout`` from ``airflow.providers.ssh.hooks.ssh.SSHHook``. Use parameter ``conn_timeout`` instead.
-     * The contextmanager of ``SSHHook`` is deprecated. Please use ``get_conn()`` as a contextmanager instead.
+     * The context manager of ``SSHHook`` is deprecated. Please use ``get_conn()`` as a context manager instead.
      * ``SSHHook.create_tunnel()`` is deprecated, Please use ``get_tunnel()`` instead.
        But please note that the order of the parameters have changed.
   * operators

--- a/providers/src/airflow/providers/ssh/hooks/ssh.py
+++ b/providers/src/airflow/providers/ssh/hooks/ssh.py
@@ -20,7 +20,6 @@
 from __future__ import annotations
 
 import os
-import warnings
 from base64 import decodebytes
 from collections.abc import Sequence
 from functools import cached_property
@@ -29,12 +28,11 @@ from select import select
 from typing import Any
 
 import paramiko
-from deprecated import deprecated
 from paramiko.config import SSH_PORT
 from sshtunnel import SSHTunnelForwarder
 from tenacity import Retrying, stop_after_attempt, wait_fixed, wait_random
 
-from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 from airflow.utils.platform import getuser
 from airflow.utils.types import NOTSET, ArgNotSet
@@ -63,8 +61,6 @@ class SSHHook(BaseHook):
     :param conn_timeout: timeout (in seconds) for the attempt to connect to the remote_host.
         The default is 10 seconds. If provided, it will replace the `conn_timeout` which was
         predefined in the connection of `ssh_conn_id`.
-    :param timeout: (Deprecated). timeout for the attempt to connect to the remote_host.
-        Use conn_timeout instead.
     :param cmd_timeout: timeout (in seconds) for executing the command. The default is 10 seconds.
         Nullable, `None` means no timeout. If provided, it will replace the `cmd_timeout`
         which was predefined in the connection of `ssh_conn_id`.
@@ -116,7 +112,6 @@ class SSHHook(BaseHook):
         password: str | None = None,
         key_file: str | None = None,
         port: int | None = None,
-        timeout: int | None = None,
         conn_timeout: int | None = None,
         cmd_timeout: int | ArgNotSet | None = NOTSET,
         keepalive_interval: int = 30,
@@ -133,7 +128,6 @@ class SSHHook(BaseHook):
         self.key_file = key_file
         self.pkey = None
         self.port = port
-        self.timeout = timeout
         self.conn_timeout = conn_timeout
         self.cmd_timeout = cmd_timeout
         self.keepalive_interval = keepalive_interval
@@ -150,7 +144,7 @@ class SSHHook(BaseHook):
         self.host_key = None
         self.look_for_keys = True
 
-        # Placeholder for deprecated __enter__
+        # Placeholder for future cached connection
         self.client: paramiko.SSHClient | None = None
 
         # Use connection to override defaults
@@ -174,16 +168,6 @@ class SSHHook(BaseHook):
                 private_key_passphrase = extra_options.get("private_key_passphrase")
                 if private_key:
                     self.pkey = self._pkey_from_private_key(private_key, passphrase=private_key_passphrase)
-
-                if "timeout" in extra_options:
-                    warnings.warn(
-                        "Extra option `timeout` is deprecated."
-                        "Please use `conn_timeout` instead."
-                        "The old option `timeout` will be removed in a future version.",
-                        category=AirflowProviderDeprecationWarning,
-                        stacklevel=2,
-                    )
-                    self.timeout = int(extra_options["timeout"])
 
                 if "conn_timeout" in extra_options and self.conn_timeout is None:
                     self.conn_timeout = int(extra_options["conn_timeout"])
@@ -234,18 +218,6 @@ class SSHHook(BaseHook):
                     decoded_host_key = decodebytes(host_key.encode("utf-8"))
                     self.host_key = key_constructor(data=decoded_host_key)
                     self.no_host_key_check = False
-
-        if self.timeout:
-            warnings.warn(
-                "Parameter `timeout` is deprecated."
-                "Please use `conn_timeout` instead."
-                "The old option `timeout` will be removed in a future version.",
-                category=AirflowProviderDeprecationWarning,
-                stacklevel=2,
-            )
-
-        if self.conn_timeout is None:
-            self.conn_timeout = self.timeout if self.timeout else TIMEOUT_DEFAULT
 
         if self.cmd_timeout is NOTSET:
             self.cmd_timeout = CMD_TIMEOUT
@@ -379,24 +351,6 @@ class SSHHook(BaseHook):
         self.client = client
         return client
 
-    @deprecated(
-        reason=(
-            "The contextmanager of SSHHook is deprecated."
-            "Please use get_conn() as a contextmanager instead."
-            "This method will be removed in Airflow 2.0"
-        ),
-        category=AirflowProviderDeprecationWarning,
-    )
-    def __enter__(self) -> SSHHook:
-        """Return an instance of SSHHook when the `with` statement is used."""
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
-        """Clear ssh client after exiting the `with` statement block."""
-        if self.client is not None:
-            self.client.close()
-            self.client = None
-
     def get_tunnel(
         self, remote_port: int, remote_host: str = "localhost", local_port: int | None = None
     ) -> SSHTunnelForwarder:
@@ -439,27 +393,6 @@ class SSHHook(BaseHook):
         client = SSHTunnelForwarder(self.remote_host, **tunnel_kwargs)
 
         return client
-
-    @deprecated(
-        reason=(
-            "SSHHook.create_tunnel is deprecated, Please "
-            "use get_tunnel() instead. But please note that the "
-            "order of the parameters have changed. "
-            "This method will be removed in Airflow 2.0"
-        ),
-        category=AirflowProviderDeprecationWarning,
-    )
-    def create_tunnel(
-        self, local_port: int, remote_port: int, remote_host: str = "localhost"
-    ) -> SSHTunnelForwarder:
-        """
-        Create a tunnel for SSH connection [Deprecated].
-
-        :param local_port: local port number
-        :param remote_port: remote port number
-        :param remote_host: remote host
-        """
-        return self.get_tunnel(remote_port, remote_host, local_port)
 
     def _pkey_from_private_key(self, private_key: str, passphrase: str | None = None) -> paramiko.PKey:
         """

--- a/providers/src/airflow/providers/ssh/operators/ssh.py
+++ b/providers/src/airflow/providers/ssh/operators/ssh.py
@@ -22,10 +22,8 @@ from collections.abc import Container, Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING
 
-from deprecated.classic import deprecated
-
 from airflow.configuration import conf
-from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning, AirflowSkipException
+from airflow.exceptions import AirflowException, AirflowSkipException
 from airflow.models import BaseOperator
 from airflow.providers.ssh.hooks.ssh import SSHHook
 from airflow.utils.types import NOTSET, ArgNotSet
@@ -143,25 +141,9 @@ class SSHOperator(BaseOperator):
     def hook(self) -> SSHHook:
         return self.ssh_hook
 
-    @deprecated(reason="use `hook` property instead.", category=AirflowProviderDeprecationWarning)
-    def get_hook(self) -> SSHHook:
-        return self.ssh_hook
-
     def get_ssh_client(self) -> SSHClient:
         # Remember to use context manager or call .close() on this when done
         return self.hook.get_conn()
-
-    @deprecated(
-        reason=(
-            "exec_ssh_client_command method on SSHOperator is deprecated, call "
-            "`ssh_hook.exec_ssh_client_command` instead"
-        ),
-        category=AirflowProviderDeprecationWarning,
-    )
-    def exec_ssh_client_command(self, ssh_client: SSHClient, command: str) -> tuple[int, bytes, bytes]:
-        return self.hook.exec_ssh_client_command(
-            ssh_client, command, timeout=self.cmd_timeout, environment=self.environment, get_pty=self.get_pty
-        )
 
     def raise_for_status(self, exit_status: int, stderr: bytes, context=None) -> None:
         if context and self.do_xcom_push:

--- a/providers/tests/ssh/hooks/test_ssh.py
+++ b/providers/tests/ssh/hooks/test_ssh.py
@@ -28,7 +28,7 @@ import paramiko
 import pytest
 
 from airflow import settings
-from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.providers.ssh.hooks.ssh import SSHHook
 from airflow.utils import db
@@ -676,180 +676,6 @@ class TestSSHHook:
                 auth_timeout=10,
             )
 
-    @mock.patch("airflow.providers.ssh.hooks.ssh.paramiko.SSHClient")
-    def test_ssh_connection_with_conn_timeout_and_timeout(self, ssh_mock):
-        with pytest.warns(AirflowProviderDeprecationWarning, match=".*Please use `conn_timeout` instead..*"):
-            hook = SSHHook(
-                remote_host="remote_host",
-                port="port",
-                username="username",
-                password="password",
-                timeout=10,
-                conn_timeout=20,
-                key_file="fake.file",
-            )
-
-        with hook.get_conn():
-            ssh_mock.return_value.connect.assert_called_once_with(
-                banner_timeout=30.0,
-                hostname="remote_host",
-                username="username",
-                password="password",
-                key_filename="fake.file",
-                timeout=20,
-                compress=True,
-                port="port",
-                sock=None,
-                look_for_keys=True,
-                auth_timeout=None,
-            )
-
-    @mock.patch("airflow.providers.ssh.hooks.ssh.paramiko.SSHClient")
-    def test_ssh_connection_with_timeout_extra(self, ssh_mock):
-        with pytest.warns(AirflowProviderDeprecationWarning, match=".*Please use `conn_timeout` instead..*"):
-            hook = SSHHook(
-                ssh_conn_id=self.CONN_SSH_WITH_TIMEOUT_EXTRA,
-                remote_host="remote_host",
-                port="port",
-                username="username",
-                timeout=10,
-            )
-
-        with hook.get_conn():
-            ssh_mock.return_value.connect.assert_called_once_with(
-                banner_timeout=30.0,
-                hostname="remote_host",
-                username="username",
-                timeout=20,
-                compress=True,
-                port="port",
-                sock=None,
-                look_for_keys=True,
-                auth_timeout=None,
-            )
-
-    @mock.patch("airflow.providers.ssh.hooks.ssh.paramiko.SSHClient")
-    def test_ssh_connection_with_conn_timeout_extra(self, ssh_mock):
-        with pytest.warns(AirflowProviderDeprecationWarning, match=".*Please use `conn_timeout` instead..*"):
-            hook = SSHHook(
-                ssh_conn_id=self.CONN_SSH_WITH_CONN_TIMEOUT_EXTRA,
-                remote_host="remote_host",
-                port="port",
-                username="username",
-                timeout=10,
-                conn_timeout=15,
-            )
-
-        # conn_timeout parameter wins over extra options
-        with hook.get_conn():
-            ssh_mock.return_value.connect.assert_called_once_with(
-                banner_timeout=30.0,
-                hostname="remote_host",
-                username="username",
-                timeout=15,
-                compress=True,
-                port="port",
-                sock=None,
-                look_for_keys=True,
-                auth_timeout=None,
-            )
-
-    @mock.patch("airflow.providers.ssh.hooks.ssh.paramiko.SSHClient")
-    def test_ssh_connection_with_timeout_extra_and_conn_timeout_extra(self, ssh_mock):
-        with pytest.warns(AirflowProviderDeprecationWarning, match=".*Please use `conn_timeout` instead..*"):
-            hook = SSHHook(
-                ssh_conn_id=self.CONN_SSH_WITH_TIMEOUT_AND_CONN_TIMEOUT_EXTRA,
-                remote_host="remote_host",
-                port="port",
-                username="username",
-                timeout=10,
-                conn_timeout=15,
-            )
-
-        # conn_timeout parameter wins over extra options
-        with hook.get_conn():
-            ssh_mock.return_value.connect.assert_called_once_with(
-                banner_timeout=30.0,
-                hostname="remote_host",
-                username="username",
-                timeout=15,
-                compress=True,
-                port="port",
-                sock=None,
-                look_for_keys=True,
-                auth_timeout=None,
-            )
-
-    @pytest.mark.parametrize(
-        "timeout, conn_timeout, timeoutextra, conn_timeoutextra, expected_value",
-        [
-            (TEST_TIMEOUT, TEST_CONN_TIMEOUT, True, True, TEST_CONN_TIMEOUT),
-            (TEST_TIMEOUT, TEST_CONN_TIMEOUT, True, False, TEST_CONN_TIMEOUT),
-            (TEST_TIMEOUT, TEST_CONN_TIMEOUT, False, True, TEST_CONN_TIMEOUT),
-            (TEST_TIMEOUT, TEST_CONN_TIMEOUT, False, False, TEST_CONN_TIMEOUT),
-            (TEST_TIMEOUT, None, True, True, TEST_CONN_TIMEOUT),
-            (TEST_TIMEOUT, None, True, False, TEST_TIMEOUT),
-            (TEST_TIMEOUT, None, False, True, TEST_CONN_TIMEOUT),
-            (TEST_TIMEOUT, None, False, False, TEST_TIMEOUT),
-            (None, TEST_CONN_TIMEOUT, True, True, TEST_CONN_TIMEOUT),
-            (None, TEST_CONN_TIMEOUT, True, False, TEST_CONN_TIMEOUT),
-            (None, TEST_CONN_TIMEOUT, False, True, TEST_CONN_TIMEOUT),
-            (None, TEST_CONN_TIMEOUT, False, False, TEST_CONN_TIMEOUT),
-            (None, None, True, True, TEST_CONN_TIMEOUT),
-            (None, None, True, False, TEST_TIMEOUT),
-            (None, None, False, True, TEST_CONN_TIMEOUT),
-            (None, None, False, False, 10),
-        ],
-    )
-    @mock.patch("airflow.providers.ssh.hooks.ssh.paramiko.SSHClient")
-    def test_ssh_connection_with_all_timeout_param_and_extra_combinations(
-        self, ssh_mock, timeout, conn_timeout, timeoutextra, conn_timeoutextra, expected_value
-    ):
-        if timeoutextra and conn_timeoutextra:
-            ssh_conn_id = self.CONN_SSH_WITH_TIMEOUT_AND_CONN_TIMEOUT_EXTRA
-        elif timeoutextra and not conn_timeoutextra:
-            ssh_conn_id = self.CONN_SSH_WITH_TIMEOUT_EXTRA
-        elif not timeoutextra and conn_timeoutextra:
-            ssh_conn_id = self.CONN_SSH_WITH_CONN_TIMEOUT_EXTRA
-        else:
-            ssh_conn_id = self.CONN_SSH_WITH_NO_EXTRA
-
-        if timeout or timeoutextra:
-            with pytest.warns(
-                AirflowProviderDeprecationWarning, match=".*Please use `conn_timeout` instead..*"
-            ):
-                hook = SSHHook(
-                    ssh_conn_id=ssh_conn_id,
-                    remote_host="remote_host",
-                    port="port",
-                    username="username",
-                    timeout=timeout,
-                    conn_timeout=conn_timeout,
-                )
-        else:
-            hook = SSHHook(
-                ssh_conn_id=ssh_conn_id,
-                remote_host="remote_host",
-                port="port",
-                username="username",
-                timeout=timeout,
-                conn_timeout=conn_timeout,
-            )
-
-        # conn_timeout parameter wins over extra options
-        with hook.get_conn():
-            ssh_mock.return_value.connect.assert_called_once_with(
-                banner_timeout=30.0,
-                hostname="remote_host",
-                username="username",
-                timeout=expected_value,
-                compress=True,
-                port="port",
-                sock=None,
-                look_for_keys=True,
-                auth_timeout=None,
-            )
-
     @pytest.mark.parametrize(
         "cmd_timeout, cmd_timeoutextra, null_cmd_timeoutextra, expected_value",
         [
@@ -899,6 +725,7 @@ class TestSSHHook:
             remote_host="remote_host",
             port="port",
             username="username",
+            conn_timeout=42,
         )
 
         with hook.get_conn():
@@ -907,7 +734,7 @@ class TestSSHHook:
                 hostname="remote_host",
                 username="username",
                 compress=True,
-                timeout=10,
+                timeout=42,
                 port="port",
                 sock=None,
                 look_for_keys=True,


### PR DESCRIPTION
In Airflow 3 Dev Call we discussed and made a LAZY CONSENSUS to remove all deprecation's in providers prior 2.11 release in https://lists.apache.org/thread/lhy7zhz8yxo3jjpln0ds8ogszgb9b469.

This PR is the first for the provider **SSH**
