### PR TITLE
AIP-72: Allow retrieving Connection from Task Context

### DIFF
--- a/task_sdk/src/airflow/sdk/__init__.py
+++ b/task_sdk/src/airflow/sdk/__init__.py
@@ -25,6 +25,7 @@ __all__ = [
     "Label",
     "TaskGroup",
     "dag",
+    "Connection",
     "__version__",
 ]
 
@@ -32,6 +33,7 @@ __version__ = "1.0.0.dev1"
 
 if TYPE_CHECKING:
     from airflow.sdk.definitions.baseoperator import BaseOperator
+    from airflow.sdk.definitions.connection import Connection
     from airflow.sdk.definitions.dag import DAG, dag
     from airflow.sdk.definitions.edges import EdgeModifier, Label
     from airflow.sdk.definitions.taskgroup import TaskGroup
@@ -43,6 +45,7 @@ __lazy_imports: dict[str, str] = {
     "TaskGroup": ".definitions.taskgroup",
     "EdgeModifier": ".definitions.edges",
     "Label": ".definitions.edges",
+    "Connection": ".definitions.connection",
 }
 
 

--- a/task_sdk/src/airflow/sdk/definitions/connection.py
+++ b/task_sdk/src/airflow/sdk/definitions/connection.py
@@ -1,0 +1,52 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import attrs
+
+
+@attrs.define
+class Connection:
+    """
+    A connection to an external data source.
+
+    :param conn_id: The connection ID.
+    :param conn_type: The connection type.
+    :param description: The connection description.
+    :param host: The host.
+    :param login: The login.
+    :param password: The password.
+    :param schema: The schema.
+    :param port: The port number.
+    :param extra: Extra metadata. Non-standard data such as private/SSH keys can be saved here. JSON
+        encoded object.
+    """
+
+    conn_id: str
+    conn_type: str
+    description: str | None = None
+    host: str | None = None
+    schema: str | None = None
+    login: str | None = None
+    password: str | None = None
+    port: int | None = None
+    extra: str | None = None
+
+    def get_uri(self): ...
+
+    def get_hook(self): ...

--- a/task_sdk/src/airflow/sdk/exceptions.py
+++ b/task_sdk/src/airflow/sdk/exceptions.py
@@ -14,3 +14,24 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
+from __future__ import annotations
+
+import enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from airflow.sdk.execution_time.comms import ErrorResponse
+
+
+class AirflowRuntimeError(Exception):
+    def __init__(self, error: ErrorResponse):
+        self.error = error
+        super().__init__(f"{error.error.value}: {error.detail}")
+
+
+class ErrorType(enum.Enum):
+    CONNECTION_NOT_FOUND = "CONNECTION_NOT_FOUND"
+    VARIABLE_NOT_FOUND = "VARIABLE_NOT_FOUND"
+    XCOM_NOT_FOUND = "XCOM_NOT_FOUND"
+    GENERIC_ERROR = "GENERIC_ERROR"

--- a/task_sdk/src/airflow/sdk/execution_time/comms.py
+++ b/task_sdk/src/airflow/sdk/execution_time/comms.py
@@ -59,7 +59,7 @@ from airflow.sdk.api.datamodels._generated import (
     VariableResponse,
     XComResponse,
 )
-from airflow.sdk.exceptions import AirflowRuntimeError, ErrorType
+from airflow.sdk.exceptions import ErrorType
 
 
 class StartupDetails(BaseModel):
@@ -102,10 +102,6 @@ class ErrorResponse(BaseModel):
     error: ErrorType = ErrorType.GENERIC_ERROR
     detail: dict | None = None
     type: Literal["ErrorResponse"] = "ErrorResponse"
