### PR TITLE
Fix check_files.py tool if tooo many providers released and switch to UV

### DIFF
--- a/dev/check_files.py
+++ b/dev/check_files.py
@@ -204,7 +204,7 @@ def providers(ctx, path: str):
     files = os.listdir(os.path.join(path, "providers"))
     pips = [f"{name}=={version}" for name, version in get_packages()]
     missing_files = check_providers(files)
-    create_docker(PROVIDERS_DOCKER.format("\n".join(f"RUN pip install '{p}'" for p in pips)))
+    create_docker(PROVIDERS_DOCKER.format("RUN uv pip install --system " + " ".join(f"'{p}'" for p in pips)))
     if missing_files:
         warn_of_missing_files(missing_files)
 


### PR DESCRIPTION
Providers release 12-2024 has soooo many providers that the `check_files.py` fails due to too many docker layers with `ERROR: failed to solve: failed to prepare w9ub7ctzfn39slk4xzv2uur10 as 2972unzauyu1g5fcm6iozhw1b: max depth exceeded`

This PR puts all PIP installs into a single layer plus switches to UV, so it is now SUPER fast and works. Also if the script is only used by noob PMC members :-D 