### PR TITLE
Fix DB isolation tests on v2-10-test

### DIFF
--- a/tests/models/test_mappedoperator.py
+++ b/tests/models/test_mappedoperator.py
@@ -1786,6 +1786,7 @@ class TestMappedSetupTeardown:
         assert states == expected
 
 
+@pytest.mark.skip_if_database_isolation_mode  # Does not work in db isolation mode
 def test_mapped_tasks_in_mapped_task_group_waits_for_upstreams_to_complete(dag_maker, session):
     """Test that one failed trigger rule works well in mapped task group"""
     with dag_maker() as dag:
@@ -1817,6 +1818,7 @@ def test_mapped_tasks_in_mapped_task_group_waits_for_upstreams_to_complete(dag_m
     assert not ti3.state
 
 
+@pytest.mark.skip_if_database_isolation_mode  # Does not work in db isolation mode
 def test_mapped_tasks_in_mapped_task_group_waits_for_upstreams_to_complete__mapped_skip_with_all_success(
     dag_maker, session
 ):

--- a/tests/models/test_skipmixin.py
+++ b/tests/models/test_skipmixin.py
@@ -116,6 +116,7 @@ class TestSkipMixin:
         assert not session.query.called
         assert not session.commit.called
 
+    @pytest.mark.skip_if_database_isolation_mode  # Does not work in db isolation mode
     def test_skip_mapped_task(self, mock_session):
         SkipMixin()._skip(
             dag_run=MagicMock(spec=DagRun),
@@ -128,6 +129,7 @@ class TestSkipMixin:
         mock_session.execute.assert_not_called()
         mock_session.commit.assert_not_called()
 
+    @pytest.mark.skip_if_database_isolation_mode  # Does not work in db isolation mode
     @patch("airflow.models.skipmixin.update")
     def test_skip_none_mapped_task(self, mock_update, mock_session):
         SkipMixin()._skip(

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -3768,6 +3768,7 @@ class TestTaskInstance:
         ti.refresh_from_db()
         assert ti.state == State.SUCCESS
 
+    @pytest.mark.skip_if_database_isolation_mode  # Does not work in db isolation mode, fails in context serialization
     @pytest.mark.parametrize(
         "code, expected_state",
         [


### PR DESCRIPTION
I failed in backporting to v2-10-test, but in both PRs some else "falls apart".

This PR fixes DB Isolation test reported as "failed" from a test CI run in https://github.com/apache/airflow/actions/runs/12388030828/job/34578488895

From my point of view the tests are OK in general but just test are broken in DB isolation mode. Seems not really being a harm in 2.10.4.