### PR TITLE
AIP-72: Handling `up_for_retry` task instance states for `AirflowTaskTimeout` and `AirflowException`

### DIFF
--- a/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -124,6 +124,12 @@ def ti_update_state(
         )
     elif isinstance(ti_patch_payload, TITerminalStatePayload):
         query = TI.duration_expression_update(ti_patch_payload.end_date, query, session.bind)
+        query = query.values(
+            state=ti_patch_payload.state,
+        )
+        if ti_patch_payload.state == State.FAILED:
+            # clear the next_method and next_kwargs
+            query = query.values(next_method=None, next_kwargs=None)
     elif isinstance(ti_patch_payload, TIDeferredStatePayload):
         # Calculate timeout if it was passed
         timeout = None

--- a/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -201,12 +201,8 @@ def ti_update_state(
 
     if isinstance(ti_patch_payload, TITerminalStatePayload):
         query = TI.duration_expression_update(ti_patch_payload.end_date, query, session.bind)
-        query = query.values(
-            state=ti_patch_payload.state,
-        )
-        if ti_patch_payload.state == State.FAILED:
-            # clear the next_method and next_kwargs
-            query = query.values(next_method=None, next_kwargs=None)
+        # clear the next_method and next_kwargs for all terminal states, as we do not want retries to pick them
+        query = query.values(state=ti_patch_payload.state, next_method=None, next_kwargs=None)
     elif isinstance(ti_patch_payload, TIDeferredStatePayload):
         # Calculate timeout if it was passed
         timeout = None

--- a/airflow/utils/state.py
+++ b/airflow/utils/state.py
@@ -39,6 +39,7 @@ class TerminalTIState(str, Enum):
     FAILED = "failed"
     SKIPPED = "skipped"  # A user can raise a AirflowSkipException from a task & it will be marked as skipped
     REMOVED = "removed"
+    UP_FOR_RETRY = "up_for_retry"  # We do not need to do anything actionable for this state, hence it is a terminal state.
 
     def __str__(self) -> str:
         return self.value
@@ -50,7 +51,6 @@ class IntermediateTIState(str, Enum):
     SCHEDULED = "scheduled"
     QUEUED = "queued"
     RESTARTING = "restarting"
-    UP_FOR_RETRY = "up_for_retry"
     UP_FOR_RESCHEDULE = "up_for_reschedule"
     UPSTREAM_FAILED = "upstream_failed"
     DEFERRED = "deferred"
@@ -80,7 +80,7 @@ class TaskInstanceState(str, Enum):
     SUCCESS = TerminalTIState.SUCCESS  # Task completed
     RESTARTING = IntermediateTIState.RESTARTING  # External request to restart (e.g. cleared when running)
     FAILED = TerminalTIState.FAILED  # Task errored out
-    UP_FOR_RETRY = IntermediateTIState.UP_FOR_RETRY  # Task failed but has retries left
+    UP_FOR_RETRY = TerminalTIState.UP_FOR_RETRY  # Task failed but has retries left
     UP_FOR_RESCHEDULE = IntermediateTIState.UP_FOR_RESCHEDULE  # A waiting `reschedule` sensor
     UPSTREAM_FAILED = IntermediateTIState.UPSTREAM_FAILED  # One or more upstream deps failed
     SKIPPED = TerminalTIState.SKIPPED  # Skipped by branching or some other mechanism

--- a/task_sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task_sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -63,7 +63,6 @@ class IntermediateTIState(str, Enum):
     SCHEDULED = "scheduled"
     QUEUED = "queued"
     RESTARTING = "restarting"
-    UP_FOR_RETRY = "up_for_retry"
     UP_FOR_RESCHEDULE = "up_for_reschedule"
     UPSTREAM_FAILED = "upstream_failed"
     DEFERRED = "deferred"
@@ -119,6 +118,7 @@ class TerminalTIState(str, Enum):
     FAILED = "failed"
     SKIPPED = "skipped"
     REMOVED = "removed"
+    UP_FOR_RETRY = "up_for_retry"
 
 
 class ValidationError(BaseModel):

--- a/task_sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task_sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -268,6 +268,8 @@ def run(ti: RuntimeTaskInstance, log: Logger):
             state=TerminalTIState.FAILED,
             end_date=datetime.now(tz=timezone.utc),
         )
+
+        # TODO: Run task failure callbacks here
     except (AirflowTaskTimeout, AirflowException, AirflowTaskTerminated):
         ...
     except SystemExit:

--- a/task_sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task_sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -260,7 +260,14 @@ def run(ti: RuntimeTaskInstance, log: Logger):
         ...
     except (AirflowFailException, AirflowSensorTimeout):
         # If AirflowFailException is raised, task should not retry.
