### PR TITLE
Wait for config API to avoid NaN passed to offset. 

### DIFF
--- a/airflow/ui/src/pages/Dag/Runs/Runs.tsx
+++ b/airflow/ui/src/pages/Dag/Runs/Runs.tsx
@@ -26,7 +26,6 @@ import {
   Text,
 } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
-import dayjs from "dayjs";
 import { useCallback } from "react";
 import {
   useParams,
@@ -43,7 +42,7 @@ import { ErrorAlert } from "src/components/ErrorAlert";
 import { RunTypeIcon } from "src/components/RunTypeIcon";
 import Time from "src/components/Time";
 import { Select, Status } from "src/components/ui";
-import { capitalize } from "src/utils";
+import { capitalize, getDuration } from "src/utils";
 
 const columns: Array<ColumnDef<DAGRunResponse>> = [
   {
@@ -90,10 +89,7 @@ const columns: Array<ColumnDef<DAGRunResponse>> = [
   },
   {
     cell: ({ row: { original } }) =>
-      `${dayjs
-        .duration(dayjs(original.end_date ?? dayjs()).diff(original.start_date))
-        .asSeconds()
-        .toFixed(2)}s`,
+      getDuration(original.start_date, original.end_date),
     header: "Duration",
   },
   {

--- a/airflow/ui/src/pages/Dag/Runs/Runs.tsx
+++ b/airflow/ui/src/pages/Dag/Runs/Runs.tsx
@@ -90,7 +90,10 @@ const columns: Array<ColumnDef<DAGRunResponse>> = [
   },
   {
     cell: ({ row: { original } }) =>
-      `${dayjs.duration(dayjs(original.end_date).diff(original.start_date)).asSeconds().toFixed(2)}s`,
+      `${dayjs
+        .duration(dayjs(original.end_date ?? dayjs()).diff(original.start_date))
+        .asSeconds()
+        .toFixed(2)}s`,
     header: "Duration",
   },
   {
@@ -133,13 +136,17 @@ export const Runs = () => {
 
   const filteredState = searchParams.get(STATE_PARAM);
 
-  const { data, error, isFetching, isLoading } = useDagRunServiceGetDagRuns({
-    dagId: dagId ?? "~",
-    limit: pagination.pageSize,
-    offset: pagination.pageIndex * pagination.pageSize,
-    orderBy,
-    state: filteredState === null ? undefined : [filteredState],
-  });
+  const { data, error, isFetching, isLoading } = useDagRunServiceGetDagRuns(
+    {
+      dagId: dagId ?? "~",
+      limit: pagination.pageSize,
+      offset: pagination.pageIndex * pagination.pageSize,
+      orderBy,
+      state: filteredState === null ? undefined : [filteredState],
+    },
+    undefined,
+    { enabled: !isNaN(pagination.pageSize) },
+  );
 
   const handleStateChange = useCallback(
     ({ value }: SelectValueChangeDetails<string>) => {

--- a/airflow/ui/src/pages/Dag/Tasks/TaskRecentRuns.tsx
+++ b/airflow/ui/src/pages/Dag/Tasks/TaskRecentRuns.tsx
@@ -42,7 +42,9 @@ export const TaskRecentRuns = ({
     ...taskInstance,
     duration:
       dayjs
-        .duration(dayjs(taskInstance.end_date).diff(taskInstance.start_date))
+        .duration(
+          dayjs(taskInstance.end_date ?? dayjs()).diff(taskInstance.start_date),
+        )
         .asSeconds() || 0,
   }));
 

--- a/airflow/ui/src/pages/Dag/Tasks/Tasks.tsx
+++ b/airflow/ui/src/pages/Dag/Tasks/Tasks.tsx
@@ -89,6 +89,7 @@ export const Tasks = () => {
         dagId,
         dagRunId: "~",
         logicalDateGte: runs.at(-1)?.logical_date ?? "",
+        orderBy: "-start_date",
       },
       undefined,
       { enabled: Boolean(runs[0]?.dag_run_id) },
@@ -101,10 +102,7 @@ export const Tasks = () => {
         {pluralize("Task", data ? data.total_entries : 0)}
       </Heading>
       <DataTable
-        cardDef={cardDef(
-          dagId,
-          taskInstancesResponse?.task_instances.reverse(),
-        )}
+        cardDef={cardDef(dagId, taskInstancesResponse?.task_instances)}
         columns={[]}
         data={data ? data.tasks : []}
         displayMode="card"

--- a/airflow/ui/src/pages/Events/Events.tsx
+++ b/airflow/ui/src/pages/Events/Events.tsx
@@ -124,14 +124,18 @@ export const Events = () => {
     error: EventsError,
     isFetching,
     isLoading,
-  } = useEventLogServiceGetEventLogs({
-    dagId,
-    limit: pagination.pageSize,
-    offset: pagination.pageIndex * pagination.pageSize,
-    orderBy,
-    runId,
-    taskId,
-  });
+  } = useEventLogServiceGetEventLogs(
+    {
+      dagId,
+      limit: pagination.pageSize,
+      offset: pagination.pageIndex * pagination.pageSize,
+      orderBy,
+      runId,
+      taskId,
+    },
+    undefined,
+    { enabled: !isNaN(pagination.pageSize) },
+  );
 
   return (
     <Box>

--- a/airflow/ui/src/pages/Run/Header.tsx
+++ b/airflow/ui/src/pages/Run/Header.tsx
@@ -69,7 +69,7 @@ export const Header = ({ dagRun }: { readonly dagRun: DAGRunResponse }) => (
       </Stat>
       <Stat label="Duration">
         {dayjs
-          .duration(dayjs(dagRun.end_date).diff(dagRun.start_date))
+          .duration(dayjs(dagRun.end_date ?? dayjs()).diff(dagRun.start_date))
           .asSeconds()
           .toFixed(2)}
         s

--- a/airflow/ui/src/pages/Run/Header.tsx
+++ b/airflow/ui/src/pages/Run/Header.tsx
@@ -17,7 +17,6 @@
  * under the License.
  */
 import { Box, Flex, Heading, HStack, SimpleGrid, Text } from "@chakra-ui/react";
-import dayjs from "dayjs";
 import { FiBarChart } from "react-icons/fi";
 import { MdOutlineModeComment } from "react-icons/md";
 
@@ -27,6 +26,7 @@ import { RunTypeIcon } from "src/components/RunTypeIcon";
 import { Stat } from "src/components/Stat";
 import Time from "src/components/Time";
 import { Status } from "src/components/ui";
+import { getDuration } from "src/utils";
 
 export const Header = ({ dagRun }: { readonly dagRun: DAGRunResponse }) => (
   <Box borderColor="border" borderRadius={8} borderWidth={1} p={2}>
@@ -68,11 +68,7 @@ export const Header = ({ dagRun }: { readonly dagRun: DAGRunResponse }) => (
         <Time datetime={dagRun.end_date} />
       </Stat>
       <Stat label="Duration">
-        {dayjs
-          .duration(dayjs(dagRun.end_date ?? dayjs()).diff(dagRun.start_date))
-          .asSeconds()
-          .toFixed(2)}
-        s
+        {getDuration(dagRun.start_date, dagRun.end_date)}s
       </Stat>
     </SimpleGrid>
   </Box>

--- a/airflow/ui/src/pages/Run/TaskInstances.tsx
+++ b/airflow/ui/src/pages/Run/TaskInstances.tsx
@@ -18,7 +18,6 @@
  */
 import { Box, Link } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
-import dayjs from "dayjs";
 import { Link as RouterLink, useParams } from "react-router-dom";
 
 import { useTaskInstanceServiceGetTaskInstances } from "openapi/queries";
@@ -28,6 +27,7 @@ import { useTableURLState } from "src/components/DataTable/useTableUrlState";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import Time from "src/components/Time";
 import { Status } from "src/components/ui";
+import { getDuration } from "src/utils";
 
 const columns: Array<ColumnDef<TaskInstanceResponse>> = [
   {
@@ -82,10 +82,7 @@ const columns: Array<ColumnDef<TaskInstanceResponse>> = [
 
   {
     cell: ({ row: { original } }) =>
-      `${dayjs
-        .duration(dayjs(original.end_date ?? dayjs()).diff(original.start_date))
-        .asSeconds()
-        .toFixed(2)}s`,
+      `${getDuration(original.start_date, original.end_date)}s`,
     header: "Duration",
   },
 ];

--- a/airflow/ui/src/pages/Run/TaskInstances.tsx
+++ b/airflow/ui/src/pages/Run/TaskInstances.tsx
@@ -82,7 +82,10 @@ const columns: Array<ColumnDef<TaskInstanceResponse>> = [
 
   {
     cell: ({ row: { original } }) =>
-      `${dayjs.duration(dayjs(original.end_date).diff(original.start_date)).asSeconds().toFixed(2)}s`,
+      `${dayjs
+        .duration(dayjs(original.end_date ?? dayjs()).diff(original.start_date))
+        .asSeconds()
+        .toFixed(2)}s`,
     header: "Duration",
   },
 ];
@@ -95,13 +98,17 @@ export const TaskInstances = () => {
   const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : "-start_date";
 
   const { data, error, isFetching, isLoading } =
-    useTaskInstanceServiceGetTaskInstances({
-      dagId,
-      dagRunId: runId,
-      limit: pagination.pageSize,
-      offset: pagination.pageIndex * pagination.pageSize,
-      orderBy,
-    });
+    useTaskInstanceServiceGetTaskInstances(
+      {
+        dagId,
+        dagRunId: runId,
+        limit: pagination.pageSize,
+        offset: pagination.pageIndex * pagination.pageSize,
+        orderBy,
+      },
+      undefined,
+      { enabled: !isNaN(pagination.pageSize) },
+    );
 
   return (
     <Box>

--- a/airflow/ui/src/pages/TaskInstance/Header.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Header.tsx
@@ -72,7 +72,11 @@ export const Header = ({
       </Stat>
       <Stat label="Duration">
         {dayjs
-          .duration(dayjs(taskInstance.end_date).diff(taskInstance.start_date))
+          .duration(
+            dayjs(taskInstance.end_date ?? dayjs()).diff(
+              taskInstance.start_date,
+            ),
+          )
           .asSeconds()
           .toFixed(2)}
         s

--- a/airflow/ui/src/pages/TaskInstance/Header.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Header.tsx
@@ -17,13 +17,13 @@
  * under the License.
  */
 import { Box, Flex, Heading, HStack, SimpleGrid, Text } from "@chakra-ui/react";
-import dayjs from "dayjs";
 import { MdOutlineModeComment, MdOutlineTask } from "react-icons/md";
 
 import type { TaskInstanceResponse } from "openapi/requests/types.gen";
 import { Stat } from "src/components/Stat";
 import Time from "src/components/Time";
 import { Status } from "src/components/ui";
+import { getDuration } from "src/utils";
 
 export const Header = ({
   taskInstance,
@@ -71,15 +71,7 @@ export const Header = ({
         <Time datetime={taskInstance.end_date} />
       </Stat>
       <Stat label="Duration">
-        {dayjs
-          .duration(
-            dayjs(taskInstance.end_date ?? dayjs()).diff(
-              taskInstance.start_date,
-            ),
-          )
-          .asSeconds()
-          .toFixed(2)}
-        s
+        {getDuration(taskInstance.start_date, taskInstance.end_date)}s
       </Stat>
     </SimpleGrid>
   </Box>

--- a/airflow/ui/src/pages/XCom/XCom.tsx
+++ b/airflow/ui/src/pages/XCom/XCom.tsx
@@ -58,14 +58,18 @@ export const XCom = () => {
   const { setTableURLState, tableURLState } = useTableURLState();
   const { pagination } = tableURLState;
 
-  const { data, error, isFetching, isLoading } = useXcomServiceGetXcomEntries({
-    dagId,
-    dagRunId: runId,
-    limit: pagination.pageSize,
-    mapIndex,
-    offset: pagination.pageIndex * pagination.pageSize,
-    taskId,
-  });
+  const { data, error, isFetching, isLoading } = useXcomServiceGetXcomEntries(
+    {
+      dagId,
+      dagRunId: runId,
+      limit: pagination.pageSize,
+      mapIndex,
+      offset: pagination.pageIndex * pagination.pageSize,
+      taskId,
+    },
+    undefined,
+    { enabled: !isNaN(pagination.pageSize) },
+  );
 
   return (
     <Box>

--- a/airflow/ui/src/queries/useDags.tsx
+++ b/airflow/ui/src/queries/useDags.tsx
@@ -50,10 +50,12 @@ export const useDags = (
     tags?: Array<string>;
   } = {},
 ) => {
+  const offsetDefined =
+    searchParams.offset === undefined ? false : !isNaN(searchParams.offset);
   const { data, error, isFetching, isLoading } = useDagServiceGetDags(
     searchParams,
     undefined,
-    queryOptions,
+    { ...queryOptions, enabled: offsetDefined },
   );
 
   const { orderBy, ...runsParams } = searchParams;
@@ -68,7 +70,7 @@ export const useDags = (
       dagRunsLimit: 14,
     },
     undefined,
-    queryOptions,
+    { ...queryOptions, enabled: offsetDefined },
   );
 
   const dags = (data?.dags ?? []).map((dag) => {

--- a/airflow/ui/src/utils/datetime_utils.ts
+++ b/airflow/ui/src/utils/datetime_utils.ts
@@ -16,7 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import dayjs from "dayjs";
 
-export { capitalize } from "./capitalize";
-export { pluralize } from "./pluralize";
-export { getDuration } from "./datetime_utils";
+export const getDuration = (startDate: string | null, endDate: string | null) =>
+  dayjs
+    .duration(dayjs(endDate ?? undefined).diff(startDate ?? undefined))
+    .asSeconds()
+    .toFixed(2);


### PR DESCRIPTION
Whenever a page is loaded the offset and limit values are passed to the API from pagination object. `limit` is fetched from `config` API through `page_size` in airflow.cfg. As `pagination.pageSize` is undefined `offset` which is `pagination.pageIndex * pagination.pageSize` becomes NaN and passed to the API causing backend to return 422 if the API call for a resource is made before `config` finishes. Once config finishes the offset value is calculated properly and then passed to API resulting in two API calls with 1 invalid returning 422 and then again passing with valid offset value to fetch the correct response. Use `enabled` option to not make call if the `offset` is `NaN`. Another option would be default value for `pagination.pageSize` but that would result in 2 API calls with default value and later the value from `config` API call.

Another issue is that for running dagruns and running/deferred task instances the `end_date` is not present causing `NaN` to be displayed in UI in dagrun duration, task instance duration, etc. Use current time if end_date is not present like the legacy UI.

To reproduce : 

1. Open console and visit http://localhost:8000/webapp/dags
2. The console will log API calls sending NaN

http://localhost:8000/public/dags?offset=NaN&only_active=true&order_by=-last_run_start_date
http://localhost:8000/ui/dags/recent_dag_runs?dag_runs_limit=14&offset=NaN&only_active=true