### PR TITLE
Add Task Details page

### DIFF
--- a/airflow/ui/src/assets/TaskIcon.tsx
+++ b/airflow/ui/src/assets/TaskIcon.tsx
@@ -1,0 +1,41 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { createIcon } from "@chakra-ui/react";
+
+export const TaskIcon = createIcon({
+  defaultProps: {
+    height: "1em",
+    width: "1em",
+  },
+  displayName: "Task Icon",
+  path: (
+    <g
+      clip-path="url(#a)"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+    >
+      <path d="m7.99967 10.6666c1.47276 0 2.66663-1.19392 2.66663-2.66668s-1.19387-2.66667-2.66663-2.66667c-1.47275 0-2.66666 1.19391-2.66666 2.66667s1.19391 2.66668 2.66666 2.66668z" />
+      <path d="m.700195 8h3.966665" />
+      <path d="m11.3398 8h3.9667" />
+    </g>
+  ),
+  viewBox: "0 0 16 16",
+});

--- a/airflow/ui/src/pages/Dag/Tasks/TaskCard.tsx
+++ b/airflow/ui/src/pages/Dag/Tasks/TaskCard.tsx
@@ -23,7 +23,9 @@ import {
   Box,
   SimpleGrid,
   Text,
+  Link,
 } from "@chakra-ui/react";
