### PR TITLE
Create util for TI links, improve positioning of empty states

### DIFF
--- a/airflow/ui/src/components/ClearRun/ClearRunTaskAccordion.tsx
+++ b/airflow/ui/src/components/ClearRun/ClearRunTaskAccordion.tsx
@@ -27,6 +27,7 @@ import type {
 } from "openapi/requests/types.gen";
 import { DataTable } from "src/components/DataTable";
 import { Status } from "src/components/ui";
+import { getTaskInstanceLink } from "src/utils/links";
 
 import { Accordion } from "../ui";
 
@@ -35,9 +36,7 @@ const columns: Array<ColumnDef<TaskInstanceResponse>> = [
     accessorKey: "task_display_name",
     cell: ({ row: { original } }) => (
       <Link asChild color="fg.info" fontWeight="bold">
-        <RouterLink
-          to={`/dags/${original.dag_id}/runs/${original.dag_run_id}/tasks/${original.task_id}${original.map_index > -1 ? `?map_index=${original.map_index}` : ""}`}
-        >
+        <RouterLink to={getTaskInstanceLink(original)}>
           {original.task_display_name}
         </RouterLink>
       </Link>

--- a/airflow/ui/src/components/DataTable/DataTable.tsx
+++ b/airflow/ui/src/components/DataTable/DataTable.tsx
@@ -130,12 +130,12 @@ export const DataTable = <TData,>({
       />
       <Toaster />
       {errorMessage}
-      {!Boolean(isLoading) && !rows.length && (
-        <Text pt={1}>{noRowsMessage ?? `No ${modelName}s found.`}</Text>
-      )}
       {display === "table" && <TableList table={table} />}
       {display === "card" && cardDef !== undefined && (
         <CardList cardDef={cardDef} isLoading={isLoading} table={table} />
+      )}
+      {!Boolean(isLoading) && !rows.length && (
+        <Text pt={1}>{noRowsMessage ?? `No ${modelName}s found.`}</Text>
       )}
       <Pagination.Root
         count={table.getRowCount()}

--- a/airflow/ui/src/pages/Dag/Tasks/TaskCard.tsx
+++ b/airflow/ui/src/pages/Dag/Tasks/TaskCard.tsx
@@ -26,6 +26,7 @@ import type {
 import TaskInstanceTooltip from "src/components/TaskInstanceTooltip";
 import Time from "src/components/Time";
 import { Status } from "src/components/ui";
+import { getTaskInstanceLink } from "src/utils/links.ts";
 
 import { TaskRecentRuns } from "./TaskRecentRuns.tsx";
 
@@ -70,9 +71,7 @@ export const TaskCard = ({ dagId, task, taskInstances }: Props) => (
         {taskInstances[0] ? (
           <TaskInstanceTooltip taskInstance={taskInstances[0]}>
             <Link asChild color="fg.info" fontSize="sm">
-              <RouterLink
-                to={`/dags/${dagId}/runs/${taskInstances[0].dag_run_id}/tasks/${task.task_id}`}
-              >
+              <RouterLink to={getTaskInstanceLink(taskInstances[0])}>
                 <Time datetime={taskInstances[0].start_date} />
                 {taskInstances[0].state === null ? undefined : (
                   <Status state={taskInstances[0].state}>

--- a/airflow/ui/src/pages/Dag/Tasks/TaskRecentRuns.tsx
+++ b/airflow/ui/src/pages/Dag/Tasks/TaskRecentRuns.tsx
@@ -23,6 +23,7 @@ import { Link } from "react-router-dom";
 
 import type { TaskInstanceResponse } from "openapi/requests/types.gen";
 import TaskInstanceTooltip from "src/components/TaskInstanceTooltip";
+import { getTaskInstanceLink } from "src/utils/links";
 import { stateColor } from "src/utils/stateColor";
 
 dayjs.extend(duration);
@@ -61,9 +62,7 @@ export const TaskRecentRuns = ({
             key={taskInstance.dag_run_id}
             taskInstance={taskInstance}
           >
-            <Link
-              to={`/dags/${taskInstance.dag_id}/runs/${taskInstance.dag_run_id}/tasks/${taskInstance.task_id}?map_index=${taskInstance.map_index}`}
-            >
+            <Link to={getTaskInstanceLink(taskInstance)}>
               <Box p={1}>
                 <Box
                   bg={stateColor[taskInstance.state]}

--- a/airflow/ui/src/pages/Run/TaskInstances.tsx
+++ b/airflow/ui/src/pages/Run/TaskInstances.tsx
@@ -28,15 +28,14 @@ import { ErrorAlert } from "src/components/ErrorAlert";
 import Time from "src/components/Time";
 import { Status } from "src/components/ui";
 import { getDuration } from "src/utils";
+import { getTaskInstanceLink } from "src/utils/links";
 
 const columns: Array<ColumnDef<TaskInstanceResponse>> = [
   {
     accessorKey: "task_display_name",
     cell: ({ row: { original } }) => (
       <Link asChild color="fg.info" fontWeight="bold">
-        <RouterLink
-          to={`/dags/${original.dag_id}/runs/${original.dag_run_id}/tasks/${original.task_id}${original.map_index > -1 ? `?map_index=${original.map_index}` : ""}`}
-        >
+        <RouterLink to={getTaskInstanceLink(original)}>
           {original.task_display_name}
         </RouterLink>
       </Link>

--- a/airflow/ui/src/pages/Task/Instances.tsx
+++ b/airflow/ui/src/pages/Task/Instances.tsx
@@ -18,7 +18,6 @@
  */
 import { Box, Link } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
-import dayjs from "dayjs";
 import { Link as RouterLink, useParams } from "react-router-dom";
 
 import {
@@ -31,6 +30,8 @@ import { useTableURLState } from "src/components/DataTable/useTableUrlState";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import Time from "src/components/Time";
 import { Status } from "src/components/ui";
+import { getDuration } from "src/utils";
+import { getTaskInstanceLink } from "src/utils/links";
 
 const columns = (
   isMapped?: boolean,
@@ -39,9 +40,7 @@ const columns = (
     accessorKey: "dag_run_id",
     cell: ({ row: { original } }) => (
       <Link asChild color="fg.info" fontWeight="bold">
-        <RouterLink
-          to={`/dags/${original.dag_id}/runs/${original.dag_run_id}/tasks/${original.task_id}`}
-        >
+        <RouterLink to={getTaskInstanceLink(original)}>
           {original.dag_run_id}
         </RouterLink>
       </Link>
@@ -84,7 +83,7 @@ const columns = (
   },
   {
     cell: ({ row: { original } }) =>
-      `${dayjs.duration(dayjs(original.end_date).diff(original.start_date)).asSeconds().toFixed(2)}s`,
+      `${getDuration(original.start_date, original.end_date)}s`,
     header: "Duration",
   },
 ];

--- a/airflow/ui/src/pages/TaskInstance/Logs.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Logs.tsx
@@ -81,7 +81,9 @@ export const Logs = () => {
   return (
     <Box p={2}>
       <HStack justifyContent="space-between" mb={2}>
-        {taskInstance === undefined ? (
+        {taskInstance === undefined ||
+        tryNumber === undefined ||
+        tryNumber <= 1 ? (
           <div />
         ) : (
           <TaskTrySelect

--- a/airflow/ui/src/pages/TaskInstance/TaskInstance.tsx
+++ b/airflow/ui/src/pages/TaskInstance/TaskInstance.tsx
@@ -74,7 +74,7 @@ export const TaskInstance = () => {
   ];
 
   if (mapIndexParam !== null) {
-    links.push({ label: mapIndexParam });
+    links.push({ label: taskInstance?.rendered_map_index ?? mapIndexParam });
   }
 
   return (

--- a/airflow/ui/src/utils/links.ts
+++ b/airflow/ui/src/utils/links.ts
@@ -1,0 +1,22 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import type { TaskInstanceResponse } from "openapi/requests/types.gen";
+
+export const getTaskInstanceLink = (ti: TaskInstanceResponse) =>
+  `/dags/${ti.dag_id}/runs/${ti.dag_run_id}/tasks/${ti.task_id}${ti.map_index >= 0 ? `?map_index=${ti.map_index}` : ""}`;


### PR DESCRIPTION
- Have a util to create links to task instances so we don't forget to add map_index
- Update position of "No values found" in the Datatable to go below instead of above the table header
- Make sure we always show the "Wrap" button on the right side of the Logs page
- Fix a few spots where we didn't use `getDuration` or `renderedMapIndex`



<img width="1112" alt="Screenshot 2024-12-19 at 2 45 59 PM" src="https://github.com/user-attachments/assets/ea3b7ec2-bcbe-49db-b1ed-977042d9e794" />
<img width="1099" alt="Screenshot 2024-12-19 at 2 46 06 PM" src="https://github.com/user-attachments/assets/9fcfadb4-4ffa-4b5d-977f-8b4c33095aa1" />



---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
