### PR TITLE
Add DagFolderDagBundle to expose the DAG folder as a bundle

### DIFF
--- a/airflow/dag_processing/bundles/dagfolder.py
+++ b/airflow/dag_processing/bundles/dagfolder.py
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from airflow import settings
+from airflow.dag_processing.bundles.local import LocalDagBundle
+
+
+class DagsFolderDagBundle(LocalDagBundle):
+    """A bundle for the DAGs folder."""
+
+    def __init__(self, **kwargs):
+        super().__init__(local_folder=settings.DAGS_FOLDER, **kwargs)

--- a/tests/dag_processing/test_dag_bundles.py
+++ b/tests/dag_processing/test_dag_bundles.py
@@ -24,6 +24,7 @@ import pytest
 from git import Repo
 
 from airflow.dag_processing.bundles.base import BaseDagBundle
+from airflow.dag_processing.bundles.dagfolder import DagsFolderDagBundle
 from airflow.dag_processing.bundles.git import GitDagBundle
 from airflow.dag_processing.bundles.local import LocalDagBundle
 from airflow.exceptions import AirflowException
@@ -70,6 +71,13 @@ class TestLocalDagBundle:
         bundle = LocalDagBundle(name="test", local_folder="/hello")
 
         assert bundle.get_current_version() is None
+
+
+class TestDagsFolderDagBundle:
+    @conf_vars({("core", "dags_folder"): "/tmp/somewhere/dags"})
+    def test_path(self):
+        bundle = DagsFolderDagBundle(name="test")
+        assert bundle.path == Path("/tmp/somewhere/dags")
 
 
 GIT_DEFAULT_BRANCH = "main"


### PR DESCRIPTION
Why not simply use LocalDagBundle? This keeps the config for the traditional `[core] dags_folder` in the Airflow config system.