### PR TITLE
Fix the error alert component

### DIFF
--- a/airflow/ui/src/components/ErrorAlert.tsx
+++ b/airflow/ui/src/components/ErrorAlert.tsx
@@ -16,12 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { HStack } from "@chakra-ui/react";
 import type { ApiError } from "openapi-gen/requests/core/ApiError";
 import type {
   HTTPExceptionResponse,
   HTTPValidationError,
 } from "openapi-gen/requests/types.gen";
-import { FiAlertTriangle } from "react-icons/fi";
 
 import { Alert } from "./ui";
 
@@ -60,10 +60,10 @@ export const ErrorAlert = ({ error: err }: Props) => {
 
   return (
     <Alert status="error">
-      <FiAlertTriangle />
-      {error.message}
-      <br />
-      {detailMessage}
+      <HStack align="start" flexDirection="column" gap={2} mt={-1}>
+        {error.message}
+        <span>{detailMessage}</span>
+      </HStack>
     </Alert>
   );
 };


### PR DESCRIPTION
Before:
<img width="882" alt="Screenshot 2024-12-23 at 1 15 12 AM" src="https://github.com/user-attachments/assets/f278e62d-d072-4ebb-b6ab-2ee945d296e6" />

After:
<img width="882" alt="Screenshot 2024-12-23 at 1 13 22 AM" src="https://github.com/user-attachments/assets/0155d581-c3c9-4a63-a244-49d98c6cac6d" />



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
