### PR TITLE
PowerBIDatasetRefreshOperator should fail when refresh fails

### DIFF
--- a/providers/src/airflow/providers/microsoft/azure/hooks/powerbi.py
+++ b/providers/src/airflow/providers/microsoft/azure/hooks/powerbi.py
@@ -44,6 +44,7 @@ class PowerBIDatasetRefreshStatus:
     DISABLED = "Disabled"
 
     TERMINAL_STATUSES = {FAILED, COMPLETED}
+    FAILURE_STATUSES = {FAILED, DISABLED}
 
 
 class PowerBIDatasetRefreshException(AirflowException):

--- a/providers/src/airflow/providers/microsoft/azure/operators/powerbi.py
+++ b/providers/src/airflow/providers/microsoft/azure/operators/powerbi.py
@@ -20,10 +20,11 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
-from airflow.exceptions import AirflowException
-from airflow.models import BaseOperator, BaseOperatorLink
 from airflow.providers.microsoft.azure.hooks.powerbi import PowerBIDatasetRefreshStatus, PowerBIHook
 from airflow.providers.microsoft.azure.triggers.powerbi import PowerBITrigger
+
+from airflow.exceptions import AirflowException
+from airflow.models import BaseOperator, BaseOperatorLink
 
 if TYPE_CHECKING:
     from msgraph_core import APIVersion
@@ -124,7 +125,6 @@ class PowerBIDatasetRefreshOperator(BaseOperator):
         Relies on trigger to throw an exception, otherwise it assumes execution was successful.
         """
         if event:
-            self.xcom_push(context=context, key="event", value=str(event))
             if (
                 event["status"] == "error"
                 or event["status"] == PowerBIDatasetRefreshStatus.FAILED

--- a/providers/src/airflow/providers/microsoft/azure/operators/powerbi.py
+++ b/providers/src/airflow/providers/microsoft/azure/operators/powerbi.py
@@ -20,11 +20,10 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
-from airflow.providers.microsoft.azure.hooks.powerbi import PowerBIDatasetRefreshStatus, PowerBIHook
-from airflow.providers.microsoft.azure.triggers.powerbi import PowerBITrigger
-
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator, BaseOperatorLink
+from airflow.providers.microsoft.azure.hooks.powerbi import PowerBIDatasetRefreshStatus, PowerBIHook
+from airflow.providers.microsoft.azure.triggers.powerbi import PowerBITrigger
 
 if TYPE_CHECKING:
     from msgraph_core import APIVersion

--- a/providers/src/airflow/providers/microsoft/azure/operators/powerbi.py
+++ b/providers/src/airflow/providers/microsoft/azure/operators/powerbi.py
@@ -47,6 +47,12 @@ class PowerBILink(BaseOperatorLink):
         return url
 
 
+class PowerBIDatasetRefreshRequestStatus(PowerBIDatasetRefreshStatus):
+    """Power BI refresh dataset request statuses: PowerBIDatasetRefreshStatus statuses and "error" status from Trigger."""
+
+    ERROR = "error"
+
+
 class PowerBIDatasetRefreshOperator(BaseOperator):
     """
     Refreshes a Power BI dataset.
@@ -125,9 +131,9 @@ class PowerBIDatasetRefreshOperator(BaseOperator):
         """
         if event:
             if (
-                event["status"] == "error"
-                or event["status"] == PowerBIDatasetRefreshStatus.FAILED
-                or event["status"] == PowerBIDatasetRefreshStatus.DISABLED
+                event["status"] == PowerBIDatasetRefreshRequestStatus.ERROR
+                or event["status"] == PowerBIDatasetRefreshRequestStatus.FAILED
+                or event["status"] == PowerBIDatasetRefreshRequestStatus.DISABLED
             ):
                 raise AirflowException(event["message"])
 

--- a/providers/src/airflow/providers/microsoft/azure/operators/powerbi.py
+++ b/providers/src/airflow/providers/microsoft/azure/operators/powerbi.py
@@ -130,11 +130,7 @@ class PowerBIDatasetRefreshOperator(BaseOperator):
         Relies on trigger to throw an exception, otherwise it assumes execution was successful.
         """
         if event:
