### PR TITLE
Revert "Revert Edge Datamodelling for Pydantic problems in Py3.9"

### DIFF
--- a/providers/src/airflow/providers/edge/worker_api/datamodels.py
+++ b/providers/src/airflow/providers/edge/worker_api/datamodels.py
@@ -17,13 +17,9 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import (  # noqa: UP035 - Pydantic not able to parse in Python 3.9
+from typing import (
     Annotated,
     Any,
-    Dict,
-    List,
-    Optional,
-    Union,
 )
 
 from pydantic import BaseModel, Field
@@ -61,7 +57,7 @@ class JsonRpcRequest(JsonRpcRequestBase):
 
     jsonrpc: Annotated[str, Field(description="JSON RPC Version", examples=["2.0"])]
     params: Annotated[
-        Optional[Dict[str, Any]],  # noqa: UP006, UP007 - Pydantic not able to parse in Python 3.9
+        dict[str, Any] | None,
         Field(description="Dictionary of parameters passed to the method."),
     ]
 
@@ -103,7 +99,7 @@ class WorkerQueuesBase(BaseModel):
     """Queues that a worker supports to run jobs on."""
 
     queues: Annotated[
-        Optional[List[str]],  # noqa: UP006, UP007 - Pydantic not able to parse in Python 3.9
+        list[str] | None,
         Field(
             None,
             description="List of queues the worker is pulling jobs from. If not provided, worker pulls from all queues.",
@@ -123,13 +119,13 @@ class WorkerStateBody(WorkerQueuesBase):
     state: Annotated[EdgeWorkerState, Field(description="State of the worker from the view of the worker.")]
     jobs_active: Annotated[int, Field(description="Number of active jobs the worker is running.")] = 0
     queues: Annotated[
-        Optional[List[str]],  # noqa: UP006, UP007 - Pydantic not able to parse in Python 3.9
+        list[str] | None,
         Field(
             description="List of queues the worker is pulling jobs from. If not provided, worker pulls from all queues."
         ),
     ] = None
     sysinfo: Annotated[
-        dict[str, Union[str, int]],  # noqa: UP007 - Pydantic not able to parse in Python 3.9
+        dict[str, str | int],
         Field(
             description="System information of the worker.",
             examples=[
@@ -148,11 +144,11 @@ class WorkerQueueUpdateBody(BaseModel):
     """Changed queues for the worker."""
 
     new_queues: Annotated[
-        Optional[List[str]],  # noqa: UP006, UP007 - Pydantic not able to parse in Python 3.9
+        list[str] | None,
         Field(description="Additional queues to be added to worker."),
     ]
     remove_queues: Annotated[
-        Optional[List[str]],  # noqa: UP006, UP007 - Pydantic not able to parse in Python 3.9
+        list[str] | None,
         Field(description="Queues to remove from worker."),
     ]
 


### PR DESCRIPTION
Reverts apache/airflow#44550

This is an example test to re-apply correct Python 3.10 style Pydantic modelling to Edge Provider.... which fails in backport. Therefore we double check here... or use the tests as a check to raise a bug with Pydantic team.