### PR TITLE
AIP-72: Allow pushing and pulling XCom from Task Context

### DIFF
--- a/airflow/utils/context.py
+++ b/airflow/utils/context.py
@@ -477,7 +477,7 @@ def lazy_mapping_from_context(source: Context) -> Mapping[str, Any]:
     """
     if not isinstance(source, Context):
         # Sometimes we are passed a plain dict (usually in tests, or in User's
-        # custom operators) -- be lienent about what we accept so we don't
+        # custom operators) -- be lenient about what we accept so we don't
         # break anything for users.
         return source
 

--- a/task_sdk/src/airflow/sdk/api/client.py
+++ b/task_sdk/src/airflow/sdk/api/client.py
@@ -207,11 +207,16 @@ class XComOperations:
     def __init__(self, client: Client):
         self.client = client
 
-    def get(self, dag_id: str, run_id: str, task_id: str, key: str, map_index: int = -1) -> XComResponse:
+    def get(
+        self, dag_id: str, run_id: str, task_id: str, key: str, map_index: int | None = None
+    ) -> XComResponse:
         """Get a XCom value from the API server."""
         # TODO: check if we need to use map_index as params in the uri
         # ref: https://github.com/apache/airflow/blob/v2-10-stable/airflow/api_connexion/openapi/v1.yaml#L1785C1-L1785C81
-        resp = self.client.get(f"xcoms/{dag_id}/{run_id}/{task_id}/{key}", params={"map_index": map_index})
+        params = {}
+        if map_index is not None:
+            params.update({"map_index": map_index})
+        resp = self.client.get(f"xcoms/{dag_id}/{run_id}/{task_id}/{key}", params=params)
         return XComResponse.model_validate_json(resp.read())
 
     def set(

--- a/task_sdk/src/airflow/sdk/execution_time/comms.py
+++ b/task_sdk/src/airflow/sdk/execution_time/comms.py
@@ -167,7 +167,7 @@ class GetXCom(BaseModel):
     dag_id: str
     run_id: str
     task_id: str
-    map_index: int = -1
+    map_index: int | None = None
     type: Literal["GetXCom"] = "GetXCom"
 
 

--- a/task_sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task_sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -62,7 +62,6 @@ from airflow.sdk.api.datamodels._generated import (
 from airflow.sdk.execution_time.comms import (
     ConnectionResult,
     DeferTask,
-    ErrorResponse,
     GetConnection,
     GetVariable,
     GetXCom,
@@ -719,7 +718,7 @@ class WatchedSubprocess:
             if isinstance(conn, ConnectionResponse):
                 conn_result = ConnectionResult.from_conn_response(conn)
                 resp = conn_result.model_dump_json(exclude_unset=True).encode()
-            elif isinstance(conn, ErrorResponse):
+            else:
                 resp = conn.model_dump_json().encode()
         elif isinstance(msg, GetVariable):
             var = self.client.variables.get(msg.key)

--- a/task_sdk/tests/api/test_client.py
+++ b/task_sdk/tests/api/test_client.py
@@ -313,13 +313,23 @@ class TestXCOMOperations:
     response parsing.
     """
 
-    def test_xcom_get_success(self):
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param("value1", id="string-value"),
+            pytest.param({"key1": "value1"}, id="dict-value"),
+            pytest.param('{"key1": "value1"}', id="dict-str-value"),
+            pytest.param(["value1", "value2"], id="list-value"),
+            pytest.param({"key": "test_key", "value": {"key2": "value2"}}, id="nested-dict-value"),
+        ],
+    )
+    def test_xcom_get_success(self, value):
         # Simulate a successful response from the server when getting an xcom
         def handle_request(request: httpx.Request) -> httpx.Response:
             if request.url.path == "/xcoms/dag_id/run_id/task_id/key":
                 return httpx.Response(
                     status_code=201,
-                    json={"key": "test_key", "value": "test_value"},
+                    json={"key": "test_key", "value": value},
                 )
             return httpx.Response(status_code=400, json={"detail": "Bad Request"})
 
@@ -332,7 +342,7 @@ class TestXCOMOperations:
         )
         assert isinstance(result, XComResponse)
         assert result.key == "test_key"
