### PR TITLE
Team Based Configuration (AIP-67)

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -85,6 +85,7 @@ core:
       type: string
       example: ~
       default: "SequentialExecutor"
+      multi_team: true
     auth_manager:
       description: |
         The auth manager class that airflow should use. Full import path to the auth manager class.
@@ -525,6 +526,13 @@ core:
       type: integer
       example: ~
       default: "4096"
+    multi_team_configurations:
+      description: |
+        A comma delimited list of team names and their respective configuration files (separated by a colon).
+      version_added: 3.1.0
+      type: string
+      example: "path/to/team_a/config:team_a,different/path/team_b/configuration:team_b"
+      default: ""
 database:
   description: ~
   options:

--- a/airflow/config_templates/team_unit_tests.cfg
+++ b/airflow/config_templates/team_unit_tests.cfg
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# NOTE FOR CONTRIBUTORS:
+#
+# Note this is an example TEAM based config.
+#
+# Values specified in this file are automatically used in our unit tests
+# run by pytest and override default airflow configuration values provided by config.yml.
+#
+# These configuration settings should provide consistent environment to run tests -
+# no matter if you are in Breeze env or use local venv or even run tests in the CI environment.
+#
+# If you want to have all unit tests to get some default configuration value, you should set it here.
+#
+# You cannot use ``conf_vars`` context manager to override the configuration for this config at this moment.
+#
+# The test configuration is loaded via setting AIRFLOW__CORE__UNIT_TEST_MODE=True
+# in a pytest fixture in tests/conftest.py. This in turn triggers reloading of the configuration
+# from this file after cleaning the respective configuration retrieved during initialization
+# of configuration. See ``load_test_config`` function in ``airflow/config.py`` for details.
+#
+
+# TODO: update this description to include team
+
+[core]
+executor = SequentialExecutor

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -216,6 +216,7 @@ class AirflowConfigParser(ConfigParser):
         self.is_validated = False
         self._suppress_future_warnings = False
         self._providers_configuration_loaded = False
+        self._team_configs = {}  # type: ignore[var-annotated]
 
     def _update_logging_deprecated_template_to_one_from_defaults(self):
         default = self.get_default_value("logging", "log_filename_template")
@@ -790,12 +791,14 @@ class AirflowConfigParser(ConfigParser):
                 continue
             mask_secret(value)
 
-    def _env_var_name(self, section: str, key: str) -> str:
-        return f"{ENV_VAR_PREFIX}{section.replace('.', '_').upper()}__{key.upper()}"
+    def _env_var_name(self, section: str, key: str, team_id: str | None = None) -> str:
+        team_component = f"{team_id.upper()}__" if team_id else ""
+        return f"{ENV_VAR_PREFIX}{team_component}{section.replace('.', '_').upper()}__{key.upper()}"
 
-    def _get_env_var_option(self, section: str, key: str):
-        # must have format AIRFLOW__{SECTION}__{KEY} (note double underscore)
-        env_var = self._env_var_name(section, key)
+    def _get_env_var_option(self, section: str, key: str, team_id: str | None = None):
+        # must have format AIRFLOW__{SECTION}__{KEY} (note double underscore) OR for team based
+        # configuration must have the format AIRFLOW__{TEAM_ID}__{SECTION}__{KEY}
+        env_var = self._env_var_name(section, key, team_id=team_id)
         if env_var in os.environ:
             return expand_env_var(os.environ[env_var])
         # alternatively AIRFLOW__{SECTION}__{KEY}_CMD (for a command)
@@ -885,6 +888,7 @@ class AirflowConfigParser(ConfigParser):
         key: str,
         suppress_warnings: bool = False,
         _extra_stacklevel: int = 0,
+        team_id: str | None = None,
         **kwargs,
     ) -> str | None:
         section = section.lower()
@@ -942,6 +946,7 @@ class AirflowConfigParser(ConfigParser):
             deprecated_section,
             key,
             section,
+            team_id=team_id,
             issue_warning=not warning_emitted,
             extra_stacklevel=_extra_stacklevel,
         )
@@ -955,6 +960,7 @@ class AirflowConfigParser(ConfigParser):
             key,
             kwargs,
             section,
+            team_id=team_id,
             issue_warning=not warning_emitted,
             extra_stacklevel=_extra_stacklevel,
         )
@@ -967,6 +973,7 @@ class AirflowConfigParser(ConfigParser):
             deprecated_section,
             key,
             section,
+            team_id=team_id,
             issue_warning=not warning_emitted,
             extra_stacklevel=_extra_stacklevel,
         )
