### PR TITLE
Add task instance state and name filter to task instances tab in a dagrun

### DIFF
--- a/airflow/ui/src/components/SearchBar.tsx
+++ b/airflow/ui/src/components/SearchBar.tsx
@@ -29,12 +29,23 @@ type Props = {
   readonly buttonProps?: ButtonProps;
   readonly defaultValue: string;
   readonly groupProps?: InputGroupProps;
+  readonly hideAdvanced?: boolean;
   readonly onChange: (value: string) => void;
   readonly placeHolder: string;
 };
 
-export const SearchBar = ({ buttonProps, defaultValue, groupProps, onChange, placeHolder }: Props) => {
-  const handleSearchChange = useDebouncedCallback((val: string) => onChange(val), debounceDelay);
+export const SearchBar = ({
+  buttonProps,
+  defaultValue,
+  groupProps,
+  hideAdvanced = false,
+  onChange,
+  placeHolder,
+}: Props) => {
+  const handleSearchChange = useDebouncedCallback(
+    (val: string) => onChange(val),
+    debounceDelay,
+  );
 
   const [value, setValue] = useState(defaultValue);
 
@@ -61,9 +72,17 @@ export const SearchBar = ({ buttonProps, defaultValue, groupProps, onChange, pla
               size="xs"
             />
           ) : undefined}
-          <Button fontWeight="normal" height="1.75rem" variant="ghost" width={140} {...buttonProps}>
-            Advanced Search
-          </Button>
+          {Boolean(hideAdvanced) ? undefined : (
+            <Button
+              fontWeight="normal"
+              height="1.75rem"
+              variant="ghost"
+              width={140}
+              {...buttonProps}
+            >
+              Advanced Search
+            </Button>
+          )}
         </>
       }
       startElement={<FiSearch />}

--- a/airflow/ui/src/components/SearchBar.tsx
+++ b/airflow/ui/src/components/SearchBar.tsx
@@ -42,10 +42,7 @@ export const SearchBar = ({
   onChange,
   placeHolder,
 }: Props) => {
-  const handleSearchChange = useDebouncedCallback(
-    (val: string) => onChange(val),
-    debounceDelay,
-  );
+  const handleSearchChange = useDebouncedCallback((val: string) => onChange(val), debounceDelay);
 
   const [value, setValue] = useState(defaultValue);
 
@@ -73,13 +70,7 @@ export const SearchBar = ({
             />
           ) : undefined}
           {Boolean(hideAdvanced) ? undefined : (
-            <Button
-              fontWeight="normal"
-              height="1.75rem"
-              variant="ghost"
-              width={140}
-              {...buttonProps}
-            >
+            <Button fontWeight="normal" height="1.75rem" variant="ghost" width={140} {...buttonProps}>
               Advanced Search
             </Button>
           )}

--- a/airflow/ui/src/pages/Run/TaskInstances.tsx
+++ b/airflow/ui/src/pages/Run/TaskInstances.tsx
@@ -16,14 +16,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Link, createListCollection, HStack, type SelectValueChangeDetails } from "@chakra-ui/react";
+import {
+  Box,
+  Flex,
+  Link,
+  createListCollection,
+  HStack,
+  type SelectValueChangeDetails,
+} from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useCallback, useState } from "react";
 import { Link as RouterLink, useParams, useSearchParams } from "react-router-dom";
 
 import { useTaskInstanceServiceGetTaskInstances } from "openapi/queries";
-import { ClearTaskInstanceButton } from "src/components/Clear";
 import type { TaskInstanceResponse, TaskInstanceState } from "openapi/requests/types.gen";
+import { ClearTaskInstanceButton } from "src/components/Clear";
 import { DataTable } from "src/components/DataTable";
 import { useTableURLState } from "src/components/DataTable/useTableUrlState";
 import { ErrorAlert } from "src/components/ErrorAlert";

