### PR TITLE
Fail a task if an inlet or outlet asset is inactive or an inactive asset is added to an asset alias

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -111,6 +111,10 @@ class AirflowFailException(AirflowException):
     """Raise when the task should be failed without retrying."""
 
 
+class AirflowExecuteWithInactiveAssetExecption(AirflowFailException):
+    """Raise when the task is exected with inactive asset."""
+
+
 class AirflowOptionalProviderFeatureException(AirflowException):
     """Raise by providers when imports are missing for optional provider features."""
 

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -22,6 +22,7 @@
 from __future__ import annotations
 
 import warnings
+from collections.abc import Collection
 from datetime import timedelta
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, NamedTuple
@@ -32,6 +33,7 @@ if TYPE_CHECKING:
     from collections.abc import Sized
 
     from airflow.models import DagRun
+    from airflow.sdk.definitions.asset import AssetUniqueKey
 
 
 class AirflowException(Exception):
@@ -112,7 +114,32 @@ class AirflowFailException(AirflowException):
 
 
 class AirflowExecuteWithInactiveAssetExecption(AirflowFailException):
-    """Raise when the task is executed with inactive asset."""
+    """Raise when the task is executed with inactive assets."""
+
+    def __init__(self, inactive_asset_unikeys: Collection[AssetUniqueKey]) -> None:
+        self.inactive_asset_unique_keys = inactive_asset_unikeys
+
+    @property
+    def inactive_assets_error_msg(self):
+        return ", ".join(
+            f'Asset(name="{key.name}", uri="{key.uri}")' for key in self.inactive_asset_unique_keys
+        )
+
+
+class AirflowInactiveAssetInInletOrOutletException(AirflowExecuteWithInactiveAssetExecption):
+    """Raise when the task is executed with inactive assets in its inlet or outlet."""
+
+    def __str__(self) -> str:
+        return f"Task has the following inactive assets in its inlets or outlets: {self.inactive_assets_error_msg}"
+
+
+class AirflowInactiveAssetAddedToAssetAliasException(AirflowExecuteWithInactiveAssetExecption):
+    """Raise when inactive assets are added to an asset alias."""
+
+    def __str__(self) -> str:
+        return (
+            f"The following assets accessed by an AssetAlias are inactive: {self.inactive_assets_error_msg}"
+        )
 
 
 class AirflowOptionalProviderFeatureException(AirflowException):

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -112,7 +112,7 @@ class AirflowFailException(AirflowException):
 
 
 class AirflowExecuteWithInactiveAssetExecption(AirflowFailException):
-    """Raise when the task is exected with inactive asset."""
+    """Raise when the task is executed with inactive asset."""
 
 
 class AirflowOptionalProviderFeatureException(AirflowException):

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -3647,12 +3647,9 @@ class TaskInstance(Base, LoggingMixin):
         if not self.task or not (self.task.outlets or self.task.inlets):
             return
 
-        inlets_and_outlets = self.task.inlets[:]
-        inlets_and_outlets.extend(self.task.outlets[:])
-
         all_assets_name_uri = {
             (inlet_or_outlet.name, inlet_or_outlet.uri)
-            for inlet_or_outlet in inlets_and_outlets
+            for inlet_or_outlet in itertools.chain(self.task.inlets, self.task.outlets)
             if isinstance(inlet_or_outlet, Asset)
         }
         active_assets_name_uri = set(
@@ -3664,8 +3661,9 @@ class TaskInstance(Base, LoggingMixin):
         )
         inactive_assets_name_uri = all_assets_name_uri - active_assets_name_uri
         if inactive_assets_name_uri:
-            error_msg = "; ".join(
-                f'Asset(name="{name}", uri="{uri}") is inactive' for name, uri in inactive_assets_name_uri
+            error_msg = "Task has the following inactive assets in its inlets or outlets: "
+            error_msg += ", ".join(
+                f'Asset(name="{name}", uri="{uri}")' for name, uri in inactive_assets_name_uri
             )
             raise AirflowExecuteWithInactiveAssetExecption(error_msg)
 

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -35,6 +35,7 @@ from functools import cache
 from typing import TYPE_CHECKING, Any, Callable
 from urllib.parse import quote
 
+import attrs
 import dill
 import jinja2
 import lazy_object_proxy
@@ -2757,7 +2758,9 @@ class TaskInstance(Base, LoggingMixin):
             AssetUniqueKey.from_asset(asset_obj): asset_obj
             for asset_obj in session.scalars(
                 select(AssetModel).where(
-                    tuple_(AssetModel.name, AssetModel.uri).in_(key.to_tuple() for key in asset_unique_keys)
+                    tuple_(AssetModel.name, AssetModel.uri).in_(
+                        attrs.astuple(key) for key in asset_unique_keys
+                    )
                 )
             )
         }
