### PR TITLE
Bugfix some Doc urls in repo

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
@@ -730,7 +730,7 @@ def should_we_run_the_build(build_ci_params: BuildCiParams) -> bool:
                     get_console().print(
                         f"[info]Please rebase your code to latest {build_ci_params.airflow_branch} "
                         "before continuing.[/]\nCheck this link to find out how "
-                        "https://github.com/apache/airflow/blob/main/contributing-docs/11_working_with_git.rst\n"
+                        "https://github.com/apache/airflow/blob/main/contributing-docs/10_working_with_git.rst\n"
                     )
                     get_console().print("[error]Exiting the process[/]\n")
                     sys.exit(1)

--- a/docs/docker-stack/README.md
+++ b/docs/docker-stack/README.md
@@ -63,7 +63,7 @@ packages or even custom providers. You can learn how to do it in [Building the i
 
 The production images are build in DockerHub from released version and release candidates. There
 are also images published from branches but they are used mainly for development and testing purpose.
-See [Airflow Git Branching](https://github.com/apache/airflow/blob/main/contributing-docs/working-with-git#airflow-git-branches)
+See [Airflow Git Branching](https://github.com/apache/airflow/blob/main/contributing-docs/10_working_with_git.rst#airflow-git-branches)
 for details.
 
 ## Usage

--- a/docs/docker-stack/index.rst
+++ b/docs/docker-stack/index.rst
@@ -80,7 +80,7 @@ packages or even custom providers. You can learn how to do it in :ref:`Building 
 
 The production images are build in DockerHub from released version and release candidates. There
 are also images published from branches but they are used mainly for development and testing purpose.
-See `Airflow Git Branching <https://github.com/apache/airflow/blob/main/contributing-docs/working-with-git#airflow-git-branches>`_
+See `Airflow Git Branching <https://github.com/apache/airflow/blob/main/contributing-docs/10_working_with_git.rst#airflow-git-branches>`_
 for details.
 
 Fixing images at release time

--- a/scripts/ci/pre_commit/new_session_in_provide_session.py
+++ b/scripts/ci/pre_commit/new_session_in_provide_session.py
@@ -119,7 +119,7 @@ def main(argv: list[str]) -> int:
         print("Only function decorated with @provide_session should use 'session: Session = NEW_SESSION'.")
         print(
             "See: https://github.com/apache/airflow/blob/main/"
-            "contributing-docs/creating_issues_and_pull_requests#database-session-handling"
+            "contributing-docs/05_pull_requests.rst#database-session-handling"
         )
     return len(errors)
 


### PR DESCRIPTION
While I was working on PR #44982 and hitting a pre-commit error I noticed that the link to the docs are outdated.

Went through the obvious links to contribution docs and updated "some" broken links with the correct URL as on main.

Does this need to be back-ported to v2-10-test branch?