### PR TITLE
Add an event status in powerbi.py

### DIFF
--- a/providers/src/airflow/providers/microsoft/azure/operators/powerbi.py
+++ b/providers/src/airflow/providers/microsoft/azure/operators/powerbi.py
@@ -70,6 +70,21 @@ class PowerBIDatasetRefreshOperator(BaseOperator):
         "group_id",
     )
     template_fields_renderers = {"parameters": "json"}
+    INTERMEDIATE_STATES = (
+        "Unknown"
+    )
+    SUCCESS_STATES = (
+        "Completed"
+    )
+    FAILURE_STATES = (
+        "Failed",
+        "Disabled"
+    )
+    TERMINAL_STATES = (
+        "Completed",
+        "Failed",
+        "Disabled"
+    )
 
     operator_extra_links = (PowerBILink(),)
 
@@ -126,7 +141,7 @@ class PowerBIDatasetRefreshOperator(BaseOperator):
         Relies on trigger to throw an exception, otherwise it assumes execution was successful.
         """
         if event:
-            if event["status"] == "error":
+            if event["status"] in self.FAILURE_STATES:
                 raise AirflowException(event["message"])
 
             self.xcom_push(


### PR DESCRIPTION
closes: #44613

Add the following statuses:

```python
INTERMEDIATE_STATES = (
    "Unknown"
)

SUCCESS_STATES = (
    "Completed"
)

FAILURE_STATES = (
    "Failed",
    "Disabled"
)

TERMINAL_STATES = (
    "Completed",
    "Failed",
    "Disabled"
)
```

Change `powerbi.py` line 144 (original line 129) 
from:
* `if event["status"] == "error":`
to:
* `if event["status"] in self.FAILURE_STATES:`

related document:
https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/get-refresh-history#refresh
