### PR TITLE
Add triggering PR and Push workflows for provider branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -118,6 +118,11 @@ github:
         required_approving_review_count: 1
       required_linear_history: true
       required_conversation_resolution: true
+    providers-fab/v1-5:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+      required_linear_history: true
+      required_conversation_resolution: true
   collaborators:
     # Max 10 collaborators allowed
     # https://github.com/apache/infrastructure-asfyaml/blob/main/README.md#assigning-the-github-triage-role-to-external-collaborators

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ on:  # yamllint disable-line rule:truthy
   schedule:
     - cron: '28 1,7,13,19 * * *'
   push:
-    branches: ['v[0-9]+-[0-9]+-test']
+    branches: ['v[0-9]+-[0-9]+-test', 'providers-*/v[0-9]+-[0-9]+]']
   pull_request:
-    branches: ['main', 'v[0-9]+-[0-9]+-test', 'v[0-9]+-[0-9]+-stable']
+    branches: ['main', 'v[0-9]+-[0-9]+-test', 'v[0-9]+-[0-9]+-stable', 'providers-*/v[0-9]+-[0-9]+']
   workflow_dispatch:
 permissions:
   # All other permissions are set to none

--- a/providers/src/airflow/providers/MANAGING_PROVIDERS_LIFECYCLE.rst
+++ b/providers/src/airflow/providers/MANAGING_PROVIDERS_LIFECYCLE.rst
@@ -471,6 +471,18 @@ considered by the release management commands.
 
 As soon as the provider is released, you should update the provider to ``state: ready``.
 
+Releasing providers for past releases
+=====================================
+
+Sometimes we might want to release provider for previous MAJOR when new release is already
+released (or bumped in main). This is done by releasing them from ``providers-<PROVIDER>/vX-Y`` branch
+- for example ``providers-fab/v1-5`` can be used to release the ``1.5.2`` when ``2.0.0`` is already being
+released or voted on.
+
+The release process looks like usual, the only difference is that the specific branch is used to release
+the provider and update all documentation, the changes and cherry-picking should be targeting that
+branch.
+
 Suspending providers
 ====================
 


### PR DESCRIPTION
With FAB 1.5.2 we have the first case where we need to build and release providers for old version. That requires `pull_request` and `push` workflows to start when they are targetted against `providers-*/v[VERSION]` branches.

The .asf.yaml is updated to make providers-fab/v1-5 protected and documentation of provider's lifecycle is updated to explain how we work with releasing past versions of providers.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
