### PR TITLE
Revert Edge Datamodelling for Pydantic problems in Py3.9

### DIFF
--- a/providers/src/airflow/providers/edge/worker_api/datamodels.py
+++ b/providers/src/airflow/providers/edge/worker_api/datamodels.py
@@ -17,9 +17,13 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import (
+from typing import (  # noqa: UP035 - Pydantic not able to parse in Python 3.9
     Annotated,
     Any,
+    Dict,
+    List,
+    Optional,
+    Union,
 )
 
 from pydantic import BaseModel, Field
@@ -57,7 +61,7 @@ class JsonRpcRequest(JsonRpcRequestBase):
 
     jsonrpc: Annotated[str, Field(description="JSON RPC Version", examples=["2.0"])]
     params: Annotated[
-        dict[str, Any] | None,
+        Optional[Dict[str, Any]],  # noqa: UP006, UP007 - Pydantic not able to parse in Python 3.9
         Field(description="Dictionary of parameters passed to the method."),
     ]
 
@@ -99,7 +103,7 @@ class WorkerQueuesBase(BaseModel):
     """Queues that a worker supports to run jobs on."""
 
     queues: Annotated[
-        list[str] | None,
+        Optional[List[str]],  # noqa: UP006, UP007 - Pydantic not able to parse in Python 3.9
         Field(
             None,
             description="List of queues the worker is pulling jobs from. If not provided, worker pulls from all queues.",
@@ -119,13 +123,13 @@ class WorkerStateBody(WorkerQueuesBase):
     state: Annotated[EdgeWorkerState, Field(description="State of the worker from the view of the worker.")]
     jobs_active: Annotated[int, Field(description="Number of active jobs the worker is running.")] = 0
     queues: Annotated[
-        list[str] | None,
+        Optional[List[str]],  # noqa: UP006, UP007 - Pydantic not able to parse in Python 3.9
         Field(
             description="List of queues the worker is pulling jobs from. If not provided, worker pulls from all queues."
         ),
     ] = None
     sysinfo: Annotated[
-        dict[str, str | int],
+        dict[str, Union[str, int]],  # noqa: UP007 - Pydantic not able to parse in Python 3.9
         Field(
             description="System information of the worker.",
             examples=[
@@ -144,11 +148,11 @@ class WorkerQueueUpdateBody(BaseModel):
     """Changed queues for the worker."""
 
     new_queues: Annotated[
-        list[str] | None,
+        Optional[List[str]],  # noqa: UP006, UP007 - Pydantic not able to parse in Python 3.9
         Field(description="Additional queues to be added to worker."),
     ]
     remove_queues: Annotated[
-        list[str] | None,
+        Optional[List[str]],  # noqa: UP006, UP007 - Pydantic not able to parse in Python 3.9
         Field(description="Queues to remove from worker."),
     ]
 


### PR DESCRIPTION
Fixes broken tests on main for back-compat, e.g. in https://github.com/apache/airflow/actions/runs/12105919009/job/33751221753

Somehow in Python 3.9 even with the fixes applied from Pydantic 2.10.3 some constructs still have parsing problems in Python 3.9. This was merged previously in https://github.com/apache/airflow/pull/44433/files#diff-88d01fd8e9c200de55dff8065993cdbdac3ff23cfcc2d4d01b0680a0a2f53f6dR60

FYI @kaxil 