### PR TITLE
Implement card view for tasks view of a dag

### DIFF
--- a/airflow/ui/src/components/TaskInstanceTooltip.tsx
+++ b/airflow/ui/src/components/TaskInstanceTooltip.tsx
@@ -1,0 +1,64 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box, Text } from "@chakra-ui/react";
+
+import type { TaskInstanceResponse } from "openapi/requests/types.gen";
+import Time from "src/components/Time";
+import { Tooltip } from "src/components/ui";
+
+const TaskInstanceTooltip = ({
+  child,
+  taskInstance,
+}: {
+  readonly child: React.ReactElement;
+  readonly taskInstance: TaskInstanceResponse;
+}) => (
+  <Tooltip
+    content={
+      <Box>
+        <Text>Run ID: {taskInstance.dag_run_id}</Text>
+        <Text>Logical Date: {taskInstance.logical_date}</Text>
+        <Text>
+          Start Date: <Time datetime={taskInstance.start_date} />
+        </Text>
+        <Text>
+          End Date: <Time datetime={taskInstance.end_date} />
+        </Text>
+        {taskInstance.try_number > 1 && (
+          <Text>Try Number: {taskInstance.try_number}</Text>
+        )}
+        <Text>Duration: {taskInstance.duration?.toFixed(2)}s</Text>
+        <Text>State: {taskInstance.state}</Text>
+      </Box>
+    }
+    key={taskInstance.dag_run_id}
+    positioning={{
+      offset: {
+        crossAxis: 5,
+        mainAxis: 5,
+      },
+      placement: "bottom-start",
+    }}
+    showArrow
+  >
+    {child}
+  </Tooltip>
+);
+
+export default TaskInstanceTooltip;

