### PR TITLE
feat: automatically inject OL info into spark properties in DataprocCreateBatchOperator

### DIFF
--- a/docs/apache-airflow-providers-openlineage/guides/user.rst
+++ b/docs/apache-airflow-providers-openlineage/guides/user.rst
@@ -413,6 +413,7 @@ This is because each emitting task sends a `ParentRunFacet <https://openlineage.
 which requires the DAG-level lineage to be enabled in some OpenLineage backend systems.
 Disabling DAG-level lineage while enabling task-level lineage might cause errors or inconsistencies.
 
+.. _options:spark_inject_parent_job_info:
 
 Passing parent job information to Spark jobs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -425,9 +426,15 @@ It allows Spark integration to automatically include ``parentRunFacet`` in appli
 creating a parent-child relationship between tasks from different integrations.
 See `Scheduling from Airflow <https://openlineage.io/docs/integrations/spark/configuration/airflow>`_.
 
-.. warning::
+This configuration serves as the default behavior for all Operators that support automatic Spark properties injection,
+unless it is explicitly overridden at the Operator level.
+To prevent a specific Operator from injecting the parent job information while
+allowing all other supported Operators to do so by default, ``openlineage_inject_parent_job_info=False``
+can be explicitly provided to that specific Operator.
 
-  If any of the above properties are manually specified in the Spark job configuration, the integration will refrain from injecting parent job properties to ensure that manually provided values are preserved.
+.. note::
+
+  If any of the ``spark.openlineage.parent*`` properties are manually specified in the Spark job configuration, the integration will refrain from injecting parent job properties to ensure that manually provided values are preserved.
 
 You can enable this automation by setting ``spark_inject_parent_job_info`` option to ``true`` in Airflow configuration.
 

--- a/docs/exts/templates/openlineage.rst.jinja2
+++ b/docs/exts/templates/openlineage.rst.jinja2
@@ -29,11 +29,14 @@ Spark operators
 ===============
 The OpenLineage integration can automatically inject information into Spark application properties when its being submitted from Airflow.
 The following is a list of supported operators along with the corresponding information that can be injected.
+See :ref:`automatic injection of parent job information <options:spark_inject_parent_job_info>` for more details.
 
 apache-airflow-providers-google
 """""""""""""""""""""""""""""""
 
 - :class:`~airflow.providers.google.cloud.operators.dataproc.DataprocSubmitJobOperator`
+    - Parent Job Information
+- :class:`~airflow.providers.google.cloud.operators.dataproc.DataprocCreateBatchOperator`
     - Parent Job Information
 
 

--- a/providers/src/airflow/providers/google/cloud/operators/dataproc.py
+++ b/providers/src/airflow/providers/google/cloud/operators/dataproc.py
@@ -55,6 +55,7 @@ from airflow.providers.google.cloud.links.dataproc import (
     DataprocWorkflowTemplateLink,
 )
 from airflow.providers.google.cloud.openlineage.utils import (
+    inject_openlineage_properties_into_dataproc_batch,
     inject_openlineage_properties_into_dataproc_job,
 )
 from airflow.providers.google.cloud.operators.cloud_base import GoogleCloudBaseOperator
@@ -2425,6 +2426,9 @@ class DataprocCreateBatchOperator(GoogleCloudBaseOperator):
         asynchronous: bool = False,
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
         polling_interval_seconds: int = 5,
+        openlineage_inject_parent_job_info: bool = conf.getboolean(
+            "openlineage", "spark_inject_parent_job_info", fallback=False
+        ),
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -2446,6 +2450,7 @@ class DataprocCreateBatchOperator(GoogleCloudBaseOperator):
         self.asynchronous = asynchronous
         self.deferrable = deferrable
         self.polling_interval_seconds = polling_interval_seconds
+        self.openlineage_inject_parent_job_info = openlineage_inject_parent_job_info
 
     def execute(self, context: Context):
         if self.asynchronous and self.deferrable:
@@ -2467,6 +2472,14 @@ class DataprocCreateBatchOperator(GoogleCloudBaseOperator):
             )
         else:
             self.log.info("Starting batch. The batch ID will be generated since it was not provided.")
