### PR TITLE
Remove Provider Deprecations in Apprise

### DIFF
--- a/providers/src/airflow/providers/apprise/CHANGELOG.rst
+++ b/providers/src/airflow/providers/apprise/CHANGELOG.rst
@@ -35,7 +35,7 @@ main
   The following breaking changes were introduced:
 
   * Hooks
-    * Paramter ``tag`` cannot be None. It is not set to MATCH_ALL_TAG as default.
+    * Parameter ``tag`` cannot be None. It is not set to MATCH_ALL_TAG as default.
   * Notifications
     * Parameter ``notify_type`` cannot be None. It is not set to NotifyType.INFO as default.
     * Parameter ``body_format`` cannot be None. It is not set to NotifyFormat.TEXT as default.

--- a/providers/src/airflow/providers/apprise/CHANGELOG.rst
+++ b/providers/src/airflow/providers/apprise/CHANGELOG.rst
@@ -27,6 +27,20 @@
 Changelog
 ---------
 
+main
+....
+
+.. warning::
+  All deprecated classes, parameters and features have been removed from the {provider_name} provider package.
+  The following breaking changes were introduced:
+
+  * Hooks
+    * Paramter ``tag`` cannot be None. It is not set to MATCH_ALL_TAG as default.
+  * Notifications
+    * Parameter ``notify_type`` cannot be None. It is not set to NotifyType.INFO as default.
+    * Parameter ``body_format`` cannot be None. It is not set to NotifyFormat.TEXT as default.
+    * Parameter ``tag`` cannot be None. It is not set to MATCH_ALL_TAG as default.
+
 1.4.1
 .....
 

--- a/providers/src/airflow/providers/apprise/hooks/apprise.py
+++ b/providers/src/airflow/providers/apprise/hooks/apprise.py
@@ -18,14 +18,12 @@
 from __future__ import annotations
 
 import json
-import warnings
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
 import apprise
 from apprise import AppriseConfig, NotifyFormat, NotifyType
 
-from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.hooks.base import BaseHook
 
 if TYPE_CHECKING:
@@ -77,7 +75,7 @@ class AppriseHook(BaseHook):
         title: str | None = None,
         notify_type: NotifyType = NotifyType.INFO,
         body_format: NotifyFormat = NotifyFormat.TEXT,
-        tag: str | Iterable[str] | None = None,
+        tag: str | Iterable[str] = "all",
         attach: AppriseAttachment | None = None,
         interpret_escapes: bool | None = None,
         config: AppriseConfig | None = None,