@@ -979,6 +986,7 @@ class AirflowConfigParser(ConfigParser):
             deprecated_section,
             key,
             section,
+            team_id=team_id,
             issue_warning=not warning_emitted,
             extra_stacklevel=_extra_stacklevel,
         )
@@ -1004,9 +1012,20 @@ class AirflowConfigParser(ConfigParser):
         deprecated_section: str | None,
         key: str,
         section: str,
+        team_id: str | None = None,
         issue_warning: bool = True,
         extra_stacklevel: int = 0,
     ) -> str | None:
+        if team_id:
+            # The number of team configs that are going to be needed will be small and so support for obscure
+            # ways to pass configuration just complicate things unnecessarily. This can always be added in
+            # the future if there is enough user demand.
+            log.debug(
+                "Secrets are not supported for team configs. "
+                "Please use environment variables or the team configuration file instead."
+            )
+            return None
+
         option = self._get_secret_option(section, key)
         if option:
             return option
@@ -1025,9 +1044,20 @@ class AirflowConfigParser(ConfigParser):
         deprecated_section: str | None,
         key: str,
         section: str,
+        team_id: str | None = None,
         issue_warning: bool = True,
         extra_stacklevel: int = 0,
     ) -> str | None:
+        if team_id:
+            # The number of team configs that are going to be needed will be small and so support for obscure
+            # ways to pass configuration just complicate things unnecessarily. This can always be added in
+            # the future if there is enough user demand.
+            log.debug(
+                "Commands are not supported for team configs. "
+                "Please use environment variables or the team configuration file instead."
+            )
+            return None
+
         option = self._get_cmd_option(section, key)
         if option:
             return option
@@ -1047,19 +1077,23 @@ class AirflowConfigParser(ConfigParser):
         key: str,
         kwargs: dict[str, Any],
         section: str,
+        team_id: str | None = None,
         issue_warning: bool = True,
         extra_stacklevel: int = 0,
     ) -> str | None:
-        if super().has_option(section, key):
+        # Get a specific team config if team_id is set otherwise use the standard conf parser
+        config_parser = self._team_configs.get(team_id, super())
+
+        if config_parser.has_option(section, key):
             # Use the parent's methods to get the actual config here to be able to
             # separate the config from default config.
-            return expand_env_var(super().get(section, key, **kwargs))
+            return expand_env_var(config_parser.get(section, key, **kwargs))
         if deprecated_section and deprecated_key:
-            if super().has_option(deprecated_section, deprecated_key):
+            if config_parser.has_option(deprecated_section, deprecated_key):
                 if issue_warning:
                     self._warn_deprecate(section, key, deprecated_section, deprecated_key, extra_stacklevel)
                 with self.suppress_future_warnings():
-                    return expand_env_var(super().get(deprecated_section, deprecated_key, **kwargs))
+                    return expand_env_var(config_parser.get(deprecated_section, deprecated_key, **kwargs))
         return None
 
     def _get_environment_variables(
@@ -1068,15 +1102,16 @@ class AirflowConfigParser(ConfigParser):
         deprecated_section: str | None,
         key: str,
         section: str,
+        team_id: str | None = None,
         issue_warning: bool = True,
         extra_stacklevel: int = 0,
     ) -> str | None:
-        option = self._get_env_var_option(section, key)
+        option = self._get_env_var_option(section, key, team_id=team_id)
         if option is not None:
             return option
         if deprecated_section and deprecated_key:
             with self.suppress_future_warnings():
-                option = self._get_env_var_option(deprecated_section, deprecated_key)
+                option = self._get_env_var_option(deprecated_section, deprecated_key, team_id=team_id)
             if option is not None:
                 if issue_warning:
                     self._warn_deprecate(section, key, deprecated_section, deprecated_key, extra_stacklevel)
@@ -1240,7 +1275,7 @@ class AirflowConfigParser(ConfigParser):
         """
         super().read_dict(dictionary=dictionary, source=source)
 
-    def has_option(self, section: str, option: str) -> bool:
+    def has_option(self, section: str, option: str, team_id=None) -> bool:
         """
         Check if option is defined.
 
@@ -1249,10 +1284,13 @@ class AirflowConfigParser(ConfigParser):
 
         :param section: section to get option from
         :param option: option to get
