### PR TITLE
AIP-72: Pass context keys from API Server to Workers

### DIFF
--- a/task_sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task_sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -44,6 +44,17 @@ class ConnectionResponse(BaseModel):
     extra: Annotated[str | None, Field(title="Extra")] = None
 
 
+class DagRunType(str, Enum):
+    """
+    Class with DagRun types.
+    """
+
+    BACKFILL = "backfill"
+    SCHEDULED = "scheduled"
+    MANUAL = "manual"
+    ASSET_TRIGGERED = "asset_triggered"
+
+
 class IntermediateTIState(str, Enum):
     """
     States that a Task Instance can be in that indicate it is not yet in a terminal or running state.
@@ -159,8 +170,34 @@ class TaskInstance(BaseModel):
     map_index: Annotated[int | None, Field(title="Map Index")] = None
 
 
+class DagRun(BaseModel):
+    """
+    Schema for DagRun model with minimal required fields needed for Runtime.
+    """
+
+    dag_id: Annotated[str, Field(title="Dag Id")]
+    run_id: Annotated[str, Field(title="Run Id")]
+    logical_date: Annotated[datetime, Field(title="Logical Date")]
+    data_interval_start: Annotated[datetime | None, Field(title="Data Interval Start")] = None
+    data_interval_end: Annotated[datetime | None, Field(title="Data Interval End")] = None
+    start_date: Annotated[datetime, Field(title="Start Date")]
+    end_date: Annotated[datetime | None, Field(title="End Date")] = None
+    run_type: DagRunType
+    conf: Annotated[dict[str, Any] | None, Field(title="Conf")] = None
+
+
 class HTTPValidationError(BaseModel):
     detail: Annotated[list[ValidationError] | None, Field(title="Detail")] = None
+
+
+class TIRunContext(BaseModel):
+    """
+    Response schema for TaskInstance run context.
+    """
+
+    dag_run: DagRun
+    variables: Annotated[list[VariableResponse] | None, Field(title="Variables")] = None
+    connections: Annotated[list[ConnectionResponse] | None, Field(title="Connections")] = None
 
 
 class TITerminalStatePayload(BaseModel):

--- a/task_sdk/src/airflow/sdk/execution_time/comms.py
+++ b/task_sdk/src/airflow/sdk/execution_time/comms.py
@@ -54,6 +54,7 @@ from airflow.sdk.api.datamodels._generated import (
     TaskInstance,
     TerminalTIState,
     TIDeferredStatePayload,
+    TIRunContext,
     VariableResponse,
     XComResponse,
 )
@@ -70,6 +71,7 @@ class StartupDetails(BaseModel):
 
     Responses will come back on stdin
     """
+    ti_context: TIRunContext
     type: Literal["StartupDetails"] = "StartupDetails"
 
 

--- a/task_sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task_sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -397,7 +397,7 @@ class WatchedSubprocess:
             # We've forked, but the task won't start doing anything until we send it the StartupDetails
             # message. But before we do that, we need to tell the server it's started (so it has the chance to
             # tell us "no, stop!" for any reason)
-            self.client.task_instances.start(ti.id, self.pid, datetime.now(tz=timezone.utc))
+            ti_context = self.client.task_instances.start(ti.id, self.pid, datetime.now(tz=timezone.utc))
             self._last_successful_heartbeat = time.monotonic()
         except Exception:
             # On any error kill that subprocess!
@@ -408,6 +408,7 @@ class WatchedSubprocess:
             ti=ti,
             file=os.fspath(path),
             requests_fd=requests_fd,
+            ti_context=ti_context,
         )
 
         # Send the message to tell the process what it needs to execute

--- a/task_sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task_sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -23,13 +23,13 @@ import os
 import sys
 from datetime import datetime, timezone
 from io import FileIO
-from typing import TYPE_CHECKING, Any, Generic, TextIO, TypeVar
+from typing import TYPE_CHECKING, Annotated, Any, Generic, TextIO, TypeVar
 
 import attrs
 import structlog
-from pydantic import BaseModel, ConfigDict, JsonValue, TypeAdapter
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, TypeAdapter
 