+import { Link as RouterLink } from "react-router-dom";
 
 import type {
   TaskResponse,
@@ -36,22 +38,27 @@ import { Status } from "src/components/ui";
 import { TaskRecentRuns } from "./TaskRecentRuns.tsx";
 
 type Props = {
+  readonly dagId: string;
   readonly task: TaskResponse;
   readonly taskInstances: Array<TaskInstanceResponse>;
 };
 
-export const TaskCard = ({ task, taskInstances }: Props) => (
+export const TaskCard = ({ dagId, task, taskInstances }: Props) => (
   <Box
     borderColor="border.emphasized"
     borderRadius={8}
     borderWidth={1}
     overflow="hidden"
+    px={3}
+    py={2}
   >
-    <Text bg="bg.info" color="fg.info" fontWeight="bold" p={2}>
-      {task.task_display_name ?? task.task_id}
-      {task.is_mapped ? "[]" : undefined}
-    </Text>
-    <SimpleGrid columns={4} gap={4} height={20} px={3} py={2}>
+    <Link asChild color="fg.info" fontWeight="bold">
+      <RouterLink to={`/dags/${dagId}/tasks/${task.task_id}`}>
+        {task.task_display_name ?? task.task_id}
+        {task.is_mapped ? "[]" : undefined}
+      </RouterLink>
+    </Link>
+    <SimpleGrid columns={4} gap={4} height={20}>
       <VStack align="flex-start" gap={1}>
         <Heading color="fg.muted" fontSize="xs">
           Operator

--- a/airflow/ui/src/pages/Dag/Tasks/TaskCard.tsx
+++ b/airflow/ui/src/pages/Dag/Tasks/TaskCard.tsx
@@ -16,15 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  Heading,
-  VStack,
-  HStack,
-  Box,
-  SimpleGrid,
-  Text,
-  Link,
-} from "@chakra-ui/react";
+import { Heading, VStack, Box, SimpleGrid, Text, Link } from "@chakra-ui/react";
 import { Link as RouterLink } from "react-router-dom";
 
 import type {
@@ -77,14 +69,18 @@ export const TaskCard = ({ dagId, task, taskInstances }: Props) => (
         </Heading>
         {taskInstances[0] ? (
           <TaskInstanceTooltip taskInstance={taskInstances[0]}>
-            <HStack fontSize="sm">
-              <Time datetime={taskInstances[0].start_date} />
-              {taskInstances[0].state === null ? undefined : (
-                <Status state={taskInstances[0].state}>
-                  {taskInstances[0].state}
-                </Status>
-              )}
-            </HStack>
+            <Link asChild color="fg.info" fontSize="sm">
+              <RouterLink
+                to={`/dags/${dagId}/runs/${taskInstances[0].dag_run_id}/tasks/${task.task_id}`}
+              >
+                <Time datetime={taskInstances[0].start_date} />
+                {taskInstances[0].state === null ? undefined : (
+                  <Status state={taskInstances[0].state}>
+                    {taskInstances[0].state}
+                  </Status>
+                )}
+              </RouterLink>
+            </Link>
           </TaskInstanceTooltip>
         ) : undefined}
       </VStack>

--- a/airflow/ui/src/pages/Dag/Tasks/Tasks.tsx
+++ b/airflow/ui/src/pages/Dag/Tasks/Tasks.tsx
@@ -36,10 +36,12 @@ import { pluralize } from "src/utils";
 import { TaskCard } from "./TaskCard";
 
 const cardDef = (
+  dagId: string,
   taskInstances?: Array<TaskInstanceResponse>,
 ): CardDef<TaskResponse> => ({
   card: ({ row }) => (
     <TaskCard
+      dagId={dagId}
       task={row}
       taskInstances={
         taskInstances
@@ -57,19 +59,19 @@ const cardDef = (
 });
 
 export const Tasks = () => {
-  const { dagId } = useParams();
+  const { dagId = "" } = useParams();
   const {
     data,
     error: tasksError,
     isFetching,
     isLoading,
   } = useTaskServiceGetTasks({
-    dagId: dagId ?? "",
+    dagId,
   });
 
   // TODO: Replace dagIdPattern with dagId once supported for better matching
   const { data: runsData } = useDagsServiceRecentDagRuns(
-    { dagIdPattern: dagId ?? "", dagRunsLimit: 14 },
+    { dagIdPattern: dagId, dagRunsLimit: 14 },
     undefined,
     {
       enabled: Boolean(dagId),
@@ -85,7 +87,7 @@ export const Tasks = () => {
   const { data: taskInstancesResponse } =
     useTaskInstanceServiceGetTaskInstances(
       {
-        dagId: dagId ?? "",
+        dagId,
         dagRunId: "~",
         logicalDateGte: runs.at(-1)?.logical_date ?? "",
       },
@@ -100,7 +102,10 @@ export const Tasks = () => {
         {pluralize("Task", data ? data.total_entries : 0)}
       </Heading>
       <DataTable
-        cardDef={cardDef(taskInstancesResponse?.task_instances.reverse())}
+        cardDef={cardDef(
+          dagId,
+          taskInstancesResponse?.task_instances.reverse(),
+        )}
         columns={[]}
         data={data ? data.tasks : []}
         displayMode="card"

--- a/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -80,13 +80,19 @@ export const DagCard = ({ dag }: Props) => {
         </Stat>
         <Stat label="Latest Run">
           {latestRun ? (
-            <DagRunInfo
-              dataIntervalEnd={latestRun.data_interval_end}
-              dataIntervalStart={latestRun.data_interval_start}
-              endDate={latestRun.end_date}
-              startDate={latestRun.start_date}
-              state={latestRun.state}
-            />
+            <Link asChild color="fg.info" fontSize="sm">
+              <RouterLink
+                to={`/dags/${latestRun.dag_id}/runs/${latestRun.dag_run_id}`}
+              >
+                <DagRunInfo
+                  dataIntervalEnd={latestRun.data_interval_end}
+                  dataIntervalStart={latestRun.data_interval_start}
+                  endDate={latestRun.end_date}
+                  startDate={latestRun.start_date}
+                  state={latestRun.state}
+                />
+              </RouterLink>
+            </Link>
           ) : undefined}
         </Stat>
         <Stat label="Next Run">

--- a/airflow/ui/src/pages/Run/TaskInstances.tsx
+++ b/airflow/ui/src/pages/Run/TaskInstances.tsx
@@ -34,24 +34,28 @@ const columns: Array<ColumnDef<TaskInstanceResponse>> = [
     accessorKey: "task_display_name",
     cell: ({ row: { original } }) => (
       <Link asChild color="fg.info" fontWeight="bold">
-        <RouterLink to={`/dags/${original.dag_id}//tasks/${original.task_id}`}>
+        <RouterLink
+          to={`/dags/${original.dag_id}/runs/${original.dag_run_id}/tasks/${original.task_id}${original.map_index > -1 ? `?map_index=${original.map_index}` : ""}`}
+        >
           {original.task_display_name}
         </RouterLink>
       </Link>
     ),
+    enableSorting: false,
     header: "Task ID",
   },
   {
+    accessorKey: "state",
+    cell: ({
+      row: {
+        original: { state },
+      },
+    }) => <Status state={state}>{state}</Status>,
+    header: () => "State",
+  },
+  {
     accessorKey: "start_date",
-    cell: ({ row: { original } }) => (
-      <Link asChild color="fg.info" fontWeight="bold">
-        <RouterLink
-          to={`/dags/${original.dag_id}/runs/${original.dag_run_id}/tasks/${original.task_id}${original.map_index > -1 ? `?map_index=${original.map_index}` : ""}`}
-        >
-          <Time datetime={original.start_date} />
-        </RouterLink>
-      </Link>
-    ),
+    cell: ({ row: { original } }) => <Time datetime={original.start_date} />,
     header: "Start Date",
   },
   {
@@ -63,15 +67,7 @@ const columns: Array<ColumnDef<TaskInstanceResponse>> = [
     accessorKey: "map_index",
     header: "Map Index",
   },
-  {
-    accessorKey: "state",
-    cell: ({
-      row: {
-        original: { state },
-      },
-    }) => <Status state={state}>{state}</Status>,
-    header: () => "State",
-  },
+
   {
     accessorKey: "try_number",
     enableSorting: false,

--- a/airflow/ui/src/pages/Task/Header.tsx
+++ b/airflow/ui/src/pages/Task/Header.tsx
@@ -1,0 +1,53 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box, Flex, Heading, HStack, SimpleGrid, Text } from "@chakra-ui/react";
+
+import type { TaskResponse } from "openapi/requests/types.gen";
+import { TaskIcon } from "src/assets/TaskIcon";
+import DagDocumentation from "src/components/DagDocumentation";
+import { Stat } from "src/components/Stat";
+
+export const Header = ({ task }: { readonly task: TaskResponse }) => (
+  <Box borderColor="border" borderRadius={8} borderWidth={1} p={2}>
+    <Flex alignItems="center" justifyContent="space-between" mb={2}>
+      <HStack alignItems="center" gap={2}>
+        <TaskIcon height={8} width={8} />
+        <Heading size="lg">
+          <strong>Task: </strong>
+          {task.task_display_name}
+          {task.is_mapped ? "[ ]" : ""}
+        </Heading>
+        <Flex>
+          <div />
+        </Flex>
+      </HStack>
+      {task.doc_md === null ? undefined : (
+        <DagDocumentation docMd={task.doc_md} />
+      )}
+    </Flex>
+    <SimpleGrid columns={4} gap={4}>
+      <Stat label="Operator">
+        <Text>{task.operator_name}</Text>
+      </Stat>
+      <Stat label="Trigger Rule">
+        <Text>{task.trigger_rule}</Text>
+      </Stat>
+    </SimpleGrid>
+  </Box>
+);

--- a/airflow/ui/src/pages/Task/Instances.tsx
+++ b/airflow/ui/src/pages/Task/Instances.tsx
@@ -36,22 +36,18 @@ const columns = (
   isMapped?: boolean,
 ): Array<ColumnDef<TaskInstanceResponse>> => [
   {
-    accessorKey: "start_date",
+    accessorKey: "dag_run_id",
     cell: ({ row: { original } }) => (
       <Link asChild color="fg.info" fontWeight="bold">
         <RouterLink
           to={`/dags/${original.dag_id}/runs/${original.dag_run_id}/tasks/${original.task_id}`}
         >
-          <Time datetime={original.start_date} />
+          {original.dag_run_id}
         </RouterLink>
       </Link>
     ),
-    header: "Start Date",
-  },
-  {
-    accessorKey: "end_date",
-    cell: ({ row: { original } }) => <Time datetime={original.end_date} />,
-    header: "End Date",
+    enableSorting: false,
+    header: "Dag Run ID",
   },
   {
     accessorKey: "state",
@@ -63,15 +59,14 @@ const columns = (
     header: () => "State",
   },
   {
-    accessorKey: "dag_run_id",
-    cell: ({ row: { original } }) => (
-      <Link asChild color="fg.info" fontWeight="bold">
-        <RouterLink to={`/dags/${original.dag_id}/runs/${original.dag_run_id}`}>
-          {original.dag_run_id}
-        </RouterLink>
-      </Link>
-    ),
-    header: "Dag Run ID",
+    accessorKey: "start_date",
+    cell: ({ row: { original } }) => <Time datetime={original.start_date} />,
+    header: "Start Date",
+  },
+  {
+    accessorKey: "end_date",
+    cell: ({ row: { original } }) => <Time datetime={original.end_date} />,
+    header: "End Date",
   },
   ...(isMapped
     ? [
@@ -86,13 +81,6 @@ const columns = (
     enableSorting: false,
     header: "Try Number",
   },
-
-  {
-    accessorKey: "operator",
-    enableSorting: false,
-    header: "Operator",
-  },
-
   {
     cell: ({ row: { original } }) =>
       `${dayjs.duration(dayjs(original.end_date).diff(original.start_date)).asSeconds().toFixed(2)}s`,

--- a/airflow/ui/src/pages/Task/Task.tsx
+++ b/airflow/ui/src/pages/Task/Task.tsx
@@ -1,0 +1,90 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { LiaSlashSolid } from "react-icons/lia";
+import { useParams, Link as RouterLink } from "react-router-dom";
+
+import {
+  useDagServiceGetDagDetails,
+  useTaskServiceGetTask,
+} from "openapi/queries";
+import { Breadcrumb } from "src/components/ui";
+import { DetailsLayout } from "src/layouts/Details/DetailsLayout";
+
+import { Header } from "./Header";
+
+const tabs = [
+  { label: "Task Instances", value: "" },
+  { label: "Events", value: "events" },
+];
+
+export const Task = () => {
+  const { dagId = "", taskId = "" } = useParams();
+
+  const {
+    data: task,
+    error,
+    isLoading,
+  } = useTaskServiceGetTask({ dagId, taskId });
+
+  const {
+    data: dag,
+    error: dagError,
+    isLoading: isDagLoading,
+  } = useDagServiceGetDagDetails({
+    dagId,
+  });
+
+  const links = [
+    { label: "Dags", value: "/dags" },
+    { label: dag?.dag_display_name ?? dagId, value: `/dags/${dagId}` },
+    { label: task?.task_display_name ?? taskId },
+  ];
+
+  return (
+    <DetailsLayout
+      dag={dag}
+      error={error ?? dagError}
+      isLoading={isLoading || isDagLoading}
+      tabs={tabs}
+    >
+      <Breadcrumb.Root mb={3} separator={<LiaSlashSolid />}>
+        {links.map((link, index) => {
+          if (index === links.length - 1) {
+            return (
+              <Breadcrumb.CurrentLink key={link.label}>
+                {link.label}
+              </Breadcrumb.CurrentLink>
+            );
+          }
+
+          return link.value === undefined ? (
+            <Breadcrumb.Link color="fg.info" key={link.label}>
+              {link.label}
+            </Breadcrumb.Link>
+          ) : (
+            <Breadcrumb.Link asChild color="fg.info" key={link.label}>
+              <RouterLink to={link.value}>{link.label}</RouterLink>
+            </Breadcrumb.Link>
+          );
+        })}
+      </Breadcrumb.Root>
+      {task === undefined ? undefined : <Header task={task} />}
+    </DetailsLayout>
+  );
+};

--- a/airflow/ui/src/pages/Task/index.ts
+++ b/airflow/ui/src/pages/Task/index.ts
@@ -1,0 +1,21 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export * from "./Task";
+export * from "./Instances";

--- a/airflow/ui/src/router.tsx
+++ b/airflow/ui/src/router.tsx
@@ -30,6 +30,7 @@ import { ErrorPage } from "src/pages/Error";
 import { Events } from "src/pages/Events";
 import { Run } from "src/pages/Run";
 import { TaskInstances } from "src/pages/Run/TaskInstances";
+import { Task, Instances } from "src/pages/Task";
 import { TaskInstance } from "src/pages/TaskInstance";
 
 import { Variables } from "./pages/Variables";
@@ -84,6 +85,14 @@ export const router = createBrowserRouter(
           ],
           element: <TaskInstance />,
           path: "dags/:dagId/runs/:runId/tasks/:taskId",
+        },
+        {
+          children: [
+            { element: <Instances />, index: true },
+            { element: <Events />, path: "events" },
+          ],
+          element: <Task />,
+          path: "dags/:dagId/tasks/:taskId",
         },
       ],
       element: <BaseLayout />,


### PR DESCRIPTION
Add a Task Details page in order to see a single task across many runs.

Closes [44669](https://github.com/apache/airflow/issues/44669)

I could use some help on deciding when to link to what level of dag/run/task/instance below:

Page with a few basic details in the header and listing only its own tasks. Start date links to the task instance while dag run id links to the dag run
<img width="1381" alt="Screenshot 2024-12-10 at 4 52 56 PM" src="https://github.com/user-attachments/assets/4b520fd4-3123-474b-b5d8-f1cdfa780780">

Dag Run details page listing its task instances. Clicking on a task name goes to a task page while clicking start_date goes to the task instance page.
<img width="1389" alt="Screenshot 2024-12-10 at 4 53 02 PM" src="https://github.com/user-attachments/assets/b989efe1-b71c-4ddf-a148-9e1fb52a5f78">

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
