### PR TITLE
Disable _sync_dag_perms until we can fix its implementation

### DIFF
--- a/airflow/dag_processing/collection.py
+++ b/airflow/dag_processing/collection.py
@@ -188,11 +188,17 @@ def _serialize_dag_capturing_errors(dag: MaybeSerializedDAG, session: Session, p
             session=session,
             processor_subdir=processor_subdir,
         )
-        if dag_was_updated:
-            _sync_dag_perms(dag, session=session)
-        else:
-            # Check and update DagCode
+        # TODO: Currently _sync_dag_perms is FAB specific. We need to re-implement it using the auth manager
+        #  interface. In the short term, we are going to disable it but this should be fixed and re-enabled
+        #  before AF3 is released
+        # if dag_was_updated:
+        #     _sync_dag_perms(dag, session=session)
+        # else:
+        #     # Check and update DagCode
+        if not dag_was_updated:
             DagCode.update_source_code(dag.dag_id, dag.fileloc)
+
+
         return []
     except OperationalError:
         raise

--- a/tests/dag_processing/test_collection.py
+++ b/tests/dag_processing/test_collection.py
@@ -177,7 +177,7 @@ class TestUpdateDagParsingResults:
         get_listener_manager().clear()
         dag_import_error_listener.clear()
 
-    @pytest.mark.skip("Skipping until we fix the implementation to not be based on FAB")
+    @pytest.mark.skip("Skipping until we fix the implementation to not be FAB-specific")
     @pytest.mark.usefixtures("clean_db")  # sync_perms in fab has bad session commit hygiene
     def test_sync_perms_syncs_dag_specific_perms_on_update(
         self, monkeypatch, spy_agency: SpyAgency, session, time_machine

--- a/tests/dag_processing/test_collection.py
+++ b/tests/dag_processing/test_collection.py
@@ -393,7 +393,7 @@ class TestUpdateDagParsingResults:
 
         assert import_errors == {"def.py"}
 
-    @pytest.mark.skip("Skipping until we fix the implementation to not be based on FAB")
+    @pytest.mark.skip("Skipping until we fix the implementation to not be FAB-specific")
     def test_sync_perm_for_dag_with_dict_access_control(self, session, spy_agency: SpyAgency):
         """
         Test that dagbag._sync_perm_for_dag will call ApplessAirflowSecurityManager.sync_perm_for_dag

--- a/tests/dag_processing/test_collection.py
+++ b/tests/dag_processing/test_collection.py
@@ -22,7 +22,6 @@ import logging
 import warnings
 from collections.abc import Generator
 from datetime import timedelta
-from typing import TYPE_CHECKING
 from unittest import mock
 from unittest.mock import patch
 
@@ -30,11 +29,9 @@ import pytest
 from sqlalchemy import func, select
 from sqlalchemy.exc import OperationalError, SAWarning
 
-import airflow.dag_processing.collection
 from airflow.dag_processing.collection import (
     AssetModelOperation,
     _get_latest_runs_stmt,
-    _sync_dag_perms,
     update_dag_parsing_results_in_db,
 )
 from airflow.exceptions import SerializationError
@@ -60,9 +57,6 @@ from tests_common.test_utils.db import (
     clear_db_serialized_dags,
     clear_db_triggers,
 )
-
-if TYPE_CHECKING:
-    from kgb import SpyAgency
 
 
 def test_statement_latest_runs_one_dag():
@@ -177,48 +171,48 @@ class TestUpdateDagParsingResults:
         get_listener_manager().clear()
         dag_import_error_listener.clear()
 
-    @pytest.mark.usefixtures("clean_db")  # sync_perms in fab has bad session commit hygiene
-    def test_sync_perms_syncs_dag_specific_perms_on_update(
-        self, monkeypatch, spy_agency: SpyAgency, session, time_machine
-    ):
-        """
-        Test that dagbag.sync_to_db will sync DAG specific permissions when a DAG is
-        new or updated
-        """
-        from airflow import settings
-
-        serialized_dags_count = session.query(func.count(SerializedDagModel.dag_id)).scalar()
-        assert serialized_dags_count == 0
-
-        monkeypatch.setattr(settings, "MIN_SERIALIZED_DAG_UPDATE_INTERVAL", 5)
-        time_machine.move_to(tz.datetime(2020, 1, 5, 0, 0, 0), tick=False)
-
-        dag = DAG(dag_id="test")
-
-        sync_perms_spy = spy_agency.spy_on(
-            airflow.dag_processing.collection._sync_dag_perms,
-            call_original=False,
-        )
-
-        def _sync_to_db():
-            sync_perms_spy.reset_calls()
-            time_machine.shift(20)
-
-            update_dag_parsing_results_in_db([dag], dict(), None, set(), session)
-
-        _sync_to_db()
-        spy_agency.assert_spy_called_with(sync_perms_spy, dag, session=session)
-
-        # DAG isn't updated
-        _sync_to_db()
-        spy_agency.assert_spy_not_called(sync_perms_spy)
-
-        # DAG is updated
-        dag.tags = {"new_tag"}
-        _sync_to_db()
-        spy_agency.assert_spy_called_with(sync_perms_spy, dag, session=session)
-
-        serialized_dags_count = session.query(func.count(SerializedDagModel.dag_id)).scalar()
+    # @pytest.mark.usefixtures("clean_db")  # sync_perms in fab has bad session commit hygiene
+    # def test_sync_perms_syncs_dag_specific_perms_on_update(
+    #     self, monkeypatch, spy_agency: SpyAgency, session, time_machine
+    # ):
+    #     """
+    #     Test that dagbag.sync_to_db will sync DAG specific permissions when a DAG is
+    #     new or updated
+    #     """
+    #     from airflow import settings
+    #
+    #     serialized_dags_count = session.query(func.count(SerializedDagModel.dag_id)).scalar()
+    #     assert serialized_dags_count == 0
+    #
+    #     monkeypatch.setattr(settings, "MIN_SERIALIZED_DAG_UPDATE_INTERVAL", 5)
+    #     time_machine.move_to(tz.datetime(2020, 1, 5, 0, 0, 0), tick=False)
+    #
+    #     dag = DAG(dag_id="test")
+    #
+    #     sync_perms_spy = spy_agency.spy_on(
+    #         airflow.dag_processing.collection._sync_dag_perms,
+    #         call_original=False,
+    #     )
+    #
+    #     def _sync_to_db():
+    #         sync_perms_spy.reset_calls()
+    #         time_machine.shift(20)
+    #
+    #         update_dag_parsing_results_in_db([dag], dict(), None, set(), session)
+    #
+    #     _sync_to_db()
+    #     spy_agency.assert_spy_called_with(sync_perms_spy, dag, session=session)
+    #
+    #     # DAG isn't updated
+    #     _sync_to_db()
+    #     spy_agency.assert_spy_not_called(sync_perms_spy)
+    #
+    #     # DAG is updated
+    #     dag.tags = {"new_tag"}
+    #     _sync_to_db()
+    #     spy_agency.assert_spy_called_with(sync_perms_spy, dag, session=session)
+    #
+    #     serialized_dags_count = session.query(func.count(SerializedDagModel.dag_id)).scalar()
 
     @patch.object(SerializedDagModel, "write_dag")
     @patch("airflow.models.dag.DAG.bulk_write_to_db")
@@ -392,33 +386,33 @@ class TestUpdateDagParsingResults:
 
         assert import_errors == {"def.py"}
 
-    def test_sync_perm_for_dag_with_dict_access_control(self, session, spy_agency: SpyAgency):
-        """
-        Test that dagbag._sync_perm_for_dag will call ApplessAirflowSecurityManager.sync_perm_for_dag
-        """
-        from airflow.www.security_appless import ApplessAirflowSecurityManager
-
-        spy = spy_agency.spy_on(
-            ApplessAirflowSecurityManager.sync_perm_for_dag, owner=ApplessAirflowSecurityManager
-        )
-
-        dag = DAG(dag_id="test")
-
-        def _sync_perms():
-            spy.reset_calls()
-            _sync_dag_perms(dag, session=session)
-
-        # perms dont exist
-        _sync_perms()
-        spy_agency.assert_spy_called_with(spy, dag.dag_id, access_control=None)
-
-        # perms now exist
-        _sync_perms()
-        spy_agency.assert_spy_called_with(spy, dag.dag_id, access_control=None)
-
-        # Always sync if we have access_control
-        dag.access_control = {"Public": {"DAGs": {"can_read"}, "DAG Runs": {"can_create"}}}
-        _sync_perms()
-        spy_agency.assert_spy_called_with(
-            spy, dag.dag_id, access_control={"Public": {"DAGs": {"can_read"}, "DAG Runs": {"can_create"}}}
-        )
+    # def test_sync_perm_for_dag_with_dict_access_control(self, session, spy_agency: SpyAgency):
+    #     """
+    #     Test that dagbag._sync_perm_for_dag will call ApplessAirflowSecurityManager.sync_perm_for_dag
+    #     """
+    #     from airflow.www.security_appless import ApplessAirflowSecurityManager
+    #
+    #     spy = spy_agency.spy_on(
+    #         ApplessAirflowSecurityManager.sync_perm_for_dag, owner=ApplessAirflowSecurityManager
+    #     )
+    #
+    #     dag = DAG(dag_id="test")
+    #
+    #     def _sync_perms():
+    #         spy.reset_calls()
+    #         _sync_dag_perms(dag, session=session)
+    #
+    #     # perms dont exist
+    #     _sync_perms()
+    #     spy_agency.assert_spy_called_with(spy, dag.dag_id, access_control=None)
+    #
+    #     # perms now exist
+    #     _sync_perms()
+    #     spy_agency.assert_spy_called_with(spy, dag.dag_id, access_control=None)
+    #
+    #     # Always sync if we have access_control
+    #     dag.access_control = {"Public": {"DAGs": {"can_read"}, "DAG Runs": {"can_create"}}}
+    #     _sync_perms()
+    #     spy_agency.assert_spy_called_with(
+    #         spy, dag.dag_id, access_control={"Public": {"DAGs": {"can_read"}, "DAG Runs": {"can_create"}}}
+    #     )


### PR DESCRIPTION
Currently _sync_dag_perms is FAB specific. We need to re-implement it using the auth manager interface. In the short term, we are going to disable it but this should be fixed and re-enabled before AF3 is released.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
