### PR TITLE
Upgrade v2-10-test dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -467,21 +467,21 @@ repos:
         files: ^docs/apache-airflow/extra-packages-ref\.rst$|^hatch_build.py
         pass_filenames: false
         entry: ./scripts/ci/pre_commit/check_extra_packages_ref.py
-        additional_dependencies: ['rich>=12.4.4', 'hatchling==1.26.3', 'tabulate']
+        additional_dependencies: ['rich>=12.4.4', 'hatchling==1.27.0', 'tabulate']
       - id: check-hatch-build-order
         name: Check order of dependencies in hatch_build.py
         language: python
         files: ^hatch_build.py$
         pass_filenames: false
         entry: ./scripts/ci/pre_commit/check_order_hatch_build.py
-        additional_dependencies: ['rich>=12.4.4', 'hatchling==1.26.3']
+        additional_dependencies: ['rich>=12.4.4', 'hatchling==1.27.0']
       - id: update-extras
         name: Update extras in documentation
         entry: ./scripts/ci/pre_commit/insert_extras.py
         language: python
         files: ^contributing-docs/12_airflow_dependencies_and_extras.rst$|^INSTALL$|^airflow/providers/.*/provider\.yaml$|^Dockerfile.*
         pass_filenames: false
-        additional_dependencies: ['rich>=12.4.4', 'hatchling==1.26.3']
+        additional_dependencies: ['rich>=12.4.4', 'hatchling==1.27.0']
       - id: check-extras-order
         name: Check order of extras in Dockerfile
         entry: ./scripts/ci/pre_commit/check_order_dockerfile_extras.py

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -16,7 +16,7 @@
 # under the License.
 
 [build-system]
-requires = ["hatchling==1.26.3"]
+requires = ["hatchling==1.27.0"]
 build-backend = "hatchling.build"
 
 [project]

--- a/docker_tests/requirements.txt
+++ b/docker_tests/requirements.txt
@@ -3,4 +3,4 @@ pytest-xdist
 # Requests 3 if it will be released, will be heavily breaking.
 requests>=2.27.0,<3
 python-on-whales>=0.70.0
-hatchling==1.26.3
+hatchling==1.27.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@
 requires = [
     "GitPython==3.1.43",
     "gitdb==4.0.11",
-    "hatchling==1.26.3",
+    "hatchling==1.27.0",
     "packaging==24.2",
     "pathspec==0.12.1",
     "pluggy==1.5.0",


### PR DESCRIPTION
I failed in backporting to v2-10-test, but in both PRs some else "falls apart".

This PR fixes depdencies reported as "fixes needed" from a test CI run in https://github.com/apache/airflow/actions/runs/12388030828/job/34578488895

(There might be more coming, let's see what other tests fail on v2-10-test)