### PR TITLE
Remove deprecated `DEFAULT_CELERY_CONFIG` from core config_templates

### DIFF
--- a/airflow/config_templates/__init__.py
+++ b/airflow/config_templates/__init__.py
@@ -15,14 +15,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from __future__ import annotations
-
-from airflow.utils.deprecation_tools import add_deprecated_classes
-
-__deprecated_classes = {
-    "default_celery": {
-        "DEFAULT_CELERY_CONFIG": "airflow.providers.celery.executors.default_celery.DEFAULT_CELERY_CONFIG",
-    },
-}
-
-add_deprecated_classes(__deprecated_classes, __name__, {}, "The `celery` provider must be >= 3.3.0 for that.")

--- a/newsfragments/1.significant.rst
+++ b/newsfragments/1.significant.rst
@@ -1,0 +1,18 @@
+Remove deprecated ``DEFAULT_CELERY_CONFIG`` from config templates
+
+``DEFAULT_CELERY_CONFIG`` has been moved into the celery provider and
+should be imported from ``airflow.providers.celery.executors.default_celery.DEFAULT_CELERY_CONFIG``.
+
+* Types of change
+
+  * [ ] DAG changes
+  * [x] Config changes
+  * [ ] API changes
+  * [ ] CLI changes
+  * [ ] Behaviour changes
+  * [ ] Plugin changes
+  * [ ] Dependency change
+
+* Migration rules needed
+
+    * AIR303 rewrite ``airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG`` to ``airflow.providers.celery.executors.default_celery.DEFAULT_CELERY_CONFIG``


### PR DESCRIPTION
This default dict has been moved to the celery provider. We no longer need to support the old import in Airflow 3.