-
-    def raise_as_exception(self):
-        """Raise an exception based on this error."""
-        raise AirflowRuntimeError(self)
 
 
 ToTask = Annotated[

--- a/task_sdk/src/airflow/sdk/execution_time/comms.py
+++ b/task_sdk/src/airflow/sdk/execution_time/comms.py
@@ -59,6 +59,7 @@ from airflow.sdk.api.datamodels._generated import (
     VariableResponse,
     XComResponse,
 )
+from airflow.sdk.exceptions import AirflowRuntimeError, ErrorType
 
 
 class StartupDetails(BaseModel):
@@ -97,8 +98,18 @@ class VariableResult(VariableResponse):
     type: Literal["VariableResult"] = "VariableResult"
 
 
+class ErrorResponse(BaseModel):
+    error: ErrorType = ErrorType.GENERIC_ERROR
+    detail: dict | None = None
+    type: Literal["ErrorResponse"] = "ErrorResponse"
+
+    def raise_as_exception(self):
+        """Raise an exception based on this error."""
+        raise AirflowRuntimeError(self)
+
+
 ToTask = Annotated[
-    Union[StartupDetails, XComResult, ConnectionResult, VariableResult],
+    Union[StartupDetails, XComResult, ConnectionResult, VariableResult, ErrorResponse],
     Field(discriminator="type"),
 ]
 

--- a/task_sdk/src/airflow/sdk/execution_time/comms.py
+++ b/task_sdk/src/airflow/sdk/execution_time/comms.py
@@ -85,6 +85,13 @@ class XComResult(XComResponse):
 class ConnectionResult(ConnectionResponse):
     type: Literal["ConnectionResult"] = "ConnectionResult"
 
+    @classmethod
+    def from_conn_response(cls, connection_response: ConnectionResponse) -> ConnectionResult:
+        # Exclude defaults to avoid sending unnecessary data
+        # Pass the type as ConnectionResult explicitly so we can then call model_dump_json with exclude_unset=True
+        # to avoid sending unset fields (which are defaults in our case).
+        return cls(**connection_response.model_dump(exclude_defaults=True), type="ConnectionResult")
+
 
 class VariableResult(VariableResponse):
     type: Literal["VariableResult"] = "VariableResult"

--- a/task_sdk/src/airflow/sdk/execution_time/context.py
+++ b/task_sdk/src/airflow/sdk/execution_time/context.py
@@ -1,0 +1,74 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+if TYPE_CHECKING:
+    from airflow.sdk.definitions.connection import Connection
+    from airflow.sdk.execution_time.comms import ConnectionResult
+
+
+def _convert_connection_result_conn(conn_result: ConnectionResult):
+    from airflow.sdk.definitions.connection import Connection
+
+    # `by_alias=True` is used to convert the `schema` field to `schema_` in the Connection model
+    return Connection(**conn_result.model_dump(exclude={"type"}, by_alias=True))
+
+
+def _get_connection(conn_id: str) -> Connection:
+    # TODO: This should probably be moved to a separate module like `airflow.sdk.execution_time.comms`
+    #   or `airflow.sdk.execution_time.connection`
+    #   A reason to not move it to `airflow.sdk.execution_time.comms` is that it
+    #   will make that module depend on Task SDK, which is not ideal because we intend to
+    #   keep Task SDK as a separate package than execution time mods.
+    from airflow.sdk.execution_time.comms import GetConnection
+    from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
+
+    log = structlog.get_logger(logger_name="task")
+    SUPERVISOR_COMMS.send_request(log=log, msg=GetConnection(conn_id=conn_id))
+    msg = SUPERVISOR_COMMS.get_message()
+    if TYPE_CHECKING:
+        assert isinstance(msg, ConnectionResult)
+    return _convert_connection_result_conn(msg)
+
+
+class ConnectionAccessor:
+    """Wrapper to access Connection entries in template."""
+
+    def __init__(self) -> None:
+        self.conn: Any = None
+
+    def __getattr__(self, key: str) -> Any:
+        self.conn = _get_connection(key)
+        return self.conn
+
+    def __repr__(self) -> str:
+        return str(self.conn)
+
+    def __eq__(self, other):
+        return self.conn == other
+
+    def get(self, conn_id: str, default_conn: Any = None) -> Any:
+        try:
+            return _get_connection(conn_id)
+        except Exception:
+            # TODO: change this to a more specific exception
+            #  It could be a 404 error from the server (`ServerResponseError`)
+            return default_conn

--- a/task_sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task_sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -49,6 +49,7 @@ from airflow.sdk.api.datamodels._generated import (
     TerminalTIState,
 )
 from airflow.sdk.execution_time.comms import (
+    ConnectionResult,
     DeferTask,
     GetConnection,
     GetVariable,
@@ -689,7 +690,8 @@ class WatchedSubprocess:
             self._task_end_time_monotonic = time.monotonic()
         elif isinstance(msg, GetConnection):
             conn = self.client.connections.get(msg.conn_id)
-            resp = conn.model_dump_json(exclude_unset=True).encode()
+            conn_result = ConnectionResult.from_conn_response(conn)
+            resp = conn_result.model_dump_json(exclude_unset=True).encode()
         elif isinstance(msg, GetVariable):
             var = self.client.variables.get(msg.key)
             resp = var.model_dump_json(exclude_unset=True).encode()

--- a/task_sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task_sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -40,6 +40,7 @@ from airflow.sdk.execution_time.comms import (
     ToSupervisor,
     ToTask,
 )
+from airflow.sdk.execution_time.context import ConnectionAccessor
 
 if TYPE_CHECKING:
     from structlog.typing import FilteringBoundLogger as Logger
@@ -53,6 +54,9 @@ class RuntimeTaskInstance(TaskInstance):
     """The Task Instance context from the API server, if any."""
 
     def get_template_context(self):
+        # TODO: Move this to `airflow.sdk.execution_time.context`
+        #   once we port the entire context logic from airflow/utils/context.py ?
+
         # TODO: Assess if we need to it through airflow.utils.timezone.coerce_datetime()
         context: dict[str, Any] = {
             # From the Task Execution interface
@@ -63,6 +67,8 @@ class RuntimeTaskInstance(TaskInstance):
             "run_id": self.run_id,
             "task": self.task,
             "task_instance": self,
+            # TODO: Ensure that ti.log_url and such are available to use in context
+            #   especially after removal of `conf` from Context.
             "ti": self,
             # "outlet_events": OutletEventAccessors(),
             # "expanded_ti_count": expanded_ti_count,
@@ -73,14 +79,13 @@ class RuntimeTaskInstance(TaskInstance):
             # "prev_data_interval_end_success": get_prev_data_interval_end_success(),
             # "prev_start_date_success": get_prev_start_date_success(),
             # "prev_end_date_success": get_prev_end_date_success(),
-            # "task_instance_key_str": f"{task.dag_id}__{task.task_id}__{ds_nodash}",
             # "test_mode": task_instance.test_mode,
             # "triggering_asset_events": lazy_object_proxy.Proxy(get_triggering_events),
             # "var": {
             #     "json": VariableAccessor(deserialize_json=True),
             #     "value": VariableAccessor(deserialize_json=False),
             # },
-            # "conn": ConnectionAccessor(),
+            "conn": ConnectionAccessor(),
         }
         if self._ti_context_from_server:
             dag_run = self._ti_context_from_server.dag_run
@@ -107,6 +112,10 @@ class RuntimeTaskInstance(TaskInstance):
             }
             context.update(context_from_server)
         return context
+
+    def xcom_pull(self, *args, **kwargs): ...
+
+    def xcom_push(self, *args, **kwargs): ...
 
 
 def parse(what: StartupDetails) -> RuntimeTaskInstance:

--- a/task_sdk/tests/execution_time/test_context.py
+++ b/task_sdk/tests/execution_time/test_context.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from airflow.sdk.definitions.connection import Connection
+from airflow.sdk.execution_time.comms import ConnectionResult
+from airflow.sdk.execution_time.context import _convert_connection_result_conn
+
+
+def test_convert_connection_result_conn():
+    """Test that the ConnectionResult is converted to a Connection object."""
+    conn = ConnectionResult(
+        conn_id="test_conn",
+        conn_type="mysql",
+        host="mysql",
+        schema="airflow",
+        login="root",
+        password="password",
+        port=1234,
+        extra='{"extra_key": "extra_value"}',
+    )
+    conn = _convert_connection_result_conn(conn)
+    assert conn == Connection(
+        conn_id="test_conn",
+        conn_type="mysql",
+        host="mysql",
+        schema="airflow",
+        login="root",
+        password="password",
+        port=1234,
+        extra='{"extra_key": "extra_value"}',
+    )

--- a/task_sdk/tests/execution_time/test_context.py
+++ b/task_sdk/tests/execution_time/test_context.py
@@ -51,15 +51,13 @@ def test_convert_connection_result_conn():
 
 
 class TestConnectionAccessor:
-    def test_lazy_fetch_connection(self):
+    def test_getattr_connection(self):
         """
-        Test that the connection is lazily fetched when accessed and also using __getattr__.
+        Test that the connection is fetched when accessed via __getattr__.
 
         The __getattr__ method is used for template rendering. Example: ``{{ conn.mysql_conn.host }}``.
         """
         accessor = ConnectionAccessor()
-        # conn is not fetched yet
-        assert accessor.conn is None
 
         # Conn from the supervisor / API Server
         conn_result = ConnectionResult(conn_id="mysql_conn", conn_type="mysql", host="mysql", port=3306)
@@ -74,7 +72,6 @@ class TestConnectionAccessor:
 
             expected_conn = Connection(conn_id="mysql_conn", conn_type="mysql", host="mysql", port=3306)
             assert conn == expected_conn
-            assert accessor.conn == expected_conn
 
     def test_get_method_valid_connection(self):
         """Test that the get method returns the requested connection using `conn.get`."""

--- a/task_sdk/tests/execution_time/test_context.py
+++ b/task_sdk/tests/execution_time/test_context.py
@@ -17,9 +17,12 @@
 
 from __future__ import annotations
 
+from unittest import mock
+
 from airflow.sdk.definitions.connection import Connection
-from airflow.sdk.execution_time.comms import ConnectionResult
-from airflow.sdk.execution_time.context import _convert_connection_result_conn
+from airflow.sdk.exceptions import ErrorType
+from airflow.sdk.execution_time.comms import ConnectionResult, ErrorResponse
+from airflow.sdk.execution_time.context import ConnectionAccessor, _convert_connection_result_conn
 
 
 def test_convert_connection_result_conn():
@@ -45,3 +48,59 @@ def test_convert_connection_result_conn():
         port=1234,
         extra='{"extra_key": "extra_value"}',
     )
