### PR TITLE
Add MessageDeduplicationId support to AWS SqsPublishOperator

### DIFF
--- a/providers/src/airflow/providers/amazon/aws/hooks/sqs.py
+++ b/providers/src/airflow/providers/amazon/aws/hooks/sqs.py
@@ -59,6 +59,7 @@ class SqsHook(AwsBaseHook):
         delay_seconds: int = 0,
         message_attributes: dict | None = None,
         message_group_id: str | None = None,
+        message_deduplication_id: str | None = None,
     ) -> dict:
         """
         Send message to the queue.
@@ -71,6 +72,7 @@ class SqsHook(AwsBaseHook):
         :param delay_seconds: seconds to delay the message
         :param message_attributes: additional attributes for the message (default: None)
         :param message_group_id: This applies only to FIFO (first-in-first-out) queues. (default: None)
+        :param message_deduplication_id: This applies only to FIFO (first-in-first-out) queues.
         :return: dict with the information about the message sent
         """
         params = {
@@ -81,5 +83,7 @@ class SqsHook(AwsBaseHook):
         }
         if message_group_id:
             params["MessageGroupId"] = message_group_id
+        if message_deduplication_id:
+            params["MessageDeduplicationId"] = message_deduplication_id
 
         return self.get_conn().send_message(**params)

--- a/providers/src/airflow/providers/amazon/aws/operators/sqs.py
+++ b/providers/src/airflow/providers/amazon/aws/operators/sqs.py
@@ -44,6 +44,8 @@ class SqsPublishOperator(AwsBaseOperator[SqsHook]):
     :param delay_seconds: message delay (templated) (default: 1 second)
     :param message_group_id: This parameter applies only to FIFO (first-in-first-out) queues. (default: None)
         For details of the attributes parameter see :py:meth:`botocore.client.SQS.send_message`
+    :param message_deduplication_id: This applies only to FIFO (first-in-first-out) queues.
+        For details of the attributes parameter see :py:meth:`botocore.client.SQS.send_message`
     :param aws_conn_id: The Airflow connection used for AWS credentials.
         If this is ``None`` or empty then the default boto3 behaviour is used. If
         running Airflow in a distributed manner and aws_conn_id is None or
@@ -63,6 +65,7 @@ class SqsPublishOperator(AwsBaseOperator[SqsHook]):
         "delay_seconds",
         "message_attributes",
         "message_group_id",
+        "message_deduplication_id",
     )
     template_fields_renderers = {"message_attributes": "json"}
     ui_color = "#6ad3fa"
@@ -75,6 +78,7 @@ class SqsPublishOperator(AwsBaseOperator[SqsHook]):
         message_attributes: dict | None = None,
         delay_seconds: int = 0,
         message_group_id: str | None = None,
+        message_deduplication_id: str | None = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -83,6 +87,7 @@ class SqsPublishOperator(AwsBaseOperator[SqsHook]):
         self.delay_seconds = delay_seconds
         self.message_attributes = message_attributes or {}
         self.message_group_id = message_group_id
+        self.message_deduplication_id = message_deduplication_id
 
     def execute(self, context: Context) -> dict:
         """
@@ -98,6 +103,7 @@ class SqsPublishOperator(AwsBaseOperator[SqsHook]):
             delay_seconds=self.delay_seconds,
             message_attributes=self.message_attributes,
             message_group_id=self.message_group_id,
+            message_deduplication_id=self.message_deduplication_id,
         )
 
         self.log.info("send_message result: %s", result)

--- a/providers/tests/amazon/aws/operators/test_sqs.py
+++ b/providers/tests/amazon/aws/operators/test_sqs.py
@@ -104,6 +104,20 @@ class TestSqsPublishOperator:
             op.execute(mocked_context)
 
     @mock_aws
+    def test_deduplication_failure(self, mocked_context):
+        self.sqs_client.create_queue(
+            QueueName=FIFO_QUEUE_NAME, Attributes={"FifoQueue": "true", "ContentBasedDeduplication": "false"}
+        )
+
+        op = SqsPublishOperator(**self.default_op_kwargs, sqs_queue=FIFO_QUEUE_NAME, message_group_id="abc")
+        error_message = (
+            r"An error occurred \(InvalidParameterValue\) when calling the SendMessage operation: "
+            r"The queue should either have ContentBasedDeduplication enabled or MessageDeduplicationId provided explicitly"
+        )
+        with pytest.raises(ClientError, match=error_message):
+            op.execute(mocked_context)
+
+    @mock_aws
     def test_execute_success_fifo_queue(self, mocked_context):
         self.sqs_client.create_queue(
             QueueName=FIFO_QUEUE_NAME, Attributes={"FifoQueue": "true", "ContentBasedDeduplication": "true"}
@@ -124,6 +138,9 @@ class TestSqsPublishOperator:
 
     def test_template_fields(self):
         operator = SqsPublishOperator(
-            **self.default_op_kwargs, sqs_queue=FIFO_QUEUE_NAME, message_group_id="abc"
+            **self.default_op_kwargs,
+            sqs_queue=FIFO_QUEUE_NAME,
+            message_group_id="abc",
+            message_deduplication_id="abc",
         )
         validate_template_fields(operator)


### PR DESCRIPTION
Closes : #44876

Currently, the `SqsPublishOperator` in Airflow does not support the `MessageDeduplicationId` parameter for deduplication of messages sent to AWS SQS FIFO queues. Users are forced to rely solely on `ContentBasedDeduplication`, which may not be suitable for all scenarios. 

This PR aims to add support for `MessageDeduplicationId ` and test for deduplication to provide more flexibility and control over message deduplication.

(https://boto3.amazonaws.com/v1/documentation/api/1.35.6/reference/services/sqs/client/send_message.html))


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
