### PR TITLE
Remove "single process" restrictions on SQLite in favour of using WAL mode

### DIFF
--- a/airflow/cli/commands/local_commands/scheduler_command.py
+++ b/airflow/cli/commands/local_commands/scheduler_command.py
@@ -40,7 +40,6 @@ log = logging.getLogger(__name__)
 
 def _run_scheduler_job(args) -> None:
     job_runner = SchedulerJobRunner(job=Job(), subdir=process_subdir(args.subdir), num_runs=args.num_runs)
-    ExecutorLoader.validate_database_executor_compatibility(job_runner.job.executor.__class__)
     enable_health_check = conf.getboolean("scheduler", "ENABLE_HEALTH_CHECK")
     with _serve_logs(args.skip_serve_logs), _serve_health_check(enable_health_check):
         run_job(job=job_runner.job, execute_callable=job_runner._execute)

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -119,7 +119,6 @@ class BaseExecutor(LoggingMixin):
     supports_sentry: bool = False
 
     is_local: bool = False
-    is_single_threaded: bool = False
     is_production: bool = True
 
     change_sensor_mode_to_reschedule: bool = False

--- a/airflow/executors/debug_executor.py
+++ b/airflow/executors/debug_executor.py
@@ -47,7 +47,6 @@ class DebugExecutor(BaseExecutor):
 
     _terminated = threading.Event()
 
-    is_single_threaded: bool = True
     is_production: bool = False
 
     change_sensor_mode_to_reschedule: bool = True

--- a/airflow/executors/executor_loader.py
+++ b/airflow/executors/executor_loader.py
@@ -18,9 +18,7 @@
 
 from __future__ import annotations
 
-import functools
 import logging
-import os
 from typing import TYPE_CHECKING
 
 from airflow.exceptions import AirflowConfigException, UnknownExecutorException
@@ -236,67 +234,28 @@ class ExecutorLoader:
         return executor
 
     @classmethod
-    def import_executor_cls(
-        cls, executor_name: ExecutorName, validate: bool = True
-    ) -> tuple[type[BaseExecutor], ConnectorSource]:
+    def import_executor_cls(cls, executor_name: ExecutorName) -> tuple[type[BaseExecutor], ConnectorSource]:
         """
         Import the executor class.
 
         Supports the same formats as ExecutorLoader.load_executor.
 
         :param executor_name: Name of core executor or module path to executor.
-        :param validate: Whether or not to validate the executor before returning
 
         :return: executor class via executor_name and executor import source
         """
-
-        def _import_and_validate(path: str) -> type[BaseExecutor]:
-            executor = import_string(path)
-            if validate:
-                cls.validate_database_executor_compatibility(executor)
-            return executor
-
-        return _import_and_validate(executor_name.module_path), executor_name.connector_source
+        return import_string(executor_name.module_path), executor_name.connector_source
 
     @classmethod
-    def import_default_executor_cls(cls, validate: bool = True) -> tuple[type[BaseExecutor], ConnectorSource]:
+    def import_default_executor_cls(cls) -> tuple[type[BaseExecutor], ConnectorSource]:
         """
         Import the default executor class.
-
-        :param validate: Whether or not to validate the executor before returning
 
         :return: executor class and executor import source
         """
         executor_name = cls.get_default_executor_name()
-        executor, source = cls.import_executor_cls(executor_name, validate=validate)
+        executor, source = cls.import_executor_cls(executor_name)
         return executor, source
-
-    @classmethod
-    @functools.cache
-    def validate_database_executor_compatibility(cls, executor: type[BaseExecutor]) -> None:
-        """
-        Validate database and executor compatibility.
-
-        Most of the databases work universally, but SQLite can only work with
-        single-threaded executors (e.g. Sequential).
-
-        This is NOT done in ``airflow.configuration`` (when configuration is
-        initialized) because loading the executor class is heavy work we want to
-        avoid unless needed.
-        """
-        # Single threaded executors can run with any backend.
-        if executor.is_single_threaded:
-            return
-
-        # This is set in tests when we want to be able to use SQLite.
-        if os.environ.get("_AIRFLOW__SKIP_DATABASE_EXECUTOR_COMPATIBILITY_CHECK") == "1":
-            return
-
-        from airflow.settings import engine
-
-        # SQLite only works with single threaded executors
-        if engine.dialect.name == "sqlite":
-            raise AirflowConfigException(f"error: cannot use SQLite with the {executor.__name__}")
 
     @classmethod
     def __load_celery_kubernetes_executor(cls) -> BaseExecutor:

