### PR TITLE
[Resolve OOM When Reading Large Logs in Webserver] Refactor to Use K-Way Merge for Log Streams Instead of Sorting Entire Log Records

### DIFF
--- a/airflow/api_connexion/endpoints/log_endpoint.py
+++ b/airflow/api_connexion/endpoints/log_endpoint.py
@@ -115,11 +115,14 @@ def get_log(
     # return_type would be either the above two or None
     logs: Any
     if return_type == "application/json" or return_type is None:  # default
-        logs, metadata = task_log_reader.read_log_chunks(ti, task_try_number, metadata)
-        logs = logs[0] if task_try_number is not None else logs
+        hosts, log_streams, metadata = task_log_reader.read_log_chunks(ti, task_try_number, metadata)
+        host = f"{hosts[0] or ''}\n"
+        logs = log_streams[0] if task_try_number is not None else log_streams
         # we must have token here, so we can safely ignore it
         token = URLSafeSerializer(key).dumps(metadata)  # type: ignore[assignment]
-        return logs_schema.dump(LogResponseObject(continuation_token=token, content=logs))
+        return logs_schema.dump(
+            LogResponseObject(continuation_token=token, content=host + "\n".join(log for log in logs))
+        )
     # text/plain. Stream
     logs = task_log_reader.read_log_stream(ti, task_try_number, metadata)
 

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import logging
 import sys
 from collections import defaultdict, deque
-from collections.abc import Generator, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -55,6 +55,7 @@ if TYPE_CHECKING:
     from airflow.executors.executor_utils import ExecutorName
     from airflow.models.taskinstance import TaskInstance
     from airflow.models.taskinstancekey import TaskInstanceKey
+    from airflow.utils.log.file_task_handler import _CompatibleLogSourceType
 
     # Command to execute - list of strings
     # the first element is always "airflow".
@@ -569,12 +570,7 @@ class BaseExecutor(LoggingMixin):
         """
         raise NotImplementedError()
 
-    def get_task_log(
-        self, ti: TaskInstance, try_number: int
-    ) -> (
-        tuple[list[str], list[Generator[tuple[pendulum.DateTime | None, int, str], None, None]], int]
-        | tuple[list[str], list[str]]
-    ):
+    def get_task_log(self, ti: TaskInstance, try_number: int) -> _CompatibleLogSourceType:
         """
         Return the task logs.
 

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import logging
 import sys
 from collections import defaultdict, deque
-from collections.abc import Sequence
+from collections.abc import Generator, Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -569,13 +569,20 @@ class BaseExecutor(LoggingMixin):
         """
         raise NotImplementedError()
 
-    def get_task_log(self, ti: TaskInstance, try_number: int) -> tuple[list[str], list[str]]:
+    def get_task_log(
+        self, ti: TaskInstance, try_number: int
+    ) -> (
+        tuple[list[str], list[Generator[tuple[pendulum.DateTime | None, int, str], None, None]], int]
+        | tuple[list[str], list[str]]
+    ):
         """
         Return the task logs.
 
         :param ti: A TaskInstance object
         :param try_number: current try_number to read log from
-        :return: tuple of logs and messages
+        :return:
+            - old interface: Tuple of messages and list of log lines.
+            - new interface: Tuple of messages, parsed log streams, total size of logs.
         """
         return [], []
 

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -207,15 +207,9 @@ def _interleave_logs(*parsed_log_streams: _ParsedLogStreamType) -> Generator[str
     # to allow removing empty streams while iterating
     log_streams: list[_ParsedLogStreamType] = [log_stream for log_stream in parsed_log_streams]
 
-    # add first record from each log stream to heap
-    _add_log_from_parsed_log_streams_to_heap(heap, log_streams)
-
     # keep adding records from logs until all logs are empty
     last = None
-    while heap:
-        if not log_streams:
-            break
-
+    while log_streams:
         _add_log_from_parsed_log_streams_to_heap(heap, log_streams)
 
         # yield HALF_HEAP_DUMP_SIZE records when heap size exceeds HEAP_DUMP_SIZE

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -63,6 +63,8 @@ _ParsedLogStreamType = Generator[_ParsedLogRecordType, None, None]
 _LogSourceType = tuple[list[str], list[_ParsedLogStreamType], int]
 """Tuple of messages, parsed log streams, total size of logs."""
 _OldLogSourceType = tuple[list[str], list[str]]
+_OldGroupedByHostLogType = tuple[list[tuple[str, str]], dict]
+"""Elasticsearch and OpenSearch log reading return type, add this to avoid mypy error during migration."""
 """Tuple of messages and list of log str, will be removed after all providers adapt to stream-based log reading."""
 _CompatibleLogSourceType = Union[_LogSourceType, _OldLogSourceType]
 """Compatible type hint for stream-based log reading and old log reading."""
@@ -487,7 +489,7 @@ class FileTaskHandler(logging.Handler):
         ti: TaskInstance,
         try_number: int,
         metadata: dict[str, Any] | None = None,
-    ) -> tuple[Iterable[str], dict[str, Any]]:
+    ) -> tuple[Iterable[str], dict[str, Any]] | _OldGroupedByHostLogType:
         """
         Template method that contains custom logic of reading logs given the try_number.
 
@@ -570,6 +572,7 @@ class FileTaskHandler(logging.Handler):
             )
             messages_list.extend(served_messages)
 
+        print("messages_list", messages_list)
         # Log message source details are grouped: they are not relevant for most users and can
         # distract them from finding the root cause of their errors
         messages = " INFO - ::group::Log message source details\n"

--- a/airflow/utils/log/log_reader.py
+++ b/airflow/utils/log/log_reader.py
@@ -94,7 +94,7 @@ class TaskLogReader:
                 log_stream: Iterable[str]
                 host, log_stream, metadata = self.read_log_chunks(ti, current_try_number, metadata)
                 for log in log_stream:
-                    yield f"\n{host or ''}\n{log}\n"
+                    yield f"{host or ''}\n{log}\n"
                 if "end_of_log" not in metadata or (
                     not metadata["end_of_log"]
                     and ti.state not in (TaskInstanceState.RUNNING, TaskInstanceState.DEFERRED)

--- a/airflow/utils/log/log_reader.py
+++ b/airflow/utils/log/log_reader.py
@@ -18,9 +18,9 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from functools import cached_property
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from airflow.configuration import conf
 from airflow.utils.helpers import render_log_filename
@@ -42,7 +42,7 @@ class TaskLogReader:
 
     def read_log_chunks(
         self, ti: TaskInstance, try_number: int | None, metadata
-    ) -> tuple[list[tuple[tuple[str, str]]], dict[str, str]]:
+    ) -> tuple[str, Iterable[str], dict[str, Any]]:
         """
         Read chunks of Task Instance logs.
 
@@ -62,9 +62,14 @@ class TaskLogReader:
         contain information about the task log which can enable you read logs to the
         end.
         """