-        assert result.value == "test_value"
+        assert result.value == value
 
     def test_xcom_get_success_with_map_index(self):
         # Simulate a successful response from the server when getting an xcom with map_index passed

--- a/task_sdk/tests/execution_time/test_context.py
+++ b/task_sdk/tests/execution_time/test_context.py
@@ -67,7 +67,7 @@ class TestConnectionAccessor:
         ) as mock_supervisor_comms:
             mock_supervisor_comms.get_message.return_value = conn_result
 
-            # Fetch the connection; Triggers __getattr__
+            # Fetch the connection; triggers __getattr__
             conn = accessor.mysql_conn
 
             expected_conn = Connection(conn_id="mysql_conn", conn_type="mysql", host="mysql", port=3306)

--- a/task_sdk/tests/execution_time/test_supervisor.py
+++ b/task_sdk/tests/execution_time/test_supervisor.py
@@ -817,7 +817,7 @@ class TestHandleRequest:
                 GetXCom(dag_id="test_dag", run_id="test_run", task_id="test_task", key="test_key"),
                 b'{"key":"test_key","value":"test_value","type":"XComResult"}\n',
                 "xcoms.get",
-                ("test_dag", "test_run", "test_task", "test_key", -1),
+                ("test_dag", "test_run", "test_task", "test_key", None),
                 XComResult(key="test_key", value="test_value"),
                 id="get_xcom",
             ),

--- a/tests/api_fastapi/execution_api/routes/test_xcoms.py
+++ b/tests/api_fastapi/execution_api/routes/test_xcoms.py
@@ -21,6 +21,7 @@ from unittest import mock
 
 import pytest
 
+from airflow.api_fastapi.execution_api.datamodels.xcom import XComResponse
 from airflow.models.dagrun import DagRun
 from airflow.models.xcom import XCom
 from airflow.utils.session import create_session
@@ -40,18 +41,20 @@ class TestXComsGetEndpoint:
     @pytest.mark.parametrize(
         ("value", "expected_value"),
         [
-            ("value1", "value1"),
-            ({"key2": "value2"}, {"key2": "value2"}),
-            ({"key2": "value2", "key3": ["value3"]}, {"key2": "value2", "key3": ["value3"]}),
-            (["value1"], ["value1"]),
+            ('"value1"', '"value1"'),
+            ('{"key2": "value2"}', '{"key2": "value2"}'),
+            ('{"key2": "value2", "key3": ["value3"]}', '{"key2": "value2", "key3": ["value3"]}'),
+            ('["value1"]', '["value1"]'),
         ],
     )
     def test_xcom_get_from_db(self, client, create_task_instance, session, value, expected_value):
         """Test that XCom value is returned from the database in JSON-compatible format."""
         ti = create_task_instance()
         ti.xcom_push(key="xcom_1", value=value, session=session)
-
         session.commit()
+
+        xcom = session.query(XCom).filter_by(task_id=ti.task_id, dag_id=ti.dag_id, key="xcom_1").first()
+        assert xcom.value == expected_value
 
         response = client.get(f"/execution/xcoms/{ti.dag_id}/{ti.run_id}/{ti.task_id}/xcom_1")
 
@@ -86,19 +89,17 @@ class TestXComsSetEndpoint:
     @pytest.mark.parametrize(
         ("value", "expected_value"),
         [
-            ('"value1"', "value1"),
-            ('{"key2": "value2"}', {"key2": "value2"}),
-            ('{"key2": "value2", "key3": ["value3"]}', {"key2": "value2", "key3": ["value3"]}),
-            ('["value1"]', ["value1"]),
+            ('"value1"', '"value1"'),
+            ('{"key2": "value2"}', '{"key2": "value2"}'),
+            ('{"key2": "value2", "key3": ["value3"]}', '{"key2": "value2", "key3": ["value3"]}'),
+            ('["value1"]', '["value1"]'),
         ],
     )
     def test_xcom_set(self, client, create_task_instance, session, value, expected_value):
         """
         Test that XCom value is set correctly. The value is passed as a JSON string in the request body.
-        This is then validated via Pydantic.Json type in the request body and converted to
-        a Python object before being sent to XCom.set. XCom.set then uses json.dumps to
-        serialize it and store the value in the database. This is done so that Task SDK in multiple
-        languages can use the same API to set XCom values.
+        XCom.set then uses json.dumps to serialize it and store the value in the database.
+        This is done so that Task SDK in multiple languages can use the same API to set XCom values.
         """
         ti = create_task_instance()
         session.commit()