@@ -3673,7 +3676,7 @@ class TaskInstance(Base, LoggingMixin):
             for name, uri in session.execute(
                 select(AssetActive.name, AssetActive.uri).where(
                     tuple_in_condition(
-                        (AssetActive.name, AssetActive.uri), [key.to_tuple() for key in asset_unique_keys]
+                        (AssetActive.name, AssetActive.uri), [attrs.astuple(key) for key in asset_unique_keys]
                     )
                 )
             )

--- a/task_sdk/src/airflow/sdk/definitions/asset/__init__.py
+++ b/task_sdk/src/airflow/sdk/definitions/asset/__init__.py
@@ -71,9 +71,6 @@ class AssetUniqueKey:
     def to_asset(self) -> Asset:
         return Asset(name=self.name, uri=self.uri)
 
-    def to_tuple(self) -> tuple[str, str]:
-        return (self.name, self.uri)
-
 
 @attrs.define(frozen=True)
 class AssetAliasUniqueKey:

--- a/task_sdk/src/airflow/sdk/definitions/asset/__init__.py
+++ b/task_sdk/src/airflow/sdk/definitions/asset/__init__.py
@@ -71,6 +71,9 @@ class AssetUniqueKey:
     def to_asset(self) -> Asset:
         return Asset(name=self.name, uri=self.uri)
 
