### PR TITLE
AIP-84 Add external dependencies to GET Structure Data Endpoint

### DIFF
--- a/airflow/api_fastapi/core_api/datamodels/ui/structure.py
+++ b/airflow/api_fastapi/core_api/datamodels/ui/structure.py
@@ -39,7 +39,7 @@ class NodeResponse(BaseModel):
     label: str
     tooltip: str | None = None
     setup_teardown_type: Literal["setup", "teardown"] | None = None
-    type: Literal["join", "task", "asset_condition"]
+    type: Literal["join", "task", "asset-condition", "asset", "asset-alias", "dag", "sensor", "trigger"]
     operator: str | None = None
 
 

--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -240,6 +240,13 @@ paths:
           type: boolean
           default: false
           title: Include Downstream
+      - name: external_dependencies
+        in: query
+        required: false
+        schema:
+          type: boolean
+          default: false
+          title: External Dependencies
       responses:
         '200':
           description: Successful Response
@@ -8043,7 +8050,12 @@ components:
           enum:
           - join
           - task
-          - asset_condition
+          - asset-condition
+          - asset
+          - asset-alias
+          - dag
+          - sensor
+          - trigger
           title: Type
         operator:
           anyOf:

--- a/airflow/api_fastapi/core_api/routes/ui/structure.py
+++ b/airflow/api_fastapi/core_api/routes/ui/structure.py
@@ -54,9 +54,7 @@ def structure_data(
             task_ids_or_regex=root, include_upstream=include_upstream, include_downstream=include_downstream
         )
 
