### PR TITLE
Remove pandas and pyarrow dependencies from `apache-airflow-providers-databricks`

### DIFF
--- a/providers/src/airflow/providers/databricks/provider.yaml
+++ b/providers/src/airflow/providers/databricks/provider.yaml
@@ -78,7 +78,6 @@ dependencies:
   - databricks-sql-connector>=3.0.0
   - aiohttp>=3.9.2, <4
   - mergedeep>=1.3.4
-  - pyarrow>=14.0.1
 
 
 additional-extras:

--- a/providers/src/airflow/providers/databricks/provider.yaml
+++ b/providers/src/airflow/providers/databricks/provider.yaml
@@ -78,8 +78,6 @@ dependencies:
   - databricks-sql-connector>=3.0.0
   - aiohttp>=3.9.2, <4
   - mergedeep>=1.3.4
-  - pandas>=2.1.2,<2.2;python_version>="3.9"
-  - pandas>=1.5.3,<2.2;python_version<"3.9"
   - pyarrow>=14.0.1
 
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Recently our project was flagged to have a vulnerability due to dependency on `pandas`, related vulnerability here; [CVE-2024-9880](https://huntr.com/bounties/a49baae1-4652-4d6c-a179-313c21c41a8d). I saw that our project has `pandas` as a transtivie dependency due to [`apache-airflow-providers-databricks`](https://airflow.apache.org/docs/apache-airflow-providers-databricks/stable/index.html) having it listed as a dependency. Upon inspection of the code, it seems it is only listed as a dependency, but not it does not seem to actually be used in the codebase:

```
➜  databricks git:(main) pwd
/Users/florian/git/airflow/providers/src/airflow/providers/databricks

➜  databricks git:(main) grep -r "pandas" .     
./CHANGELOG.rst:* ``Update pandas minimum requirement for Python 3.12 (#40272)``
./provider.yaml:  - pandas>=2.1.2,<2.2;python_version>="3.9"
./provider.yaml:  - pandas>=1.5.3,<2.2;python_version<"3.9"

➜  databricks git:(main) grep -r "pyarrow" .
./provider.yaml:  - pyarrow>=14.0.1
```

As you can see, the same holds for `pyarrow`. I assume this means the dependencies are not needed? I am not familiar with Airflow's codebase, so apologies in advance if I am overlooking something here. I did find some explanation about cross-dependencies with other providers packages, and the `generated/provider_dependencies.json` file, but not quite sure if that applies here. In any case; feel free to close this PR if you think it is not valid.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
