### PR TITLE
 feat(cli): add "core.task_runner" and "core.enable_xcom_pickling" to unsupported config check to command "airflow config lint"

### DIFF
--- a/airflow/cli/commands/remote_commands/config_command.py
+++ b/airflow/cli/commands/remote_commands/config_command.py
@@ -190,6 +190,8 @@ CONFIGS_CHANGES = [
         config=ConfigParameter("core", "max_db_retries"),
         renamed_to=ConfigParameter("database", "max_db_retries"),
     ),
+    ConfigChange(config=ConfigParameter("core", "task_runner")),
+    ConfigChange(config=ConfigParameter("core", "enable_xcom_pickling")),
     # api
     ConfigChange(
         config=ConfigParameter("api", "access_control_allow_origin"),

--- a/airflow/cli/commands/remote_commands/config_command.py
+++ b/airflow/cli/commands/remote_commands/config_command.py
@@ -110,6 +110,7 @@ class ConfigChange:
 
 
 CONFIGS_CHANGES = [
+    # admin
     ConfigChange(
         config=ConfigParameter("admin", "hide_sensitive_variable_fields"),
         renamed_to=ConfigParameter("core", "hide_sensitive_var_conn_fields"),
@@ -118,6 +119,7 @@ CONFIGS_CHANGES = [
         config=ConfigParameter("admin", "sensitive_variable_fields"),
         renamed_to=ConfigParameter("core", "sensitive_var_conn_names"),
     ),
+    # core
     ConfigChange(
         config=ConfigParameter("core", "check_slas"),
         suggestion="The SLA feature is removed in Airflow 3.0, to be replaced with Airflow Alerts in "
@@ -188,6 +190,7 @@ CONFIGS_CHANGES = [
         config=ConfigParameter("core", "max_db_retries"),
         renamed_to=ConfigParameter("database", "max_db_retries"),
     ),
+    # api
     ConfigChange(
         config=ConfigParameter("api", "access_control_allow_origin"),
         renamed_to=ConfigParameter("api", "access_control_allow_origins"),
@@ -196,11 +199,13 @@ CONFIGS_CHANGES = [
         config=ConfigParameter("api", "auth_backend"),
         renamed_to=ConfigParameter("api", "auth_backends"),
     ),
+    # logging
     ConfigChange(
         config=ConfigParameter("logging", "enable_task_context_logger"),
         suggestion="Remove TaskContextLogger: Replaced by the Log table for better handling of task log "
         "messages outside the execution context.",
     ),
+    # metrics
     ConfigChange(
         config=ConfigParameter("metrics", "metrics_use_pattern_match"),
     ),
@@ -218,12 +223,15 @@ CONFIGS_CHANGES = [
         config=ConfigParameter("metrics", "statsd_block_list"),
         renamed_to=ConfigParameter("metrics", "metrics_block_list"),
     ),
+    # traces
     ConfigChange(
         config=ConfigParameter("traces", "otel_task_log_event"),
     ),
+    # operators
     ConfigChange(
         config=ConfigParameter("operators", "allow_illegal_arguments"),
     ),
+    # webserver
     ConfigChange(
         config=ConfigParameter("webserver", "allow_raw_html_descriptions"),
     ),
@@ -247,10 +255,12 @@ CONFIGS_CHANGES = [
         config=ConfigParameter("webserver", "force_log_out_after"),
         renamed_to=ConfigParameter("webserver", "session_lifetime_minutes"),
     ),
+    # policy
     ConfigChange(
         config=ConfigParameter("policy", "airflow_local_settings"),
         renamed_to=ConfigParameter("policy", "task_policy"),
     ),
+    # scheduler
     ConfigChange(
         config=ConfigParameter("scheduler", "dependency_detector"),
     ),
@@ -305,6 +315,7 @@ CONFIGS_CHANGES = [
         config=ConfigParameter("scheduler", "statsd_custom_client_path"),
         renamed_to=ConfigParameter("metrics", "statsd_custom_client_path"),
     ),
+    # celery
     ConfigChange(
         config=ConfigParameter("celery", "stalled_task_timeout"),
         renamed_to=ConfigParameter("scheduler", "task_queued_timeout"),
@@ -317,6 +328,7 @@ CONFIGS_CHANGES = [
         config=ConfigParameter("celery", "task_adoption_timeout"),
         renamed_to=ConfigParameter("scheduler", "task_queued_timeout"),
     ),
+    # kubernetes_executor
     ConfigChange(
         config=ConfigParameter("kubernetes_executor", "worker_pods_pending_timeout"),
         renamed_to=ConfigParameter("scheduler", "task_queued_timeout"),
@@ -325,6 +337,7 @@ CONFIGS_CHANGES = [
         config=ConfigParameter("kubernetes_executor", "worker_pods_pending_timeout_check_interval"),
         renamed_to=ConfigParameter("scheduler", "task_queued_timeout_check_interval"),
     ),
+    # smtp
     ConfigChange(
         config=ConfigParameter("smtp", "smtp_user"),
         suggestion="Please use the SMTP connection (`smtp_default`).",


### PR DESCRIPTION
## Why
Config `core.task_runner` and `core.enable_xcom_pickling` are removed and will no longer exist in airflow 3.0

## What
Add lint rules to check these 2 configs

Closes: #45213

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
