### PR TITLE
Bump hatch version in breeze and prevent "get-workflow-info" failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,12 +160,15 @@ jobs:
       - name: "Get information about the Workflow"
         id: source-run-info
         run: breeze ci get-workflow-info 2>> ${GITHUB_OUTPUT}
+        env:
+          SKIP_BREEZE_SELF_UPGRADE_CHECK: "true"
       - name: Selective checks
         id: selective-checks
         env:
           PR_LABELS: "${{ steps.source-run-info.outputs.pr-labels }}"
           COMMIT_REF: "${{ github.sha }}"
           VERBOSE: "false"
+
         run: breeze ci selective-check 2>> ${GITHUB_OUTPUT}
       - name: env
         run: printenv

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -52,6 +52,8 @@ jobs:
       - name: "Get information about the Workflow"
         id: source-run-info
         run: breeze ci get-workflow-info 2>> ${GITHUB_OUTPUT}
+        env:
+          SKIP_BREEZE_SELF_UPGRADE_CHECK: "true"
       - name: Selective checks
         id: selective-checks
         env:

--- a/dev/breeze/README.md
+++ b/dev/breeze/README.md
@@ -128,6 +128,6 @@ PLEASE DO NOT MODIFY THE HASH BELOW! IT IS AUTOMATICALLY UPDATED BY PRE-COMMIT.
 
 ---------------------------------------------------------------------------------------------------------
 
-Package config hash: d58974d3f120f707d02ad2594b03c96cdda42fe07621d940dbb357ef5eafce5a49dc9725a0e1a076800a126616196205ecb2a2a6e6f6541e12c1284aaf307df2
+Package config hash: d9c2c903940272a1640ebf7e9db4e4df4a153bbc6c491932978ae805a5b4031b33ae621321f48c8e157a3ad5dd16203fa45eb4819fdef04fcec2cb0a7e36dfab
 
 ---------------------------------------------------------------------------------------------------------

--- a/dev/breeze/pyproject.toml
+++ b/dev/breeze/pyproject.toml
@@ -52,23 +52,14 @@ dependencies = [
     # It turns out that when packages are prepared metadata version in the produced packages
     # is taken from the front-end not from the backend, so in order to make sure that the
     # packages are reproducible, we should pin both backend in "build-system" and frontend in
-    # "dependencies" of the environment that is used to build the packages.
-    #
-    # TODO(potiuk): automate bumping the version of flit in breeze and sync it with
-    # the version in the template for provider packages with pre-commit also add instructions in
-    # the source packages explaining that reproducibility can only be achieved by using the same
-    # version of flit front-end to build the package
-    #
+    # "dependencies" of the environment that is used to build the packages
     "flit==3.10.1",
     "flit-core==3.10.1",
     "google-api-python-client>=2.142.0",
     "google-auth-httplib2>=0.2.0",
     "google-auth-oauthlib>=1.2.0",
     "gitpython>=3.1.40",
-    "hatch==1.9.4",
-    # Importib_resources 6.2.0-6.3.1 break pytest_rewrite
-    # see https://github.com/python/importlib_resources/issues/299
-    "importlib_resources>=5.2,!=6.2.0,!=6.3.0,!=6.3.1;python_version<\"3.9\"",
+    "hatch==1.14.0",
     "inputimeout>=1.0.4",
     "jinja2>=3.1.0",
     "jsonschema>=4.19.1",


### PR DESCRIPTION
We enabled dependabot to bump dependencies for various Python requirements we have in Airflow and it found out that we have pretty out-dated hatch - pinned because of metadata stability when building packages. The update caused "get-workflow-info" step in CI to fail because the "get-workflow-info" commmand contained output from uv upgrading breeze while it was running.

This PR bumps the version manually to the latest version, also it sets `SKIP_BREEZE_SELF_UPGRADE_CHECK` variable to true in the `get-workflow-info` step - to prevent breeze from checking and automatically upgrading itself.

This will not make future dependabot PRs to succeed, because those PRs will not update hash of README file - so the PRs will fail at the pre-commit stage, but at least it will be clear what should be done to fix it.

Also a bit of cleanup has been done opportunistically:

* the TODO on flit automation can now be removed as we have
  dependabot taking care about it automatically in both places
  that we were supposed to automate

* the importlib_resources exclusions were only used for Python
  < 3.9 and we are now >= 3.0 so we can remove it

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
