### PR TITLE
Fixes DatabricksPartitionSensor from immediately failing; returns false in poke method for DatabricksPartitionSensor

### DIFF
--- a/providers/src/airflow/providers/databricks/sensors/databricks_partition.py
+++ b/providers/src/airflow/providers/databricks/sensors/databricks_partition.py
@@ -224,4 +224,5 @@ class DatabricksPartitionSensor(BaseSensorOperator):
             return True
         else:
             message = f"Specified partition(s): {self.partitions} were not found."
-            raise AirflowException(message)
+            self.log.debug(message)
+            return False


### PR DESCRIPTION
Databricks Partition should return False, not an error. As is, it fails immediately if the partition isn't present. Ie; it has no ability to poke. Let me know if you want any changes.

closes: https://github.com/apache/airflow/issues/44950
related: #ISSUE

---