### PR TITLE
Correctly import isabs from os.path

### DIFF
--- a/providers/src/airflow/providers/fab/auth_manager/cli_commands/utils.py
+++ b/providers/src/airflow/providers/fab/auth_manager/cli_commands/utils.py
@@ -21,6 +21,7 @@ import os
 from collections.abc import Generator
 from contextlib import contextmanager
 from functools import cache
+from os.path import isabs
 from typing import TYPE_CHECKING
 
 from flask import Flask
@@ -28,7 +29,7 @@ from flask import Flask
 import airflow
 from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException
-from airflow.www.app import isabs, make_url
+from airflow.www.app import make_url
 from airflow.www.extensions.init_appbuilder import init_appbuilder
 from airflow.www.extensions.init_session import init_airflow_session_interface
 from airflow.www.extensions.init_views import init_plugins


### PR DESCRIPTION
The #45139 imported isabs from "airflow.www.app" - but isabs has been added there fairly recently and it is anyhow stdlib's os.path isabs - so it should be imported from there.

This breaks fab 1.5.2 backport compatibility tests, so we need to cherry-pick it there alongside #45139

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
