### PR TITLE
Set Autocomplete Off on Login Form - Main

### DIFF
--- a/airflow/www/static/js/main.js
+++ b/airflow/www/static/js/main.js
@@ -323,6 +323,6 @@ $(document).ready(() => {
   $(".js-tooltip").tooltip();
 
   // Turn off autocomplete for login form
-  $("#username:input")[0].autocomplete="off";
-  $("#password:input")[0].autocomplete="off";
+  $("#username:input")[0].autocomplete = "off";
+  $("#password:input")[0].autocomplete = "off";
 });

--- a/airflow/www/static/js/main.js
+++ b/airflow/www/static/js/main.js
@@ -321,4 +321,8 @@ $(document).ready(() => {
 
   // Global Tooltip selector
   $(".js-tooltip").tooltip();
+
+  // Turn off autocomplete for login form
+  $("#username:input")[0].autocomplete="off";
+  $("#password:input")[0].autocomplete="off";
 });


### PR DESCRIPTION
closes: #44019

Updated main Javascript to apply autocomplete="off" to both username and password inputs on login page. This will help prevent the browser from providing hints for the username (and password), as requested in the Issue.

Based on Flask-AppBuilder source code, i.e. https://github.com/dpgaspar/Flask-AppBuilder/tree/master/flask_appbuilder/templates/appbuilder/general/security (see login_db.html and login_ldap.html), this should work for both AUTH_DB (default) and AUTH_LDAP authentication, since they both apparently use the same HTML elements in the form.