### PR TITLE
[Edge] Make edge executor db access multi instance save

### DIFF
--- a/providers/src/airflow/providers/edge/CHANGELOG.rst
+++ b/providers/src/airflow/providers/edge/CHANGELOG.rst
@@ -27,6 +27,14 @@
 Changelog
 ---------
 
+0.9.1pre0
+.........
+
+Misc
+~~~~
+
+* ``Make edge executor DB access is multi instance save.``
+
 0.9.0pre0
 .........
 

--- a/providers/src/airflow/providers/edge/__init__.py
+++ b/providers/src/airflow/providers/edge/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "0.9.0pre0"
+__version__ = "0.9.1pre0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.10.0"

--- a/providers/src/airflow/providers/edge/executors/edge_executor.py
+++ b/providers/src/airflow/providers/edge/executors/edge_executor.py
@@ -135,6 +135,7 @@ class EdgeExecutor(BaseExecutor):
         heartbeat_interval: int = conf.getint("edge", "heartbeat_interval")
         lifeless_workers: list[EdgeWorkerModel] = (
             session.query(EdgeWorkerModel)
+            .with_for_update(skip_locked=True)
             .filter(
                 EdgeWorkerModel.state.not_in([EdgeWorkerState.UNKNOWN, EdgeWorkerState.OFFLINE]),
                 EdgeWorkerModel.last_update < (timezone.utcnow() - timedelta(seconds=heartbeat_interval * 5)),
@@ -154,6 +155,7 @@ class EdgeExecutor(BaseExecutor):
         heartbeat_interval: int = conf.getint("scheduler", "scheduler_zombie_task_threshold")
         lifeless_jobs: list[EdgeJobModel] = (
             session.query(EdgeJobModel)
+            .with_for_update(skip_locked=True)
             .filter(
                 EdgeJobModel.state == TaskInstanceState.RUNNING,
                 EdgeJobModel.last_update < (timezone.utcnow() - timedelta(seconds=heartbeat_interval)),
@@ -180,6 +182,7 @@ class EdgeExecutor(BaseExecutor):
         job_fail_purge = conf.getint("edge", "job_fail_purge")
         jobs: list[EdgeJobModel] = (
             session.query(EdgeJobModel)
+            .with_for_update(skip_locked=True)
             .filter(
                 EdgeJobModel.state.in_(
                     [

--- a/providers/src/airflow/providers/edge/provider.yaml
+++ b/providers/src/airflow/providers/edge/provider.yaml
@@ -27,7 +27,7 @@ source-date-epoch: 1729683247
 
 # note that those versions are maintained by release manager - do not update them manually
 versions:
-  - 0.9.0pre0
+  - 0.9.1pre0
 
 dependencies:
   - apache-airflow>=2.10.0


### PR DESCRIPTION
# Description

We see in our multi scheduler deployment cyclic crashes of the scheduler. This points to the issue that different edge executors trying to work on the same DB items during cleaning up the edge jobs items. Add usage of locks so that the edge executor only works which DB items which are not used by other edge executors.

# Details about changes
* Usage of locks on DB items with are used by the edge executor.
* Locked items are ignored by the other edge executors.