### PR TITLE
Avoid 1.1.8 version of msgraph-core

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -838,7 +838,7 @@
       "microsoft-kiota-http>=1.3.0,!=1.3.4",
       "microsoft-kiota-serialization-json==1.0.0",
       "microsoft-kiota-serialization-text==1.0.0",
-      "msgraph-core>=1.0.0"
+      "msgraph-core>=1.0.0,!=1.1.8"
     ],
     "devel-deps": [
       "pywinrm>=0.4"

--- a/providers/src/airflow/providers/microsoft/azure/provider.yaml
+++ b/providers/src/airflow/providers/microsoft/azure/provider.yaml
@@ -109,7 +109,9 @@ dependencies:
   - azure-mgmt-datafactory>=2.0.0
   - azure-mgmt-containerregistry>=8.0.0
   - azure-mgmt-containerinstance>=10.1.0
-  - msgraph-core>=1.0.0
+  # msgraph-core 1.1.8 has a bug which causes ABCMeta object is not subscriptable error
+  # See https://github.com/microsoftgraph/msgraph-sdk-python-core/issues/781
+  - msgraph-core>=1.0.0,!=1.1.8
   # msgraph-core has transient import failures with microsoft-kiota-http==1.3.4
   # See https://github.com/microsoftgraph/msgraph-sdk-python-core/issues/706
   - microsoft-kiota-http>=1.3.0,!=1.3.4


### PR DESCRIPTION
The 1.1.8 version of msgraph-core is buggy - importing some basic classes causes import error "ABCMeta" is not subscriptable.

We are removing the version from azure provider dependencies hoping that it will be fixed in the next version.

https://github.com/microsoftgraph/msgraph-sdk-python-core/issues/781

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
