### PR TITLE
[v2-10-test] Fix task id validation in BaseOperator

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -965,12 +965,13 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
                 category=RemovedInAirflow3Warning,
                 stacklevel=3,
             )
-        validate_key(task_id)
+
 
         dag = dag or DagContext.get_current_dag()
         task_group = task_group or TaskGroupContext.get_current_task_group(dag)
 
         self.task_id = task_group.child_id(task_id) if task_group else task_id
+        validate_key(self.task_id)
         if not self.__from_mapped and task_group:
             task_group.add(self)
 

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -966,12 +966,13 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
                 stacklevel=3,
             )
 
-
         dag = dag or DagContext.get_current_dag()
         task_group = task_group or TaskGroupContext.get_current_task_group(dag)
 
         self.task_id = task_group.child_id(task_id) if task_group else task_id
+
         validate_key(self.task_id)
+
         if not self.__from_mapped and task_group:
             task_group.add(self)
 

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -568,8 +568,8 @@ class TestBaseOperator:
         """Test exception is raised when operator task id + taskgroup id > 250 chars."""
         dag = DAG(dag_id="foo", schedule=None, start_date=datetime.now())
 
+        tg1 = TaskGroup("A" * 20, dag=dag)
         with pytest.raises(AirflowException, match="The key has to be less than 250 characters"):
-            tg1 = TaskGroup("A" * 20, dag=dag)
             BaseOperator(task_id="1" * 250, task_group=tg1, dag=dag)
 
     def test_chain_linear(self):

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -564,6 +564,14 @@ class TestBaseOperator:
         assert [op2] == tgop3.get_direct_relatives(upstream=False)
         assert [op2] == tgop4.get_direct_relatives(upstream=False)
 
+    def test_baseoperator_raises_exception_when_task_id_invalid(self):
+        """Test exception is raised when operator task id + taskgroup id > 250 chars."""
+        dag = DAG(dag_id="foo", schedule=None, start_date=datetime.now())
+
+        with pytest.raises(AirflowException, match="The key has to be less than 250 characters"):
+            tg1 = TaskGroup("A" * 20, dag=dag)
+            BaseOperator(task_id="1" * 250, task_group=tg1, dag=dag)
+
     def test_chain_linear(self):
         dag = DAG(dag_id="test_chain_linear", schedule=None, start_date=datetime.now())
 

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -564,13 +564,32 @@ class TestBaseOperator:
         assert [op2] == tgop3.get_direct_relatives(upstream=False)
         assert [op2] == tgop4.get_direct_relatives(upstream=False)
 
-    def test_baseoperator_raises_exception_when_task_id_invalid(self):
+    def test_baseoperator_raises_exception_when_task_id_plus_taskgroup_id_exceeds_250_chars(self):
         """Test exception is raised when operator task id + taskgroup id > 250 chars."""
         dag = DAG(dag_id="foo", schedule=None, start_date=datetime.now())
 
         tg1 = TaskGroup("A" * 20, dag=dag)
         with pytest.raises(AirflowException, match="The key has to be less than 250 characters"):
             BaseOperator(task_id="1" * 250, task_group=tg1, dag=dag)
+
+    def test_baseoperator_with_task_id_and_taskgroup_id_less_than_250_chars(self):
+        """Test exception is not raised when operator task id + taskgroup id < 250 chars."""
+        dag = DAG(dag_id="foo", schedule=None, start_date=datetime.now())
+
+        tg1 = TaskGroup("A" * 10, dag=dag)
+        try:
+            BaseOperator(task_id="1" * 239, task_group=tg1, dag=dag)
+        except Exception as e:
+            pytest.fail(f"Exception raised: {e}")
+
+    def test_baseoperator_with_task_id_less_than_250_chars(self):
+        """Test exception is not raised when operator task id  < 250 chars."""
+        dag = DAG(dag_id="foo", schedule=None, start_date=datetime.now())
+
+        try:
+            BaseOperator(task_id="1" * 249, dag=dag)
+        except Exception as e:
+            pytest.fail(f"Exception raised: {e}")
 
     def test_chain_linear(self):
         dag = DAG(dag_id="test_chain_linear", schedule=None, start_date=datetime.now())


### PR DESCRIPTION
When dag contains TaskGroup, currently its not accounting TaskGroup id in the task id validation. Causing the scheduler loop failures.

backports: #44939

closes: #44738

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
