### PR TITLE
feat: Add CLL to OpenLineage in BigQueryInsertJobOperator

### DIFF
--- a/providers/src/airflow/providers/google/cloud/operators/bigquery.py
+++ b/providers/src/airflow/providers/google/cloud/operators/bigquery.py
@@ -48,7 +48,7 @@ from airflow.providers.google.cloud.links.bigquery import (
     BigQueryJobDetailLink,
     BigQueryTableLink,
 )
-from airflow.providers.google.cloud.openlineage.mixins import _BigQueryOpenLineageMixin
+from airflow.providers.google.cloud.openlineage.mixins import _BigQueryInsertJobOperatorOpenLineageMixin
 from airflow.providers.google.cloud.operators.cloud_base import GoogleCloudBaseOperator
 from airflow.providers.google.cloud.triggers.bigquery import (
     BigQueryCheckTrigger,
@@ -2491,7 +2491,7 @@ class BigQueryUpdateTableSchemaOperator(GoogleCloudBaseOperator):
         return table
 
 
-class BigQueryInsertJobOperator(GoogleCloudBaseOperator, _BigQueryOpenLineageMixin):
+class BigQueryInsertJobOperator(GoogleCloudBaseOperator, _BigQueryInsertJobOperatorOpenLineageMixin):
     """
     Execute a BigQuery job.
 

--- a/providers/tests/google/cloud/openlineage/test_mixins.py
+++ b/providers/tests/google/cloud/openlineage/test_mixins.py
@@ -16,24 +16,93 @@
 # under the License.
 from __future__ import annotations
 
+import copy
 import json
+import logging
 import os
 from unittest.mock import MagicMock
 
 import pytest
 
 from airflow.providers.common.compat.openlineage.facet import (
+    ColumnLineageDatasetFacet,
+    Dataset,
     ExternalQueryRunFacet,
+    Fields,
     InputDataset,
+    InputField,
     OutputDataset,
     OutputStatisticsOutputDatasetFacet,
     SchemaDatasetFacet,
     SchemaDatasetFacetFields,
 )
-from airflow.providers.google.cloud.openlineage.mixins import _BigQueryOpenLineageMixin
+from airflow.providers.google.cloud.openlineage.mixins import _BigQueryInsertJobOperatorOpenLineageMixin
 from airflow.providers.google.cloud.openlineage.utils import (
     BigQueryJobRunFacet,
 )
+from airflow.providers.openlineage.sqlparser import SQLParser
+
+QUERY_JOB_PROPERTIES = {
+    "configuration": {
+        "query": {
+            "query": """
+            INSERT INTO dest_project.dest_dataset.dest_table
+            SELECT a, b, c FROM source_project.source_dataset.source_table
+            UNION ALL
+            SELECT a, b, c FROM source_table2
+            """,
+            "defaultDataset": {"datasetId": "default_dataset", "projectId": "default_project"},
+        }
+    }
+}
+OUTPUT_DATASET = OutputDataset(
+    namespace="bigquery",
+    name="dest_project.dest_dataset.dest_table",
+    facets={
+        "schema": SchemaDatasetFacet(
+            fields=[
+                SchemaDatasetFacetFields("a", "STRING"),
+                SchemaDatasetFacetFields("b", "STRING"),
+                SchemaDatasetFacetFields("c", "STRING"),
+                SchemaDatasetFacetFields("d", "STRING"),
+                SchemaDatasetFacetFields("e", "STRING"),
+                SchemaDatasetFacetFields("f", "STRING"),
+                SchemaDatasetFacetFields("g", "STRING"),
+            ]
+        )
+    },
+)
+INPUT_DATASETS = [
+    InputDataset(
+        namespace="bigquery",
+        name="source_project.source_dataset.source_table",
+        facets={
+            "schema": SchemaDatasetFacet(
+                fields=[
+                    SchemaDatasetFacetFields("a", "STRING"),
+                    SchemaDatasetFacetFields("b", "STRING"),
+                    SchemaDatasetFacetFields("c", "STRING"),
+                    SchemaDatasetFacetFields("x", "STRING"),
+                ]
+            )
+        },
+    ),
+    InputDataset(
+        namespace="bigquery",
+        name="default_project.default_dataset.source_table2",
+        facets={
+            "schema": SchemaDatasetFacet(
+                fields=[
+                    SchemaDatasetFacetFields("a", "STRING"),
+                    SchemaDatasetFacetFields("b", "STRING"),
+                    SchemaDatasetFacetFields("c", "STRING"),
+                    SchemaDatasetFacetFields("y", "STRING"),
+                ]
+            )
+        },
+    ),
+    InputDataset("bigquery", "some.random.tb"),
+]
 
 
 def read_common_json_file(rel: str):
@@ -61,10 +130,12 @@ class TestBigQueryOpenLineageMixin:
         hook = MagicMock()
         self.client = MagicMock()
 
-        class BQOperator(_BigQueryOpenLineageMixin):
+        class BQOperator(_BigQueryInsertJobOperatorOpenLineageMixin):
             sql = ""
             job_id = "job_id"
+            project_id = "project_id"
             location = None
+            log = logging.getLogger("BQOperator")
 
             @property
             def hook(self):
@@ -202,6 +273,100 @@ class TestBigQueryOpenLineageMixin:
         assert second_result.name == "d2"
         assert second_result.facets == {"t20": "t20"}
 
+    def test_deduplicate_outputs_with_cll(self):
+        outputs = [
+            None,
+            OutputDataset(
+                name="a.b.c",
+                namespace="bigquery",
+                facets={
+                    "columnLineage": ColumnLineageDatasetFacet(
+                        fields={
+                            "c": Fields(
+                                inputFields=[InputField("bigquery", "a.b.1", "c")],
+                                transformationType="",
+                                transformationDescription="",
+                            ),
+                            "d": Fields(
+                                inputFields=[InputField("bigquery", "a.b.2", "d")],
+                                transformationType="",
+                                transformationDescription="",
+                            ),
+                        }
+                    )
+                },
+            ),
+            OutputDataset(
+                name="a.b.c",
+                namespace="bigquery",
+                facets={
+                    "columnLineage": ColumnLineageDatasetFacet(
+                        fields={
+                            "c": Fields(
+                                inputFields=[InputField("bigquery", "a.b.3", "x")],
+                                transformationType="",
+                                transformationDescription="",
+                            ),
+                            "e": Fields(
+                                inputFields=[InputField("bigquery", "a.b.1", "e")],
+                                transformationType="",
+                                transformationDescription="",
+                            ),
+                        }
+                    )
+                },
+            ),
+            OutputDataset(
+                name="x.y.z",
+                namespace="bigquery",
+                facets={
+                    "columnLineage": ColumnLineageDatasetFacet(
+                        fields={
+                            "c": Fields(
+                                inputFields=[InputField("bigquery", "a.b.3", "x")],
+                                transformationType="",
+                                transformationDescription="",
+                            )
+                        }
+                    )
+                },
+            ),
+        ]
+        result = self.operator._deduplicate_outputs(outputs)
+        assert len(result) == 2
+        first_result = result[0]
+        assert first_result.name == "a.b.c"
+        assert first_result.facets["columnLineage"] == ColumnLineageDatasetFacet(
+            fields={
+                "c": Fields(
+                    inputFields=[InputField("bigquery", "a.b.1", "c"), InputField("bigquery", "a.b.3", "x")],
+                    transformationType="",
+                    transformationDescription="",
+                ),
+                "d": Fields(
+                    inputFields=[InputField("bigquery", "a.b.2", "d")],
+                    transformationType="",
+                    transformationDescription="",
+                ),
+                "e": Fields(
+                    inputFields=[InputField("bigquery", "a.b.1", "e")],
+                    transformationType="",
+                    transformationDescription="",
+                ),
+            }
+        )
+        second_result = result[1]
+        assert second_result.name == "x.y.z"
+        assert second_result.facets["columnLineage"] == ColumnLineageDatasetFacet(
+            fields={
+                "c": Fields(
+                    inputFields=[InputField("bigquery", "a.b.3", "x")],
+                    transformationType="",
+                    transformationDescription="",
+                )
+            }
+        )
+
     @pytest.mark.parametrize("cache", (None, "false", False, 0))
     def test_get_job_run_facet_no_cache_and_with_bytes(self, cache):
         properties = {
@@ -259,3 +424,276 @@ class TestBigQueryOpenLineageMixin:
         result = self.operator._get_statistics_dataset_facet(properties)
         assert result.rowCount == 123
         assert result.size == 321
+
+    def test_get_column_level_lineage_facet(self):
+        result = self.operator._get_column_level_lineage_facet(
+            QUERY_JOB_PROPERTIES, OUTPUT_DATASET, INPUT_DATASETS
+        )
+        assert result == ColumnLineageDatasetFacet(
+            fields={
+                col: Fields(
+                    inputFields=[
+                        InputField("bigquery", "default_project.default_dataset.source_table2", col),
+                        InputField("bigquery", "source_project.source_dataset.source_table", col),
+                    ],
+                    transformationType="",
+                    transformationDescription="",
+                )
+                for col in ("a", "b", "c")
+            }
+        )
+
+    def test_get_column_level_lineage_facet_early_exit_empty_cll_from_parser(self):
+        properties = {"configuration": {"query": {"query": "SELECT 1"}}}
+        assert (
+            self.operator._get_column_level_lineage_facet(properties, OUTPUT_DATASET, INPUT_DATASETS) is None
+        )
+        assert self.operator._get_column_level_lineage_facet({}, OUTPUT_DATASET, INPUT_DATASETS) is None
+
+    def test_get_column_level_lineage_facet_early_exit_output_table_id_mismatch(self):
+        output = copy.deepcopy(OUTPUT_DATASET)
+        output.name = "different.name.table"
+        assert (
+            self.operator._get_column_level_lineage_facet(QUERY_JOB_PROPERTIES, output, INPUT_DATASETS)
+            is None
+        )
+
+    def test_get_column_level_lineage_facet_early_exit_output_columns_mismatch(self):
+        output = copy.deepcopy(OUTPUT_DATASET)
+        output.facets["schema"].fields = [
+            SchemaDatasetFacetFields("different_col", "STRING"),
+        ]
+        assert (
+            self.operator._get_column_level_lineage_facet(QUERY_JOB_PROPERTIES, output, INPUT_DATASETS)
+            is None
+        )
+
+    def test_get_column_level_lineage_facet_early_exit_wrong_parsed_input_tables(self):
+        properties = {
+            "configuration": {
+                "query": {
+                    "query": """
+                    INSERT INTO dest_project.dest_dataset.dest_table
+                    SELECT a, b, c FROM some.wrong.source_table
+                    """,
+                }
+            }
+        }
+        assert (
+            self.operator._get_column_level_lineage_facet(properties, OUTPUT_DATASET, INPUT_DATASETS) is None
+        )
+
+    def test_get_column_level_lineage_facet_early_exit_wrong_parsed_input_columns(self):
+        properties = {
+            "configuration": {
+                "query": {
+                    "query": """
+                    INSERT INTO dest_project.dest_dataset.dest_table
+                    SELECT wrong_col, wrong2, wrong3 FROM source_project.source_dataset.source_table
+                    """,
+                }
+            }
+        }
+        assert (
+            self.operator._get_column_level_lineage_facet(properties, OUTPUT_DATASET, INPUT_DATASETS) is None
+        )
+
+    def test_get_qualified_name_from_parse_result(self):
+        class _Table:  # Replacement for SQL parser TableMeta
+            database = "project"
+            schema = "dataset"
+            name = "table"
+
+        class _TableNoSchema:  # Replacement for SQL parser TableMeta
+            database = None
+            schema = "dataset"
+            name = "table"
+
+        class _TableNoSchemaNoDb:  # Replacement for SQL parser TableMeta
+            database = None
+            schema = None
+            name = "table"
+
+        result = self.operator._get_qualified_name_from_parse_result(
+            table=_Table(),
+            default_project="default_project",
+            default_dataset="default_dataset",
+        )
+        assert result == "project.dataset.table"
+
+        result = self.operator._get_qualified_name_from_parse_result(
+            table=_TableNoSchema(),
+            default_project="default_project",
+            default_dataset="default_dataset",
+        )
+        assert result == "default_project.dataset.table"
+
+        result = self.operator._get_qualified_name_from_parse_result(
+            table=_TableNoSchemaNoDb(),
+            default_project="default_project",
+            default_dataset="default_dataset",
+        )
+        assert result == "default_project.default_dataset.table"
+
+    def test_extract_default_dataset_and_project(self):
+        properties = {"configuration": {"query": {"defaultDataset": {"datasetId": "default_dataset"}}}}
+        result = self.operator._extract_default_dataset_and_project(properties, "default_project")
+        assert result == ("default_dataset", "default_project")
+
+        properties = {
+            "configuration": {
+                "query": {"defaultDataset": {"datasetId": "default_dataset", "projectId": "default_project"}}
+            }
+        }
+        result = self.operator._extract_default_dataset_and_project(properties, "another_project")
+        assert result == ("default_dataset", "default_project")
+
+        result = self.operator._extract_default_dataset_and_project({}, "default_project")
+        assert result == ("", "default_project")
+
+    def test_validate_output_table_id_no_table(self):
+        parse_result = SQLParser("bigquery").parse(SQLParser.split_sql_string("SELECT 1"))
+        assert parse_result.out_tables == []
+        assert self.operator._validate_output_table_id(parse_result, None, None, None) is False
+
+    def test_validate_output_table_id_multiple_tables(self):
+        query = "INSERT INTO a.b.c VALUES (1); INSERT INTO d.e.f VALUES (2);"
+        parse_result = SQLParser("bigquery").parse(SQLParser.split_sql_string(query))
+        assert len(parse_result.out_tables) == 2
+        assert self.operator._validate_output_table_id(parse_result, None, None, None) is False
+
+    def test_validate_output_table_id_mismatch(self):
+        parse_result = SQLParser("bigquery").parse(SQLParser.split_sql_string("INSERT INTO a.b.c VALUES (1)"))
+        assert len(parse_result.out_tables) == 1
+        assert parse_result.out_tables[0].qualified_name == "a.b.c"
+        assert (
+            self.operator._validate_output_table_id(parse_result, OutputDataset("", "d.e.f"), None, None)
+            is False
+        )
+
+    def test_validate_output_table_id(self):
+        parse_result = SQLParser("bigquery").parse(SQLParser.split_sql_string("INSERT INTO a.b.c VALUES (1)"))
+        assert len(parse_result.out_tables) == 1
+        assert parse_result.out_tables[0].qualified_name == "a.b.c"
+        assert (
+            self.operator._validate_output_table_id(parse_result, OutputDataset("", "a.b.c"), None, None)
+            is True
+        )
+
+    def test_validate_output_table_id_query_with_table_name_only(self):
+        parse_result = SQLParser("bigquery").parse(SQLParser.split_sql_string("INSERT INTO c VALUES (1)"))
+        assert len(parse_result.out_tables) == 1
+        assert parse_result.out_tables[0].qualified_name == "c"
+        assert (
+            self.operator._validate_output_table_id(parse_result, OutputDataset("", "a.b.c"), "a", "b")
+            is True
+        )
+
+    def test_extract_column_names_dataset_without_schema(self):
+        assert self.operator._extract_column_names(Dataset("a", "b")) == []
+
+    def test_extract_column_names_dataset_(self):
+        ds = Dataset(
+            "a",
+            "b",
+            facets={
+                "schema": SchemaDatasetFacet(
+                    fields=[
+                        SchemaDatasetFacetFields("col1", "STRING"),
+                        SchemaDatasetFacetFields("col2", "STRING"),
+                    ]
+                )
+            },
+        )
+        assert self.operator._extract_column_names(ds) == ["col1", "col2"]
+
+    def test_validate_output_columns_mismatch(self):
+        ds = OutputDataset(
+            "a",
+            "b",
+            facets={
+                "schema": SchemaDatasetFacet(
+                    fields=[
+                        SchemaDatasetFacetFields("col1", "STRING"),
+                        SchemaDatasetFacetFields("col2", "STRING"),
+                    ]
+                )
+            },
+        )
+        parse_result = SQLParser("bigquery").parse(SQLParser.split_sql_string("SELECT a , b FROM c"))
+        assert self.operator._validate_output_columns(parse_result, ds) is False
+
+    def test_validate_output_columns(self):
+        ds = OutputDataset(
+            "a",
+            "b",
+            facets={
+                "schema": SchemaDatasetFacet(
+                    fields=[
+                        SchemaDatasetFacetFields("a", "STRING"),
+                        SchemaDatasetFacetFields("b", "STRING"),
+                    ]
+                )
+            },
+        )
+        parse_result = SQLParser("bigquery").parse(SQLParser.split_sql_string("SELECT a , b FROM c"))
+        assert self.operator._validate_output_columns(parse_result, ds) is True
+
+    def test_extract_parsed_input_tables(self):
+        query = "INSERT INTO x SELECT a, b from project1.ds1.tb1; INSERT INTO y SELECT c, d from tb2;"
+        parse_result = SQLParser("bigquery").parse(SQLParser.split_sql_string(query))
+        assert self.operator._extract_parsed_input_tables(parse_result, "default_project", "default_ds") == {
+            "project1.ds1.tb1": ["a", "b"],
+            "default_project.default_ds.tb2": ["c", "d"],
+        }
+
+    def test_extract_parsed_input_tables_no_cll(self):
+        parse_result = SQLParser("bigquery").parse(SQLParser.split_sql_string("SELECT 1"))
+        assert self.operator._extract_parsed_input_tables(parse_result, "p", "d") == {}
+
+    def test_validate_input_tables_mismatch(self):
+        result = self.operator._validate_input_tables({"a": None, "b": None}, {"a": None, "c": None})
+        assert result is False
+
+    def test_validate_input_tables_bq_has_more_tables(self):
+        result = self.operator._validate_input_tables({"a": None}, {"a": None, "c": None})
+        assert result is True
+
+    def test_validate_input_tables_empty(self):
+        result = self.operator._validate_input_tables({}, {"a": None, "c": None})
+        assert result is False
+
+    def test_validate_input_columns_mismatch(self):
+        result = self.operator._validate_input_columns(
+            {"a": ["1", "2"], "b": ["3", "4"]}, {"a": ["1", "2", "3"], "c": ["4", "5"]}
+        )
+        assert result is False
+
+    def test_validate_input_columns_bq_has_more_cols(self):
+        result = self.operator._validate_input_columns(
+            {"a": ["1", "2"]}, {"a": ["1", "2", "3"], "c": ["4", "5"]}
+        )
+        assert result is True
+
+    def test_validate_input_columns_empty(self):
+        result = self.operator._validate_input_columns({}, {"a": ["1", "2", "3"], "c": ["4", "5"]})
+        assert result is False
+
+    def test_generate_column_lineage_facet(self):
+        query = "INSERT INTO b.c SELECT c, d from tb2;"
+        parse_result = SQLParser("bigquery").parse(SQLParser.split_sql_string(query))
+        result = self.operator._generate_column_lineage_facet(parse_result, "default_project", "default_ds")
+        assert result == ColumnLineageDatasetFacet(
+            fields={
+                "c": Fields(
+                    inputFields=[InputField("bigquery", "default_project.default_ds.tb2", "c")],
+                    transformationType="",
+                    transformationDescription="",
+                ),
+                "d": Fields(
+                    inputFields=[InputField("bigquery", "default_project.default_ds.tb2", "d")],
+                    transformationType="",
+                    transformationDescription="",
+                ),
+            }
+        )

--- a/providers/tests/google/cloud/utils/job_details.json
+++ b/providers/tests/google/cloud/utils/job_details.json
@@ -225,11 +225,18 @@
             "billingTier": 1,
             "totalSlotMs": "825",
             "cacheHit": false,
-            "referencedTables": [{
-                "projectId": "airflow-openlineage",
-                "datasetId": "new_dataset",
-                "tableId": "test_table"
-            }],
+            "referencedTables": [
+                {
+                    "projectId": "airflow-openlineage",
+                    "datasetId": "new_dataset",
+                    "tableId": "test_table"
+                },
+                {
+                    "projectId": "airflow-openlineage",
+                    "datasetId": "new_dataset",
+                    "tableId": "output_table"
+                }
+            ],
             "statementType": "SELECT"
         },
         "totalSlotMs": "825"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
BigQueryInsertJobOperator already support OpenLineage for QUERY type jobs, but it lacks Column Level Lineage (CLL). 

This PR introduces CLL (Column-Level Lineage) to this operator based on SQL parsing, which can be useful in straightforward scenarios. However, since SQL parsing alone might not always provide all the details (e.g. in SQL query we can reference table only by table name, or dataset.table without the project_id), checks have been implemented to ensure accurate lineage. As a result CLL may not be included when there is uncertainty about its correctness.

There is another change not related to CLL: right now output table is duplicated into input tables. We are creating a list of input tables based on `referencedTables` property provided by Google and as it turns out, this also includes the destination table. So f.e. this query: 
`INSERT INTO `a.b.c` VALUES (1, "a", 23)`
 would return `a.b.c` as input table and output table.

This PR fixes it by removing output table from input tables. I am not sure if it's a correct approach as sometimes users may write a query that performs a process that moves data from one table to the same table but i think this is rare and also this kind of lineage information (from A to A) does not provide much value. Please let me know if you think I'm wrong.

I also refactored the mixin a bit to make it clearer and prepare for adding support for job types other than QUERY. I also change the class name - in the beginning it's supposed to be a general mixin, but BigQueryInsertJobOperator is so complex that this mixin will only be used with that class.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
