### PR TITLE
Remove hash on GitDagBundle

### DIFF
--- a/airflow/dag_processing/bundles/git.py
+++ b/airflow/dag_processing/bundles/git.py
@@ -93,8 +93,15 @@ class GitDagBundle(BaseDagBundle):
             if not self._has_version(self.bare_repo, self.version):
                 raise AirflowException(f"Version {self.version} not found in the repository")
 
-    def __hash__(self) -> int:
-        return hash((self.name, self.get_current_version()))
+    def __repr__(self):
+        return (
+            f"<GitDagBundle("
+            f"name={self.name!r}, "
+            f"tracking_ref={self.tracking_ref!r}, "
+            f"subdir={self.subdir!r}, "
+            f"version={self.version!r}"
+            f")>"
+        )
 
     def get_current_version(self) -> str:
         return self.repo.head.commit.hexsha


### PR DESCRIPTION
It's a bit sketchy to to make this hashable, I think.  The idea of what is the identity of a dag bundle is not very well defined.  In the orm sense, it's just the name.  But in another context it might mean name + version. So, we should just leave it to the call site to be explicit about it.  Meanwhile, I add a better repr.

My assumption is this isn't being used at this point.  If there's a really compelling reason to add it later we can.