### PR TITLE
Fix DB isolation tests on v2-10-test

### DIFF
--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -289,6 +289,7 @@ class TestPythonOperator(BasePythonTest):
 
         self.run_as_task(func, op_kwargs={"custom": 1})
 
+    @pytest.mark.skip_if_database_isolation_mode  # Does not work in db isolation mode, fails in context serialization
     def test_context_with_kwargs(self):
         def func(**context):
             # check if context is being set


### PR DESCRIPTION
Unfortunately in #45021 I over-looked and left one failure in pytests.
With this v2-10-test should be green again.