+        :param team_id: team_id to get option from
         :return:
         """
         try:
-            value = self.get(section, option, fallback=None, _extra_stacklevel=1, suppress_warnings=True)
+            value = self.get(
+                section, option, fallback=None, _extra_stacklevel=1, suppress_warnings=True, team_id=team_id
+            )
             if value is None:
                 return False
             return True
@@ -1763,6 +1801,29 @@ class AirflowConfigParser(ConfigParser):
         """Checks if providers have been loaded."""
         return self._providers_configuration_loaded
 
+    def setup_team_configs(self, from_dict: dict | None = None):
+        """
+        Load the team configurations if any are specified.
+
+        They are a comma delimited list of items where each item is a path to a team configuration
+        file and a team id (separated by a colon).
+        """
+        team_configs = self.get("core", "multi_team_configurations")
+        if not team_configs:
+            return
+        for team_config in team_configs.split(","):
+            team_config_path, team_id = team_config.split(":")
+            # Create a parser for each team, teams will implement the same configurations so they get their
+            # own parsers such that they do not overwrite each other
+            team_parser = create_default_config_parser(self.configuration_description, multi_team=True)
+            if from_dict:
+                team_parser.read_dict(from_dict)
+            else:
+                # Load the config file into the team config parser
+                team_parser.read(team_config_path)
+
+            self._team_configs[team_id] = team_parser
+
     def load_providers_configuration(self):
         """
         Load configuration for providers.
@@ -1874,9 +1935,11 @@ def _generate_fernet_key() -> str:
     return Fernet.generate_key().decode()
 
 
-def create_default_config_parser(configuration_description: dict[str, dict[str, Any]]) -> ConfigParser:
+def create_default_config_parser(
+    configuration_description: dict[str, dict[str, Any]], multi_team: bool = False
+) -> ConfigParser:
     """
-    Create default config parser based on configuration description.
+    Create default Airflow or multi-team config parser based on configuration description.
 
     It creates ConfigParser with all default values retrieved from the configuration description and
     expands all the variables from the global and local variables defined in this module.
@@ -1888,9 +1951,14 @@ def create_default_config_parser(configuration_description: dict[str, dict[str, 
     parser = ConfigParser()
     all_vars = get_all_expansion_variables()
     for section, section_desc in configuration_description.items():
+        # TODO: Should we avoid adding sections that don't have any team specific configs? Will that cause
+        # any issues?
         parser.add_section(section)
         options = section_desc["options"]
         for key in options:
+            if multi_team and not options[key].get("multi_team", False):
+                # We are building a multi-team config and this option is not multi-team, skip it.
+                continue
             default_value = options[key]["default"]
             is_template = options[key].get("is_template", False)
             if default_value is not None:
@@ -2025,6 +2093,16 @@ def initialize_config() -> AirflowConfigParser:
     # Set the WEBSERVER_CONFIG variable
     global WEBSERVER_CONFIG
     WEBSERVER_CONFIG = airflow_config_parser.get("webserver", "config_file")
+    # Set up the configs for any teams
+    if airflow_config_parser.getboolean("core", "unit_test_mode"):
+        # Set the path to a test team config file
+        team_unit_test_config_file = (
+            pathlib.Path(__file__).parent / "config_templates" / "team_unit_tests.cfg"
+        )
+        multi_team_config = f"{team_unit_test_config_file}:unit_test_team"
+        airflow_config_parser.set("core", "multi_team_configurations", multi_team_config)
+    airflow_config_parser.setup_team_configs()
+
     return airflow_config_parser
 
 

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -108,6 +108,25 @@ class RunningRetryAttemptType:
         return True
 
 
+class ExecutorConf:
+    """
+    This class is used to fetch configuration for an executor for a particular team_id.
+
+    It wraps the implementation of the configuration.get() to look for the particular section and key
+    prefixed with the team_id. This makes it easy for child classes (i.e. concrete executors) to fetch
+    configuration values for a particular team_id without having to worry about passing through the team_id.
+    """
+
+    def __init__(self, team_id: str | None = None):
+        self.team_id = team_id
+
+    def get(self, *args, **kwargs):
+        return conf.get(*args, **kwargs, team_id=self.team_id)
+
+    def getboolean(self, *args, **kwargs):
+        return conf.getboolean(*args, **kwargs, team_id=self.team_id)
+
+
 class BaseExecutor(LoggingMixin):
     """
     Base class to inherit for concrete executors such as Celery, Kubernetes, Local, Sequential, etc.
@@ -132,6 +151,7 @@ class BaseExecutor(LoggingMixin):
         super().__init__()
         self.parallelism: int = parallelism
         self.team_id: str | None = team_id
