### PR TITLE
Use Airflow config in `SimpleAuthManager` instead of Flask app config

### DIFF
--- a/airflow/auth/managers/simple/views/auth.py
+++ b/airflow/auth/managers/simple/views/auth.py
@@ -75,7 +75,9 @@ class SimpleAuthManagerAuthenticationViews(AirflowBaseView):
         next_url = request.args.get("next")
 
         found_users = [
-            user for user in self.users if user[0] == username and self.passwords[user[0]] == password
+            user
+            for user in self.users
+            if user["username"] == username and self.passwords[user["username"]] == password
         ]
 
         if not username or not password or len(found_users) == 0:
@@ -83,7 +85,7 @@ class SimpleAuthManagerAuthenticationViews(AirflowBaseView):
 
         user = SimpleAuthManagerUser(
             username=username,
-            role=found_users[0][1],
+            role=found_users[0]["role"],
         )
         # Will be removed once Airflow uses the new UI
         session["user"] = user

--- a/airflow/auth/managers/simple/views/auth.py
+++ b/airflow/auth/managers/simple/views/auth.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import logging
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from flask import redirect, request, session, url_for
@@ -29,8 +28,6 @@ from airflow.utils.state import State
 from airflow.www.app import csrf
 from airflow.www.extensions.init_auth_manager import get_auth_manager
 from airflow.www.views import AirflowBaseView
-
-logger = logging.getLogger(__name__)
 
 
 class SimpleAuthManagerAuthenticationViews(AirflowBaseView):
@@ -78,9 +75,7 @@ class SimpleAuthManagerAuthenticationViews(AirflowBaseView):
         next_url = request.args.get("next")
 
         found_users = [
-            user
-            for user in self.users
-            if user["username"] == username and self.passwords[user["username"]] == password
+            user for user in self.users if user[0] == username and self.passwords[user[0]] == password
         ]
 
         if not username or not password or len(found_users) == 0:
@@ -88,7 +83,7 @@ class SimpleAuthManagerAuthenticationViews(AirflowBaseView):
 
         user = SimpleAuthManagerUser(
             username=username,
-            role=found_users[0]["role"],
+            role=found_users[0][1],
         )
         # Will be removed once Airflow uses the new UI
         session["user"] = user

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -101,8 +101,8 @@ core:
         role. Roles are predefined in simple auth managers: viewer, user, op, admin.
       version_added: 3.0.0
       type: string
-      example: "bob,admin peter,viewer"
-      default: "admin,admin"
+      example: "bob:admin,peter:viewer"
+      default: "admin:admin"
     simple_auth_manager_all_admins:
       description: |
         Whether to disable authentication and allow everyone as admin in the environment.

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -92,6 +92,24 @@ core:
       type: string
       example: ~
       default: "airflow.providers.fab.auth_manager.fab_auth_manager.FabAuthManager"
+    simple_auth_manager_users:
+      description: |
+        The list of users and their associated role in simple auth manager. If the simple auth manager is
+        used in your environment, this list controls who can access the environment.
+
+        List of user-role delimited with a space. Each user-role is a comma delimited couple of username and
+        role. Roles are predefined in simple auth managers: viewer, user, op, admin.
+      version_added: 3.0.0
+      type: string
+      example: "bob,admin peter,viewer"
+      default: "admin,admin"
+    simple_auth_manager_all_admins:
+      description: |
+        Whether to disable authentication and allow everyone as admin in the environment.
+      version_added: 3.0.0
+      type: string
+      example: ~
+      default: "False"
     parallelism:
       description: |
         This defines the maximum number of task instances that can run concurrently per scheduler in

--- a/airflow/config_templates/default_webserver_config.py
+++ b/airflow/config_templates/default_webserver_config.py
@@ -130,23 +130,3 @@ AUTH_TYPE = AUTH_DB
 # APP_THEME = "superhero.css"
 # APP_THEME = "united.css"
 # APP_THEME = "yeti.css"
