### PR TITLE
AIP-67 - Introduce team id to executor names and loader

### DIFF
--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -129,9 +129,10 @@ class BaseExecutor(LoggingMixin):
     name: None | ExecutorName = None
     callback_sink: BaseCallbackSink | None = None
 
-    def __init__(self, parallelism: int = PARALLELISM):
+    def __init__(self, parallelism: int = PARALLELISM, team_id: str | None = None):
         super().__init__()
         self.parallelism: int = parallelism
+        self.team_id: str | None = team_id
         self.queued_tasks: dict[TaskInstanceKey, QueuedTaskInstanceType] = {}
         self.running: set[TaskInstanceKey] = set()
         self.event_buffer: dict[TaskInstanceKey, EventBufferValueType] = {}

--- a/airflow/executors/executor_utils.py
+++ b/airflow/executors/executor_utils.py
@@ -23,35 +23,42 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 class ExecutorName(LoggingMixin):
     """Representation of an executor config/name."""
 
-    def __init__(self, module_path, alias=None):
-        self.module_path = module_path
-        self.alias = alias
+    def __init__(self, module_path: str, alias: str | None = None, team_id: str | None = None) -> None:
+        self.module_path: str = module_path
+        self.alias: str | None = alias
+        self.team_id: str | None = team_id
         self.set_connector_source()
 
