### PR TITLE
Remove Provider Deprecations in Microsoft-PSRP

### DIFF
--- a/providers/src/airflow/providers/microsoft/psrp/CHANGELOG.rst
+++ b/providers/src/airflow/providers/microsoft/psrp/CHANGELOG.rst
@@ -27,6 +27,15 @@
 Changelog
 ---------
 
+main
+....
+
+.. warning::
+  All deprecated classes, parameters and features have been removed from the Microsoft.PSRP provider package.
+  The following breaking changes were introduced:
+
+  * Passing kwargs to ``invoke_cmdlet`` was removed. Please use ``parameters`` instead.
+
 2.8.0
 .....
 

--- a/providers/src/airflow/providers/microsoft/psrp/hooks/psrp.py
+++ b/providers/src/airflow/providers/microsoft/psrp/hooks/psrp.py
@@ -22,7 +22,6 @@ from contextlib import contextmanager
 from copy import copy
 from logging import DEBUG, ERROR, INFO, WARNING
 from typing import TYPE_CHECKING, Any, Callable
-from warnings import warn
 from weakref import WeakKeyDictionary
 
 from pypsrp.host import PSHost
@@ -30,7 +29,7 @@ from pypsrp.messages import MessageType
 from pypsrp.powershell import PowerShell, PSInvocationState, RunspacePool
 from pypsrp.wsman import WSMan
 
-from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 
 INFORMATIONAL_RECORD_LEVEL_MAP = {
@@ -229,21 +228,8 @@ class PsrpHook(BaseHook):
         use_local_scope: bool | None = None,
         arguments: list[str] | None = None,
         parameters: dict[str, str] | None = None,
-        **kwargs: str,
     ) -> PowerShell:
         """Invoke a PowerShell cmdlet and return session."""
-        if kwargs:
-            if parameters:
-                raise ValueError("**kwargs not allowed when 'parameters' is used at the same time.")
-            warn(
-                "Passing **kwargs to 'invoke_cmdlet' is deprecated "
-                "and will be removed in a future release. Please use 'parameters' "
-                "instead.",
-                AirflowProviderDeprecationWarning,
-                stacklevel=2,
-            )
-            parameters = kwargs
-
         with self.invoke() as ps:
             ps.add_cmdlet(name, use_local_scope=use_local_scope)
             for argument in arguments or ():

--- a/providers/tests/microsoft/psrp/hooks/test_psrp.py
+++ b/providers/tests/microsoft/psrp/hooks/test_psrp.py
@@ -25,7 +25,7 @@ from pypsrp.host import PSHost
 from pypsrp.messages import MessageType
 from pypsrp.powershell import PSInvocationState
 
-from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.providers.microsoft.psrp.hooks.psrp import PsrpHook
 
@@ -194,16 +194,6 @@ class TestPsrpHook:
             assert [call("foo", use_local_scope=None)] == ps.add_cmdlet.mock_calls
             assert [call({"bar": "1", "baz": "2"})] == ps.add_parameters.mock_calls
             assert [call(arg) for arg in arguments] == ps.add_argument.mock_calls
-
-    def test_invoke_cmdlet_deprecated_kwargs(self, *mocks):
-        with PsrpHook(CONNECTION_ID) as hook:
-            with pytest.warns(
-                AirflowProviderDeprecationWarning,
-                match=r"Passing \*\*kwargs to 'invoke_cmdlet' is deprecated and will be removed in a future release. Please use 'parameters' instead.",
-            ):
-                ps = hook.invoke_cmdlet("foo", bar="1", baz="2")
-            assert [call("foo", use_local_scope=None)] == ps.add_cmdlet.mock_calls
-            assert [call({"bar": "1", "baz": "2"})] == ps.add_parameters.mock_calls
 
     def test_invoke_powershell(self, *mocks):
         with PsrpHook(CONNECTION_ID) as hook:


### PR DESCRIPTION
In Airflow 3 Dev Call we discussed and made a LAZY CONSENSUS to remove all deprecation's in providers prior 2.11 release in https://lists.apache.org/thread/lhy7zhz8yxo3jjpln0ds8ogszgb9b469.

This PR is for the provider Microsoft-PSRP

Relates to https://github.com/apache/airflow/issues/44559