### PR TITLE
Set Autocomplete Off on Login Form

### DIFF
--- a/airflow/www/static/js/main.js
+++ b/airflow/www/static/js/main.js
@@ -286,4 +286,8 @@ $(document).ready(() => {
 
   // Global Tooltip selector
   $(".js-tooltip").tooltip();
+
+  // Issue 44019: Turn off autocomplete for login form
+  $("#username:input")[0].autocomplete="off";
+  $("#password:input")[0].autocomplete="off";
 });

--- a/airflow/www/static/js/main.js
+++ b/airflow/www/static/js/main.js
@@ -287,7 +287,7 @@ $(document).ready(() => {
   // Global Tooltip selector
   $(".js-tooltip").tooltip();
 
-  // Issue 44019: Turn off autocomplete for login form
+  // Turn off autocomplete for login form
   $("#username:input")[0].autocomplete="off";
   $("#password:input")[0].autocomplete="off";
 });


### PR DESCRIPTION
Closes #44019

Updated main Javascript to apply `autocomplete="off"` to both username and password inputs on login page. This will help prevent the browser from providing hints for the username (and password), as requested in the Issue.

Based on Flask-AppBuilder source code, i.e. https://github.com/dpgaspar/Flask-AppBuilder/tree/master/flask_appbuilder/templates/appbuilder/general/security (see `login_db.html` and `login_ldap.html`), this should work for both `AUTH_DB` (default) and `AUTH_LDAP` authentication, since they both apparently use the same HTML elements in the form. 