### PR TITLE
Update task try selector dropdown

### DIFF
--- a/airflow/ui/src/components/TaskTrySelect.tsx
+++ b/airflow/ui/src/components/TaskTrySelect.tsx
@@ -116,11 +116,14 @@ export const TaskTrySelect = ({
             </Select.ValueText>
           </Select.Trigger>
           <Select.Content>
-            {tryOptions.items.map((option) => (
+            {tryOptions.items.reverse().map((option) => (
               <Select.Item item={option} key={option.value}>
-                <Status state={option.task_instance.state}>
-                  {option.value}
-                </Status>
+                <span>
+                  {option.value}:
+                  <Status ml={2} state={option.task_instance.state}>
+                    {option.task_instance.state}
+                  </Status>
+                </span>
               </Select.Item>
             ))}
           </Select.Content>


### PR DESCRIPTION
Reverse order of options in the Task Try selector so that the latest try is always at the top. Also, add the state in text and not just a colored circle.

<img width="300" alt="Screenshot 2024-12-20 at 10 32 47 AM" src="https://github.com/user-attachments/assets/197defe9-f5be-4162-a369-1f70455db09a" />

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