-    def set_connector_source(self):
+    def set_connector_source(self) -> None:
         if self.alias in CORE_EXECUTOR_NAMES:
             self.connector_source = ConnectorSource.CORE
         else:
             # Executor must be a module
             self.connector_source = ConnectorSource.CUSTOM_PATH
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Implement repr."""
         if self.alias in CORE_EXECUTOR_NAMES:
-            return self.alias
-        return f"{self.alias}:{self.module_path}" if self.alias else f"{self.module_path}"
+            # This is a "core executor" we can refer to it by its known short name
+            return f"{self.team_id if self.team_id else ''}:{self.alias}:"
+        return (
+            f"{self.team_id if self.team_id else ''}:"
+            f"{self.alias if self.alias else ''}:"
+            f"{self.module_path}"
+        )
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         """Implement eq."""
         if (
             self.alias == other.alias
             and self.module_path == other.module_path
             and self.connector_source == other.connector_source
+            and self.team_id == other.team_id
         ):
             return True
         else:
             return False
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         """Implement hash."""
         return hash(self.__repr__())

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -237,7 +237,7 @@ class TestCli:
         assert celery_executor_command.name in commands
         assert ecs_executor_command.name not in commands
         assert (
-            "Failed to load CLI commands from executor: airflow.providers.amazon.aws.executors.ecs.ecs_executor.AwsEcsExecutor"
+            "Failed to load CLI commands from executor: ::airflow.providers.amazon.aws.executors.ecs.ecs_executor.AwsEcsExecutor"
             in caplog.messages[0]
         )
 
@@ -265,7 +265,7 @@ class TestCli:
         commands = [command.name for command in cli_parser.airflow_commands]
         assert ecs_executor_command.name in commands
         assert (
-            "Failed to load CLI commands from executor: airflow.providers.incorrect.executor.Executor"
+            "Failed to load CLI commands from executor: ::airflow.providers.incorrect.executor.Executor"
             in caplog.messages[0]
         )
 

--- a/tests/executors/test_executor_utils.py
+++ b/tests/executors/test_executor_utils.py
@@ -18,28 +18,110 @@ from __future__ import annotations
 
 import pytest
 
-from airflow.executors.executor_loader import ExecutorName
+from airflow.executors.executor_constants import LOCAL_EXECUTOR, ConnectorSource
+from airflow.executors.executor_loader import ExecutorLoader, ExecutorName
+
+CORE_EXEC_ALIAS = LOCAL_EXECUTOR
+CORE_EXEC_MODULE_PATH = ExecutorLoader.executors[CORE_EXEC_ALIAS]
+CORE_EXEC_TEAM_ID = "team_a"
+CUSTOM_EXEC_MODULE_PATH = "custom.module.path"
+CUSTOM_EXEC_ALIAS = "custom_executor"
+CUSTOM_EXEC_TEAM_ID = "team_b"
 
 
 class TestExecutorName:
-    def test_executor_name_repr_alias(self):
-        executor_name = ExecutorName(module_path="foo.bar", alias="my_alias")
-        assert str(executor_name) == "my_alias:foo.bar"
+    @pytest.fixture
+    def core_executor(self):
+        return ExecutorName(alias=CORE_EXEC_ALIAS, module_path=CORE_EXEC_MODULE_PATH)
 
-    def test_executor_name_repr_no_alias(self):
-        executor_name = ExecutorName(module_path="foo.bar")
-        assert str(executor_name) == "foo.bar"
+    @pytest.fixture
+    def core_executor_team_id(self):
+        return ExecutorName(
+            alias=CORE_EXEC_ALIAS, module_path=CORE_EXEC_MODULE_PATH, team_id=CORE_EXEC_TEAM_ID
+        )
 
-    @pytest.mark.parametrize(
-        ("name_args_1", "name_args_2", "expected_result"),
-        [
-            (["foo.bar", "my_alias"], ["foo.bar", "my_alias"], True),
-            (["foo.bar"], ["foo.bar"], True),
-            (["foo.bar"], ["foo.bar", "my_alias"], False),
-        ],
-    )
-    def test_executor_name_eq(self, name_args_1, name_args_2, expected_result):
-        executor_name_1 = ExecutorName(*name_args_1)
-        executor_name_2 = ExecutorName(*name_args_2)
-        eq_result = executor_name_1 == executor_name_2
-        assert eq_result == expected_result
+    @pytest.fixture
+    def custom_executor(self):
+        return ExecutorName(module_path=CUSTOM_EXEC_MODULE_PATH)
+
+    @pytest.fixture
+    def custom_executor_alias(self):
+        return ExecutorName(module_path=CUSTOM_EXEC_MODULE_PATH, alias=CUSTOM_EXEC_ALIAS)
+
+    @pytest.fixture
+    def custom_executor_team_id(self):
+        return ExecutorName(module_path=CUSTOM_EXEC_MODULE_PATH, team_id=CUSTOM_EXEC_TEAM_ID)
+
+    @pytest.fixture
+    def custom_executor_team_id_alias(self):
+        return ExecutorName(
+            module_path=CUSTOM_EXEC_MODULE_PATH, alias=CUSTOM_EXEC_ALIAS, team_id=CUSTOM_EXEC_TEAM_ID
+        )
+
+    def test_initialization(
+        self,
+        core_executor,
+        core_executor_team_id,
+        custom_executor,
+        custom_executor_team_id,
+        custom_executor_alias,
+        custom_executor_team_id_alias,
+    ):
+        assert core_executor.module_path == CORE_EXEC_MODULE_PATH
+        assert core_executor.alias is CORE_EXEC_ALIAS
+        assert core_executor.team_id is None
+        assert core_executor.connector_source == ConnectorSource.CORE
+
+        assert core_executor_team_id.module_path == CORE_EXEC_MODULE_PATH
+        assert core_executor_team_id.alias is CORE_EXEC_ALIAS
+        assert core_executor_team_id.team_id == CORE_EXEC_TEAM_ID
+        assert core_executor_team_id.connector_source == ConnectorSource.CORE
+
+        assert custom_executor.module_path == CUSTOM_EXEC_MODULE_PATH
+        assert custom_executor.alias is None
+        assert custom_executor.team_id is None
+        assert custom_executor.connector_source == ConnectorSource.CUSTOM_PATH
+
+        assert custom_executor_team_id.module_path == CUSTOM_EXEC_MODULE_PATH
+        assert custom_executor_team_id.alias is None
+        assert custom_executor_team_id.team_id == CUSTOM_EXEC_TEAM_ID
+        assert custom_executor_team_id.connector_source == ConnectorSource.CUSTOM_PATH
+
+        assert custom_executor_alias.module_path == CUSTOM_EXEC_MODULE_PATH
+        assert custom_executor_alias.alias == CUSTOM_EXEC_ALIAS
+        assert custom_executor_alias.team_id is None
+        assert custom_executor_alias.connector_source == ConnectorSource.CUSTOM_PATH
+
+        assert custom_executor_team_id_alias.module_path == CUSTOM_EXEC_MODULE_PATH
+        assert custom_executor_team_id_alias.alias == CUSTOM_EXEC_ALIAS
+        assert custom_executor_team_id_alias.team_id == CUSTOM_EXEC_TEAM_ID
+        assert custom_executor_team_id_alias.connector_source == ConnectorSource.CUSTOM_PATH
+
+    def test_repr_all(self, core_executor, core_executor_team_id, custom_executor_team_id_alias):
+        assert repr(core_executor) == f":{CORE_EXEC_ALIAS}:"
+        assert repr(core_executor_team_id) == f"{CORE_EXEC_TEAM_ID}:{CORE_EXEC_ALIAS}:"
+        assert (
+            repr(custom_executor_team_id_alias)
+            == f"{CUSTOM_EXEC_TEAM_ID}:{CUSTOM_EXEC_ALIAS}:{CUSTOM_EXEC_MODULE_PATH}"
+        )
+
+    def test_eq_same(self, core_executor_team_id):
+        compare_exec = ExecutorName(
+            alias=CORE_EXEC_ALIAS, module_path=CORE_EXEC_MODULE_PATH, team_id=CORE_EXEC_TEAM_ID
+        )
+
+        assert core_executor_team_id == compare_exec
+
+    def test_eq_different(self, core_executor, core_executor_team_id, custom_executor_team_id):
+        assert core_executor != core_executor_team_id
+        assert core_executor_team_id != custom_executor_team_id
+
+    def test_hash_same(self, core_executor_team_id):
+        compare_exec = ExecutorName(
+            alias=CORE_EXEC_ALIAS, module_path=CORE_EXEC_MODULE_PATH, team_id=CORE_EXEC_TEAM_ID
+        )
+        assert hash(core_executor_team_id) == hash(compare_exec)
+
+    def test_hash_different(self, core_executor, core_executor_team_id, custom_executor_team_id_alias):
+        assert hash(core_executor) != hash(core_executor_team_id)
+        assert hash(core_executor_team_id) != hash(custom_executor_team_id_alias)


### PR DESCRIPTION
When multi team (AIP-67) is eventually in place, the scheduler will need to initialize a set of executors for each team. This change is a first step towards that which updates the ExecutorName data model and the executor loader to be "team aware".

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