+
+
+class TestConnectionAccessor:
+    def test_lazy_fetch_connection(self):
+        """
+        Test that the connection is lazily fetched when accessed and also using __getattr__.
+
+        The __getattr__ method is used for template rendering. Example: ``{{ conn.mysql_conn.host }}``.
+        """
+        accessor = ConnectionAccessor()
+        # conn is not fetched yet
+        assert accessor.conn is None
+
+        # Conn from the supervisor / API Server
+        conn_result = ConnectionResult(conn_id="mysql_conn", conn_type="mysql", host="mysql", port=3306)
+
+        with mock.patch(
+            "airflow.sdk.execution_time.task_runner.SUPERVISOR_COMMS", create=True
+        ) as mock_supervisor_comms:
+            mock_supervisor_comms.get_message.return_value = conn_result
+
+            # Fetch the connection; Triggers __getattr__
+            conn = accessor.mysql_conn
+
+            expected_conn = Connection(conn_id="mysql_conn", conn_type="mysql", host="mysql", port=3306)
+            assert conn == expected_conn
+            assert accessor.conn == expected_conn
+
+    def test_get_method_valid_connection(self):
+        """Test that the get method returns the requested connection using `conn.get`."""
+        accessor = ConnectionAccessor()
+        conn_result = ConnectionResult(conn_id="mysql_conn", conn_type="mysql", host="mysql", port=3306)
+
+        with mock.patch(
+            "airflow.sdk.execution_time.task_runner.SUPERVISOR_COMMS", create=True
+        ) as mock_supervisor_comms:
+            mock_supervisor_comms.get_message.return_value = conn_result
+
+            conn = accessor.get("mysql_conn")
+            assert conn == Connection(conn_id="mysql_conn", conn_type="mysql", host="mysql", port=3306)
+
+    def test_get_method_with_default(self):
+        """Test that the get method returns the default connection when the requested connection is not found."""
+        accessor = ConnectionAccessor()
+        default_conn = {"conn_id": "default_conn", "conn_type": "sqlite"}
+        error_response = ErrorResponse(
+            error=ErrorType.CONNECTION_NOT_FOUND, detail={"conn_id": "nonexistent_conn"}
+        )
+
+        with mock.patch(
+            "airflow.sdk.execution_time.task_runner.SUPERVISOR_COMMS", create=True
+        ) as mock_supervisor_comms:
+            mock_supervisor_comms.get_message.return_value = error_response
+
+            conn = accessor.get("nonexistent_conn", default_conn=default_conn)
+            assert conn == default_conn