-from airflow.sdk.api.datamodels._generated import TaskInstance, TerminalTIState
+from airflow.sdk.api.datamodels._generated import TaskInstance, TerminalTIState, TIRunContext
 from airflow.sdk.definitions.baseoperator import BaseOperator
 from airflow.sdk.execution_time.comms import (
     DeferTask,
@@ -48,9 +48,13 @@ class RuntimeTaskInstance(TaskInstance):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     task: BaseOperator
+    _ti_context_from_server: Annotated[TIRunContext | None, Field(repr=False)] = None
+    """The Task Instance context from the API server, if any."""
 
     def get_template_context(self):
+        # TODO: Assess if we need to it through airflow.utils.timezone.coerce_datetime()
         context: dict[str, Any] = {
+            # From the Task Execution interface
             "dag": self.task.dag,
             "inlets": self.task.inlets,
             "map_index_template": self.task.map_index_template,
@@ -59,15 +63,9 @@ class RuntimeTaskInstance(TaskInstance):
             "task": self.task,
             "task_instance": self,
             "ti": self,
-            # "dag_run": dag_run,
-            # "data_interval_end": timezone.coerce_datetime(data_interval.end),
-            # "data_interval_start": timezone.coerce_datetime(data_interval.start),
             # "outlet_events": OutletEventAccessors(),
-            # "ds": ds,
-            # "ds_nodash": ds_nodash,
             # "expanded_ti_count": expanded_ti_count,
             # "inlet_events": InletEventsAccessors(task.inlets, session=session),
-            # "logical_date": logical_date,
             # "macros": macros,
             # "params": validated_params,
             # "prev_data_interval_start_success": get_prev_data_interval_start_success(),
@@ -77,15 +75,36 @@ class RuntimeTaskInstance(TaskInstance):
             # "task_instance_key_str": f"{task.dag_id}__{task.task_id}__{ds_nodash}",
             # "test_mode": task_instance.test_mode,
             # "triggering_asset_events": lazy_object_proxy.Proxy(get_triggering_events),
-            # "ts": ts,
-            # "ts_nodash": ts_nodash,
-            # "ts_nodash_with_tz": ts_nodash_with_tz,
             # "var": {
             #     "json": VariableAccessor(deserialize_json=True),
             #     "value": VariableAccessor(deserialize_json=False),
             # },
             # "conn": ConnectionAccessor(),
         }
+        if self._ti_context_from_server:
+            dag_run = self._ti_context_from_server.dag_run
+
+            logical_date = dag_run.logical_date
+            ds = logical_date.strftime("%Y-%m-%d")
+            ds_nodash = ds.replace("-", "")
+            ts = logical_date.isoformat()
+            ts_nodash = logical_date.strftime("%Y%m%dT%H%M%S")
+            ts_nodash_with_tz = ts.replace("-", "").replace(":", "")
+
+            context_from_server = {
+                # TODO: Assess if we need to pass these through timezone.coerce_datetime
+                "dag_run": dag_run,
+                "data_interval_end": dag_run.data_interval_end,
+                "data_interval_start": dag_run.data_interval_start,
+                "logical_date": logical_date,
+                "ds": ds,
+                "ds_nodash": ds_nodash,
+                "task_instance_key_str": f"{self.task.dag_id}__{self.task.task_id}__{ds_nodash}",
+                "ts": ts,
+                "ts_nodash": ts_nodash,
+                "ts_nodash_with_tz": ts_nodash_with_tz,
+            }
+            context.update(context_from_server)
         return context
 
 
@@ -113,7 +132,11 @@ def parse(what: StartupDetails) -> RuntimeTaskInstance:
     if not isinstance(task, BaseOperator):
         raise TypeError(f"task is of the wrong type, got {type(task)}, wanted {BaseOperator}")
 
-    return RuntimeTaskInstance.model_construct(**what.ti.model_dump(exclude_unset=True), task=task)
+    return RuntimeTaskInstance.model_construct(
+        **what.ti.model_dump(exclude_unset=True),
+        task=task,
+        _ti_context_from_server=what.ti_context,
+    )
 
 
 SendMsgType = TypeVar("SendMsgType", bound=BaseModel)

--- a/task_sdk/tests/conftest.py
+++ b/task_sdk/tests/conftest.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, NoReturn
+from typing import TYPE_CHECKING, Any, NoReturn, Protocol
 
 import pytest
 
@@ -29,7 +29,11 @@ pytest_plugins = "tests_common.pytest_plugin"
 os.environ["_AIRFLOW_SKIP_DB_TESTS"] = "true"
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
     from structlog.typing import EventDict, WrappedLogger
+
+    from airflow.sdk.api.datamodels._generated import TIRunContext
 
 
 @pytest.hookimpl()
@@ -116,7 +120,7 @@ def _disable_ol_plugin():
     # The OpenLineage plugin imports setproctitle, and that now causes (C) level thread calls, which on Py
     # 3.12+ issues a warning when os.fork happens. So for this plugin we disable it
 
-    # And we load plugins when setting the priorty_weight field
+    # And we load plugins when setting the priority_weight field
     import airflow.plugins_manager
 
     old = airflow.plugins_manager.plugins
@@ -128,3 +132,85 @@ def _disable_ol_plugin():
     yield
 
     airflow.plugins_manager.plugins = None
+
+
+class MakeTIContextCallable(Protocol):
+    def __call__(
+        self,
+        dag_id: str = ...,
+        run_id: str = ...,
+        logical_date: str | datetime = ...,
+        data_interval_start: str | datetime = ...,
+        data_interval_end: str | datetime = ...,
+        start_date: str | datetime = ...,
+        run_type: str = ...,
+    ) -> TIRunContext: ...
+
+
+class MakeTIContextDictCallable(Protocol):
+    def __call__(
+        self,
+        dag_id: str = ...,
+        run_id: str = ...,
+        logical_date: str = ...,
+        data_interval_start: str | datetime = ...,
+        data_interval_end: str | datetime = ...,
+        start_date: str | datetime = ...,
+        run_type: str = ...,
+    ) -> dict[str, Any]: ...
+
+
+@pytest.fixture
+def make_ti_context() -> MakeTIContextCallable:
+    """Factory for creating TIRunContext objects."""
+    from airflow.sdk.api.datamodels._generated import DagRun, TIRunContext
+
+    def _make_context(
+        dag_id: str = "test_dag",
+        run_id: str = "test_run",
+        logical_date: str | datetime = "2024-12-01T01:00:00Z",
+        data_interval_start: str | datetime = "2024-12-01T00:00:00Z",
+        data_interval_end: str | datetime = "2024-12-01T01:00:00Z",
+        start_date: str | datetime = "2024-12-01T01:00:00Z",
+        run_type: str = "manual",
+    ) -> TIRunContext:
+        return TIRunContext(
+            dag_run=DagRun(
+                dag_id=dag_id,
+                run_id=run_id,
+                logical_date=logical_date,  # type: ignore
+                data_interval_start=data_interval_start,  # type: ignore
+                data_interval_end=data_interval_end,  # type: ignore
+                start_date=start_date,  # type: ignore
+                run_type=run_type,  # type: ignore
+            )
+        )
+
+    return _make_context
+
+
+@pytest.fixture
+def make_ti_context_dict(make_ti_context: MakeTIContextCallable) -> MakeTIContextDictCallable:
+    """Factory for creating context dictionaries suited for API Server response."""
+
+    def _make_context_dict(
+        dag_id: str = "test_dag",
+        run_id: str = "test_run",
+        logical_date: str | datetime = "2024-12-01T00:00:00Z",
+        data_interval_start: str | datetime = "2024-12-01T00:00:00Z",
+        data_interval_end: str | datetime = "2024-12-01T01:00:00Z",
+        start_date: str | datetime = "2024-12-01T00:00:00Z",
+        run_type: str = "manual",
+    ) -> dict[str, Any]:
+        context = make_ti_context(
+            dag_id=dag_id,
+            run_id=run_id,
+            logical_date=logical_date,
+            data_interval_start=data_interval_start,
+            data_interval_end=data_interval_end,
+            start_date=start_date,
+            run_type=run_type,
+        )
+        return context.model_dump(exclude_unset=True, mode="json")
+
+    return _make_context_dict


### PR DESCRIPTION
Part of https://github.com/apache/airflow/issues/44481

This commit augments the TI context available in the Task Execution Interface with the one from the Execution API Server.

In future PRs the following will be added:

- More methods on TI like ti.xcom_pull, ti.xcom_push etc
- Lazy fetching of connections, variables
- Verifying the "get_current_context" is working
f3ea195c89

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