-        logs, metadatas = self.log_handler.read(ti, try_number, metadata=metadata)
-        metadata = metadatas[0]
-        return logs, metadata
+        hosts: list[str]
+        log_streams: list[Iterable[str]]
+        metadata_array: list[dict[str, Any]]
+        hosts, log_streams, metadata_array = self.log_handler.read(ti, try_number, metadata=metadata)
+        host = hosts[0]
+        log_stream = log_streams[0]
+        metadata = metadata_array[0]
+        return host, log_stream, metadata
 
     def read_log_stream(self, ti: TaskInstance, try_number: int | None, metadata: dict) -> Iterator[str]:
         """
@@ -85,14 +90,16 @@ class TaskLogReader:
             metadata.pop("offset", None)
             metadata.pop("log_pos", None)
             while True:
-                logs, metadata = self.read_log_chunks(ti, current_try_number, metadata)
-                for host, log in logs[0]:
-                    yield "\n".join([host or "", log]) + "\n"
+                host: str
+                log_stream: Iterable[str]
+                host, log_stream, metadata = self.read_log_chunks(ti, current_try_number, metadata)
+                for log in log_stream:
+                    yield f"\n{host or ''}\n{log}\n"
                 if "end_of_log" not in metadata or (
                     not metadata["end_of_log"]
                     and ti.state not in (TaskInstanceState.RUNNING, TaskInstanceState.DEFERRED)
                 ):
-                    if not logs[0]:
+                    if not log_stream:
                         # we did not receive any logs in this loop
                         # sleeping to conserve resources / limit requests on external services
                         time.sleep(self.STREAM_LOOP_SLEEP_SECONDS)

--- a/airflow/utils/serve_logs.py
+++ b/airflow/utils/serve_logs.py
@@ -133,7 +133,7 @@ def create_app():
 
     @flask_app.route("/log/<path:filename>")
     def serve_logs_view(filename):
-        return send_from_directory(log_directory, filename, mimetype="application/json", as_attachment=False)
+        return send_from_directory(log_directory, filename, mimetype="text/plain", as_attachment=False)
 
     return flask_app
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1720,9 +1720,10 @@ class Airflow(AirflowBaseView):
                 ti.task = dag.get_task(ti.task_id)
 
             if response_format == "json":
-                logs, metadata = task_log_reader.read_log_chunks(ti, try_number, metadata)
-                message = logs[0] if try_number is not None else logs
-                return {"message": message, "metadata": metadata}
+                hosts, log_streams, metadata = task_log_reader.read_log_chunks(ti, try_number, metadata)
+                host = f"{hosts[0] or ''}\n"
+                log_stream = log_streams[0]
+                return {"message": host + "\n".join(log for log in log_stream), "metadata": metadata}
 
             metadata["download_logs"] = True
             attachment_filename = task_log_reader.render_log_filename(ti, try_number, session=session)

--- a/providers/amazon/tests/unit/amazon/aws/log/test_cloudwatch_task_handler.py
+++ b/providers/amazon/tests/unit/amazon/aws/log/test_cloudwatch_task_handler.py
@@ -37,6 +37,10 @@ from airflow.utils.state import State
 from airflow.utils.timezone import datetime
 
 from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.file_task_handler import (
+    mark_test_for_old_read_log_method,
+    mark_test_for_stream_based_read_log_method,
+)
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 
@@ -130,7 +134,39 @@ class TestCloudwatchTaskHandler:
             ]
         )
 
+    @mark_test_for_old_read_log_method
     def test_read(self):
+        # Confirmed via AWS Support call:
+        # CloudWatch events must be ordered chronologically otherwise
+        # boto3 put_log_event API throws InvalidParameterException
+        # (moto does not throw this exception)
+        current_time = int(time.time()) * 1000
+        generate_log_events(
+            self.conn,
+            self.remote_log_group,
+            self.remote_log_stream,
+            [
+                {"timestamp": current_time - 2000, "message": "First"},
+                {"timestamp": current_time - 1000, "message": "Second"},
+                {"timestamp": current_time, "message": "Third"},
+            ],
+        )
+
+        msg_template = "*** Reading remote log from Cloudwatch log_group: {} log_stream: {}.\n{}\n"
+        events = "\n".join(
+            [
+                f"[{get_time_str(current_time-2000)}] First",
+                f"[{get_time_str(current_time-1000)}] Second",
+                f"[{get_time_str(current_time)}] Third",
+            ]
+        )
+        assert self.cloudwatch_task_handler.read(self.ti) == (
+            [[("", msg_template.format(self.remote_log_group, self.remote_log_stream, events))]],
+            [{"end_of_log": True}],
+        )
+
+    @mark_test_for_stream_based_read_log_method
+    def test_stream_based_read(self):
         # Confirmed via AWS Support call:
         # CloudWatch events must be ordered chronologically otherwise
         # boto3 put_log_event API throws InvalidParameterException

--- a/providers/amazon/tests/unit/amazon/aws/log/test_cloudwatch_task_handler.py
+++ b/providers/amazon/tests/unit/amazon/aws/log/test_cloudwatch_task_handler.py
@@ -147,7 +147,7 @@ class TestCloudwatchTaskHandler:
             ],
         )
 
-        msg_template = "*** Reading remote log from Cloudwatch log_group: {} log_stream: {}.\n{}\n"
+        msg_template = "*** Reading remote log from Cloudwatch log_group: {} log_stream: {}.\n{}"
         events = "\n".join(
             [
                 f"[{get_time_str(current_time-2000)}] First",
@@ -155,10 +155,11 @@ class TestCloudwatchTaskHandler:
                 f"[{get_time_str(current_time)}] Third",
             ]
         )
-        assert self.cloudwatch_task_handler.read(self.ti) == (
-            [[("", msg_template.format(self.remote_log_group, self.remote_log_stream, events))]],
-            [{"end_of_log": True}],
-        )
+        hosts, log_streams, metadatas = self.cloudwatch_task_handler.read(self.ti)
+        assert hosts == [""]
+        log_str = "\n".join(line for line in log_streams[0])
+        assert log_str == msg_template.format(self.remote_log_group, self.remote_log_stream, events)
+        assert metadatas == [{"end_of_log": True}]
 
     @pytest.mark.parametrize(
         "end_date, expected_end_time",

--- a/providers/amazon/tests/unit/amazon/aws/log/test_s3_task_handler.py
+++ b/providers/amazon/tests/unit/amazon/aws/log/test_s3_task_handler.py
@@ -35,6 +35,10 @@ from airflow.utils.state import State, TaskInstanceState
 from airflow.utils.timezone import datetime
 
 from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.file_task_handler import (
+    mark_test_for_old_read_log_method,
+    mark_test_for_stream_based_read_log_method,
+)
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 
@@ -126,24 +130,48 @@ class TestS3TaskHandler:
         mock_open.assert_called_once_with(os.path.join(self.local_log_location, "1.log"), "w")
         mock_open().write.assert_not_called()
 
+    @mark_test_for_old_read_log_method
     def test_read(self):
         self.conn.put_object(Bucket="bucket", Key=self.remote_log_key, Body=b"Log line\n")
         ti = copy.copy(self.ti)
         ti.state = TaskInstanceState.SUCCESS
+        log, metadata = self.s3_task_handler.read(ti)
+        actual = log[0][0][-1]
+        assert "*** Found logs in s3:\n***   * s3://bucket/remote/log/location/1.log\n" in actual
+        assert actual.endswith("Log line")
+        assert metadata == [{"end_of_log": True, "log_pos": 8}]
+
+    @mark_test_for_stream_based_read_log_method
+    def test_stream_based_read(self):
+        self.conn.put_object(Bucket="bucket", Key=self.remote_log_key, Body=b"Log line\n")
+        ti = copy.copy(self.ti)
+        ti.state = TaskInstanceState.SUCCESS
         read_result = self.s3_task_handler.read(ti)
-        print("read_result", read_result)
         _, log_streams, metadata_array = read_result
         log_str = "".join(line for line in log_streams[0])
         assert "*** Found logs in s3:\n***   * s3://bucket/remote/log/location/1.log\n" in log_str
         assert log_str.endswith("Log line\n")
         assert metadata_array == [{"end_of_log": True, "log_pos": 9}]
 
+    @mark_test_for_old_read_log_method
     def test_read_when_s3_log_missing(self):
+        ti = copy.copy(self.ti)
+        ti.state = TaskInstanceState.SUCCESS
+        self.s3_task_handler._read_from_logs_server = mock.Mock(return_value=([], []))
+        log, metadata = self.s3_task_handler.read(ti)
+        assert len(log) == 1
+        assert len(log) == len(metadata)
+        actual = log[0][0][-1]
+        expected = "*** No logs found on s3 for ti=<TaskInstance: dag_for_testing_s3_task_handler.task_for_testing_s3_log_handler test [success]>\n"
+        assert expected in actual
+        assert metadata[0] == {"end_of_log": True, "log_pos": 0}
+
+    @mark_test_for_stream_based_read_log_method
+    def test_stream_based_read_when_s3_log_missing(self):
         ti = copy.copy(self.ti)
         ti.state = TaskInstanceState.SUCCESS
         self.s3_task_handler._read_from_logs_server = mock.Mock(return_value=([], [], 0))
         read_result = self.s3_task_handler.read(ti)
-        print("read_result", read_result)
         _, log_streams, metadata_array = read_result
         assert len(log_streams) == 1
         assert len(log_streams) == len(metadata_array)

--- a/providers/celery/tests/unit/celery/log_handlers/test_log_handlers.py
+++ b/providers/celery/tests/unit/celery/log_handlers/test_log_handlers.py
@@ -37,7 +37,11 @@ from airflow.utils.timezone import datetime
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.config import conf_vars
-from tests_common.test_utils.file_task_handler import log_str_to_parsed_log_stream
+from tests_common.test_utils.file_task_handler import (
+    log_str_to_parsed_log_stream,
+    mark_test_for_old_read_log_method,
+    mark_test_for_stream_based_read_log_method,
+)
 
 pytestmark = pytest.mark.db_test
 
@@ -61,7 +65,33 @@ class TestFileTaskLogHandler:
     def teardown_method(self):
         self.clean_up()
 
+    @mark_test_for_old_read_log_method
     def test__read_for_celery_executor_fallbacks_to_worker(self, create_task_instance):
+        """Test for executors which do not have `get_task_log` method, it fallbacks to reading
+        log from worker"""
+        executor_name = "CeleryExecutor"
+        ti = create_task_instance(
+            dag_id="dag_for_testing_celery_executor_log_read",
+            task_id="task_for_testing_celery_executor_log_read",
+            run_type=DagRunType.SCHEDULED,
+            logical_date=DEFAULT_DATE,
+        )
+        ti.state = TaskInstanceState.RUNNING
+        ti.try_number = 1
+        with conf_vars({("core", "executor"): executor_name}):
+            reload(executor_loader)
+            fth = FileTaskHandler("")
+
+            fth._read_from_logs_server = mock.Mock()
+            fth._read_from_logs_server.return_value = ["this message"], ["this\nlog\ncontent"]
+            actual = fth._read(ti=ti, try_number=1)
+            fth._read_from_logs_server.assert_called_once()
+        assert "*** this message\n" in actual[0]
+        assert actual[0].endswith("this\nlog\ncontent")
+        assert actual[1] == {"end_of_log": False, "log_pos": 16}
+
+    @mark_test_for_stream_based_read_log_method
+    def test_stream_based__read_for_celery_executor_fallbacks_to_worker(self, create_task_instance):
         """Test for executors which do not have `get_task_log` method, it fallbacks to reading
         log from worker"""
         executor_name = "CeleryExecutor"

--- a/providers/celery/tests/unit/celery/log_handlers/test_log_handlers.py
+++ b/providers/celery/tests/unit/celery/log_handlers/test_log_handlers.py
@@ -37,6 +37,7 @@ from airflow.utils.timezone import datetime
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.file_task_handler import log_str_to_parsed_log_stream
 
 pytestmark = pytest.mark.db_test
 
@@ -77,9 +78,14 @@ class TestFileTaskLogHandler:
             fth = FileTaskHandler("")
 
             fth._read_from_logs_server = mock.Mock()
-            fth._read_from_logs_server.return_value = ["this message"], ["this\nlog\ncontent"]
-            actual = fth._read(ti=ti, try_number=1)
+            fth._read_from_logs_server.return_value = (
+                ["this message"],
+                [log_str_to_parsed_log_stream("this\nlog\ncontent")],
+                len("this\nlog\ncontent"),
+            )
+            log_stream, metadata = fth._read(ti=ti, try_number=1)
+            log_str = "\n".join(line for line in log_stream)
             fth._read_from_logs_server.assert_called_once()
-        assert "*** this message\n" in actual[0]
-        assert actual[0].endswith("this\nlog\ncontent")
-        assert actual[1] == {"end_of_log": False, "log_pos": 16}
+        assert "*** this message\n" in log_str
+        assert log_str.endswith("this\nlog\ncontent")
+        assert metadata == {"end_of_log": False, "log_pos": 16}

--- a/providers/elasticsearch/tests/unit/elasticsearch/log/test_es_task_handler.py
+++ b/providers/elasticsearch/tests/unit/elasticsearch/log/test_es_task_handler.py
@@ -48,6 +48,10 @@ from unit.elasticsearch.log.elasticmock.utilities import SearchFailedException
 
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import clear_db_dags, clear_db_runs
+from tests_common.test_utils.file_task_handler import (
+    mark_test_for_old_read_log_method,
+    mark_test_for_stream_based_read_log_method,
+)
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 pytestmark = pytest.mark.db_test
@@ -202,7 +206,23 @@ class TestElasticsearchTaskHandler:
         )
         assert handler.index_patterns == patterns
 
+    @mark_test_for_old_read_log_method
     def test_read(self, ti):
+        ts = pendulum.now()
+        logs, metadatas = self.es_task_handler.read(
+            ti, 1, {"offset": 0, "last_log_timestamp": str(ts), "end_of_log": False}
+        )
+
+        assert len(logs) == 1
+        assert len(logs) == len(metadatas)
+        assert len(logs[0]) == 1
+        assert self.test_message == logs[0][0][-1]
+        assert not metadatas[0]["end_of_log"]
+        assert metadatas[0]["offset"] == "1"
+        assert timezone.parse(metadatas[0]["last_log_timestamp"]) > ts
+
+    @mark_test_for_stream_based_read_log_method
+    def test_stream_based_read(self, ti):
         ts = pendulum.now()
         _, log_streams, metadatas = self.es_task_handler.read(
             ti, 1, {"offset": 0, "last_log_timestamp": str(ts), "end_of_log": False}
@@ -216,7 +236,24 @@ class TestElasticsearchTaskHandler:
         assert metadatas[0]["offset"] == "1"
         assert timezone.parse(metadatas[0]["last_log_timestamp"]) > ts
 
+    @mark_test_for_old_read_log_method
     def test_read_with_patterns(self, ti):
+        ts = pendulum.now()
+        with mock.patch.object(self.es_task_handler, "index_patterns", new="test_*,other_*"):
+            logs, metadatas = self.es_task_handler.read(
+                ti, 1, {"offset": 0, "last_log_timestamp": str(ts), "end_of_log": False}
+            )
+
+        assert len(logs) == 1
+        assert len(logs) == len(metadatas)
+        assert len(logs[0]) == 1
+        assert self.test_message == logs[0][0][-1]
+        assert not metadatas[0]["end_of_log"]
+        assert metadatas[0]["offset"] == "1"
+        assert timezone.parse(metadatas[0]["last_log_timestamp"]) > ts
+
+    @mark_test_for_stream_based_read_log_method
+    def test_stream_based_read_with_patterns(self, ti):
         ts = pendulum.now()
         with mock.patch.object(self.es_task_handler, "index_patterns", new="test_*,other_*"):
             _, log_streams, metadatas = self.es_task_handler.read(
@@ -231,7 +268,24 @@ class TestElasticsearchTaskHandler:
         assert metadatas[0]["offset"] == "1"
         assert timezone.parse(metadatas[0]["last_log_timestamp"]) > ts
 
+    @mark_test_for_old_read_log_method
     def test_read_with_patterns_no_match(self, ti):
+        ts = pendulum.now()
+        with mock.patch.object(self.es_task_handler, "index_patterns", new="test_other_*,test_another_*"):
+            logs, metadatas = self.es_task_handler.read(
+                ti, 1, {"offset": 0, "last_log_timestamp": str(ts), "end_of_log": False}
+            )
+
+        assert len(logs) == 1
+        assert len(logs) == len(metadatas)
+        assert logs == [[]]
+        assert not metadatas[0]["end_of_log"]
+        assert metadatas[0]["offset"] == "0"
+        # last_log_timestamp won't change if no log lines read.
+        assert timezone.parse(metadatas[0]["last_log_timestamp"]) == ts
+
+    @mark_test_for_stream_based_read_log_method
+    def test_stream_based_read_with_patterns_no_match(self, ti):
         ts = pendulum.now()
         with mock.patch.object(self.es_task_handler, "index_patterns", new="test_other_*,test_another_*"):
             _, log_streams, metadatas = self.es_task_handler.read(
@@ -255,8 +309,42 @@ class TestElasticsearchTaskHandler:
                     ti, 1, {"offset": 0, "last_log_timestamp": str(ts), "end_of_log": False}
                 )
 
+    @mark_test_for_old_read_log_method
     @pytest.mark.parametrize("seconds", [3, 6])
     def test_read_missing_logs(self, seconds, create_task_instance):
+        """
+        When the log actually isn't there to be found, we only want to wait for 5 seconds.
+        In this case we expect to receive a message of the form 'Log {log_id} not found in elasticsearch ...'
+        """
+        ti = get_ti(
+            self.DAG_ID,
+            self.TASK_ID,
+            pendulum.instance(self.LOGICAL_DATE).add(days=1),  # so logs are not found
+            create_task_instance=create_task_instance,
+        )
+        ts = pendulum.now().add(seconds=-seconds)
+        logs, metadatas = self.es_task_handler.read(ti, 1, {"offset": 0, "last_log_timestamp": str(ts)})
+
+        assert len(logs) == 1
+        if seconds > 5:
+            # we expect a log not found message when checking began more than 5 seconds ago
+            assert len(logs[0]) == 1
+            actual_message = logs[0][0][1]
+            expected_pattern = r"^\*\*\* Log .* not found in Elasticsearch.*"
+            assert re.match(expected_pattern, actual_message) is not None
+            assert metadatas[0]["end_of_log"] is True
+        else:
+            # we've "waited" less than 5 seconds so it should not be "end of log" and should be no log message
+            assert len(logs[0]) == 0
+            assert logs == [[]]
+            assert metadatas[0]["end_of_log"] is False
+        assert len(logs) == len(metadatas)
+        assert metadatas[0]["offset"] == "0"
+        assert timezone.parse(metadatas[0]["last_log_timestamp"]) == ts
+
+    @mark_test_for_stream_based_read_log_method
+    @pytest.mark.parametrize("seconds", [3, 6])
+    def test_stream_based_read_missing_logs(self, seconds, create_task_instance):
         """
         When the log actually isn't there to be found, we only want to wait for 5 seconds.
         In this case we expect to receive a message of the form 'Log {log_id} not found in elasticsearch ...'