+        self.conf = ExecutorConf(team_id)
         self.queued_tasks: dict[TaskInstanceKey, QueuedTaskInstanceType] = {}
         self.running: set[TaskInstanceKey] = set()
         self.event_buffer: dict[TaskInstanceKey, EventBufferValueType] = {}

--- a/providers/src/airflow/providers/amazon/aws/executors/ecs/ecs_executor.py
+++ b/providers/src/airflow/providers/amazon/aws/executors/ecs/ecs_executor.py
@@ -32,7 +32,6 @@ from typing import TYPE_CHECKING
 
 from botocore.exceptions import ClientError, NoCredentialsError
 
-from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.executors.base_executor import BaseExecutor
 from airflow.providers.amazon.aws.executors.ecs.boto_schema import BotoDescribeTasksSchema, BotoRunTaskSchema
@@ -90,13 +89,6 @@ class AwsEcsExecutor(BaseExecutor):
      Airflow TaskInstance's executor_config.
     """
 
-    # Maximum number of retries to run an ECS task.
-    MAX_RUN_TASK_ATTEMPTS = conf.get(
-        CONFIG_GROUP_NAME,
-        AllEcsConfigKeys.MAX_RUN_TASK_ATTEMPTS,
-        fallback=CONFIG_DEFAULTS[AllEcsConfigKeys.MAX_RUN_TASK_ATTEMPTS],
-    )
-
     # AWS limits the maximum number of ARNs in the describe_tasks function.
     DESCRIBE_TASKS_BATCH_SIZE = 99
 
@@ -105,8 +97,8 @@ class AwsEcsExecutor(BaseExecutor):
         self.active_workers: EcsTaskCollection = EcsTaskCollection()
         self.pending_tasks: deque = deque()
 
-        self.cluster = conf.get(CONFIG_GROUP_NAME, AllEcsConfigKeys.CLUSTER)
-        self.container_name = conf.get(CONFIG_GROUP_NAME, AllEcsConfigKeys.CONTAINER_NAME)
+        self.cluster = self.conf.get(CONFIG_GROUP_NAME, AllEcsConfigKeys.CLUSTER)
+        self.container_name = self.conf.get(CONFIG_GROUP_NAME, AllEcsConfigKeys.CONTAINER_NAME)
         self.attempts_since_last_successful_connection = 0
 
         self.load_ecs_connection(check_connection=False)
@@ -114,9 +106,16 @@ class AwsEcsExecutor(BaseExecutor):
 
         self.run_task_kwargs = self._load_run_kwargs()
 
+        # Maximum number of retries to run an ECS task.
+        self.max_run_task_attempts = self.conf.get(
+            CONFIG_GROUP_NAME,
+            AllEcsConfigKeys.MAX_RUN_TASK_ATTEMPTS,
+            fallback=CONFIG_DEFAULTS[AllEcsConfigKeys.MAX_RUN_TASK_ATTEMPTS],
+        )
+
     def start(self):
         """Call this when the Executor is run for the first time by the scheduler."""
-        check_health = conf.getboolean(
+        check_health = self.conf.getboolean(
             CONFIG_GROUP_NAME, AllEcsConfigKeys.CHECK_HEALTH_ON_STARTUP, fallback=False
         )
 
@@ -180,12 +179,12 @@ class AwsEcsExecutor(BaseExecutor):
 
     def load_ecs_connection(self, check_connection: bool = True):
         self.log.info("Loading Connection information")
-        aws_conn_id = conf.get(
+        aws_conn_id = self.conf.get(
             CONFIG_GROUP_NAME,
             AllEcsConfigKeys.AWS_CONN_ID,
             fallback=CONFIG_DEFAULTS[AllEcsConfigKeys.AWS_CONN_ID],
         )
-        region_name = conf.get(CONFIG_GROUP_NAME, AllEcsConfigKeys.REGION_NAME, fallback=None)
+        region_name = self.conf.get(CONFIG_GROUP_NAME, AllEcsConfigKeys.REGION_NAME, fallback=None)
         self.ecs = EcsHook(aws_conn_id=aws_conn_id, region_name=region_name).conn
         self.attempts_since_last_successful_connection += 1
         self.last_connection_reload = timezone.utcnow()
@@ -302,13 +301,13 @@ class AwsEcsExecutor(BaseExecutor):
         queue = task_info.queue
         exec_info = task_info.config
         failure_count = self.active_workers.failure_count_by_key(task_key)
-        if int(failure_count) < int(self.__class__.MAX_RUN_TASK_ATTEMPTS):
+        if int(failure_count) < int(self.max_run_task_attempts):
             self.log.warning(
                 "Airflow task %s failed due to %s. Failure %s out of %s occurred on %s. Rescheduling.",
                 task_key,
                 reason,
                 failure_count,
-                self.__class__.MAX_RUN_TASK_ATTEMPTS,
+                self.max_run_task_attempts,
                 task_arn,
             )
             self.pending_tasks.append(
@@ -378,8 +377,8 @@ class AwsEcsExecutor(BaseExecutor):
                     failure_reasons.extend([f["reason"] for f in run_task_response["failures"]])
 
             if failure_reasons:
-                # Make sure the number of attempts does not exceed MAX_RUN_TASK_ATTEMPTS
-                if int(attempt_number) < int(self.__class__.MAX_RUN_TASK_ATTEMPTS):
+                # Make sure the number of attempts does not exceed max_run_task_attempts
+                if int(attempt_number) < int(self.max_run_task_attempts):
                     ecs_task.attempt_number += 1
                     ecs_task.next_attempt_time = timezone.utcnow() + calculate_next_attempt_delay(
                         attempt_number
@@ -495,7 +494,7 @@ class AwsEcsExecutor(BaseExecutor):
     def _load_run_kwargs(self) -> dict:
         from airflow.providers.amazon.aws.executors.ecs.ecs_executor_config import build_task_kwargs
 
-        ecs_executor_run_task_kwargs = build_task_kwargs()
+        ecs_executor_run_task_kwargs = build_task_kwargs(self.conf)
 
         try:
             self.get_container(ecs_executor_run_task_kwargs["overrides"]["containerOverrides"])["command"]

--- a/providers/src/airflow/providers/amazon/aws/executors/ecs/ecs_executor.py
+++ b/providers/src/airflow/providers/amazon/aws/executors/ecs/ecs_executor.py
@@ -97,6 +97,14 @@ class AwsEcsExecutor(BaseExecutor):
         self.active_workers: EcsTaskCollection = EcsTaskCollection()
         self.pending_tasks: deque = deque()
 
+        # Check if self has the ExecutorConf set on the self.conf attribute, and if not, set it to the global
+        # configuration object. This allows the changes to be backwards compatible with older versions of
+        # Airflow.
+        if not hasattr(self, "conf"):
+            from airflow.configuration import conf
+
+            self.conf = conf
+
         self.cluster = self.conf.get(CONFIG_GROUP_NAME, AllEcsConfigKeys.CLUSTER)
         self.container_name = self.conf.get(CONFIG_GROUP_NAME, AllEcsConfigKeys.CONTAINER_NAME)
         self.attempts_since_last_successful_connection = 0

--- a/providers/tests/amazon/aws/executors/ecs/test_ecs_executor.py
+++ b/providers/tests/amazon/aws/executors/ecs/test_ecs_executor.py
@@ -446,7 +446,7 @@ class TestAwsEcsExecutor:
         mock_executor.execute_async(mock_airflow_key, mock_cmd)
 
         # No matter what, don't schedule until run_task becomes successful.
-        for _ in range(int(mock_executor.MAX_RUN_TASK_ATTEMPTS) * 2):
+        for _ in range(int(mock_executor.max_run_task_attempts) * 2):
             mock_executor.attempt_task_runs()
             # Task is not stored in active workers.
             assert len(mock_executor.active_workers) == 0
@@ -463,7 +463,7 @@ class TestAwsEcsExecutor:
         mock_executor.execute_async(mock_airflow_key, mock_cmd)
 
         # No matter what, don't schedule until run_task becomes successful.
-        for _ in range(int(mock_executor.MAX_RUN_TASK_ATTEMPTS) * 2):
+        for _ in range(int(mock_executor.max_run_task_attempts) * 2):
             mock_executor.attempt_task_runs()
             # Task is not stored in active workers.
             assert len(mock_executor.active_workers) == 0
@@ -475,7 +475,7 @@ class TestAwsEcsExecutor:
 
         The executor should attempt each task exactly once per sync() iteration.
         It should preserve the order of tasks, and attempt each task up to
-        `MAX_RUN_TASK_ATTEMPTS` times before dropping the task.
+        `max_run_task_attempts` times before dropping the task.
         """
         airflow_keys = [
             TaskInstanceKey("a", "task_a", "c", 1, -1),
@@ -535,7 +535,7 @@ class TestAwsEcsExecutor:
 
         The executor should attempt each task exactly once per sync() iteration.
         It should preserve the order of tasks, and attempt each task up to
-        `MAX_RUN_TASK_ATTEMPTS` times before dropping the task. If a task succeeds, the task
+        `max_run_task_attempts` times before dropping the task. If a task succeeds, the task
         should be removed from pending_jobs and into active_workers.
         """
         airflow_keys = [
@@ -613,7 +613,7 @@ class TestAwsEcsExecutor:
         """
         Test API failure retries.
         """
-        AwsEcsExecutor.MAX_RUN_TASK_ATTEMPTS = "2"
+        mock_executor.max_run_task_attempts = "2"
         airflow_keys = ["TaskInstanceKey1", "TaskInstanceKey2"]
         airflow_commands = [mock.Mock(spec=list), mock.Mock(spec=list)]
 
@@ -742,7 +742,7 @@ class TestAwsEcsExecutor:
     @mock.patch.object(BaseExecutor, "success")
     def test_failed_sync(self, success_mock, fail_mock, mock_executor):
         """Test success and failure states."""
-        AwsEcsExecutor.MAX_RUN_TASK_ATTEMPTS = "1"
+        mock_executor.max_run_task_attempts = "1"
         self._mock_sync(mock_executor, State.FAILED)
 
         mock_executor.sync()
@@ -758,7 +758,7 @@ class TestAwsEcsExecutor:
     @mock.patch.object(BaseExecutor, "fail")
     def test_removed_sync(self, fail_mock, success_mock, mock_executor):
         """A removed task will be treated as a failed task."""
-        AwsEcsExecutor.MAX_RUN_TASK_ATTEMPTS = "1"
+        mock_executor.max_run_task_attempts = "1"
         self._mock_sync(mock_executor, expected_state=State.REMOVED, set_task_state=State.REMOVED)
 
         mock_executor.sync_running_tasks()
@@ -774,7 +774,7 @@ class TestAwsEcsExecutor:
     @mock.patch.object(ecs_executor, "calculate_next_attempt_delay", return_value=dt.timedelta(seconds=0))
     def test_failed_sync_cumulative_fail(self, _, success_mock, fail_mock, mock_airflow_key, mock_executor):
         """Test that failure_count/attempt_number is cumulative for pending tasks and active workers."""
-        AwsEcsExecutor.MAX_RUN_TASK_ATTEMPTS = "5"
+        mock_executor.max_run_task_attempts = "5"
         mock_executor.ecs.run_task.return_value = {
             "tasks": [],
             "failures": [
@@ -887,8 +887,8 @@ class TestAwsEcsExecutor:
         assert len(mock_executor.active_workers.get_all_arns()) == 1
         task_key = mock_executor.active_workers.arn_to_key[ARN1]
 
-        # Call Sync 2 times with failures. The task can only fail MAX_RUN_TASK_ATTEMPTS times.
-        for check_count in range(1, int(AwsEcsExecutor.MAX_RUN_TASK_ATTEMPTS)):
+        # Call Sync 2 times with failures. The task can only fail max_run_task_attempts times.
+        for check_count in range(1, int(mock_executor.max_run_task_attempts)):
             mock_executor.sync_running_tasks()
             assert mock_executor.ecs.describe_tasks.call_count == check_count
 
@@ -1122,7 +1122,7 @@ class TestAwsEcsExecutor:
         mock_success_function.assert_called_once()
 
     def test_update_running_tasks_failed(self, mock_executor, caplog):
-        AwsEcsExecutor.MAX_RUN_TASK_ATTEMPTS = "1"
+        mock_executor.max_run_task_attempts = "1"
         caplog.set_level(logging.WARNING)
         self._add_mock_task(mock_executor, ARN1)
         test_response_task_json = {
@@ -1249,7 +1249,7 @@ class TestEcsExecutorConfig:
         }
         with conf_vars(conf_overrides):
             with pytest.raises(ValueError) as raised:
-                ecs_executor_config.build_task_kwargs()
+                ecs_executor_config.build_task_kwargs(conf)
         assert raised.match("At least one subnet is required to run a task.")
 
     def test_team_config(self):
@@ -1304,7 +1304,7 @@ class TestEcsExecutorConfig:
     def test_config_defaults_are_applied(self, assign_subnets):
         from airflow.providers.amazon.aws.executors.ecs import ecs_executor_config
 
-        task_kwargs = _recursive_flatten_dict(ecs_executor_config.build_task_kwargs())
+        task_kwargs = _recursive_flatten_dict(ecs_executor_config.build_task_kwargs(conf))
         found_keys = {convert_camel_to_snake(key): key for key in task_kwargs.keys()}
 
         for expected_key, expected_value in CONFIG_DEFAULTS.items():
@@ -1342,12 +1342,12 @@ class TestEcsExecutorConfig:
         monkeypatch.delenv(run_task_kwargs_env_key, raising=False)
         from airflow.providers.amazon.aws.executors.ecs import ecs_executor_config
 
-        task_kwargs = ecs_executor_config.build_task_kwargs()
+        task_kwargs = ecs_executor_config.build_task_kwargs(conf)
         assert task_kwargs["platformVersion"] == default_version
 
         # Provide a new value explicitly and assert that it is applied over the default.
         monkeypatch.setenv(platform_version_env_key, first_explicit_version)
-        task_kwargs = ecs_executor_config.build_task_kwargs()
+        task_kwargs = ecs_executor_config.build_task_kwargs(conf)
         assert task_kwargs["platformVersion"] == first_explicit_version
 
         # Provide a value via template and assert that it is applied over the explicit value.
@@ -1355,12 +1355,12 @@ class TestEcsExecutorConfig:
             run_task_kwargs_env_key,
             json.dumps({AllEcsConfigKeys.PLATFORM_VERSION: templated_version}),
         )
-        task_kwargs = ecs_executor_config.build_task_kwargs()
+        task_kwargs = ecs_executor_config.build_task_kwargs(conf)
         assert task_kwargs["platformVersion"] == templated_version
 
         # Provide a new value explicitly and assert it is not applied over the templated values.
         monkeypatch.setenv(platform_version_env_key, second_explicit_version)
-        task_kwargs = ecs_executor_config.build_task_kwargs()
+        task_kwargs = ecs_executor_config.build_task_kwargs(conf)
         assert task_kwargs["platformVersion"] == templated_version
 
     @mock.patch.object(EcsHook, "conn")
@@ -1382,7 +1382,7 @@ class TestEcsExecutorConfig:
             f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.RUN_TASK_KWARGS}".upper(),
             json.dumps(provided_run_task_kwargs),
         )
-        task_kwargs = ecs_executor_config.build_task_kwargs()
+        task_kwargs = ecs_executor_config.build_task_kwargs(conf)
         assert task_kwargs["platformVersion"] == templated_version
         assert task_kwargs["cluster"] == templated_cluster
 
@@ -1399,7 +1399,7 @@ class TestEcsExecutorConfig:
 
         run_task_kwargs_env_key = f"AIRFLOW__{CONFIG_GROUP_NAME}__{AllEcsConfigKeys.RUN_TASK_KWARGS}".upper()
         monkeypatch.setenv(run_task_kwargs_env_key, json.dumps(provided_run_task_kwargs))
-        task_kwargs = ecs_executor_config.build_task_kwargs()
+        task_kwargs = ecs_executor_config.build_task_kwargs(conf)
 
         # Verify that tag names are exempt from the camel-case conversion.
         assert task_kwargs["tags"] == templated_tags
@@ -1419,7 +1419,7 @@ class TestEcsExecutorConfig:
         for key, value in kwargs_to_test.items():
             monkeypatch.setenv(f"AIRFLOW__{CONFIG_GROUP_NAME}__{key}".upper(), value)
 
-        run_task_kwargs = ecs_executor_config.build_task_kwargs()
+        run_task_kwargs = ecs_executor_config.build_task_kwargs(conf)
         run_task_kwargs_network_config = run_task_kwargs["networkConfiguration"]["awsvpcConfiguration"]
         for key, value in kwargs_to_test.items():
             # Assert that the values are not at the root of the kwargs
@@ -1523,7 +1523,7 @@ class TestEcsExecutorConfig:
         with conf_vars(conf_overrides):
             from airflow.providers.amazon.aws.executors.ecs import ecs_executor_config
 
-            task_kwargs = ecs_executor_config.build_task_kwargs()
+            task_kwargs = ecs_executor_config.build_task_kwargs(conf)
             assert "launchType" not in task_kwargs
             assert task_kwargs["capacityProviderStrategy"] == valid_capacity_provider
 
@@ -1537,7 +1537,7 @@ class TestEcsExecutorConfig:
         with conf_vars({(CONFIG_GROUP_NAME, AllEcsConfigKeys.LAUNCH_TYPE): None}):
             from airflow.providers.amazon.aws.executors.ecs import ecs_executor_config
 
-            task_kwargs = ecs_executor_config.build_task_kwargs()
+            task_kwargs = ecs_executor_config.build_task_kwargs(conf)
             assert "launchType" not in task_kwargs
             assert "capacityProviderStrategy" not in task_kwargs
             mock_conn.describe_clusters.assert_called_once()
@@ -1550,7 +1550,7 @@ class TestEcsExecutorConfig:
         with conf_vars({(CONFIG_GROUP_NAME, AllEcsConfigKeys.LAUNCH_TYPE): None}):
             from airflow.providers.amazon.aws.executors.ecs import ecs_executor_config
 
-            task_kwargs = ecs_executor_config.build_task_kwargs()
+            task_kwargs = ecs_executor_config.build_task_kwargs(conf)
             assert task_kwargs["launchType"] == "FARGATE"
 
     @pytest.mark.parametrize(

--- a/providers/tests/amazon/aws/executors/ecs/test_ecs_executor.py
+++ b/providers/tests/amazon/aws/executors/ecs/test_ecs_executor.py
@@ -60,7 +60,7 @@ from airflow.version import version as airflow_version_str
 
 from tests_common import RUNNING_TESTS_AGAINST_AIRFLOW_PACKAGES
 from tests_common.test_utils.config import conf_vars
-from tests_common.test_utils.version_compat import AIRFLOW_V_2_10_PLUS
+from tests_common.test_utils.version_compat import AIRFLOW_V_2_10_PLUS, AIRFLOW_V_3_0_PLUS
 
 pytestmark = pytest.mark.db_test
 
@@ -1252,6 +1252,8 @@ class TestEcsExecutorConfig:
                 ecs_executor_config.build_task_kwargs(conf)
         assert raised.match("At least one subnet is required to run a task.")
 
+    # TODO: When merged this needs updating to the actually supported version
+    @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Test requires Airflow 3.0+")
     def test_team_config(self):
         # Team name to be used throughout
         team_name = "team_a"

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -146,6 +146,17 @@ class TestConf:
 
         assert conf.has_option("testsection", "testkey")
 
+    def test_config_team(self):
+        assert conf.get("core", "executor") == "LocalExecutor"
+        assert conf.get("core", "executor", team_id="unit_test_team") == "SequentialExecutor"
+
+    def test_env_team(self):
+        with patch(
+            "os.environ", {"AIRFLOW__CORE__EXECUTOR": "FOO", "AIRFLOW__UNIT_TEST_TEAM__CORE__EXECUTOR": "BAR"}
+        ):
+            assert conf.get("core", "executor") == "FOO"
+            assert conf.get("core", "executor", team_id="unit_test_team") == "BAR"
+
     @conf_vars({("core", "percent"): "with%%inside"})
     def test_conf_as_dict(self):
         cfg_dict = conf.as_dict()


### PR DESCRIPTION
### PLEASE READ DESCRIPTION

Context: In the context of multi team airflow, teams will have their own configuration files for the components that run on team-only hosts (for workers, dag parsers, etc running on those hosts). However some team components must live along side one another on the scheduler host, namely executors, and some airflow configuration affecting teams must also be accessible to the scheduler.

This commit delivers the capability for airflow `conf` to load and allow access to multiple team configurations in addition to the main/global configuration we have today.

A new config is added `core.multi_team_configurations` (the name is not set in stone) in which teams and their associated configuration files are specified. E.g.:
```
path/to/team_a/config:team_a,different/path/team_b/configuration:team_b
```

Airflow conf, during initialization, loads each of these configurations and makes them accessible by id, e.g.: `conf.get("core", "executor", team_id="team_a")`

Within those team configurations, teams can specify the executors they would like to use and the associated configuration for those executors. Since each team configuration is loaded and stored separately, this allows multiple instances of the same executor to be configured.

The Base executor has been updated with a config shim to allow easier access to team based executor configations and the AWS ECS executor has been updated to use it as a proof of concept. Other executors will need to be updated to be "multi team compliant" at a later time to minimize the size and scope of this commit.

#### NOTE: There was an initial proposal to move to TOML format for Airflow config and store all configuration (both team and gloabl) in one file. This is still a possibility in the future, but the approach in this commit was decided for the following reasons:
1. It leverages the same configuration format as Airflow always had, so there is less barrier to entry and migration for users
2. It is a simpler implementation, which simplifies the overall process of releasing an initial version of multi-team airflow
3. Separate files for teams is actually a nice mechanism for management of the overall cluster. Teams can update their own files as they see fit and they only need to be synced onto the scheduler host for pickup, rather than the configuration changes needing to be made to a shared file which no team should be able to view (otherwise they would see the configuration from other teams).

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
