### PR TITLE
Fix clear dagrun endpoint

### DIFF
--- a/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -245,8 +245,8 @@ def clear_dag_run(
         )
     else:
         dag.clear(
-            start_date=dag_run.start_date,
-            end_date=dag_run.end_date,
+            start_date=start_date,
+            end_date=end_date,
             task_ids=None,
             only_failed=False,
             session=session,


### PR DESCRIPTION
During the development of the associated frontend I noticed that this endpoint wasn't working properly.

There was a small difference introduced compared to the legacy implementation, tasks were not cleared for some dags.