-        ...
+        # If a sensor in reschedule mode reaches timeout, task should not retry.
+
+        # TODO: Handle fail_stop here: https://github.com/apache/airflow/issues/44951
+        # TODO: Handle addition to Log table: https://github.com/apache/airflow/issues/44952
+        msg = TaskState(
+            state=TerminalTIState.FAILED,
+            end_date=datetime.now(tz=timezone.utc),
+        )
     except (AirflowTaskTimeout, AirflowException, AirflowTaskTerminated):
         ...
     except SystemExit:

--- a/task_sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task_sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -294,8 +294,12 @@ def run(ti: RuntimeTaskInstance, log: Logger):
 
         # TODO: Run task failure callbacks here
     except (AirflowTaskTimeout, AirflowException):
-        # TODO: handle the case of up_for_retry here
-        ...
+        msg = TaskState(
+            state=TerminalTIState.UP_FOR_RETRY,
+            end_date=datetime.now(tz=timezone.utc),
+        )
+
+        # TODO: Run task retry callbacks here
     except AirflowTaskTerminated:
         # External state updates are already handled with `ti_heartbeat` and will be
         # updated already be another UI API. So, these exceptions should ideally never be thrown.

--- a/task_sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task_sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -293,8 +293,18 @@ def run(ti: RuntimeTaskInstance, log: Logger):
         )
 
         # TODO: Run task failure callbacks here
-    except (AirflowTaskTimeout, AirflowException, AirflowTaskTerminated):
+    except AirflowTaskTimeout:
+        # TODO: handle the case of up_for_retry here
         ...
+    except (AirflowException, AirflowTaskTerminated):
+        # External state updates are already handled with `ti_heartbeat` and will be
+        # updated already be another UI API. So, these exceptions should ideally never be thrown.
+        # If these are thrown, we should mark the TI state as failed.
+        msg = TaskState(
+            state=TerminalTIState.FAILED,
+            end_date=datetime.now(tz=timezone.utc),
+        )
+        # TODO: Run task failure callbacks here
     except SystemExit:
         ...
     except BaseException:

--- a/task_sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task_sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -293,10 +293,10 @@ def run(ti: RuntimeTaskInstance, log: Logger):
         )
 
         # TODO: Run task failure callbacks here
-    except AirflowTaskTimeout:
+    except (AirflowTaskTimeout, AirflowException):
         # TODO: handle the case of up_for_retry here
         ...
-    except (AirflowException, AirflowTaskTerminated):
+    except AirflowTaskTerminated:
         # External state updates are already handled with `ti_heartbeat` and will be
         # updated already be another UI API. So, these exceptions should ideally never be thrown.
         # If these are thrown, we should mark the TI state as failed.

--- a/task_sdk/tests/execution_time/test_supervisor.py
+++ b/task_sdk/tests/execution_time/test_supervisor.py
@@ -857,6 +857,14 @@ class TestHandleRequest:
                 "",
                 id="patch_task_instance_to_skipped",
             ),
+            pytest.param(
+                TaskState(state=TerminalTIState.FAILED, end_date=timezone.parse("2024-10-31T12:00:00Z")),
+                b"",
+                "",
+                (),
+                "",
+                id="patch_task_instance_to_failed",
+            ),
         ],
     )
     def test_handle_requests(

--- a/task_sdk/tests/execution_time/test_supervisor.py
+++ b/task_sdk/tests/execution_time/test_supervisor.py
@@ -870,6 +870,16 @@ class TestHandleRequest:
                 "",
                 id="patch_task_instance_to_failed",
             ),
+            pytest.param(
+                TaskState(
+                    state=TerminalTIState.UP_FOR_RETRY, end_date=timezone.parse("2024-10-31T12:00:00Z")
+                ),
+                b"",
+                "",
+                (),
+                "",
+                id="patch_task_instance_to_retry",
+            ),
         ],
     )
     def test_handle_requests(

--- a/task_sdk/tests/execution_time/test_task_runner.py
+++ b/task_sdk/tests/execution_time/test_task_runner.py
@@ -26,7 +26,13 @@ from unittest import mock
 import pytest
 from uuid6 import uuid7
 
-from airflow.exceptions import AirflowFailException, AirflowSensorTimeout, AirflowSkipException
+from airflow.exceptions import (
+    AirflowException,
+    AirflowFailException,
+    AirflowSensorTimeout,
+    AirflowSkipException,
+    AirflowTaskTerminated,
+)
 from airflow.sdk import DAG, BaseOperator
 from airflow.sdk.api.datamodels._generated import TaskInstance, TerminalTIState
 from airflow.sdk.execution_time.comms import DeferTask, SetRenderedFields, StartupDetails, TaskState
@@ -343,6 +349,16 @@ def test_startup_dag_with_templated_fields(
             "basic_failed2",
             "sensor-timeout-exception",
             AirflowSensorTimeout("Oops. Failing by AirflowSensorTimeout!"),
+        ),
+        pytest.param(
+            "basic_failed3",
+            "airflow-exception",
+            AirflowException("Oops. Failing by AirflowException!"),
+        ),
+        pytest.param(
+            "basic_failed4",
+            "task-terminated-exception",
+            AirflowTaskTerminated("Oops. Failing by AirflowTaskTerminated!"),
         ),
     ],
 )

