### PR TITLE
Add HTTP retry handling into task SDK api.client

### DIFF
--- a/task_sdk/pyproject.toml
+++ b/task_sdk/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "msgspec>=0.18.6",
     "psutil>=6.1.0",
     "structlog>=24.4.0",
+    "retryhttp>=1.2.0",
 ]
 classifiers = [
   "Framework :: Apache Airflow",

--- a/task_sdk/src/airflow/sdk/api/client.py
+++ b/task_sdk/src/airflow/sdk/api/client.py
@@ -275,6 +275,7 @@ def noop_handler(request: httpx.Request) -> httpx.Response:
 # Config options for SDK how retries on HTTP requests should be handled
 # Note: Given defaults make attempts after 1, 3, 7, 15, 31seconds, 1:03, 2:07, 3:37 and fails after 5:07min
 # So far there is no other config facility in SDK we use ENV for the moment
+# TODO: Consider these env variables while handling airflow confs in task sdk
 API_RETRIES = int(os.getenv("AIRFLOW__WORKERS__API_RETRIES", 10))
 API_RETRY_WAIT_MIN = float(os.getenv("AIRFLOW__WORKERS__API_RETRY_WAIT_MIN", 1.0))
 API_RETRY_WAIT_MAX = float(os.getenv("AIRFLOW__WORKERS__API_RETRY_WAIT_MAX", 90.0))

--- a/task_sdk/src/airflow/sdk/api/client.py
+++ b/task_sdk/src/airflow/sdk/api/client.py
@@ -276,8 +276,8 @@ def noop_handler(request: httpx.Request) -> httpx.Response:
 # Note: Given defaults make attempts after 1, 3, 7, 15, 31seconds, 1:03, 2:07, 3:37 and fails after 5:07min
 # So far there is no other config facility in SDK we use ENV for the moment
 API_RETRIES = int(os.getenv("AIRFLOW__WORKERS__API_RETRIES", 10))
-API_RETRY_WAIT_MIN = int(os.getenv("AIRFLOW__WORKERS__API_RETRY_WAIT_MIN", 1))
-API_RETRY_WAIT_MAX = int(os.getenv("AIRFLOW__WORKERS__API_RETRY_WAIT_MAX", 90))
+API_RETRY_WAIT_MIN = float(os.getenv("AIRFLOW__WORKERS__API_RETRY_WAIT_MIN", 1.0))
+API_RETRY_WAIT_MAX = float(os.getenv("AIRFLOW__WORKERS__API_RETRY_WAIT_MAX", 90.0))
 
 
 class Client(httpx.Client):

--- a/task_sdk/src/airflow/sdk/api/client.py
+++ b/task_sdk/src/airflow/sdk/api/client.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import sys
 import uuid
@@ -28,7 +29,7 @@ import msgspec
 import structlog
 from pydantic import BaseModel
 from retryhttp import retry, wait_retry_after
-from tenacity import wait_random_exponential
+from tenacity import before_log, wait_random_exponential
 from uuid6 import uuid7
 
 from airflow.sdk import __version__
@@ -309,6 +310,7 @@ class Client(httpx.Client):
         wait_network_errors=_default_wait,
         wait_timeouts=_default_wait,
         wait_rate_limited=wait_retry_after(fallback=_default_wait),  # No infinite timeout on HTTP 429
+        before_sleep=before_log(log, logging.WARNING),
     )
     def request(self, *args, **kwargs):
         """Implement a convenience for httpx.Client.request with a retry layer."""

--- a/task_sdk/src/airflow/sdk/api/client.py
+++ b/task_sdk/src/airflow/sdk/api/client.py
@@ -274,7 +274,7 @@ def noop_handler(request: httpx.Request) -> httpx.Response:
 
 # Config options for SDK how retries on HTTP requests should be handled
 # Note: Given defaults make attempts after 1, 3, 7, 15, 31seconds, 1:03, 2:07, 3:37 and fails after 5:07min
-# As long as there is no other config facility in SDK we use ENV for the moment
+# So far there is no other config facility in SDK we use ENV for the moment
 API_RETRIES = int(os.getenv("AIRFLOW__WORKERS__API_RETRIES", 10))
 API_RETRY_WAIT_MIN = int(os.getenv("AIRFLOW__WORKERS__API_RETRY_WAIT_MIN", 1))
 API_RETRY_WAIT_MAX = int(os.getenv("AIRFLOW__WORKERS__API_RETRY_WAIT_MAX", 90))

--- a/tests/cli/commands/remote_commands/test_task_command.py
+++ b/tests/cli/commands/remote_commands/test_task_command.py
@@ -496,6 +496,8 @@ class TestCliTasks:
                 mock.patch(
                     "airflow.executors.executor_loader.ExecutorLoader.get_default_executor"
                 ) as get_default_mock,
+                mock.patch("airflow.executors.local_executor.SimpleQueue"),  # Prevent a task being queued
+                mock.patch("airflow.executors.local_executor.LocalExecutor.end"),
             ):
                 EmptyOperator(task_id="task1")
                 EmptyOperator(task_id="task2", executor="foo_executor_alias")


### PR DESCRIPTION
closes: #44355

Add HTTP retry handling to Task SDK.