--- a/airflow/executors/sequential_executor.py
+++ b/airflow/executors/sequential_executor.py
@@ -49,7 +49,6 @@ class SequentialExecutor(BaseExecutor):
     """
 
     is_local: bool = True
-    is_single_threaded: bool = True
     is_production: bool = False
 
     serve_logs: bool = True

--- a/airflow/sentry.py
+++ b/airflow/sentry.py
@@ -85,7 +85,7 @@ if conf.getboolean("sentry", "sentry_on", fallback=False):
             # LoggingIntegration is set by default.
             integrations = [sentry_flask]
 
-            executor_class, _ = ExecutorLoader.import_default_executor_cls(validate=False)
+            executor_class, _ = ExecutorLoader.import_default_executor_cls()
 
             if executor_class.supports_sentry:
                 from sentry_sdk.integrations.celery import CeleryIntegration

--- a/airflow/utils/orm_event_handlers.py
+++ b/airflow/utils/orm_event_handlers.py
@@ -46,6 +46,7 @@ def setup_event_handlers(engine):
         def set_sqlite_pragma(dbapi_connection, connection_record):
             cursor = dbapi_connection.cursor()
             cursor.execute("PRAGMA foreign_keys=ON")
+            cursor.execute("PRAGMA journal_mode=WAL")
             cursor.close()
 
     # this ensures coherence in mysql when storing datetimes (not required for postgres)

--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -52,7 +52,6 @@ from airflow_breeze.global_constants import (
     DOCKER_DEFAULT_PLATFORM,
     MIN_DOCKER_COMPOSE_VERSION,
     MIN_DOCKER_VERSION,
-    SEQUENTIAL_EXECUTOR,
 )
 from airflow_breeze.utils.console import Output, get_console
 from airflow_breeze.utils.run_utils import (
@@ -724,16 +723,13 @@ def execute_command_in_shell(
     :param command:
     """
     shell_params.backend = "sqlite"
-    shell_params.executor = SEQUENTIAL_EXECUTOR
     shell_params.forward_ports = False
     shell_params.project_name = project_name
     shell_params.quiet = True
     shell_params.skip_environment_initialization = True
     shell_params.skip_image_upgrade_check = True
     if get_verbose():
-        get_console().print(f"[warning]Backend forced to: sqlite and {SEQUENTIAL_EXECUTOR}[/]")
         get_console().print("[warning]Sqlite DB is cleaned[/]")
-        get_console().print(f"[warning]Executor forced to {SEQUENTIAL_EXECUTOR}[/]")
         get_console().print("[warning]Disabled port forwarding[/]")
         get_console().print(f"[warning]Project name set to: {project_name}[/]")
         get_console().print("[warning]Forced quiet mode[/]")
@@ -775,13 +771,6 @@ def enter_shell(shell_params: ShellParams, output: Output | None = None) -> RunC
         )
         bring_compose_project_down(preserve_volumes=False, shell_params=shell_params)
 
-    if shell_params.backend == "sqlite" and shell_params.executor != SEQUENTIAL_EXECUTOR:
-        get_console().print(
-            f"\n[warning]backend: sqlite is not "
-            f"compatible with executor: {shell_params.executor}. "
-            f"Changing the executor to {SEQUENTIAL_EXECUTOR}.\n"
-        )
-        shell_params.executor = SEQUENTIAL_EXECUTOR
     if shell_params.restart:
         bring_compose_project_down(preserve_volumes=False, shell_params=shell_params)
     if shell_params.include_mypy_volume:

--- a/providers/tests/celery/executors/test_celery_kubernetes_executor.py
+++ b/providers/tests/celery/executors/test_celery_kubernetes_executor.py
@@ -46,9 +46,6 @@ class TestCeleryKubernetesExecutor:
     def test_serve_logs_default_value(self):
         assert not CeleryKubernetesExecutor.serve_logs
 
-    def test_is_single_threaded_default_value(self):
-        assert not CeleryKubernetesExecutor.is_single_threaded
-
     def test_cli_commands_vended(self):
         assert CeleryKubernetesExecutor.get_cli_commands()
 

