### PR TITLE
Small fix to asset compilation retry

### DIFF
--- a/scripts/ci/pre_commit/compile_ui_assets.py
+++ b/scripts/ci/pre_commit/compile_ui_assets.py
@@ -71,12 +71,13 @@ if __name__ == "__main__":
     env = os.environ.copy()
     env["FORCE_COLOR"] = "true"
     for try_num in range(3):
-        print(f"### Trying to install yarn dependencies: attempt: {try_num} ###")
+        print(f"### Trying to install yarn dependencies: attempt: {try_num + 1} ###")
         result = subprocess.run(
             ["pnpm", "install", "--frozen-lockfile", "--config.confirmModulesPurge=false"],
             cwd=os.fspath(ui_directory),
             text=True,
             check=False,
+            capture_output=True,
         )
         if result.returncode == 0:
             break

--- a/scripts/ci/pre_commit/compile_www_assets.py
+++ b/scripts/ci/pre_commit/compile_www_assets.py
@@ -71,9 +71,13 @@ if __name__ == "__main__":
     env = os.environ.copy()
     env["FORCE_COLOR"] = "true"
     for try_num in range(3):
-        print(f"### Trying to install yarn dependencies: attempt: {try_num} ###")
+        print(f"### Trying to install yarn dependencies: attempt: {try_num + 1} ###")
         result = subprocess.run(
-            ["yarn", "install", "--frozen-lockfile"], cwd=os.fspath(www_directory), text=True, check=False
+            ["yarn", "install", "--frozen-lockfile"],
+            cwd=os.fspath(www_directory),
+            text=True,
+            check=False,
+            capture_output=True,
         )
         if result.returncode == 0:
             break


### PR DESCRIPTION
Try num printed is now more human, and capture_output is added - it was missing in the original #45143

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
