### PR TITLE
Remove deprecated code from Pagerduty provider 

### DIFF
--- a/providers/src/airflow/providers/pagerduty/CHANGELOG.rst
+++ b/providers/src/airflow/providers/pagerduty/CHANGELOG.rst
@@ -34,8 +34,7 @@ main
    All deprecated classes, parameters and features have been removed from the pagerduty provider package.
    The following breaking changes were introduced:
 
-   * Removed deprecated method ``create_event`` from providers.pagerduty.hooks.pagerduty. Please use the ``airflow.providers.pagerduty.hooks.PagerdutyEventsHook`` to interact with the Events API
-   * Removed deprecated method ``create_event`` from providers.pagerduty.hooks.pagerduty_events. Please use the ``PagerdutyEventsHook.send_event`` to interact with the Events API
+   * Removed deprecated method ``create_event`` from ``providers.pagerduty.hooks.pagerduty`` and ``providers.pagerduty.hooks.pagerduty_events``. Please use the ``airflow.providers.pagerduty.hooks.pagerduty_events.PagerdutyEventsHook.send_event`` to interact with the Events API
 
 3.8.1
 .....

--- a/providers/src/airflow/providers/pagerduty/CHANGELOG.rst
+++ b/providers/src/airflow/providers/pagerduty/CHANGELOG.rst
@@ -27,6 +27,16 @@
 Changelog
 ---------
 
+main
+.....
+
+.. warning::
+   All deprecated classes, parameters and features have been removed from the pagerduty provider package.
+   The following breaking changes were introduced:
+
+   * Removed deprecated method ``create_event`` from providers.pagerduty.hooks.pagerduty. Please use the ``airflow.providers.pagerduty.hooks.PagerdutyEventsHook`` to interact with the Events API
+   * Removed deprecated method ``create_event`` from providers.pagerduty.hooks.pagerduty_events. Please use the ``PagerdutyEventsHook.send_event`` to interact with the Events API
+
 3.8.1
 .....
 

--- a/providers/src/airflow/providers/pagerduty/hooks/pagerduty.py
+++ b/providers/src/airflow/providers/pagerduty/hooks/pagerduty.py
@@ -22,9 +22,8 @@ from __future__ import annotations
 from typing import Any
 
 import pdpyras
-from deprecated import deprecated
 
-from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 from airflow.providers.pagerduty.hooks.pagerduty_events import PagerdutyEventsHook
 
