### PR TITLE
Add support for custom celery configs

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2607,6 +2607,7 @@ config:
   celery:
     flower_url_prefix: '{{ ternary "" .Values.ingress.flower.path (eq .Values.ingress.flower.path "/") }}'
     worker_concurrency: 16
+    extra_celery_config: '{}'
   scheduler:
     standalone_dag_processor: '{{ ternary "True" "False" .Values.dagProcessor.enabled }}'
     # statsd params included for Airflow 1.10 backward compatibility; moved to [metrics] in 2.0

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2607,7 +2607,6 @@ config:
   celery:
     flower_url_prefix: '{{ ternary "" .Values.ingress.flower.path (eq .Values.ingress.flower.path "/") }}'
     worker_concurrency: 16
-    extra_celery_config: '{}'
   scheduler:
     standalone_dag_processor: '{{ ternary "True" "False" .Values.dagProcessor.enabled }}'
     # statsd params included for Airflow 1.10 backward compatibility; moved to [metrics] in 2.0

--- a/providers/src/airflow/providers/celery/executors/default_celery.py
+++ b/providers/src/airflow/providers/celery/executors/default_celery.py
@@ -87,7 +87,7 @@ DEFAULT_CELERY_CONFIG = {
     ),
     "worker_concurrency": conf.getint("celery", "WORKER_CONCURRENCY", fallback=16),
     "worker_enable_remote_control": conf.getboolean("celery", "worker_enable_remote_control", fallback=True),
-    **extra_celery_config,
+    **(extra_celery_config if isinstance(extra_celery_config, dict) else {}),
 }
 
 

--- a/providers/src/airflow/providers/celery/executors/default_celery.py
+++ b/providers/src/airflow/providers/celery/executors/default_celery.py
@@ -69,6 +69,8 @@ else:
     log.debug("Value for celery result_backend not found. Using sql_alchemy_conn with db+ prefix.")
     result_backend = f'db+{conf.get("database", "SQL_ALCHEMY_CONN")}'
 
+extra_celery_config: dict = conf.getjson("celery", "extra_celery_config", fallback={}) if conf.has_option("celery", "extra_celery_config") else {}
+
 DEFAULT_CELERY_CONFIG = {
     "accept_content": ["json"],
     "event_serializer": "json",
@@ -85,6 +87,7 @@ DEFAULT_CELERY_CONFIG = {
     ),
     "worker_concurrency": conf.getint("celery", "WORKER_CONCURRENCY", fallback=16),
     "worker_enable_remote_control": conf.getboolean("celery", "worker_enable_remote_control", fallback=True),
+    **extra_celery_config
 }
 
 

--- a/providers/src/airflow/providers/celery/executors/default_celery.py
+++ b/providers/src/airflow/providers/celery/executors/default_celery.py
@@ -87,7 +87,7 @@ DEFAULT_CELERY_CONFIG = {
     ),
     "worker_concurrency": conf.getint("celery", "WORKER_CONCURRENCY", fallback=16),
     "worker_enable_remote_control": conf.getboolean("celery", "worker_enable_remote_control", fallback=True),
-    **extra_celery_config
+    **extra_celery_config,
 }
 
 

--- a/providers/src/airflow/providers/celery/executors/default_celery.py
+++ b/providers/src/airflow/providers/celery/executors/default_celery.py
@@ -69,7 +69,7 @@ else:
     log.debug("Value for celery result_backend not found. Using sql_alchemy_conn with db+ prefix.")
     result_backend = f'db+{conf.get("database", "SQL_ALCHEMY_CONN")}'
 