@@ -287,7 +375,32 @@ class TestElasticsearchTaskHandler:
         assert metadatas[0]["offset"] == "0"
         assert timezone.parse(metadatas[0]["last_log_timestamp"]) == ts
 
+    @mark_test_for_old_read_log_method
     def test_read_with_match_phrase_query(self, ti):
+        similar_log_id = (
+            f"{TestElasticsearchTaskHandler.TASK_ID}-"
+            f"{TestElasticsearchTaskHandler.DAG_ID}-2016-01-01T00:00:00+00:00-1"
+        )
+        another_test_message = "another message"
+
+        another_body = {"message": another_test_message, "log_id": similar_log_id, "offset": 1}
+        self.es.index(index=self.index_name, doc_type=self.doc_type, body=another_body, id=1)
+
+        ts = pendulum.now()
+        logs, metadatas = self.es_task_handler.read(
+            ti, 1, {"offset": "0", "last_log_timestamp": str(ts), "end_of_log": False, "max_offset": 2}
+        )
+        assert len(logs) == 1
+        assert len(logs) == len(metadatas)
+        assert self.test_message == logs[0][0][-1]
+        assert another_test_message != logs[0]
+
+        assert not metadatas[0]["end_of_log"]
+        assert metadatas[0]["offset"] == "1"
+        assert timezone.parse(metadatas[0]["last_log_timestamp"]) > ts
+
+    @mark_test_for_stream_based_read_log_method
+    def test_stream_based_read_with_match_phrase_query(self, ti):
         similar_log_id = (
             f"{TestElasticsearchTaskHandler.TASK_ID}-"
             f"{TestElasticsearchTaskHandler.DAG_ID}-2016-01-01T00:00:00+00:00-1"
@@ -311,7 +424,18 @@ class TestElasticsearchTaskHandler:
         assert metadatas[0]["offset"] == "1"
         assert timezone.parse(metadatas[0]["last_log_timestamp"]) > ts
 
+    @mark_test_for_old_read_log_method
     def test_read_with_none_metadata(self, ti):
+        logs, metadatas = self.es_task_handler.read(ti, 1)
+        assert len(logs) == 1
+        assert len(logs) == len(metadatas)
+        assert self.test_message == logs[0][0][-1]
+        assert not metadatas[0]["end_of_log"]
+        assert metadatas[0]["offset"] == "1"
+        assert timezone.parse(metadatas[0]["last_log_timestamp"]) < pendulum.now()
+
+    @mark_test_for_stream_based_read_log_method
+    def test_stream_based_read_with_none_metadata(self, ti):
         _, log_streams, metadatas = self.es_task_handler.read(ti, 1)
         assert len(log_streams) == 1
         assert len(log_streams) == len(metadatas)
@@ -321,7 +445,26 @@ class TestElasticsearchTaskHandler:
         assert metadatas[0]["offset"] == "1"
         assert timezone.parse(metadatas[0]["last_log_timestamp"]) < pendulum.now()
 
+    @mark_test_for_old_read_log_method
     def test_read_nonexistent_log(self, ti):
+        ts = pendulum.now()
+        # In ElasticMock, search is going to return all documents with matching index
+        # and doc_type regardless of match filters, so we delete the log entry instead
+        # of making a new TaskInstance to query.
+        self.es.delete(index=self.index_name, doc_type=self.doc_type, id=1)
+        logs, metadatas = self.es_task_handler.read(
+            ti, 1, {"offset": 0, "last_log_timestamp": str(ts), "end_of_log": False}
+        )
+        assert len(logs) == 1
+        assert len(logs) == len(metadatas)
+        assert logs == [[]]
+        assert not metadatas[0]["end_of_log"]
+        assert metadatas[0]["offset"] == "0"
+        # last_log_timestamp won't change if no log lines read.
+        assert timezone.parse(metadatas[0]["last_log_timestamp"]) == ts
+
+    @mark_test_for_stream_based_read_log_method
+    def test_stream_based_read_nonexistent_log(self, ti):
         ts = pendulum.now()
         # In ElasticMock, search is going to return all documents with matching index
         # and doc_type regardless of match filters, so we delete the log entry instead
@@ -339,7 +482,35 @@ class TestElasticsearchTaskHandler:
         # last_log_timestamp won't change if no log lines read.
         assert timezone.parse(metadatas[0]["last_log_timestamp"]) == ts
 
+    @mark_test_for_old_read_log_method
     def test_read_with_empty_metadata(self, ti):
+        ts = pendulum.now()
+        logs, metadatas = self.es_task_handler.read(ti, 1, {})
+        assert len(logs) == 1
+        assert len(logs) == len(metadatas)
+        assert self.test_message == logs[0][0][-1]
+        assert not metadatas[0]["end_of_log"]
+        # offset should be initialized to 0 if not provided.
+        assert metadatas[0]["offset"] == "1"
+        # last_log_timestamp will be initialized using log reading time
+        # if not last_log_timestamp is provided.
+        assert timezone.parse(metadatas[0]["last_log_timestamp"]) > ts
+
+        # case where offset is missing but metadata not empty.
+        self.es.delete(index=self.index_name, doc_type=self.doc_type, id=1)
+        logs, metadatas = self.es_task_handler.read(ti, 1, {"end_of_log": False})
+        assert len(logs) == 1
+        assert len(logs) == len(metadatas)
+        assert logs == [[]]
+        assert not metadatas[0]["end_of_log"]
+        # offset should be initialized to 0 if not provided.
+        assert metadatas[0]["offset"] == "0"
+        # last_log_timestamp will be initialized using log reading time
+        # if not last_log_timestamp is provided.
+        assert timezone.parse(metadatas[0]["last_log_timestamp"]) > ts
+
+    @mark_test_for_stream_based_read_log_method
+    def test_stream_based_read_with_empty_metadata(self, ti):
         ts = pendulum.now()
         _, log_streams, metadatas = self.es_task_handler.read(ti, 1, {})
         assert len(log_streams) == 1
@@ -367,7 +538,33 @@ class TestElasticsearchTaskHandler:
         # if not last_log_timestamp is provided.
         assert timezone.parse(metadatas[0]["last_log_timestamp"]) > ts
 
+    @mark_test_for_old_read_log_method
     def test_read_timeout(self, ti):
+        ts = pendulum.now().subtract(minutes=5)
+
+        self.es.delete(index=self.index_name, doc_type=self.doc_type, id=1)
+        # in the below call, offset=1 implies that we have already retrieved something
+        # if we had never retrieved any logs at all (offset=0), then we would have gotten
+        # a "logs not found" message after 5 seconds of trying
+        offset = 1
+        logs, metadatas = self.es_task_handler.read(
+            task_instance=ti,
+            try_number=1,
+            metadata={
+                "offset": offset,
+                "last_log_timestamp": str(ts),
+                "end_of_log": False,
+            },
+        )
+        assert len(logs) == 1
+        assert len(logs) == len(metadatas)
+        assert logs == [[]]
+        assert metadatas[0]["end_of_log"]
+        assert str(offset) == metadatas[0]["offset"]
+        assert timezone.parse(metadatas[0]["last_log_timestamp"]) == ts
+
+    @mark_test_for_stream_based_read_log_method
+    def test_stream_based_read_timeout(self, ti):
         ts = pendulum.now().subtract(minutes=5)
 
         self.es.delete(index=self.index_name, doc_type=self.doc_type, id=1)
@@ -392,7 +589,25 @@ class TestElasticsearchTaskHandler:
         assert str(offset) == metadatas[0]["offset"]
         assert timezone.parse(metadatas[0]["last_log_timestamp"]) == ts
 
+    @mark_test_for_old_read_log_method
     def test_read_as_download_logs(self, ti):
+        ts = pendulum.now()
+        logs, metadatas = self.es_task_handler.read(
+            ti,
+            1,
+            {"offset": 0, "last_log_timestamp": str(ts), "download_logs": True, "end_of_log": False},
+        )
+        assert len(logs) == 1
+        assert len(logs) == len(metadatas)
+        assert len(logs[0]) == 1
+        assert self.test_message == logs[0][0][-1]
+        assert not metadatas[0]["end_of_log"]
+        assert metadatas[0]["download_logs"]
+        assert metadatas[0]["offset"] == "1"
+        assert timezone.parse(metadatas[0]["last_log_timestamp"]) > ts
+
+    @mark_test_for_stream_based_read_log_method
+    def test_stream_based_read_as_download_logs(self, ti):
         ts = pendulum.now()
         _, log_streams, metadatas = self.es_task_handler.read(
             ti,
@@ -408,7 +623,23 @@ class TestElasticsearchTaskHandler:
         assert metadatas[0]["offset"] == "1"
         assert timezone.parse(metadatas[0]["last_log_timestamp"]) > ts
 
+    @mark_test_for_old_read_log_method
     def test_read_raises(self, ti):
+        with mock.patch.object(self.es_task_handler.log, "exception") as mock_exception:
+            with mock.patch.object(self.es_task_handler.client, "search") as mock_execute:
+                mock_execute.side_effect = SearchFailedException("Failed to read")
+                logs, metadatas = self.es_task_handler.read(ti, 1)
+            assert mock_exception.call_count == 1
+            args, kwargs = mock_exception.call_args
+            assert "Could not read log with log_id:" in args[0]
+        assert len(logs) == 1
+        assert len(logs) == len(metadatas)
+        assert logs == [[]]
+        assert not metadatas[0]["end_of_log"]
+        assert metadatas[0]["offset"] == "0"
+
+    @mark_test_for_stream_based_read_log_method
+    def test_stream_based_read_raises(self, ti):
         with mock.patch.object(self.es_task_handler.log, "exception") as mock_exception:
             with mock.patch.object(self.es_task_handler.client, "search") as mock_execute:
                 mock_execute.side_effect = SearchFailedException("Failed to read")
@@ -434,7 +665,34 @@ class TestElasticsearchTaskHandler:
         self.es_task_handler.json_format = True
         self.es_task_handler.set_context(ti)
 
+    @mark_test_for_old_read_log_method
     def test_read_with_json_format(self, ti):
+        ts = pendulum.now()
+        formatter = logging.Formatter(
+            "[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s - %(exc_text)s"
+        )
+        self.es_task_handler.formatter = formatter
+        self.es_task_handler.json_format = True
+
+        self.body = {
+            "message": self.test_message,
+            "log_id": f"{self.DAG_ID}-{self.TASK_ID}-2016_01_01T00_00_00_000000-1",
+            "offset": 1,
+            "asctime": "2020-12-24 19:25:00,962",
+            "filename": "taskinstance.py",
+            "lineno": 851,
+            "levelname": "INFO",
+        }
+        self.es_task_handler.set_context(ti)
+        self.es.index(index=self.index_name, doc_type=self.doc_type, body=self.body, id=id)
+
+        logs, _ = self.es_task_handler.read(
+            ti, 1, {"offset": 0, "last_log_timestamp": str(ts), "end_of_log": False}
+        )
+        assert logs[0][0][1] == "[2020-12-24 19:25:00,962] {taskinstance.py:851} INFO - some random stuff - "
+
+    @mark_test_for_stream_based_read_log_method
+    def test_stream_based_read_with_json_format(self, ti):
         ts = pendulum.now()
         formatter = logging.Formatter(
             "[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s - %(exc_text)s"
@@ -460,7 +718,37 @@ class TestElasticsearchTaskHandler:
         log_str = "".join(line for line in log_streams[0])
         assert log_str == "[2020-12-24 19:25:00,962] {taskinstance.py:851} INFO - some random stuff - "
 
+    @mark_test_for_old_read_log_method
     def test_read_with_json_format_with_custom_offset_and_host_fields(self, ti):
+        ts = pendulum.now()
+        formatter = logging.Formatter(
+            "[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s - %(exc_text)s"
+        )
+        self.es_task_handler.formatter = formatter
+        self.es_task_handler.json_format = True
+        self.es_task_handler.host_field = "host.name"
+        self.es_task_handler.offset_field = "log.offset"
+
+        self.body = {
+            "message": self.test_message,
+            "log_id": f"{self.DAG_ID}-{self.TASK_ID}-2016_01_01T00_00_00_000000-1",
+            "log": {"offset": 1},
+            "host": {"name": "somehostname"},
+            "asctime": "2020-12-24 19:25:00,962",
+            "filename": "taskinstance.py",
+            "lineno": 851,
+            "levelname": "INFO",
+        }
+        self.es_task_handler.set_context(ti)
+        self.es.index(index=self.index_name, doc_type=self.doc_type, body=self.body, id=id)
+
+        logs, _ = self.es_task_handler.read(
+            ti, 1, {"offset": 0, "last_log_timestamp": str(ts), "end_of_log": False}
+        )
+        assert logs[0][0][1] == "[2020-12-24 19:25:00,962] {taskinstance.py:851} INFO - some random stuff - "
+
+    @mark_test_for_stream_based_read_log_method
+    def test_stream_based_read_with_json_format_with_custom_offset_and_host_fields(self, ti):
         ts = pendulum.now()
         formatter = logging.Formatter(
             "[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s - %(exc_text)s"
@@ -489,7 +777,30 @@ class TestElasticsearchTaskHandler:
         log_str = "".join(line for line in log_streams[0])
         assert log_str == "[2020-12-24 19:25:00,962] {taskinstance.py:851} INFO - some random stuff - "
 
+    @mark_test_for_old_read_log_method
     def test_read_with_custom_offset_and_host_fields(self, ti):
+        ts = pendulum.now()
+        # Delete the existing log entry as it doesn't have the new offset and host fields
+        self.es.delete(index=self.index_name, doc_type=self.doc_type, id=1)
+
+        self.es_task_handler.host_field = "host.name"
+        self.es_task_handler.offset_field = "log.offset"
+
+        self.body = {
+            "message": self.test_message,
+            "log_id": self.LOG_ID,
+            "log": {"offset": 1},
+            "host": {"name": "somehostname"},
+        }
+        self.es.index(index=self.index_name, doc_type=self.doc_type, body=self.body, id=id)
+
+        logs, _ = self.es_task_handler.read(
+            ti, 1, {"offset": 0, "last_log_timestamp": str(ts), "end_of_log": False}
+        )
+        assert self.test_message == logs[0][0][1]
+
+    @mark_test_for_stream_based_read_log_method
+    def test_stream_based_read_with_custom_offset_and_host_fields(self, ti):
         ts = pendulum.now()
         # Delete the existing log entry as it doesn't have the new offset and host fields
         self.es.delete(index=self.index_name, doc_type=self.doc_type, id=1)

--- a/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
+++ b/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
@@ -205,7 +205,7 @@ class TestGCSTaskHandler:
             (
                 "airflow.providers.google.cloud.log.gcs_task_handler.GCSTaskHandler",
                 logging.ERROR,
-                "Could not write logs to \x1b[1mgs://bucket/remote/log/location/1.log\x1b[22m: \x1b[1mFailed to connect\x1b[22m",
+                "Could not write logs to gs://bucket/remote/log/location/1.log: Failed to connect",
             ),
         ]
         mock_blob.assert_has_calls(

--- a/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
+++ b/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
@@ -30,6 +30,10 @@ from airflow.utils.timezone import datetime
 
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import clear_db_dags, clear_db_runs
+from tests_common.test_utils.file_task_handler import (
+    mark_test_for_old_read_log_method,
+    mark_test_for_stream_based_read_log_method,
+)
 
 
 @pytest.mark.db_test
@@ -87,6 +91,7 @@ class TestGCSTaskHandler:
         )
         assert mock_client.return_value == return_value
 
+    @mark_test_for_old_read_log_method
     @conf_vars({("logging", "remote_log_conn_id"): "gcs_default"})
     @mock.patch(
         "airflow.providers.google.cloud.log.gcs_task_handler.get_credentials_and_project_id",
@@ -95,6 +100,31 @@ class TestGCSTaskHandler:
     @mock.patch("google.cloud.storage.Client")
     @mock.patch("google.cloud.storage.Blob")
     def test_should_read_logs_from_remote(self, mock_blob, mock_client, mock_creds, session):
+        mock_obj = MagicMock()
+        mock_obj.name = "remote/log/location/1.log"
+        mock_client.return_value.list_blobs.return_value = [mock_obj]
+        mock_blob.from_string.return_value.download_as_bytes.return_value = b"CONTENT"
+        ti = copy.copy(self.ti)
+        ti.state = TaskInstanceState.SUCCESS
+        session.add(ti)
+        session.commit()
+        logs, metadata = self.gcs_task_handler._read(ti, self.ti.try_number)
+        mock_blob.from_string.assert_called_once_with(
+            "gs://bucket/remote/log/location/1.log", mock_client.return_value
+        )
+        assert "*** Found remote logs:\n***   * gs://bucket/remote/log/location/1.log\n" in logs
+        assert logs.endswith("CONTENT")
+        assert metadata == {"end_of_log": True, "log_pos": 7}
+
+    @mark_test_for_stream_based_read_log_method
+    @conf_vars({("logging", "remote_log_conn_id"): "gcs_default"})
+    @mock.patch(
+        "airflow.providers.google.cloud.log.gcs_task_handler.get_credentials_and_project_id",
+        return_value=("TEST_CREDENTIALS", "TEST_PROJECT_ID"),
+    )
+    @mock.patch("google.cloud.storage.Client")
+    @mock.patch("google.cloud.storage.Blob")
+    def test_stream_based_should_read_logs_from_remote(self, mock_blob, mock_client, mock_creds, session):
         mock_obj = MagicMock()
         mock_obj.name = "remote/log/location/1.log"
         mock_client.return_value.list_blobs.return_value = [mock_obj]
@@ -112,6 +142,7 @@ class TestGCSTaskHandler:
         assert log_str.endswith("CONTENT")
         assert metadata == {"end_of_log": True, "log_pos": 7}
 
+    @mark_test_for_old_read_log_method
     @mock.patch(
         "airflow.providers.google.cloud.log.gcs_task_handler.get_credentials_and_project_id",
         return_value=("TEST_CREDENTIALS", "TEST_PROJECT_ID"),
@@ -119,6 +150,36 @@ class TestGCSTaskHandler:
     @mock.patch("google.cloud.storage.Client")
     @mock.patch("google.cloud.storage.Blob")
     def test_should_read_from_local_on_logs_read_error(self, mock_blob, mock_client, mock_creds):
+        mock_obj = MagicMock()
+        mock_obj.name = "remote/log/location/1.log"
+        mock_client.return_value.list_blobs.return_value = [mock_obj]
+        mock_blob.from_string.return_value.download_as_bytes.side_effect = Exception("Failed to connect")
+
+        self.gcs_task_handler.set_context(self.ti)
+        ti = copy.copy(self.ti)
+        ti.state = TaskInstanceState.SUCCESS
+        log, metadata = self.gcs_task_handler._read(ti, self.ti.try_number)
+
+        assert (
+            "*** Found remote logs:\n"
+            "***   * gs://bucket/remote/log/location/1.log\n"
+            "*** Unable to read remote log Failed to connect\n"
+            "*** Found local files:\n"
+            f"***   * {self.gcs_task_handler.local_base}/1.log\n"
+        ) in log
+        assert metadata == {"end_of_log": True, "log_pos": 0}
+        mock_blob.from_string.assert_called_once_with(
+            "gs://bucket/remote/log/location/1.log", mock_client.return_value
+        )
+
+    @mark_test_for_stream_based_read_log_method
+    @mock.patch(
+        "airflow.providers.google.cloud.log.gcs_task_handler.get_credentials_and_project_id",
+        return_value=("TEST_CREDENTIALS", "TEST_PROJECT_ID"),
+    )
+    @mock.patch("google.cloud.storage.Client")
+    @mock.patch("google.cloud.storage.Blob")
+    def test_stream_based_should_read_from_local_on_logs_read_error(self, mock_blob, mock_client, mock_creds):
         mock_obj = MagicMock()
         mock_obj.name = "remote/log/location/1.log"
         mock_client.return_value.list_blobs.return_value = [mock_obj]

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/log/test_wasb_task_handler.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/log/test_wasb_task_handler.py
@@ -32,6 +32,10 @@ from airflow.utils.timezone import datetime
 
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import clear_db_dags, clear_db_runs
+from tests_common.test_utils.file_task_handler import (
+    mark_test_for_old_read_log_method,
+    mark_test_for_stream_based_read_log_method,
+)
 
 pytestmark = pytest.mark.db_test
 
@@ -104,8 +108,26 @@ class TestWasbTaskHandler:
             self.container_name, self.remote_log_location
         )
 
+    @mark_test_for_old_read_log_method
     @mock.patch("airflow.providers.microsoft.azure.hooks.wasb.WasbHook")
     def test_wasb_read(self, mock_hook_cls, ti):
+        mock_hook = mock_hook_cls.return_value
+        mock_hook.get_blobs_list.return_value = ["abc/hello.log"]
+        mock_hook.read_file.return_value = "Log line"
+        assert self.wasb_task_handler.wasb_read(self.remote_log_location) == "Log line"
+        ti = copy.copy(ti)
+        ti.state = TaskInstanceState.SUCCESS
+        assert self.wasb_task_handler.read(ti)[0][0][0][0] == "localhost"
+        assert (
+            "*** Found remote logs:\n***   * https://wasb-container.blob.core.windows.net/abc/hello.log\n"
+            in self.wasb_task_handler.read(ti)[0][0][0][1]
+        )
+        assert "Log line" in self.wasb_task_handler.read(ti)[0][0][0][1]
+        assert self.wasb_task_handler.read(ti)[1][0] == {"end_of_log": True, "log_pos": 8}
+
+    @mark_test_for_stream_based_read_log_method
+    @mock.patch("airflow.providers.microsoft.azure.hooks.wasb.WasbHook")
+    def test_stream_based_wasb_read(self, mock_hook_cls, ti):
         mock_hook = mock_hook_cls.return_value
         mock_hook.get_blobs_list.return_value = ["abc/hello.log"]
         mock_hook.read_file.return_value = "Log line"

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/log/test_wasb_task_handler.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/log/test_wasb_task_handler.py
@@ -112,13 +112,15 @@ class TestWasbTaskHandler:
         assert self.wasb_task_handler.wasb_read(self.remote_log_location) == "Log line"
         ti = copy.copy(ti)
         ti.state = TaskInstanceState.SUCCESS
-        assert self.wasb_task_handler.read(ti)[0][0][0][0] == "localhost"
+        hosts, log_streams, metadatas = self.wasb_task_handler.read(ti)
+        assert hosts[0] == "localhost"
+        log_str = "".join(line for line in log_streams[0])
         assert (
             "*** Found remote logs:\n***   * https://wasb-container.blob.core.windows.net/abc/hello.log\n"
-            in self.wasb_task_handler.read(ti)[0][0][0][1]
+            in log_str
         )
-        assert "Log line" in self.wasb_task_handler.read(ti)[0][0][0][1]
-        assert self.wasb_task_handler.read(ti)[1][0] == {"end_of_log": True, "log_pos": 8}
+        assert "Log line" in log_str
+        assert metadatas[0] == {"end_of_log": True, "log_pos": 8}
 
     @mock.patch(
         "airflow.providers.microsoft.azure.hooks.wasb.WasbHook",

--- a/providers/opensearch/tests/unit/opensearch/log/test_os_task_handler.py
+++ b/providers/opensearch/tests/unit/opensearch/log/test_os_task_handler.py
@@ -45,6 +45,10 @@ from unit.opensearch.conftest import MockClient
 
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import clear_db_dags, clear_db_runs
+from tests_common.test_utils.file_task_handler import (
+    mark_test_for_old_read_log_method,
+    mark_test_for_stream_based_read_log_method,
+)
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 opensearchpy = pytest.importorskip("opensearchpy")
@@ -189,7 +193,27 @@ class TestOpensearchTaskHandler:
         )
         assert handler.index_patterns == patterns
 
+    @mark_test_for_old_read_log_method
     def test_read(self, ti):
+        ts = pendulum.now()
+        logs, metadatas = self.os_task_handler.read(
+            ti, 1, {"offset": 0, "last_log_timestamp": str(ts), "end_of_log": False}
+        )
+
+        assert len(logs) == 1
+        assert len(logs) == len(metadatas)
+        assert len(logs[0]) == 1
+        assert (
+            logs[0][0][-1] == "Dependencies all met for dep_context=non-requeueable"
+            " deps ti=<TaskInstance: example_bash_operator.run_after_loop owen_run_run [queued]>\n"
+            "Starting attempt 1 of 1\nExecuting <Task(BashOperator): run_after_loop> "
+            "on 2023-07-09 07:47:32+00:00"
+        )
+        assert not metadatas[0]["end_of_log"]
+        assert timezone.parse(metadatas[0]["last_log_timestamp"]) > ts
+
+    @mark_test_for_stream_based_read_log_method
+    def test_stream_based_read(self, ti):
         ts = pendulum.now()
         hosts, log_streams, metadata_array = self.os_task_handler.read(
             ti, 1, {"offset": 0, "last_log_timestamp": str(ts), "end_of_log": False}
@@ -208,7 +232,28 @@ class TestOpensearchTaskHandler:
         assert not metadata_array[0]["end_of_log"]
         assert timezone.parse(metadata_array[0]["last_log_timestamp"]) > ts
 
+    @mark_test_for_old_read_log_method
     def test_read_with_patterns(self, ti):
+        ts = pendulum.now()
+        with mock.patch.object(self.os_task_handler, "index_patterns", new="test_*,other_*"):
+            logs, metadatas = self.os_task_handler.read(
+                ti, 1, {"offset": 0, "last_log_timestamp": str(ts), "end_of_log": False}
+            )
+
+        assert len(logs) == 1
+        assert len(logs) == len(metadatas)
+        assert len(logs[0]) == 1
+        assert (
+            logs[0][0][-1] == "Dependencies all met for dep_context=non-requeueable"
+            " deps ti=<TaskInstance: example_bash_operator.run_after_loop owen_run_run [queued]>\n"
+            "Starting attempt 1 of 1\nExecuting <Task(BashOperator): run_after_loop> "
+            "on 2023-07-09 07:47:32+00:00"
+        )
+        assert not metadatas[0]["end_of_log"]
+        assert timezone.parse(metadatas[0]["last_log_timestamp"]) > ts
+
+    @mark_test_for_stream_based_read_log_method
+    def test_stream_based_read_with_patterns(self, ti):
         ts = pendulum.now()
         with mock.patch.object(self.os_task_handler, "index_patterns", new="test_*,other_*"):
             _, log_streams, metadatas = self.os_task_handler.read(
@@ -227,7 +272,34 @@ class TestOpensearchTaskHandler:
         assert not metadatas[0]["end_of_log"]
         assert timezone.parse(metadatas[0]["last_log_timestamp"]) > ts
 
+    @mark_test_for_old_read_log_method
     def test_read_with_patterns_no_match(self, ti):
+        ts = pendulum.now()
+        with mock.patch.object(self.os_task_handler, "index_patterns", new="test_other_*,test_another_*"):
+            with mock.patch.object(
+                self.os_task_handler.client,
+                "search",
+                return_value={
+                    "_shards": {"failed": 0, "skipped": 0, "successful": 7, "total": 7},
+                    "hits": {"hits": []},
+                    "timed_out": False,
+                    "took": 7,
+                },
+            ):
+                logs, metadatas = self.os_task_handler.read(
+                    ti, 1, {"offset": 0, "last_log_timestamp": str(ts), "end_of_log": False}
+                )
+
+        assert len(logs) == 1
+        assert len(logs) == len(metadatas)
+        assert logs == [[]]
+        assert not metadatas[0]["end_of_log"]
+        assert metadatas[0]["offset"] == "0"
+        # last_log_timestamp won't change if no log lines read.
+        assert timezone.parse(metadatas[0]["last_log_timestamp"]) == ts
+
+    @mark_test_for_stream_based_read_log_method
+    def test_stream_based_read_with_patterns_no_match(self, ti):
         ts = pendulum.now()
         with mock.patch.object(self.os_task_handler, "index_patterns", new="test_other_*,test_another_*"):
             with mock.patch.object(
@@ -264,8 +336,52 @@ class TestOpensearchTaskHandler:
                         ti, 1, {"offset": 0, "last_log_timestamp": str(ts), "end_of_log": False}
                     )
 
+    @mark_test_for_old_read_log_method
     @pytest.mark.parametrize("seconds", [3, 6])
     def test_read_missing_logs(self, seconds, create_task_instance):
+        """
+        When the log actually isn't there to be found, we only want to wait for 5 seconds.
+        In this case we expect to receive a message of the form 'Log {log_id} not found in Opensearch ...'
+        """
+        ti = get_ti(
+            self.DAG_ID,
+            self.TASK_ID,
+            pendulum.instance(self.LOGICAL_DATE).add(days=1),  # so logs are not found
+            create_task_instance=create_task_instance,
+        )
+        ts = pendulum.now().add(seconds=-seconds)
+        with mock.patch.object(
+            self.os_task_handler.client,
+            "search",
+            return_value={
+                "_shards": {"failed": 0, "skipped": 0, "successful": 7, "total": 7},
+                "hits": {"hits": []},
+                "timed_out": False,
+                "took": 7,
+            },
+        ):
+            logs, metadatas = self.os_task_handler.read(ti, 1, {"offset": 0, "last_log_timestamp": str(ts)})
+
+        assert len(logs) == 1
+        if seconds > 5:
+            # we expect a log not found message when checking began more than 5 seconds ago
+            assert len(logs[0]) == 1
+            actual_message = logs[0][0][1]
+            expected_pattern = r"^\*\*\* Log .* not found in Opensearch.*"
+            assert re.match(expected_pattern, actual_message) is not None
+            assert metadatas[0]["end_of_log"] is True
+        else:
+            # we've "waited" less than 5 seconds so it should not be "end of log" and should be no log message
+            assert len(logs[0]) == 0
+            assert logs == [[]]
+            assert metadatas[0]["end_of_log"] is False
+        assert len(logs) == len(metadatas)
+        assert metadatas[0]["offset"] == "0"
+        assert timezone.parse(metadatas[0]["last_log_timestamp"]) == ts
+
+    @mark_test_for_stream_based_read_log_method
+    @pytest.mark.parametrize("seconds", [3, 6])
+    def test_stream_based_read_missing_logs(self, seconds, create_task_instance):
         """
         When the log actually isn't there to be found, we only want to wait for 5 seconds.
         In this case we expect to receive a message of the form 'Log {log_id} not found in Opensearch ...'
@@ -306,7 +422,22 @@ class TestOpensearchTaskHandler:
         assert metadatas[0]["offset"] == "0"
         assert timezone.parse(metadatas[0]["last_log_timestamp"]) == ts
 
+    @mark_test_for_old_read_log_method
     def test_read_with_none_metadata(self, ti):
+        logs, metadatas = self.os_task_handler.read(ti, 1)
+        assert len(logs) == 1
+        assert len(logs) == len(metadatas)
+        assert (
+            logs[0][0][-1] == "Dependencies all met for dep_context=non-requeueable"
+            " deps ti=<TaskInstance: example_bash_operator.run_after_loop owen_run_run [queued]>\n"
+            "Starting attempt 1 of 1\nExecuting <Task(BashOperator): run_after_loop> "
+            "on 2023-07-09 07:47:32+00:00"
+        )
+        assert not metadatas[0]["end_of_log"]
+        assert timezone.parse(metadatas[0]["last_log_timestamp"]) < pendulum.now()
+
+    @mark_test_for_stream_based_read_log_method
+    def test_stream_based_read_with_none_metadata(self, ti):
         _, log_streams, metadatas = self.os_task_handler.read(ti, 1)
         assert len(log_streams) == 1
         assert len(log_streams) == len(metadatas)

--- a/providers/redis/tests/unit/redis/log/test_redis_task_handler.py
+++ b/providers/redis/tests/unit/redis/log/test_redis_task_handler.py
@@ -103,7 +103,10 @@ class TestRedisTaskHandler:
 
         with patch("redis.Redis.lrange") as lrange:
             lrange.return_value = [b"Line 1", b"Line 2"]
-            logs = handler.read(ti)
+            hosts, log_streams, metadatas = handler.read(ti)
 
-        assert logs == ([[("", "Line 1\nLine 2")]], [{"end_of_log": True}])
+        assert hosts == [""]
+        log_str = "\n".join(line for line in log_streams[0])
+        assert log_str == "Line 1\nLine 2"
+        assert metadatas == [{"end_of_log": True}]
         lrange.assert_called_once_with(key, start=0, end=-1)

--- a/providers/redis/tests/unit/redis/log/test_redis_task_handler.py
+++ b/providers/redis/tests/unit/redis/log/test_redis_task_handler.py
@@ -30,6 +30,10 @@ from airflow.utils.state import State
 from airflow.utils.timezone import datetime
 
 from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.file_task_handler import (
+    mark_test_for_old_read_log_method,
+    mark_test_for_stream_based_read_log_method,
+)
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 pytestmark = pytest.mark.db_test
@@ -89,8 +93,29 @@ class TestRedisTaskHandler:
         pipeline.return_value.expire.assert_called_once_with(key, time=2)
         pipeline.return_value.execute.assert_called_once_with()
 
+    @mark_test_for_old_read_log_method
     @conf_vars({("logging", "remote_log_conn_id"): "redis_default"})
     def test_read(self, ti):
+        handler = RedisTaskHandler("any")
+        handler.set_context(ti)
+        logger = logging.getLogger(__name__)
+        logger.addHandler(handler)
+
+        key = (
+            "dag_id=dag_for_testing_redis_task_handler/run_id=test"
+            "/task_id=task_for_testing_redis_log_handler/attempt=1.log"
+        )
+
+        with patch("redis.Redis.lrange") as lrange:
+            lrange.return_value = [b"Line 1", b"Line 2"]
+            logs = handler.read(ti)
+
+        assert logs == ([[("", "Line 1\nLine 2")]], [{"end_of_log": True}])
+        lrange.assert_called_once_with(key, start=0, end=-1)
+
+    @mark_test_for_stream_based_read_log_method
+    @conf_vars({("logging", "remote_log_conn_id"): "redis_default"})
+    def test_stream_based_read(self, ti):
         handler = RedisTaskHandler("any")
         handler.set_context(ti)
         logger = logging.getLogger(__name__)

--- a/tests/api_fastapi/core_api/routes/public/test_log.py
+++ b/tests/api_fastapi/core_api/routes/public/test_log.py
@@ -165,9 +165,9 @@ class TestTaskInstancesLog:
         )
         expected_filename = f"{self.log_dir}/dag_id={self.DAG_ID}/run_id={self.RUN_ID}/task_id={self.TASK_ID}/attempt={try_number}.log"
         log_content = "Log for testing." if try_number == 1 else "Log for testing 2."
-        assert "[('localhost'," in response.json()["content"]
-        assert f"*** Found local files:\\n***   * {expected_filename}\\n" in response.json()["content"]
-        assert f"{log_content}')]" in response.json()["content"]
+        assert response.json()["content"].startswith("localhost\n")
+        assert f"*** Found local files:\n***   * {expected_filename}\n" in response.json()["content"]
+        assert log_content in response.json()["content"]
 
         info = serializer.loads(response.json()["continuation_token"])
         assert info == {"end_of_log": True, "log_pos": 16 if try_number == 1 else 18}
@@ -295,10 +295,10 @@ class TestTaskInstancesLog:
     @pytest.mark.parametrize("try_number", [1, 2])
     def test_get_logs_with_metadata_as_download_large_file(self, try_number):
         with mock.patch("airflow.utils.log.file_task_handler.FileTaskHandler.read") as read_mock:
-            first_return = ([[("", "1st line")]], [{}])
-            second_return = ([[("", "2nd line")]], [{"end_of_log": False}])
-            third_return = ([[("", "3rd line")]], [{"end_of_log": True}])
-            fourth_return = ([[("", "should never be read")]], [{"end_of_log": True}])
+            first_return = ([""], [iter(["1st line"])], [{}])
+            second_return = ([""], [iter(["2nd line"])], [{"end_of_log": False}])
+            third_return = ([""], [iter(["3rd line"])], [{"end_of_log": True}])
+            fourth_return = ([""], [iter(["should never be read"])], [{"end_of_log": True}])
             read_mock.side_effect = [first_return, second_return, third_return, fourth_return]
 
             response = self.client.get(

--- a/tests/utils/log/test_log_reader.py
+++ b/tests/utils/log/test_log_reader.py
@@ -125,76 +125,79 @@ class TestLogView:
         task_log_reader = TaskLogReader()
         ti = copy.copy(self.ti)
         ti.state = TaskInstanceState.SUCCESS
-        logs, metadatas = task_log_reader.read_log_chunks(ti=ti, try_number=1, metadata={})
-        assert logs[0] == [
-            (
-                "localhost",
-                " INFO - ::group::Log message source details\n"
-                "*** Found local files:\n"
-                f"***   * {self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/1.log\n"
-                " INFO - ::endgroup::\n"
-                "try_number=1.",
-            )
-        ]
-        assert metadatas == {"end_of_log": True, "log_pos": 13}
+        hosts, log_streams, metadatas = task_log_reader.read_log_chunks(ti=ti, try_number=1, metadata={})
+        assert hosts == ["localhost"]
+        log_str = "".join(line for line in log_streams[0])
+        assert log_str == (
+            " INFO - ::group::Log message source details\n"
+            "*** Found local files:\n"
+            f"***   * {self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/1.log\n"
+            " INFO - ::endgroup::\n"
+            "try_number=1."
+        )
+        assert metadatas == {"end_of_log": True, "log_pos": 14}
 
     def test_test_read_log_chunks_should_read_all_files(self):
         task_log_reader = TaskLogReader()
         ti = copy.copy(self.ti)
         ti.state = TaskInstanceState.SUCCESS
-        logs, metadatas = task_log_reader.read_log_chunks(ti=ti, try_number=None, metadata={})
-
+        hosts, log_streams, metadatas = task_log_reader.read_log_chunks(ti=ti, try_number=None, metadata={})
         for i in range(0, 3):
-            assert logs[i][0][0] == "localhost"
+            log_str = "".join(line for line in log_streams[i])
+            assert hosts[i] == "localhost"
             assert (
                 "*** Found local files:\n"
                 f"***   * {self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/{i + 1}.log\n"
-            ) in logs[i][0][1]
-            assert f"try_number={i + 1}." in logs[i][0][1]
-        assert metadatas == {"end_of_log": True, "log_pos": 13}
+            ) in log_str
+            assert f"try_number={i + 1}." in log_str
+        assert metadatas == {"end_of_log": True, "log_pos": 14}
 
     def test_test_test_read_log_stream_should_read_one_try(self):
         task_log_reader = TaskLogReader()
         ti = copy.copy(self.ti)
         ti.state = TaskInstanceState.SUCCESS
         stream = task_log_reader.read_log_stream(ti=ti, try_number=1, metadata={})
-        assert list(stream) == [
-            "localhost\n INFO - ::group::Log message source details\n*** Found local files:\n"
+        log_str = "".join(line for line in stream)
+        assert log_str == (
+            "localhost\n INFO - ::group::Log message source details\n"
+            "*** Found local files:\n"
             f"***   * {self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/1.log\n"
-            " INFO - ::endgroup::\ntry_number=1.\n"
-        ]
+            " INFO - ::endgroup::\n\ntry_number=1.\n"
+        )
 
     def test_test_test_read_log_stream_should_read_all_logs(self):
         task_log_reader = TaskLogReader()
         self.ti.state = TaskInstanceState.SUCCESS  # Ensure mocked instance is completed to return stream
         stream = task_log_reader.read_log_stream(ti=self.ti, try_number=None, metadata={})
-        assert list(stream) == [
+        log_str = "".join(line for line in stream)
+        assert log_str == (
             "localhost\n INFO - ::group::Log message source details\n*** Found local files:\n"
             f"***   * {self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/1.log\n"
-            " INFO - ::endgroup::\ntry_number=1."
-            "\n",
+            " INFO - ::endgroup::\n\ntry_number=1."
+            "\n"
             "localhost\n INFO - ::group::Log message source details\n*** Found local files:\n"
             f"***   * {self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/2.log\n"
-            " INFO - ::endgroup::\ntry_number=2."
-            "\n",
+            " INFO - ::endgroup::\n\ntry_number=2."
+            "\n"
             "localhost\n INFO - ::group::Log message source details\n*** Found local files:\n"
             f"***   * {self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/3.log\n"
-            " INFO - ::endgroup::\ntry_number=3."
-            "\n",
-        ]
+            " INFO - ::endgroup::\n\ntry_number=3."
+            "\n"
+        )
 
     @mock.patch("airflow.utils.log.file_task_handler.FileTaskHandler.read")
     def test_read_log_stream_should_support_multiple_chunks(self, mock_read):
-        first_return = ([[("", "1st line")]], [{}])
-        second_return = ([[("", "2nd line")]], [{"end_of_log": False}])
-        third_return = ([[("", "3rd line")]], [{"end_of_log": True}])
-        fourth_return = ([[("", "should never be read")]], [{"end_of_log": True}])
+        first_return = ([""], [iter(["1st line"])], [{}])
+        second_return = ([""], [iter(["2nd line"])], [{"end_of_log": False}])
+        third_return = ([""], [iter(["3rd line"])], [{"end_of_log": True}])
+        fourth_return = ([""], [iter(["should never be read"])], [{"end_of_log": True}])
         mock_read.side_effect = [first_return, second_return, third_return, fourth_return]
 
         task_log_reader = TaskLogReader()
         self.ti.state = TaskInstanceState.SUCCESS
         log_stream = task_log_reader.read_log_stream(ti=self.ti, try_number=1, metadata={})
-        assert list(log_stream) == ["\n1st line\n", "\n2nd line\n", "\n3rd line\n"]
+        log_str = "".join(line for line in log_stream)
+        assert log_str == "".join(["\n1st line\n", "\n2nd line\n", "\n3rd line\n"])
 
         mock_read.assert_has_calls(
             [
@@ -207,15 +210,16 @@ class TestLogView:
 
     @mock.patch("airflow.utils.log.file_task_handler.FileTaskHandler.read")
     def test_read_log_stream_should_read_each_try_in_turn(self, mock_read):
-        first_return = ([[("", "try_number=1.")]], [{"end_of_log": True}])
-        second_return = ([[("", "try_number=2.")]], [{"end_of_log": True}])
-        third_return = ([[("", "try_number=3.")]], [{"end_of_log": True}])
-        fourth_return = ([[("", "should never be read")]], [{"end_of_log": True}])
+        first_return = ([""], [iter(["try_number=1."])], [{"end_of_log": True}])
+        second_return = ([""], [iter(["try_number=2."])], [{"end_of_log": True}])
+        third_return = ([""], [iter(["try_number=3."])], [{"end_of_log": True}])
+        fourth_return = ([""], [iter(["try_number=4."])], [{"end_of_log": True}])
         mock_read.side_effect = [first_return, second_return, third_return, fourth_return]
 
         task_log_reader = TaskLogReader()
         log_stream = task_log_reader.read_log_stream(ti=self.ti, try_number=None, metadata={})
-        assert list(log_stream) == ["\ntry_number=1.\n", "\ntry_number=2.\n", "\ntry_number=3.\n"]
+        log_str = "".join(line for line in log_stream)
+        assert log_str == "".join(["\ntry_number=1.\n", "\ntry_number=2.\n", "\ntry_number=3.\n"])
 
         mock_read.assert_has_calls(
             [

--- a/tests/utils/test_log_handlers.py
+++ b/tests/utils/test_log_handlers.py
@@ -393,9 +393,10 @@ class TestFileTaskLogHandler:
         find_current_log = False
         find_rotate_log_1 = False
         for log_stream in log_streams:
-            if log_filename in "\n".join(line for line in log_stream):
+            log_str = "".join(line for line in log_stream)
+            if log_filename in log_str:
                 find_current_log = True
-            if log_rotate_1_name in "\n".join(line for line in log_stream):
+            if log_rotate_1_name in log_str:
                 find_rotate_log_1 = True
         assert find_current_log is True
         assert find_rotate_log_1 is True

--- a/tests/utils/test_log_handlers.py
+++ b/tests/utils/test_log_handlers.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import logging
 import logging.config
 import os
-import re
 from contextlib import suppress
 from http import HTTPStatus
 from importlib import reload
@@ -160,7 +159,7 @@ class TestFileTaskLogHandler:
 
     def test_file_task_handler(self, dag_maker, session):
         def task_callable(ti):
-            ti.log.info("test")
+            ti.log.info("test_log_stdout_in_callable")
 
         with dag_maker("dag_for_testing_file_task_handler", schedule=None, session=session):
             PythonOperator(
@@ -203,13 +202,11 @@ class TestFileTaskLogHandler:
         assert len(log_streams) == len(metadata_array)
         self._assert_is_log_stream_type(log_streams[0])
         assert isinstance(metadata_array[0], dict)
-        target_re = r"\n\[[^\]]+\] {test_log_handlers.py:\d+} INFO - test\n"
 
         # We should expect our log line from the callable above to appear in
         # the logs we read back
         log_str = "\n".join(line for line in log_streams[0])
-        log_lines = log_str.splitlines()
-        assert re.search(target_re, log_lines[-2]), "Logs were " + log_str
+        assert "test_log_stdout_in_callable" in log_str
 
         # Remove the generated tmp log file.
         os.remove(log_filename)

--- a/tests/www/views/test_views_log.py
+++ b/tests/www/views/test_views_log.py
@@ -334,10 +334,10 @@ def test_get_logs_for_changed_filename_format_db(
 @unittest.mock.patch(
     "airflow.utils.log.file_task_handler.FileTaskHandler.read",
     side_effect=[
-        ([[("default_log", "1st line")]], [{}]),
-        ([[("default_log", "2nd line")]], [{"end_of_log": False}]),
-        ([[("default_log", "3rd line")]], [{"end_of_log": True}]),
-        ([[("default_log", "should never be read")]], [{"end_of_log": True}]),
+        (["default_log"], [["1st line"]], [{}]),
+        (["default_log"], [["2nd line"]], [{"end_of_log": False}]),
+        (["default_log"], [["3rd line"]], [{"end_of_log": True}]),
+        (["default_log"], [["should never be read"]], [{"end_of_log": True}]),
     ],
 )
 def test_get_logs_with_metadata_as_download_large_file(_, log_admin_client):
@@ -409,7 +409,7 @@ def test_get_logs_with_invalid_metadata(log_admin_client):
 
 @unittest.mock.patch(
     "airflow.utils.log.file_task_handler.FileTaskHandler.read",
-    return_value=(["airflow log line"], [{"end_of_log": True}]),
+    return_value=([""], [["airflow log line"]], [{"end_of_log": True}]),
 )
 def test_get_logs_with_metadata_for_removed_dag(_, log_admin_client):
     url_template = "get_logs_with_metadata?dag_id={}&task_id={}&logical_date={}&try_number={}&metadata={}"
@@ -474,7 +474,7 @@ def test_get_logs_with_json_response_format(log_admin_client, create_expected_lo
 
     assert "message" in response.json
     assert "metadata" in response.json
-    assert "Log for testing." in response.json["message"][0][1]
+    assert "Log for testing." in response.json["message"]
 
 
 def test_get_logs_invalid_execution_data_format(log_admin_client):

--- a/tests_common/test_utils/file_task_handler.py
+++ b/tests_common/test_utils/file_task_handler.py
@@ -18,9 +18,13 @@ from __future__ import annotations
 
 from contextlib import suppress
 
+import pytest
+
 from airflow.utils.log.file_task_handler import (
     _parse_timestamp,
 )
+
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 
 def log_str_to_parsed_log_stream(log_sample: str):
@@ -35,3 +39,11 @@ def log_str_to_parsed_log_stream(log_sample: str):
             if next_timestamp:
                 timestamp = next_timestamp
             yield timestamp, idx, line
+
+
+mark_test_for_stream_based_read_log_method = pytest.mark.skipif(
+    not AIRFLOW_V_3_0_PLUS, reason="Test case for new stream-based read log method"
+)
+mark_test_for_old_read_log_method = pytest.mark.skipif(
+    AIRFLOW_V_3_0_PLUS, reason="Test case for old read log method"
+)

--- a/tests_common/test_utils/file_task_handler.py
+++ b/tests_common/test_utils/file_task_handler.py
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from contextlib import suppress
+
+from airflow.utils.log.file_task_handler import (
+    _parse_timestamp,
+)
+
+
+def log_str_to_parsed_log_stream(log_sample: str):
+    lines = log_sample.splitlines()
+    timestamp = None
+    next_timestamp = None
+    for idx, line in enumerate(lines):
+        if line:
+            with suppress(Exception):
+                # next_timestamp unchanged if line can't be parsed
+                next_timestamp = _parse_timestamp(line)
+            if next_timestamp:
+                timestamp = next_timestamp
+            yield timestamp, idx, line


### PR DESCRIPTION

related: #45079 

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