-
-# ----------------------------------------------------
-# Simple auth manager config
-# ----------------------------------------------------
-# This list contains the list of users and their associated role in simple auth manager.
-# If the simple auth manager is used in your environment, this list controls who can access the environment.
-# Example:
-# [{
-#     "username": "admin",
-#     "role": "admin",
-# }]
-SIMPLE_AUTH_MANAGER_USERS = [
-    {
-        "username": "admin",
-        "role": "admin",
-    }
-]
-
-# Turn this flag on to disable authentication and allow everyone as admin
-SIMPLE_AUTH_MANAGER_ALL_ADMINS = False

--- a/docs/apache-airflow/core-concepts/auth-manager/simple.rst
+++ b/docs/apache-airflow/core-concepts/auth-manager/simple.rst
@@ -31,22 +31,29 @@ the logic and implementation of the simple auth manager is **simple**.
 Manage users
 ------------
 
-Users are managed through the `webserver config file <https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#config-file>`__.
-In this file, the list of users are defined in the constant ``SIMPLE_AUTH_MANAGER_USERS``. Example:
+Users are managed through the Airflow configuration. Example:
 
-.. code-block:: python
+.. code-block:: ini
 
-  SIMPLE_AUTH_MANAGER_USERS = [
-      {
-          "username": "admin",
-          "role": "admin",
-      }
-  ]
+  [core]
+  simple_auth_manager_users = "bob,admin peter,viewer"
 
+or
+
+.. code-block:: bash
+
+  export AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_USERS='bob,admin peter,viewer'
+
+The list of users are separated with a space and each user is a couple username/role separated by a comma.
 Each user needs two pieces of information:
 
 * **username**. The user's username
 * **role**. The role associated to the user. For more information about these roles, :ref:`see next section <roles-permissions>`.
+
+In the example above, two users are defined:
+
+* **bob** whose role is **admin**
+* **peter** whose role is **viewer**
 
 The password is auto-generated for each user and printed out in the webserver logs.
 When generated, these passwords are also saved in your environment, therefore they will not change if you stop or restart your environment.
@@ -75,9 +82,15 @@ Disable authentication and allow everyone as admin
 This option allow you to disable authentication and allow everyone as admin.
 As a consequence, whoever access the Airflow UI is automatically logged in as an admin with all permissions.
 
-To enable this feature, you need to set the constant ``SIMPLE_AUTH_MANAGER_ALL_ADMINS`` to ``True`` in the `webserver config file <https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#config-file>`__.
-Example:
+you can enable this feature through the config. Example:
 
-.. code-block:: python
+.. code-block:: ini
 
-  SIMPLE_AUTH_MANAGER_ALL_ADMINS = True
+  [core]
+  simple_auth_manager_all_admins = "True"
+
+or
+
+.. code-block:: bash
+
+  export AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_ALL_ADMINS='True'

--- a/docs/apache-airflow/core-concepts/auth-manager/simple.rst
+++ b/docs/apache-airflow/core-concepts/auth-manager/simple.rst
@@ -36,15 +36,9 @@ Users are managed through the Airflow configuration. Example:
 .. code-block:: ini
 
   [core]
-  simple_auth_manager_users = "bob,admin peter,viewer"
+  simple_auth_manager_users = "bob:admin,peter:viewer"
 
-or
-
-.. code-block:: bash
-
-  export AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_USERS='bob,admin peter,viewer'
-
-The list of users are separated with a space and each user is a couple username/role separated by a comma.
+The list of users are separated with a comma and each user is a couple username/role separated by a colon.
 Each user needs two pieces of information:
 
 * **username**. The user's username
@@ -88,9 +82,3 @@ you can enable this feature through the config. Example:
 
   [core]
   simple_auth_manager_all_admins = "True"
-
-or
-
-.. code-block:: bash
-
-  export AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_ALL_ADMINS='True'

