### PR TITLE
[edge] Sync executor with job table

### DIFF
--- a/providers/src/airflow/providers/edge/CHANGELOG.rst
+++ b/providers/src/airflow/providers/edge/CHANGELOG.rst
@@ -27,6 +27,14 @@
 Changelog
 ---------
 
+0.9.4pre0
+.........
+
+Misc
+~~~~
+
+* ``Fix to keep edge executor and edge job table in sync. Important in multi scheduler deployments.``
+
 0.9.3pre0
 .........
 

--- a/providers/src/airflow/providers/edge/__init__.py
+++ b/providers/src/airflow/providers/edge/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "0.9.3pre0"
+__version__ = "0.9.4pre0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.10.0"

--- a/providers/src/airflow/providers/edge/executors/edge_executor.py
+++ b/providers/src/airflow/providers/edge/executors/edge_executor.py
@@ -197,6 +197,11 @@ class EdgeExecutor(BaseExecutor):
             )
             .all()
         )
+
+        # Sync DB with executor otherwise runs out of sync in multi scheduler deployment
+        already_removed = self.running - set(job.key for job in jobs)
+        self.running = self.running - already_removed
+
         for job in jobs:
             if job.key in self.running:
                 if job.state == TaskInstanceState.RUNNING:

--- a/providers/src/airflow/providers/edge/provider.yaml
+++ b/providers/src/airflow/providers/edge/provider.yaml
@@ -27,7 +27,7 @@ source-date-epoch: 1729683247
 
 # note that those versions are maintained by release manager - do not update them manually
 versions:
-  - 0.9.3pre0
+  - 0.9.4pre0
 
 dependencies:
   - apache-airflow>=2.10.0


### PR DESCRIPTION
# Description

In multi scheduler deployment the Edge_Job table an executor self.running (contains the running task_instance keys which were scheduled by the scheduler)  running out of sync. This PR adds a sync for the running. First it detect the jobs which are in the self.running but removed in the table. Then it removed this jobs from the running. After that the self.runnig contains only the job with were run by the executor and available in the DB.

# Details about changes
* Sync self.running with the edge_job table