--- a/airflow/ui/src/components/TaskInstanceTooltip.tsx
+++ b/airflow/ui/src/components/TaskInstanceTooltip.tsx
@@ -43,7 +43,7 @@ const TaskInstanceTooltip = ({
         {taskInstance.try_number > 1 && (
           <Text>Try Number: {taskInstance.try_number}</Text>
         )}
-        <Text>Duration: {taskInstance.duration?.toFixed(2)}s</Text>
+        <Text>Duration: {taskInstance.duration?.toFixed(2) ?? 0}s</Text>
         <Text>State: {taskInstance.state}</Text>
       </Box>
     }

--- a/airflow/ui/src/components/TaskInstanceTooltip.tsx
+++ b/airflow/ui/src/components/TaskInstanceTooltip.tsx
@@ -20,12 +20,11 @@ import { Box, Text } from "@chakra-ui/react";
 
 import type { TaskInstanceResponse } from "openapi/requests/types.gen";
 import Time from "src/components/Time";
-import { Tooltip } from "src/components/ui";
+import { Tooltip, type TooltipProps } from "src/components/ui";
 
 type Props = {
-  readonly children: React.ReactNode;
   readonly taskInstance: TaskInstanceResponse;
-};
+} & Omit<TooltipProps, "content">;
 
 const TaskInstanceTooltip = ({ children, taskInstance }: Props) => (
   <Tooltip

--- a/airflow/ui/src/components/TaskInstanceTooltip.tsx
+++ b/airflow/ui/src/components/TaskInstanceTooltip.tsx
@@ -22,13 +22,12 @@ import type { TaskInstanceResponse } from "openapi/requests/types.gen";
 import Time from "src/components/Time";
 import { Tooltip } from "src/components/ui";
 
-const TaskInstanceTooltip = ({
-  child,
-  taskInstance,
-}: {
-  readonly child: React.ReactElement;
+type Props = {
+  readonly children: React.ReactNode;
   readonly taskInstance: TaskInstanceResponse;
-}) => (
+};
+
+const TaskInstanceTooltip = ({ children, taskInstance }: Props) => (
   <Tooltip
     content={
       <Box>
@@ -57,7 +56,7 @@ const TaskInstanceTooltip = ({
     }}
     showArrow
   >
-    {child}
+    {children}
   </Tooltip>
 );
 

--- a/airflow/ui/src/pages/DagsList/Dag/Tasks/TaskCard.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Tasks/TaskCard.tsx
@@ -29,6 +29,7 @@ import type {
   TaskResponse,
   TaskInstanceResponse,
 } from "openapi/requests/types.gen";
+import TaskInstanceTooltip from "src/components/TaskInstanceTooltip";
 import Time from "src/components/Time";
 import { Status } from "src/components/ui";
 
@@ -68,14 +69,19 @@ export const TaskCard = ({ task, taskInstances }: Props) => (
           Last Instance
         </Heading>
         {taskInstances[0] ? (
-          <HStack fontSize="sm">
-            <Time datetime={taskInstances[0].start_date} />
-            {taskInstances[0].state === null ? undefined : (
-              <Status state={taskInstances[0].state}>
-                {taskInstances[0].state}
-              </Status>
-            )}
-          </HStack>
+          <TaskInstanceTooltip
+            child={
+              <HStack fontSize="sm">
+                <Time datetime={taskInstances[0].start_date} />
+                {taskInstances[0].state === null ? undefined : (
+                  <Status state={taskInstances[0].state}>
+                    {taskInstances[0].state}
+                  </Status>
+                )}
+              </HStack>
+            }
+            taskInstance={taskInstances[0]}
+          />
         ) : undefined}
       </VStack>
       {/* TODO: Handled mapped tasks to not plot each map index as a task instance */}

--- a/airflow/ui/src/pages/DagsList/Dag/Tasks/TaskCard.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Tasks/TaskCard.tsx
@@ -29,6 +29,7 @@ import type {
   TaskResponse,
   TaskInstanceResponse,
 } from "openapi/requests/types.gen";
+import Time from "src/components/Time";
 import { Status } from "src/components/ui";
 
 import { TaskRecentRuns } from "./TaskRecentRuns.tsx";
@@ -45,7 +46,7 @@ export const TaskCard = ({ task, taskInstances }: Props) => (
     borderWidth={1}
     overflow="hidden"
   >
-    <Text bg="bg.info" color="fg.info" p={2}>
+    <Text bg="bg.info" color="fg.info" fontWeight="bold" p={2}>
       {task.task_display_name ?? task.task_id}
       {task.is_mapped ? "[]" : undefined}
     </Text>
@@ -64,11 +65,11 @@ export const TaskCard = ({ task, taskInstances }: Props) => (
       </VStack>
       <VStack align="flex-start" gap={1}>
         <Heading color="fg.muted" fontSize="xs">
-          Last Run
+          Last Instance
         </Heading>
         {taskInstances[0] ? (
           <HStack fontSize="sm">
-            <Text> {taskInstances[0].logical_date} </Text>
+            <Time datetime={taskInstances[0].start_date} />
             {taskInstances[0].state === null ? undefined : (
               <Status state={taskInstances[0].state}>
                 {taskInstances[0].state}

--- a/airflow/ui/src/pages/DagsList/Dag/Tasks/TaskCard.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Tasks/TaskCard.tsx
@@ -1,0 +1,83 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {
+  Heading,
+  VStack,
+  HStack,
+  Box,
+  SimpleGrid,
+  Text,
+} from "@chakra-ui/react";
+
+import type {
+  TaskResponse,
+  TaskInstanceResponse,
+} from "openapi/requests/types.gen";
+import { StateCircle } from "src/components/StateCircle";
+import { stateColor } from "src/utils/stateColor";
+
+type Props = {
+  readonly task: TaskResponse;
+  readonly taskInstance: Array<TaskInstanceResponse>;
+};
+
+export const TaskCard = ({ task, taskInstance }: Props) => (
+  <Box
+    borderColor="border.emphasized"
+    borderRadius={8}
+    borderWidth={1}
+    overflow="hidden"
+  >
+    <Text bg="bg.info" color="fg.info" p={2}>
+      {task.task_display_name ?? task.task_id}
+    </Text>
+    <SimpleGrid columns={3} gap={4} height={20} px={3} py={2}>
+      <VStack align="flex-start" gap={1}>
+        <Heading color="fg.muted" fontSize="xs">
+          Operator
+        </Heading>
+        {task.operator_name}
+      </VStack>
+      <VStack align="flex-start" gap={1}>
+        <Heading color="fg.muted" fontSize="xs">
+          Trigger Rule
+        </Heading>
+        {task.trigger_rule}
+      </VStack>
+      <VStack align="flex-start" gap={1}>
+        <Heading color="fg.muted" fontSize="xs">
+          Last Run
+        </Heading>
+        {taskInstance[0] ? (
+          <HStack fontSize="sm">
+            <Text> {taskInstance[0].logical_date} </Text>
+            {taskInstance[0].state === null ? undefined : (
+              <>
+                <StateCircle state={taskInstance[0].state} />
+                <Text color={stateColor[taskInstance[0].state]}>
+                  {taskInstance[0].state}
+                </Text>
+              </>
+            )}
+          </HStack>
+        ) : undefined}
+      </VStack>
+    </SimpleGrid>
+  </Box>
+);

--- a/airflow/ui/src/pages/DagsList/Dag/Tasks/TaskCard.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Tasks/TaskCard.tsx
@@ -69,19 +69,16 @@ export const TaskCard = ({ task, taskInstances }: Props) => (
           Last Instance
         </Heading>
         {taskInstances[0] ? (
-          <TaskInstanceTooltip
-            child={
-              <HStack fontSize="sm">
-                <Time datetime={taskInstances[0].start_date} />
-                {taskInstances[0].state === null ? undefined : (
-                  <Status state={taskInstances[0].state}>
-                    {taskInstances[0].state}
-                  </Status>
-                )}
-              </HStack>
-            }
-            taskInstance={taskInstances[0]}
-          />
+          <TaskInstanceTooltip taskInstance={taskInstances[0]}>
+            <HStack fontSize="sm">
+              <Time datetime={taskInstances[0].start_date} />
+              {taskInstances[0].state === null ? undefined : (
+                <Status state={taskInstances[0].state}>
+                  {taskInstances[0].state}
+                </Status>
+              )}
+            </HStack>
+          </TaskInstanceTooltip>
         ) : undefined}
       </VStack>
       {/* TODO: Handled mapped tasks to not plot each map index as a task instance */}

--- a/airflow/ui/src/pages/DagsList/Dag/Tasks/TaskCard.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Tasks/TaskCard.tsx
@@ -32,12 +32,14 @@ import type {
 import { StateCircle } from "src/components/StateCircle";
 import { stateColor } from "src/utils/stateColor";
 
+import { TaskRecentRuns } from "./TaskRecentRuns.tsx";
+
 type Props = {
   readonly task: TaskResponse;
-  readonly taskInstance: Array<TaskInstanceResponse>;
+  readonly taskInstances: Array<TaskInstanceResponse>;
 };
 
-export const TaskCard = ({ task, taskInstance }: Props) => (
+export const TaskCard = ({ task, taskInstances }: Props) => (
   <Box
     borderColor="border.emphasized"
     borderRadius={8}
@@ -46,8 +48,9 @@ export const TaskCard = ({ task, taskInstance }: Props) => (
   >
     <Text bg="bg.info" color="fg.info" p={2}>
       {task.task_display_name ?? task.task_id}
+      {task.is_mapped ? "[]" : undefined}
     </Text>
-    <SimpleGrid columns={3} gap={4} height={20} px={3} py={2}>
+    <SimpleGrid columns={4} gap={4} height={20} px={3} py={2}>
       <VStack align="flex-start" gap={1}>
         <Heading color="fg.muted" fontSize="xs">
           Operator
@@ -64,20 +67,22 @@ export const TaskCard = ({ task, taskInstance }: Props) => (
         <Heading color="fg.muted" fontSize="xs">
           Last Run
         </Heading>
-        {taskInstance[0] ? (
+        {taskInstances[0] ? (
           <HStack fontSize="sm">
-            <Text> {taskInstance[0].logical_date} </Text>
-            {taskInstance[0].state === null ? undefined : (
+            <Text> {taskInstances[0].logical_date} </Text>
+            {taskInstances[0].state === null ? undefined : (
               <>
-                <StateCircle state={taskInstance[0].state} />
-                <Text color={stateColor[taskInstance[0].state]}>
-                  {taskInstance[0].state}
+                <StateCircle state={taskInstances[0].state} />
+                <Text color={stateColor[taskInstances[0].state]}>
+                  {taskInstances[0].state}
                 </Text>
               </>
             )}
           </HStack>
         ) : undefined}
       </VStack>
+      {/* TODO: Handled mapped tasks to not plot each map index as a task instance */}
+      {!task.is_mapped && <TaskRecentRuns taskInstances={taskInstances} />}
     </SimpleGrid>
   </Box>
 );

--- a/airflow/ui/src/pages/DagsList/Dag/Tasks/TaskCard.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Tasks/TaskCard.tsx
@@ -52,13 +52,13 @@ export const TaskCard = ({ task, taskInstance }: Props) => (
         <Heading color="fg.muted" fontSize="xs">
           Operator
         </Heading>
-        {task.operator_name}
+        <Text fontSize="sm">{task.operator_name}</Text>
       </VStack>
       <VStack align="flex-start" gap={1}>
         <Heading color="fg.muted" fontSize="xs">
           Trigger Rule
         </Heading>
-        {task.trigger_rule}
+        <Text fontSize="sm">{task.trigger_rule}</Text>
       </VStack>
       <VStack align="flex-start" gap={1}>
         <Heading color="fg.muted" fontSize="xs">

--- a/airflow/ui/src/pages/DagsList/Dag/Tasks/TaskCard.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Tasks/TaskCard.tsx
@@ -29,8 +29,7 @@ import type {
   TaskResponse,
   TaskInstanceResponse,
 } from "openapi/requests/types.gen";
-import { StateCircle } from "src/components/StateCircle";
-import { stateColor } from "src/utils/stateColor";
+import { Status } from "src/components/ui";
 
 import { TaskRecentRuns } from "./TaskRecentRuns.tsx";
 
@@ -71,12 +70,9 @@ export const TaskCard = ({ task, taskInstances }: Props) => (
           <HStack fontSize="sm">
             <Text> {taskInstances[0].logical_date} </Text>
             {taskInstances[0].state === null ? undefined : (
-              <>
-                <StateCircle state={taskInstances[0].state} />
-                <Text color={stateColor[taskInstances[0].state]}>
-                  {taskInstances[0].state}
-                </Text>
-              </>
+              <Status state={taskInstances[0].state}>
+                {taskInstances[0].state}
+              </Status>
             )}
           </HStack>
         ) : undefined}

--- a/airflow/ui/src/pages/DagsList/Dag/Tasks/TaskRecentRuns.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Tasks/TaskRecentRuns.tsx
@@ -56,20 +56,19 @@ export const TaskRecentRuns = ({
       {taskInstancesWithDuration.map((taskInstance) =>
         taskInstance.state === null ? undefined : (
           <TaskInstanceTooltip
-            child={
-              <Box p={1}>
-                <Box
-                  bg={stateColor[taskInstance.state]}
-                  borderRadius="4px"
-                  height={`${(taskInstance.duration / max) * BAR_HEIGHT}px`}
-                  minHeight={1}
-                  width="4px"
-                />
-              </Box>
-            }
             key={taskInstance.dag_run_id}
             taskInstance={taskInstance}
-          />
+          >
+            <Box p={1}>
+              <Box
+                bg={stateColor[taskInstance.state]}
+                borderRadius="4px"
+                height={`${(taskInstance.duration / max) * BAR_HEIGHT}px`}
+                minHeight={1}
+                width="4px"
+              />
+            </Box>
+          </TaskInstanceTooltip>
         ),
       )}
     </Flex>

--- a/airflow/ui/src/pages/DagsList/Dag/Tasks/TaskRecentRuns.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Tasks/TaskRecentRuns.tsx
@@ -66,7 +66,9 @@ export const TaskRecentRuns = ({
                 <Text>
                   End Date: <Time datetime={taskInstance.end_date} />
                 </Text>
-                <Text>Try Number: {taskInstance.try_number}</Text>
+                {taskInstance.try_number > 1 && (
+                  <Text>Try Number: {taskInstance.try_number}</Text>
+                )}
                 <Text>Duration: {taskInstance.duration.toFixed(2)}s</Text>
               </Box>
             }

--- a/airflow/ui/src/pages/DagsList/Dag/Tasks/TaskRecentRuns.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Tasks/TaskRecentRuns.tsx
@@ -16,14 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Text } from "@chakra-ui/react";
+import { Box } from "@chakra-ui/react";
 import { Flex } from "@chakra-ui/react";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
 
 import type { TaskInstanceResponse } from "openapi/requests/types.gen";
-import Time from "src/components/Time";
-import { Tooltip } from "src/components/ui";
+import TaskInstanceTooltip from "src/components/TaskInstanceTooltip";
 import { stateColor } from "src/utils/stateColor";
 
 dayjs.extend(duration);
@@ -56,42 +55,21 @@ export const TaskRecentRuns = ({
     <Flex alignItems="flex-end" flexDirection="row-reverse">
       {taskInstancesWithDuration.map((taskInstance) =>
         taskInstance.state === null ? undefined : (
-          <Tooltip
-            content={
-              <Box>
-                <Text>State: {taskInstance.state}</Text>
-                <Text>
-                  Start Date: <Time datetime={taskInstance.start_date} />
-                </Text>
-                <Text>
-                  End Date: <Time datetime={taskInstance.end_date} />
-                </Text>
-                {taskInstance.try_number > 1 && (
-                  <Text>Try Number: {taskInstance.try_number}</Text>
-                )}
-                <Text>Duration: {taskInstance.duration.toFixed(2)}s</Text>
+          <TaskInstanceTooltip
+            child={
+              <Box p={1}>
+                <Box
+                  bg={stateColor[taskInstance.state]}
+                  borderRadius="4px"
+                  height={`${(taskInstance.duration / max) * BAR_HEIGHT}px`}
+                  minHeight={1}
+                  width="4px"
+                />
               </Box>
             }
             key={taskInstance.dag_run_id}
-            positioning={{
-              offset: {
-                crossAxis: 5,
-                mainAxis: 5,
-              },
-              placement: "bottom-start",
-            }}
-            showArrow
-          >
-            <Box p={1}>
-              <Box
-                bg={stateColor[taskInstance.state]}
-                borderRadius="4px"
-                height={`${(taskInstance.duration / max) * BAR_HEIGHT}px`}
-                minHeight={1}
-                width="4px"
-              />
-            </Box>
-          </Tooltip>
+            taskInstance={taskInstance}
+          />
         ),
       )}
     </Flex>

--- a/airflow/ui/src/pages/DagsList/Dag/Tasks/TaskRecentRuns.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Tasks/TaskRecentRuns.tsx
@@ -1,0 +1,97 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box, Text } from "@chakra-ui/react";
+import { Flex } from "@chakra-ui/react";
+import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
+
+import type { TaskInstanceResponse } from "openapi/requests/types.gen";
+import Time from "src/components/Time";
+import { Tooltip } from "src/components/ui";
+import { stateColor } from "src/utils/stateColor";
+
+dayjs.extend(duration);
+
+const BAR_HEIGHT = 60;
+
+export const TaskRecentRuns = ({
+  taskInstances,
+}: {
+  readonly taskInstances: Array<TaskInstanceResponse>;
+}) => {
+  if (!taskInstances.length) {
+    return undefined;
+  }
+
+  const taskInstancesWithDuration = taskInstances.map((taskInstance) => ({
+    ...taskInstance,
+    duration:
+      dayjs
+        .duration(dayjs(taskInstance.end_date).diff(taskInstance.start_date))
+        .asSeconds() || 0,
+  }));
+
+  const max = Math.max.apply(
+    undefined,
+    taskInstancesWithDuration.map((taskInstance) => taskInstance.duration),
+  );
+
+  return (
+    <Flex alignItems="flex-end" flexDirection="row-reverse">
+      {taskInstancesWithDuration.map((taskInstance) =>
+        taskInstance.state === null ? undefined : (
+          <Tooltip
+            content={
+              <Box>
+                <Text>State: {taskInstance.state}</Text>
+                <Text>
+                  Start Date: <Time datetime={taskInstance.start_date} />
+                </Text>
+                <Text>
+                  End Date: <Time datetime={taskInstance.end_date} />
+                </Text>
+                <Text>Try Number: {taskInstance.try_number}</Text>
+                <Text>Duration: {taskInstance.duration.toFixed(2)}s</Text>
+              </Box>
+            }
+            key={taskInstance.dag_run_id}
+            positioning={{
+              offset: {
+                crossAxis: 5,
+                mainAxis: 5,
+              },
+              placement: "bottom-start",
+            }}
+            showArrow
+          >
+            <Box p={1}>
+              <Box
+                bg={stateColor[taskInstance.state]}
+                borderRadius="4px"
+                height={`${(taskInstance.duration / max) * BAR_HEIGHT}px`}
+                minHeight={1}
+                width="4px"
+              />
+            </Box>
+          </Tooltip>
+        ),
+      )}
+    </Flex>
+  );
+};

--- a/airflow/ui/src/pages/DagsList/Dag/Tasks/Tasks.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Tasks/Tasks.tsx
@@ -17,7 +17,6 @@
  * under the License.
  */
 import { Heading, Skeleton, Box } from "@chakra-ui/react";
-import type { ColumnDef } from "@tanstack/react-table";
 import { useParams } from "react-router-dom";
 
 import {
@@ -55,39 +54,6 @@ const cardDef = (
   },
 });
 
-const tasksColumn = (): Array<ColumnDef<TaskResponse>> => [
-  {
-    accessorKey: "task_id",
-    header: "Task ID",
-    meta: {
-      skeletonWidth: 10,
-    },
-  },
-  {
-    accessorKey: "operator_name",
-    header: "Dag ID",
-    meta: {
-      skeletonWidth: 10,
-    },
-  },
-  {
-    accessorKey: "operator_name",
-    enableSorting: true,
-    header: "Operator",
-    meta: {
-      skeletonWidth: 10,
-    },
-  },
-  {
-    accessorKey: "trigger_rule",
-    enableSorting: true,
-    header: "Trigger Rule",
-    meta: {
-      skeletonWidth: 10,
-    },
-  },
-];
-
 export const Tasks = () => {
   const { dagId } = useParams();
   const {
@@ -114,7 +80,7 @@ export const Tasks = () => {
       </Heading>
       <DataTable
         cardDef={cardDef(TaskInstancesResponse?.task_instances)}
-        columns={tasksColumn()}
+        columns={[]}
         data={data ? data.tasks : []}
         displayMode="card"
         isFetching={isFetching}

--- a/airflow/ui/src/pages/DagsList/Dag/Tasks/Tasks.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Tasks/Tasks.tsx
@@ -1,0 +1,128 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Heading, Skeleton, Box } from "@chakra-ui/react";
+import type { ColumnDef } from "@tanstack/react-table";
+import { useParams } from "react-router-dom";
+
+import {
+  useTaskServiceGetTasks,
+  useTaskInstanceServiceGetTaskInstances,
+} from "openapi/queries";
+import type {
+  TaskResponse,
+  TaskInstanceResponse,
+} from "openapi/requests/types.gen";
+import { DataTable } from "src/components/DataTable";
+import type { CardDef } from "src/components/DataTable/types";
+import { ErrorAlert } from "src/components/ErrorAlert";
+
+import { TaskCard } from "./TaskCard";
+
+const cardDef = (
+  taskInstances?: Array<TaskInstanceResponse>,
+): CardDef<TaskResponse> => ({
+  card: ({ row }) => (
+    <TaskCard
+      task={row}
+      taskInstance={
+        taskInstances
+          ? taskInstances.filter(
+              (instance: TaskInstanceResponse) =>
+                instance.task_id === row.task_id,
+            )
+          : []
+      }
+    />
+  ),
+  meta: {
+    customSkeleton: <Skeleton height="120px" width="100%" />,
+  },
+});
+
+const tasksColumn = (): Array<ColumnDef<TaskResponse>> => [
+  {
+    accessorKey: "task_id",
+    header: "Task ID",
+    meta: {
+      skeletonWidth: 10,
+    },
+  },
+  {
+    accessorKey: "operator_name",
+    header: "Dag ID",
+    meta: {
+      skeletonWidth: 10,
+    },
+  },
+  {
+    accessorKey: "operator_name",
+    enableSorting: true,
+    header: "Operator",
+    meta: {
+      skeletonWidth: 10,
+    },
+  },
+  {
+    accessorKey: "trigger_rule",
+    enableSorting: true,
+    header: "Trigger Rule",
+    meta: {
+      skeletonWidth: 10,
+    },
+  },
+];
+
+export const Tasks = () => {
+  const { dagId } = useParams();
+  const {
+    data,
+    error: TasksError,
+    isFetching,
+    isLoading,
+  } = useTaskServiceGetTasks({
+    dagId: dagId ?? "",
+  });
+
+  // TODO : Get the latest dag run and then pass it to dagRunId for better querying
+  const { data: TaskInstancesResponse } =
+    useTaskInstanceServiceGetTaskInstances({
+      dagId: dagId ?? "",
+      dagRunId: "~",
+    });
+
+  return (
+    <Box>
+      <ErrorAlert error={TasksError} />
+      <Heading my={1} size="md">
+        {data ? data.total_entries : 0} Tasks
+      </Heading>
+      <DataTable
+        cardDef={cardDef(TaskInstancesResponse?.task_instances)}
+        columns={tasksColumn()}
+        data={data ? data.tasks : []}
+        displayMode="card"
+        isFetching={isFetching}
+        isLoading={isLoading}
+        modelName="Task"
+        skeletonCount={undefined}
+        total={data ? data.total_entries : 0}
+      />
+    </Box>
+  );
+};

--- a/airflow/ui/src/pages/DagsList/Dag/Tasks/Tasks.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Tasks/Tasks.tsx
@@ -31,6 +31,7 @@ import type {
 import { DataTable } from "src/components/DataTable";
 import type { CardDef } from "src/components/DataTable/types";
 import { ErrorAlert } from "src/components/ErrorAlert";
+import { pluralize } from "src/utils";
 
 import { TaskCard } from "./TaskCard";
 
@@ -96,7 +97,7 @@ export const Tasks = () => {
     <Box>
       <ErrorAlert error={TasksError} />
       <Heading my={1} size="md">
-        {data ? data.total_entries : 0} Tasks
+        {pluralize("Task", data ? data.total_entries : 0)}
       </Heading>
       <DataTable
         cardDef={cardDef(TaskInstancesResponse?.task_instances.reverse())}

--- a/airflow/ui/src/pages/DagsList/Dag/Tasks/Tasks.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Tasks/Tasks.tsx
@@ -40,7 +40,7 @@ const cardDef = (
   card: ({ row }) => (
     <TaskCard
       task={row}
-      taskInstance={
+      taskInstances={
         taskInstances
           ? taskInstances.filter(
               (instance: TaskInstanceResponse) =>
@@ -68,7 +68,7 @@ export const Tasks = () => {
 
   // TODO: Replace dagIdPattern with dagId once supported for better matching
   const { data: runsData } = useDagsServiceRecentDagRuns(
-    { dagIdPattern: dagId ?? "", dagRunsLimit: 1 },
+    { dagIdPattern: dagId ?? "", dagRunsLimit: 14 },
     undefined,
     {
       enabled: Boolean(dagId),
@@ -79,12 +79,14 @@ export const Tasks = () => {
     runsData?.dags.find((dagWithRuns) => dagWithRuns.dag_id === dagId)
       ?.latest_dag_runs ?? [];
 
-  // Fetch the latest dag run and get task instances since we only display last run
+  // TODO: Revisit this endpoint since only 100 task instances are returned and
+  // only duration is calculated with other attributes unused.
   const { data: TaskInstancesResponse } =
     useTaskInstanceServiceGetTaskInstances(
       {
         dagId: dagId ?? "",
-        dagRunId: runs[0]?.dag_run_id ?? "~",
+        dagRunId: "~",
+        logicalDateGte: runs.at(-1)?.logical_date ?? "",
       },
       undefined,
       { enabled: Boolean(runs[0]?.dag_run_id) },
@@ -97,7 +99,7 @@ export const Tasks = () => {
         {data ? data.total_entries : 0} Tasks
       </Heading>
       <DataTable
-        cardDef={cardDef(TaskInstancesResponse?.task_instances)}
+        cardDef={cardDef(TaskInstancesResponse?.task_instances.reverse())}
         columns={[]}
         data={data ? data.tasks : []}
         displayMode="card"

--- a/airflow/ui/src/pages/DagsList/Dag/Tasks/Tasks.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Tasks/Tasks.tsx
@@ -66,10 +66,9 @@ export const Tasks = () => {
     dagId: dagId ?? "",
   });
 
-  // Only the latest dagrun id is needed with recent dag runs of 14 returned for filtering.
-  // This could be switched to the endpoint to get dag with only latest run once available.
+  // TODO: Replace dagIdPattern with dagId once supported for better matching
   const { data: runsData } = useDagsServiceRecentDagRuns(
-    { dagIdPattern: dagId ?? "" },
+    { dagIdPattern: dagId ?? "", dagRunsLimit: 1 },
     undefined,
     {
       enabled: Boolean(dagId),

--- a/airflow/ui/src/pages/DagsList/Dag/Tasks/Tasks.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Tasks/Tasks.tsx
@@ -60,7 +60,7 @@ export const Tasks = () => {
   const { dagId } = useParams();
   const {
     data,
-    error: TasksError,
+    error: tasksError,
     isFetching,
     isLoading,
   } = useTaskServiceGetTasks({
@@ -82,7 +82,7 @@ export const Tasks = () => {
 
   // TODO: Revisit this endpoint since only 100 task instances are returned and
   // only duration is calculated with other attributes unused.
-  const { data: TaskInstancesResponse } =
+  const { data: taskInstancesResponse } =
     useTaskInstanceServiceGetTaskInstances(
       {
         dagId: dagId ?? "",
@@ -95,12 +95,12 @@ export const Tasks = () => {
 
   return (
     <Box>
-      <ErrorAlert error={TasksError} />
+      <ErrorAlert error={tasksError} />
       <Heading my={1} size="md">
         {pluralize("Task", data ? data.total_entries : 0)}
       </Heading>
       <DataTable
-        cardDef={cardDef(TaskInstancesResponse?.task_instances.reverse())}
+        cardDef={cardDef(taskInstancesResponse?.task_instances.reverse())}
         columns={[]}
         data={data ? data.tasks : []}
         displayMode="card"

--- a/airflow/ui/src/pages/DagsList/Dag/Tasks/index.ts
+++ b/airflow/ui/src/pages/DagsList/Dag/Tasks/index.ts
@@ -1,0 +1,20 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export { Tasks } from "./Tasks";

--- a/airflow/ui/src/router.tsx
+++ b/airflow/ui/src/router.tsx
@@ -26,14 +26,10 @@ import { Overview } from "src/pages/DagsList/Dag/Overview";
 import { Runs } from "src/pages/DagsList/Dag/Runs";
 import { Run } from "src/pages/DagsList/Run";
 import { Dashboard } from "src/pages/Dashboard";
-import { BaseLayout } from "./layouts/BaseLayout";
-import { Dag } from "./pages/DagsList/Dag";
-import { Code } from "./pages/DagsList/Dag/Code";
-import { Overview } from "./pages/DagsList/Dag/Overview";
+
 import { Tasks } from "./pages/DagsList/Dag/Tasks";
 import { ErrorPage } from "./pages/Error";
 import { Events } from "./pages/Events";
-
 
 export const router = createBrowserRouter(
   [

--- a/airflow/ui/src/router.tsx
+++ b/airflow/ui/src/router.tsx
@@ -24,12 +24,11 @@ import { Dag } from "src/pages/DagsList/Dag";
 import { Code } from "src/pages/DagsList/Dag/Code";
 import { Overview } from "src/pages/DagsList/Dag/Overview";
 import { Runs } from "src/pages/DagsList/Dag/Runs";
+import { Tasks } from "src/pages/DagsList/Dag/Tasks";
 import { Run } from "src/pages/DagsList/Run";
 import { Dashboard } from "src/pages/Dashboard";
-
-import { Tasks } from "./pages/DagsList/Dag/Tasks";
-import { ErrorPage } from "./pages/Error";
-import { Events } from "./pages/Events";
+import { ErrorPage } from "src/pages/Error";
+import { Events } from "src/pages/Events";
 
 export const router = createBrowserRouter(
   [

--- a/airflow/ui/src/router.tsx
+++ b/airflow/ui/src/router.tsx
@@ -26,8 +26,14 @@ import { Overview } from "src/pages/DagsList/Dag/Overview";
 import { Runs } from "src/pages/DagsList/Dag/Runs";
 import { Run } from "src/pages/DagsList/Run";
 import { Dashboard } from "src/pages/Dashboard";
-import { ErrorPage } from "src/pages/Error";
-import { Events } from "src/pages/Events";
+import { BaseLayout } from "./layouts/BaseLayout";
+import { Dag } from "./pages/DagsList/Dag";
+import { Code } from "./pages/DagsList/Dag/Code";
+import { Overview } from "./pages/DagsList/Dag/Overview";
+import { Tasks } from "./pages/DagsList/Dag/Tasks";
+import { ErrorPage } from "./pages/Error";
+import { Events } from "./pages/Events";
+
 
 export const router = createBrowserRouter(
   [
@@ -49,7 +55,7 @@ export const router = createBrowserRouter(
           children: [
             { element: <Overview />, index: true },
             { element: <Runs />, path: "runs" },
-            { element: <div>Tasks</div>, path: "tasks" },
+            { element: <Tasks />, path: "tasks" },
             { element: <Events />, path: "events" },
             { element: <Code />, path: "code" },
           ],


### PR DESCRIPTION
Use `tasks` endpoint to fill the card view first. Get dag's recent dagruns and get the last dagrun id and pass it to taskinstances endpoint to get the last run and the corresponding task instance state. 

Comments for reviewers and self :

1. Disable pagination since tasks and task instances doesn't support limit or pagination.
2. Colors are slightly off with `stateColor` and the theme which will be fixed overall. Please let me know if I am missing some other configuration.
3. The historical view of the task instances which is the last column in the card view is using list task instances endpoint which returns like 100 task instances and the limit is easily reached with 14 task instances per task. All task instance attributes are also not used with only start_date, end_date, try_number, duration and state used which could be fetched efficiently.
4. Do we need to display a tooltip for the last run. Perhaps the start time, end time and try number of the last task instance.

This PR probably needs a rebase after https://github.com/apache/airflow/pull/44269 is merged.

![image](https://github.com/user-attachments/assets/71d01a4a-93af-43bf-8b63-b6f2886293a9)

![image](https://github.com/user-attachments/assets/adbe71c5-57aa-401b-8db7-c2f5389e04e7)
