### PR TITLE
Include driver classpath in --jars cmd docstring in spark-submit hook and operator

### DIFF
--- a/providers/src/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/providers/src/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -58,7 +58,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
     :param archives: Archives that spark should unzip (and possibly tag with #ALIAS) into
         the application working directory.
     :param driver_class_path: Additional, driver-specific, classpath settings.
-    :param jars: Submit additional jars to upload and place them in executor classpath.
+    :param jars: Submit additional jars to upload and place them in driver and executor classpath.
     :param java_class: the main class of the Java application
     :param packages: Comma-separated list of maven coordinates of jars to include on the
         driver and executor classpaths

--- a/providers/src/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/providers/src/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -58,7 +58,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
     :param archives: Archives that spark should unzip (and possibly tag with #ALIAS) into
         the application working directory.
     :param driver_class_path: Additional, driver-specific, classpath settings.
-    :param jars: Submit additional jars to upload and place them in driver and executor classpath.
+    :param jars: Submit additional jars to upload and place them in driver and executor classpaths.
     :param java_class: the main class of the Java application
     :param packages: Comma-separated list of maven coordinates of jars to include on the
         driver and executor classpaths

--- a/providers/src/airflow/providers/apache/spark/operators/spark_submit.py
+++ b/providers/src/airflow/providers/apache/spark/operators/spark_submit.py
@@ -44,7 +44,7 @@ class SparkSubmitOperator(BaseOperator):
                   comma. Files will be placed in the working directory of each executor.
                   For example, serialized objects. (templated)
     :param py_files: Additional python files used by the job, can be .zip, .egg or .py. (templated)
-    :param jars: Submit additional jars to upload and place them in executor classpath. (templated)
+    :param jars: Submit additional jars to upload and place them in driver and executor classpath. (templated)
     :param driver_class_path: Additional, driver-specific, classpath settings. (templated)
     :param java_class: the main class of the Java application
     :param packages: Comma-separated list of maven coordinates of jars to include on the

--- a/providers/src/airflow/providers/apache/spark/operators/spark_submit.py
+++ b/providers/src/airflow/providers/apache/spark/operators/spark_submit.py
@@ -44,7 +44,7 @@ class SparkSubmitOperator(BaseOperator):
                   comma. Files will be placed in the working directory of each executor.
                   For example, serialized objects. (templated)
     :param py_files: Additional python files used by the job, can be .zip, .egg or .py. (templated)
-    :param jars: Submit additional jars to upload and place them in driver and executor classpath. (templated)
+    :param jars: Submit additional jars to upload and place them in driver and executor classpaths. (templated)
     :param driver_class_path: Additional, driver-specific, classpath settings. (templated)
     :param java_class: the main class of the Java application
     :param packages: Comma-separated list of maven coordinates of jars to include on the


### PR DESCRIPTION
Like it can be read in the [official Spark docs](https://spark.apache.org/docs/3.5.3/submitting-applications.html#advanced-dependency-management), when using the `--jars` option, the jars provided will be included in both the driver and the executor classpaths.

The driver classpath is excluded in the `docstring`. This PR changes that.