### PR TITLE
Fetch recent dag runs using dag id instead of dag display pattern.

### DIFF
--- a/airflow/ui/src/pages/Dag/Dag.tsx
+++ b/airflow/ui/src/pages/Dag/Dag.tsx
@@ -50,7 +50,7 @@ export const Dag = () => {
     data: runsData,
     error: runsError,
     isLoading: isLoadingRuns,
-  } = useDagsServiceRecentDagRuns({ dagIdPattern: dagId }, undefined, {
+  } = useDagsServiceRecentDagRuns({ dagIds: [dagId] }, undefined, {
     enabled: Boolean(dagId),
   });
 

--- a/airflow/ui/src/pages/Dag/Tasks/Tasks.tsx
+++ b/airflow/ui/src/pages/Dag/Tasks/Tasks.tsx
@@ -69,9 +69,8 @@ export const Tasks = () => {
     dagId,
   });
 
-  // TODO: Replace dagIdPattern with dagId once supported for better matching
   const { data: runsData } = useDagsServiceRecentDagRuns(
-    { dagIdPattern: dagId, dagRunsLimit: 14 },
+    { dagIds: [dagId], dagRunsLimit: 14 },
     undefined,
     {
       enabled: Boolean(dagId),


### PR DESCRIPTION
Support to filter by dag id was added in https://github.com/apache/airflow/pull/44737 . Using this filter makes matching better since dagIdPattern might cause other dags which are substrings to be also matched.