### PR TITLE
Rename `head` to `tracking_ref` in `GitDagBundle`

### DIFF
--- a/airflow/dag_processing/bundles/git.py
+++ b/airflow/dag_processing/bundles/git.py
@@ -38,26 +38,26 @@ class GitDagBundle(BaseDagBundle):
     and then do a clone for each version from there.
 
     :param repo_url: URL of the git repository
-    :param head: Branch or tag for this DAG bundle
+    :param tracking_ref: Branch or tag for this DAG bundle
     :param subdir: Subdirectory within the repository where the DAGs are stored (Optional)
     """
 
     supports_versioning = True
 
-    def __init__(self, *, repo_url: str, head: str, subdir: str | None = None, **kwargs) -> None:
+    def __init__(self, *, repo_url: str, tracking_ref: str, subdir: str | None = None, **kwargs) -> None:
         super().__init__(**kwargs)
         self.repo_url = repo_url
-        self.head = head
+        self.tracking_ref = tracking_ref
         self.subdir = subdir
 
         self.bare_repo_path = self._dag_bundle_root_storage_path / "git" / self.name
         self.repo_path = (
-            self._dag_bundle_root_storage_path / "git" / (self.name + f"+{self.version or self.head}")
+            self._dag_bundle_root_storage_path / "git" / (self.name + f"+{self.version or self.tracking_ref}")
         )
         self._clone_bare_repo_if_required()
         self._ensure_version_in_bare_repo()
         self._clone_repo_if_required()
-        self.repo.git.checkout(self.head)
+        self.repo.git.checkout(self.tracking_ref)
 
         if self.version:
             if not self._has_version(self.repo, self.version):

--- a/tests/dag_processing/test_dag_bundles.py
+++ b/tests/dag_processing/test_dag_bundles.py
@@ -90,12 +90,12 @@ class TestGitDagBundle:
 
     def test_uses_dag_bundle_root_storage_path(self, git_repo):
         repo_path, repo = git_repo
-        bundle = GitDagBundle(name="test", repo_url=repo_path, head="master")
+        bundle = GitDagBundle(name="test", repo_url=repo_path, tracking_ref="master")
         assert str(bundle._dag_bundle_root_storage_path) in str(bundle.path)
 
     def test_get_current_version(self, git_repo):
         repo_path, repo = git_repo
-        bundle = GitDagBundle(name="test", repo_url=repo_path, head="master")
+        bundle = GitDagBundle(name="test", repo_url=repo_path, tracking_ref="master")
 
         assert bundle.get_current_version() == repo.head.commit.hexsha
 
@@ -110,7 +110,9 @@ class TestGitDagBundle:
         repo.index.add([file_path])
         repo.index.commit("Another commit")
 
-        bundle = GitDagBundle(name="test", version=starting_commit.hexsha, repo_url=repo_path, head="master")
+        bundle = GitDagBundle(
+            name="test", version=starting_commit.hexsha, repo_url=repo_path, tracking_ref="master"
+        )
 
         assert bundle.get_current_version() == starting_commit.hexsha
 
@@ -132,7 +134,7 @@ class TestGitDagBundle:
         repo.index.add([file_path])
         repo.index.commit("Another commit")
 
-        bundle = GitDagBundle(name="test", version="test", repo_url=repo_path, head="master")
+        bundle = GitDagBundle(name="test", version="test", repo_url=repo_path, tracking_ref="master")
 
         assert bundle.get_current_version() == starting_commit.hexsha
 
@@ -149,7 +151,7 @@ class TestGitDagBundle:
         repo.index.add([file_path])
         repo.index.commit("Another commit")
 
-        bundle = GitDagBundle(name="test", repo_url=repo_path, head="master")
+        bundle = GitDagBundle(name="test", repo_url=repo_path, tracking_ref="master")
 
         assert bundle.get_current_version() != starting_commit.hexsha
 
@@ -160,7 +162,7 @@ class TestGitDagBundle:
         repo_path, repo = git_repo
         starting_commit = repo.head.commit
 
-        bundle = GitDagBundle(name="test", repo_url=repo_path, head="master")
+        bundle = GitDagBundle(name="test", repo_url=repo_path, tracking_ref="master")
 
         assert bundle.get_current_version() == starting_commit.hexsha
 
@@ -184,14 +186,14 @@ class TestGitDagBundle:
         repo_path, repo = git_repo
 
         repo.create_head("test")
-        bundle = GitDagBundle(name="test", repo_url=repo_path, head="test")
+        bundle = GitDagBundle(name="test", repo_url=repo_path, tracking_ref="test")
         assert bundle.repo.head.ref.name == "test"
 
     def test_version_not_found(self, git_repo):
         repo_path, repo = git_repo
 
         with pytest.raises(AirflowException, match="Version not_found not found in the repository"):
-            GitDagBundle(name="test", version="not_found", repo_url=repo_path, head="master")
+            GitDagBundle(name="test", version="not_found", repo_url=repo_path, tracking_ref="master")
 
     def test_subdir(self, git_repo):
         repo_path, repo = git_repo
@@ -206,7 +208,7 @@ class TestGitDagBundle:
         repo.index.add([file_path])
         repo.index.commit("Initial commit")
 
-        bundle = GitDagBundle(name="test", repo_url=repo_path, head="master", subdir=subdir)
+        bundle = GitDagBundle(name="test", repo_url=repo_path, tracking_ref="master", subdir=subdir)
 
         files_in_repo = {f.name for f in bundle.path.iterdir() if f.is_file()}
         assert str(bundle.path).endswith(subdir)


### PR DESCRIPTION
Head is confusing cus in git speak it means "what you have checked out".  That's not what we mean here.  Here we're trying to describe the branch in the repo that the user wants this bundle to track or "follow".  Technically it could be a tag but that makes less sense since you shouldn't really be moving tags should you...