@@ -97,14 +95,6 @@ class AppriseHook(BaseHook):
             sequences such as \n and \r to their respective ascii new-line and carriage return characters
         :param config: Specify one or more configuration
         """
-        if tag is None:
-            warnings.warn(
-                "`tag` cannot be None. Assign it to be MATCH_ALL_TAG",
-                AirflowProviderDeprecationWarning,
-                stacklevel=2,
-            )
-            tag = "all"
-
         title = title or ""
 
         apprise_obj = apprise.Apprise()

--- a/providers/src/airflow/providers/apprise/notifications/apprise.py
+++ b/providers/src/airflow/providers/apprise/notifications/apprise.py
@@ -17,13 +17,11 @@
 
 from __future__ import annotations
 
-import warnings
 from collections.abc import Iterable
 from functools import cached_property
 
 from apprise import AppriseConfig, NotifyFormat, NotifyType
 
-from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.notifications.basenotifier import BaseNotifier
 from airflow.providers.apprise.hooks.apprise import AppriseHook
 
@@ -53,38 +51,14 @@ class AppriseNotifier(BaseNotifier):
         *,
         body: str,
         title: str | None = None,
-        notify_type: NotifyType | None = None,
-        body_format: NotifyFormat | None = None,
-        tag: str | Iterable[str] | None = None,
+        notify_type: NotifyType = NotifyType.INFO,
+        body_format: NotifyFormat = NotifyFormat.TEXT,
+        tag: str | Iterable[str] = "all",
         attach: str | None = None,
         interpret_escapes: bool | None = None,
         config: AppriseConfig | None = None,
         apprise_conn_id: str = AppriseHook.default_conn_name,
     ):
-        if tag is None:
-            warnings.warn(
-                "`tag` cannot be None. Assign it to be MATCH_ALL_TAG",
-                AirflowProviderDeprecationWarning,
-                stacklevel=2,
-            )
-            tag = "all"
-
-        if notify_type is None:
-            warnings.warn(
-                "`notify_type` cannot be None. Assign it to be NotifyType.INFO",
-                AirflowProviderDeprecationWarning,
-                stacklevel=2,
-            )
-            notify_type = NotifyType.INFO
-
-        if body_format is None:
-            warnings.warn(
-                "`body_format` cannot be None. Assign it to be  NotifyFormat.TEXT",
-                AirflowProviderDeprecationWarning,
-                stacklevel=2,
-            )
-            body_format = NotifyFormat.TEXT
-
         super().__init__()
         self.apprise_conn_id = apprise_conn_id
         self.body = body

--- a/providers/tests/apprise/hooks/test_apprise.py
+++ b/providers/tests/apprise/hooks/test_apprise.py
@@ -24,7 +24,6 @@ import apprise
 import pytest
 from apprise import NotifyFormat, NotifyType
 
-from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import Connection
 from airflow.providers.apprise.hooks.apprise import AppriseHook
 
@@ -114,8 +113,7 @@ class TestAppriseHook:
         apprise_obj.add = MagicMock()
         with patch.object(apprise, "Apprise", return_value=apprise_obj):
             hook = AppriseHook()
-            with pytest.warns(AirflowProviderDeprecationWarning):
-                hook.notify(body="test")
+            hook.notify(body="test")
 
         apprise_obj.notify.assert_called_once_with(
             body="test",

--- a/providers/tests/apprise/notifications/test_apprise.py
+++ b/providers/tests/apprise/notifications/test_apprise.py
@@ -22,7 +22,6 @@ from unittest import mock
 import pytest
 from apprise import NotifyFormat, NotifyType
 
-from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.operators.empty import EmptyOperator
 from airflow.providers.apprise.notifications.apprise import (
     AppriseNotifier,
@@ -37,8 +36,7 @@ class TestAppriseNotifier:
     def test_notifier(self, mock_apprise_hook, dag_maker):
         with dag_maker("test_notifier") as dag:
             EmptyOperator(task_id="task1")
-        with pytest.warns(AirflowProviderDeprecationWarning):
-            notifier = send_apprise_notification(body="DISK at 99%", notify_type=NotifyType.FAILURE)
+        notifier = send_apprise_notification(body="DISK at 99%", notify_type=NotifyType.FAILURE)
         notifier({"dag": dag})
         mock_apprise_hook.return_value.notify.assert_called_once_with(
             body="DISK at 99%",
@@ -55,8 +53,7 @@ class TestAppriseNotifier:
     def test_notifier_with_notifier_class(self, mock_apprise_hook, dag_maker):
         with dag_maker("test_notifier") as dag:
             EmptyOperator(task_id="task1")
-        with pytest.warns(AirflowProviderDeprecationWarning):
-            notifier = AppriseNotifier(body="DISK at 99%", notify_type=NotifyType.FAILURE)
+        notifier = AppriseNotifier(body="DISK at 99%", notify_type=NotifyType.FAILURE)
         notifier({"dag": dag})
         mock_apprise_hook.return_value.notify.assert_called_once_with(
             body="DISK at 99%",
@@ -74,12 +71,11 @@ class TestAppriseNotifier:
         with dag_maker("test_notifier") as dag:
             EmptyOperator(task_id="task1")
 
-        with pytest.warns(AirflowProviderDeprecationWarning):
-            notifier = AppriseNotifier(
-                notify_type=NotifyType.FAILURE,
-                title="DISK at 99% {{dag.dag_id}}",
-                body="System can crash soon {{dag.dag_id}}",
-            )
+        notifier = AppriseNotifier(
+            notify_type=NotifyType.FAILURE,
+            title="DISK at 99% {{dag.dag_id}}",
+            body="System can crash soon {{dag.dag_id}}",
+        )
         context = {"dag": dag}
         notifier(context)
         mock_apprise_hook.return_value.notify.assert_called_once_with(
@@ -92,16 +88,3 @@ class TestAppriseNotifier:
             interpret_escapes=None,
             config=None,
         )
-
-    @mock.patch("airflow.providers.apprise.notifications.apprise.AppriseHook")
-    def test_apprise_deprecation_warnning(self, mock_apprise_hook):
-        with pytest.warns(AirflowProviderDeprecationWarning) as record:
-            AppriseNotifier(
-                title="DISK at 99% {{dag.dag_id}}",
-                body="System can crash soon {{dag.dag_id}}",
-            )
-        assert len(record) == 3
-
-        assert record[0].message.args[0] == "`tag` cannot be None. Assign it to be MATCH_ALL_TAG"
-        assert record[1].message.args[0] == "`notify_type` cannot be None. Assign it to be NotifyType.INFO"
-        assert record[2].message.args[0] == "`body_format` cannot be None. Assign it to be  NotifyFormat.TEXT"


### PR DESCRIPTION
In Airflow 3 Dev Call we discussed and made a LAZY CONSENSUS to remove all deprecation's in providers prior 2.11 release in https://lists.apache.org/thread/lhy7zhz8yxo3jjpln0ds8ogszgb9b469.

This PR is the first for the provider Apprise

Relates to https://github.com/apache/airflow/issues/44559