--- a/providers/tests/cncf/kubernetes/executors/test_local_kubernetes_executor.py
+++ b/providers/tests/cncf/kubernetes/executors/test_local_kubernetes_executor.py
@@ -43,9 +43,6 @@ class TestLocalKubernetesExecutor:
     def test_serve_logs_default_value(self):
         assert LocalKubernetesExecutor.serve_logs
 
-    def test_is_single_threaded_default_value(self):
-        assert not LocalKubernetesExecutor.is_single_threaded
-
     def test_cli_commands_vended(self):
         assert LocalKubernetesExecutor.get_cli_commands()
 

--- a/tests/cli/commands/local_commands/test_scheduler_command.py
+++ b/tests/cli/commands/local_commands/test_scheduler_command.py
@@ -48,20 +48,9 @@ class TestSchedulerCommand:
             ("LocalKubernetesExecutor", True),
         ],
     )
-    @mock.patch(
-        "airflow.cli.commands.local_commands.scheduler_command.ExecutorLoader.validate_database_executor_compatibility",
-        side_effect=None,
-    )
     @mock.patch("airflow.cli.commands.local_commands.scheduler_command.SchedulerJobRunner")
     @mock.patch("airflow.cli.commands.local_commands.scheduler_command.Process")
-    def test_serve_logs_on_scheduler(
-        self,
-        mock_process,
-        mock_scheduler_job,
-        mock_validate,
-        executor,
-        expect_serve_logs,
-    ):
+    def test_serve_logs_on_scheduler(self, mock_process, mock_scheduler_job, executor, expect_serve_logs):
         mock_scheduler_job.return_value.job_type = "SchedulerJob"
         args = self.parser.parse_args(["scheduler"])
 
@@ -74,14 +63,10 @@ class TestSchedulerCommand:
                 with pytest.raises(AssertionError):
                     mock_process.assert_has_calls([mock.call(target=serve_logs)])
 
-    @mock.patch(
-        "airflow.cli.commands.local_commands.scheduler_command.ExecutorLoader.validate_database_executor_compatibility",
-        side_effect=None,
-    )
     @mock.patch("airflow.cli.commands.local_commands.scheduler_command.SchedulerJobRunner")
     @mock.patch("airflow.cli.commands.local_commands.scheduler_command.Process")
     @pytest.mark.parametrize("executor", ["LocalExecutor", "SequentialExecutor"])
-    def test_skip_serve_logs(self, mock_process, mock_scheduler_job, mock_validate, executor):
+    def test_skip_serve_logs(self, mock_process, mock_scheduler_job, executor):
         mock_scheduler_job.return_value.job_type = "SchedulerJob"
         args = self.parser.parse_args(["scheduler", "--skip-serve-logs"])
         with conf_vars({("core", "executor"): executor}):
@@ -90,17 +75,11 @@ class TestSchedulerCommand:
             with pytest.raises(AssertionError):
                 mock_process.assert_has_calls([mock.call(target=serve_logs)])
 
-    @mock.patch(
-        "airflow.cli.commands.local_commands.scheduler_command.ExecutorLoader.validate_database_executor_compatibility",
-        side_effect=None,
-    )
     @mock.patch("airflow.utils.db.check_and_run_migrations")
     @mock.patch("airflow.utils.db.synchronize_log_template")
     @mock.patch("airflow.cli.commands.local_commands.scheduler_command.SchedulerJobRunner")
     @mock.patch("airflow.cli.commands.local_commands.scheduler_command.Process")
-    def test_check_migrations_is_false(
-        self, mock_process, mock_scheduler_job, mock_log, mock_run_migration, mock_validate
-    ):
+    def test_check_migrations_is_false(self, mock_process, mock_scheduler_job, mock_log, mock_run_migration):
         mock_scheduler_job.return_value.job_type = "SchedulerJob"
         args = self.parser.parse_args(["scheduler"])
         with conf_vars({("database", "check_migrations"): "False"}):
@@ -108,17 +87,11 @@ class TestSchedulerCommand:
             mock_run_migration.assert_not_called()
             mock_log.assert_called_once()
 
