### PR TITLE
Remove Provider Deprecations in Oracle

### DIFF
--- a/docs/apache-airflow-providers-oracle/operators/index.rst
+++ b/docs/apache-airflow-providers-oracle/operators/index.rst
@@ -22,20 +22,6 @@ Oracle Operators
 ================
 The Oracle connection type provides connection to a Oracle database.
 
-Execute SQL in an Oracle database
----------------------------------
-
-To execute arbitrary SQL in an Oracle database, use the
-:class:`~airflow.providers.oracle.operators.oracle.OracleOperator`.
-
-An example of executing a simple query is as follows:
-
-.. exampleinclude:: /../../providers/src/airflow/providers/oracle/example_dags/example_oracle.py
-    :language: python
-    :start-after: [START howto_oracle_operator]
-    :end-before: [END howto_oracle_operator]
-
-
 Execute a Stored Procedure in an Oracle database
 ------------------------------------------------
 

--- a/providers/src/airflow/providers/oracle/CHANGELOG.rst
+++ b/providers/src/airflow/providers/oracle/CHANGELOG.rst
@@ -27,6 +27,21 @@
 Changelog
 ---------
 
+main
+....
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+.. warning::
+  All deprecated classes, parameters and features have been removed from the Oracle provider package.
+  The following breaking changes were introduced:
+
+  * Hooks
+     * Remove deprecated support setting the Oracle Service Name using ``conn.schema``. Please use ``conn.extra.service_name`` instead.
+  * Operators
+     * Remove ``airflow.providers.oracle.operators.oracle.OracleOperator``. Please use ``airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`` instead.
+
 3.12.1
 ......
 

--- a/providers/src/airflow/providers/oracle/example_dags/example_oracle.py
+++ b/providers/src/airflow/providers/oracle/example_dags/example_oracle.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 from datetime import datetime
 
 from airflow import DAG
-from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 from airflow.providers.oracle.operators.oracle import OracleStoredProcedureOperator
 
 with DAG(
@@ -29,14 +28,6 @@ with DAG(
     start_date=datetime(2023, 1, 1),
     dag_id="example_oracle",
 ) as dag:
-    # [START howto_oracle_operator]
-
-    opr_sql = SQLExecuteQueryOperator(
-        task_id="task_sql", conn_id="oracle", sql="SELECT 1 FROM DUAL", autocommit=True
-    )
-
-    # [END howto_oracle_operator]
-
     # [START howto_oracle_stored_procedure_operator_with_list_inout]
 
     opr_stored_procedure_with_list_input_output = OracleStoredProcedureOperator(

--- a/providers/src/airflow/providers/oracle/hooks/oracle.py
+++ b/providers/src/airflow/providers/oracle/hooks/oracle.py
@@ -23,7 +23,6 @@ from datetime import datetime
 
 import oracledb
 
-from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.common.sql.hooks.sql import DbApiHook
 
 PARAM_TYPES = {bool, float, int, str}
@@ -197,14 +196,6 @@ class OracleHook(DbApiHook):
                     dsn += f":{conn.port}"
                 if service_name:
                     dsn += f"/{service_name}"
-                elif conn.schema:
-                    warnings.warn(
-                        """Using conn.schema to pass the Oracle Service Name is deprecated.
-                        Please use conn.extra.service_name instead.""",
-                        AirflowProviderDeprecationWarning,
-                        stacklevel=2,
-                    )
-                    dsn += f"/{conn.schema}"
             conn_config["dsn"] = dsn
 
         if "events" in conn.extra_dejson:

--- a/providers/src/airflow/providers/oracle/operators/oracle.py
+++ b/providers/src/airflow/providers/oracle/operators/oracle.py
@@ -19,53 +19,15 @@ from __future__ import annotations
 
 import re
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING
 
 import oracledb
-from deprecated import deprecated
 
-from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import BaseOperator
-from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 from airflow.providers.oracle.hooks.oracle import OracleHook
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
-
-
-@deprecated(
-    reason="Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`.",
-    category=AirflowProviderDeprecationWarning,
-)
-class OracleOperator(SQLExecuteQueryOperator):
-    """
-    Executes sql code in a specific Oracle database.
-
-    This class is deprecated.
-
-    Please use :class:`airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`.
-
-    :param sql: the sql code to be executed. Can receive a str representing a sql statement,
-        a list of str (sql statements), or reference to a template file.
-        Template reference are recognized by str ending in '.sql'
-        (templated)
-    :param oracle_conn_id: The :ref:`Oracle connection id <howto/connection:oracle>`
-        reference to a specific Oracle database.
-    :param parameters: (optional, templated) the parameters to render the SQL query with.
-    :param autocommit: if True, each command is automatically committed.
-        (default value: False)
-    """
-
-    template_fields: Sequence[str] = (
-        "parameters",
-        "sql",
-    )
-    template_ext: Sequence[str] = (".sql",)
-    template_fields_renderers: ClassVar[dict] = {"sql": "sql"}
-    ui_color = "#ededed"
-
-    def __init__(self, *, oracle_conn_id: str = "oracle_default", **kwargs) -> None:
-        super().__init__(conn_id=oracle_conn_id, **kwargs)
 
 
 class OracleStoredProcedureOperator(BaseOperator):

--- a/providers/tests/oracle/operators/test_oracle.py
+++ b/providers/tests/oracle/operators/test_oracle.py
@@ -23,39 +23,9 @@ from unittest import mock
 import oracledb
 import pytest
 
-from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import TaskInstance
-from airflow.providers.common.sql.hooks.sql import fetch_all_handler
 from airflow.providers.oracle.hooks.oracle import OracleHook
-from airflow.providers.oracle.operators.oracle import OracleOperator, OracleStoredProcedureOperator
-
-
-class TestOracleOperator:
-    @mock.patch("airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator.get_db_hook")
-    def test_execute(self, mock_get_db_hook):
-        sql = "SELECT * FROM test_table"
-        oracle_conn_id = "oracle_default"
-        parameters = {"parameter": "value"}
-        autocommit = False
-        context = "test_context"
-        task_id = "test_task_id"
-
-        with pytest.warns(AirflowProviderDeprecationWarning, match="Call to deprecated class *"):
-            operator = OracleOperator(
-                sql=sql,
-                oracle_conn_id=oracle_conn_id,
-                parameters=parameters,
-                autocommit=autocommit,
-                task_id=task_id,
-            )
-        operator.execute(context=context)
-        mock_get_db_hook.return_value.run.assert_called_once_with(
-            sql=sql,
-            autocommit=autocommit,
-            parameters=parameters,
-            handler=fetch_all_handler,
-            return_last=True,
-        )
+from airflow.providers.oracle.operators.oracle import OracleStoredProcedureOperator
 
 
 class TestOracleStoredProcedureOperator:


### PR DESCRIPTION
In Airflow 3 Dev Call we discussed and made a LAZY CONSENSUS to remove all deprecation's in providers prior 2.11 release in https://lists.apache.org/thread/lhy7zhz8yxo3jjpln0ds8ogszgb9b469.

This PR is for the provider Oracle

Relates to https://github.com/apache/airflow/issues/44559