--- a/airflow/ui/src/pages/Run/TaskInstances.tsx
+++ b/airflow/ui/src/pages/Run/TaskInstances.tsx
@@ -99,7 +99,7 @@ const columns: Array<ColumnDef<TaskInstanceResponse>> = [
   },
 ];
 
-const stateOptions = createListCollection({
+const stateOptions = createListCollection<{ label: string; value: TaskInstanceState | "all" | "none" }>({
   items: [
     { label: "All States", value: "all" },
     { label: "Scheduled", value: "scheduled" },
@@ -114,6 +114,7 @@ const stateOptions = createListCollection({
     { label: "Skipped", value: "skipped" },
     { label: "Deferred", value: "deferred" },
     { label: "Removed", value: "removed" },
+    { label: "No Status", value: "none" },
   ],
 });
 
@@ -159,12 +160,12 @@ export const TaskInstances = () => {
     } else {
       searchParams.delete(NAME_PATTERN_PARAM);
     }
-    setSearchParams(searchParams);
     setTableURLState({
       pagination: { ...pagination, pageIndex: 0 },
       sorting,
     });
     setTaskDisplayNamePattern(value);
+    setSearchParams(searchParams);
   };
 
   const { data, error, isFetching, isLoading } = useTaskInstanceServiceGetTaskInstances(
@@ -202,7 +203,7 @@ export const TaskInstances = () => {
                   <HStack gap="10px">
                     {filteredState.map((state) => (
                       <Status key={state} state={state as TaskInstanceState}>
-                        {capitalize(state)}
+                        {state === "none" ? "No Status" : capitalize(state)}
                       </Status>
                     ))}
                   </HStack>

--- a/airflow/ui/src/pages/Run/TaskInstances.tsx
+++ b/airflow/ui/src/pages/Run/TaskInstances.tsx
@@ -16,38 +16,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  Box,
-  Link,
-  createListCollection,
-  HStack,
-  type SelectValueChangeDetails,
-} from "@chakra-ui/react";
-
+import { Box, Link, createListCollection, HStack, type SelectValueChangeDetails } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useCallback, useState } from "react";
-import {
-  Link as RouterLink,
-  useParams,
-  useSearchParams,
-} from "react-router-dom";
+import { Link as RouterLink, useParams, useSearchParams } from "react-router-dom";
 
 import { useTaskInstanceServiceGetTaskInstances } from "openapi/queries";
 import { ClearTaskInstanceButton } from "src/components/Clear";
-import type {
-  TaskInstanceResponse,
-  TaskInstanceState,
-} from "openapi/requests/types.gen";
+import type { TaskInstanceResponse, TaskInstanceState } from "openapi/requests/types.gen";
 import { DataTable } from "src/components/DataTable";
 import { useTableURLState } from "src/components/DataTable/useTableUrlState";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import { SearchBar } from "src/components/SearchBar";
 import Time from "src/components/Time";
 import { Select, Status } from "src/components/ui";
-import {
-  SearchParamsKeys,
-  type SearchParamsKeysType,
-} from "src/constants/searchParams";
+import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
 import { capitalize, getDuration } from "src/utils";
 import { getTaskInstanceLink } from "src/utils/links";
 
@@ -144,8 +127,7 @@ export const TaskInstances = () => {
   const [sort] = sorting;
   const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : "-start_date";
   const filteredState = searchParams.get(STATE_PARAM);
-  const { NAME_PATTERN: NAME_PATTERN_PARAM }: SearchParamsKeysType =
-    SearchParamsKeys;
+  const { NAME_PATTERN: NAME_PATTERN_PARAM }: SearchParamsKeysType = SearchParamsKeys;
 
   const [taskDisplayNamePattern, setTaskDisplayNamePattern] = useState(
     searchParams.get(NAME_PATTERN_PARAM) ?? undefined,
@@ -183,22 +165,19 @@ export const TaskInstances = () => {
     setTaskDisplayNamePattern(value);
   };
 
-  const { data, error, isFetching, isLoading } =
-    useTaskInstanceServiceGetTaskInstances(
-      {
-        dagId,
-        dagRunId: runId,
-        limit: pagination.pageSize,
-        offset: pagination.pageIndex * pagination.pageSize,
-        orderBy,
-        state: filteredState === null ? undefined : [filteredState],
-        taskDisplayNamePattern: Boolean(taskDisplayNamePattern)
-          ? taskDisplayNamePattern
-          : undefined,
-      },
-      undefined,
-      { enabled: !isNaN(pagination.pageSize) },
-    );
+  const { data, error, isFetching, isLoading } = useTaskInstanceServiceGetTaskInstances(
+    {
+      dagId,
+      dagRunId: runId,
+      limit: pagination.pageSize,
+      offset: pagination.pageIndex * pagination.pageSize,
+      orderBy,
+      state: filteredState === null ? undefined : [filteredState],
+      taskDisplayNamePattern: Boolean(taskDisplayNamePattern) ? taskDisplayNamePattern : undefined,
+    },
+    undefined,
+    { enabled: !isNaN(pagination.pageSize) },
+  );
 
   return (
     <Box pt={4}>
@@ -209,19 +188,13 @@ export const TaskInstances = () => {
           onValueChange={handleStateChange}
           value={[filteredState ?? "all"]}
         >
-          <Select.Trigger
-            clearable
-            colorPalette="blue"
-            isActive={Boolean(filteredState)}
-          >
+          <Select.Trigger clearable colorPalette="blue" isActive={Boolean(filteredState)}>
             <Select.ValueText>
               {() =>
                 filteredState === null ? (
                   "All States"
                 ) : (
-                  <Status state={filteredState as TaskInstanceState}>
-                    {capitalize(filteredState)}
-                  </Status>
+                  <Status state={filteredState as TaskInstanceState}>{capitalize(filteredState)}</Status>
                 )
               }
             </Select.ValueText>
@@ -232,9 +205,7 @@ export const TaskInstances = () => {
                 {option.value === "all" ? (
                   option.label
                 ) : (
-                  <Status state={option.value as TaskInstanceState}>
-                    {option.label}
-                  </Status>
+                  <Status state={option.value as TaskInstanceState}>{option.label}</Status>
                 )}
               </Select.Item>
             ))}

--- a/airflow/ui/src/pages/Run/TaskInstances.tsx
+++ b/airflow/ui/src/pages/Run/TaskInstances.tsx
@@ -209,7 +209,11 @@ export const TaskInstances = () => {
           onValueChange={handleStateChange}
           value={[filteredState ?? "all"]}
         >
-          <Select.Trigger colorPalette="blue" isActive={Boolean(filteredState)}>
+          <Select.Trigger
+            clearable
+            colorPalette="blue"
+            isActive={Boolean(filteredState)}
+          >
             <Select.ValueText>
               {() =>
                 filteredState === null ? (

--- a/airflow/ui/src/utils/stateColor.ts
+++ b/airflow/ui/src/utils/stateColor.ts
@@ -22,6 +22,7 @@
 export const stateColor = {
   deferred: "mediumpurple",
   failed: "red",
+  none: "lightblue",
   null: "lightblue",
   queued: "gray",
   removed: "lightgrey",


### PR DESCRIPTION
A dagrun might have a lot of task instances that are paginated. This PR adds filters to filter by state e.g. failed task instances which is similar to the filter in dagrun page now. I have also added search by task_id or task_display_name so that users can quickly get to the required task instance in a paginated setting. Slightly related issues for grid view to search by name #32239 . This also updates the URLs so that it's shareable.

Notes for reviewer and self : 

* I reused the `searchBar` component but doesn't need advanced search as of now as it's not implemented and not useful here where search by task name is only needed. This can be added in future and the `hideAdvanced` part can be removed.

Screenshot : 

![image](https://github.com/user-attachments/assets/c35e0c24-3174-48cd-b26c-eed942b2d3e3)