-            if (
-                event["status"] == PowerBIDatasetRefreshRequestStatus.ERROR
-                or event["status"] == PowerBIDatasetRefreshRequestStatus.FAILED
-                or event["status"] == PowerBIDatasetRefreshRequestStatus.DISABLED
-            ):
+            if event["status"] == "error":
                 raise AirflowException(event["message"])
 
             self.xcom_push(

--- a/providers/src/airflow/providers/microsoft/azure/operators/powerbi.py
+++ b/providers/src/airflow/providers/microsoft/azure/operators/powerbi.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator, BaseOperatorLink
-from airflow.providers.microsoft.azure.hooks.powerbi import PowerBIDatasetRefreshStatus, PowerBIHook
+from airflow.providers.microsoft.azure.hooks.powerbi import PowerBIHook
 from airflow.providers.microsoft.azure.triggers.powerbi import PowerBITrigger
 
 if TYPE_CHECKING:
@@ -45,12 +45,6 @@ class PowerBILink(BaseOperatorLink):
         )
 
         return url
-
-
-class PowerBIDatasetRefreshRequestStatus(PowerBIDatasetRefreshStatus):
-    """Power BI refresh dataset request statuses: PowerBIDatasetRefreshStatus statuses and "error" status from Trigger."""
-
-    ERROR = "error"
 
 
 class PowerBIDatasetRefreshOperator(BaseOperator):

--- a/providers/src/airflow/providers/microsoft/azure/triggers/powerbi.py
+++ b/providers/src/airflow/providers/microsoft/azure/triggers/powerbi.py
@@ -22,10 +22,8 @@ import time
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING
 
-from airflow.providers.microsoft.azure.hooks.powerbi import (
-    PowerBIDatasetRefreshStatus,
-    PowerBIHook,
-)
+from airflow.providers.microsoft.azure.hooks.powerbi import PowerBIDatasetRefreshStatus, PowerBIHook
+
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 
 if TYPE_CHECKING:
@@ -106,20 +104,20 @@ class PowerBITrigger(BaseTrigger):
             group_id=self.group_id,
         )
 
-        async def fetch_refresh_status() -> str:
-            """Fetch the current status of the dataset refresh."""
+        async def fetch_refresh_status_and_error() -> tuple[str, str]:
+            """Fetch the current status and error of the dataset refresh."""
             refresh_details = await self.hook.get_refresh_details_by_refresh_id(
                 dataset_id=self.dataset_id,
                 group_id=self.group_id,
                 refresh_id=self.dataset_refresh_id,
             )
-            return refresh_details["status"]
+            return refresh_details["status"], refresh_details["error"]
 
         try:
-            dataset_refresh_status = await fetch_refresh_status()
+            dataset_refresh_status, dataset_refresh_error = await fetch_refresh_status_and_error()
             start_time = time.monotonic()
             while start_time + self.timeout > time.monotonic():