@@ -114,6 +115,24 @@ class TestXComsSetEndpoint:
         xcom = session.query(XCom).filter_by(task_id=ti.task_id, dag_id=ti.dag_id, key="xcom_1").first()
         assert xcom.value == expected_value
 
+    @pytest.mark.parametrize(
+        "value",
+        ["value1", {"key2": "value2"}, ["value1"]],
+    )
+    def test_xcom_set_invalid_json(self, client, create_task_instance, value):
+        response = client.post(
+            "/execution/xcoms/dag/runid/task/xcom_1",
+            json="invalid_json",
+        )
+
+        assert response.status_code == 400
+        assert response.json() == {
+            "detail": {
+                "reason": "invalid_format",
+                "message": "XCom value is not a valid JSON-formatted string",
+            }
+        }
+
     def test_xcom_access_denied(self, client):
         with mock.patch("airflow.api_fastapi.execution_api.routes.xcoms.has_xcom_access", return_value=False):
             response = client.post(
@@ -128,3 +147,41 @@ class TestXComsSetEndpoint:
                 "message": "Task does not have access to set XCom key 'xcom_perms'",
             }
         }
+
+    @pytest.mark.parametrize(
+        ("value", "expected_value"),
+        [
+            ('"value1"', '"value1"'),
+            ('{"key2": "value2"}', '{"key2": "value2"}'),
+            ('{"key2": "value2", "key3": ["value3"]}', '{"key2": "value2", "key3": ["value3"]}'),
+            ('["value1"]', '["value1"]'),
+        ],
+    )
+    def test_xcom_roundtrip(self, client, create_task_instance, session, value, expected_value):
+        """
+        Test that XCom value is set and retrieved correctly using API.
+
+        This test sets an XCom value using the API and then retrieves it using the API so we can
+        ensure client and server are working correctly together. The server expects a JSON string
+        and it will also return a JSON string. It is the client's responsibility to parse the JSON
+        string into a native object. This is useful for Task SDKs in other languages.
+        """
+        ti = create_task_instance()
+
+        session.commit()
+        client.post(
+            f"/execution/xcoms/{ti.dag_id}/{ti.run_id}/{ti.task_id}/test_xcom_roundtrip",
+            json=value,
+        )
+
+        xcom = (
+            session.query(XCom)
+            .filter_by(task_id=ti.task_id, dag_id=ti.dag_id, key="test_xcom_roundtrip")
+            .first()
+        )
+        assert xcom.value == expected_value
+
+        response = client.get(f"/execution/xcoms/{ti.dag_id}/{ti.run_id}/{ti.task_id}/test_xcom_roundtrip")
+
+        assert response.status_code == 200
+        assert XComResponse.model_validate_json(response.read()).value == expected_value

--- a/tests/models/test_xcom.py
+++ b/tests/models/test_xcom.py
@@ -324,18 +324,30 @@ class TestXComGet:
 
 
 class TestXComSet:
-    def test_xcom_set(self, session, task_instance):
+    @pytest.mark.parametrize(
+        ("key", "value", "expected_value"),
+        [
+            pytest.param("xcom_dict", {"key": "value"}, {"key": "value"}, id="dict"),
+            pytest.param("xcom_int", 123, 123, id="int"),
+            pytest.param("xcom_float", 45.67, 45.67, id="float"),
+            pytest.param("xcom_str", "hello", "hello", id="str"),
+            pytest.param("xcom_bool", True, True, id="bool"),
+            pytest.param("xcom_list", [1, 2, 3], [1, 2, 3], id="list"),
+        ],
+    )
+    def test_xcom_set(self, session, task_instance, key, value, expected_value):
         XCom.set(
-            key="xcom_1",
-            value={"key": "value"},
+            key=key,
+            value=value,
             dag_id=task_instance.dag_id,
             task_id=task_instance.task_id,
             run_id=task_instance.run_id,
             session=session,
         )
         stored_xcoms = session.query(XCom).all()
