### PR TITLE
Add information about chicken-egg providers in contributing docs

### DIFF
--- a/contributing-docs/11_provider_packages.rst
+++ b/contributing-docs/11_provider_packages.rst
@@ -28,8 +28,8 @@ Airflow 2.0 is split into core and providers. They are delivered as separate pac
 Where providers are kept in our repository
 ------------------------------------------
 
-Airflow Providers are stored in the same source tree as Airflow Core (under ``airflow.providers``) package. This
-means that Airflow's repository is a monorepo, that keeps multiple packages in a single repository. This has a number
+Airflow Providers are stored in the separate tree than Airflow Core (under ``providers`` directory).
+Airflow's repository is a monorepo, that keeps multiple packages in a single repository. This has a number
 of advantages, because code and CI infrastructure and tests can be shared. Also contributions are happening to a
 single repository - so no matter if you contribute to Airflow or Providers, you are contributing to the same
 repository and project.
@@ -49,7 +49,7 @@ dependencies including runtime dependencies. See `local virtualenv <../07_local_
 for more information.
 
 Therefore, until we can introduce multiple ``pyproject.toml`` for providers information/meta-data about the providers
-is kept in ``provider.yaml`` file in the right sub-directory of ``airflow\providers``. This file contains:
+is kept in ``provider.yaml`` file in the right sub-directory of ``providers``. This file contains:
 
 * package name (``apache-airflow-provider-*``)
 * user-facing name of the provider package
@@ -89,6 +89,19 @@ and pre-commit will generate new entry in ``generated/provider_dependencies.json
 ``pyproject.toml`` so that the package extra dependencies are properly handled when package
 might be installed when breeze is restarted or by your IDE or by running ``pip install -e ".[devel]"``.
 
+Chicken-egg providers
+---------------------
+
+Sometimes, when provider depends on another provider, you might want to add a new feature that spans across
+two providers. In this case, you might need to add a new feature to the "dependent" provider, but you need
+to add a new feature to the "dependency" provider as well. This is a chicken-egg problem and by default
+some CI jobs (like generating PyPI constraints) will fail because they cannot use the source version of
+the provider package. This is handled by adding the "dependent" provider to the chicken-egg list of
+"providers" in ``dev/breeze/src/airflow_breeze/global_constants.py``. By doing this, the provider is build
+locally from sources rather than downloaded from PyPI when generating constraints.
+
+More information about the chicken-egg providers and how release is handled can be found in
+the `Release Provider Packages documentation <../dev/README_RELEASE_PROVIDER_PACKAGES.md#chicken-egg-providers>`_
 
 Developing community managed provider packages
 ----------------------------------------------

--- a/contributing-docs/11_provider_packages.rst
+++ b/contributing-docs/11_provider_packages.rst
@@ -28,7 +28,7 @@ Airflow 2.0 is split into core and providers. They are delivered as separate pac
 Where providers are kept in our repository
 ------------------------------------------
 
-Airflow Providers are stored in the separate tree than Airflow Core (under ``providers`` directory).
+Airflow Providers are stored in a separate tree other than the Airflow Core (under ``providers`` directory).
 Airflow's repository is a monorepo, that keeps multiple packages in a single repository. This has a number
 of advantages, because code and CI infrastructure and tests can be shared. Also contributions are happening to a
 single repository - so no matter if you contribute to Airflow or Providers, you are contributing to the same

--- a/contributing-docs/11_provider_packages.rst
+++ b/contributing-docs/11_provider_packages.rst
@@ -92,8 +92,8 @@ might be installed when breeze is restarted or by your IDE or by running ``pip i
 Chicken-egg providers
 ---------------------
 
-Sometimes, when provider depends on another provider, you might want to add a new feature that spans across
-two providers. In this case, you might need to add a new feature to the "dependent" provider, but you need
+Sometimes, when a provider depends on another provider, and you want to add a new feature that spans across
+two providers, you might need to add a new feature to the "dependent" provider, you need
 to add a new feature to the "dependency" provider as well. This is a chicken-egg problem and by default
 some CI jobs (like generating PyPI constraints) will fail because they cannot use the source version of
 the provider package. This is handled by adding the "dependent" provider to the chicken-egg list of

--- a/dev/README_RELEASE_PROVIDER_PACKAGES.md
+++ b/dev/README_RELEASE_PROVIDER_PACKAGES.md
@@ -203,6 +203,15 @@ release should get it changed to `>= x.y.z`. This is a rare case and should be h
 We call such case chicken-egg providers as it's not clear who should be released first - the provider or
 the Airflow.
 
+Similar case is when provider depends on another provider (usually `common.*`) that is not yet released
+because you it contains new feature and you want to release the providers together.
+
+In such case the "common" provider should be added to the list of "chicken-egg" providers in the
+`./dev/breeze/src/airflow_breeze/global_constants.py` file and version of the provider should be bumped
+in the PR by author of the PR that adds both the functionality. This will make sure that the
+provider is build in CI from sources, when CI jobs are run rather than latest version downloaded from PyPI
+when constraints are generated.
+
 # Prepare Regular Provider packages (RC)
 
 ## Move provider into remove state


### PR DESCRIPTION
Chicken-egg providers have not been fully described - the case where two providers depend on each other have not been mentioned as a use case in release management docs, also the providers have not been mentioned in provider's contributing docs.

This PR addresses both problems.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
