### PR TITLE
Fix type of "moment" when running an e2e example for deferred TI

### DIFF
--- a/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
+++ b/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
@@ -30,6 +30,8 @@ from airflow.api_fastapi.execution_api.datamodels.variable import VariableRespon
 from airflow.utils.state import IntermediateTIState, TaskInstanceState as TIState, TerminalTIState
 from airflow.utils.types import DagRunType
 
+AwareDatetimeAdapter = TypeAdapter(AwareDatetime)
+
 
 class TIEnterRunningPayload(BaseModel):
     """Schema for updating TaskInstance to 'RUNNING' state with minimal required fields."""
@@ -85,12 +87,8 @@ class TIDeferredStatePayload(BaseModel):
 
     @field_validator("trigger_kwargs")
     def validate_moment(cls, v):
-        if "moment" in v and isinstance(v["moment"], str):
-            moment_adapter = TypeAdapter(AwareDatetime)
-            try:
-                v["moment"] = moment_adapter.validate_strings(v["moment"].replace("Z", "+00:00"))
-            except ValueError:
-                raise ValueError("Invalid datetime format for 'moment'. Missing timezone information")
+        if "moment" in v:
+            v["moment"] = AwareDatetimeAdapter.validate_strings(v["moment"])
         return v
 
 

--- a/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
+++ b/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
@@ -83,7 +83,7 @@ class TIDeferredStatePayload(BaseModel):
     next_method: str
     trigger_timeout: timedelta | None = None
 
-    @field_validator("trigger_kwargs", mode="before")
+    @field_validator("trigger_kwargs")
     def validate_moment(cls, v):
         from datetime import datetime
 

--- a/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -216,6 +216,7 @@ def ti_update_state(
             kwargs=ti_patch_payload.trigger_kwargs,
         )
         session.add(trigger_row)
+        session.flush()
 
         # TODO: HANDLE execution timeout later as it requires a call to the DB
         # either get it from the serialised DAG or get it from the API

--- a/tests/api_fastapi/execution_api/routes/test_task_instances.py
+++ b/tests/api_fastapi/execution_api/routes/test_task_instances.py
@@ -259,7 +259,7 @@ class TestTIUpdateState:
 
         payload = {
             "state": "deferred",
-            "trigger_kwargs": {"key": "value"},
+            "trigger_kwargs": {"key": "value", "moment": "2024-12-18T00:00:00Z"},
             "classpath": "my-classpath",
             "next_method": "execute_callback",
             "trigger_timeout": "P1D",  # 1 day
@@ -277,14 +277,20 @@ class TestTIUpdateState:
 
         assert tis[0].state == TaskInstanceState.DEFERRED
         assert tis[0].next_method == "execute_callback"
-        assert tis[0].next_kwargs == {"key": "value"}
+        assert tis[0].next_kwargs == {
+            "key": "value",
+            "moment": datetime(2024, 12, 18, 00, 00, 00, tzinfo=timezone.utc),
+        }
         assert tis[0].trigger_timeout == timezone.make_aware(datetime(2024, 11, 23), timezone=timezone.utc)
 
         t = session.query(Trigger).all()
         assert len(t) == 1
         assert t[0].created_date == instant
         assert t[0].classpath == "my-classpath"
-        assert t[0].kwargs == {"key": "value"}
+        assert t[0].kwargs == {
+            "key": "value",
+            "moment": datetime(2024, 12, 18, 00, 00, 00, tzinfo=timezone.utc),
+        }
 
 
 class TestTIHealthEndpoint:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

While trying to run an e2e example of a task that defers and then launches a trigger:
```
from airflow import DAG

from airflow.providers.standard.sensors.date_time import DateTimeSensorAsync
from airflow.utils import timezone
import datetime

with DAG(
    dag_id="demo_deferred",
    schedule=None,
    catchup=False,
) as dag:
    DateTimeSensorAsync(
            task_id="async",
            target_time=str(timezone.utcnow() + datetime.timedelta(seconds=3)),
            poke_interval=60,
            timeout=600,
        )
```

I realised that the "moment" inside "trigger_kwargs" is of `pendulum.DateTime` type, and since we have a "dict[str, ANY]`, defined here: https://github.com/apache/airflow/blob/main/airflow/api_fastapi/execution_api/datamodels/taskinstance.py#L82
 
on its datamodel (we cant really have a `UtcDateTime` for one specific field, like we do [here](https://github.com/apache/airflow/blob/main/airflow/api_fastapi/execution_api/datamodels/taskinstance.py#L57C15-L57C26)), it fails to match the type defined in the `Trigger` table which is datetime. 

So, I have added a "before" validator that checks for the type being string and if it is a string, translates it to a datetime object. 


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
