### PR TITLE
Add ability to pass extra parameters to Hive Client Wrapper connection

### DIFF
--- a/docs/apache-airflow-providers-apache-hive/connections/hive_cli.rst
+++ b/docs/apache-airflow-providers-apache-hive/connections/hive_cli.rst
@@ -77,6 +77,16 @@ High Availability (optional)
     Specify as ``True`` if you want to connect to a Hive installation running in high
     availability mode. Specify host accordingly.
 
+SSL Trust Store (optional)
+    Specify the path to SSL trust store to be used with Hive Beeline.
+
+SSL Trust Store Password (optional)
+    Specify the password to SSL trust store to be used with Hive Beeline.
+
+Transport mode (optional)
+    Specify the transport mode to be used with Hive Beeline.
+
+
 
 When specifying the connection in environment variable you should specify
 it using URI syntax.


### PR DESCRIPTION
Closes: #45049

Add extra fields to Hive Client Wrapper connection so it is possible to pass extra parameters which are used to construct JDBC connection string. The extra fields are SSL Trust Store, SSL Trust Store password and Transport mode.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
