### PR TITLE
AIP-84 structure_data endpoint 404 not found for missing dag

### DIFF
--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -237,12 +237,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StructureDataResponse'
-        '400':
+        '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPExceptionResponse'
-          description: Bad Request
+          description: Not Found
         '422':
           description: Validation Error
           content:

--- a/airflow/api_fastapi/core_api/routes/ui/structure.py
+++ b/airflow/api_fastapi/core_api/routes/ui/structure.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from fastapi import Request, status
+from fastapi import HTTPException, Request, status
 
 from airflow.api_fastapi.common.db.common import SessionDep
 from airflow.api_fastapi.common.router import AirflowRouter
@@ -31,7 +31,7 @@ structure_router = AirflowRouter(tags=["Structure"], prefix="/structure")
 @structure_router.get(
     "/structure_data",
     include_in_schema=False,
-    responses=create_openapi_http_exception_doc([status.HTTP_400_BAD_REQUEST]),
+    responses=create_openapi_http_exception_doc([status.HTTP_404_NOT_FOUND]),
 )
 def structure_data(
     session: SessionDep,
@@ -43,6 +43,10 @@ def structure_data(
 ) -> StructureDataResponse:
     """Get Structure Data."""
     dag = request.app.state.dag_bag.get_dag(dag_id)
+
+    if dag is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"Dag with id {dag_id} was not found")
+
     if root:
         dag = dag.partial_subset(
             task_ids_or_regex=root, include_upstream=include_upstream, include_downstream=include_downstream

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -690,7 +690,7 @@ export class StructureService {
         include_downstream: data.includeDownstream,
       },
       errors: {
-        400: "Bad Request",
+        404: "Not Found",
         422: "Validation Error",
       },
     });

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -2456,9 +2456,9 @@ export type $OpenApiTs = {
          */
         200: StructureDataResponse;
         /**
-         * Bad Request
+         * Not Found
          */
-        400: HTTPExceptionResponse;
+        404: HTTPExceptionResponse;
         /**
          * Validation Error
          */

--- a/tests/api_fastapi/core_api/routes/ui/test_structure.py
+++ b/tests/api_fastapi/core_api/routes/ui/test_structure.py
@@ -128,7 +128,12 @@ class TestStructureDataEndpoint:
         ],
     )
     @pytest.mark.usefixtures("make_dag")
-    def test_historical_metrics_data(self, test_client, params, expected):
+    def test_should_return_200(self, test_client, params, expected):
         response = test_client.get("/ui/structure/structure_data", params=params)
         assert response.status_code == 200
         assert response.json() == expected
+
+    def test_should_return_404(self, test_client):
+        response = test_client.get("/ui/structure/structure_data", params={"dag_id": "not_existing"})
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Dag with id not_existing was not found"


### PR DESCRIPTION
When the dag is missing, raise a 404 not found error instead of an unhandled 500 server error.