### PR TITLE
AIP-72: Improve handling of `deferred` state in Supervisor

### DIFF
--- a/task_sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task_sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -168,13 +168,11 @@ def run(ti: RuntimeTaskInstance, log: Logger):
         next_method = defer.method_name
         timeout = defer.timeout
         msg = DeferTask(
-            state="deferred",
             classpath=classpath,
             trigger_kwargs=trigger_kwargs,
             next_method=next_method,
             trigger_timeout=timeout,
         )
-        global SUPERVISOR_COMMS
         SUPERVISOR_COMMS.send_request(msg=msg, log=log)
     except AirflowSkipException:
         ...


### PR DESCRIPTION
- Added `_terminal_state` in `WatchedSubprocess` to manage task final states like `deferred` directly.
- Updated `wait` method in `WatchedSubprocess` to finalize task states and call the API with the terminal states (success, failure, etc)
- Simplified the `final_state` property by removing unnecessary setter logic.
- Fixed a bug where `make_buffered_socket_reader` was using `memoryview` and `msg = decoder.validate_json(line)` expected bytes.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
