### PR TITLE
Fix tries disappearing when first try is selected out of multiple tries.

### DIFF
--- a/airflow/ui/src/pages/TaskInstance/Logs.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Logs.tsx
@@ -83,7 +83,7 @@ export const Logs = () => {
       <HStack justifyContent="space-between" mb={2}>
         {taskInstance === undefined ||
         tryNumber === undefined ||
-        tryNumber <= 1 ? (
+        taskInstance.try_number <= 1 ? (
           <div />
         ) : (
           <TaskTrySelect


### PR DESCRIPTION
Check for taskInstance.try_number to show tries instead of current selected tryNumber that makes other tries to disappear on selection of first try.

To reproduce : 

1. Go to a task instance with multiple tries.
2. Select the first try and the tries component disappears.