### PR TITLE
Evaluate None in SQLAlchemy's extended JSON type decorator

### DIFF
--- a/airflow/utils/sqlalchemy.py
+++ b/airflow/utils/sqlalchemy.py
@@ -110,6 +110,8 @@ class ExtendedJSON(TypeDecorator):
 
     cache_ok = True
 
+    should_evaluate_none = True
+
     def load_dialect_impl(self, dialect) -> TypeEngine:
         return dialect.type_descriptor(JSON)
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #22245

As of today, at least in mapped operators for `map_index > 0`, the `next_kwargs` column is saved as the string `null` in the DB, instead of a real `<null>`. That is unlike mapped operators with indeces `-1` or `0`, as well as unmapped operators.
As far as I'm concerned, this inconsistency doesn't affect any logic that depends on it, since it is still deserialized as Python's `None` - but it will be nice to save a few bytes and ensure consistency.
While I haven't figured out *why* it happens only in that case - I've found that applying the flag `should_evaluate_none = True` seems to solve it. I didn't find a proper way to test it, since it is always deserialized as Python's `None`.

Mapped operators are yet to be implemented in the `main` with the new task sdk, but if tests won't indicate that it breaks anything - I think that it will be ok to merge.



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
