### PR TITLE
Prefer rendered_map_index value if defined over map_index.

### DIFF
--- a/airflow/ui/src/components/ClearRun/ClearRunDialog.tsx
+++ b/airflow/ui/src/components/ClearRun/ClearRunDialog.tsx
@@ -104,7 +104,7 @@ const ClearRunDialog = ({
                 { label: "Clear only failed tasks", value: "only_failed" },
                 {
                   disabled: true,
-                  label: "Queued up new tasks",
+                  label: "Queue up new tasks",
                   value: "new_tasks",
                 },
               ]}

--- a/airflow/ui/src/components/ClearRun/ClearRunTaskAccordion.tsx
+++ b/airflow/ui/src/components/ClearRun/ClearRunTaskAccordion.tsx
@@ -56,7 +56,8 @@ const columns: Array<ColumnDef<TaskInstanceResponse>> = [
     header: () => "State",
   },
   {
-    accessorKey: "map_index",
+    accessorFn: (row: TaskInstanceResponse) =>
+      row.rendered_map_index ?? row.map_index,
     enableSorting: false,
     header: "Map Index",
   },

--- a/airflow/ui/src/components/ui/Tooltip.tsx
+++ b/airflow/ui/src/components/ui/Tooltip.tsx
@@ -55,7 +55,7 @@ export const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(
                 <ChakraTooltip.Arrow>
                   <ChakraTooltip.ArrowTip />
                 </ChakraTooltip.Arrow>
-              ) : null}
+              ) : undefined}
               {content}
             </ChakraTooltip.Content>
           </ChakraTooltip.Positioner>

--- a/airflow/ui/src/pages/Run/TaskInstances.tsx
+++ b/airflow/ui/src/pages/Run/TaskInstances.tsx
@@ -64,7 +64,8 @@ const columns: Array<ColumnDef<TaskInstanceResponse>> = [
     header: "End Date",
   },
   {
-    accessorKey: "map_index",
+    accessorFn: (row: TaskInstanceResponse) =>
+      row.rendered_map_index ?? row.map_index,
     header: "Map Index",
   },
 

--- a/airflow/ui/src/pages/Task/Instances.tsx
+++ b/airflow/ui/src/pages/Task/Instances.tsx
@@ -71,7 +71,8 @@ const columns = (
   ...(isMapped
     ? [
         {
-          accessorKey: "map_index",
+          accessorFn: (row: TaskInstanceResponse) =>
+            row.rendered_map_index ?? row.map_index,
           header: "Map Index",
         },
       ]

--- a/airflow/ui/src/pages/TaskInstance/Header.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Header.tsx
@@ -57,7 +57,9 @@ export const Header = ({
     <SimpleGrid columns={6} gap={4} my={2}>
       <Stat label="Operator">{taskInstance.operator}</Stat>
       {taskInstance.map_index > -1 ? (
-        <Stat label="Map Index">{taskInstance.map_index}</Stat>
+        <Stat label="Map Index">
+          {taskInstance.rendered_map_index ?? taskInstance.map_index}
+        </Stat>
       ) : undefined}
       {taskInstance.try_number > 1 ? (
         <Stat label="Try Number">{taskInstance.try_number}</Stat>


### PR DESCRIPTION
`rendered_map_index` when defined will have more user friendly value which can be used in the UI instead of `map_index` which is only a number. This is useful in mapped tasks and legacy UI had this preference.

Minor changes : 

* Fix a warning regarding prefer undefined over null from eslint in tooltip.tsx
* Use `queue up new tasks` as per the legacy UI.

main

![image](https://github.com/user-attachments/assets/1b005646-1b99-42bb-a5e8-02243995676a)

With PR

![image](https://github.com/user-attachments/assets/d7b7ebea-b8c9-4256-8c34-49deddb9477f)

