### PR TITLE
Include .ssh dir when --forward-credentials

### DIFF
--- a/scripts/ci/docker-compose/forward-credentials.yml
+++ b/scripts/ci/docker-compose/forward-credentials.yml
@@ -29,3 +29,4 @@ services:
       - ${HOME}/.config:/root/.config:cached
       - ${HOME}/.docker:/root/.docker:cached
       - ${HOME}/.snowsql:/root/.snowsql:cached
+      - ${HOME}/.ssh:/root/.ssh:cached


### PR DESCRIPTION
This is helpful e.g. when trying to use git in breez env.