-    @mock.patch(
-        "airflow.cli.commands.local_commands.scheduler_command.ExecutorLoader.validate_database_executor_compatibility",
-        side_effect=None,
-    )
     @mock.patch("airflow.utils.db.check_and_run_migrations")
     @mock.patch("airflow.utils.db.synchronize_log_template")
     @mock.patch("airflow.cli.commands.local_commands.scheduler_command.SchedulerJobRunner")
     @mock.patch("airflow.cli.commands.local_commands.scheduler_command.Process")
-    def test_check_migrations_is_true(
-        self, mock_process, mock_scheduler_job, mock_log, mock_run_migration, mock_validate
-    ):
+    def test_check_migrations_is_true(self, mock_process, mock_scheduler_job, mock_log, mock_run_migration):
         mock_scheduler_job.return_value.job_type = "SchedulerJob"
         args = self.parser.parse_args(["scheduler"])
         with conf_vars({("database", "check_migrations"): "True"}):
@@ -126,14 +99,10 @@ class TestSchedulerCommand:
             mock_run_migration.assert_called_once()
             mock_log.assert_called_once()
 
-    @mock.patch(
-        "airflow.cli.commands.local_commands.scheduler_command.ExecutorLoader.validate_database_executor_compatibility",
-        side_effect=None,
-    )
     @mock.patch("airflow.cli.commands.local_commands.scheduler_command.SchedulerJobRunner")
     @mock.patch("airflow.cli.commands.local_commands.scheduler_command.Process")
     @pytest.mark.parametrize("executor", ["LocalExecutor", "SequentialExecutor"])
-    def test_graceful_shutdown(self, mock_process, mock_scheduler_job, mock_validate, executor):
+    def test_graceful_shutdown(self, mock_process, mock_scheduler_job, executor):
         mock_scheduler_job.return_value.job_type = "SchedulerJob"
         args = self.parser.parse_args(["scheduler"])
         with conf_vars({("core", "executor"): executor}):
@@ -144,36 +113,18 @@ class TestSchedulerCommand:
             finally:
                 mock_process().terminate.assert_called()
 
-    @mock.patch(
-        "airflow.cli.commands.local_commands.scheduler_command.ExecutorLoader.validate_database_executor_compatibility",
-        side_effect=None,
-    )
     @mock.patch("airflow.cli.commands.local_commands.scheduler_command.SchedulerJobRunner")
     @mock.patch("airflow.cli.commands.local_commands.scheduler_command.Process")
-    def test_enable_scheduler_health(
-        self,
-        mock_process,
-        mock_scheduler_job,
-        mock_validate,
-    ):
+    def test_enable_scheduler_health(self, mock_process, mock_scheduler_job):
         with conf_vars({("scheduler", "enable_health_check"): "True"}):
             mock_scheduler_job.return_value.job_type = "SchedulerJob"
             args = self.parser.parse_args(["scheduler"])
             scheduler_command.scheduler(args)
             mock_process.assert_has_calls([mock.call(target=serve_health_check)])
 
-    @mock.patch(
-        "airflow.cli.commands.local_commands.scheduler_command.ExecutorLoader.validate_database_executor_compatibility",
-        side_effect=None,
-    )
     @mock.patch("airflow.cli.commands.local_commands.scheduler_command.SchedulerJobRunner")
     @mock.patch("airflow.cli.commands.local_commands.scheduler_command.Process")
-    def test_disable_scheduler_health(
-        self,
-        mock_process,
-        mock_scheduler_job,
-        mock_validate,
-    ):
+    def test_disable_scheduler_health(self, mock_process, mock_scheduler_job):
         mock_scheduler_job.return_value.job_type = "SchedulerJob"
         args = self.parser.parse_args(["scheduler"])
         scheduler_command.scheduler(args)
@@ -196,23 +147,13 @@ class TestSchedulerCommand:
             serve_health_check()
         assert http_server_mock.call_args.args[0] == (health_check_host, health_check_port)
 
-    @mock.patch(
-        "airflow.cli.commands.local_commands.scheduler_command.ExecutorLoader.validate_database_executor_compatibility",
-        side_effect=None,
-    )
     @mock.patch("airflow.cli.commands.local_commands.scheduler_command.SchedulerJobRunner")
     @mock.patch("airflow.cli.commands.local_commands.scheduler_command.Process")
     @mock.patch(
         "airflow.cli.commands.local_commands.scheduler_command.run_job",
         side_effect=Exception("run_job failed"),
     )