--- a/tests/auth/managers/simple/test_simple_auth_manager.py
+++ b/tests/auth/managers/simple/test_simple_auth_manager.py
@@ -53,11 +53,11 @@ class TestSimpleAuthManager:
     def test_get_users(self, auth_manager):
         with conf_vars(
             {
-                ("core", "simple_auth_manager_users"): "test1,viewer test2,viewer",
+                ("core", "simple_auth_manager_users"): "test1:viewer,test2:viewer",
             }
         ):
             users = auth_manager.get_users()
-            assert users == [["test1", "viewer"], ["test2", "viewer"]]
+            assert users == [{"role": "viewer", "username": "test1"}, {"role": "viewer", "username": "test2"}]
 
     @pytest.mark.db_test
     def test_init_with_default_user(self, auth_manager):
@@ -72,7 +72,7 @@ class TestSimpleAuthManager:
     def test_init_with_users(self, auth_manager):
         with conf_vars(
             {
-                ("core", "simple_auth_manager_users"): "test1,viewer test2,viewer",
+                ("core", "simple_auth_manager_users"): "test1:viewer,test2:viewer",
             }
         ):
             auth_manager.init()

--- a/tests/auth/managers/simple/test_simple_auth_manager.py
+++ b/tests/auth/managers/simple/test_simple_auth_manager.py
@@ -28,6 +28,8 @@ from airflow.auth.managers.simple.user import SimpleAuthManagerUser
 from airflow.auth.managers.simple.views.auth import SimpleAuthManagerAuthenticationViews
 from airflow.www.extensions.init_appbuilder import init_appbuilder
 
+from tests_common.test_utils.config import conf_vars
+
 
 @pytest.fixture
 def auth_manager():
@@ -48,49 +50,62 @@ def test_user():
 
 class TestSimpleAuthManager:
     @pytest.mark.db_test
-    def test_init_with_no_user(self, auth_manager_with_appbuilder):
-        auth_manager_with_appbuilder.init()
-        with open(auth_manager_with_appbuilder.get_generated_password_file()) as file:
-            passwords_str = file.read().strip()
-            user_passwords_from_file = json.loads(passwords_str)
-
-            assert user_passwords_from_file == {}
+    def test_get_users(self, auth_manager):
+        with conf_vars(
+            {
+                ("core", "simple_auth_manager_users"): "test1,viewer test2,viewer",
+            }
+        ):
+            users = auth_manager.get_users()
+            assert users == [["test1", "viewer"], ["test2", "viewer"]]
 
     @pytest.mark.db_test
-    def test_init_with_users(self, auth_manager_with_appbuilder):
-        auth_manager_with_appbuilder.appbuilder.app.config["SIMPLE_AUTH_MANAGER_USERS"] = [
-            {
-                "username": "test",
-                "role": "admin",
-            }
-        ]
-        auth_manager_with_appbuilder.init()
-        with open(auth_manager_with_appbuilder.get_generated_password_file()) as file:
+    def test_init_with_default_user(self, auth_manager):
+        auth_manager.init()
+        with open(auth_manager.get_generated_password_file()) as file:
             passwords_str = file.read().strip()
             user_passwords_from_file = json.loads(passwords_str)
 
             assert len(user_passwords_from_file) == 1
 
     @pytest.mark.db_test
-    def test_is_logged_in(self, auth_manager_with_appbuilder, app, test_user):
+    def test_init_with_users(self, auth_manager):
+        with conf_vars(
+            {
+                ("core", "simple_auth_manager_users"): "test1,viewer test2,viewer",
+            }
+        ):
+            auth_manager.init()
+            with open(auth_manager.get_generated_password_file()) as file:
+                passwords_str = file.read().strip()
+                user_passwords_from_file = json.loads(passwords_str)
+
+                assert len(user_passwords_from_file) == 2
+
+    @pytest.mark.db_test
+    def test_is_logged_in(self, auth_manager, app, test_user):
         with app.test_request_context():
             session["user"] = test_user
-            result = auth_manager_with_appbuilder.is_logged_in()
+            result = auth_manager.is_logged_in()
         assert result
 
     @pytest.mark.db_test
