### PR TITLE
Remove reparse on DAG depending on asset alias

### DIFF
--- a/airflow/assets/manager.py
+++ b/airflow/assets/manager.py
@@ -174,11 +174,6 @@ class AssetManager(LoggingMixin):
                     if alias_ref.dag.is_active and not alias_ref.dag.is_paused
                 }
 
-        dags_to_reparse = dags_to_queue_from_asset_alias - dags_to_queue_from_asset
-        if dags_to_reparse:
-            file_locs = {dag.fileloc for dag in dags_to_reparse}
-            cls._send_dag_priority_parsing_request(file_locs, session)
-
         cls.notify_asset_changed(asset=asset)
 
         Stats.incr("asset.updates")

--- a/tests/assets/test_manager.py
+++ b/tests/assets/test_manager.py
@@ -35,7 +35,6 @@ from airflow.models.asset import (
     DagScheduleAssetReference,
 )
 from airflow.models.dag import DagModel
-from airflow.models.dagbag import DagPriorityParsingRequest
 from airflow.sdk.definitions.asset import Asset, AssetAlias
 from airflow.serialization.pydantic.taskinstance import TaskInstancePydantic
 
@@ -182,7 +181,6 @@ class TestAssetManager:
         # Ensure we've created an asset
         assert session.query(AssetEvent).filter_by(asset_id=asm.id).count() == 1
         assert session.query(AssetDagRunQueue).count() == 2
-        assert session.query(DagPriorityParsingRequest).count() == 2
 
     def test_register_asset_change_no_downstreams(self, session, mock_task_instance):
         asset_manager = AssetManager()


### PR DESCRIPTION
I suspect we no longer need this since alias resolution now happens very late in the scheduling process. A DAG *should* be able to automatically understand the alias is resolved without a reparse after refactorings introduced in cccc9334e3123423f678c7d237c544b45a76743e.

Let’s see what CI thinks.