--- a/task_sdk/tests/execution_time/test_supervisor.py
+++ b/task_sdk/tests/execution_time/test_supervisor.py
@@ -764,7 +764,7 @@ class TestHandleRequest:
         [
             pytest.param(
                 GetConnection(conn_id="test_conn"),
-                b'{"conn_id":"test_conn","conn_type":"mysql"}\n',
+                b'{"conn_id":"test_conn","conn_type":"mysql","type":"ConnectionResult"}\n',
                 "connections.get",
                 ("test_conn",),
                 ConnectionResult(conn_id="test_conn", conn_type="mysql"),

--- a/task_sdk/tests/execution_time/test_task_runner.py
+++ b/task_sdk/tests/execution_time/test_task_runner.py
@@ -27,9 +27,16 @@ import pytest
 from uuid6 import uuid7
 
 from airflow.exceptions import AirflowFailException, AirflowSensorTimeout, AirflowSkipException
-from airflow.sdk import DAG, BaseOperator
+from airflow.sdk import DAG, BaseOperator, Connection
 from airflow.sdk.api.datamodels._generated import TaskInstance, TerminalTIState
-from airflow.sdk.execution_time.comms import DeferTask, SetRenderedFields, StartupDetails, TaskState
+from airflow.sdk.execution_time.comms import (
+    ConnectionResult,
+    DeferTask,
+    GetConnection,
+    SetRenderedFields,
+    StartupDetails,
+    TaskState,
+)
 from airflow.sdk.execution_time.task_runner import CommsDecoder, RuntimeTaskInstance, parse, run, startup
 from airflow.utils import timezone
 
@@ -399,6 +406,7 @@ class TestRuntimeTaskInstance:
 
         # Verify the context keys and values
         assert context == {
+            "conn": None,
             "dag": runtime_ti.task.dag,
             "inlets": task.inlets,
             "map_index_template": task.map_index_template,
@@ -431,6 +439,7 @@ class TestRuntimeTaskInstance:
         context = runtime_ti.get_template_context()
 
         assert context == {
+            "conn": None,
             "dag": runtime_ti.task.dag,
             "inlets": task.inlets,
             "map_index_template": task.map_index_template,
@@ -450,3 +459,57 @@ class TestRuntimeTaskInstance:
             "ts_nodash": "20241201T010000",
             "ts_nodash_with_tz": "20241201T010000+0000",
         }
+
+    def test_get_connection_from_context(self, mocked_parse, make_ti_context):
+        """Test that the connection is fetched from the API server via the Supervisor lazily when accessed"""
+
+        task = BaseOperator(task_id="hello")
+
+        ti_id = uuid7()
+        ti = TaskInstance(
+            id=ti_id, task_id=task.task_id, dag_id="basic_task", run_id="test_run", try_number=1
+        )
+        conn = ConnectionResult(
+            conn_id="test_conn",
+            conn_type="mysql",
+            host="mysql",
+            schema="airflow",
+            login="root",
+            password="password",
+            port=1234,
+            extra='{"extra_key": "extra_value"}',
+        )
+
+        what = StartupDetails(ti=ti, file="", requests_fd=0, ti_context=make_ti_context())
+        runtime_ti = mocked_parse(what, ti.dag_id, task)
+        with mock.patch(
+            "airflow.sdk.execution_time.task_runner.SUPERVISOR_COMMS", create=True
+        ) as mock_supervisor_comms:
+            mock_supervisor_comms.get_message.return_value = conn
+
+            context = runtime_ti.get_template_context()
+
+            # Assert that the connection is not fetched from the API server yet!
+            # The connection should be only fetched connection is accessed
+            mock_supervisor_comms.send_request.assert_not_called()
+            mock_supervisor_comms.get_message.assert_not_called()
+
+            # Access the connection from the context
+            conn_from_context = context["conn"].test_conn
+
+            mock_supervisor_comms.send_request.assert_called_once_with(
+                log=mock.ANY, msg=GetConnection(conn_id="test_conn")
+            )
+            mock_supervisor_comms.get_message.assert_called_once_with()
+
+            assert conn_from_context == Connection(
+                conn_id="test_conn",
+                conn_type="mysql",
+                description=None,
+                host="mysql",
+                schema="airflow",
+                login="root",
+                password="password",
+                port=1234,
+                extra='{"extra_key": "extra_value"}',
+            )

--- a/task_sdk/tests/execution_time/test_task_runner.py
+++ b/task_sdk/tests/execution_time/test_task_runner.py
@@ -37,6 +37,7 @@ from airflow.sdk.execution_time.comms import (
     StartupDetails,
     TaskState,
 )
+from airflow.sdk.execution_time.context import ConnectionAccessor
 from airflow.sdk.execution_time.task_runner import CommsDecoder, RuntimeTaskInstance, parse, run, startup
 from airflow.utils import timezone
 
@@ -406,7 +407,7 @@ class TestRuntimeTaskInstance:
 
         # Verify the context keys and values
         assert context == {
-            "conn": None,
+            "conn": ConnectionAccessor(),
             "dag": runtime_ti.task.dag,
             "inlets": task.inlets,
             "map_index_template": task.map_index_template,
@@ -439,7 +440,7 @@ class TestRuntimeTaskInstance:
         context = runtime_ti.get_template_context()
 
         assert context == {
-            "conn": None,
+            "conn": ConnectionAccessor(),
             "dag": runtime_ti.task.dag,
             "inlets": task.inlets,
             "map_index_template": task.map_index_template,


### PR DESCRIPTION
part of https://github.com/apache/airflow/issues/44481

- Added a minimal Connection user-facing object in Task SDK definition for use in the DAG file
- Added logic to get Connections in the context. Fixed some bugs in the way related to Connection parsing/serializing!


Now, we have following Connection related objects:
- `ConnectionResponse` is auto-generated and tightly coupled with the API schema.
- `ConnectionResult` is runtime-specific and meant for internal communication between Supervisor & Task Runner.
- `Connection` class here is where the public-facing, user-relevant aspects are exposed, hiding internal details.

**Next up**:

- Same for XCom & Variable
- Implementation of BaseHook.get_conn

Tested it with a DAG:

<img width="1711" alt="image" src="https://github.com/user-attachments/assets/14d28fb7-f6c5-4fbe-b226-46873af2d0f3" />

DAG:

```py
from __future__ import annotations

from airflow.models.baseoperator import BaseOperator
from airflow.models.dag import dag


class CustomOperator(BaseOperator):
    def execute(self, context):
        import os
        os.environ["AIRFLOW_CONN_AIRFLOW_DB"] = "sqlite:///home/airflow/airflow.db"
        task_id = context["task_instance"].task_id
        print(f"Hello World {task_id}!")
        print(context)
        print(context["conn"].airflow_db)
        assert context["conn"].airflow_db.conn_id == "airflow_db"


@dag()
def super_basic_run():
    CustomOperator(task_id="hello")


super_basic_run()

```

For case where a **connection is not found**

<img width="1435" alt="image" src="https://github.com/user-attachments/assets/7c5e0cb4-6ed4-41aa-9a57-e5641adce954" />


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
