### PR TITLE
Remove unnecessary compatibility code in S3 asset import

### DIFF
--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -607,7 +607,7 @@ DEFAULT_EXTRAS = [
     # END OF EXTRAS LIST UPDATED BY PRE COMMIT
 ]
 
-CHICKEN_EGG_PROVIDERS = " ".join(["standard amazon common.sql"])
+CHICKEN_EGG_PROVIDERS = " ".join(["common.compat"])
 
 
 PROVIDERS_COMPATIBILITY_TESTS_MATRIX: list[dict[str, str | list[str]]] = [

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -26,7 +26,7 @@
   "amazon": {
     "deps": [
       "PyAthena>=3.0.10",
-      "apache-airflow-providers-common-compat>=1.2.1",
+      "apache-airflow-providers-common-compat>=1.3.0",
       "apache-airflow-providers-common-sql>=1.20.0",
       "apache-airflow-providers-http",
       "apache-airflow>=2.8.0",

--- a/providers/src/airflow/providers/amazon/aws/assets/s3.py
+++ b/providers/src/airflow/providers/amazon/aws/assets/s3.py
@@ -19,30 +19,14 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from airflow.providers.common.compat.assets import Asset
 
 if TYPE_CHECKING:
     from urllib.parse import SplitResult
 
-    from airflow.providers.common.compat.assets import Asset
     from airflow.providers.common.compat.openlineage.facet import (
         Dataset as OpenLineageDataset,
     )
-else:
-    # TODO: Remove this try-exception block after bumping common provider to 1.3.0
-    # This is due to common provider AssetDetails import error handling
-    try:
-        from airflow.providers.common.compat.assets import Asset
-    except ImportError:
-        from packaging.version import Version
-
-        from airflow import __version__ as AIRFLOW_VERSION
-
-        AIRFLOW_V_3_0_PLUS = Version(Version(AIRFLOW_VERSION).base_version) >= Version("3.0.0")
-        if AIRFLOW_V_3_0_PLUS:
-            from airflow.sdk.definitions.asset import Asset
-        else:
-            # dataset is renamed to asset since Airflow 3.0
-            from airflow.datasets import Dataset as Asset
 
 
 def create_asset(*, bucket: str, key: str, extra=None) -> Asset:

--- a/providers/src/airflow/providers/amazon/provider.yaml
+++ b/providers/src/airflow/providers/amazon/provider.yaml
@@ -94,7 +94,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.8.0
-  - apache-airflow-providers-common-compat>=1.2.1
+  - apache-airflow-providers-common-compat>=1.3.0
   - apache-airflow-providers-common-sql>=1.20.0
   - apache-airflow-providers-http
   # We should update minimum version of boto3 and here regularly to avoid `pip` backtracking with the number

--- a/providers/src/airflow/providers/common/compat/provider.yaml
+++ b/providers/src/airflow/providers/common/compat/provider.yaml
@@ -25,6 +25,7 @@ state: ready
 source-date-epoch: 1731569875
 # note that those versions are maintained by release manager - do not update them manually
 versions:
+  - 1.3.0
   - 1.2.2
   - 1.2.1
   - 1.2.0


### PR DESCRIPTION
The S3 asset import had a conditional code to import assets but
it is unnecessary, because the compatibility code is added to
common.compat provider - but only in the upcoming version so we have
to make sure that common.compat is added to "chicken-egg" providers,
so that constaraints are properly generated for PyPI packages.

This is also the case where we can bump manually provider version
without waiting for release time - because we need to depend on the
new provider version in amazon provider.


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
