### PR TITLE
Add missing changelog to breaking change for Standard provider breaking changes

### DIFF
--- a/providers/src/airflow/providers/standard/CHANGELOG.rst
+++ b/providers/src/airflow/providers/standard/CHANGELOG.rst
@@ -35,6 +35,15 @@
 Changelog
 ---------
 
+0.0.3
+.....
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+* ``The deprecated parameter use_dill was removed in PythonOperator and all virtualenv and branching derivates. Please use serializer='dill' instead.``
+* ``The deprecated parameter use_dill was removed in all Python task decorators and virtualenv and branching derivates. Please use serializer='dill' instead.``
+
 0.0.2
 .....
 


### PR DESCRIPTION
Follow-up of #44541

Didi I correctly understood how breaking changes are added to providers?

relates to https://github.com/apache/airflow/issues/44559