### PR TITLE
Import `os` in executor_loader

### DIFF
--- a/airflow/executors/executor_loader.py
+++ b/airflow/executors/executor_loader.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import TYPE_CHECKING
 
 from airflow.exceptions import AirflowConfigException, UnknownExecutorException


### PR DESCRIPTION
That import was removed in #44839, but #44710 wasn't up-to-date with main so static checks there didn't fail. This simply adds it back.