### PR TITLE
[Edge] Fix edge worker api support none default base api url

### DIFF
--- a/providers/src/airflow/providers/edge/CHANGELOG.rst
+++ b/providers/src/airflow/providers/edge/CHANGELOG.rst
@@ -27,6 +27,14 @@
 Changelog
 ---------
 
+0.9.2pre0
+.........
+
+Misc
+~~~~
+
+* ``Fix check api call with different root url.``
+
 0.9.1pre0
 .........
 

--- a/providers/src/airflow/providers/edge/CHANGELOG.rst
+++ b/providers/src/airflow/providers/edge/CHANGELOG.rst
@@ -33,7 +33,7 @@ Changelog
 Misc
 ~~~~
 
-* ``Fix check api call with different root url.``
+* ``Fix check edge worker api call authentication with different base url. Authentication failed when Airflow is not installed in webserver root.``
 
 0.9.1pre0
 .........

--- a/providers/src/airflow/providers/edge/__init__.py
+++ b/providers/src/airflow/providers/edge/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "0.9.1pre0"
+__version__ = "0.9.2pre0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.10.0"

--- a/providers/src/airflow/providers/edge/cli/api_client.py
+++ b/providers/src/airflow/providers/edge/cli/api_client.py
@@ -22,7 +22,7 @@ from datetime import datetime
 from http import HTTPStatus
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-from urllib.parse import quote, urljoin, urlparse
+from urllib.parse import quote, urljoin
 
 import requests
 import tenacity
@@ -74,11 +74,10 @@ def _is_retryable_exception(exception: BaseException) -> bool:
 def _make_generic_request(method: str, rest_path: str, data: str | None = None) -> Any:
     signer = jwt_signer()
     api_url = conf.get("edge", "api_url")
-    path = urlparse(api_url).path.replace("/rpcapi", "")
     headers = {
         "Content-Type": "application/json",
         "Accept": "application/json",
-        "Authorization": signer.generate_signed_token({"method": str(Path(path, rest_path))}),
+        "Authorization": signer.generate_signed_token({"method": rest_path}),
     }
     api_endpoint = urljoin(api_url, rest_path)
     response = requests.request(method, url=api_endpoint, data=data, headers=headers)

--- a/providers/src/airflow/providers/edge/provider.yaml
+++ b/providers/src/airflow/providers/edge/provider.yaml
@@ -27,7 +27,7 @@ source-date-epoch: 1729683247
 
 # note that those versions are maintained by release manager - do not update them manually
 versions:
-  - 0.9.1pre0
+  - 0.9.2pre0
 
 dependencies:
   - apache-airflow>=2.10.0

--- a/providers/src/airflow/providers/edge/worker_api/auth.py
+++ b/providers/src/airflow/providers/edge/worker_api/auth.py
@@ -69,9 +69,8 @@ def jwt_token_authorization(method: str, authorization: str):
         # worker sends method without api_url
         api_url = conf.get("edge", "api_url")
         base_url = conf.get("webserver", "base_url")
-        url_prefix = api_url.replace(base_url, "").replace("/rpcapi", "")
+        url_prefix = api_url.replace(base_url, "").replace("/rpcapi", "/")
         pure_method = method.replace(url_prefix, "")
-        pure_method = pure_method[1:]
         payload = jwt_signer().verify_token(authorization)
         signed_method = payload.get("method")
         if not signed_method or signed_method != pure_method:

--- a/providers/src/airflow/providers/edge/worker_api/auth.py
+++ b/providers/src/airflow/providers/edge/worker_api/auth.py
@@ -71,6 +71,7 @@ def jwt_token_authorization(method: str, authorization: str):
         base_url = conf.get("webserver", "base_url")
         url_prefix = api_url.replace(base_url, "").replace("/rpcapi", "")
         pure_method = method.replace(url_prefix, "")
+        pure_method = pure_method[1:]
         payload = jwt_signer().verify_token(authorization)
         signed_method = payload.get("method")
         if not signed_method or signed_method != pure_method:


### PR DESCRIPTION
# Description

If Airflow deployment runs on none default base url the Edge worker api auth fails. The Edge worker api auth compares the method names which include  the url path. But auth does not know on which sub url it is running. Auth detects a mismatch and blocks the request.

# Details about changes
* Edge worker uses pure method name (url path without base url)
* Edge worker api auth compares method name without using the url_prefix