### PR TITLE
Removed deprecated code from Alibaba provider package

### DIFF
--- a/providers/src/airflow/providers/alibaba/CHANGELOG.rst
+++ b/providers/src/airflow/providers/alibaba/CHANGELOG.rst
@@ -26,6 +26,20 @@
 Changelog
 ---------
 
+
+
+.. warning::
+   All deprecated classes, parameters and features have been removed from the alibaba provider package.
+   The following breaking changes were introduced:
+
+   * Operators
+      * Remove ``get_hook`` method from  ``AnalyticDBSparkBaseOperator``. Use ``self.hook`` instead.
+
+   * sensors
+      * Remove ``get_hook`` method from ``AnalyticDBSparkSensor``. Use ``self.hook`` instead.
+
+
+
 2.9.1
 .....
 

--- a/providers/src/airflow/providers/alibaba/cloud/operators/analyticdb_spark.py
+++ b/providers/src/airflow/providers/alibaba/cloud/operators/analyticdb_spark.py
@@ -22,8 +22,6 @@ from collections.abc import Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
-from deprecated.classic import deprecated
-
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.models import BaseOperator
 from airflow.providers.alibaba.cloud.hooks.analyticdb_spark import AnalyticDBSparkHook, AppState
@@ -55,11 +53,6 @@ class AnalyticDBSparkBaseOperator(BaseOperator):
     def hook(self) -> AnalyticDBSparkHook:
         """Get valid hook."""
         return AnalyticDBSparkHook(adb_spark_conn_id=self._adb_spark_conn_id, region=self._region)
-
-    @deprecated(reason="use `hook` property instead.", category=AirflowProviderDeprecationWarning)
-    def get_hook(self) -> AnalyticDBSparkHook:
-        """Get valid hook."""
-        return self.hook
 
     def execute(self, context: Context) -> Any: ...
 

--- a/providers/src/airflow/providers/alibaba/cloud/operators/analyticdb_spark.py
+++ b/providers/src/airflow/providers/alibaba/cloud/operators/analyticdb_spark.py
@@ -22,7 +22,7 @@ from collections.abc import Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
-from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.alibaba.cloud.hooks.analyticdb_spark import AnalyticDBSparkHook, AppState
 

--- a/providers/src/airflow/providers/alibaba/cloud/sensors/analyticdb_spark.py
+++ b/providers/src/airflow/providers/alibaba/cloud/sensors/analyticdb_spark.py
@@ -21,7 +21,6 @@ from collections.abc import Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
-from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.alibaba.cloud.hooks.analyticdb_spark import AnalyticDBSparkHook, AppState
 from airflow.sensors.base import BaseSensorOperator
 

--- a/providers/src/airflow/providers/alibaba/cloud/sensors/analyticdb_spark.py
+++ b/providers/src/airflow/providers/alibaba/cloud/sensors/analyticdb_spark.py
@@ -21,8 +21,6 @@ from collections.abc import Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
-from deprecated.classic import deprecated
-
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.alibaba.cloud.hooks.analyticdb_spark import AnalyticDBSparkHook, AppState
 from airflow.sensors.base import BaseSensorOperator
@@ -59,11 +57,6 @@ class AnalyticDBSparkSensor(BaseSensorOperator):
     def hook(self) -> AnalyticDBSparkHook:
         """Get valid hook."""
         return AnalyticDBSparkHook(adb_spark_conn_id=self._adb_spark_conn_id, region=self._region)
-
-    @deprecated(reason="use `hook` property instead.", category=AirflowProviderDeprecationWarning)
-    def get_hook(self) -> AnalyticDBSparkHook:
-        """Get valid hook."""
-        return self.hook
 
     def poke(self, context: Context) -> bool:
         app_id = self.app_id


### PR DESCRIPTION
Relates to: https://github.com/apache/airflow/issues/44559

Removed deprecated code from the Alibaba providers.

^ Add meaningful description above
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines) for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named {pr_number}.significant.rst or {issue_number}.significant.rst, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).

