### PR TITLE
Revert removal of Pydantic model support from PR 44552 to restore compatibility with Airflow 2.10

### DIFF
--- a/providers/src/airflow/providers/edge/CHANGELOG.rst
+++ b/providers/src/airflow/providers/edge/CHANGELOG.rst
@@ -27,6 +27,14 @@
 Changelog
 ---------
 
+0.9.5pre0
+.........
+
+Misc
+~~~~
+
+* ``Revert removal of Pydantic model support from PR 44552 to restore compatibility with Airflow 2.10.``
+
 0.9.4pre0
 .........
 

--- a/providers/src/airflow/providers/edge/__init__.py
+++ b/providers/src/airflow/providers/edge/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "0.9.4pre0"
+__version__ = "0.9.5pre0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.10.0"

--- a/providers/src/airflow/providers/edge/provider.yaml
+++ b/providers/src/airflow/providers/edge/provider.yaml
@@ -27,7 +27,7 @@ source-date-epoch: 1729683247
 
 # note that those versions are maintained by release manager - do not update them manually
 versions:
-  - 0.9.4pre0
+  - 0.9.5pre0
 
 dependencies:
   - apache-airflow>=2.10.0


### PR DESCRIPTION
PR #44552 removed Pydantic models as cleanup for Airflow 3.

Unfortunately it seems I approved and over-looked in the review that in the compatibility layer to Airflow 2.10 the method calls for serialization using pydantic models were also "cleaned".

This PR reverts the code in these sections to make Edge Worker compatible with Airflow 2.10 again.