-                dataset_refresh_status = await fetch_refresh_status()
+                dataset_refresh_status, dataset_refresh_error = await fetch_refresh_status_and_error()
 
                 if dataset_refresh_status == PowerBIDatasetRefreshStatus.COMPLETED:
                     yield TriggerEvent(
@@ -134,7 +132,7 @@ class PowerBITrigger(BaseTrigger):
                     yield TriggerEvent(
                         {
                             "status": dataset_refresh_status,
-                            "message": f"The dataset refresh {self.dataset_refresh_id} has {dataset_refresh_status}.",
+                            "message": f"The dataset refresh {self.dataset_refresh_id} has {dataset_refresh_status}. Error: {dataset_refresh_error}",
                             "dataset_refresh_id": self.dataset_refresh_id,
                         }
                     )

--- a/providers/src/airflow/providers/microsoft/azure/triggers/powerbi.py
+++ b/providers/src/airflow/providers/microsoft/azure/triggers/powerbi.py
@@ -23,7 +23,6 @@ from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING
 
 from airflow.providers.microsoft.azure.hooks.powerbi import PowerBIDatasetRefreshStatus, PowerBIHook
-
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 
 if TYPE_CHECKING:

--- a/providers/src/airflow/providers/microsoft/azure/triggers/powerbi.py
+++ b/providers/src/airflow/providers/microsoft/azure/triggers/powerbi.py
@@ -121,16 +121,18 @@ class PowerBITrigger(BaseTrigger):
                 if dataset_refresh_status == PowerBIDatasetRefreshStatus.COMPLETED:
                     yield TriggerEvent(
                         {
-                            "status": dataset_refresh_status,
+                            "status": "success",
+                            "dataset_refresh_status": dataset_refresh_status,
                             "message": f"The dataset refresh {self.dataset_refresh_id} has {dataset_refresh_status}.",
                             "dataset_refresh_id": self.dataset_refresh_id,
                         }
                     )
                     return
-                elif dataset_refresh_status == PowerBIDatasetRefreshStatus.FAILED:
+                elif dataset_refresh_status in PowerBIDatasetRefreshStatus.FAILURE_STATUSES:
                     yield TriggerEvent(
                         {
-                            "status": dataset_refresh_status,
+                            "status": "error",
+                            "dataset_refresh_status": dataset_refresh_status,
                             "message": f"The dataset refresh {self.dataset_refresh_id} has {dataset_refresh_status}. Error: {dataset_refresh_error}",
                             "dataset_refresh_id": self.dataset_refresh_id,
                         }
@@ -147,6 +149,7 @@ class PowerBITrigger(BaseTrigger):
             yield TriggerEvent(
                 {
                     "status": "error",
+                    "dataset_refresh_status": dataset_refresh_status,
                     "message": f"Timeout occurred while waiting for dataset refresh to complete: The dataset refresh {self.dataset_refresh_id} has status {dataset_refresh_status}.",
                     "dataset_refresh_id": self.dataset_refresh_id,
                 }
@@ -169,6 +172,7 @@ class PowerBITrigger(BaseTrigger):
                     yield TriggerEvent(
                         {
                             "status": "error",
+                            "dataset_refresh_status": None,
                             "message": f"An error occurred while canceling dataset: {e}",
                             "dataset_refresh_id": self.dataset_refresh_id,
                         }
@@ -177,6 +181,7 @@ class PowerBITrigger(BaseTrigger):
             yield TriggerEvent(
                 {
                     "status": "error",
+                    "dataset_refresh_status": None,
                     "message": f"An error occurred: {error}",
                     "dataset_refresh_id": self.dataset_refresh_id,
                 }

--- a/providers/tests/microsoft/azure/operators/test_powerbi.py
+++ b/providers/tests/microsoft/azure/operators/test_powerbi.py
@@ -21,15 +21,16 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
+
+from airflow.exceptions import AirflowException, TaskDeferred
 from airflow.providers.microsoft.azure.hooks.powerbi import (
     PowerBIDatasetRefreshFields,
     PowerBIDatasetRefreshStatus,
 )
 from airflow.providers.microsoft.azure.operators.powerbi import PowerBIDatasetRefreshOperator
 from airflow.providers.microsoft.azure.triggers.powerbi import PowerBITrigger
-
-from airflow.exceptions import AirflowException, TaskDeferred
 from airflow.utils import timezone
+
 from providers.tests.microsoft.azure.base import Base
 from providers.tests.microsoft.conftest import get_airflow_connection, mock_context
 

--- a/providers/tests/microsoft/azure/operators/test_powerbi.py
+++ b/providers/tests/microsoft/azure/operators/test_powerbi.py
@@ -50,7 +50,7 @@ NEW_REFRESH_REQUEST_ID = "5e2d9921-e91b-491f-b7e1-e7d8db49194c"
 
 SUCCESS_TRIGGER_EVENT = {
     "status": "success",
-    "dataset_refresh_status": "Completed",
+    "dataset_refresh_status": PowerBIDatasetRefreshStatus.COMPLETED,
     "message": "success",
     "dataset_refresh_id": NEW_REFRESH_REQUEST_ID,
 }
@@ -131,7 +131,7 @@ class TestPowerBIDatasetRefreshOperator(Base):
                 context=context,
                 event={
                     "status": "error",
-                    "dataset_refresh_status": "Failed",
+                    "dataset_refresh_status": PowerBIDatasetRefreshStatus.FAILED,
                     "message": "error message",
                     "dataset_refresh_id": "1234",
                 },

--- a/providers/tests/microsoft/azure/operators/test_powerbi.py
+++ b/providers/tests/microsoft/azure/operators/test_powerbi.py
@@ -50,6 +50,7 @@ NEW_REFRESH_REQUEST_ID = "5e2d9921-e91b-491f-b7e1-e7d8db49194c"
 
 SUCCESS_TRIGGER_EVENT = {
     "status": "success",
+    "dataset_refresh_status": "Completed",
     "message": "success",
     "dataset_refresh_id": NEW_REFRESH_REQUEST_ID,
 }
@@ -109,7 +110,12 @@ class TestPowerBIDatasetRefreshOperator(Base):
         with pytest.raises(AirflowException) as exc:
             operator.execute_complete(
                 context=context,
-                event={"status": "error", "message": "error", "dataset_refresh_id": "1234"},
+                event={
+                    "status": "error",
+                    "dataset_refresh_status": None,
+                    "message": "error",
+                    "dataset_refresh_id": "1234",
+                },
             )
         assert context["ti"].xcom_push.call_count == 0
         assert str(exc.value) == "error"
@@ -123,7 +129,12 @@ class TestPowerBIDatasetRefreshOperator(Base):
         with pytest.raises(AirflowException) as exc:
             operator.execute_complete(
                 context=context,
-                event={"status": "Failed", "message": "error message", "dataset_refresh_id": "1234"},
+                event={
+                    "status": "error",
+                    "dataset_refresh_status": "Failed",
+                    "message": "error message",
+                    "dataset_refresh_id": "1234",
+                },
             )
         assert context["ti"].xcom_push.call_count == 0
         assert str(exc.value) == "error message"

--- a/providers/tests/microsoft/azure/triggers/test_powerbi.py
+++ b/providers/tests/microsoft/azure/triggers/test_powerbi.py
@@ -21,10 +21,11 @@ import asyncio
 from unittest import mock
 
 import pytest
+
 from airflow.providers.microsoft.azure.hooks.powerbi import PowerBIDatasetRefreshStatus
 from airflow.providers.microsoft.azure.triggers.powerbi import PowerBITrigger
-
 from airflow.triggers.base import TriggerEvent
+
 from providers.tests.microsoft.conftest import get_airflow_connection
 
 POWERBI_CONN_ID = "powerbi_default"

--- a/providers/tests/microsoft/azure/triggers/test_powerbi.py
+++ b/providers/tests/microsoft/azure/triggers/test_powerbi.py
@@ -21,11 +21,10 @@ import asyncio
 from unittest import mock
 
 import pytest
-
 from airflow.providers.microsoft.azure.hooks.powerbi import PowerBIDatasetRefreshStatus
 from airflow.providers.microsoft.azure.triggers.powerbi import PowerBITrigger
-from airflow.triggers.base import TriggerEvent
 
+from airflow.triggers.base import TriggerEvent
 from providers.tests.microsoft.conftest import get_airflow_connection
 
 POWERBI_CONN_ID = "powerbi_default"
@@ -89,7 +88,8 @@ class TestPowerBITrigger:
     ):
         """Assert task isn't completed until timeout if dataset refresh is in progress."""
         mock_get_refresh_details_by_refresh_id.return_value = {
-            "status": PowerBIDatasetRefreshStatus.IN_PROGRESS
+            "status": PowerBIDatasetRefreshStatus.IN_PROGRESS,
+            "error": None,
         }
         mock_trigger_dataset_refresh.return_value = DATASET_REFRESH_ID
         task = asyncio.create_task(powerbi_trigger.run().__anext__())
@@ -106,7 +106,10 @@ class TestPowerBITrigger:
         self, mock_trigger_dataset_refresh, mock_get_refresh_details_by_refresh_id, powerbi_trigger
     ):
         """Assert event is triggered upon failed dataset refresh."""
-        mock_get_refresh_details_by_refresh_id.return_value = {"status": PowerBIDatasetRefreshStatus.FAILED}
+        mock_get_refresh_details_by_refresh_id.return_value = {
+            "status": PowerBIDatasetRefreshStatus.FAILED,
+            "error": "Test error",
+        }
         mock_trigger_dataset_refresh.return_value = DATASET_REFRESH_ID
 
         generator = powerbi_trigger.run()
@@ -115,7 +118,7 @@ class TestPowerBITrigger:
             {
                 "status": "Failed",
                 "message": f"The dataset refresh {DATASET_REFRESH_ID} has "
-                f"{PowerBIDatasetRefreshStatus.FAILED}.",
+                f"{PowerBIDatasetRefreshStatus.FAILED}. Error: Test error",
                 "dataset_refresh_id": DATASET_REFRESH_ID,
             }
         )
@@ -129,7 +132,8 @@ class TestPowerBITrigger:
     ):
         """Assert event is triggered upon successful dataset refresh."""
         mock_get_refresh_details_by_refresh_id.return_value = {
-            "status": PowerBIDatasetRefreshStatus.COMPLETED
+            "status": PowerBIDatasetRefreshStatus.COMPLETED,
+            "error": None,
         }
         mock_trigger_dataset_refresh.return_value = DATASET_REFRESH_ID
 
@@ -233,7 +237,8 @@ class TestPowerBITrigger:
     ):
         """Assert that powerbi run times out after end_time elapses"""
         mock_get_refresh_details_by_refresh_id.return_value = {
-            "status": PowerBIDatasetRefreshStatus.IN_PROGRESS
+            "status": PowerBIDatasetRefreshStatus.IN_PROGRESS,
+            "error": None,
         }
         mock_trigger_dataset_refresh.return_value = DATASET_REFRESH_ID
 

