### PR TITLE
Use custom dag_folder not settings.DAGS_FOLDER for FileLoadStat

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -596,7 +596,7 @@ class DagBag(LoggingMixin):
                 file_parse_end_dttm = timezone.utcnow()
                 stats.append(
                     FileLoadStat(
-                        file=filepath.replace(settings.DAGS_FOLDER, ""),
+                        file=filepath.replace(str(dag_folder), ""),
                         duration=file_parse_end_dttm - file_parse_start_dttm,
                         dag_num=len(found_dags),
                         task_num=sum(len(dag.tasks) for dag in found_dags),

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -848,6 +848,13 @@ with airflow.DAG(
         dagbag = DagBag(dag_folder=TEST_DAGS_FOLDER, include_examples=False)
         assert dagbag.dags
 
+    def test_dagbag_collect_dags_stats_have_filepath_without_dag_folder(self):
+        with conf_vars({("core", "DAGS_FOLDER"): "/different/path"}):
+            dagbag = DagBag(dag_folder=TEST_DAGS_FOLDER, include_examples=False)
+
+            assert dagbag.dagbag_stats
+            assert str(TEST_DAGS_FOLDER) not in dagbag.dagbag_stats[0].file
+
     def test_dabgag_captured_warnings(self):
         dag_file = os.path.join(TEST_DAGS_FOLDER, "test_dag_warnings.py")
         dagbag = DagBag(dag_folder=dag_file, include_examples=False, collect_dags=False)


### PR DESCRIPTION
The stats would still use `settings.DAGS_FOLDER` despite dag_folder arg being set to a different path and used for the actual dags parsing.