+    def to_tuple(self) -> tuple[str, str]:
+        return (self.name, self.uri)
+
 
 @attrs.define(frozen=True)
 class AssetAliasUniqueKey:

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -42,8 +42,8 @@ from airflow import settings
 from airflow.decorators import task, task_group
 from airflow.exceptions import (
     AirflowException,
-    AirflowExecuteWithInactiveAssetExecption,
     AirflowFailException,
+    AirflowInactiveAssetInInletOrOutletException,
     AirflowRescheduleException,
     AirflowSensorTimeout,
     AirflowSkipException,
@@ -4099,7 +4099,7 @@ class TestTaskInstance:
         tis = {ti.task_id: ti for ti in dag_maker.create_dagrun().task_instances}
 
         tis["asset_task_in_inlet"].run(session=session)
-        with pytest.raises(AirflowExecuteWithInactiveAssetExecption) as exc:
+        with pytest.raises(AirflowInactiveAssetInInletOrOutletException) as exc:
             tis["duplicate_asset_task_in_outlet"].run(session=session)
 
         assert 'Asset(name="asset_second", uri="asset_second")' in exc.value.args[0]
@@ -4123,7 +4123,7 @@ class TestTaskInstance:
 
         tis = {ti.task_id: ti for ti in dag_maker.create_dagrun().task_instances}
         tis["first_asset_task"].run(session=session)
-        with pytest.raises(AirflowExecuteWithInactiveAssetExecption) as exc:
+        with pytest.raises(AirflowInactiveAssetInInletOrOutletException) as exc:
             tis["duplicate_asset_task"].run(session=session)
 
         assert exc.value.args[0] == (
@@ -4152,7 +4152,7 @@ class TestTaskInstance:
             duplicate_asset_task()
 
         tis = {ti.task_id: ti for ti in dag_maker.create_dagrun().task_instances}
-        with pytest.raises(AirflowExecuteWithInactiveAssetExecption) as exc:
+        with pytest.raises(AirflowInactiveAssetInInletOrOutletException) as exc:
             tis["duplicate_asset_task"].run(session=session)
 
         assert exc.value.args[0] == (
@@ -4177,7 +4177,7 @@ class TestTaskInstance:
             first_asset_task() >> duplicate_asset_task()
 
         tis = {ti.task_id: ti for ti in dag_maker.create_dagrun().task_instances}
-        with pytest.raises(AirflowExecuteWithInactiveAssetExecption) as exc:
+        with pytest.raises(AirflowInactiveAssetInInletOrOutletException) as exc:
             tis["first_asset_task"].run(session=session)
 
         assert exc.value.args[0] == (
@@ -4206,7 +4206,7 @@ class TestTaskInstance:
             duplicate_asset_task()
 
         tis = {ti.task_id: ti for ti in dag_maker.create_dagrun().task_instances}
-        with pytest.raises(AirflowExecuteWithInactiveAssetExecption) as exc:
+        with pytest.raises(AirflowInactiveAssetInInletOrOutletException) as exc:
             tis["duplicate_asset_task"].run(session=session)
 
         assert exc.value.args[0] == (


### PR DESCRIPTION
## Why this change
In AIP-74, we introduce a new "name" column to the Asset. We do not expect to have assets with the same name or URI. For example, `Asset(name="test-name", uri="test://asset")` and `Asset("test-name")` would be considered assets that violate this rule.

> Similar to how Dataset works, an asset can be declared by instantiating an Asset object. One difference from Dataset is that Asset will have an additional name argument. If given, this must be unique in the Airflow deployment, and is used to represent the asset in user-facing interfaces,

Currently, we do nothing when a task has an unexpected asset as an inlet or outlet. The following example works fine now, even though it should not.

```python
from __future__ import annotations


from airflow.decorators import dag, task
from airflow.sdk.definitions.asset import Asset


@dag(
    start_date=None,
    schedule=None,
    catchup=False,
)
def my_producer_dag():
    @task(
    	inlets=[
    		# name="test", uri=""s3://my-bucket/my-key/"
    		Asset("test", "s3://my-bucket/my-key/")
    	],
    	outlets=[
    		# name="s3://my-bucket/my-key/", uri=""s3://my-bucket/my-key/"
    		Asset("s3://my-bucket/my-key/") 
    	]
    )
    def my_producer_task():
        pass

    my_producer_task()


my_producer_dag()
```

Back to https://github.com/apache/airflow/pull/42612, we introduced the concept of AssetActive. These assets that are classified as inactive. While the first asset can still be activated, subsequent assets will not be activated. For example, if `Asset("test", "s3://my-bucket/my-key/")` is activated first, then `Asset("s3://my-bucket/my-key/")` will not be activated. This rule applies even if the assets are defined in different DAGs or in separate files.

## What's the change
The activation status of an asset has already been addressed in previous pull requests. In this pull request, we have implemented a task that checks for any inactive assets in the outlets or inlets. If any inactive assets are found, it raises an `AirflowExecuteWithInactiveAssetException`, which inherits from `AirflowFailException`, causing the task to fail.

Closes: https://github.com/apache/airflow/issues/44600

## Test

Tested with the following test cases. All of them worked fine before this fix and received a similar error message to the screenshot below after this fix.

<details>
    <summary>Inactive assets in inlets</summary>

```python
from __future__ import annotations

from airflow.decorators import dag, task
from airflow.sdk.definitions.asset import Asset


@dag(start_date=None, schedule=None, catchup=False)
def inactive_assets_in_inlets_dag():
    @task(
        inlets=[
            Asset("inlet-test", "s3://inlet/my-key/"),
            Asset("s3://inlet/my-key/"),
            Asset("inlet-test2"),
        ],
    )
    def first_asset_task():
        pass

    @task(inlets=[Asset(uri="inlet-test2")])
    def second_asset_task():
        pass

    first_asset_task() >> second_asset_task()


inactive_assets_in_inlets_dag()
```

</details>


<details>
    <summary>Inactive assets in outlets</summary>

```python
from __future__ import annotations

from airflow.decorators import dag, task
from airflow.sdk.definitions.asset import Asset


@dag(start_date=None, schedule=None, catchup=False)
def inactive_assets_in_outlets_dag():
    @task(
        outlets=[
            Asset("outlet-test", "s3://outlet/my-key/"),
            Asset("s3://outlet/my-key/"),
            Asset("outlet-test-2"),
        ],
    )
    def first_asset_task():
        pass

    @task(outlets=[Asset(uri="outlet-test-2")])
    def second_asset_task():
        pass

    first_asset_task() >> second_asset_task()


inactive_assets_in_outlets_dag()
```

</details>

<details>
    <summary>Inactive assets mixed in inlets and outlets</summary>


```python
from __future__ import annotations

from airflow.decorators import dag, task
from airflow.sdk.definitions.asset import Asset


@dag(start_date=None, schedule=None, catchup=False)
def inactive_assets_mixed_in_inlets_outlet_dag():
    @task(
        inlets=[
            Asset("test", "s3://my-bucket/my-key/"),
        ],
        outlets=[Asset("test2")],
    )
    def first_asset_task():
        pass

    @task(
        inlets=[
            Asset(uri="test2"),
        ],
        outlets=[
            Asset("s3://my-bucket/my-key/"),
        ],
    )
    def second_asset_task():
        pass

    first_asset_task() >> second_asset_task()


inactive_assets_mixed_in_inlets_outlet_dag()
```

</details>

<details>
    <summary>Inactive assets cross files</summary>

```python
from __future__ import annotations

from airflow.decorators import dag, task
from airflow.sdk.definitions.asset import Asset


@dag(start_date=None, schedule=None, catchup=False)
def inactive_active_cross_file_dag_1():
    @task(inlets=[Asset("cross", "s3://cross/my-key/")])
    def first_asset_task():
        pass

    @task(outlets=[Asset("cross2", "s3://cross2/my-key/")])
    def second_asset_task():
        pass

    first_asset_task() >> second_asset_task()


inactive_active_cross_file_dag_1()
```

```python
from __future__ import annotations

from airflow.decorators import dag, task
from airflow.sdk.definitions.asset import Asset


@dag(start_date=None, schedule=None, catchup=False)
def inactive_active_cross_file_dag_2():
    @task(inlets=[Asset("s3://cross2/my-key/")])
    def first_asset_task():
        pass

    @task(outlets=[Asset("cross")])
    def second_asset_task():
        pass

    first_asset_task() >> second_asset_task()


inactive_active_cross_file_dag_2()
```

</details>



<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
