### PR TITLE
Allow Dynamic Tasks to be Searchable Using map_index_template

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -5217,6 +5217,7 @@ class TaskInstanceModelView(AirflowModelView):
         "task_id",
         "run_id",
         "map_index",
+        "rendered_map_index",
         "logical_date",
         "operator",
         "start_date",


### PR DESCRIPTION
I know we should not add "new features" to the legacy UI - but just took a look and realized that this request is actually a single-line change. So I propose to "just make it". Also I see this quite useful in my daily life.

closes: #45100