+
+        if self.openlineage_inject_parent_job_info:
+            self.log.info("Automatic injection of OpenLineage information into Spark properties is enabled.")
+            self.batch = inject_openlineage_properties_into_dataproc_batch(
+                batch=self.batch,
+                context=context,
+                inject_parent_job_info=self.openlineage_inject_parent_job_info,
+            )
 
         try:
             self.operation = self.hook.create_batch(

--- a/providers/tests/google/cloud/openlineage/test_utils.py
+++ b/providers/tests/google/cloud/openlineage/test_utils.py
@@ -22,6 +22,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from google.cloud.bigquery.table import Table
+from google.cloud.dataproc_v1 import Batch, RuntimeConfig
 
 from airflow.providers.common.compat.openlineage.facet import (
     ColumnLineageDatasetFacet,
@@ -35,12 +36,16 @@ from airflow.providers.common.compat.openlineage.facet import (
     SymlinksDatasetFacet,
 )
 from airflow.providers.google.cloud.openlineage.utils import (
+    _extract_dataproc_batch_properties,
     _extract_supported_job_type_from_dataproc_job,
+    _is_dataproc_batch_of_supported_type,
     _is_openlineage_provider_accessible,
+    _replace_dataproc_batch_properties,
     _replace_dataproc_job_properties,
     extract_ds_name_from_gcs_path,
     get_facets_from_bq_table,
     get_identity_column_lineage_facet,
+    inject_openlineage_properties_into_dataproc_batch,
     inject_openlineage_properties_into_dataproc_job,
 )
 
@@ -419,3 +424,277 @@ def test_inject_openlineage_properties_into_dataproc_job(mock_is_ol_accessible):
     job = {"sparkJob": {"properties": {"existingProperty": "value"}}}
     result = inject_openlineage_properties_into_dataproc_job(job, context, True)
     assert result == {"sparkJob": {"properties": expected_properties}}
+
+
+@pytest.mark.parametrize(
+    "batch, expected",
+    [
+        ({"spark_batch": {}}, True),
+        ({"pyspark_batch": {}}, True),
+        ({"unsupported_batch": {}}, False),
+        ({}, False),
+        (Batch(spark_batch={"jar_file_uris": ["uri"]}), True),
+        (Batch(pyspark_batch={"main_python_file_uri": "uri"}), True),
+        (Batch(pyspark_batch={}), False),
+        (Batch(spark_sql_batch={}), False),
+        (Batch(), False),
+    ],
+)
+def test_is_dataproc_batch_of_supported_type(batch, expected):
+    assert _is_dataproc_batch_of_supported_type(batch) == expected
+
+
+def test__extract_dataproc_batch_properties_batch_object_with_runtime_object():
+    properties = {"key1": "value1", "key2": "value2"}
+    mock_runtime_config = RuntimeConfig(properties=properties)
+    mock_batch = Batch(runtime_config=mock_runtime_config)
+    result = _extract_dataproc_batch_properties(mock_batch)
+    assert result == properties
+
+
+def test_extract_dataproc_batch_properties_batch_object_with_runtime_dict():
+    properties = {"key1": "value1", "key2": "value2"}
+    mock_batch = Batch(runtime_config={"properties": properties})
+    result = _extract_dataproc_batch_properties(mock_batch)
+    assert result == {"key1": "value1", "key2": "value2"}
+
+
+def test_extract_dataproc_batch_properties_batch_object_with_runtime_object_empty():
+    mock_batch = Batch(runtime_config=RuntimeConfig())
+    result = _extract_dataproc_batch_properties(mock_batch)
+    assert result == {}
+
+
+def test_extract_dataproc_batch_properties_dict_with_runtime_config_object():
+    properties = {"key1": "value1", "key2": "value2"}
+    mock_runtime_config = RuntimeConfig(properties=properties)
+    mock_batch_dict = {"runtime_config": mock_runtime_config}
+
+    result = _extract_dataproc_batch_properties(mock_batch_dict)
+    assert result == properties
+
+
+def test_extract_dataproc_batch_properties_dict_with_properties_dict():
+    properties = {"key1": "value1", "key2": "value2"}
+    mock_batch_dict = {"runtime_config": {"properties": properties}}
+    result = _extract_dataproc_batch_properties(mock_batch_dict)
+    assert result == properties
+
+
+def test_extract_dataproc_batch_properties_empty_runtime_config():
+    mock_batch_dict = {"runtime_config": {}}
+    result = _extract_dataproc_batch_properties(mock_batch_dict)
+    assert result == {}
+
+
+def test_extract_dataproc_batch_properties_empty_dict():
+    assert _extract_dataproc_batch_properties({}) == {}
+
+
+def test_extract_dataproc_batch_properties_empty_batch():
+    assert _extract_dataproc_batch_properties(Batch()) == {}
+
+
+def test_replace_dataproc_batch_properties_with_batch_object():
+    original_batch = Batch(
+        spark_batch={
+            "jar_file_uris": ["file:///usr/lib/spark/examples/jars/spark-examples.jar"],
+            "main_class": "org.apache.spark.examples.SparkPi",
+        },
+        runtime_config=RuntimeConfig(properties={"existingProperty": "value"}),
+    )
+    new_properties = {"newProperty": "newValue"}
+    expected_batch = Batch(
+        spark_batch={
+            "jar_file_uris": ["file:///usr/lib/spark/examples/jars/spark-examples.jar"],
+            "main_class": "org.apache.spark.examples.SparkPi",
+        },
+        runtime_config=RuntimeConfig(properties={"newProperty": "newValue"}),
+    )
+
+    updated_batch = _replace_dataproc_batch_properties(original_batch, new_properties)
+
+    assert updated_batch == expected_batch
+    assert original_batch.runtime_config.properties == {"existingProperty": "value"}
+    assert original_batch.spark_batch.main_class == "org.apache.spark.examples.SparkPi"
+
+
+def test_replace_dataproc_batch_properties_with_batch_object_and_run_time_config_dict():
+    original_batch = Batch(
+        spark_batch={
+            "jar_file_uris": ["file:///usr/lib/spark/examples/jars/spark-examples.jar"],
+            "main_class": "org.apache.spark.examples.SparkPi",
+        },
+        runtime_config={"properties": {"existingProperty": "value"}},
+    )
+    new_properties = {"newProperty": "newValue"}
+    expected_batch = Batch(
+        spark_batch={
+            "jar_file_uris": ["file:///usr/lib/spark/examples/jars/spark-examples.jar"],
+            "main_class": "org.apache.spark.examples.SparkPi",
+        },
+        runtime_config={"properties": {"newProperty": "newValue"}},
+    )
+
+    updated_batch = _replace_dataproc_batch_properties(original_batch, new_properties)
+
+    assert updated_batch == expected_batch
+    assert original_batch.runtime_config.properties == {"existingProperty": "value"}
+    assert original_batch.spark_batch.main_class == "org.apache.spark.examples.SparkPi"
+
+
+def test_replace_dataproc_batch_properties_with_empty_batch_object():
+    original_batch = Batch()
+    new_properties = {"newProperty": "newValue"}
+    expected_batch = Batch(runtime_config=RuntimeConfig(properties={"newProperty": "newValue"}))
+
+    updated_batch = _replace_dataproc_batch_properties(original_batch, new_properties)
+
+    assert updated_batch == expected_batch
+    assert original_batch == Batch()
+
+
+def test_replace_dataproc_batch_properties_with_dict():
+    original_batch = {
+        "spark_batch": {
+            "jar_file_uris": ["file:///usr/lib/spark/examples/jars/spark-examples.jar"],
+            "main_class": "org.apache.spark.examples.SparkPi",
+        },
+        "runtime_config": {"properties": {"existingProperty": "value"}},
+    }
+    new_properties = {"newProperty": "newValue"}
+    expected_batch = {
+        "spark_batch": {
+            "jar_file_uris": ["file:///usr/lib/spark/examples/jars/spark-examples.jar"],
+            "main_class": "org.apache.spark.examples.SparkPi",
+        },
+        "runtime_config": {"properties": {"newProperty": "newValue"}},
+    }
+
+    updated_batch = _replace_dataproc_batch_properties(original_batch, new_properties)
+
+    assert updated_batch == expected_batch
+    assert original_batch["runtime_config"]["properties"] == {"existingProperty": "value"}
+    assert original_batch["spark_batch"]["main_class"] == "org.apache.spark.examples.SparkPi"
+
+
+def test_replace_dataproc_batch_properties_with_dict_and_run_time_config_object():
+    original_batch = {
+        "spark_batch": {
+            "jar_file_uris": ["file:///usr/lib/spark/examples/jars/spark-examples.jar"],
+            "main_class": "org.apache.spark.examples.SparkPi",
+        },
+        "runtime_config": RuntimeConfig(properties={"existingProperty": "value"}),
+    }
+    new_properties = {"newProperty": "newValue"}
+    expected_batch = {
+        "spark_batch": {
+            "jar_file_uris": ["file:///usr/lib/spark/examples/jars/spark-examples.jar"],
+            "main_class": "org.apache.spark.examples.SparkPi",
+        },
+        "runtime_config": RuntimeConfig(properties={"newProperty": "newValue"}),
+    }
+
+    updated_batch = _replace_dataproc_batch_properties(original_batch, new_properties)
+
+    assert updated_batch == expected_batch
+    assert original_batch["runtime_config"].properties == {"existingProperty": "value"}
+    assert original_batch["spark_batch"]["main_class"] == "org.apache.spark.examples.SparkPi"
+
+
+def test_replace_dataproc_batch_properties_with_empty_dict():
+    original_batch = {}
+    new_properties = {"newProperty": "newValue"}
+    expected_batch = {"runtime_config": {"properties": {"newProperty": "newValue"}}}
+
+    updated_batch = _replace_dataproc_batch_properties(original_batch, new_properties)
+
+    assert updated_batch == expected_batch
+    assert original_batch == {}
+
+
+@patch("airflow.providers.google.cloud.openlineage.utils._is_openlineage_provider_accessible")
+def test_inject_openlineage_properties_into_dataproc_batch_provider_not_accessible(mock_is_accessible):
+    mock_is_accessible.return_value = False
+    batch = {
+        "spark_batch": {
+            "jar_file_uris": ["file:///usr/lib/spark/examples/jars/spark-examples.jar"],
+            "main_class": "org.apache.spark.examples.SparkPi",
+        },
+        "runtime_config": {"properties": {"existingProperty": "value"}},
+    }
+    result = inject_openlineage_properties_into_dataproc_batch(batch, None, True)
+    assert result == batch
+
+
+@patch("airflow.providers.google.cloud.openlineage.utils._is_openlineage_provider_accessible")
+@patch("airflow.providers.google.cloud.openlineage.utils._is_dataproc_batch_of_supported_type")
+def test_inject_openlineage_properties_into_dataproc_batch_unsupported_batch_type(
+    mock_valid_job_type, mock_is_accessible
+):
+    mock_is_accessible.return_value = True
+    mock_valid_job_type.return_value = False
+    batch = {
+        "unsupported_batch": {
+            "jar_file_uris": ["file:///usr/lib/spark/examples/jars/spark-examples.jar"],
+            "main_class": "org.apache.spark.examples.SparkPi",
+        },
+        "runtime_config": {"properties": {"existingProperty": "value"}},
+    }
+    result = inject_openlineage_properties_into_dataproc_batch(batch, None, True)
+    assert result == batch
+
+
+@patch("airflow.providers.google.cloud.openlineage.utils._is_openlineage_provider_accessible")
+@patch("airflow.providers.google.cloud.openlineage.utils._is_dataproc_batch_of_supported_type")
+def test_inject_openlineage_properties_into_dataproc_batch_no_inject_parent_job_info(
+    mock_valid_job_type, mock_is_accessible
+):
+    mock_is_accessible.return_value = True
+    mock_valid_job_type.return_value = True
+    inject_parent_job_info = False
+    batch = {
+        "spark_batch": {
+            "jar_file_uris": ["file:///usr/lib/spark/examples/jars/spark-examples.jar"],
+            "main_class": "org.apache.spark.examples.SparkPi",
+        },
+        "runtime_config": {"properties": {"existingProperty": "value"}},
+    }
+    result = inject_openlineage_properties_into_dataproc_batch(batch, None, inject_parent_job_info)
+    assert result == batch
+
+
+@patch("airflow.providers.google.cloud.openlineage.utils._is_openlineage_provider_accessible")
+def test_inject_openlineage_properties_into_dataproc_batch(mock_is_ol_accessible):
+    mock_is_ol_accessible.return_value = True
+    context = {
+        "ti": MagicMock(
+            dag_id="dag_id",
+            task_id="task_id",
+            try_number=1,
+            map_index=1,
+            logical_date=dt.datetime(2024, 11, 11),
+        )
+    }
+    batch = {
+        "spark_batch": {
+            "jar_file_uris": ["file:///usr/lib/spark/examples/jars/spark-examples.jar"],
+            "main_class": "org.apache.spark.examples.SparkPi",
+        },
+        "runtime_config": {"properties": {"existingProperty": "value"}},
+    }
+    expected_properties = {
+        "existingProperty": "value",
+        "spark.openlineage.parentJobName": "dag_id.task_id",
+        "spark.openlineage.parentJobNamespace": "default",
+        "spark.openlineage.parentRunId": "01931885-2800-7be7-aa8d-aaa15c337267",
+    }
+    expected_batch = {
+        "spark_batch": {
+            "jar_file_uris": ["file:///usr/lib/spark/examples/jars/spark-examples.jar"],
+            "main_class": "org.apache.spark.examples.SparkPi",
+        },
+        "runtime_config": {"properties": expected_properties},
+    }
+    result = inject_openlineage_properties_into_dataproc_batch(batch, context, True)
+    assert result == expected_batch


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
This PR integrates a newly introduced (#44477) OpenLineage feature into another Dataproc operator. With this enhancement, users no longer need to manually provide parent job information for the OpenLineage Spark integration to generate the parent job facet. Detailed information about this feature can be found in the description of #44477.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
