### PR TITLE
AIP-84 Remove sensor from structure node type and rename attribute

### DIFF
--- a/airflow/api_fastapi/core_api/datamodels/ui/structure.py
+++ b/airflow/api_fastapi/core_api/datamodels/ui/structure.py
@@ -39,7 +39,7 @@ class NodeResponse(BaseModel):
     label: str
     tooltip: str | None = None
     setup_teardown_type: Literal["setup", "teardown"] | None = None
-    type: Literal["join", "sensor", "task", "asset_condition"]
+    type: Literal["join", "task", "asset_condition"]
     operator: str | None = None
 
 

--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -7809,7 +7809,6 @@ components:
           type: string
           enum:
           - join
-          - sensor
           - task
           - asset_condition
           title: Type

--- a/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -3171,7 +3171,7 @@ export const $NodeResponse = {
     },
     type: {
       type: "string",
-      enum: ["join", "sensor", "task", "asset_condition"],
+      enum: ["join", "task", "asset_condition"],
       title: "Type",
     },
     operator: {

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -766,11 +766,11 @@ export type NodeResponse = {
   label: string;
   tooltip?: string | null;
   setup_teardown_type?: "setup" | "teardown" | null;
-  type: "join" | "sensor" | "task" | "asset_condition";
+  type: "join" | "task" | "asset_condition";
   operator?: string | null;
 };
 
-export type type = "join" | "sensor" | "task" | "asset_condition";
+export type type = "join" | "task" | "asset_condition";
 
 /**
  * Request body for Clear Task Instances endpoint.

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -82,7 +82,6 @@ def task_group_to_dict(task_item_or_group):
     from airflow.models.abstractoperator import AbstractOperator
     from airflow.models.baseoperator import BaseOperator
     from airflow.models.mappedoperator import MappedOperator
-    from airflow.sensors.base import BaseSensorOperator
 
     if isinstance(task := task_item_or_group, AbstractOperator):
         setup_teardown_type = {}
@@ -95,8 +94,6 @@ def task_group_to_dict(task_item_or_group):
             setup_teardown_type["setup_teardown_type"] = "teardown"
         if isinstance(task, MappedOperator):
             is_mapped["is_mapped"] = True
-        if isinstance(task, BaseSensorOperator):
-            node_type["type"] = "sensor"
         if isinstance(task, BaseOperator) or isinstance(task, MappedOperator):
             node_operator["operator"] = task.operator_name
 


### PR DESCRIPTION
This wasn't tested and is actually not working. As of today we cannot retrieve from the `SerializedBaseOperator` the information if an Operator is a Sensor or a regular operator.

Removing this from the possible types for now. More effort would be required for it to work.