### PR TITLE
Add codeowners for Airflow/FAB migrations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -112,3 +112,7 @@ ISSUE_TRIAGE_PROCESS.rst @eladkal
 /providers/src/airflow/providers/**/fs/ @bolkedebruin
 /providers/src/airflow/providers/common/io/ @bolkedebruin
 /docs/apache-airflow/core-concepts/objectstorage.rst @bolkedebruin
+
+# Migrations
+/airflow/migrations/ @ephraimbuddy
+/providers/src/airflow/providers/fab/migrations/ @ephraimbuddy


### PR DESCRIPTION
Added myself and would be happy to add anyone interested in the migration changes, please suggest in the reviews

