### PR TITLE
fix(providers/common/compat): add back add_input_dataset and add_output_dataset to NoOpCollector

### DIFF
--- a/providers/src/airflow/providers/common/compat/lineage/hook.py
+++ b/providers/src/airflow/providers/common/compat/lineage/hook.py
@@ -90,7 +90,7 @@ def get_hook_lineage_collector():
         return _get_asset_compat_hook_lineage_collector()
 
     # For the case that airflow has not yet upgraded to 2.10 or higher,
-    # but using the providers that alreay uses `get_hook_lineage_collector`
+    # but using the providers that already uses `get_hook_lineage_collector`
     class NoOpCollector:
         """
         NoOpCollector is a hook lineage collector that does nothing.
@@ -98,7 +98,7 @@ def get_hook_lineage_collector():
         It is used when you want to disable lineage collection.
         """
 
-        # for providers that supports asset rename
+        # for providers that support asset rename
         def add_input_asset(self, *_, **__):
             pass
 

--- a/providers/src/airflow/providers/common/compat/lineage/hook.py
+++ b/providers/src/airflow/providers/common/compat/lineage/hook.py
@@ -89,6 +89,8 @@ def get_hook_lineage_collector():
     if AIRFLOW_V_2_10_PLUS:
         return _get_asset_compat_hook_lineage_collector()
 
+    # For the case that airflow has not yet upgraded to 2.10 or higher,
+    # but using the providers that alreay uses `get_hook_lineage_collector`
     class NoOpCollector:
         """
         NoOpCollector is a hook lineage collector that does nothing.
@@ -96,10 +98,18 @@ def get_hook_lineage_collector():
         It is used when you want to disable lineage collection.
         """
 
+        # for providers that supports asset rename
         def add_input_asset(self, *_, **__):
             pass
 
         def add_output_asset(self, *_, **__):
+            pass
+
+        # for providers that do not support asset rename
+        def add_input_dataset(self, *_, **__):
+            pass
+
+        def add_output_dataset(self, *_, **__):
             pass
 
     return NoOpCollector()

--- a/providers/tests/common/compat/lineage/test_hook.py
+++ b/providers/tests/common/compat/lineage/test_hook.py
@@ -16,9 +16,37 @@
 # under the License.
 from __future__ import annotations
 
+import pytest
+
 from airflow.providers.common.compat.lineage.hook import get_hook_lineage_collector
+
+from tests_common.test_utils.compat import AIRFLOW_V_3_0_PLUS
 
 
 def test_that_compat_does_not_raise():
     # On compat tests this goes into ImportError code path
     assert get_hook_lineage_collector() is not None
+    assert get_hook_lineage_collector() is not None
+
+
+@pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Test requires Airflow 3.0+")
+def test_compat_has_only_asset_methods():
+    hook_lienage_collector = get_hook_lineage_collector()
+
+    assert hook_lienage_collector.add_input_asset is not None
+    assert hook_lienage_collector.add_output_asset is not None
+
+    with pytest.raises(AttributeError):
+        hook_lienage_collector.add_input_dataset
+    with pytest.raises(AttributeError):
+        hook_lienage_collector.add_output_dataset
+
+
+@pytest.mark.skipif(AIRFLOW_V_3_0_PLUS, reason="Test requires Airflow < 3.0")
+def test_compat_has_asset_and_dataset_methods():
+    hook_lienage_collector = get_hook_lineage_collector()
+
+    assert hook_lienage_collector.add_input_asset is not None
+    assert hook_lienage_collector.add_output_asset is not None
+    assert hook_lienage_collector.add_input_dataset is not None
+    assert hook_lienage_collector.add_output_dataset is not None


### PR DESCRIPTION
## Why
When the user has airflow < 2.10 installed, a provider that has not yet renamed datasets as assets (e.g., `apache-airflow-providers-amazon==8.28.0`) and `apache-airflow-providers-common-compat>=1.2.1` (with asset rename backward compatibility layer.), the user will get the following `hook_lineage_collector` after calling `get_hook_lineage_collector`.

```python
    class NoOpCollector:
        """
        NoOpCollector is a hook lineage collector that does nothing.

        It is used when you want to disable lineage collection.
        """


        def add_input_asset(self, *_, **__):
            pass

        def add_output_asset(self, *_, **__):
            pass
```

As the provider has not yet been updated to use asset methods, it is still called `add_input_dataset`, which causes an AttributeError as `add_input_dataset` does not exist in the returned `NoOpCollector`

## What

add back `add_input_dataset` and `add_output_dataset` for backward compat

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
