### PR TITLE
AIP-79 Generate assets for Flask application in FAB provider

### DIFF
--- a/scripts/ci/pre_commit/compile_www_assets.py
+++ b/scripts/ci/pre_commit/compile_www_assets.py
@@ -18,11 +18,11 @@
 from __future__ import annotations
 
 import hashlib
+import importlib.util
 import os
 import re
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 
 # NOTE!. This script is executed from node environment created by pre-commit and this environment
@@ -52,17 +52,18 @@ if __name__ not in ("__main__", "__mp_main__"):
         f"To run this script, run the ./{__file__} command"
     )
 
-if __name__ == "__main__":
-    www_directory = AIRFLOW_SOURCES_PATH / "airflow" / "www"
+
+def compile_assets(www_directory: Path, www_hash_file_name: str):
     node_modules_directory = www_directory / "node_modules"
     dist_directory = www_directory / "static" / "dist"
-    WWW_HASH_FILE.parent.mkdir(exist_ok=True, parents=True)
+    www_hash_file = AIRFLOW_SOURCES_PATH / ".build" / "www" / www_hash_file_name
+    www_hash_file.parent.mkdir(exist_ok=True, parents=True)
     if node_modules_directory.exists() and dist_directory.exists():
-        old_hash = WWW_HASH_FILE.read_text() if WWW_HASH_FILE.exists() else ""
+        old_hash = www_hash_file.read_text() if www_hash_file.exists() else ""
         new_hash = get_directory_hash(www_directory, skip_path_regexp=r".*node_modules.*")
         if new_hash == old_hash:
             print("The WWW directory has not changed! Skip regeneration.")
-            sys.exit(0)
+            return
     else:
         shutil.rmtree(node_modules_directory, ignore_errors=True)
         shutil.rmtree(dist_directory, ignore_errors=True)
@@ -71,4 +72,20 @@ if __name__ == "__main__":
     subprocess.check_call(["yarn", "install", "--frozen-lockfile"], cwd=os.fspath(www_directory))
     subprocess.check_call(["yarn", "run", "build"], cwd=os.fspath(www_directory), env=env)
     new_hash = get_directory_hash(www_directory, skip_path_regexp=r".*node_modules.*")
-    WWW_HASH_FILE.write_text(new_hash)
+    www_hash_file.write_text(new_hash)
+
+
+def is_fab_provider_installed() -> bool:
+    return importlib.util.find_spec("airflow.providers.fab") is not None
+
+
+if __name__ == "__main__":
+    # Compile assets for main
+    main_www_directory = AIRFLOW_SOURCES_PATH / "airflow" / "www"
+    compile_assets(main_www_directory, "hash.txt")
+    if is_fab_provider_installed():
+        # Compile assets for fab provider
+        fab_provider_www_directory = (
+            AIRFLOW_SOURCES_PATH / "providers" / "src" / "airflow" / "providers" / "fab" / "www"
+        )
+        compile_assets(fab_provider_www_directory, "hash_fab.txt")


### PR DESCRIPTION
Follow up of #44464.

In #44464, we copied a minimal version of the Flask application in FAB provider to support Airflow 2 plugins. This Flask application required assets (like the Flask application in core).

In this PR I update the script `compile_www_assets.py` to also generate the assets for the Flash application in FAB provider. 

For later: when the current UI is gone, we'll be able to stop generating the assets for the main Flask application in core (then maybe move the script to FAB provider?).

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