-    def test_is_logged_in_return_false_when_no_user_in_session(self, auth_manager_with_appbuilder, app):
+    def test_is_logged_in_return_false_when_no_user_in_session(self, auth_manager, app):
         with app.test_request_context():
-            result = auth_manager_with_appbuilder.is_logged_in()
+            result = auth_manager.is_logged_in()
 
         assert result is False
 
     @pytest.mark.db_test
-    def test_is_logged_in_with_all_admins(self, auth_manager_with_appbuilder, app):
-        auth_manager_with_appbuilder.appbuilder.app.config["SIMPLE_AUTH_MANAGER_ALL_ADMINS"] = True
-        with app.test_request_context():
-            result = auth_manager_with_appbuilder.is_logged_in()
-        assert result
+    def test_is_logged_in_with_all_admins(self, auth_manager, app):
+        with conf_vars(
+            {
+                ("core", "simple_auth_manager_all_admins"): "True",
+            }
+        ):
+            with app.test_request_context():
+                result = auth_manager.is_logged_in()
+            assert result
 
     @patch("airflow.auth.managers.simple.simple_auth_manager.url_for")
     def test_get_url_login(self, mock_url_for, auth_manager):
@@ -104,23 +119,27 @@ class TestSimpleAuthManager:
 
     @pytest.mark.db_test
     @patch.object(SimpleAuthManager, "is_logged_in")
-    def test_get_user(self, mock_is_logged_in, auth_manager_with_appbuilder, app, test_user):
+    def test_get_user(self, mock_is_logged_in, auth_manager, app, test_user):
         mock_is_logged_in.return_value = True
 
         with app.test_request_context():
             session["user"] = test_user
-            result = auth_manager_with_appbuilder.get_user()
+            result = auth_manager.get_user()
 
         assert result == test_user
 
     @pytest.mark.db_test
     @patch.object(SimpleAuthManager, "is_logged_in")
-    def test_get_user_with_all_admins(self, mock_is_logged_in, auth_manager_with_appbuilder, app):
+    def test_get_user_with_all_admins(self, mock_is_logged_in, auth_manager, app):
         mock_is_logged_in.return_value = True
 
-        auth_manager_with_appbuilder.appbuilder.app.config["SIMPLE_AUTH_MANAGER_ALL_ADMINS"] = True
-        with app.test_request_context():
-            result = auth_manager_with_appbuilder.get_user()
+        with conf_vars(
+            {
+                ("core", "simple_auth_manager_all_admins"): "True",
+            }
+        ):
+            with app.test_request_context():
+                result = auth_manager.get_user()
 
         assert result.username == "anonymous"
         assert result.role == "admin"
@@ -167,13 +186,13 @@ class TestSimpleAuthManager:
         ],
     )
     def test_is_authorized_methods(
-        self, mock_is_logged_in, auth_manager_with_appbuilder, app, api, is_logged_in, role, method, result
+        self, mock_is_logged_in, auth_manager, app, api, is_logged_in, role, method, result
     ):
         mock_is_logged_in.return_value = is_logged_in
 
         with app.test_request_context():
             session["user"] = SimpleAuthManagerUser(username="test", role=role)
-            assert getattr(auth_manager_with_appbuilder, api)(method=method) is result
+            assert getattr(auth_manager, api)(method=method) is result
 
     @pytest.mark.db_test
     @patch.object(SimpleAuthManager, "is_logged_in")
@@ -201,13 +220,13 @@ class TestSimpleAuthManager:
         ],
     )
     def test_is_authorized_view_methods(
-        self, mock_is_logged_in, auth_manager_with_appbuilder, app, api, kwargs, is_logged_in, role, result
+        self, mock_is_logged_in, auth_manager, app, api, kwargs, is_logged_in, role, result
     ):
         mock_is_logged_in.return_value = is_logged_in
 
         with app.test_request_context():
             session["user"] = SimpleAuthManagerUser(username="test", role=role)
