### PR TITLE
Correct the Session argument's type hint in ApplessSecurityManager

### DIFF
--- a/airflow/www/security_appless.py
+++ b/airflow/www/security_appless.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING
 from airflow.providers.fab.auth_manager.security_manager.override import FabAirflowSecurityManagerOverride
 
 if TYPE_CHECKING:
-    from flask_session import Session
+    from sqlalchemy.orm import Session
 
 
 class FakeAppBuilder:


### PR DESCRIPTION
In #33901 this was moved to a new file and mistakenly changed to
flask_session.

It's not clear to me why this didn't cause errors, but it was highlighted in
my editor as an invalid type :shrug:
