### PR TITLE
AIP-72: Handle `SIGTERM` signal on Supervisor

### DIFF
--- a/task_sdk/tests/dags/sleeper_dag.py
+++ b/task_sdk/tests/dags/sleeper_dag.py
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from airflow.providers.standard.operators.bash import BashOperator
+from airflow.sdk.definitions.dag import dag
+
+
+@dag()
+def sleeper_dag():
+    BashOperator(task_id="sleep", bash_command="sleep 10")
+
+
+sleeper_dag()


### PR DESCRIPTION
As part of AIP-72, this PR introduces proper signal handling for the supervisor process. The supervisor now intercepts `SIGTERM` signals to ensure that child processes (task processes) are terminated gracefully.

Without signal handling, terminating the supervisor process (e.g., via `kill -TERM`) could leave child processes running as orphaned tasks. This change ensures that when the supervisor is stopped, all managed subprocesses are also terminated cleanly.

Sample Output when Superviser receives SIGTERM with (`kill -TERM 138`):
```
2024-12-09 09:28:53 [debug    ] DAG file parsed                [task] [task] file=/files/dags/example_bash_operator.py
2024-12-09 09:28:53 [warning  ] BashOperator.execute cannot be called outside TaskInstance! [airflow.task.operators.airflow.providers.standard.operators.bash.BashOperator] [task]
2024-12-09 09:28:53 [info     ] Tmp dir root location: /tmp    [airflow.task.hooks.airflow.providers.standard.hooks.subprocess.SubprocessHook] [task]
2024-12-09 09:28:53 [info     ] Running command: ['/usr/bin/bash', '-c', 'sleep 10000000'] [airflow.task.hooks.airflow.providers.standard.hooks.subprocess.SubprocessHook] [task]
2024-12-09 09:28:53 [info     ] Output:                        [airflow.task.hooks.airflow.providers.standard.hooks.subprocess.SubprocessHook] [task]
[2024-12-09T09:28:58.945+0000] {_client.py:1026} INFO - HTTP Request: PUT http://localhost:9091/execution/task-instances/01938d9d-a579-7b8e-aa91-0a2093a318d5/heartbeat "HTTP/1.1 204 No Content"
[2024-12-09T09:29:04.176+0000] {_client.py:1026} INFO - HTTP Request: PUT http://localhost:9091/execution/task-instances/01938d9d-a579-7b8e-aa91-0a2093a318d5/heartbeat "HTTP/1.1 204 No Content"
[2024-12-09T09:29:09.229+0000] {_client.py:1026} INFO - HTTP Request: PUT http://localhost:9091/execution/task-instances/01938d9d-a579-7b8e-aa91-0a2093a318d5/heartbeat "HTTP/1.1 204 No Content"
2024-12-09 09:29:09 [error    ] Received termination signal in supervisor. Terminating watched subprocess [supervisor] process_pid=139 signal=15 supervisor_pid=138
2024-12-09 09:29:09 [debug    ] Task process exited            [supervisor] exit_code=<Negsignal.SIGTERM: -15>
2024-12-09 09:29:09 [info     ] Process exited                 [supervisor] exit_code=<Negsignal.SIGTERM: -15> pid=139 signal=SIGTERM
[2024-12-09T09:29:14.262+0000] {_client.py:1026} INFO - HTTP Request: PATCH http://localhost:9091/execution/task-instances/01938d9d-a579-7b8e-aa91-0a2093a318d5/state "HTTP/1.1 204 No Content"
2024-12-09 09:29:14 [info     ] Task finished                  [supervisor] duration=21.38433257100405 exit_code=<Negsignal.SIGTERM: -15> final_state=failed
```
<img width="1613" alt="image" src="https://github.com/user-attachments/assets/c1548856-facb-4ebe-b389-89af4da4014b">

vs without signal handling:

```
024-12-09 09:34:47 [debug    ] Loaded DAG <DAG: example_bash_op> [airflow.models.dagbag.DagBag] [task]
2024-12-09 09:34:47 [debug    ] DAG file parsed                [task] [task] file=/files/dags/example_bash_operator.py
2024-12-09 09:34:47 [warning  ] BashOperator.execute cannot be called outside TaskInstance! [airflow.task.operators.airflow.providers.standard.operators.bash.BashOperator] [task]
2024-12-09 09:34:47 [info     ] Tmp dir root location: /tmp    [airflow.task.hooks.airflow.providers.standard.hooks.subprocess.SubprocessHook] [task]
2024-12-09 09:34:47 [info     ] Running command: ['/usr/bin/bash', '-c', 'sleep 10000000'] [airflow.task.hooks.airflow.providers.standard.hooks.subprocess.SubprocessHook] [task]
2024-12-09 09:34:47 [info     ] Output:                        [airflow.task.hooks.airflow.providers.standard.hooks.subprocess.SubprocessHook] [task]
[2024-12-09T09:34:52.417+0000] {_client.py:1026} INFO - HTTP Request: PUT http://localhost:9091/execution/task-instances/01938d9d-a579-7b8e-aa91-0a2093a318d5/heartbeat "HTTP/1.1 204 No Content"
Terminated
```

<img width="1553" alt="image" src="https://github.com/user-attachments/assets/6e076549-2312-4ab1-9c7e-2048b5946051">


A key difference is in first case the task is also set to `failed` state as it should while before it kept the TI as `running`

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
