### PR TITLE
Correctly set `owners` on DagModel after TaskSDK parsing change

### DIFF
--- a/airflow/dag_processing/collection.py
+++ b/airflow/dag_processing/collection.py
@@ -383,7 +383,7 @@ class DagModelOperation(NamedTuple):
         for dag_id, dm in sorted(orm_dags.items()):
             dag = self.dags[dag_id]
             dm.fileloc = dag.fileloc
-            dm.owners = dag.owner
+            dm.owners = dag.owner or conf.get("operators", "default_owner")
             dm.is_active = True
             dm.has_import_errors = False
             dm.last_parsed_time = utcnow()

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -1930,6 +1930,12 @@ class LazyDeserializedDAG(pydantic.BaseModel):
     def has_task_concurrency_limits(self) -> bool:
         return any(task.get("max_active_tis_per_dag") is not None for task in self.data["dag"]["tasks"])
 
+    @property
+    def owner(self) -> str:
+        return ", ".join(
+            set(filter(None, (task[Encoding.VAR].get("owner") for task in self.data["dag"]["tasks"])))
+        )
+
     def get_task_assets(
         self,
         inlets: bool = True,

--- a/tests/dag_processing/test_collection.py
+++ b/tests/dag_processing/test_collection.py
@@ -476,7 +476,7 @@ class TestUpdateDagParsingResults:
 
     def test_existing_dag_is_paused_upon_creation(self, session):
         dag = DAG("dag_paused", schedule=None)
-        update_dag_parsing_results_in_db([self.dag_to_lazy_serdag(dag)], {}, None, set(), session)
+        update_dag_parsing_results_in_db([self.dag_to_lazy_serdag(dag)], {}, set(), session)
         orm_dag = session.get(DagModel, ("dag_paused",))
         assert orm_dag.is_paused is False
 

--- a/tests/dag_processing/test_collection.py
+++ b/tests/dag_processing/test_collection.py
@@ -462,7 +462,7 @@ class TestUpdateDagParsingResults:
         if tasks:
             dag.add_tasks(tasks)
 
-        update_dag_parsing_results_in_db([self.dag_to_lazy_serdag(dag)], {}, None, set(), session)
+        update_dag_parsing_results_in_db([self.dag_to_lazy_serdag(dag)], {}, set(), session)
 
         orm_dag = session.get(DagModel, ("dag",))
 

--- a/tests/dag_processing/test_collection.py
+++ b/tests/dag_processing/test_collection.py
@@ -481,7 +481,7 @@ class TestUpdateDagParsingResults:
         assert orm_dag.is_paused is False
 
         dag = DAG("dag_paused", schedule=None, is_paused_upon_creation=True)
-        update_dag_parsing_results_in_db([self.dag_to_lazy_serdag(dag)], {}, None, set(), session)
+        update_dag_parsing_results_in_db([self.dag_to_lazy_serdag(dag)], {}, set(), session)
         # Since the dag existed before, it should not follow the pause flag upon creation
         orm_dag = session.get(DagModel, ("dag_paused",))
         assert orm_dag.is_paused is False

--- a/tests/dag_processing/test_collection.py
+++ b/tests/dag_processing/test_collection.py
@@ -31,6 +31,7 @@ from sqlalchemy import func, select
 from sqlalchemy.exc import OperationalError, SAWarning
 
 import airflow.dag_processing.collection
+from airflow.configuration import conf
 from airflow.dag_processing.collection import (
     AssetModelOperation,
     _get_latest_runs_stmt,
@@ -50,6 +51,7 @@ from airflow.models.serialized_dag import SerializedDagModel
 from airflow.operators.empty import EmptyOperator
 from airflow.providers.standard.triggers.temporal import TimeDeltaTrigger
 from airflow.sdk.definitions.asset import Asset
+from airflow.serialization.serialized_objects import LazyDeserializedDAG, SerializedDAG
 from airflow.utils import timezone as tz
 from airflow.utils.session import create_session
 
@@ -176,6 +178,10 @@ class TestUpdateDagParsingResults:
         yield dag_import_error_listener
         get_listener_manager().clear()
         dag_import_error_listener.clear()
+
+    def dag_to_lazy_serdag(self, dag: DAG) -> LazyDeserializedDAG:
+        ser_dict = SerializedDAG.to_dict(dag)
+        return LazyDeserializedDAG(data=ser_dict)
 
     @pytest.mark.usefixtures("clean_db")  # sync_perms in fab has bad session commit hygiene
     def test_sync_perms_syncs_dag_specific_perms_on_update(
@@ -414,3 +420,68 @@ class TestUpdateDagParsingResults:
         spy_agency.assert_spy_called_with(
             spy, dag.dag_id, access_control={"Public": {"DAGs": {"can_read"}, "DAG Runs": {"can_create"}}}
         )
+
+    @pytest.mark.parametrize(
+        ("attrs", "expected"),
+        [
+            pytest.param(
+                {
+                    "_tasks_": [
+                        EmptyOperator(task_id="task", owner="owner1"),
+                        EmptyOperator(task_id="task2", owner="owner2"),
+                        EmptyOperator(task_id="task3"),
+                        EmptyOperator(task_id="task4", owner="owner2"),
+                    ]
+                },
+                {
+                    "default_view": conf.get("webserver", "dag_default_view").lower(),
+                    "owners": ["owner1", "owner2"],
+                },
+                id="tasks-multiple-owners",
+            ),
+            pytest.param(
+                {"is_paused_upon_creation": True},
+                {"is_paused": True},
+                id="is_paused_upon_creation",
+            ),
+            pytest.param(
+                {},
+                {"owners": ["airflow"]},
+                id="default-owner",
+            ),
+        ],
+    )
+    @pytest.mark.usefixtures("clean_db")
+    def test_dagmodel_properties(self, attrs, expected, session, time_machine):
+        """Test that properties on the dag model are correctly set when dealing with a LazySerializedDag"""
+        dt = tz.datetime(2020, 1, 5, 0, 0, 0)
+        time_machine.move_to(dt, tick=False)
+
+        tasks = attrs.pop("_tasks_", None)
+        dag = DAG("dag", **attrs)
+        if tasks:
+            dag.add_tasks(tasks)
+
+        update_dag_parsing_results_in_db([self.dag_to_lazy_serdag(dag)], {}, None, set(), session)
+
+        orm_dag = session.get(DagModel, ("dag",))
+
+        for attrname, expected_value in expected.items():
+            if attrname == "owners":
+                assert sorted(orm_dag.owners.split(", ")) == expected_value
+            else:
+                assert getattr(orm_dag, attrname) == expected_value
+
+        assert orm_dag.last_parsed_time == dt
+
+    def test_existing_dag_is_paused_upon_creation(self, session):
+        dag = DAG("dag_paused", schedule=None)
+        update_dag_parsing_results_in_db([self.dag_to_lazy_serdag(dag)], {}, None, set(), session)
+        orm_dag = session.get(DagModel, ("dag_paused",))
+        assert orm_dag.is_paused is False
+
+        dag = DAG("dag_paused", schedule=None, is_paused_upon_creation=True)
+        update_dag_parsing_results_in_db([self.dag_to_lazy_serdag(dag)], {}, None, set(), session)
+        # Since the dag existed before, it should not follow the pause flag upon creation
+        orm_dag = session.get(DagModel, ("dag_paused",))
+        assert orm_dag.is_paused is False


### PR DESCRIPTION
It turns out this behaviour wasn't adequetely tested, at least not using
serialized DAGs, and broke as a result of #44972

This test fixes this case, and adds/moves some of the tests from
models/test_dag.py into test_collection which more accurately represents where
the code it is testing now lives.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
