### PR TITLE
Add back `eval-type-backport` to entrypoint_ci.sh as pydantic workaround

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -993,6 +993,22 @@ function determine_airflow_to_use() {
            --constraint https://raw.githubusercontent.com/apache/airflow/constraints-main/constraints-${PYTHON_MAJOR_MINOR_VERSION}.txt
         # Some packages might leave legacy typing module which causes test issues
         pip uninstall -y typing || true
+        # We need to install `eval-type-backport` to avoid problems with Pydantic 2.10.+ released in
+        # November 2024 for python 3.8 and 3.9. While Pydantic 2.10.0/2.10.1 completely broke Airflow 2
+        # installation and Pydantic 2.10.2 fixed the issue for past versions of Airflow, there are still
+        # Some Typing constructs that are not handled well by Pydantic and in case Pydantic fails with
+        # those errors, it will STILL fall back to `eval-type-backport` to handle those cases (if
+        # if `eval-type-backport` is installed. Therefore - until we have Airflow 2.10.3 for backwards
+        # compatibility tests and we attempt to install "edge" provider that might use such breaking
+        # constructs, we need to install `eval-type-backport` to avoid problems with Pydantic 2.10.2+
+        # as well. As soon as we move to Airflow 2.10.4, we can remove this workaround because Airflow
+        # 2.10.4 adds "eval-type-backport" as a dependency and it will be installed automatically.
+        if [[ ${PYTHON_MAJOR_MINOR_VERSION} == "3.8" || ${PYTHON_MAJOR_MINOR_VERSION} == "3.9" ]]; then
+            echo
+            echo "${COLOR_BLUE}Installing eval-type-backport for Python ${PYTHON_MAJOR_MINOR_VERSION} to workaround Pydantic 2.10.0/2.10.1 issue with new typing style.${COLOR_RESET}"
+            echo
+            pip install eval-type-backport>=0.2.0
+        fi
         if [[ ${LINK_PROVIDERS_TO_AIRFLOW_PACKAGE=} == "true" ]]; then
             echo
             echo "${COLOR_BLUE}Linking providers to airflow package as we are using them from mounted sources.${COLOR_RESET}"

--- a/scripts/docker/entrypoint_ci.sh
+++ b/scripts/docker/entrypoint_ci.sh
@@ -226,6 +226,22 @@ function determine_airflow_to_use() {
            --constraint https://raw.githubusercontent.com/apache/airflow/constraints-main/constraints-${PYTHON_MAJOR_MINOR_VERSION}.txt
         # Some packages might leave legacy typing module which causes test issues
         pip uninstall -y typing || true
+        # We need to install `eval-type-backport` to avoid problems with Pydantic 2.10.+ released in
+        # November 2024 for python 3.8 and 3.9. While Pydantic 2.10.0/2.10.1 completely broke Airflow 2
+        # installation and Pydantic 2.10.2 fixed the issue for past versions of Airflow, there are still
+        # Some Typing constructs that are not handled well by Pydantic and in case Pydantic fails with
+        # those errors, it will STILL fall back to `eval-type-backport` to handle those cases (if
+        # if `eval-type-backport` is installed. Therefore - until we have Airflow 2.10.3 for backwards
+        # compatibility tests and we attempt to install "edge" provider that might use such breaking
+        # constructs, we need to install `eval-type-backport` to avoid problems with Pydantic 2.10.2+
+        # as well. As soon as we move to Airflow 2.10.4, we can remove this workaround because Airflow
+        # 2.10.4 adds "eval-type-backport" as a dependency and it will be installed automatically.
+        if [[ ${PYTHON_MAJOR_MINOR_VERSION} == "3.8" || ${PYTHON_MAJOR_MINOR_VERSION} == "3.9" ]]; then
+            echo
+            echo "${COLOR_BLUE}Installing eval-type-backport for Python ${PYTHON_MAJOR_MINOR_VERSION} to workaround Pydantic 2.10.0/2.10.1 issue with new typing style.${COLOR_RESET}"
+            echo
+            pip install eval-type-backport>=0.2.0
+        fi
         if [[ ${LINK_PROVIDERS_TO_AIRFLOW_PACKAGE=} == "true" ]]; then
             echo
             echo "${COLOR_BLUE}Linking providers to airflow package as we are using them from mounted sources.${COLOR_RESET}"


### PR DESCRIPTION
We need to install `eval-type-backport` to avoid problems with Pydantic 2.10.+ released in November 2024 for python 3.8 and 3.9. While Pydantic 2.10.0/2.10.1 completely broke Airflow 2 installation and Pydantic 2.10.2 fixed the issue for past versions of Airflow, there are still Some Typing constructs that are not handled well by Pydantic and in case Pydantic fails with those errors, it will STILL fall back to `eval-type-backport` to handle those cases (if if `eval-type-backport` is installed. Therefore - until we have Airflow 2.10.3 for backwards compatibility tests and we attempt to install "edge" provider that might use such breaking constructs, we need to install `eval-type-backport` to avoid problems with Pydantic 2.10.2+ as well. As soon as we move to Airflow 2.10.4, we can remove this workaround because Airflow 2.10.4 adds "eval-type-backport" as a dependency and it will be installed automatically.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
