### PR TITLE
Expose timestamp filter on dataset event endpoint

### DIFF
--- a/airflow/api_connexion/endpoints/dataset_endpoint.py
+++ b/airflow/api_connexion/endpoints/dataset_endpoint.py
@@ -114,7 +114,13 @@ def get_datasets(
 
 @security.requires_access_dataset("GET")
 @provide_session
-@format_parameters({"limit": check_limit})
+@format_parameters(
+    {
+        "timestamp_gte": format_datetime,
+        "timestamp_lte": format_datetime,
+        "limit": check_limit,
+    }
+)
 def get_dataset_events(
     *,
     limit: int,
@@ -125,6 +131,9 @@ def get_dataset_events(
     source_task_id: str | None = None,
     source_run_id: str | None = None,
     source_map_index: int | None = None,
+    timestamp_gte: str | None = None,
+    timestamp_lte: str | None = None,
+
     session: Session = NEW_SESSION,
 ) -> APIResponse:
     """Get dataset events."""
@@ -142,6 +151,11 @@ def get_dataset_events(
         query = query.where(DatasetEvent.source_run_id == source_run_id)
     if source_map_index:
         query = query.where(DatasetEvent.source_map_index == source_map_index)
+    # filter timestamp
+    if timestamp_gte:
+        query = query.filter(DatasetEvent.timestamp >= timestamp_gte)
+    if timestamp_lte:
+        query = query.filter(DatasetEvent.timestamp <= timestamp_lte)
 
     query = query.options(subqueryload(DatasetEvent.created_dagruns))
 

--- a/airflow/api_connexion/endpoints/dataset_endpoint.py
+++ b/airflow/api_connexion/endpoints/dataset_endpoint.py
@@ -133,7 +133,6 @@ def get_dataset_events(
     source_map_index: int | None = None,
     timestamp_gte: str | None = None,
     timestamp_lte: str | None = None,
-
     session: Session = NEW_SESSION,
 ) -> APIResponse:
     """Get dataset events."""

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -2399,6 +2399,8 @@ paths:
         - $ref: "#/components/parameters/FilterSourceTaskID"
         - $ref: "#/components/parameters/FilterSourceRunID"
         - $ref: "#/components/parameters/FilterSourceMapIndex"
+        - $ref: "#/components/parameters/FilterTimestampGTE"
+        - $ref: "#/components/parameters/FilterTimestampLTE"
       responses:
         "200":
           description: Success.
@@ -6012,6 +6014,34 @@ components:
         type: string
       required: false
       description: Returns objects matched by the Run ID.
+
+    FilterTimestampGTE:
+      in: query
+      name: timestamp_gte
+      schema:
+        type: string
+        format: date-time
+      required: false
+      description: |
+        Returns objects greater or equal the specified date.
+
+        This can be combined with timestamp_lte parameter to receive only the selected period.
+
+        *New in version 2.11.0*
+
+    FilterTimestampLTE:
+      in: query
+      name: timestamp_lte
+      schema:
+        type: string
+        format: date-time
+      required: false
+      description: |
+        Returns objects less or equal the specified date.
+
+        This can be combined with timestamp_gte parameter to receive only the selected period.
+
+        *New in version 2.11.0*
 
     # Other parameters
     FileToken:

--- a/tests/api_connexion/endpoints/test_dataset_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dataset_endpoint.py
@@ -539,9 +539,9 @@ class TestGetDatasetEvents(TestDatasetEndpoint):
     @pytest.mark.parametrize(
         "timestamp_gte, timestamp_lte, expected_ids",
         [
-            (timezone.parse("2020-06-11T00:00:00"), timezone.parse("2020-06-12T00:00:00"), [1]),
-            (timezone.parse("2020-06-12T00:00:00"), timezone.parse("2020-06-13T00:00:00"), [2]),
-            (timezone.parse("2020-06-11T00:00:00"), timezone.parse("2020-06-13T00:00:00"), [1, 2]),
+            ("2020-06-11T00:00:00", "2020-06-12T00:00:00", [1]),
+            ("2020-06-12T00:00:00", "2020-06-13T00:00:00", [2]),
+            ("2020-06-11T00:00:00", "2020-06-13T00:00:00", [1, 2]),
         ],
     )
     @provide_session
@@ -581,7 +581,7 @@ class TestGetDatasetEvents(TestDatasetEndpoint):
 
         # Construct query URL with timestamp_gte and timestamp_lte filters
         response = self.client.get(
-            f"/api/v1/datasets/events?timestamp_gte={timestamp_gte.isoformat()}&timestamp_lte={timestamp_lte.isoformat()}",
+            f"/api/v1/datasets/events?timestamp_gte={timestamp_gte}&timestamp_lte={timestamp_lte}",
             environ_overrides={"REMOTE_USER": "test"}
         )
 

--- a/tests/api_connexion/endpoints/test_dataset_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dataset_endpoint.py
@@ -17,10 +17,10 @@
 from __future__ import annotations
 
 import urllib
+from datetime import timedelta
 from typing import Generator
 from unittest.mock import ANY
 
-from datetime import timedelta
 import pytest
 import time_machine
 
@@ -570,7 +570,7 @@ class TestGetDatasetEvents(TestDatasetEndpoint):
                 source_task_id=f"task{i}",
                 source_run_id=f"run{i}",
                 source_map_index=i,
-                timestamp=event_timestamp_base + timedelta(days=i-1),  # Vary timestamps for testing
+                timestamp=event_timestamp_base + timedelta(days=i - 1),  # Vary timestamps for testing
             )
             for i in [1, 2, 3]
         ]
@@ -582,14 +582,14 @@ class TestGetDatasetEvents(TestDatasetEndpoint):
         # Construct query URL with timestamp_gte and timestamp_lte filters
         response = self.client.get(
             f"/api/v1/datasets/events?timestamp_gte={timestamp_gte}&timestamp_lte={timestamp_lte}",
-            environ_overrides={"REMOTE_USER": "test"}
+            environ_overrides={"REMOTE_USER": "test"},
         )
 
         assert response.status_code == 200
         response_data = response.json
 
         # Check if the returned dataset events' ids match the expected ones
-        dataset_event_ids = [event['id'] for event in response_data['dataset_events']]
+        dataset_event_ids = [event["id"] for event in response_data["dataset_events"]]
         assert sorted(dataset_event_ids) == sorted(expected_ids)
 
         # Validate total entries match expected number of results


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
Exposes a timestamp filter for the dataset event endpoint.
closes: https://github.com/apache/airflow/issues/41126
