### PR TITLE
Fix flaky task_sdk test by comparing the list in unordered fashion

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -267,6 +267,7 @@ DEVEL_EXTRAS: dict[str, list[str]] = {
         "pytest-mock>=3.12.0",
         "pytest-rerunfailures>=13.0",
         "pytest-timeouts>=1.2.1",
+        "pytest-unordered>=0.6.1",
         "pytest-xdist>=3.5.0",
         "pytest>=8.2,<9",
         "requests_mock>=1.11.0",

--- a/task_sdk/pyproject.toml
+++ b/task_sdk/pyproject.toml
@@ -80,6 +80,7 @@ dev-dependencies = [
     "kgb>=7.1.1",
     "pytest-asyncio>=0.24.0",
     "pytest-mock>=3.14.0",
+    "pytest-unordered>=0.6.1",
     "pytest>=8.3.3",
 ]
 

--- a/task_sdk/tests/execution_time/test_supervisor.py
+++ b/task_sdk/tests/execution_time/test_supervisor.py
@@ -32,6 +32,7 @@ from unittest.mock import MagicMock
 import httpx
 import psutil
 import pytest
+from pytest_unordered import unordered
 from uuid6 import uuid7
 
 from airflow.sdk.api import client as sdk_client
@@ -110,44 +111,46 @@ class TestWatchedSubprocess:
         rc = proc.wait()
 
         assert rc == 0
-        assert captured_logs == [
-            {
-                "chan": "stdout",
-                "event": "I'm a short message",
-                "level": "info",
-                "logger": "task",
-                "timestamp": "2024-11-07T12:34:56.078901Z",
-            },
-            {
-                "chan": "stderr",
-                "event": "stderr message",
-                "level": "error",
-                "logger": "task",
-                "timestamp": "2024-11-07T12:34:56.078901Z",
-            },
-            {
-                "chan": "stdout",
-                "event": "Message split across two writes",
-                "level": "info",
-                "logger": "task",
-                "timestamp": "2024-11-07T12:34:56.078901Z",
-            },
-            {
-                "event": "An error message",
-                "level": "error",
-                "logger": "airflow.foobar",
-                "timestamp": instant.replace(tzinfo=None),
-            },
-            {
-                "category": "UserWarning",
-                "event": "Warning should be captured too",
-                "filename": __file__,
-                "level": "warning",
-                "lineno": line,
-                "logger": "py.warnings",
-                "timestamp": instant.replace(tzinfo=None),
-            },
-        ]
+        assert captured_logs == unordered(
+            [
+                {
+                    "chan": "stdout",
+                    "event": "I'm a short message",
+                    "level": "info",
+                    "logger": "task",
+                    "timestamp": "2024-11-07T12:34:56.078901Z",
+                },
+                {
+                    "chan": "stderr",
+                    "event": "stderr message",
+                    "level": "error",
+                    "logger": "task",
+                    "timestamp": "2024-11-07T12:34:56.078901Z",
+                },
+                {
+                    "chan": "stdout",
+                    "event": "Message split across two writes",
+                    "level": "info",
+                    "logger": "task",
+                    "timestamp": "2024-11-07T12:34:56.078901Z",
+                },
+                {
+                    "event": "An error message",
+                    "level": "error",
+                    "logger": "airflow.foobar",
+                    "timestamp": instant.replace(tzinfo=None),
+                },
+                {
+                    "category": "UserWarning",
+                    "event": "Warning should be captured too",
+                    "filename": __file__,
+                    "level": "warning",
+                    "lineno": line,
+                    "logger": "py.warnings",
+                    "timestamp": instant.replace(tzinfo=None),
+                },
+            ]
+        )
 
     def test_subprocess_sigkilled(self):
         main_pid = os.getpid()


### PR DESCRIPTION
The test_reading_from_pipes can sometimes return the logs in a different order, because the order in which messages will be read from stdout and stderr and values are put in the log are not deterministic. Unfortunately this is comparing list of dicts and dicts are not hashable, so we cannot use the usual trick of converting the list to set. Instead we are using "pytest-unordered" library that implements `unordered` helper to run such asserts.

The native pytest for unordered collection comparision is highly requested but apparently stalled by maintainers. See the https://github.com/pytest-dev/pytest/issues/10032 issue.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
