### PR TITLE
Update doc build timeout

### DIFF
--- a/docs/exts/docs_build/code_utils.py
+++ b/docs/exts/docs_build/code_utils.py
@@ -30,7 +30,7 @@ AIRFLOW_DIR = os.path.join(ROOT_PROJECT_DIR, "airflow")
 ALL_PROVIDER_YAMLS = load_package_data()
 ALL_PROVIDER_YAMLS_WITH_SUSPENDED = load_package_data(include_suspended=True)
 AIRFLOW_SITE_DIR: str = os.environ.get("AIRFLOW_SITE_DIRECTORY") or ""
-PROCESS_TIMEOUT = 15 * 60
+PROCESS_TIMEOUT = 15 * 60 * 2
 
 CONSOLE_WIDTH = 180
 


### PR DESCRIPTION
To avoid error on Amazon provider doc build:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/usr/local/lib/python3.9/multiprocessing/pool.py", line 48, in mapstar
    return list(map(*args))
  File "/opt/airflow/docs/build_docs.py", line 200, in perform_docs_build_for_single_package
    errors=builder.build_sphinx_docs(
  File "/opt/airflow/docs/exts/docs_build/docs_builder.py", line 222, in build_sphinx_docs
    completed_proc = run(
  File "/usr/local/lib/python3.9/subprocess.py", line 507, in run
    stdout, stderr = process.communicate(input, timeout=timeout)
  File "/usr/local/lib/python3.9/subprocess.py", line 1134, in communicate
    stdout, stderr = self._communicate(input, endtime, timeout)
  File "/usr/local/lib/python3.9/subprocess.py", line 2021, in _communicate
    self.wait(timeout=self._remaining_time(endtime))
  File "/usr/local/lib/python3.9/subprocess.py", line 1189, in wait
    return self._wait(timeout=timeout)
  File "/usr/local/lib/python3.9/subprocess.py", line 1925, in _wait
    raise TimeoutExpired(self.args, timeout)
subprocess.TimeoutExpired: Command '['sphinx-build', '-T', '--color', '-b', 'html', '-d', '/opt/airflow/docs/_doctrees/docs/apache-airflow-providers-amazon', '-c', '/opt/airflow/docs', '-w', '/opt/airflow/docs/_build/docs/apache-airflow-providers-amazon/stable/warning-build-apache-airflow-providers-amazon.log', '/opt/airflow/docs/apache-airflow-providers-amazon', '/opt/airflow/docs/_build/docs/apache-airflow-providers-amazon/stable']' timed out after 899.9998589580064 seconds
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/opt/airflow/docs/build_docs.py", line 622, in <module>
    main()
  File "/opt/airflow/docs/build_docs.py", line 502, in main
    package_build_errors, package_spelling_errors = build_docs_for_packages(
  File "/opt/airflow/docs/build_docs.py", line 241, in build_docs_for_packages
    run_in_parallel(
  File "/opt/airflow/docs/build_docs.py", line 309, in run_in_parallel
    run_docs_build_in_parallel(
  File "/opt/airflow/docs/build_docs.py", line 355, in run_docs_build_in_parallel
    result_list = pool.map(perform_docs_build_for_single_package, doc_build_specifications)
  File "/usr/local/lib/python3.9/multiprocessing/pool.py", line 364, in map
    return self._map_async(func, iterable, mapstar, chunksize).get()
  File "/usr/local/lib/python3.9/multiprocessing/pool.py", line 771, in get
    raise self._value
subprocess.TimeoutExpired: Command '['sphinx-build', '-T', '--color', '-b', 'html', '-d', '/opt/airflow/docs/_doctrees/docs/apache-airflow-providers-amazon', '-c', '/opt/airflow/docs', '-w', '/opt/airflow/docs/_build/docs/apache-airflow-providers-amazon/stable/warning-build-apache-airflow-providers-amazon.log', '/opt/airflow/docs/apache-airflow-providers-amazon', '/opt/airflow/docs/_build/docs/apache-airflow-providers-amazon/stable']' timed out after 899.9998589580064 seconds
```