### PR TITLE
Add fallback during `[core] dag_bundle_storage_path` retrieval

### DIFF
--- a/airflow/dag_processing/bundles/base.py
+++ b/airflow/dag_processing/bundles/base.py
@@ -56,7 +56,7 @@ class BaseDagBundle(ABC):
 
         This is the root path, shared by various bundles. Each bundle should have its own subdirectory.
         """
-        if configured_location := conf.get("core", "dag_bundle_storage_path"):
+        if configured_location := conf.get("core", "dag_bundle_storage_path", fallback=None):
             return Path(configured_location)
         return Path(tempfile.gettempdir(), "airflow", "dag_bundles")
 

--- a/tests/dag_processing/test_dag_bundles.py
+++ b/tests/dag_processing/test_dag_bundles.py
@@ -23,6 +23,7 @@ from pathlib import Path
 import pytest
 from git import Repo
 
+from airflow.dag_processing.bundles.base import BaseDagBundle
 from airflow.dag_processing.bundles.git import GitDagBundle
 from airflow.dag_processing.bundles.local import LocalDagBundle
 from airflow.exceptions import AirflowException
@@ -39,6 +40,22 @@ def bundle_temp_dir(tmp_path):
 def test_default_dag_storage_path():
     with conf_vars({("core", "dag_bundle_storage_path"): ""}):
         bundle = LocalDagBundle(name="test", local_folder="/hello")
+        assert bundle._dag_bundle_root_storage_path == Path(tempfile.gettempdir(), "airflow", "dag_bundles")
+
+
+def test_dag_bundle_root_storage_path():
+    class BasicBundle(BaseDagBundle):
+        def refresh(self):
+            pass
+
+        def get_current_version(self):
+            pass
+
+        def path(self):
+            pass
+
+    with conf_vars({("core", "dag_bundle_storage_path"): None}):
+        bundle = BasicBundle(name="test")
         assert bundle._dag_bundle_root_storage_path == Path(tempfile.gettempdir(), "airflow", "dag_bundles")
 
 


### PR DESCRIPTION
Turns out a default of `None` doesn't actually work. And we want people to be able to use the default!