### PR TITLE
AIP-38 Fix Graph not updating

### DIFF
--- a/airflow/ui/src/pages/DagsList/Dag/Graph/Graph.tsx
+++ b/airflow/ui/src/pages/DagsList/Dag/Graph/Graph.tsx
@@ -48,6 +48,7 @@ export const Graph = ({ dagId }: { readonly dagId: DAGResponse["dag_id"] }) => {
 
   const { data } = useGraphLayout({
     ...graphData,
+    dagId,
     openGroupIds,
   });
 

--- a/airflow/ui/src/pages/DagsList/Dag/Graph/useGraphLayout.ts
+++ b/airflow/ui/src/pages/DagsList/Dag/Graph/useGraphLayout.ts
@@ -20,6 +20,7 @@ import { useQuery } from "@tanstack/react-query";
 import ELK, { type ElkNode, type ElkExtendedEdge, type ElkShape } from "elkjs";
 
 import type {
+  DAGResponse,
   EdgeResponse,
   NodeResponse,
   StructureDataResponse,
@@ -247,11 +248,13 @@ const generateElkGraph = ({
 };
 
 type LayoutProps = {
+  dagId: DAGResponse["dag_id"];
   openGroupIds: Array<string>;
 } & StructureDataResponse;
 
 export const useGraphLayout = ({
   arrange = "LR",
+  dagId,
   edges,
   nodes,
   openGroupIds = [],
@@ -290,5 +293,5 @@ export const useGraphLayout = ({
 
       return { edges: formattedEdges, nodes: flattenedData.nodes };
     },
-    queryKey: ["graphLayout", nodes.length, openGroupIds, arrange],
+    queryKey: ["graphLayout", nodes.length, openGroupIds, arrange, dagId],
   });


### PR DESCRIPTION
Under certain circumstances, the graph would not update. (When switching between two dags with the same number of nodes).

For instance switching from:
- `asset_consumes_1`
- to `asset1_producer`

Would still display the old graph. (1 node in both)