### PR TITLE
Update min version of click also in airflow to 8.1.8

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -150,9 +150,7 @@ DOC_EXTRAS: dict[str, list[str]] = {
     "doc": [
         "astroid>=2.12.3,<3.0",
         "checksumdir>=1.2.0",
-        # click 8.1.4 and 8.1.5 generate mypy errors due to typing issue in the upstream package:
-        # https://github.com/pallets/click/issues/2558
-        "click>=8.0,!=8.1.4,!=8.1.5",
+        "click>=8.1.8",
         # Docutils 0.17.0 converts generated <div class="section"> into <section> and breaks our doc formatting
         # By adding a lot of whitespace separation. This limit can be lifted when we update our doc to handle
         # <section> tags for sections


### PR DESCRIPTION
Click introduced breaking change for breeze opts behaviour fixed in #45156 however it did not force breeze image to upgrade click to newer version and it could have caused out-dated images to use older click version even if the image has been rebuilt.

This PR also updates click version in the breeze image.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
