### PR TITLE
Fix MetastoreHivePartitionSensor failing due to duplicate aliases

### DIFF
--- a/providers/src/airflow/providers/google/cloud/hooks/dataproc_metastore.py
+++ b/providers/src/airflow/providers/google/cloud/hooks/dataproc_metastore.py
@@ -60,11 +60,16 @@ class DataprocMetastoreHook(GoogleBaseHook):
 
     def wait_for_operation(self, timeout: float | None, operation: Operation):
         """Wait for long-lasting operation to complete."""
+        self.log.info("Waiting for operation (timeout: %s seconds)", timeout)
+
         try:
-            return operation.result(timeout=timeout)
-        except Exception:
+            result = operation.result(timeout=timeout)
+            self.log.info("Operation completed successfully")
+            return result
+        except Exception as e:
+            self.log.error("Operation failed: %s", str(e))
             error = operation.exception(timeout=timeout)
-            raise AirflowException(error)
+            raise AirflowException(f"Operation failed: {error}")
 
     @GoogleBaseHook.fallback_to_default_project_id
     def create_backup(
@@ -670,22 +675,33 @@ class DataprocMetastoreHook(GoogleBaseHook):
         _partitions = list(dict.fromkeys(partition_names)) if partition_names else []
 
         query = f"""
-                SELECT *
-                FROM PARTITIONS
-                INNER JOIN TBLS
-                ON PARTITIONS.TBL_ID = TBLS.TBL_ID
-                WHERE
-                    TBLS.TBL_NAME = '{table}'"""
+            SELECT PARTITIONS.*, TBLS.TBL_TYPE, TBLS.TBL_NAME
+            FROM PARTITIONS
+            INNER JOIN TBLS ON PARTITIONS.TBL_ID = TBLS.TBL_ID
+            WHERE TBLS.TBL_NAME = '{table}'"""
+
         if _partitions:
+            partition_list = ", ".join(f"'{p}'" for p in _partitions)
             query += f"""
-                    AND PARTITIONS.PART_NAME IN ({', '.join(f"'{p}'" for p in _partitions)})"""
+                AND PARTITIONS.PART_NAME IN ({partition_list})"""
         query += ";"
 
-        client = self.get_dataproc_metastore_client_v1beta()
-        result = client.query_metadata(
-            request={
-                "service": f"projects/{project_id}/locations/{region}/services/{service_id}",
-                "query": query,
-            }
-        )
-        return result
+        request = {
+            "service": f"projects/{project_id}/locations/{region}/services/{service_id}",
+            "query": query,
+        }
+
+        self.log.info("Prepared request:")
+        self.log.info(request)
+
+        # Execute query
+        try:
+            self.log.info("Getting Dataproc Metastore client (v1beta)...")
+            client = self.get_dataproc_metastore_client_v1beta()
+            self.log.info("Executing query_metadata...")
+            result = client.query_metadata(request=request)
+            self.log.info("Query executed successfully")
+            return result
+        except Exception as e:
+            self.log.error("Error executing query_metadata: %s", str(e))
+            raise

--- a/providers/src/airflow/providers/google/cloud/hooks/dataproc_metastore.py
+++ b/providers/src/airflow/providers/google/cloud/hooks/dataproc_metastore.py
@@ -674,17 +674,20 @@ class DataprocMetastoreHook(GoogleBaseHook):
         # because dictionaries are ordered since Python 3.7+
         _partitions = list(dict.fromkeys(partition_names)) if partition_names else []
 
-        query = f"""
-            SELECT PARTITIONS.*, TBLS.TBL_TYPE, TBLS.TBL_NAME
-            FROM PARTITIONS
-            INNER JOIN TBLS ON PARTITIONS.TBL_ID = TBLS.TBL_ID
-            WHERE TBLS.TBL_NAME = '{table}'"""
-
         if _partitions:
             partition_list = ", ".join(f"'{p}'" for p in _partitions)
-            query += f"""
-                AND PARTITIONS.PART_NAME IN ({partition_list})"""
-        query += ";"
+            query = f"""
+    SELECT PARTITIONS.*, TBLS.TBL_TYPE, TBLS.TBL_NAME
+    FROM PARTITIONS
+    INNER JOIN TBLS ON PARTITIONS.TBL_ID = TBLS.TBL_ID
+    WHERE TBLS.TBL_NAME = '{table}'
+        AND PARTITIONS.PART_NAME IN ({partition_list});"""
+        else:
+            query = f"""
+    SELECT PARTITIONS.*, TBLS.TBL_TYPE, TBLS.TBL_NAME
+    FROM PARTITIONS
+    INNER JOIN TBLS ON PARTITIONS.TBL_ID = TBLS.TBL_ID
+    WHERE TBLS.TBL_NAME = '{table}';"""
 
         request = {
             "service": f"projects/{project_id}/locations/{region}/services/{service_id}",

--- a/providers/tests/google/cloud/hooks/test_dataproc_metastore.py
+++ b/providers/tests/google/cloud/hooks/test_dataproc_metastore.py
@@ -60,20 +60,17 @@ TEST_TABLE_ID: str = "test_table"
 TEST_PARTITION_NAME = "column=value"
 TEST_SUBPARTITION_NAME = "column1=value1/column2=value2"
 TEST_PARTITIONS_QUERY_ALL = """
-                SELECT *
-                FROM PARTITIONS
-                INNER JOIN TBLS
-                ON PARTITIONS.TBL_ID = TBLS.TBL_ID
-                WHERE
-                    TBLS.TBL_NAME = '{}';"""
+    SELECT PARTITIONS.*, TBLS.TBL_TYPE, TBLS.TBL_NAME
+    FROM PARTITIONS
+    INNER JOIN TBLS ON PARTITIONS.TBL_ID = TBLS.TBL_ID
+    WHERE TBLS.TBL_NAME = '{}';"""
+
 TEST_PARTITIONS_QUERY = """
-                SELECT *
-                FROM PARTITIONS
-                INNER JOIN TBLS
-                ON PARTITIONS.TBL_ID = TBLS.TBL_ID
-                WHERE
-                    TBLS.TBL_NAME = '{}'
-                    AND PARTITIONS.PART_NAME IN ({});"""
+    SELECT PARTITIONS.*, TBLS.TBL_TYPE, TBLS.TBL_NAME
+    FROM PARTITIONS
+    INNER JOIN TBLS ON PARTITIONS.TBL_ID = TBLS.TBL_ID
+    WHERE TBLS.TBL_NAME = '{}'
+        AND PARTITIONS.PART_NAME IN ({});"""
 BASE_STRING = "airflow.providers.google.common.hooks.base_google.{}"
 DATAPROC_METASTORE_STRING = "airflow.providers.google.cloud.hooks.dataproc_metastore.{}"
 


### PR DESCRIPTION
MetastoreHivePartitionSensor is not working.

The query it uses to list partitions https://github.com/apache/airflow/blob/83da311e4ce5a7965b2e1c412941a8f26ad8225e/providers/src/airflow/providers/google/cloud/hooks/dataproc_metastore.py#L648
        
```
query = f"""
                SELECT *
                FROM PARTITIONS
                INNER JOIN TBLS
                ON PARTITIONS.TBL_ID = TBLS.TBL_ID
                WHERE
                    TBLS.TBL_NAME = '{table}'"""
```

fails, due to Duplicate Aliases (https://cloud.google.com/spanner/docs/reference/standard-sql/query-syntax#duplicate_aliases)

This query fixes the issue:

```
query = f"""
            SELECT PARTITIONS.*, TBLS.TBL_TYPE, TBLS.TBL_NAME
            FROM PARTITIONS
            INNER JOIN TBLS ON PARTITIONS.TBL_ID = TBLS.TBL_ID
            WHERE TBLS.TBL_NAME = '{table}'"""
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
