### PR TITLE
Update Helm eviction configuration guide to reflect `workers.safeToEvict` default value

### DIFF
--- a/docs/helm-chart/production-guide.rst
+++ b/docs/helm-chart/production-guide.rst
@@ -236,7 +236,8 @@ This setting can be configured in the Airflow chart at different levels:
   webserver:
     safeToEvict: true
 
-When using ``KubernetesExecutor``, ``workers.safeToEvict`` should be set to ``false`` to avoid them being removed before finishing.
+``workers.safeToEvict`` defaults to ``false``, and when using ``KubernetesExecutor``
+``workers.safeToEvict`` shouldn't be set to ``true`` or workers may be removed before finishing.
 
 Extending and customizing Airflow Image
 ---------------------------------------


### PR DESCRIPTION
The `workers.safeToEvict` default value was changed to `false` in #40229 and the Helm chart guide should reflect that.

related: #40229

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
