### PR TITLE
Add asset alias detail route

### DIFF
--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -405,6 +405,50 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /public/assets/aliases/{asset_alias_id}:
+    get:
+      tags:
+      - Asset
+      summary: Get Asset Alias
+      description: Get an asset alias.
+      operationId: get_asset_alias
+      parameters:
+      - name: asset_alias_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          title: Asset Alias Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Unauthorized
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Forbidden
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Not Found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /public/assets/events:
     get:
       tags:

--- a/airflow/api_fastapi/core_api/routes/public/assets.py
+++ b/airflow/api_fastapi/core_api/routes/public/assets.py
@@ -40,6 +40,7 @@ from airflow.api_fastapi.common.parameters import (
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.datamodels.assets import (
     AssetAliasCollectionResponse,
+    AssetAliasResponse,
     AssetCollectionResponse,
     AssetEventCollectionResponse,
     AssetEventResponse,
@@ -142,6 +143,21 @@ def get_asset_aliases(
         asset_aliases=session.scalars(asset_aliases_select),
         total_entries=total_entries,
     )
+
+
+@assets_router.get(
+    "/assets/aliases/{asset_alias_id:int}",
+    responses=create_openapi_http_exception_doc([status.HTTP_404_NOT_FOUND]),
+)
+def get_asset_alias(asset_alias_id: int, session: SessionDep):
+    """Get an asset alias."""
+    alias = session.scalar(select(AssetAliasModel).where(AssetAliasModel.id == asset_alias_id))
+    if alias is None:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            f"The Asset Alias with ID: `{asset_alias_id}` was not found",
+        )
+    return AssetAliasResponse.model_validate(alias)
 
 
 @assets_router.get(

--- a/airflow/api_fastapi/core_api/routes/public/assets.py
+++ b/airflow/api_fastapi/core_api/routes/public/assets.py
@@ -146,7 +146,7 @@ def get_asset_aliases(
 
 
 @assets_router.get(
-    "/assets/aliases/{asset_alias_id:int}",
+    "/assets/aliases/{asset_alias_id}",
     responses=create_openapi_http_exception_doc([status.HTTP_404_NOT_FOUND]),
 )
 def get_asset_alias(asset_alias_id: int, session: SessionDep):

--- a/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow/ui/openapi-gen/queries/common.ts
@@ -103,6 +103,22 @@ export const UseAssetServiceGetAssetAliasesKeyFn = (
   useAssetServiceGetAssetAliasesKey,
   ...(queryKey ?? [{ limit, namePattern, offset, orderBy }]),
 ];
+export type AssetServiceGetAssetAliasDefaultResponse = Awaited<
+  ReturnType<typeof AssetService.getAssetAlias>
+>;
+export type AssetServiceGetAssetAliasQueryResult<
+  TData = AssetServiceGetAssetAliasDefaultResponse,
+  TError = unknown,
+> = UseQueryResult<TData, TError>;
+export const useAssetServiceGetAssetAliasKey = "AssetServiceGetAssetAlias";
+export const UseAssetServiceGetAssetAliasKeyFn = (
+  {
+    assetAliasId,
+  }: {
+    assetAliasId: number;
+  },
+  queryKey?: Array<unknown>,
+) => [useAssetServiceGetAssetAliasKey, ...(queryKey ?? [{ assetAliasId }])];
 export type AssetServiceGetAssetEventsDefaultResponse = Awaited<
   ReturnType<typeof AssetService.getAssetEvents>
 >;

--- a/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -136,6 +136,26 @@ export const prefetchUseAssetServiceGetAssetAliases = (
       AssetService.getAssetAliases({ limit, namePattern, offset, orderBy }),
   });
 /**
+ * Get Asset Alias
+ * Get an asset alias.
+ * @param data The data for the request.
+ * @param data.assetAliasId
+ * @returns unknown Successful Response
+ * @throws ApiError
+ */
+export const prefetchUseAssetServiceGetAssetAlias = (
+  queryClient: QueryClient,
+  {
+    assetAliasId,
+  }: {
+    assetAliasId: number;
+  },
+) =>
+  queryClient.prefetchQuery({
+    queryKey: Common.UseAssetServiceGetAssetAliasKeyFn({ assetAliasId }),
+    queryFn: () => AssetService.getAssetAlias({ assetAliasId }),
+  });
+/**
  * Get Asset Events
  * Get asset events.
  * @param data The data for the request.

--- a/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow/ui/openapi-gen/queries/queries.ts
@@ -178,6 +178,35 @@ export const useAssetServiceGetAssetAliases = <
     ...options,
   });
 /**
+ * Get Asset Alias
+ * Get an asset alias.
+ * @param data The data for the request.
+ * @param data.assetAliasId
+ * @returns unknown Successful Response
+ * @throws ApiError
+ */
+export const useAssetServiceGetAssetAlias = <
+  TData = Common.AssetServiceGetAssetAliasDefaultResponse,
+  TError = unknown,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  {
+    assetAliasId,
+  }: {
+    assetAliasId: number;
+  },
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
+) =>
+  useQuery<TData, TError>({
+    queryKey: Common.UseAssetServiceGetAssetAliasKeyFn(
+      { assetAliasId },
+      queryKey,
+    ),
+    queryFn: () => AssetService.getAssetAlias({ assetAliasId }) as TData,
+    ...options,
+  });
+/**
  * Get Asset Events
  * Get asset events.
  * @param data The data for the request.

--- a/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow/ui/openapi-gen/queries/suspense.ts
@@ -153,6 +153,35 @@ export const useAssetServiceGetAssetAliasesSuspense = <
     ...options,
   });
 /**
+ * Get Asset Alias
+ * Get an asset alias.
+ * @param data The data for the request.
+ * @param data.assetAliasId
+ * @returns unknown Successful Response
+ * @throws ApiError
+ */
+export const useAssetServiceGetAssetAliasSuspense = <
+  TData = Common.AssetServiceGetAssetAliasDefaultResponse,
+  TError = unknown,
+  TQueryKey extends Array<unknown> = unknown[],
+>(
+  {
+    assetAliasId,
+  }: {
+    assetAliasId: number;
+  },
+  queryKey?: TQueryKey,
+  options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
+) =>
+  useSuspenseQuery<TData, TError>({
+    queryKey: Common.UseAssetServiceGetAssetAliasKeyFn(
+      { assetAliasId },
+      queryKey,
+    ),
+    queryFn: () => AssetService.getAssetAlias({ assetAliasId }) as TData,
+    ...options,
+  });
+/**
  * Get Asset Events
  * Get asset events.
  * @param data The data for the request.

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -9,6 +9,8 @@ import type {
   GetAssetsResponse,
   GetAssetAliasesData,
   GetAssetAliasesResponse,
+  GetAssetAliasData,
+  GetAssetAliasResponse,
   GetAssetEventsData,
   GetAssetEventsResponse,
   CreateAssetEventData,
@@ -263,6 +265,32 @@ export class AssetService {
         offset: data.offset,
         name_pattern: data.namePattern,
         order_by: data.orderBy,
+      },
+      errors: {
+        401: "Unauthorized",
+        403: "Forbidden",
+        404: "Not Found",
+        422: "Validation Error",
+      },
+    });
+  }
+
+  /**
+   * Get Asset Alias
+   * Get an asset alias.
+   * @param data The data for the request.
+   * @param data.assetAliasId
+   * @returns unknown Successful Response
+   * @throws ApiError
+   */
+  public static getAssetAlias(
+    data: GetAssetAliasData,
+  ): CancelablePromise<GetAssetAliasResponse> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/public/assets/aliases/{asset_alias_id}",
+      path: {
+        asset_alias_id: data.assetAliasId,
       },
       errors: {
         401: "Unauthorized",

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1327,6 +1327,12 @@ export type GetAssetAliasesData = {
 
 export type GetAssetAliasesResponse = AssetAliasCollectionResponse;
 
+export type GetAssetAliasData = {
+  assetAliasId: number;
+};
+
+export type GetAssetAliasResponse = unknown;
+
 export type GetAssetEventsData = {
   assetId?: number | null;
   limit?: number;
@@ -2121,6 +2127,33 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: AssetAliasCollectionResponse;
+        /**
+         * Unauthorized
+         */
+        401: HTTPExceptionResponse;
+        /**
+         * Forbidden
+         */
+        403: HTTPExceptionResponse;
+        /**
+         * Not Found
+         */
+        404: HTTPExceptionResponse;
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError;
+      };
+    };
+  };
+  "/public/assets/aliases/{asset_alias_id}": {
+    get: {
+      req: GetAssetAliasData;
+      res: {
+        /**
+         * Successful Response
+         */
+        200: unknown;
         /**
          * Unauthorized
          */

--- a/tests/api_fastapi/core_api/routes/public/test_assets.py
+++ b/tests/api_fastapi/core_api/routes/public/test_assets.py
@@ -767,6 +767,22 @@ class TestGetAssetEndpoint(TestAssets):
         }
 
 
+class TestGetAssetAliasEndpoint(TestAssetAliases):
+    @provide_session
+    def test_should_respond_200(self, test_client, session):
+        self.create_asset_aliases(num=1)
+        assert session.query(AssetAliasModel).count() == 1
+        with assert_queries_count(6):
+            response = test_client.get("/public/assets/aliases/1")
+        assert response.status_code == 200
+        assert response.json() == {"id": 1, "name": "simple1", "group": "alias"}
+
+    def test_should_respond_404(self, test_client):
+        response = test_client.get("/public/assets/aliases/1")
+        assert response.status_code == 404
+        assert response.json()["detail"] == "The Asset Alias with ID: `1` was not found"
+
+
 class TestQueuedEventEndpoint(TestAssets):
     def _create_asset_dag_run_queues(self, dag_id, asset_id, session):
         adrq = AssetDagRunQueue(target_dag_id=dag_id, asset_id=asset_id)


### PR DESCRIPTION
This should work as-is now. ~~Tests are currently failing because  `/assets/alises/1` gets interpreted as an asset endpoint call to `aliases/1` currently. Depends on #44801.~~ Fixed.