### PR TITLE
Add get_airflow_version helper

### DIFF
--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -58,10 +58,20 @@ if sys.platform == "win32":
 # very easily cause import cycles in the conf init/validate code (since downstream code from
 # those functions likely import settings).
 # configuration is therefore initted early here, simply by importing it.
+
+from packaging.version import Version
+
 from airflow import configuration, settings
+
+
+def get_airflow_version() -> Version:
+    """Return packaging Version object representing the base version."""
+    return Version(Version(__version__).base_version)
+
 
 __all__ = [
     "__version__",
+    "get_airflow_version",
     "DAG",
     "Asset",
     "XComArg",


### PR DESCRIPTION
The point of this helper is to make it simpler to figure out what airflow version is installed, in particular to implement conditional logic in providers.

Currently the logic is too complicated and this has resulted in the proliferation of sort of redundant constants.  Here's an example:

```
from airflow import __version__ as AIRFLOW_VERSION

AIRFLOW_V_3_0_PLUS = Version(Version(AIRFLOW_VERSION).base_version) >= Version("3.0.0")
if AIRFLOW_V_3_0_PLUS:
    from airflow.sdk.definitions.asset import Asset
```

With this helper, we can do this instead:

```
from airflow import get_airflow_version

if get_airflow_version() > Version("3.0.0"):
    from airflow.sdk.definitions.asset import Asset
```

We can't make use of this helper in providers until they are bumped to min airflow version == 2.11.0.