### PR TITLE
Run RC release command CI check only on canary runs.

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -293,6 +293,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_USERNAME: ${{ github.actor }}
       VERBOSE: "true"
+    if: inputs.canary-run == 'true'
     steps:
       - name: "Cleanup repo"
         shell: bash


### PR DESCRIPTION
This check takes around 9-10 minutes. As discussed in slack, this check can be run only on canary builds. This helps in improving PRs related to new UI (AIP 38) reducing current time from 10 minutes including this check to 2-3 minutes per run as this step is skipped and also saving CI resources for other PRs.

Ref : https://apache-airflow.slack.com/archives/C07813CNKA8/p1733985375943499