@@ -109,74 +108,6 @@ class PagerdutyHook(BaseHook):
         """
         self._session = pdpyras.APISession(self.token)
         return self._session
-
-    @deprecated(
-        reason=(
-            "This method will be deprecated. Please use the "
-            "`airflow.providers.pagerduty.hooks.PagerdutyEventsHook` to interact with the Events API"
-        ),
-        category=AirflowProviderDeprecationWarning,
-    )
-    def create_event(
-        self,
-        summary: str,
-        severity: str,
-        source: str = "airflow",
-        action: str = "trigger",
-        routing_key: str | None = None,
-        dedup_key: str | None = None,
-        custom_details: Any | None = None,
-        group: str | None = None,
-        component: str | None = None,
-        class_type: str | None = None,
-        images: list[Any] | None = None,
-        links: list[Any] | None = None,
-    ) -> dict:
-        """
-        Create event for service integration.
-
-        :param summary: Summary for the event
-        :param severity: Severity for the event, needs to be one of: info, warning, error, critical
-        :param source: Specific human-readable unique identifier, such as a
-            hostname, for the system having the problem.
-        :param action: Event action, needs to be one of: trigger, acknowledge,
-            resolve. Default to trigger if not specified.
-        :param routing_key: Integration key. If not specified, will try to read
-            from connection's extra json blob.
-        :param dedup_key: A string which identifies the alert triggered for the given event.
-            Required for the actions acknowledge and resolve.
-        :param custom_details: Free-form details from the event. Can be a dictionary or a string.
-            If a dictionary is passed it will show up in PagerDuty as a table.
-        :param group: A cluster or grouping of sources. For example, sources
-            "prod-datapipe-02" and "prod-datapipe-03" might both be part of "prod-datapipe"
-        :param component: The part or component of the affected system that is broken.
-        :param class_type: The class/type of the event.
-        :param images: List of images to include. Each dictionary in the list accepts the following keys:
-            `src`: The source (URL) of the image being attached to the incident. This image must be served via
-            HTTPS.
-            `href`: [Optional] URL to make the image a clickable link.
-            `alt`: [Optional] Alternative text for the image.
-        :param links: List of links to include. Each dictionary in the list accepts the following keys:
-            `href`: URL of the link to be attached.
-            `text`: [Optional] Plain text that describes the purpose of the link, and can be used as the
-            link's text.
-        :return: PagerDuty Events API v2 response.
-        """
-        routing_key = routing_key or self.routing_key
-
-        return PagerdutyEventsHook(integration_key=routing_key).create_event(
-            summary=summary,
-            severity=severity,
-            source=source,
-            action=action,
-            dedup_key=dedup_key,
-            custom_details=custom_details,
-            group=group,
-            component=component,
-            class_type=class_type,
-            images=images,
-            links=links,
-        )
 
     def test_connection(self):
         try:

--- a/providers/src/airflow/providers/pagerduty/hooks/pagerduty.py
+++ b/providers/src/airflow/providers/pagerduty/hooks/pagerduty.py
@@ -25,7 +25,6 @@ import pdpyras
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
-from airflow.providers.pagerduty.hooks.pagerduty_events import PagerdutyEventsHook
 
 
 class PagerdutyHook(BaseHook):

--- a/providers/src/airflow/providers/pagerduty/hooks/pagerduty_events.py
+++ b/providers/src/airflow/providers/pagerduty/hooks/pagerduty_events.py
@@ -22,9 +22,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 import pdpyras
-from deprecated import deprecated
 
-from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 
 if TYPE_CHECKING:
@@ -76,75 +75,6 @@ class PagerdutyEventsHook(BaseHook):
             raise AirflowException(
                 "Cannot get token: No valid integration key nor pagerduty_events_conn_id supplied."
             )
-
-    @deprecated(
-        reason=(
-            "This method will be deprecated. Please use the "
-            "`PagerdutyEventsHook.send_event` to interact with the Events API"
-        ),
-        category=AirflowProviderDeprecationWarning,
-    )
-    def create_event(
-        self,
-        summary: str,
-        severity: str,
-        source: str = "airflow",
-        action: str = "trigger",
-        dedup_key: str | None = None,
-        custom_details: Any | None = None,
-        group: str | None = None,
-        component: str | None = None,
-        class_type: str | None = None,
-        images: list[Any] | None = None,
-        links: list[Any] | None = None,
-    ) -> dict:
-        """
-        Create event for service integration.
-
-        :param summary: Summary for the event
-        :param severity: Severity for the event, needs to be one of: info, warning, error, critical
-        :param source: Specific human-readable unique identifier, such as a
-            hostname, for the system having the problem.
-        :param action: Event action, needs to be one of: trigger, acknowledge,
-            resolve. Default to trigger if not specified.
-        :param dedup_key: A string which identifies the alert triggered for the given event.
-            Required for the actions acknowledge and resolve.
-        :param custom_details: Free-form details from the event. Can be a dictionary or a string.
-            If a dictionary is passed it will show up in PagerDuty as a table.
-        :param group: A cluster or grouping of sources. For example, sources
-            "prod-datapipe-02" and "prod-datapipe-03" might both be part of "prod-datapipe"
-        :param component: The part or component of the affected system that is broken.
-        :param class_type: The class/type of the event.
-        :param images: List of images to include. Each dictionary in the list accepts the following keys:
-            `src`: The source (URL) of the image being attached to the incident. This image must be served via
-            HTTPS.
-            `href`: [Optional] URL to make the image a clickable link.
-            `alt`: [Optional] Alternative text for the image.
-        :param links: List of links to include. Each dictionary in the list accepts the following keys:
-            `href`: URL of the link to be attached.
-            `text`: [Optional] Plain text that describes the purpose of the link, and can be used as the
-            link's text.
-        :return: PagerDuty Events API v2 response.
-        """
-        data = PagerdutyEventsHook.prepare_event_data(
-            summary=summary,
-            severity=severity,
-            source=source,
-            custom_details=custom_details,
-            component=component,
-            group=group,
-            class_type=class_type,
-            action=action,
-            dedup_key=dedup_key,
-            images=images,
-            links=links,
-            action_key_name="event_action",
-        )
-
-        session = pdpyras.EventsAPISession(self.integration_key)
-        resp = session.post("/v2/enqueue", json=data)
-        resp.raise_for_status()
-        return resp.json()
 
     def send_event(
         self,

--- a/providers/tests/pagerduty/hooks/test_pagerduty.py
+++ b/providers/tests/pagerduty/hooks/test_pagerduty.py
@@ -17,11 +17,8 @@
 # under the License.
 from __future__ import annotations
 
-from unittest import mock
-
 import pytest
 
-from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import Connection
 from airflow.providers.pagerduty.hooks.pagerduty import PagerdutyHook
 from airflow.providers.pagerduty.hooks.pagerduty_events import PagerdutyEventsHook
@@ -79,49 +76,3 @@ class TestPagerdutyHook:
         session = hook.get_session()
         resp = session.rget("/services/PZYX321")
         assert resp == mock_response_body
-
-    @mock.patch.object(PagerdutyEventsHook, "__init__")
-    @mock.patch.object(PagerdutyEventsHook, "create_event")
-    def test_create_event(self, events_hook_create_event, events_hook_init):
-        events_hook_init.return_value = None
-        hook = PagerdutyHook(pagerduty_conn_id=DEFAULT_CONN_ID)
-        with pytest.warns(
-            AirflowProviderDeprecationWarning,
-            match="This method will be deprecated. Please use the `airflow.providers.pagerduty.hooks.PagerdutyEventsHook` to interact with the Events API",
-        ):
-            hook.create_event(
-                summary="test",
-                source="airflow_test",
-                severity="error",
-            )
-        events_hook_init.assert_called_with(integration_key="integration_key")
-        events_hook_create_event.assert_called_with(
-            summary="test",
-            source="airflow_test",
-            severity="error",
-            action="trigger",
-            dedup_key=None,
-            custom_details=None,
-            group=None,
-            component=None,
-            class_type=None,
-            images=None,
-            links=None,
-        )
-
-    @mock.patch.object(PagerdutyEventsHook, "create_event", mock.MagicMock(return_value=None))
-    @mock.patch.object(PagerdutyEventsHook, "__init__")
-    def test_create_event_override(self, events_hook_init):
-        events_hook_init.return_value = None
-        hook = PagerdutyHook(pagerduty_conn_id=DEFAULT_CONN_ID)
-        with pytest.warns(
-            AirflowProviderDeprecationWarning,
-            match="This method will be deprecated. Please use the `airflow.providers.pagerduty.hooks.PagerdutyEventsHook` to interact with the Events API",
-        ):
-            hook.create_event(
-                routing_key="different_key",
-                summary="test",
-                source="airflow_test",
-                severity="error",
-            )
-        events_hook_init.assert_called_with(integration_key="different_key")

--- a/providers/tests/pagerduty/hooks/test_pagerduty.py
+++ b/providers/tests/pagerduty/hooks/test_pagerduty.py
@@ -21,7 +21,6 @@ import pytest
 
 from airflow.models import Connection
 from airflow.providers.pagerduty.hooks.pagerduty import PagerdutyHook
-from airflow.providers.pagerduty.hooks.pagerduty_events import PagerdutyEventsHook
 from airflow.utils import db
 
 pytestmark = pytest.mark.db_test

--- a/providers/tests/pagerduty/hooks/test_pagerduty_events.py
+++ b/providers/tests/pagerduty/hooks/test_pagerduty_events.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import pytest
 
 from airflow.models import Connection
-from airflow.providers.pagerduty.hooks.pagerduty import PagerdutyEventsHook
+from airflow.providers.pagerduty.hooks.pagerduty_events import PagerdutyEventsHook
 from airflow.utils import db
 
 pytestmark = pytest.mark.db_test

--- a/providers/tests/pagerduty/hooks/test_pagerduty_events.py
+++ b/providers/tests/pagerduty/hooks/test_pagerduty_events.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import pytest
 
-from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import Connection
 from airflow.providers.pagerduty.hooks.pagerduty import PagerdutyEventsHook
 from airflow.utils import db
@@ -43,25 +42,6 @@ class TestPagerdutyEventsHook:
         hook = PagerdutyEventsHook(integration_key="override_key", pagerduty_events_conn_id=DEFAULT_CONN_ID)
         assert hook.integration_key == "override_key", "token initialised."
 
-    def test_create_event(self, requests_mock, events_connections):
-        hook = PagerdutyEventsHook(pagerduty_events_conn_id=DEFAULT_CONN_ID)
-        mock_response_body = {
-            "status": "success",
-            "message": "Event processed",
-            "dedup_key": "samplekeyhere",
-        }
-        requests_mock.post("https://events.pagerduty.com/v2/enqueue", json=mock_response_body)
-        with pytest.warns(
-            AirflowProviderDeprecationWarning,
-            match="This method will be deprecated. Please use the `PagerdutyEventsHook.send_event` to interact with the Events API",
-        ):
-            resp = hook.create_event(
-                summary="test",
-                source="airflow_test",
-                severity="error",
-            )
-        assert resp == mock_response_body
-
     def test_create_change_event(self, requests_mock, events_connections):
         hook = PagerdutyEventsHook(pagerduty_events_conn_id=DEFAULT_CONN_ID)
         change_event_id = "change_event_id"
@@ -81,22 +61,3 @@ class TestPagerdutyEventsHook:
         requests_mock.post("https://events.pagerduty.com/v2/enqueue", json=mock_response_body)
         resp = hook.send_event(summary="test", source="airflow_test", severity="error", dedup_key=dedup_key)
         assert resp == dedup_key
-
-    def test_create_event_deprecation_warning(self, requests_mock, events_connections):
-        hook = PagerdutyEventsHook(pagerduty_events_conn_id=DEFAULT_CONN_ID)
-        mock_response_body = {
-            "status": "success",
-            "message": "Event processed",
-            "dedup_key": "samplekeyhere",
-        }
-        requests_mock.post("https://events.pagerduty.com/v2/enqueue", json=mock_response_body)
-        warning = (
-            "This method will be deprecated. Please use the `PagerdutyEventsHook.send_event`"
-            " to interact with the Events API"
-        )
-        with pytest.warns(AirflowProviderDeprecationWarning, match=warning):
-            hook.create_event(
-                summary="test",
-                source="airflow_test",
-                severity="error",
-            )


### PR DESCRIPTION
related: #44559 

remove-deprecated-code, remove test ,update changelog from-pagerduty provider
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
