### PR TITLE
feat: add OpenLineage support for BigQuery Create Table operators

### DIFF
--- a/providers/src/airflow/providers/google/cloud/operators/bigquery.py
+++ b/providers/src/airflow/providers/google/cloud/operators/bigquery.py
@@ -1365,7 +1365,7 @@ class BigQueryCreateEmptyTableOperator(GoogleCloudBaseOperator):
 
         try:
             self.log.info("Creating table")
-            table = bq_hook.create_empty_table(
+            self._table = bq_hook.create_empty_table(
                 project_id=self.project_id,
                 dataset_id=self.dataset_id,
                 table_id=self.table_id,
@@ -1382,12 +1382,15 @@ class BigQueryCreateEmptyTableOperator(GoogleCloudBaseOperator):
             persist_kwargs = {
                 "context": context,
                 "task_instance": self,
-                "project_id": table.to_api_repr()["tableReference"]["projectId"],
-                "dataset_id": table.to_api_repr()["tableReference"]["datasetId"],
-                "table_id": table.to_api_repr()["tableReference"]["tableId"],
+                "project_id": self._table.to_api_repr()["tableReference"]["projectId"],
+                "dataset_id": self._table.to_api_repr()["tableReference"]["datasetId"],
+                "table_id": self._table.to_api_repr()["tableReference"]["tableId"],
             }
             self.log.info(
-                "Table %s.%s.%s created successfully", table.project, table.dataset_id, table.table_id
+                "Table %s.%s.%s created successfully",
+                self._table.project,
+                self._table.dataset_id,
+                self._table.table_id,
             )
         except Conflict:
             error_msg = f"Table {self.dataset_id}.{self.table_id} already exists."
@@ -1406,6 +1409,24 @@ class BigQueryCreateEmptyTableOperator(GoogleCloudBaseOperator):
                 raise AirflowSkipException(error_msg)
 
         BigQueryTableLink.persist(**persist_kwargs)
+
+    def get_openlineage_facets_on_complete(self, task_instance):
+        from airflow.providers.common.compat.openlineage.facet import Dataset
+        from airflow.providers.google.cloud.openlineage.utils import (
+            BIGQUERY_NAMESPACE,
+            get_facets_from_bq_table,
+        )
+        from airflow.providers.openlineage.extractors import OperatorLineage
+
+        table_info = self._table.to_api_repr()["tableReference"]
+        table_id = ".".join((table_info["projectId"], table_info["datasetId"], table_info["tableId"]))
+        output_dataset = Dataset(
+            namespace=BIGQUERY_NAMESPACE,
+            name=table_id,
+            facets=get_facets_from_bq_table(self._table),
+        )
+
+        return OperatorLineage(outputs=[output_dataset])
 
 
 class BigQueryCreateExternalTableOperator(GoogleCloudBaseOperator):
@@ -1632,15 +1653,15 @@ class BigQueryCreateExternalTableOperator(GoogleCloudBaseOperator):
             impersonation_chain=self.impersonation_chain,
         )
         if self.table_resource:
-            table = bq_hook.create_empty_table(
+            self._table = bq_hook.create_empty_table(
                 table_resource=self.table_resource,
             )
             BigQueryTableLink.persist(
                 context=context,
                 task_instance=self,
-                dataset_id=table.to_api_repr()["tableReference"]["datasetId"],
-                project_id=table.to_api_repr()["tableReference"]["projectId"],
-                table_id=table.to_api_repr()["tableReference"]["tableId"],
+                dataset_id=self._table.to_api_repr()["tableReference"]["datasetId"],
+                project_id=self._table.to_api_repr()["tableReference"]["projectId"],
+                table_id=self._table.to_api_repr()["tableReference"]["tableId"],
             )
             return
 
@@ -1691,17 +1712,35 @@ class BigQueryCreateExternalTableOperator(GoogleCloudBaseOperator):
             "encryptionConfiguration": self.encryption_configuration,
         }
 
-        table = bq_hook.create_empty_table(
+        self._table = bq_hook.create_empty_table(
             table_resource=table_resource,
         )
 
         BigQueryTableLink.persist(
             context=context,
             task_instance=self,
-            dataset_id=table.to_api_repr()["tableReference"]["datasetId"],
-            project_id=table.to_api_repr()["tableReference"]["projectId"],
-            table_id=table.to_api_repr()["tableReference"]["tableId"],
+            dataset_id=self._table.to_api_repr()["tableReference"]["datasetId"],
+            project_id=self._table.to_api_repr()["tableReference"]["projectId"],
+            table_id=self._table.to_api_repr()["tableReference"]["tableId"],
         )
+
+    def get_openlineage_facets_on_complete(self, task_instance):
+        from airflow.providers.common.compat.openlineage.facet import Dataset
+        from airflow.providers.google.cloud.openlineage.utils import (
+            BIGQUERY_NAMESPACE,
+            get_facets_from_bq_table,
+        )
+        from airflow.providers.openlineage.extractors import OperatorLineage
+
+        table_info = self._table.to_api_repr()["tableReference"]
+        table_id = ".".join((table_info["projectId"], table_info["datasetId"], table_info["tableId"]))
+        output_dataset = Dataset(
+            namespace=BIGQUERY_NAMESPACE,
+            name=table_id,
+            facets=get_facets_from_bq_table(self._table),
+        )
+
+        return OperatorLineage(outputs=[output_dataset])
 
 
 class BigQueryDeleteDatasetOperator(GoogleCloudBaseOperator):

--- a/providers/tests/google/cloud/openlineage/test_utils.py
+++ b/providers/tests/google/cloud/openlineage/test_utils.py
@@ -27,9 +27,11 @@ from airflow.providers.common.compat.openlineage.facet import (
     Dataset,
     DocumentationDatasetFacet,
     Fields,
+    Identifier,
     InputField,
     SchemaDatasetFacet,
     SchemaDatasetFacetFields,
+    SymlinksDatasetFacet,
 )
 from airflow.providers.google.cloud.openlineage.utils import (
     extract_ds_name_from_gcs_path,
@@ -48,6 +50,10 @@ TEST_TABLE_API_REPR = {
             {"name": "field1", "type": "STRING", "description": "field1 description"},
             {"name": "field2", "type": "INTEGER"},
         ]
+    },
+    "externalDataConfiguration": {
+        "sourceFormat": "CSV",
+        "sourceUris": ["gs://bucket/path/to/files*", "gs://second_bucket/path/to/other/files*"],
     },
 }
 TEST_TABLE: Table = Table.from_api_repr(TEST_TABLE_API_REPR)
@@ -84,6 +90,12 @@ def test_get_facets_from_bq_table():
             ]
         ),
         "documentation": DocumentationDatasetFacet(description="Table description."),
+        "symlink": SymlinksDatasetFacet(
+            identifiers=[
+                Identifier(namespace="gs://bucket", name="path/to", type="file"),
+                Identifier(namespace="gs://second_bucket", name="path/to/other", type="file"),
+            ]
+        ),
     }
     result = get_facets_from_bq_table(TEST_TABLE)
     assert result == expected_facets


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
This PR adds OpenLineage support for BigQueryCreateExternalTableOperator and BigQueryCreateEmptyTableOperator.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
