### PR TITLE
Better error handling to prevent flaky test_last_chance_exception_handling test

### DIFF
--- a/task_sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task_sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -412,8 +412,13 @@ class WatchedSubprocess:
 
         # Send the message to tell the process what it needs to execute
         log.debug("Sending", msg=msg)
-        self.stdin.write(msg.model_dump_json().encode())
-        self.stdin.write(b"\n")
+
+        try:
+            self.stdin.write(msg.model_dump_json().encode())
+            self.stdin.write(b"\n")
+        except BrokenPipeError:
+            # Debug is fine, the process will have shown _something_ in it's last_chance exception handler
+            log.debug("Couldn't send startup message to Subprocess - it died very early", pid=self.pid)
 
     def kill(
         self,


### PR DESCRIPTION
If the launched subprocess (which in tests just _immediately_ raises an
Exception) exits very quickly before we even try to send the startup message
it would fail with a BrokenPipeError. All we need to do in this case is handle
it as the exit code of the task and it's message (which we already test) will
cover it.

This particular behaviour is hard to reliably catch in tests, so no tests are
added here.