-    def test_run_job_exception_handling(
-        self,
-        mock_run_job,
-        mock_process,
-        mock_scheduler_job,
-        mock_validate,
-    ):
+    def test_run_job_exception_handling(self, mock_run_job, mock_process, mock_scheduler_job):
         args = self.parser.parse_args(["scheduler"])
         with pytest.raises(Exception, match="run_job failed"):
             scheduler_command.scheduler(args)

--- a/tests/executors/test_base_executor.py
+++ b/tests/executors/test_base_executor.py
@@ -46,10 +46,6 @@ def test_is_local_default_value():
     assert not BaseExecutor.is_local
 
 
-def test_is_single_threaded_default_value():
-    assert not BaseExecutor.is_single_threaded
-
-
 def test_is_production_default_value():
     assert BaseExecutor.is_production
 

--- a/tests/executors/test_debug_executor.py
+++ b/tests/executors/test_debug_executor.py
@@ -119,9 +119,6 @@ class TestDebugExecutor:
     def test_reschedule_mode(self):
         assert DebugExecutor.change_sensor_mode_to_reschedule
 
-    def test_is_single_threaded(self):
-        assert DebugExecutor.is_single_threaded
-
     def test_is_production_default_value(self):
         assert not DebugExecutor.is_production
 

--- a/tests/executors/test_sequential_executor.py
+++ b/tests/executors/test_sequential_executor.py
@@ -35,9 +35,6 @@ class TestSequentialExecutor:
     def test_serve_logs_default_value(self):
         assert SequentialExecutor.serve_logs
 
-    def test_is_single_threaded_default_value(self):
-        assert SequentialExecutor.is_single_threaded
-
     @mock.patch("airflow.executors.sequential_executor.SequentialExecutor.sync")
     @mock.patch("airflow.executors.base_executor.BaseExecutor.trigger_tasks")
     @mock.patch("airflow.executors.base_executor.Stats.gauge")

--- a/tests_common/pytest_plugin.py
+++ b/tests_common/pytest_plugin.py
@@ -1438,18 +1438,13 @@ def _clear_db(request):
 
 @pytest.fixture(autouse=True)
 def clear_lru_cache():
-    from airflow.executors.executor_loader import ExecutorLoader
     from airflow.utils.entry_points import _get_grouped_entry_points
 
-    ExecutorLoader.validate_database_executor_compatibility.cache_clear()
+    _get_grouped_entry_points.cache_clear()
     try:
-        _get_grouped_entry_points.cache_clear()
-        try:
-            yield
-        finally:
-            _get_grouped_entry_points.cache_clear()
+        yield
     finally:
-        ExecutorLoader.validate_database_executor_compatibility.cache_clear()
+        _get_grouped_entry_points.cache_clear()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Since 2010(!) sqlite has had a WAL, or Write-Ahead Log mode of journalling
which allos multiple concurrent readers and one writer. More than good enough
for us for "local" use.

The primary driver for this change was a realisation that it is possible and
to reduce the amount of code in complexity in DagProcessorManager before
reworking it for AIP-72 support :- we have a lot of code in the
DagProcessorManager to support `if async_mode` that makes understanding the
flow complex.

Some useful docs and articles about this mode:

- [The offical docs](https://sqlite.org/wal.html)
- [Simon Willison's TIL](https://til.simonwillison.net/sqlite/enabling-wal-mode)
- [fly.io article about scaling read concurrency](https://fly.io/blog/sqlite-internals-wal/)

This still keeps the warning against using SQLite in production, but it
greatly reduces the restrictions what combos and settings can use this. In
short, when using an SQLite db it is now possible to:

- use LocalExecutor, including with more than 1 concurrent worker slot
- have multiple DAG parsing processes (even before AIP-72/TaskSDK changes to
  that)

We execute the `PRAGMA journal_mode` every time we connect, which is more
often that is strictly needed as this is one of the few modes thatis
persistent and a property of the DB file just for ease and to ensure that it
it is in the mode we want.

I have tested this with `breeze -b sqlite start_airflow` and a kicking off a
lot of tasks concurrently.

Will this be without problems? No, not entirely, but due to the
scheduler+webserver+api server process we've _already_ got the case where
multiple processes are operating on the DB file. This change just makes the
best use of that following the guidance of the SQLite project: Ensuring that
only a single process accesses the DB concurrently is not a requirement
anymore!
