### PR TITLE
Remove Provider Deprecations in Redis

### DIFF
--- a/providers/src/airflow/providers/redis/CHANGELOG.rst
+++ b/providers/src/airflow/providers/redis/CHANGELOG.rst
@@ -27,6 +27,19 @@
 Changelog
 ---------
 
+main
+....
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+.. warning::
+  All deprecated classes, parameters and features have been removed from the Redis provider package.
+  The following breaking changes were introduced:
+
+  * Hooks
+     * Extra parameter ``ssl_cert_file`` was removed. Please use the direct replacement ``ssl_certfile`` instead.
+
 3.8.0
 .....
 

--- a/providers/src/airflow/providers/redis/hooks/redis.py
+++ b/providers/src/airflow/providers/redis/hooks/redis.py
@@ -19,12 +19,10 @@
 
 from __future__ import annotations
 
-import warnings
 from typing import Any
 
 from redis import Redis
 
-from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.hooks.base import BaseHook
 
 DEFAULT_SSL_CERT_REQS = "required"
@@ -37,7 +35,7 @@ class RedisHook(BaseHook):
 
     You can set your db in the extra field of your connection as ``{"db": 3}``.
     Also you can set ssl parameters as:
-    ``{"ssl": true, "ssl_cert_reqs": "require", "ssl_cert_file": "/path/to/cert.pem", etc}``.
+    ``{"ssl": true, "ssl_cert_reqs": "require", "ssl_certfile": "/path/to/cert.pem", etc}``.
     """
 
     conn_name_attr = "redis_conn_id"
@@ -80,16 +78,6 @@ class RedisHook(BaseHook):
             "ssl_check_hostname",
         ]
         ssl_args = {name: val for name, val in conn.extra_dejson.items() if name in ssl_arg_names}
-
-        # This logic is for backward compatibility only
-        if "ssl_cert_file" in conn.extra_dejson and "ssl_certfile" not in conn.extra_dejson:
-            warnings.warn(
-                "Extra parameter `ssl_cert_file` deprecated and will be removed "
-                "in a future release. Please use `ssl_certfile` instead.",
-                AirflowProviderDeprecationWarning,
-                stacklevel=2,
-            )
-            ssl_args["ssl_certfile"] = conn.extra_dejson.get("ssl_cert_file")
 
         if not self.redis:
             self.log.debug(

--- a/providers/tests/redis/hooks/test_redis.py
+++ b/providers/tests/redis/hooks/test_redis.py
@@ -21,7 +21,6 @@ from unittest import mock
 
 import pytest
 
-from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import Connection
 from airflow.providers.redis.hooks.redis import RedisHook
 
@@ -79,44 +78,6 @@ class TestRedisHook:
             ssl_ca_certs=connection.extra_dejson["ssl_ca_certs"],
             ssl_keyfile=connection.extra_dejson["ssl_keyfile"],
             ssl_certfile=connection.extra_dejson["ssl_certfile"],
-            ssl_check_hostname=connection.extra_dejson["ssl_check_hostname"],
-        )
-
-    @mock.patch("airflow.providers.redis.hooks.redis.Redis")
-    @mock.patch(
-        "airflow.providers.redis.hooks.redis.RedisHook.get_connection",
-        return_value=Connection(
-            password="password",
-            host="remote_host",
-            port=1234,
-            extra="""{
-                        "db": 2,
-                        "ssl": true,
-                        "ssl_cert_reqs": "required",
-                        "ssl_ca_certs": "/path/to/custom/ca-cert",
-                        "ssl_keyfile": "/path/to/key-file",
-                        "ssl_cert_file": "/path/to/cert-file",
-                        "ssl_check_hostname": true
-                    }""",
-        ),
-    )
-    def test_get_conn_with_deprecated_extra_config(self, mock_get_connection, mock_redis):
-        connection = mock_get_connection.return_value
-        hook = RedisHook()
-
-        with pytest.warns(AirflowProviderDeprecationWarning, match=self.deprecation_message):
-            hook.get_conn()
-        mock_redis.assert_called_once_with(
-            host=connection.host,
-            password=connection.password,
-            username=None,
-            port=connection.port,
-            db=connection.extra_dejson["db"],
-            ssl=connection.extra_dejson["ssl"],
-            ssl_cert_reqs=connection.extra_dejson["ssl_cert_reqs"],
-            ssl_ca_certs=connection.extra_dejson["ssl_ca_certs"],
-            ssl_keyfile=connection.extra_dejson["ssl_keyfile"],
-            ssl_certfile=connection.extra_dejson["ssl_cert_file"],
             ssl_check_hostname=connection.extra_dejson["ssl_check_hostname"],
         )
 


### PR DESCRIPTION
In Airflow 3 Dev Call we discussed and made a LAZY CONSENSUS to remove all deprecation's in providers prior 2.11 release in https://lists.apache.org/thread/lhy7zhz8yxo3jjpln0ds8ogszgb9b469.

This PR is for the provider Redis

Relates to https://github.com/apache/airflow/issues/44559