--- a/providers/tests/microsoft/azure/triggers/test_powerbi.py
+++ b/providers/tests/microsoft/azure/triggers/test_powerbi.py
@@ -118,7 +118,7 @@ class TestPowerBITrigger:
         expected = TriggerEvent(
             {
                 "status": "error",
-                "dataset_refresh_status": "Failed",
+                "dataset_refresh_status": PowerBIDatasetRefreshStatus.FAILED,
                 "message": f"The dataset refresh {DATASET_REFRESH_ID} has "
                 f"{PowerBIDatasetRefreshStatus.FAILED}. Error: Test error",
                 "dataset_refresh_id": DATASET_REFRESH_ID,
@@ -144,7 +144,7 @@ class TestPowerBITrigger:
         expected = TriggerEvent(
             {
                 "status": "success",
-                "dataset_refresh_status": "Completed",
+                "dataset_refresh_status": PowerBIDatasetRefreshStatus.COMPLETED,
                 "message": f"The dataset refresh {DATASET_REFRESH_ID} has "
                 f"{PowerBIDatasetRefreshStatus.COMPLETED}.",
                 "dataset_refresh_id": DATASET_REFRESH_ID,

--- a/providers/tests/microsoft/azure/triggers/test_powerbi.py
+++ b/providers/tests/microsoft/azure/triggers/test_powerbi.py
@@ -117,7 +117,8 @@ class TestPowerBITrigger:
         actual = await generator.asend(None)
         expected = TriggerEvent(
             {
-                "status": "Failed",
+                "status": "error",
+                "dataset_refresh_status": "Failed",
                 "message": f"The dataset refresh {DATASET_REFRESH_ID} has "
                 f"{PowerBIDatasetRefreshStatus.FAILED}. Error: Test error",
                 "dataset_refresh_id": DATASET_REFRESH_ID,
@@ -142,7 +143,8 @@ class TestPowerBITrigger:
         actual = await generator.asend(None)
         expected = TriggerEvent(
             {
-                "status": "Completed",
+                "status": "success",
+                "dataset_refresh_status": "Completed",
                 "message": f"The dataset refresh {DATASET_REFRESH_ID} has "
                 f"{PowerBIDatasetRefreshStatus.COMPLETED}.",
                 "dataset_refresh_id": DATASET_REFRESH_ID,
@@ -169,6 +171,7 @@ class TestPowerBITrigger:
         response = TriggerEvent(
             {
                 "status": "error",
+                "dataset_refresh_status": None,
                 "message": "An error occurred: Test exception",
                 "dataset_refresh_id": DATASET_REFRESH_ID,
             }
@@ -197,6 +200,7 @@ class TestPowerBITrigger:
         response = TriggerEvent(
             {
                 "status": "error",
+                "dataset_refresh_status": None,
                 "message": "An error occurred while canceling dataset: Exception caused by cancel_dataset_refresh",
                 "dataset_refresh_id": DATASET_REFRESH_ID,
             }
@@ -223,6 +227,7 @@ class TestPowerBITrigger:
         response = TriggerEvent(
             {
                 "status": "error",
+                "dataset_refresh_status": None,
                 "message": "An error occurred: Test exception for no dataset_refresh_id",
                 "dataset_refresh_id": None,
             }
@@ -248,6 +253,7 @@ class TestPowerBITrigger:
         expected = TriggerEvent(
             {
                 "status": "error",
+                "dataset_refresh_status": PowerBIDatasetRefreshStatus.IN_PROGRESS,
                 "message": f"Timeout occurred while waiting for dataset refresh to complete: The dataset refresh {DATASET_REFRESH_ID} has status {PowerBIDatasetRefreshStatus.IN_PROGRESS}.",
                 "dataset_refresh_id": DATASET_REFRESH_ID,
             }


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/44613

The PR aims to:
- make the `PowerBIDatasetRefreshOperator` check the dataset refresh status, so that the task fails if the refresh has failed
- transmit the refresh error message in the logs if the refresh has failed:

<img width="750" alt="image" src="https://github.com/user-attachments/assets/c06c3c0f-a4be-4253-8c61-496a719e6805">


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