-            assert getattr(auth_manager_with_appbuilder, api)(**kwargs) is result
+            assert getattr(auth_manager, api)(**kwargs) is result
 
     @pytest.mark.db_test
     @patch.object(SimpleAuthManager, "is_logged_in")
@@ -231,13 +250,13 @@ class TestSimpleAuthManager:
         ],
     )
     def test_is_authorized_methods_op_role_required(
-        self, mock_is_logged_in, auth_manager_with_appbuilder, app, api, role, method, result
+        self, mock_is_logged_in, auth_manager, app, api, role, method, result
     ):
         mock_is_logged_in.return_value = True
 
         with app.test_request_context():
             session["user"] = SimpleAuthManagerUser(username="test", role=role)
-            assert getattr(auth_manager_with_appbuilder, api)(method=method) is result
+            assert getattr(auth_manager, api)(method=method) is result
 
     @pytest.mark.db_test
     @patch.object(SimpleAuthManager, "is_logged_in")
@@ -256,13 +275,13 @@ class TestSimpleAuthManager:
         ],
     )
     def test_is_authorized_methods_user_role_required(
-        self, mock_is_logged_in, auth_manager_with_appbuilder, app, api, role, method, result
+        self, mock_is_logged_in, auth_manager, app, api, role, method, result
     ):
         mock_is_logged_in.return_value = True
 
         with app.test_request_context():
             session["user"] = SimpleAuthManagerUser(username="test", role=role)
-            assert getattr(auth_manager_with_appbuilder, api)(method=method) is result
+            assert getattr(auth_manager, api)(method=method) is result
 
     @pytest.mark.db_test
     @patch.object(SimpleAuthManager, "is_logged_in")
@@ -281,13 +300,13 @@ class TestSimpleAuthManager:
         ],
     )
     def test_is_authorized_methods_viewer_role_required_for_get(
-        self, mock_is_logged_in, auth_manager_with_appbuilder, app, api, role, method, result
+        self, mock_is_logged_in, auth_manager, app, api, role, method, result
     ):
         mock_is_logged_in.return_value = True
 
         with app.test_request_context():
             session["user"] = SimpleAuthManagerUser(username="test", role=role)
-            assert getattr(auth_manager_with_appbuilder, api)(method=method) is result
+            assert getattr(auth_manager, api)(method=method) is result
 
     @pytest.mark.db_test
     def test_register_views(self, auth_manager_with_appbuilder):

--- a/tests/auth/managers/simple/views/test_auth.py
+++ b/tests/auth/managers/simple/views/test_auth.py
@@ -36,23 +36,14 @@ def simple_app():
                 "core",
                 "auth_manager",
             ): "airflow.auth.managers.simple.simple_auth_manager.SimpleAuthManager",
+            ("core", "simple_auth_manager_users"): "test,admin",
         }
     ):
         with open(SimpleAuthManager.get_generated_password_file(), "w") as file:
             user = {"test": "test"}
             file.write(json.dumps(user))
 
-        return application.create_app(
-            testing=True,
-            config={
-                "SIMPLE_AUTH_MANAGER_USERS": [
-                    {
-                        "username": "test",
-                        "role": "admin",
-                    }
-                ]
-            },
-        )
+        return application.create_app(testing=True)
 
 
 @pytest.mark.db_test

--- a/tests/auth/managers/simple/views/test_auth.py
+++ b/tests/auth/managers/simple/views/test_auth.py
@@ -36,7 +36,7 @@ def simple_app():
                 "core",
                 "auth_manager",
             ): "airflow.auth.managers.simple.simple_auth_manager.SimpleAuthManager",
-            ("core", "simple_auth_manager_users"): "test,admin",
+            ("core", "simple_auth_manager_users"): "test:admin",
         }
     ):
         with open(SimpleAuthManager.get_generated_password_file(), "w") as file:


### PR DESCRIPTION
The simple auth manager uses the Flask config to get the list of users. Since we are moving away from Flask and simple auth manager should work without Flask, I propose to use the Airflow config instead. That also makes us one step closer to have the simple auth manager no longer dependent on Flask appbuilder. 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
