### PR TITLE
Prevent occasional 500 errors when installing npm dependencies

### DIFF
--- a/scripts/ci/pre_commit/compile_ui_assets.py
+++ b/scripts/ci/pre_commit/compile_ui_assets.py
@@ -33,6 +33,8 @@ from pathlib import Path
 AIRFLOW_SOURCES_PATH = Path(__file__).parents[3].resolve()
 UI_HASH_FILE = AIRFLOW_SOURCES_PATH / ".build" / "ui" / "hash.txt"
 
+INTERNAL_SERVER_ERROR = "500 Internal Server Error"
+
 
 def get_directory_hash(directory: Path, skip_path_regexp: str | None = None) -> str:
     files = sorted(directory.rglob("*"))
@@ -68,10 +70,19 @@ if __name__ == "__main__":
         shutil.rmtree(dist_directory, ignore_errors=True)
     env = os.environ.copy()
     env["FORCE_COLOR"] = "true"
-    subprocess.check_call(
-        ["pnpm", "install", "--frozen-lockfile", "--config.confirmModulesPurge=false"],
-        cwd=os.fspath(ui_directory),
-    )
+    for try_num in range(3):
+        print(f"### Trying to install yarn dependencies: attempt: {try_num} ###")
+        result = subprocess.run(
+            ["pnpm", "install", "--frozen-lockfile", "--config.confirmModulesPurge=false"],
+            cwd=os.fspath(ui_directory),
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            break
+        if try_num == 2 or INTERNAL_SERVER_ERROR not in result.stderr + result.stdout:
+            print(result.stdout + "\n" + result.stderr)
+            sys.exit(result.returncode)
     subprocess.check_call(["pnpm", "run", "build"], cwd=os.fspath(ui_directory), env=env)
     new_hash = get_directory_hash(ui_directory, skip_path_regexp=r".*node_modules.*")
     UI_HASH_FILE.write_text(new_hash)

--- a/scripts/ci/pre_commit/compile_www_assets.py
+++ b/scripts/ci/pre_commit/compile_www_assets.py
@@ -52,6 +52,8 @@ if __name__ not in ("__main__", "__mp_main__"):
         f"To run this script, run the ./{__file__} command"
     )
 
+INTERNAL_SERVER_ERROR = "500 Internal Server Error"
+
 if __name__ == "__main__":
     www_directory = AIRFLOW_SOURCES_PATH / "airflow" / "www"
     node_modules_directory = www_directory / "node_modules"
@@ -68,7 +70,16 @@ if __name__ == "__main__":
         shutil.rmtree(dist_directory, ignore_errors=True)
     env = os.environ.copy()
     env["FORCE_COLOR"] = "true"
-    subprocess.check_call(["yarn", "install", "--frozen-lockfile"], cwd=os.fspath(www_directory))
+    for try_num in range(3):
+        print(f"### Trying to install yarn dependencies: attempt: {try_num} ###")
+        result = subprocess.run(
+            ["yarn", "install", "--frozen-lockfile"], cwd=os.fspath(www_directory), text=True, check=False
+        )
+        if result.returncode == 0:
+            break
+        if try_num == 2 or INTERNAL_SERVER_ERROR not in result.stderr + result.stdout:
+            print(result.stdout + "\n" + result.stderr)
+            sys.exit(result.returncode)
     subprocess.check_call(["yarn", "run", "build"], cwd=os.fspath(www_directory), env=env)
     new_hash = get_directory_hash(www_directory, skip_path_regexp=r".*node_modules.*")
     WWW_HASH_FILE.write_text(new_hash)


### PR DESCRIPTION
When we are installing npm dependencies, occasionally in CI we get 500 Internal Error. This change adds max 3 tries of such installations - retrying when 500 internal error is detected.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
