### PR TITLE
feat(asset): change asset inactive warning to log Asset instead of AssetModel

### DIFF
--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -2218,7 +2218,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             for ref in itertools.chain(offending.consuming_dags, offending.producing_tasks):
                 yield (
                     ref.dag_id,
-                    f"Cannot activate asset {offending}; {attr} is already associated to {value!r}",
+                    f"Cannot activate asset {offending.to_public()}; {attr} is already associated to {value!r}",
                 )
 
         def _activate_assets_generate_warnings() -> Iterator[tuple[str, str]]:

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -2218,7 +2218,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             for ref in itertools.chain(offending.consuming_dags, offending.producing_tasks):
                 yield (
                     ref.dag_id,
-                    f"Cannot activate asset {offending.to_public()}; {attr} is already associated to {value!r}",
+                    (
+                        "Cannot activate asset "
+                        f'Asset(name="{offending.name}", uri="{offending.uri}", group="{offending.group}"); '
+                        f"{attr} is already associated to {value!r}"
+                    ),
                 )
 
         def _activate_assets_generate_warnings() -> Iterator[tuple[str, str]]:

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -6319,10 +6319,11 @@ class TestSchedulerJob:
             )
         )
         assert dag_warning.message == (
-            'Cannot activate asset Asset(name="it\'s also a duplicate",'
-            " uri='s3://bucket/key/1', group='asset', extra={'foo': 'bar'}, watchers=[]); uri is already associated to 'asset1'\n"
-            "Cannot activate asset Asset(name='asset1', uri"
-            "=\"it's duplicate\", group='asset', extra={'foo': 'bar'}, watchers=[]); name is already associated to 's3://bucket/key/1'"
+            'Cannot activate asset Asset(name="asset1", uri="it\'s duplica'
+            'te", group="asset"); name is already associated to \'s3://buck'
+            "et/key/1'\nCannot activate asset Asset(name=\"it's also a dup"
+            'licate", uri="s3://bucket/key/1", group="asset"); uri is alrea'
+            "dy associated to 'asset1'"
         )
 
     def test_activate_referenced_assets_with_existing_warnings(self, session):
@@ -6357,7 +6358,7 @@ class TestSchedulerJob:
             )
         )
         assert dag_warning.message == (
-            "Cannot activate asset Asset(name='asset1', uri=\"it's duplicate\", group='asset', extra={'foo': 'bar'}, watchers=[]); "
+            'Cannot activate asset Asset(name="asset1", uri="it\'s duplicate", group="asset"); '
             "name is already associated to 's3://bucket/key/1'"
         )
 
@@ -6374,7 +6375,7 @@ class TestSchedulerJob:
             )
         )
         assert dag_warning.message == (
-            "Cannot activate asset Asset(name='asset1', uri=\"it's duplicate 2\", group='asset', extra={'foo': 'bar'}, watchers=[]); "
+            'Cannot activate asset Asset(name="asset1", uri="it\'s duplicate 2", group="asset"); '
             "name is already associated to 's3://bucket/key/1'"
         )
 

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -6319,10 +6319,10 @@ class TestSchedulerJob:
             )
         )
         assert dag_warning.message == (
-            'Cannot activate asset AssetModel(name="it\'s also a duplicate",'
-            " uri='s3://bucket/key/1', extra={'foo': 'bar'}); uri is already associated to 'asset1'\n"
-            "Cannot activate asset AssetModel(name='asset1', uri"
-            "=\"it's duplicate\", extra={'foo': 'bar'}); name is already associated to 's3://bucket/key/1'"
+            'Cannot activate asset Asset(name="it\'s also a duplicate",'
+            " uri='s3://bucket/key/1', group='asset', extra={'foo': 'bar'}, watchers=[]); uri is already associated to 'asset1'\n"
+            "Cannot activate asset Asset(name='asset1', uri"
+            "=\"it's duplicate\", group='asset', extra={'foo': 'bar'}, watchers=[]); name is already associated to 's3://bucket/key/1'"
         )
 
     def test_activate_referenced_assets_with_existing_warnings(self, session):
@@ -6357,7 +6357,7 @@ class TestSchedulerJob:
             )
         )
         assert dag_warning.message == (
-            "Cannot activate asset AssetModel(name='asset1', uri=\"it's duplicate\", extra={'foo': 'bar'}); "
+            "Cannot activate asset Asset(name='asset1', uri=\"it's duplicate\", group='asset', extra={'foo': 'bar'}, watchers=[]); "
             "name is already associated to 's3://bucket/key/1'"
         )
 
@@ -6374,7 +6374,7 @@ class TestSchedulerJob:
             )
         )
         assert dag_warning.message == (
-            "Cannot activate asset AssetModel(name='asset1', uri=\"it's duplicate 2\", extra={'foo': 'bar'}); "
+            "Cannot activate asset Asset(name='asset1', uri=\"it's duplicate 2\", group='asset', extra={'foo': 'bar'}, watchers=[]); "
             "name is already associated to 's3://bucket/key/1'"
         )
 


### PR DESCRIPTION
## Why
As we don't want users to access the models directly, it might be better if we do not expose it in the log message 

## What
Change the "asset cannot be activated" warning to log Asset info instead of AssetModel.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