-extra_celery_config: dict = conf.getjson("celery", "extra_celery_config", fallback={}) if conf.has_option("celery", "extra_celery_config") else {}
+extra_celery_config: dict = conf.getjson("celery", "extra_celery_config", fallback={})
 
 DEFAULT_CELERY_CONFIG = {
     "accept_content": ["json"],

--- a/providers/src/airflow/providers/celery/executors/default_celery.py
+++ b/providers/src/airflow/providers/celery/executors/default_celery.py
@@ -69,7 +69,7 @@ else:
     log.debug("Value for celery result_backend not found. Using sql_alchemy_conn with db+ prefix.")
     result_backend = f'db+{conf.get("database", "SQL_ALCHEMY_CONN")}'
 
-extra_celery_config: dict = conf.getjson("celery", "extra_celery_config", fallback={})
+extra_celery_config = conf.getjson("celery", "extra_celery_config", fallback={})
 
 DEFAULT_CELERY_CONFIG = {
     "accept_content": ["json"],

--- a/providers/src/airflow/providers/celery/provider.yaml
+++ b/providers/src/airflow/providers/celery/provider.yaml
@@ -332,7 +332,9 @@ config:
         default: "False"
       extra_celery_config:
         description: |
-          Extra celery configs to include in the celery worker. Any of the celery config can be added to this config and it will be applied while starting the celery worker. e.g. {"worker_max_tasks_per_child": 10}
+          Extra celery configs to include in the celery worker.
+          Any of the celery config can be added to this config and it
+          will be applied while starting the celery worker. e.g. {"worker_max_tasks_per_child": 10}
           See also:
           https://docs.celeryq.dev/en/stable/userguide/configuration.html#configuration-and-defaults
         version_added: ~

--- a/providers/src/airflow/providers/celery/provider.yaml
+++ b/providers/src/airflow/providers/celery/provider.yaml
@@ -340,7 +340,7 @@ config:
         version_added: ~
         type: string
         example: ~
-        default: "{}"
+        default: "{{}}"
   celery_broker_transport_options:
     description: |
       This section is for specifying options which can be passed to the

--- a/providers/src/airflow/providers/celery/provider.yaml
+++ b/providers/src/airflow/providers/celery/provider.yaml
@@ -332,7 +332,9 @@ config:
         default: "False"
       extra_celery_config:
         description: |
-          Extra celery configs to include in the celery worker
+          Extra celery configs to include in the celery worker. Any of the celery config can be added to this config and it will be applied while starting the celery worker. e.g. {"worker_max_tasks_per_child": 10}
+          See also:
+          https://docs.celeryq.dev/en/stable/userguide/configuration.html#configuration-and-defaults
         version_added: ~
         type: string
         example: ~

--- a/providers/src/airflow/providers/celery/provider.yaml
+++ b/providers/src/airflow/providers/celery/provider.yaml
@@ -330,6 +330,13 @@ config:
         type: string
         example: ~
         default: "False"
+      extra_celery_config:
+        description: |
+          Extra celery configs to include in the celery worker
+        version_added: ~
+        type: string
+        example: ~
+        default: "{}"
   celery_broker_transport_options:
     description: |
       This section is for specifying options which can be passed to the

--- a/providers/tests/celery/executors/test_celery_executor.py
+++ b/providers/tests/celery/executors/test_celery_executor.py
@@ -407,6 +407,4 @@ def test_celery_extra_celery_config_loaded_from_string():
 
     # reload celery conf to apply the new config
     importlib.reload(default_celery)
-    assert default_celery.DEFAULT_CELERY_CONFIG["extra_celery_config"] == {
-        "worker_max_tasks_per_child": 10
-    }
+    assert default_celery.DEFAULT_CELERY_CONFIG["extra_celery_config"] == {"worker_max_tasks_per_child": 10}

--- a/providers/tests/celery/executors/test_celery_executor.py
+++ b/providers/tests/celery/executors/test_celery_executor.py
@@ -399,3 +399,14 @@ def test_celery_task_acks_late_loaded_from_string():
     # reload celery conf to apply the new config
     importlib.reload(default_celery)
     assert default_celery.DEFAULT_CELERY_CONFIG["task_acks_late"] is False
+
+
+@conf_vars({("celery", "extra_celery_config"): '{"worker_max_tasks_per_child": 10}'})
+def test_celery_extra_celery_config_loaded_from_string():
+    import importlib
+
+    # reload celery conf to apply the new config
+    importlib.reload(default_celery)
+    assert default_celery.DEFAULT_CELERY_CONFIG["extra_celery_config"] == {
+        "worker_max_tasks_per_child": 10
+    }

--- a/providers/tests/celery/executors/test_celery_executor.py
+++ b/providers/tests/celery/executors/test_celery_executor.py
@@ -407,4 +407,4 @@ def test_celery_extra_celery_config_loaded_from_string():
 
     # reload celery conf to apply the new config
     importlib.reload(default_celery)
-    assert default_celery.DEFAULT_CELERY_CONFIG["extra_celery_config"] == {"worker_max_tasks_per_child": 10}
+    assert default_celery.DEFAULT_CELERY_CONFIG["extra_celery_config"] == 10

--- a/providers/tests/celery/executors/test_celery_executor.py
+++ b/providers/tests/celery/executors/test_celery_executor.py
@@ -407,4 +407,4 @@ def test_celery_extra_celery_config_loaded_from_string():
 
     # reload celery conf to apply the new config
     importlib.reload(default_celery)
-    assert default_celery.DEFAULT_CELERY_CONFIG["extra_celery_config"] == 10
+    assert default_celery.DEFAULT_CELERY_CONFIG["worker_max_tasks_per_child"] == 10


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/45037

Description:
Currently Airflow support limited celery options only. This PR adds the support for the additional celery config for celery workers.

1. Changes are completely backward compatible
2. No test cases found for these changes
3. If the config is not available then default value of {} is taken which will be same as earlier only
4. If config is available then it will be added to the celery config and applied to celery workers.