### PR TITLE
Fix ContinuousTimetable false triggering when last run ends in future

### DIFF
--- a/airflow-core/src/airflow/timetables/simple.py
+++ b/airflow-core/src/airflow/timetables/simple.py
@@ -135,14 +135,18 @@ class ContinuousTimetable(_TrivialTimetable):
     ) -> DagRunInfo | None:
         if restriction.earliest is None:  # No start date, won't run.
             return None
+
+        current_time = timezone.coerce_datetime(timezone.utcnow())
+
         if last_automated_data_interval is not None:  # has already run once
             start = last_automated_data_interval.end
-            end = timezone.coerce_datetime(timezone.utcnow())
+            end = current_time
+
+            if start > end:  # Skip scheduling if the last run ended in the future
+                return None
         else:  # first run
             start = restriction.earliest
-            end = max(
-                restriction.earliest, timezone.coerce_datetime(timezone.utcnow())
-            )  # won't run any earlier than start_date
+            end = max(restriction.earliest, current_time)
 
         if restriction.latest is not None and end > restriction.latest:
             return None

--- a/airflow-core/src/airflow/timetables/simple.py
+++ b/airflow-core/src/airflow/timetables/simple.py
@@ -139,11 +139,14 @@ class ContinuousTimetable(_TrivialTimetable):
         current_time = timezone.coerce_datetime(timezone.utcnow())
 
         if last_automated_data_interval is not None:  # has already run once
-            start = last_automated_data_interval.end
-            end = current_time
+            if last_automated_data_interval.end > current_time:  # start date is future
+                start = restriction.earliest
+                elapsed = last_automated_data_interval.end - last_automated_data_interval.start
 
-            if start > end:  # Skip scheduling if the last run ended in the future
-                return None
+                end = start + elapsed.as_timedelta()
+            else:
+                start = last_automated_data_interval.end
+                end = current_time
         else:  # first run
             start = restriction.earliest
             end = max(restriction.earliest, current_time)

--- a/airflow-core/tests/unit/timetables/test_continuous_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_continuous_timetable.py
@@ -89,3 +89,15 @@ def test_no_runs_after_end_date(timetable, restriction):
     )
 
     assert next_info is None
+
+
+@time_machine.travel(DURING_DATE)
+def test_no_false_triggering_with_future_start_date_after_run(timetable, restriction):
+    FUTURE_DATE = DURING_DATE.add(days=1)
+
+    next_info = timetable.next_dagrun_info(
+        last_automated_data_interval=DataInterval(START_DATE, FUTURE_DATE),
+        restriction=restriction,
+    )
+
+    assert next_info is None

--- a/airflow-core/tests/unit/timetables/test_continuous_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_continuous_timetable.py
@@ -91,13 +91,12 @@ def test_no_runs_after_end_date(timetable, restriction):
     assert next_info is None
 
 
-@time_machine.travel(DURING_DATE)
+@time_machine.travel(BEFORE_DATE)
 def test_no_false_triggering_with_future_start_date_after_run(timetable, restriction):
-    FUTURE_DATE = DURING_DATE.add(days=1)
-
     next_info = timetable.next_dagrun_info(
-        last_automated_data_interval=DataInterval(START_DATE, FUTURE_DATE),
+        last_automated_data_interval=DataInterval(BEFORE_DATE, BEFORE_DATE.add(hours=1)),
         restriction=restriction,
     )
 
-    assert next_info is None
+    assert next_info is not None
+    assert next_info.data_interval.start == START_DATE


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #45081 


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