--- a/task_sdk/tests/execution_time/test_task_runner.py
+++ b/task_sdk/tests/execution_time/test_task_runner.py
@@ -26,7 +26,7 @@ from unittest import mock
 import pytest
 from uuid6 import uuid7
 
-from airflow.exceptions import AirflowSkipException
+from airflow.exceptions import AirflowFailException, AirflowSensorTimeout, AirflowSkipException
 from airflow.sdk import DAG, BaseOperator
 from airflow.sdk.api.datamodels._generated import TaskInstance, TerminalTIState
 from airflow.sdk.execution_time.comms import DeferTask, SetRenderedFields, StartupDetails, TaskState
@@ -317,4 +317,49 @@ def test_startup_dag_with_templated_fields(mocked_parse, task_params, expected_r
         mock_supervisor_comms.send_request.assert_called_once_with(
             msg=SetRenderedFields(rendered_fields=expected_rendered_fields),
             log=mock.ANY,
+        )
+
+
+@pytest.mark.parametrize(
+    ["dag_id", "task_id", "fail_with_exception"],
+    [
+        pytest.param(
+            "basic_failed", "fail-exception", AirflowFailException("Oops. Failing by AirflowFailException!")
+        ),
+        pytest.param(
+            "basic_failed2",
+            "sensor-timeout-exception",
+            AirflowSensorTimeout("Oops. Failing by AirflowSensorTimeout!"),
+        ),
+    ],
+)
+def test_run_basic_failed(time_machine, mocked_parse, dag_id, task_id, fail_with_exception):
+    """Test running a basic task that marks itself as failed by raising exception."""
+    from airflow.providers.standard.operators.python import PythonOperator
+
+    task = PythonOperator(
+        task_id=task_id,
+        python_callable=lambda: (_ for _ in ()).throw(
+            fail_with_exception,
+        ),
+    )
+
+    what = StartupDetails(
+        ti=TaskInstance(id=uuid7(), task_id=task_id, dag_id=dag_id, run_id="c", try_number=1),
+        file="",
+        requests_fd=0,
+    )
+
+    ti = mocked_parse(what, dag_id, task)
+
+    instant = timezone.datetime(2024, 12, 3, 10, 0)
+    time_machine.move_to(instant, tick=False)
+
+    with mock.patch(
+        "airflow.sdk.execution_time.task_runner.SUPERVISOR_COMMS", create=True
+    ) as mock_supervisor_comms:
+        run(ti, log=mock.MagicMock())
+
+        mock_supervisor_comms.send_request.assert_called_once_with(
+            msg=TaskState(state=TerminalTIState.FAILED, end_date=instant), log=mock.ANY
         )

--- a/task_sdk/tests/execution_time/test_task_runner.py
+++ b/task_sdk/tests/execution_time/test_task_runner.py
@@ -27,7 +27,6 @@ import pytest
 from uuid6 import uuid7
 
 from airflow.exceptions import (
-    AirflowException,
     AirflowFailException,
     AirflowSensorTimeout,
     AirflowSkipException,
@@ -352,11 +351,6 @@ def test_startup_dag_with_templated_fields(
         ),
         pytest.param(
             "basic_failed3",
-            "airflow-exception",
-            AirflowException("Oops. Failing by AirflowException!"),
-        ),
-        pytest.param(
-            "basic_failed4",
             "task-terminated-exception",
             AirflowTaskTerminated("Oops. Failing by AirflowTaskTerminated!"),
         ),

--- a/tests/api_fastapi/execution_api/routes/test_task_instances.py
+++ b/tests/api_fastapi/execution_api/routes/test_task_instances.py
@@ -150,6 +150,7 @@ class TestTIUpdateState:
             (State.SUCCESS, DEFAULT_END_DATE, State.SUCCESS),
             (State.FAILED, DEFAULT_END_DATE, State.FAILED),
             (State.SKIPPED, DEFAULT_END_DATE, State.SKIPPED),
+            (State.UP_FOR_RETRY, DEFAULT_END_DATE, State.UP_FOR_RETRY),
         ],
     )
     def test_ti_update_state_to_terminal(

--- a/tests/api_fastapi/execution_api/routes/test_task_instances.py
+++ b/tests/api_fastapi/execution_api/routes/test_task_instances.py
@@ -438,7 +438,7 @@ class TestTIHealthEndpoint:
         assert ti.state == State.FAILED
         assert ti.next_method is None
         assert ti.next_kwargs is None
-        assert ti.duration == 3599.999986588955
+        assert ti.duration == 3600.00
 
 
 class TestTIPutRTIF:

--- a/tests/api_fastapi/execution_api/routes/test_task_instances.py
+++ b/tests/api_fastapi/execution_api/routes/test_task_instances.py
@@ -413,6 +413,8 @@ class TestTIHealthEndpoint:
         assert ti.last_heartbeat_at == time_now.add(minutes=10)
 
     def test_ti_update_state_to_failed_table_check(self, client, session, create_task_instance):
+        from math import ceil
+
         ti = create_task_instance(
             task_id="test_ti_update_state_to_terminal",
             start_date=DEFAULT_START_DATE,
@@ -438,7 +440,7 @@ class TestTIHealthEndpoint:
         assert ti.state == State.FAILED
         assert ti.next_method is None
         assert ti.next_kwargs is None
-        assert ti.duration == 3600.00
+        assert ceil(ti.duration) == 3600.00
 
 
 class TestTIPutRTIF:

--- a/tests/api_fastapi/execution_api/routes/test_task_instances.py
+++ b/tests/api_fastapi/execution_api/routes/test_task_instances.py
@@ -412,6 +412,34 @@ class TestTIHealthEndpoint:
         session.refresh(ti)
         assert ti.last_heartbeat_at == time_now.add(minutes=10)
 
+    def test_ti_update_state_to_failed_table_check(self, client, session, create_task_instance):
+        ti = create_task_instance(
+            task_id="test_ti_update_state_to_terminal",
+            start_date=DEFAULT_START_DATE,
+            state=State.RUNNING,
+        )
+        ti.start_date = DEFAULT_START_DATE
+        session.commit()
+
+        response = client.patch(
+            f"/execution/task-instances/{ti.id}/state",
+            json={
+                "state": State.FAILED,
+                "end_date": DEFAULT_END_DATE.isoformat(),
+            },
+        )
+
+        assert response.status_code == 204
+        assert response.text == ""
+
+        session.expire_all()
+
+        ti = session.get(TaskInstance, ti.id)
+        assert ti.state == State.FAILED
+        assert ti.next_method is None
+        assert ti.next_kwargs is None
+        assert ti.duration == 3599.999986588955
+
 
 class TestTIPutRTIF:
     def setup_method(self):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Only last 2 commits are relevant.

Dependent on https://github.com/apache/airflow/pull/44977 and hence on https://github.com/apache/airflow/pull/44954.
Handling the case of `up_for_retry` from the task SDK.

This exception can be thrown in multiple cases, two valid examples are:

1. I have a dag which times out in 1 second but the task sleeps for 100 seconds, it will end up throwing the `AirflowTaskTimeout` exception:
```
import sys
from time import sleep

from airflow import DAG
from airflow.providers.standard.operators.python import PythonOperator
from datetime import datetime, timedelta

from airflow.sdk.definitions.baseoperator import AirflowException


def print_hello():
    sleep(100)

with DAG(
    dag_id="hello_world_single_task",
    default_args={
        "owner": "airflow",
        "depends_on_past": False,
        "retries": 1,
    },
    description="A simple Hello World DAG with one task",
    schedule=None,
    start_date=datetime(2024, 1, 1),
    catchup=False,
    tags=["example"],
) as dag:
    hello_task = PythonOperator(
        retries=1,
        task_id="say_hello",
        execution_timeout=timedelta(seconds=1),
        python_callable=print_hello,
    )
```
Should be marked with `up_for_retry`
<img width="1722" alt="image" src="https://github.com/user-attachments/assets/8de40ddb-0bfb-4faa-a02e-5a6567570e15" />


2. A task raises the `AirflowException` 
Example: If we are unable to render the pod template for K8s while using K8sExecutor with Airflow.
```
@provide_session
def get_rendered_k8s_spec(task_instance: TaskInstance, session=NEW_SESSION) -> dict | None:
    """Fetch rendered template fields from DB."""
    from airflow.models.renderedtifields import RenderedTaskInstanceFields

    rendered_k8s_spec = RenderedTaskInstanceFields.get_k8s_pod_yaml(task_instance, session=session)
    if not rendered_k8s_spec:
        try:
            rendered_k8s_spec = render_k8s_pod_yaml(task_instance)
        except (TemplateAssertionError, UndefinedError) as e:
            raise AirflowException(f"Unable to render a k8s spec for this taskinstance: {e}") from e
    return rendered_k8s_spec
```


Key changes:
1. This PR adds the `up_for_retry` state into `TerminalTIState` as it is a terminal state and on hitting this state, anything additional work apart from marking it to that state needn't be done.
2. Called the API from task runner when AirflowTaskTimeout, AirflowException is raised.




<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
