### PR TITLE
Fix docker version for Rancher Desktop

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -205,7 +205,8 @@ def check_docker_version(quiet: bool = False):
             dry_run_override=False,
         )
         if docker_version_result.returncode == 0:
-            docker_version = docker_version_result.stdout.strip()
+            regex = re.compile(r"^(" + version.VERSION_PATTERN + r").*$", re.VERBOSE | re.IGNORECASE)
+            docker_version = re.sub(regex, r"\1", docker_version_result.stdout.strip())
         if docker_version == "":
             get_console().print(
                 f"""

--- a/dev/breeze/tests/test_docker_command_utils.py
+++ b/dev/breeze/tests/test_docker_command_utils.py
@@ -127,6 +127,28 @@ def test_check_docker_version_higher(mock_get_console, mock_run_command, mock_ch
     mock_get_console.return_value.print.assert_called_with("[success]Good version of Docker: 24.0.0.[/]")
 
 
+@mock.patch("airflow_breeze.utils.docker_command_utils.check_docker_permission_denied")
+@mock.patch("airflow_breeze.utils.docker_command_utils.run_command")
+@mock.patch("airflow_breeze.utils.docker_command_utils.get_console")
+def test_check_docker_version_higher_rancher_desktop(
+    mock_get_console, mock_run_command, mock_check_docker_permission_denied
+):
+    mock_check_docker_permission_denied.return_value = False
+    mock_run_command.return_value.returncode = 0
+    mock_run_command.return_value.stdout = "24.0.0-rd"
+    check_docker_version()
+    mock_check_docker_permission_denied.assert_called()
+    mock_run_command.assert_called_with(
+        ["docker", "version", "--format", "{{.Client.Version}}"],
+        no_output_dump_on_exception=True,
+        capture_output=True,
+        text=True,
+        check=False,
+        dry_run_override=False,
+    )
+    mock_get_console.return_value.print.assert_called_with("[success]Good version of Docker: 24.0.0-r.[/]")
+
+
 @mock.patch("airflow_breeze.utils.docker_command_utils.run_command")
 @mock.patch("airflow_breeze.utils.docker_command_utils.get_console")
 def test_check_docker_compose_version_unknown(mock_get_console, mock_run_command):


### PR DESCRIPTION
Fix an issue where the Docker version could not be recognized when using Rancher Desktop and running the breeze command.
Changed to extract only the parts that can be recognized as versions from the version string.


Command that cause problems.
```
breeze --python 3.9 --backend postgres
```

Error message.
```
Traceback (most recent call last):
  File "/Users/tnk-ysk/.local/bin/breeze", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/tnk-ysk/.local/share/uv/tools/apache-airflow-breeze/lib/python3.11/site-packages/rich_click/rich_command.py", line 367, in __call__
    return super().__call__(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tnk-ysk/.local/share/uv/tools/apache-airflow-breeze/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tnk-ysk/.local/share/uv/tools/apache-airflow-breeze/lib/python3.11/site-packages/rich_click/rich_command.py", line 152, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/tnk-ysk/.local/share/uv/tools/apache-airflow-breeze/lib/python3.11/site-packages/click/core.py", line 1666, in invoke
    rv = super().invoke(ctx)
         ^^^^^^^^^^^^^^^^^^^
  File "/Users/tnk-ysk/.local/share/uv/tools/apache-airflow-breeze/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tnk-ysk/.local/share/uv/tools/apache-airflow-breeze/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tnk-ysk/.local/share/uv/tools/apache-airflow-breeze/lib/python3.11/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tnk-ysk/work/study/tnk-ysk/airflow/dev/breeze/src/airflow_breeze/commands/main_command.py", line 133, in main
    ctx.forward(shell, extra_args={})
  File "/Users/tnk-ysk/.local/share/uv/tools/apache-airflow-breeze/lib/python3.11/site-packages/click/core.py", line 804, in forward
    return __self.invoke(__cmd, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tnk-ysk/.local/share/uv/tools/apache-airflow-breeze/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tnk-ysk/work/study/tnk-ysk/airflow/dev/breeze/src/airflow_breeze/commands/developer_commands.py", line 456, in shell
    result = enter_shell(shell_params=shell_params)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tnk-ysk/work/study/tnk-ysk/airflow/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py", line 757, in enter_shell
    perform_environment_checks(quiet=shell_params.quiet)
  File "/Users/tnk-ysk/work/study/tnk-ysk/airflow/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py", line 511, in perform_environment_checks
    check_docker_version(quiet)
  File "/Users/tnk-ysk/work/study/tnk-ysk/airflow/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py", line 218, in check_docker_version
    good_version = compare_version(docker_version, MIN_DOCKER_VERSION)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tnk-ysk/work/study/tnk-ysk/airflow/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py", line 165, in compare_version
    return version.parse(current_version) >= version.parse(min_version)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tnk-ysk/.local/share/uv/tools/apache-airflow-breeze/lib/python3.11/site-packages/packaging/version.py", line 56, in parse
    return Version(version)
           ^^^^^^^^^^^^^^^^
  File "/Users/tnk-ysk/.local/share/uv/tools/apache-airflow-breeze/lib/python3.11/site-packages/packaging/version.py", line 202, in __init__
    raise InvalidVersion(f"Invalid version: {version!r}")
packaging.version.InvalidVersion: Invalid version: '27.2.1-rd'
```