-    nodes = [
-        task_group_to_dict(child) for child in sorted(dag.task_group.children.values(), key=lambda t: t.label)
-    ]
+    nodes = [task_group_to_dict(child) for child in dag.task_group.children.values()]
     edges = dag_edges(dag)
 
     data = {

--- a/airflow/api_fastapi/core_api/routes/ui/structure.py
+++ b/airflow/api_fastapi/core_api/routes/ui/structure.py
@@ -64,8 +64,11 @@ def structure_data(
     }
 
     if external_dependencies:
-        entry_node_ref = nodes[0]
-        exit_node_ref = nodes[-1]
+        entry_node_ref = nodes[0] if nodes else None
+        exit_node_ref = nodes[-1] if nodes else None
+
+        start_edges: list[dict] = []
+        end_edges: list[dict] = []
 
         for dependency_dag_id, dependencies in SerializedDagModel.get_dag_dependencies().items():
             for dependency in dependencies:
@@ -83,11 +86,13 @@ def structure_data(
 
                 # Add edges
                 # start dependency
-                if dependency.target != dependency.dependency_type:
-                    edges.insert(0, {"source_id": dependency.node_id, "target_id": entry_node_ref["id"]})
+                if dependency.target != dependency.dependency_type and entry_node_ref:
+                    start_edges.append({"source_id": dependency.node_id, "target_id": entry_node_ref["id"]})
 
                 # end dependency
-                elif dependency.source != dependency.dependency_type:
-                    edges.append({"source_id": exit_node_ref["id"], "target_id": dependency.node_id})
+                elif dependency.source != dependency.dependency_type and exit_node_ref:
+                    end_edges.append({"source_id": exit_node_ref["id"], "target_id": dependency.node_id})
+
+        data["edges"] = start_edges + edges + end_edges
 
     return StructureDataResponse(**data)

--- a/airflow/api_fastapi/core_api/routes/ui/structure.py
+++ b/airflow/api_fastapi/core_api/routes/ui/structure.py
@@ -31,7 +31,6 @@ structure_router = AirflowRouter(tags=["Structure"], prefix="/structure")
 
 @structure_router.get(
     "/structure_data",
-    include_in_schema=False,
     responses=create_openapi_http_exception_doc([status.HTTP_404_NOT_FOUND]),
 )
 def structure_data(
@@ -79,18 +78,22 @@ def structure_data(
                 nodes.append(
                     {
                         "id": dependency.node_id,
-                        "label": dependency.node_id,
+                        "label": dependency.dependency_id,
                         "type": dependency.dependency_type,
                     }
                 )
 
                 # Add edges
                 # start dependency
-                if dependency.target != dependency.dependency_type and entry_node_ref:
+                if (
+                    dependency.source == dependency.dependency_type or dependency.target == dag_id
+                ) and entry_node_ref:
                     start_edges.append({"source_id": dependency.node_id, "target_id": entry_node_ref["id"]})
 
                 # end dependency
-                elif dependency.source != dependency.dependency_type and exit_node_ref:
+                elif (
+                    dependency.target == dependency.dependency_type or dependency.source == dag_id
+                ) and exit_node_ref:
                     end_edges.append({"source_id": exit_node_ref["id"], "target_id": dependency.node_id})
 
         data["edges"] = start_edges + edges + end_edges

--- a/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow/ui/openapi-gen/queries/common.ts
@@ -387,11 +387,13 @@ export const useStructureServiceStructureDataKey =
 export const UseStructureServiceStructureDataKeyFn = (
   {
     dagId,
+    externalDependencies,
     includeDownstream,
     includeUpstream,
     root,
   }: {
     dagId: string;
+    externalDependencies?: boolean;
     includeDownstream?: boolean;
     includeUpstream?: boolean;
     root?: string;
@@ -399,7 +401,9 @@ export const UseStructureServiceStructureDataKeyFn = (
   queryKey?: Array<unknown>,
 ) => [
   useStructureServiceStructureDataKey,
-  ...(queryKey ?? [{ dagId, includeDownstream, includeUpstream, root }]),
+  ...(queryKey ?? [
+    { dagId, externalDependencies, includeDownstream, includeUpstream, root },
+  ]),
 ];
 export type BackfillServiceListBackfillsDefaultResponse = Awaited<
   ReturnType<typeof BackfillService.listBackfills>

--- a/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -489,6 +489,7 @@ export const prefetchUseDashboardServiceHistoricalMetrics = (
  * @param data.root
  * @param data.includeUpstream
  * @param data.includeDownstream
+ * @param data.externalDependencies
  * @returns StructureDataResponse Successful Response
  * @throws ApiError
  */
@@ -496,11 +497,13 @@ export const prefetchUseStructureServiceStructureData = (
   queryClient: QueryClient,
   {
     dagId,
+    externalDependencies,
     includeDownstream,
     includeUpstream,
     root,
   }: {
     dagId: string;
+    externalDependencies?: boolean;
     includeDownstream?: boolean;
     includeUpstream?: boolean;
     root?: string;
@@ -509,6 +512,7 @@ export const prefetchUseStructureServiceStructureData = (
   queryClient.prefetchQuery({
     queryKey: Common.UseStructureServiceStructureDataKeyFn({
       dagId,
+      externalDependencies,
       includeDownstream,
       includeUpstream,
       root,
@@ -516,6 +520,7 @@ export const prefetchUseStructureServiceStructureData = (
     queryFn: () =>
       StructureService.structureData({
         dagId,
+        externalDependencies,
         includeDownstream,
         includeUpstream,
         root,

--- a/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow/ui/openapi-gen/queries/queries.ts
@@ -613,6 +613,7 @@ export const useDashboardServiceHistoricalMetrics = <
  * @param data.root
  * @param data.includeUpstream
  * @param data.includeDownstream
+ * @param data.externalDependencies
  * @returns StructureDataResponse Successful Response
  * @throws ApiError
  */
@@ -623,11 +624,13 @@ export const useStructureServiceStructureData = <
 >(
   {
     dagId,
+    externalDependencies,
     includeDownstream,
     includeUpstream,
     root,
   }: {
     dagId: string;
+    externalDependencies?: boolean;
     includeDownstream?: boolean;
     includeUpstream?: boolean;
     root?: string;
@@ -637,12 +640,13 @@ export const useStructureServiceStructureData = <
 ) =>
   useQuery<TData, TError>({
     queryKey: Common.UseStructureServiceStructureDataKeyFn(
-      { dagId, includeDownstream, includeUpstream, root },
+      { dagId, externalDependencies, includeDownstream, includeUpstream, root },
       queryKey,
     ),
     queryFn: () =>
       StructureService.structureData({
         dagId,
+        externalDependencies,
         includeDownstream,
         includeUpstream,
         root,

--- a/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow/ui/openapi-gen/queries/suspense.ts
@@ -588,6 +588,7 @@ export const useDashboardServiceHistoricalMetricsSuspense = <
  * @param data.root
  * @param data.includeUpstream
  * @param data.includeDownstream
+ * @param data.externalDependencies
  * @returns StructureDataResponse Successful Response
  * @throws ApiError
  */
@@ -598,11 +599,13 @@ export const useStructureServiceStructureDataSuspense = <
 >(
   {
     dagId,
+    externalDependencies,
     includeDownstream,
     includeUpstream,
     root,
   }: {
     dagId: string;
+    externalDependencies?: boolean;
     includeDownstream?: boolean;
     includeUpstream?: boolean;
     root?: string;
@@ -612,12 +615,13 @@ export const useStructureServiceStructureDataSuspense = <
 ) =>
   useSuspenseQuery<TData, TError>({
     queryKey: Common.UseStructureServiceStructureDataKeyFn(
-      { dagId, includeDownstream, includeUpstream, root },
+      { dagId, externalDependencies, includeDownstream, includeUpstream, root },
       queryKey,
     ),
     queryFn: () =>
       StructureService.structureData({
         dagId,
+        externalDependencies,
         includeDownstream,
         includeUpstream,
         root,

--- a/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -3186,7 +3186,16 @@ export const $NodeResponse = {
     },
     type: {
       type: "string",
-      enum: ["join", "task", "asset_condition"],
+      enum: [
+        "join",
+        "task",
+        "asset-condition",
+        "asset",
+        "asset-alias",
+        "dag",
+        "sensor",
+        "trigger",
+      ],
       title: "Type",
     },
     operator: {

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -742,6 +742,7 @@ export class StructureService {
    * @param data.root
    * @param data.includeUpstream
    * @param data.includeDownstream
+   * @param data.externalDependencies
    * @returns StructureDataResponse Successful Response
    * @throws ApiError
    */
@@ -756,6 +757,7 @@ export class StructureService {
         root: data.root,
         include_upstream: data.includeUpstream,
         include_downstream: data.includeDownstream,
+        external_dependencies: data.externalDependencies,
       },
       errors: {
         404: "Not Found",

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -773,11 +773,27 @@ export type NodeResponse = {
   label: string;
   tooltip?: string | null;
   setup_teardown_type?: "setup" | "teardown" | null;
-  type: "join" | "task" | "asset_condition";
+  type:
+    | "join"
+    | "task"
+    | "asset-condition"
+    | "asset"
+    | "asset-alias"
+    | "dag"
+    | "sensor"
+    | "trigger";
   operator?: string | null;
 };
 
-export type type = "join" | "task" | "asset_condition";
+export type type =
+  | "join"
+  | "task"
+  | "asset-condition"
+  | "asset"
+  | "asset-alias"
+  | "dag"
+  | "sensor"
+  | "trigger";
 
 /**
  * Request body for Clear Task Instances endpoint.
@@ -1443,6 +1459,7 @@ export type HistoricalMetricsResponse = HistoricalMetricDataResponse;
 
 export type StructureDataData = {
   dagId: string;
+  externalDependencies?: boolean;
   includeDownstream?: boolean;
   includeUpstream?: boolean;
   root?: string | null;

--- a/airflow/ui/src/layouts/Details/Graph/useGraphLayout.ts
+++ b/airflow/ui/src/layouts/Details/Graph/useGraphLayout.ts
@@ -211,7 +211,7 @@ const generateElkGraph = ({
     if (node.type === "join") {
       width = 10;
       height = 10;
-    } else if (node.type === "asset_condition") {
+    } else if (node.type === "asset-condition") {
       width = 30;
       height = 30;
     }

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3228,6 +3228,7 @@ class Airflow(AirflowBaseView):
         else:
             return {"url": None, "error": f"No URL found for {link_name}"}, 404
 
+    @mark_fastapi_migration_done
     @expose("/object/graph_data")
     @auth.has_access_dag("GET", DagAccessEntity.TASK_INSTANCE)
     @gzipped

--- a/tests/api_fastapi/core_api/routes/ui/test_structure.py
+++ b/tests/api_fastapi/core_api/routes/ui/test_structure.py
@@ -31,6 +31,7 @@ from tests_common.test_utils.db import clear_db_runs
 pytestmark = pytest.mark.db_test
 
 DAG_ID = "test_dag_id"
+DAG_ID_EXTERNAL_TRIGGER = "external_trigger"
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -50,7 +51,7 @@ def clean():
 @pytest.fixture
 def make_dag(dag_maker, session, time_machine):
     with dag_maker(
-        dag_id="external_trigger",
+        dag_id=DAG_ID_EXTERNAL_TRIGGER,
         serialized=True,
         session=session,
         start_date=pendulum.DateTime(2023, 2, 1, 0, 0, 0, tzinfo=pendulum.UTC),
@@ -257,7 +258,7 @@ class TestStructureDataEndpoint:
                             "children": None,
                             "id": "trigger:external_trigger:test_dag_id:trigger_dag_run_operator",
                             "is_mapped": None,
-                            "label": "trigger:external_trigger:test_dag_id:trigger_dag_run_operator",
+                            "label": "trigger_dag_run_operator",
                             "tooltip": None,
                             "setup_teardown_type": None,
                             "type": "trigger",
@@ -267,7 +268,7 @@ class TestStructureDataEndpoint:
                             "children": None,
                             "id": "asset:asset1",
                             "is_mapped": None,
-                            "label": "asset:asset1",
+                            "label": "asset1",
                             "tooltip": None,
                             "setup_teardown_type": None,
                             "type": "asset",
@@ -277,7 +278,7 @@ class TestStructureDataEndpoint:
                             "children": None,
                             "id": "asset:asset2",
                             "is_mapped": None,
-                            "label": "asset:asset2",
+                            "label": "asset2",
                             "tooltip": None,
                             "setup_teardown_type": None,
                             "type": "asset",
@@ -287,7 +288,7 @@ class TestStructureDataEndpoint:
                             "children": None,
                             "id": "asset-alias:example-alias",
                             "is_mapped": None,
-                            "label": "asset-alias:example-alias",
+                            "label": "example-alias",
                             "tooltip": None,
                             "setup_teardown_type": None,
                             "type": "asset-alias",
@@ -297,7 +298,7 @@ class TestStructureDataEndpoint:
                             "children": None,
                             "id": "asset:s3://dataset-bucket/example.csv",
                             "is_mapped": None,
-                            "label": "asset:s3://dataset-bucket/example.csv",
+                            "label": "s3://dataset-bucket/example.csv",
                             "tooltip": None,
                             "setup_teardown_type": None,
                             "type": "asset",
@@ -307,10 +308,46 @@ class TestStructureDataEndpoint:
                             "children": None,
                             "id": "sensor:test_dag_id:test_dag_id:external_task_sensor",
                             "is_mapped": None,
-                            "label": "sensor:test_dag_id:test_dag_id:external_task_sensor",
+                            "label": "external_task_sensor",
                             "tooltip": None,
                             "setup_teardown_type": None,
                             "type": "sensor",
+                            "operator": None,
+                        },
+                    ],
+                    "arrange": "LR",
+                },
+            ),
+            (
+                {"dag_id": DAG_ID_EXTERNAL_TRIGGER, "external_dependencies": True},
+                {
+                    "edges": [
+                        {
+                            "is_setup_teardown": None,
+                            "label": None,
+                            "source_id": "trigger_dag_run_operator",
+                            "target_id": "trigger:external_trigger:test_dag_id:trigger_dag_run_operator",
+                        }
+                    ],
+                    "nodes": [
+                        {
+                            "children": None,
+                            "id": "trigger_dag_run_operator",
+                            "is_mapped": None,
+                            "label": "trigger_dag_run_operator",
+                            "tooltip": None,
+                            "setup_teardown_type": None,
+                            "type": "task",
+                            "operator": "TriggerDagRunOperator",
+                        },
+                        {
+                            "children": None,
+                            "id": "trigger:external_trigger:test_dag_id:trigger_dag_run_operator",
+                            "is_mapped": None,
+                            "label": "trigger_dag_run_operator",
+                            "tooltip": None,
+                            "setup_teardown_type": None,
+                            "type": "trigger",
                             "operator": None,
                         },
                     ],

--- a/tests/api_fastapi/core_api/routes/ui/test_structure.py
+++ b/tests/api_fastapi/core_api/routes/ui/test_structure.py
@@ -176,19 +176,7 @@ class TestStructureDataEndpoint:
                         {
                             "is_setup_teardown": None,
                             "label": None,
-                            "source_id": "sensor:test_dag_id:test_dag_id:external_task_sensor",
-                            "target_id": "task_1",
-                        },
-                        {
-                            "is_setup_teardown": None,
-                            "label": None,
-                            "source_id": "asset-alias:example-alias",
-                            "target_id": "task_1",
-                        },
-                        {
-                            "is_setup_teardown": None,
-                            "label": None,
-                            "source_id": "asset:asset2",
+                            "source_id": "trigger:external_trigger:test_dag_id:trigger_dag_run_operator",
                             "target_id": "task_1",
                         },
                         {
@@ -200,7 +188,19 @@ class TestStructureDataEndpoint:
                         {
                             "is_setup_teardown": None,
                             "label": None,
-                            "source_id": "trigger:external_trigger:test_dag_id:trigger_dag_run_operator",
+                            "source_id": "asset:asset2",
+                            "target_id": "task_1",
+                        },
+                        {
+                            "is_setup_teardown": None,
+                            "label": None,
+                            "source_id": "asset-alias:example-alias",
+                            "target_id": "task_1",
+                        },
+                        {
+                            "is_setup_teardown": None,
+                            "label": None,
+                            "source_id": "sensor:test_dag_id:test_dag_id:external_task_sensor",
                             "target_id": "task_1",
                         },
                         {


### PR DESCRIPTION
Related to: https://github.com/apache/airflow/issues/42367

Adds the `external_dependencies` query parameter.

Supports `trigger`, `sensor`, `asset`, `asset_aliases`.

Sensor is back because `ExternalTaskSensor` is creating a `sensor` dependency type.

For now all that is `external` to the dag, and not specific to the `task_level`. Meaning that they are attached to the dag (first task of the dag) and not to the specific tasks. (i.e task outlets for assets for instance)