### PR TITLE
Fix accidental db tests in Task SDK

### DIFF
--- a/airflow/models/asset.py
+++ b/airflow/models/asset.py
@@ -47,10 +47,7 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
 
-def _fetch_active_assets_by_name(
-    names: Iterable[str],
-    session: Session,
-) -> dict[str, Asset]:
+def fetch_active_assets_by_name(names: Iterable[str], session: Session) -> dict[str, Asset]:
     return {
         asset_model[0].name: asset_model[0].to_public()
         for asset_model in session.execute(
@@ -59,6 +56,16 @@ def _fetch_active_assets_by_name(
             .where(AssetActive.name.in_(name for name in names))
         )
     }
+
+
+def expand_alias_to_assets(alias_name: str, session: Session) -> Iterable[AssetModel]:
+    """Expand asset alias to resolved assets."""
+    asset_alias_obj = session.scalar(
+        select(AssetAliasModel).where(AssetAliasModel.name == alias_name).limit(1)
+    )
+    if asset_alias_obj:
+        return list(asset_alias_obj.assets)
+    return []
 
 
 alias_association_table = Table(

--- a/airflow/models/asset.py
+++ b/airflow/models/asset.py
@@ -42,13 +42,13 @@ from airflow.utils import timezone
 from airflow.utils.sqlalchemy import UtcDateTime
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterable
 
     from sqlalchemy.orm import Session
 
 
 def _fetch_active_assets_by_name(
-    names: Sequence[str],
+    names: Iterable[str],
     session: Session,
 ) -> dict[str, Asset]:
     return {

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1856,6 +1856,7 @@ class DAG(TaskSDKDag, LoggingMixin):
         orm_asset_aliases = asset_op.add_asset_aliases(session=session)
         session.flush()  # This populates id so we can create fks in later calls.
 
+        orm_dags = dag_op.find_orm_dags(session=session)  # Refetch so relationship is up to date.
         asset_op.add_dag_asset_references(orm_dags, orm_assets, session=session)
         asset_op.add_dag_asset_alias_references(orm_dags, orm_asset_aliases, session=session)
         asset_op.add_task_asset_references(orm_dags, orm_assets, session=session)

--- a/airflow/utils/context.py
+++ b/airflow/utils/context.py
@@ -35,7 +35,7 @@ import lazy_object_proxy
 from sqlalchemy import select
 
 from airflow.exceptions import RemovedInAirflow3Warning
-from airflow.models.asset import AssetAliasModel, AssetEvent, AssetModel, _fetch_active_assets_by_name
+from airflow.models.asset import AssetAliasModel, AssetEvent, AssetModel, fetch_active_assets_by_name
 from airflow.sdk.definitions.asset import (
     Asset,
     AssetAlias,
@@ -250,7 +250,7 @@ class InletEventsAccessors(Mapping[str, LazyAssetEventSelectSequence]):
                 _asset_ref_names.append(inlet.name)
 
         if _asset_ref_names:
-            for asset_name, asset in _fetch_active_assets_by_name(_asset_ref_names, self._session).items():
+            for asset_name, asset in fetch_active_assets_by_name(_asset_ref_names, self._session).items():
                 self._assets[asset_name] = asset
 
     def __iter__(self) -> Iterator[str]:

--- a/providers/src/airflow/providers/common/compat/assets/__init__.py
+++ b/providers/src/airflow/providers/common/compat/assets/__init__.py
@@ -28,24 +28,24 @@ from airflow.providers.common.compat import (
 
 if TYPE_CHECKING:
     from airflow.auth.managers.models.resource_details import AssetDetails
+    from airflow.models.asset import expand_alias_to_assets
     from airflow.sdk.definitions.asset import (
         Asset,
         AssetAlias,
         AssetAliasEvent,
         AssetAll,
         AssetAny,
-        expand_alias_to_assets,
     )
 else:
     if AIRFLOW_V_3_0_PLUS:
         from airflow.auth.managers.models.resource_details import AssetDetails
+        from airflow.models.asset import expand_alias_to_assets
         from airflow.sdk.definitions.asset import (
             Asset,
             AssetAlias,
             AssetAliasEvent,
             AssetAll,
             AssetAny,
-            expand_alias_to_assets,
         )
     else:
         # dataset is renamed to asset since Airflow 3.0

--- a/task_sdk/src/airflow/sdk/definitions/asset/decorators.py
+++ b/task_sdk/src/airflow/sdk/definitions/asset/decorators.py
@@ -54,7 +54,7 @@ class _AssetMainOperator(PythonOperator):
             yield key, value
 
     def determine_kwargs(self, context: Mapping[str, Any]) -> Mapping[str, Any]:
-        from airflow.models.asset import _fetch_active_assets_by_name
+        from airflow.models.asset import fetch_active_assets_by_name
         from airflow.utils.session import create_session
 
         asset_names = {asset_ref.name for asset_ref in self.inlets if isinstance(asset_ref, AssetRef)}
@@ -63,7 +63,7 @@ class _AssetMainOperator(PythonOperator):
 
         if asset_names:
             with create_session() as session:
-                active_assets = _fetch_active_assets_by_name(asset_names, session)
+                active_assets = fetch_active_assets_by_name(asset_names, session)
         else:
             active_assets = {}
         return dict(self._iter_kwargs(context, active_assets))

--- a/task_sdk/src/airflow/sdk/definitions/asset/decorators.py
+++ b/task_sdk/src/airflow/sdk/definitions/asset/decorators.py
@@ -24,7 +24,6 @@ import attrs
 
 from airflow.providers.standard.operators.python import PythonOperator
 from airflow.sdk.definitions.asset import Asset, AssetRef
-from airflow.utils.session import create_session
 
 if TYPE_CHECKING:
     from collections.abc import Collection, Iterator, Mapping
@@ -56,10 +55,11 @@ class _AssetMainOperator(PythonOperator):
 
     def determine_kwargs(self, context: Mapping[str, Any]) -> Mapping[str, Any]:
         from airflow.models.asset import _fetch_active_assets_by_name
+        from airflow.utils.session import create_session
 
-        asset_names = [asset_ref.name for asset_ref in self.inlets if isinstance(asset_ref, AssetRef)]
+        asset_names = {asset_ref.name for asset_ref in self.inlets if isinstance(asset_ref, AssetRef)}
         if "self" in inspect.signature(self.python_callable).parameters:
-            asset_names.append(self._definition_name)
+            asset_names.add(self._definition_name)
 
         if asset_names:
             with create_session() as session:
@@ -140,6 +140,8 @@ class asset:
         return AssetDefinition(
             name=name,
             uri=name if self.uri is None else str(self.uri),
+            group=self.group,
+            extra=self.extra,
             function=f,
             source=self,
         )

--- a/task_sdk/tests/conftest.py
+++ b/task_sdk/tests/conftest.py
@@ -49,6 +49,12 @@ def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line("norecursedirs", "tests/test_dags")
 
 
+@pytest.hookimpl(tryfirst=True)
+def pytest_runtest_setup(item):
+    if next(item.iter_markers(name="db_test"), None):
+        pytest.fail("Task SDK tests must not use database")
+
+
 class LogCapture:
     # Like structlog.typing.LogCapture, but that doesn't add log_level in to the event dict
     entries: list[EventDict]

--- a/task_sdk/tests/defintions/test_asset.py
+++ b/task_sdk/tests/defintions/test_asset.py
@@ -466,7 +466,7 @@ def test_sanitize_uri_raises_exception():
 
 
 @mock.patch("airflow.sdk.definitions.asset._get_uri_normalizer", return_value=None)
-def test_normalize_uri_no_normalizer_found():
+def test_normalize_uri_no_normalizer_found(mock_get_uri_normalizer):
     asset = Asset(uri="any_uri_without_normalizer_defined")
     assert asset.normalized_uri is None
 
@@ -482,7 +482,7 @@ def test_normalize_uri_invalid_uri():
 
 @mock.patch("airflow.sdk.definitions.asset._get_uri_normalizer", _mock_get_uri_normalizer_noop)
 @mock.patch("airflow.sdk.definitions.asset._get_normalized_scheme", return_value="valid_scheme")
-def test_normalize_uri_valid_uri():
+def test_normalize_uri_valid_uri(mock_get_normalized_scheme):
     asset = Asset(uri="valid_aip60_uri")
     assert asset.normalized_uri == "valid_aip60_uri"
 

--- a/task_sdk/tests/defintions/test_asset.py
+++ b/task_sdk/tests/defintions/test_asset.py
@@ -18,15 +18,11 @@
 from __future__ import annotations
 
 import os
-from collections import defaultdict
 from typing import Callable
-from unittest.mock import patch
+from unittest import mock
 
 import pytest
-from sqlalchemy.sql import select
 
-from airflow.models.asset import AssetAliasModel, AssetDagRunQueue, AssetModel
-from airflow.models.serialized_dag import SerializedDagModel
 from airflow.operators.empty import EmptyOperator
 from airflow.sdk.definitions.asset import (
     Asset,
@@ -40,18 +36,10 @@ from airflow.sdk.definitions.asset import (
     _get_normalized_scheme,
     _sanitize_uri,
 )
+from airflow.sdk.definitions.dag import DAG
 from airflow.serialization.serialized_objects import BaseSerialization, SerializedDAG
 
 ASSET_MODULE_PATH = "airflow.sdk.definitions.asset"
-
-
-@pytest.fixture
-def clear_assets():
-    from tests_common.test_utils.db import clear_db_assets
-
-    clear_db_assets()
-    yield
-    clear_db_assets()
 
 
 @pytest.mark.parametrize(
@@ -173,7 +161,6 @@ def test_asset_iter_assets():
     assert list(asset1.iter_assets()) == [(("asset-1", "s3://bucket1/data1"), asset1)]
 
 
-@pytest.mark.db_test
 def test_asset_iter_asset_aliases():
     base_asset = AssetAll(
         AssetAlias(name="example-alias-1"),
@@ -318,22 +305,16 @@ def test_nested_asset_conditions_with_serialization(status_values, expected_eval
 
 
 @pytest.fixture
-def create_test_assets(session):
+def create_test_assets():
     """Fixture to create test assets and corresponding models."""
-    assets = [Asset(uri=f"test://asset{i}", name=f"hello{i}") for i in range(1, 3)]
-    for asset in assets:
-        session.add(AssetModel(uri=asset.uri))
-    session.commit()
-    return assets
+    return [Asset(uri=f"test://asset{i}", name=f"hello{i}") for i in range(1, 3)]
 
 
-@pytest.mark.db_test
-@pytest.mark.usefixtures("clear_assets")
-def test_asset_trigger_setup_and_serialization(session, dag_maker, create_test_assets):
+def test_asset_trigger_setup_and_serialization(create_test_assets):
     assets = create_test_assets
 
     # Create DAG with asset triggers
-    with dag_maker(schedule=AssetAny(*assets)) as dag:
+    with DAG(dag_id="test", schedule=AssetAny(*assets), catchup=False) as dag:
         EmptyOperator(task_id="hello")
 
     # Verify assets are set up correctly
@@ -349,81 +330,6 @@ def test_asset_trigger_setup_and_serialization(session, dag_maker, create_test_a
     assert (
         deserialized_dag.timetable.asset_condition.objects == dag.timetable.asset_condition.objects
     ), "Deserialized assets should match original"
-
-
-@pytest.mark.db_test
-@pytest.mark.usefixtures("clear_assets")
-def test_asset_dag_run_queue_processing(session, clear_assets, dag_maker, create_test_assets):
-    assets = create_test_assets
-    asset_models = session.query(AssetModel).all()
-
-    with dag_maker(schedule=AssetAny(*assets)) as dag:
-        EmptyOperator(task_id="hello")
-
-    # Add AssetDagRunQueue entries to simulate asset event processing
-    for am in asset_models:
-        session.add(AssetDagRunQueue(asset_id=am.id, target_dag_id=dag.dag_id))
-    session.commit()
-
-    # Fetch and evaluate asset triggers for all DAGs affected by asset events
-    records = session.scalars(select(AssetDagRunQueue)).all()
-    dag_statuses = defaultdict(lambda: defaultdict(bool))
-    for record in records:
-        dag_statuses[record.target_dag_id][record.asset.uri] = True
-
-    serialized_dags = session.execute(
-        select(SerializedDagModel).where(SerializedDagModel.dag_id.in_(dag_statuses.keys()))
-    ).fetchall()
-
-    for (serialized_dag,) in serialized_dags:
-        dag = SerializedDAG.deserialize(serialized_dag.data)
-        for asset_uri, status in dag_statuses[dag.dag_id].items():
-            cond = dag.timetable.asset_condition
-            assert cond.evaluate({asset_uri: status}), "DAG trigger evaluation failed"
-
-
-@pytest.mark.db_test
-@pytest.mark.usefixtures("clear_assets")
-def test_dag_with_complex_asset_condition(session, dag_maker):
-    # Create Asset instances
-    asset1 = Asset(uri="test://asset1", name="hello1")
-    asset2 = Asset(uri="test://asset2", name="hello2")
-
-    # Create and add AssetModel instances to the session
-    am1 = AssetModel(uri=asset1.uri, name=asset1.name, group="asset")
-    am2 = AssetModel(uri=asset2.uri, name=asset2.name, group="asset")
-    session.add_all([am1, am2])
-    session.commit()
-
-    # Setup a DAG with complex asset triggers (AssetAny with AssetAll)
-    with dag_maker(schedule=AssetAny(asset1, AssetAll(asset2, asset1))) as dag:
-        EmptyOperator(task_id="hello")
-
-    assert isinstance(
-        dag.timetable.asset_condition, AssetAny
-    ), "DAG's asset trigger should be an instance of AssetAny"
-    assert any(
-        isinstance(trigger, AssetAll) for trigger in dag.timetable.asset_condition.objects
-    ), "DAG's asset trigger should include AssetAll"
-
-    serialized_triggers = SerializedDAG.serialize(dag.timetable.asset_condition)
-
-    deserialized_triggers = SerializedDAG.deserialize(serialized_triggers)
-
-    assert isinstance(
-        deserialized_triggers, AssetAny
-    ), "Deserialized triggers should be an instance of AssetAny"
-    assert any(
-        isinstance(trigger, AssetAll) for trigger in deserialized_triggers.objects
-    ), "Deserialized triggers should include AssetAll"
-
-    serialized_timetable_dict = SerializedDAG.to_dict(dag)["dag"]["timetable"]["__var"]
-    assert (
-        "asset_condition" in serialized_timetable_dict
-    ), "Serialized timetable should contain 'asset_condition'"
-    assert isinstance(
-        serialized_timetable_dict["asset_condition"], dict
-    ), "Serialized 'asset_condition' should be a dict"
 
 
 def assets_equal(a1: BaseAsset, a2: BaseAsset) -> bool:
@@ -548,7 +454,7 @@ def _mock_get_uri_normalizer_noop(normalized_scheme):
     return normalizer
 
 
-@patch(
+@mock.patch(
     "airflow.sdk.definitions.asset._get_uri_normalizer",
     _mock_get_uri_normalizer_raising_error,
 )
@@ -559,13 +465,13 @@ def test_sanitize_uri_raises_exception():
     assert str(e_info.value) == "Incorrect URI format"
 
 
-@patch("airflow.sdk.definitions.asset._get_uri_normalizer", lambda x: None)
+@mock.patch("airflow.sdk.definitions.asset._get_uri_normalizer", return_value=None)
 def test_normalize_uri_no_normalizer_found():
     asset = Asset(uri="any_uri_without_normalizer_defined")
     assert asset.normalized_uri is None
 
 
-@patch(
+@mock.patch(
     "airflow.sdk.definitions.asset._get_uri_normalizer",
     _mock_get_uri_normalizer_raising_error,
 )
@@ -574,73 +480,85 @@ def test_normalize_uri_invalid_uri():
     assert asset.normalized_uri is None
 
 
-@patch("airflow.sdk.definitions.asset._get_uri_normalizer", _mock_get_uri_normalizer_noop)
-@patch("airflow.sdk.definitions.asset._get_normalized_scheme", lambda x: "valid_scheme")
+@mock.patch("airflow.sdk.definitions.asset._get_uri_normalizer", _mock_get_uri_normalizer_noop)
+@mock.patch("airflow.sdk.definitions.asset._get_normalized_scheme", return_value="valid_scheme")
 def test_normalize_uri_valid_uri():
     asset = Asset(uri="valid_aip60_uri")
     assert asset.normalized_uri == "valid_aip60_uri"
 
 
-@pytest.mark.db_test
-@pytest.mark.usefixtures("clear_assets")
+class FakeSession:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        pass
+
+
+FAKE_SESSION = FakeSession()
+
+
 class TestAssetAliasCondition:
     @pytest.fixture
-    def asset_model(self, session):
+    def asset_model(self):
         """Example asset links to asset alias resolved_asset_alias_2."""
-        asset_model = AssetModel(
+        from airflow.models.asset import AssetModel
+
+        return AssetModel(
             id=1,
             uri="test://asset1/",
             name="test_name",
             group="asset",
         )
 
-        session.add(asset_model)
-        session.commit()
-
-        return asset_model
-
     @pytest.fixture
-    def asset_alias_1(self, session):
+    def asset_alias_1(self):
         """Example asset alias links to no assets."""
-        asset_alias_model = AssetAliasModel(
-            name="test_name",
-            group="test",
-        )
+        from airflow.models.asset import AssetAliasModel
 
-        session.add(asset_alias_model)
-        session.commit()
-
-        return asset_alias_model
+        return AssetAliasModel(name="test_name", group="test")
 
     @pytest.fixture
-    def resolved_asset_alias_2(self, session, asset_model):
+    def resolved_asset_alias_2(self, asset_model):
         """Example asset alias links to asset asset_alias_1."""
+        from airflow.models.asset import AssetAliasModel
+
         asset_alias_2 = AssetAliasModel(name="test_name_2")
         asset_alias_2.assets.append(asset_model)
-
-        session.add(asset_alias_2)
-        session.commit()
-
         return asset_alias_2
-
-    def test_init(self, asset_alias_1, asset_model, resolved_asset_alias_2):
-        cond = AssetAliasCondition.from_asset_alias(asset_alias_1)
-        assert cond.objects == []
-
-        cond = AssetAliasCondition.from_asset_alias(resolved_asset_alias_2)
-        assert cond.objects == [Asset(uri=asset_model.uri, name=asset_model.name)]
 
     def test_as_expression(self, asset_alias_1, resolved_asset_alias_2):
         for asset_alias in (asset_alias_1, resolved_asset_alias_2):
             cond = AssetAliasCondition.from_asset_alias(asset_alias)
             assert cond.as_expression() == {"alias": {"name": asset_alias.name, "group": asset_alias.group}}
 
-    def test_evalute(self, asset_alias_1, resolved_asset_alias_2, asset_model):
+    @mock.patch("airflow.models.asset.expand_alias_to_assets")
+    @mock.patch("airflow.utils.session.create_session", return_value=FAKE_SESSION)
+    def test_evalute_empty(
+        self, mock_create_session, mock_expand_alias_to_assets, asset_alias_1, asset_model
+    ):
+        mock_expand_alias_to_assets.return_value = []
+
         cond = AssetAliasCondition.from_asset_alias(asset_alias_1)
         assert cond.evaluate({asset_model.uri: True}) is False
 
+        assert mock_expand_alias_to_assets.mock_calls == [mock.call(asset_alias_1.name, FAKE_SESSION)]
+        assert mock_create_session.mock_calls == [mock.call()]
+
+    @mock.patch("airflow.models.asset.expand_alias_to_assets")
+    @mock.patch("airflow.utils.session.create_session", return_value=FAKE_SESSION)
+    def test_evalute_resolved(
+        self, mock_create_session, mock_expand_alias_to_assets, resolved_asset_alias_2, asset_model
+    ):
+        mock_expand_alias_to_assets.return_value = [asset_model]
+
         cond = AssetAliasCondition.from_asset_alias(resolved_asset_alias_2)
         assert cond.evaluate({asset_model.uri: True}) is True
+
+        assert mock_expand_alias_to_assets.mock_calls == [
+            mock.call(resolved_asset_alias_2.name, FAKE_SESSION),
+        ]
+        assert mock_create_session.mock_calls == [mock.call()]
 
 
 class TestAssetSubclasses:

--- a/task_sdk/tests/defintions/test_asset_decorators.py
+++ b/task_sdk/tests/defintions/test_asset_decorators.py
@@ -21,11 +21,9 @@ from unittest.mock import ANY
 
 import pytest
 
-from airflow.models.asset import AssetActive, AssetModel
+from airflow.models.asset import AssetModel
 from airflow.sdk.definitions.asset import Asset, AssetRef
 from airflow.sdk.definitions.asset.decorators import _AssetMainOperator, asset
-
-pytestmark = pytest.mark.db_test
 
 
 @pytest.fixture
@@ -65,20 +63,20 @@ class TestAssetDecorator:
 
         assert asset_definition.name == "example_asset_func"
         assert asset_definition.uri == "example_asset_func"
-        assert asset_definition.group == ""
+        assert asset_definition.group == "asset"
         assert asset_definition.extra == {}
-        assert asset_definition.function == example_asset_func
-        assert asset_definition.schedule is None
+        assert asset_definition._function == example_asset_func
+        assert asset_definition._source.schedule is None
 
     def test_with_uri(self, example_asset_func):
         asset_definition = asset(schedule=None, uri="s3://bucket/object")(example_asset_func)
 
         assert asset_definition.name == "example_asset_func"
         assert asset_definition.uri == "s3://bucket/object"
-        assert asset_definition.group == ""
+        assert asset_definition.group == "asset"
         assert asset_definition.extra == {}
-        assert asset_definition.function == example_asset_func
-        assert asset_definition.schedule is None
+        assert asset_definition._function == example_asset_func
+        assert asset_definition._source.schedule is None
 
     def test_with_group_and_extra(self, example_asset_func):
         asset_definition = asset(schedule=None, uri="s3://bucket/object", group="MLModel", extra={"k": "v"})(
@@ -88,8 +86,8 @@ class TestAssetDecorator:
         assert asset_definition.uri == "s3://bucket/object"
         assert asset_definition.group == "MLModel"
         assert asset_definition.extra == {"k": "v"}
-        assert asset_definition.function == example_asset_func
-        assert asset_definition.schedule is None
+        assert asset_definition._function == example_asset_func
+        assert asset_definition._source.schedule is None
 
     def test_nested_function(self):
         def root_func():
@@ -111,16 +109,8 @@ class TestAssetDecorator:
 
 
 class TestAssetDefinition:
-    def test_serialzie(self, example_asset_definition):
-        assert example_asset_definition.serialize() == {
-            "extra": {"k": "v"},
-            "group": "MLModel",
-            "name": "example_asset_func",
-            "uri": "s3://bucket/object",
-        }
-
-    @mock.patch("airflow.sdk.definitions.decorators._AssetMainOperator")
-    @mock.patch("airflow.sdk.definitions.decorators.DAG")
+    @mock.patch("airflow.sdk.definitions.asset.decorators._AssetMainOperator")
+    @mock.patch("airflow.models.dag.DAG")
     def test__attrs_post_init__(
         self, DAG, _AssetMainOperator, example_asset_func_with_valid_arg_as_inlet_asset
     ):
@@ -128,7 +118,17 @@ class TestAssetDefinition:
             example_asset_func_with_valid_arg_as_inlet_asset
         )
 
-        DAG.assert_called_once_with(dag_id="example_asset_func", schedule=None, auto_register=True)
+        DAG.assert_called_once_with(
+            dag_id="example_asset_func",
+            dag_display_name="example_asset_func",
+            description=None,
+            schedule=None,
+            is_paused_upon_creation=None,
+            on_failure_callback=None,
+            on_success_callback=None,
+            params=None,
+            auto_register=True,
+        )
         _AssetMainOperator.assert_called_once_with(
             task_id="__main__",
             inlets=[
@@ -146,19 +146,30 @@ class TestAssetDefinition:
 
 
 class Test_AssetMainOperator:
-    def test_determine_kwargs(self, example_asset_func_with_valid_arg_as_inlet_asset, session):
-        example_asset_model = AssetModel(uri="s3://bucket/object1", name="inlet_asset_1")
+    @mock.patch("airflow.models.asset._fetch_active_assets_by_name")
+    @mock.patch("airflow.utils.session.create_session")
+    def test_determine_kwargs(
+        self,
+        mock_create_session,
+        mock_fetch_active_assets_by_name,
+        example_asset_func_with_valid_arg_as_inlet_asset,
+    ):
         asset_definition = asset(schedule=None, uri="s3://bucket/object", group="MLModel", extra={"k": "v"})(
             example_asset_func_with_valid_arg_as_inlet_asset
         )
 
-        ad_asset_model = AssetModel.from_public(asset_definition)
+        class FakeSession:
+            def __enter__(self):
+                return self
 
-        session.add(example_asset_model)
-        session.add(ad_asset_model)
-        session.add(AssetActive.for_asset(example_asset_model))
-        session.add(AssetActive.for_asset(ad_asset_model))
-        session.commit()
+            def __exit__(self, *args, **kwargs):
+                pass
+
+        mock_create_session.return_value = fake_session = FakeSession()
+        mock_fetch_active_assets_by_name.return_value = {
+            "example_asset_func": AssetModel.from_public(asset_definition),
+            "inlet_asset_1": AssetModel(uri="s3://bucket/object1", name="inlet_asset_1"),
+        }
 
         op = _AssetMainOperator(
             task_id="__main__",
@@ -178,3 +189,7 @@ class Test_AssetMainOperator:
             "inlet_asset_1": Asset(name="inlet_asset_1", uri="s3://bucket/object1"),
             "inlet_asset_2": Asset(name="inlet_asset_2"),
         }
+
+        assert mock_fetch_active_assets_by_name.mock_calls == [
+            mock.call({"example_asset_func", "inlet_asset_1", "inlet_asset_2"}, fake_session),
+        ]

--- a/task_sdk/tests/defintions/test_asset_decorators.py
+++ b/task_sdk/tests/defintions/test_asset_decorators.py
@@ -146,7 +146,7 @@ class TestAssetDefinition:
 
 
 class Test_AssetMainOperator:
-    @mock.patch("airflow.models.asset._fetch_active_assets_by_name")
+    @mock.patch("airflow.models.asset.fetch_active_assets_by_name")
     @mock.patch("airflow.utils.session.create_session")
     def test_determine_kwargs(
         self,

--- a/task_sdk/tests/defintions/test_baseoperator.py
+++ b/task_sdk/tests/defintions/test_baseoperator.py
@@ -29,25 +29,6 @@ from airflow.task.priority_strategy import _DownstreamPriorityWeightStrategy, _U
 DEFAULT_DATE = datetime(2016, 1, 1, tzinfo=timezone.utc)
 
 
-@pytest.fixture(autouse=True, scope="module")
-def _disable_ol_plugin():
-    # The OpenLineage plugin imports setproctitle, and that now causes (C) level thread calls, which on Py
-    # 3.12+ issues a warning when os.fork happens. So for this plugin we disable it
-
-    # And we load plugins when setting the priorty_weight field
-    import airflow.plugins_manager
-
-    old = airflow.plugins_manager.plugins
-
-    assert old is None, "Plugins already loaded, too late to stop them being loaded!"
-
-    airflow.plugins_manager.plugins = []
-
-    yield
-
-    airflow.plugins_manager.plugins = None
-
-
 # Essentially similar to airflow.models.baseoperator.BaseOperator
 class FakeOperator(metaclass=BaseOperatorMeta):
     def __init__(self, test_param, params=None, default_args=None):

--- a/tests/models/test_asset.py
+++ b/tests/models/test_asset.py
@@ -17,13 +17,62 @@
 
 from __future__ import annotations
 
-from airflow.models.asset import AssetAliasModel
+import pytest
+
+from airflow.models.asset import AssetAliasModel, AssetModel, expand_alias_to_assets
 from airflow.sdk.definitions.asset import AssetAlias
+
+pytestmark = pytest.mark.db_test
+
+
+@pytest.fixture
+def clear_assets():
+    from tests_common.test_utils.db import clear_db_assets
+
+    clear_db_assets()
+    yield
+    clear_db_assets()
+
+
+def test_asset_alias_from_public():
+    asset_alias = AssetAlias(name="test_alias")
+    asset_alias_model = AssetAliasModel.from_public(asset_alias)
+    assert asset_alias_model.name == "test_alias"
 
 
 class TestAssetAliasModel:
-    def test_from_public(self):
-        asset_alias = AssetAlias(name="test_alias")
-        asset_alias_model = AssetAliasModel.from_public(asset_alias)
+    @pytest.fixture
+    def asset_model(self, session):
+        """Example asset links to asset alias resolved_asset_alias_2."""
+        asset_model = AssetModel(
+            id=1,
+            uri="test://asset1/",
+            name="test_name",
+            group="asset",
+        )
+        session.add(asset_model)
+        session.flush()
+        return asset_model
 
-        assert asset_alias_model.name == "test_alias"
+    @pytest.fixture
+    def asset_alias_1(self, session):
+        """Example asset alias links to no assets."""
+        asset_alias_model = AssetAliasModel(name="test_name", group="test")
+        session.add(asset_alias_model)
+        session.flush()
+        return asset_alias_model
+
+    @pytest.fixture
+    def resolved_asset_alias_2(self, session, asset_model):
+        """Example asset alias links to asset asset_alias_1."""
+        asset_alias_2 = AssetAliasModel(name="test_name_2")
+        asset_alias_2.assets.append(asset_model)
+        session.add(asset_alias_2)
+        session.flush()
+        return asset_alias_2
+
+    def test_expand_alias_to_assets_empty(self, session, asset_alias_1):
+        assert expand_alias_to_assets(asset_alias_1.name, session) == []
+
+    def test_expand_alias_to_assets_resolved(self, session, resolved_asset_alias_2, asset_model):
+        assert expand_alias_to_assets(resolved_asset_alias_2.name, session) == [asset_model]


### PR DESCRIPTION
We accidentally added some db tests in the SDK test suite, which has been incorrectly skipped since the SDK is not supposed to interact with db. The test is legistimate (it’s for a custom operator only used on task execution), but we need to mock those db calls instead.

Calls that need db are now always done lazily (when Airflow core is available), and functions all moved to `airflow.models` and tested there instead.

A Pytest hook is also added to check the `db_test` marker does not exist, to ensure this does not happen again.