### PR TITLE
Upgrade cryptography package to fix vulnerable OpenSSL

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -11,3 +11,4 @@ rich
 rich_click
 semver
 tabulate
+cryptography>43.0.1


### PR DESCRIPTION
Upgrade cryptography package to fix vulnerable OpenSSL

https://github.com/advisories/GHSA-h4gh-qq45-vh27