### PR TITLE
AIP-38 Add operator name and type to graph

### DIFF
--- a/airflow/ui/src/pages/DagsList/Dag/Graph/TaskNode.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Graph/TaskNode.tsx
@@ -34,7 +34,9 @@ export const TaskNode = ({
     isMapped,
     isOpen,
     label,
+    operator,
     setupTeardownType,
+    type: nodeType,
     width,
   },
   id,
@@ -61,9 +63,11 @@ export const TaskNode = ({
           width={`${width}px`}
         >
           <Box>
-            {/* TODO: replace 'Operator' */}
-            <Text fontSize="xs" fontWeight="lighter" textTransform="uppercase">
-              {isGroup ? "Task Group" : "Operator"}
+            <Text fontSize="xs" fontWeight="lighter" textTransform="capitalize">
+              {isGroup ? "Task Group" : operator}
+            </Text>
+            <Text color="blue.solid" textTransform="capitalize">
+              {nodeType}
             </Text>
             <TaskName
               id={id}

--- a/airflow/ui/src/pages/DagsList/Dag/Graph/reactflowUtils.ts
+++ b/airflow/ui/src/pages/DagsList/Dag/Graph/reactflowUtils.ts
@@ -31,7 +31,9 @@ export type CustomNodeProps = {
   isMapped?: boolean;
   isOpen?: boolean;
   label: string;
+  operator?: string | null;
   setupTeardownType?: NodeResponse["setup_teardown_type"];
+  type: string;
   width?: number;
 };
 

--- a/airflow/ui/src/pages/DagsList/Dag/Graph/useGraphLayout.ts
+++ b/airflow/ui/src/pages/DagsList/Dag/Graph/useGraphLayout.ts
@@ -222,6 +222,7 @@ const generateElkGraph = ({
       isGroup: Boolean(node.children),
       isMapped: node.is_mapped === null ? undefined : node.is_mapped,
       label: node.label,
+      operator: node.operator,
       setupTeardownType: node.setup_teardown_type,
       type: node.type,
       width,


### PR DESCRIPTION
Depends on: https://github.com/apache/airflow/pull/44651

Only the last commit is relevant.

This add the `operator_name` to the graph as well as general `type` handling.

Before:
![Screenshot 2024-12-04 at 18 06 33](https://github.com/user-attachments/assets/56606e80-eae8-42c7-ad54-6ae991e1e6d3)


After:
![Screenshot 2024-12-04 at 19 28 30](https://github.com/user-attachments/assets/25f0e2cb-051f-4d94-900f-a10c3f562204)

