### PR TITLE
Update sort and filter defaults

### DIFF
--- a/airflow/ui/src/components/TimeRangeSelector.tsx
+++ b/airflow/ui/src/components/TimeRangeSelector.tsx
@@ -41,7 +41,7 @@ const defaultTimeOptions = createListCollection({
     { label: "Last 1 hour", value: "1" },
     { label: "Last 12 hours", value: "12" },
     { label: "Last 24 hours", value: "24" },
-    { label: "Last week", value: "168" },
+    { label: "Past week", value: "168" },
   ],
 });
 

--- a/airflow/ui/src/pages/Dag/Overview/Overview.tsx
+++ b/airflow/ui/src/pages/Dag/Overview/Overview.tsx
@@ -29,7 +29,7 @@ import TimeRangeSelector from "src/components/TimeRangeSelector";
 import { TrendCountButton } from "src/components/TrendCountButton";
 import { stateColor } from "src/utils/stateColor";
 
-const defaultHour = "12";
+const defaultHour = "168";
 
 export const Overview = () => {
   const { dagId } = useParams();

--- a/airflow/ui/src/pages/Dag/Runs/Runs.tsx
+++ b/airflow/ui/src/pages/Dag/Runs/Runs.tsx
@@ -111,17 +111,10 @@ export const Runs = () => {
 
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const { setTableURLState, tableURLState } = useTableURLState({
-    sorting: [
-      {
-        desc: true,
-        id: "start_date",
-      },
-    ],
-  });
+  const { setTableURLState, tableURLState } = useTableURLState();
   const { pagination, sorting } = tableURLState;
   const [sort] = sorting;
-  const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : undefined;
+  const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : "-start_date";
 
   const filteredState = searchParams.get(STATE_PARAM);
 

--- a/airflow/ui/src/pages/Dag/Runs/Runs.tsx
+++ b/airflow/ui/src/pages/Dag/Runs/Runs.tsx
@@ -111,7 +111,14 @@ export const Runs = () => {
 
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const { setTableURLState, tableURLState } = useTableURLState();
+  const { setTableURLState, tableURLState } = useTableURLState({
+    sorting: [
+      {
+        desc: true,
+        id: "start_date",
+      },
+    ],
+  });
   const { pagination, sorting } = tableURLState;
   const [sort] = sorting;
   const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : undefined;

--- a/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -169,14 +169,7 @@ export const DagsList = () => {
   ) as DagRunState;
   const selectedTags = searchParams.getAll(TAGS_PARAM);
 
-  const { setTableURLState, tableURLState } = useTableURLState({
-    sorting: [
-      {
-        desc: true,
-        id: "last_run_start_date",
-      },
-    ],
-  });
+  const { setTableURLState, tableURLState } = useTableURLState();
 
   const { pagination, sorting } = tableURLState;
   const [dagDisplayNamePattern, setDagDisplayNamePattern] = useState(
@@ -184,7 +177,9 @@ export const DagsList = () => {
   );
 
   const [sort] = sorting;
-  const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : undefined;
+  const orderBy = sort
+    ? `${sort.desc ? "-" : ""}${sort.id}`
+    : "-last_run_start_date";
 
   const handleSearchChange = (value: string) => {
     if (value) {
@@ -260,11 +255,7 @@ export const DagsList = () => {
         <DataTable
           cardDef={cardDef}
           columns={columns}
-          // We need to rename latest_dag_runs so that react-table can handle the sort correctly
-          data={data.dags.map((dag) => ({
-            ...dag,
-            last_run_start_date: dag.latest_dag_runs,
-          }))}
+          data={data.dags}
           displayMode={display}
           errorMessage={<ErrorAlert error={error} />}
           initialState={tableURLState}

--- a/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -100,11 +100,10 @@ const columns: Array<ColumnDef<DAGWithLatestDagRunsResponse>> = [
           nextDagrunCreateAfter={original.next_dagrun_create_after}
         />
       ) : undefined,
-    enableSorting: false,
     header: "Next Dag Run",
   },
   {
-    accessorKey: "latest_dag_runs",
+    accessorKey: "last_run_start_date",
     cell: ({ row: { original } }) =>
       original.latest_dag_runs[0] ? (
         <DagRunInfo
@@ -115,7 +114,6 @@ const columns: Array<ColumnDef<DAGWithLatestDagRunsResponse>> = [
           state={original.latest_dag_runs[0].state}
         />
       ) : undefined,
-    enableSorting: false,
     header: "Last Dag Run",
   },
   {
@@ -171,7 +169,15 @@ export const DagsList = () => {
   ) as DagRunState;
   const selectedTags = searchParams.getAll(TAGS_PARAM);
 
-  const { setTableURLState, tableURLState } = useTableURLState();
+  const { setTableURLState, tableURLState } = useTableURLState({
+    sorting: [
+      {
+        desc: true,
+        id: "last_run_start_date",
+      },
+    ],
+  });
+
   const { pagination, sorting } = tableURLState;
   const [dagDisplayNamePattern, setDagDisplayNamePattern] = useState(
     searchParams.get(NAME_PATTERN_PARAM) ?? undefined,
@@ -254,7 +260,11 @@ export const DagsList = () => {
         <DataTable
           cardDef={cardDef}
           columns={columns}
-          data={data.dags}
+          // We need to rename latest_dag_runs so that react-table can handle the sort correctly
+          data={data.dags.map((dag) => ({
+            ...dag,
+            last_run_start_date: dag.latest_dag_runs,
+          }))}
           displayMode={display}
           errorMessage={<ErrorAlert error={error} />}
           initialState={tableURLState}

--- a/airflow/ui/src/pages/Dashboard/HistoricalMetrics/HistoricalMetrics.tsx
+++ b/airflow/ui/src/pages/Dashboard/HistoricalMetrics/HistoricalMetrics.tsx
@@ -28,7 +28,7 @@ import { DagRunMetrics } from "./DagRunMetrics";
 import { MetricSectionSkeleton } from "./MetricSectionSkeleton";
 import { TaskInstanceMetrics } from "./TaskInstanceMetrics";
 
-const defaultHour = "12";
+const defaultHour = "168";
 
 export const HistoricalMetrics = () => {
   const now = dayjs();

--- a/airflow/ui/src/pages/Events/Events.tsx
+++ b/airflow/ui/src/pages/Events/Events.tsx
@@ -113,13 +113,11 @@ const eventsColumn = (
 
 export const Events = () => {
   const { dagId, runId, taskId } = useParams();
-  const { setTableURLState, tableURLState } = useTableURLState({
-    sorting: [{ desc: true, id: "when" }],
-  });
+  const { setTableURLState, tableURLState } = useTableURLState();
   const { pagination, sorting } = tableURLState;
   const [sort] = sorting;
 
-  const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : undefined;
+  const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : "-when";
 
   const {
     data,

--- a/airflow/ui/src/pages/Run/TaskInstances.tsx
+++ b/airflow/ui/src/pages/Run/TaskInstances.tsx
@@ -88,7 +88,14 @@ const columns: Array<ColumnDef<TaskInstanceResponse>> = [
 
 export const TaskInstances = () => {
   const { dagId = "", runId = "" } = useParams();
-  const { setTableURLState, tableURLState } = useTableURLState();
+  const { setTableURLState, tableURLState } = useTableURLState({
+    sorting: [
+      {
+        desc: true,
+        id: "start_date",
+      },
+    ],
+  });
   const { pagination, sorting } = tableURLState;
   const [sort] = sorting;
   const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : undefined;

--- a/airflow/ui/src/pages/Run/TaskInstances.tsx
+++ b/airflow/ui/src/pages/Run/TaskInstances.tsx
@@ -88,17 +88,10 @@ const columns: Array<ColumnDef<TaskInstanceResponse>> = [
 
 export const TaskInstances = () => {
   const { dagId = "", runId = "" } = useParams();
-  const { setTableURLState, tableURLState } = useTableURLState({
-    sorting: [
-      {
-        desc: true,
-        id: "start_date",
-      },
-    ],
-  });
+  const { setTableURLState, tableURLState } = useTableURLState();
   const { pagination, sorting } = tableURLState;
   const [sort] = sorting;
-  const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : undefined;
+  const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : "-start_date";
 
   const { data, error, isFetching, isLoading } =
     useTaskInstanceServiceGetTaskInstances({

--- a/airflow/ui/src/pages/Task/Instances.tsx
+++ b/airflow/ui/src/pages/Task/Instances.tsx
@@ -90,7 +90,14 @@ const columns = (
 
 export const Instances = () => {
   const { dagId = "", taskId } = useParams();
-  const { setTableURLState, tableURLState } = useTableURLState();
+  const { setTableURLState, tableURLState } = useTableURLState({
+    sorting: [
+      {
+        desc: true,
+        id: "start_date",
+      },
+    ],
+  });
   const { pagination, sorting } = tableURLState;
   const [sort] = sorting;
   const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : undefined;

--- a/airflow/ui/src/pages/Task/Instances.tsx
+++ b/airflow/ui/src/pages/Task/Instances.tsx
@@ -90,17 +90,10 @@ const columns = (
 
 export const Instances = () => {
   const { dagId = "", taskId } = useParams();
-  const { setTableURLState, tableURLState } = useTableURLState({
-    sorting: [
-      {
-        desc: true,
-        id: "start_date",
-      },
-    ],
-  });
+  const { setTableURLState, tableURLState } = useTableURLState();
   const { pagination, sorting } = tableURLState;
   const [sort] = sorting;
-  const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : undefined;
+  const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : "-start_date";
 
   const {
     data: task,

--- a/airflow/ui/src/pages/Variables/Variables.tsx
+++ b/airflow/ui/src/pages/Variables/Variables.tsx
@@ -57,9 +57,7 @@ const columns: Array<ColumnDef<VariableResponse>> = [
 ];
 
 export const Variables = () => {
-  const { setTableURLState, tableURLState } = useTableURLState({
-    sorting: [{ desc: false, id: "key" }],
-  });
+  const { setTableURLState, tableURLState } = useTableURLState();
   const [searchParams, setSearchParams] = useSearchParams();
   const { NAME_PATTERN: NAME_PATTERN_PARAM }: SearchParamsKeysType =
     SearchParamsKeys;
@@ -70,7 +68,7 @@ export const Variables = () => {
   const [sort] = sorting;
   const orderBy = sort
     ? `${sort.desc ? "-" : ""}${sort.id === "value" ? "_val" : sort.id}`
-    : undefined;
+    : "-key";
 
   const { data, error, isFetching, isLoading } = useVariableServiceGetVariables(
     {

--- a/airflow/ui/src/queries/useDags.tsx
+++ b/airflow/ui/src/queries/useDags.tsx
@@ -20,7 +20,10 @@ import {
   useDagServiceGetDags,
   useDagsServiceRecentDagRuns,
 } from "openapi/queries";
-import type { DagRunState } from "openapi/requests/types.gen";
+import type {
+  DagRunState,
+  DAGWithLatestDagRunsResponse,
+} from "openapi/requests/types.gen";
 
 const queryOptions = {
   refetchOnMount: true,
@@ -28,6 +31,10 @@ const queryOptions = {
   refetchOnWindowFocus: false,
   staleTime: 5 * 60 * 1000,
 };
+
+export type DagWithLatest = {
+  last_run_start_date: string;
+} & DAGWithLatestDagRunsResponse;
 
 export const useDags = (
   searchParams: {
@@ -69,11 +76,13 @@ export const useDags = (
       (runsDag) => runsDag.dag_id === dag.dag_id,
     );
 
-    // For dags with recent dag runs replace the dag data from useDagsServiceRecentDagRuns
-    // which might be stale with updated dag data from useDagServiceGetDags
-    return dagWithRuns
-      ? { ...dagWithRuns, ...dag }
-      : { ...dag, latest_dag_runs: [] };
+    return {
+      latest_dag_runs: [],
+      ...dagWithRuns,
+      ...dag,
+      // We need last_run_start_date to exist on the object in order for react-table sort to work correctly
+      last_run_start_date: "",
+    };
   });
 
   return {


### PR DESCRIPTION
Make it easier to navigate around the new UI with some better defaults

All dag run and task instance tables to sort by start_date
Dags list to sort by last_run_start_date
Time range selectors to the Past Week


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
