### PR TITLE
[edge] Replaced null value with question mark in edge logs

### DIFF
--- a/providers/src/airflow/providers/edge/CHANGELOG.rst
+++ b/providers/src/airflow/providers/edge/CHANGELOG.rst
@@ -27,6 +27,14 @@
 Changelog
 ---------
 
+0.9.6pre0
+.........
+
+Misc
+~~~~
+
+* ``Replace null value in log file chunk with question mark to fix exception by pushing log into DB.``
+
 0.9.5pre0
 .........
 

--- a/providers/src/airflow/providers/edge/__init__.py
+++ b/providers/src/airflow/providers/edge/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "0.9.5pre0"
+__version__ = "0.9.6pre0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.10.0"

--- a/providers/src/airflow/providers/edge/cli/edge_command.py
+++ b/providers/src/airflow/providers/edge/cli/edge_command.py
@@ -275,7 +275,8 @@ class _EdgeWorkerCli:
                     read_data = logfile.read()
                     job.logsize += len(read_data)
                     # backslashreplace to keep not decoded characters and not raising exception
-                    log_data = read_data.decode(errors="backslashreplace")
+                    # replace null with question mark to fix issue during DB push
+                    log_data = read_data.decode(errors="backslashreplace").replace("\x00", "\ufffd")
                     while True:
                         chunk_data = log_data[:push_log_chunk_size]
                         log_data = log_data[push_log_chunk_size:]

--- a/providers/src/airflow/providers/edge/provider.yaml
+++ b/providers/src/airflow/providers/edge/provider.yaml
@@ -27,7 +27,7 @@ source-date-epoch: 1729683247
 
 # note that those versions are maintained by release manager - do not update them manually
 versions:
-  - 0.9.5pre0
+  - 0.9.6pre0
 
 dependencies:
   - apache-airflow>=2.10.0


### PR DESCRIPTION
# Overview

In our environment we facing sporadically a null value in a log chunk and this breaks the push into the postgres. Idea of this PR is to replace the null value with question mark to be able to find the null value in the log file and having a not crashing instance.

# Details of changes:
* Replace null value in log chunk with question mark sign.