### PR TITLE
Deferrable HttpSensor does not move to Triggerer when using response_check

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -456,6 +456,10 @@ class TaskDeferralTimeout(AirflowException):
     """Raise when there is a timeout on the deferral."""
 
 
+class ResponseCheckFailedException(AirflowException):
+    """Raise when response check failed."""
+
+
 # The try/except handling is needed after we moved all k8s classes to cncf.kubernetes provider
 # These two exceptions are used internally by Kubernetes Executor but also by PodGenerator, so we need
 # to leave them here in case older version of cncf.kubernetes provider is used to run KubernetesPodOperator

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -457,7 +457,7 @@ class TaskDeferralTimeout(AirflowException):
 
 
 class ResponseCheckFailedException(AirflowException):
-    """Raise when response check failed."""
+    """Raise when response check condition is not met."""
 
 
 # The try/except handling is needed after we moved all k8s classes to cncf.kubernetes provider

--- a/providers/src/airflow/providers/http/sensors/http.py
+++ b/providers/src/airflow/providers/http/sensors/http.py
@@ -18,11 +18,11 @@
 from __future__ import annotations
 
 import base64
-import pickle
 from collections.abc import Sequence
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Callable
 
+import cloudpickle
 from requests import Response
 
 from airflow.configuration import conf
@@ -177,8 +177,6 @@ class HttpSensor(BaseSensorOperator):
                     method=self.method,
                     extra_options=self.extra_options,
                     poke_interval=self.poke_interval,
-                    response_check=self.response_check,
-                    context=context,
                 ),
                 method_name="execute_complete",
             )
@@ -214,7 +212,7 @@ class HttpSensor(BaseSensorOperator):
         if event["status"] == "success":
             response = event["response"]
             if self.response_check:
-                retrieved_data = pickle.loads(base64.standard_b64decode(response))
+                retrieved_data = cloudpickle.loads(base64.standard_b64decode(response))
                 if self.process_response(context=context, response=retrieved_data):
                     self.log.info("response_check condition is matched for %s", self.task_id)
                 else:

--- a/providers/src/airflow/providers/http/sensors/http.py
+++ b/providers/src/airflow/providers/http/sensors/http.py
@@ -205,7 +205,7 @@ class HttpSensor(BaseSensorOperator):
         if self.response_check:
             kwargs = determine_kwargs(self.response_check, [response], context)
             if not self.response_check(response, **kwargs):
-                raise AirflowException("Response check returned False.")
+                raise ResponseCheckFailedException("Response check returned False.")
         return make_default_response()
 
     def execute_complete(self, context: Context, event: dict[str, Any]) -> None:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Closes: https://github.com/apache/airflow/issues/40209

DAG Code:
<img width="691" alt="image" src="https://github.com/user-attachments/assets/0e1091f1-55b9-4289-b000-e2110a5cb2c9">

Task going to Deferrable mode:
<img width="1483" alt="image" src="https://github.com/user-attachments/assets/89c8bd8e-286a-4033-bda2-e33be64cae1d">

Output of the task:
<img width="1486" alt="image" src="https://github.com/user-attachments/assets/75919a53-11bf-4099-b173-60ed8ad65daa">


<!-- Please keep an empty line above the dashes. -->
---

