### PR TITLE
Fix test_deprecated_options_with_new_section

### DIFF
--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -974,7 +974,7 @@ class TestDeprecatedConf:
                 with mock.patch.dict("os.environ", AIRFLOW__CORE__LOGGING_LEVEL="VALUE"):
                     assert conf.get("logging", "logging_level") == "VALUE"
 
-            with pytest.warns(FutureWarning, match="Please update your `conf.get"):
+            with pytest.warns(DeprecationWarning, match=r"The logging_level option in \[core\]"):
                 with mock.patch.dict("os.environ", AIRFLOW__CORE__LOGGING_LEVEL="VALUE"):
                     assert conf.get("core", "logging_level") == "VALUE"
 


### PR DESCRIPTION
This [PR](https://github.com/apache/airflow/commit/a58ed9d53b43dcfaf7e95ed17baaa15e0202efcb) is causing the the CI to break, on branch v2-10-test. It's working in main because we removed the test in this [PR](https://github.com/apache/airflow/pull/42100/files). We cannot backport the  [PR](https://github.com/apache/airflow/pull/42100/files) from main as it contains breaking changes. This PR makes the CI green for v2-10-test branch.