### PR TITLE
Fix python task context test - conf has been removed

### DIFF
--- a/providers/tests/standard/operators/test_python.py
+++ b/providers/tests/standard/operators/test_python.py
@@ -925,6 +925,7 @@ class BaseTestPythonVirtualenvOperator(BasePythonTest):
                 "next_execution_date",
                 "prev_execution_date",
                 "prev_execution_date_success",
+                "conf",
             }
         else:
             declared_keys.remove("triggering_asset_events")


### PR DESCRIPTION
PR #44820 removed `conf` from task context, but these tests still expect it.