### PR TITLE
Raise alarm in Slack only on first attempt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -739,7 +739,7 @@ jobs:
       - tests-kubernetes
       - tests-task-sdk
       - finalize-tests
-    if: github.event_name == 'schedule' && failure()
+    if: github.event_name == 'schedule' && failure() && github.run_attempt == 1
     runs-on: ["ubuntu-22.04"]
     steps:
       - name: Notify Slack


### PR DESCRIPTION
We have this cool Slack alarm from Github in internal-ci-cd channel.

Sometimes we have a flaky infrastructure or intermittend problem. Also if we make a re-run we get an alarm to slack again on repeated failure.
This PR checkes and only raises an alarm on first attempt.