### PR TITLE
AIP-72: Adding missing supervisor handler for RTIF

### DIFF
--- a/task_sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task_sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -68,6 +68,7 @@ from airflow.sdk.execution_time.comms import (
     GetXCom,
     PutVariable,
     RescheduleTask,
+    SetRenderedFields,
     SetXCom,
     StartupDetails,
     TaskState,
@@ -733,6 +734,8 @@ class WatchedSubprocess:
             self.client.xcoms.set(msg.dag_id, msg.run_id, msg.task_id, msg.key, msg.value, msg.map_index)
         elif isinstance(msg, PutVariable):
             self.client.variables.set(msg.key, msg.value, msg.description)
+        elif isinstance(msg, SetRenderedFields):
+            self.client.task_instances.set_rtif(self.id, msg.rendered_fields)
         else:
             log.error("Unhandled request", msg=msg)
             return

--- a/task_sdk/tests/execution_time/test_supervisor.py
+++ b/task_sdk/tests/execution_time/test_supervisor.py
@@ -887,12 +887,7 @@ class TestHandleRequest:
                 SetRenderedFields(rendered_fields={"field1": "rendered_value1", "field2": "rendered_value2"}),
                 b"",
                 "task_instances.set_rtif",
-                (
-                    TI_ID,
-                    SetRenderedFields(
-                        rendered_fields={"field1": "rendered_value1", "field2": "rendered_value2"}
-                    ),
-                ),
+                (TI_ID, {"field1": "rendered_value1", "field2": "rendered_value2"}),
                 {"ok": True},
                 id="set_rtif",
             ),

--- a/task_sdk/tests/execution_time/test_supervisor.py
+++ b/task_sdk/tests/execution_time/test_supervisor.py
@@ -46,6 +46,7 @@ from airflow.sdk.execution_time.comms import (
     GetXCom,
     PutVariable,
     RescheduleTask,
+    SetRenderedFields,
     SetXCom,
     TaskState,
     VariableResult,
@@ -881,6 +882,19 @@ class TestHandleRequest:
                 (),
                 "",
                 id="patch_task_instance_to_skipped",
+            ),
+            pytest.param(
+                SetRenderedFields(rendered_fields={"field1": "rendered_value1", "field2": "rendered_value2"}),
+                b"",
+                "task_instances.set_rtif",
+                (
+                    TI_ID,
+                    SetRenderedFields(
+                        rendered_fields={"field1": "rendered_value1", "field2": "rendered_value2"}
+                    ),
+                ),
+                {"ok": True},
+                id="set_rtif",
             ),
         ],
     )


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

While testing some end to end scenarios for RTIF and other DAGs, I realised that the RTIF table wasnt getting populated with RTIFs. It was empty, the UI showed it however.

The reason is because there was no handler in the supervisor which was sending the client request to the execution API server. This PR adds that while adding tests to supervisor and to the task runner which was only testing the "startup" and not "run". Removed an unecessary test too.

After changes:
<img width="1311" alt="image" src="https://github.com/user-attachments/assets/86db7017-928d-4e26-8a20-efd9d468cd75" />



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
