### PR TITLE
Ensure that we don't try sending any more heartbeat messages once the process has exited.

### DIFF
--- a/task_sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task_sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -518,11 +518,14 @@ class WatchedSubprocess:
             )
             # Block until events are ready or the timeout is reached
             # This listens for activity (e.g., subprocess output) on registered file objects
-            self._service_subprocess(max_wait_time=max_wait_time)
+            alive = self._service_subprocess(max_wait_time=max_wait_time) is None
 
-            self._send_heartbeat_if_needed()
+            if alive:
+                # We don't need to heartbeat if the process has shutdown, as we are just finishing of reading the
+                # logs
+                self._send_heartbeat_if_needed()
 
-            self._handle_task_overtime_if_needed()
+                self._handle_task_overtime_if_needed()
 
     def _handle_task_overtime_if_needed(self):
         """Handle termination of auxiliary processes if the task exceeds the configured overtime."""


### PR DESCRIPTION
We noticed sometimes in CI that we would get 3 requests made, which
"shouldn't" happen, once it gets the 4xx error to the heartbeat it is meant to
kill the task process.

The vause of this was mostly an artifect of the short heartbeat interval we
used in the tests, and how we poll for the subprocess exit code. I don't think
it could have happened in practice (and it wouldn't affect anything if it did)
but I've made it more-robust anyway.

This is the longer term fix for #44760