-        assert stored_xcoms[0].key == "xcom_1"
-        assert stored_xcoms[0].value == {"key": "value"}
+        assert stored_xcoms[0].key == key
+        assert isinstance(stored_xcoms[0].value, type(expected_value))
+        assert stored_xcoms[0].value == expected_value
         assert stored_xcoms[0].dag_id == "dag"
         assert stored_xcoms[0].task_id == "task_1"
         assert stored_xcoms[0].logical_date == task_instance.logical_date


### PR DESCRIPTION
Part of https://github.com/apache/airflow/issues/44481

There is a lot of cleanup to do but I wanted to get a basic DAG that uses XCom working first.

Example DAG used: `tutorial_dag`

```py

from __future__ import annotations

# [START tutorial]
# [START import_module]
import json
import textwrap

import pendulum

# The DAG object; we'll need this to instantiate a DAG
from airflow.models.dag import DAG

# Operators; we need this to operate!
from airflow.providers.standard.operators.python import PythonOperator

# [END import_module]

# [START instantiate_dag]
with DAG(
    "tutorial_dag",
    # [START default_args]
    # These args will get passed on to each operator
    # You can override them on a per-task basis during operator initialization
    default_args={"retries": 2},
    # [END default_args]
    description="DAG tutorial",
    schedule=None,
    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
    catchup=False,
    tags=["example"],
) as dag:
    # [END instantiate_dag]
    # [START documentation]
    dag.doc_md = __doc__
    # [END documentation]

    # [START extract_function]
    def extract(**kwargs):
        ti = kwargs["ti"]
        data_string = '{"1001": 301.27, "1002": 433.21, "1003": 502.22}'
        ti.xcom_push("order_data", data_string)

    # [END extract_function]

    # [START transform_function]
    def transform(**kwargs):
        ti = kwargs["ti"]
        extract_data_string = ti.xcom_pull(task_ids="extract", key="order_data")
        order_data = json.loads(extract_data_string)

        total_order_value = 0
        for value in order_data.values():
            total_order_value += value

        total_value = {"total_order_value": total_order_value}
        total_value_json_string = json.dumps(total_value)
        ti.xcom_push("total_order_value", total_value_json_string)

    # [END transform_function]

    # [START load_function]
    def load(**kwargs):
        ti = kwargs["ti"]
        total_value_string = ti.xcom_pull(task_ids="transform", key="total_order_value")
        total_order_value = json.loads(total_value_string)

        print(total_order_value)

    # [END load_function]

    # [START main_flow]
    extract_task = PythonOperator(
        task_id="extract",
        python_callable=extract,
    )
    extract_task.doc_md = textwrap.dedent(
        """\
    #### Extract task
    A simple Extract task to get data ready for the rest of the data pipeline.
    In this case, getting data is simulated by reading from a hardcoded JSON string.
    This data is then put into xcom, so that it can be processed by the next task.
    """
    )

    transform_task = PythonOperator(
        task_id="transform",
        python_callable=transform,
    )
    transform_task.doc_md = textwrap.dedent(
        """\
    #### Transform task
    A simple Transform task which takes in the collection of order data from xcom
    and computes the total order value.
    This computed value is then put into xcom, so that it can be processed by the next task.
    """
    )

    load_task = PythonOperator(
        task_id="load",
        python_callable=load,
    )
    load_task.doc_md = textwrap.dedent(
        """\
    #### Load task
    A simple Load task which takes in the result of the Transform task, by reading it
    from xcom and instead of saving it to end user review, just prints it out.
    """
    )

    extract_task >> transform_task >> load_task
```

---
<img width="1703" alt="image" src="https://github.com/user-attachments/assets/10025ef4-0410-4c2a-9bb6-1e68f51a8805" />

<img width="1710" alt="image" src="https://github.com/user-attachments/assets/201b61c0-3998-4b06-b0d4-2145120321f8" />

---
<img width="1721" alt="image" src="https://github.com/user-attachments/assets/dd9c50e3-20c5-4762-99f9-c02a8c16732e" />


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
