### PR TITLE
Fix Trino Provider intergation test after removal of deprecations

### DIFF
--- a/providers/tests/integration/trino/hooks/test_trino.py
+++ b/providers/tests/integration/trino/hooks/test_trino.py
@@ -50,7 +50,9 @@ class TestTrinoHookIntegration:
 
     @mock.patch.dict("os.environ", AIRFLOW_CONN_TRINO_DEFAULT="trino://airflow@trino:8080/")
     def test_openlineage_methods(self):
-        op = SQLExecuteQueryOperator(task_id="trino_test", sql="SELECT name FROM tpch.sf1.customer LIMIT 3")
+        op = SQLExecuteQueryOperator(
+            task_id="trino_test", sql="SELECT name FROM tpch.sf1.customer LIMIT 3", conn_id="trino_default"
+        )
         op.execute({})
         lineage = op.get_openlineage_facets_on_start()
         assert lineage.inputs[0].namespace == "trino://trino:8080"


### PR DESCRIPTION
Fix failing trino integration test after #44717 as reported failure in 
https://github.com/apache/airflow/actions/runs/12257257539/job/34194827484