### PR TITLE
AIP-72: Fix floating point imprecision in TI Duration calculation for SQLite

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -3615,7 +3615,10 @@ class TaskInstance(Base, LoggingMixin):
             return query.values(
                 {
                     "end_date": end_date,
-                    "duration": (func.julianday(end_date) - func.julianday(cls.start_date)) * 86400,
+                    "duration": (
+                        (func.strftime("%s", end_date) - func.strftime("%s", cls.start_date))
+                        + func.round((func.strftime("%f", end_date) - func.strftime("%f", cls.start_date)), 3)
+                    ),
                 }
             )
         elif bind.dialect.name == "postgresql":

--- a/tests/api_fastapi/execution_api/routes/test_task_instances.py
+++ b/tests/api_fastapi/execution_api/routes/test_task_instances.py
@@ -456,8 +456,6 @@ class TestTIHealthEndpoint:
         assert ti.last_heartbeat_at == time_now.add(minutes=10)
 
     def test_ti_update_state_to_failed_table_check(self, client, session, create_task_instance):
-        from math import ceil
-
         ti = create_task_instance(
             task_id="test_ti_update_state_to_failed_table_check",
             state=State.RUNNING,
@@ -482,8 +480,7 @@ class TestTIHealthEndpoint:
         assert ti.state == State.FAILED
         assert ti.next_method is None
         assert ti.next_kwargs is None
-        # TODO: remove/amend this once https://github.com/apache/airflow/pull/45002 is merged
-        assert ceil(ti.duration) == 3600.00
+        assert ti.duration == 3600.00
 
 
 class TestTIPutRTIF:


### PR DESCRIPTION
[julianday](https://www.sqlite.org/lang_datefunc.html#:~:text=The%20number%20of%20days%20including%20fractional%20days%20since%20%2D4713%2D11%2D24%2012%3A00%3A00%20Example%3A%202460825.09444444) returns timestamps as fractional days. Multiplying this value by 86400 (seconds in a day) introduces minor floating-point inaccuracies, which can cause subtle errors in downstream calculations or assertions.

Example ( [PR failure](https://github.com/apache/airflow/actions/runs/12350551354/job/34464066950#step:7:2178) ):

```sql
SELECT (julianday('2024-06-01T01:00:00') - julianday('2024-06-01T00:00:00')) * 86400;
-- Result: 3599.999986588955 (instead of 3600.0)
```

After:

```sql
SELECT 
  (strftime('%s', '2024-06-01T01:00:00') - strftime('%s', '2024-06-01T00:00:00'))
  + ROUND((strftime('%f', '2024-06-01T01:00:00') - strftime('%f', '2024-06-01T00:00:00')), 3);
-- Result: 3600.0
```

Even with the milli-second precision:

```sql
SELECT 
  (strftime('%s', '2024-06-01T01:00:00.456') - strftime('%s', '2024-06-01T00:00:00.123'))
  + ROUND((strftime('%f', '2024-06-01T01:00:00.456') - strftime('%f', '2024-06-01T00:00:00.123')), 3);
-- Result: 3600.333
```

Some sources:

- https://stackoverflow.com/questions/289680/difference-between-2-dates-in-sqlite
- https://stackoverflow.com/questions/40419417/operating-with-datetimes-in-sqlite
- https://stackoverflow.com/questions/35552867/sqlite-difference-between-dates-in-millisecond
- [https://www.sqlite.org/lang_datefunc.html](https://www.sqlite.org/lang_datefunc.html#:~:text=The%20number%20of%20days%20including%20fractional%20days%20since%20%2D4713%2D11%2D24%2012%3A00%3A00%20Example%3A%202460825.09444444)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
