### PR TITLE
Remove Provider Deprecations in Apache Livy

### DIFF
--- a/providers/src/airflow/providers/apache/livy/CHANGELOG.rst
+++ b/providers/src/airflow/providers/apache/livy/CHANGELOG.rst
@@ -28,6 +28,17 @@
 Changelog
 ---------
 
+main
+.....
+
+.. warning::
+   All deprecated classes, parameters and features have been removed from the Livy provider package.
+   The following breaking changes were introduced:
+
+   * Operators
+
+      * Removed ``get_hook`` method from ``LivyOperator``. Use ``hook`` property instead
+
 3.9.2
 .....
 

--- a/providers/src/airflow/providers/apache/livy/operators/livy.py
+++ b/providers/src/airflow/providers/apache/livy/operators/livy.py
@@ -23,10 +23,8 @@ from collections.abc import Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
-from deprecated.classic import deprecated
-
 from airflow.configuration import conf
-from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.apache.livy.hooks.livy import BatchState, LivyHook
 from airflow.providers.apache.livy.triggers.livy import LivyTrigger
@@ -142,11 +140,6 @@ class LivyOperator(BaseOperator):
             extra_options=self._extra_options,
             auth_type=self._livy_conn_auth_type,
         )
-
-    @deprecated(reason="use `hook` property instead.", category=AirflowProviderDeprecationWarning)
-    def get_hook(self) -> LivyHook:
-        """Get valid hook."""
-        return self.hook
 
     def execute(self, context: Context) -> Any:
         self._batch_id = self.hook.post_batch(**self.spark_params)

--- a/providers/tests/apache/livy/operators/test_livy.py
+++ b/providers/tests/apache/livy/operators/test_livy.py
@@ -21,7 +21,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.models.dag import DAG
 from airflow.providers.apache.livy.hooks.livy import BatchState
@@ -416,12 +416,6 @@ class TestLivyOperator:
             )
         mock_delete.assert_called_once_with(BATCH_ID)
         self.mock_context["ti"].xcom_push.assert_not_called()
-
-    def test_deprecated_get_hook(self):
-        op = LivyOperator(task_id="livy_example", file="sparkapp")
-        with pytest.warns(AirflowProviderDeprecationWarning, match="use `hook` property instead"):
-            hook = op.get_hook()
-        assert hook is op.hook
 
 
 @pytest.mark.db_test


### PR DESCRIPTION

related: #44559




<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
