### PR TITLE
Refactor the Dag trigger form 

### DIFF
--- a/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -134,8 +134,7 @@ const TriggerDAGForm: React.FC<TriggerDAGFormProps> = ({
 
   return (
     <>
-      <ErrorAlert error={errorTrigger} />
-      <Accordion.Root collapsible mt={4} size="lg" variant="enclosed">
+      <Accordion.Root collapsible mb={4} mt={4} size="lg" variant="enclosed">
         <Accordion.Item key="advancedOptions" value="advancedOptions">
           <Accordion.ItemTrigger cursor="button">
             Advanced Options
@@ -253,6 +252,7 @@ const TriggerDAGForm: React.FC<TriggerDAGFormProps> = ({
           </Accordion.ItemContent>
         </Accordion.Item>
       </Accordion.Root>
+      <ErrorAlert error={errorTrigger} />
       <Box as="footer" display="flex" justifyContent="flex-end" mt={4}>
         <HStack w="full">
           {isDirty ? (

--- a/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -50,7 +50,7 @@ const TriggerDAGForm: React.FC<TriggerDAGFormProps> = ({
   onClose,
   open,
 }) => {
-  const [errors, setErrors] = useState<{ conf?: string; date?: string }>({});
+  const [errors, setErrors] = useState<{ conf?: string; date?: unknown }>({});
   const conf = useDagParams(dagId, open);
   const { error: errorTrigger, isPending, triggerDagRun } = useTrigger(onClose);
 
@@ -103,7 +103,12 @@ const TriggerDAGForm: React.FC<TriggerDAGFormProps> = ({
     if (Boolean(data.dataIntervalStart) !== Boolean(data.dataIntervalEnd)) {
       setErrors((prev) => ({
         ...prev,
-        date: "Either both Data Interval Start and End must be provided, or both must be empty.",
+        date: {
+          body: {
+            detail:
+              "Either both Data Interval Start and End must be provided, or both must be empty.",
+          },
+        },
       }));
 
       return;
@@ -177,9 +182,6 @@ const TriggerDAGForm: React.FC<TriggerDAGFormProps> = ({
                       size="sm"
                       type="datetime-local"
                     />
-                    {Boolean(errors.date) ? (
-                      <Field.ErrorText>{errors.date}</Field.ErrorText>
-                    ) : undefined}
                   </Field.Root>
                 )}
               />
@@ -252,7 +254,7 @@ const TriggerDAGForm: React.FC<TriggerDAGFormProps> = ({
           </Accordion.ItemContent>
         </Accordion.Item>
       </Accordion.Root>
-      <ErrorAlert error={errorTrigger} />
+      <ErrorAlert error={errors.date ?? errorTrigger} />
       <Box as="footer" display="flex" justifyContent="flex-end" mt={4}>
         <HStack w="full">
           {isDirty ? (

--- a/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -20,7 +20,7 @@ import { Input, Button, Box, Text, Spacer, HStack } from "@chakra-ui/react";
 import { json } from "@codemirror/lang-json";
 import { githubLight, githubDark } from "@uiw/codemirror-themes-all";
 import CodeMirror from "@uiw/react-codemirror";
-import { useEffect, useMemo, useState } from "react";
+import { useState } from "react";
 import { useForm, Controller } from "react-hook-form";
 import { FiPlay } from "react-icons/fi";
 
@@ -54,17 +54,6 @@ const TriggerDAGForm: React.FC<TriggerDAGFormProps> = ({
   const conf = useDagParams(dagId, open);
   const { error: errorTrigger, isPending, triggerDagRun } = useTrigger(onClose);
 
-  const dagRunRequestBody: DagRunTriggerParams = useMemo(
-    () => ({
-      conf,
-      dagRunId: "",
-      dataIntervalEnd: "",
-      dataIntervalStart: "",
-      note: "",
-    }),
-    [conf],
-  );
-
   const {
     control,
     formState: { isDirty },
@@ -72,14 +61,23 @@ const TriggerDAGForm: React.FC<TriggerDAGFormProps> = ({
     reset,
     setValue,
     watch,
-  } = useForm<DagRunTriggerParams>({ defaultValues: dagRunRequestBody });
+  } = useForm<DagRunTriggerParams>({
+    defaultValues: {
+      conf,
+      dagRunId: "",
+      dataIntervalEnd: "",
+      dataIntervalStart: "",
+      note: "",
+    },
+  });
 
   const dataIntervalStart = watch("dataIntervalStart");
   const dataIntervalEnd = watch("dataIntervalEnd");
 
-  useEffect(() => {
-    reset(dagRunRequestBody);
-  }, [dagRunRequestBody, reset]);
+  const handleReset = () => {
+    setErrors({ conf: undefined, date: undefined });
+    reset();
+  };
 
   const validateAndPrettifyJson = (value: string) => {
     try {
@@ -259,7 +257,7 @@ const TriggerDAGForm: React.FC<TriggerDAGFormProps> = ({
       <Box as="footer" display="flex" justifyContent="flex-end" mt={4}>
         <HStack w="full">
           {isDirty ? (
-            <Button onClick={() => reset()} variant="outline">
+            <Button onClick={handleReset} variant="outline">
               Reset
             </Button>
           ) : undefined}

--- a/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -16,15 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  Input,
-  Button,
-  Box,
-  Text,
-  Spacer,
-  HStack,
-  Field,
-} from "@chakra-ui/react";
+import { Input, Button, Box, Spacer, HStack, Field } from "@chakra-ui/react";
 import { json } from "@codemirror/lang-json";
 import { githubLight, githubDark } from "@uiw/codemirror-themes-all";
 import CodeMirror from "@uiw/react-codemirror";
@@ -154,7 +146,7 @@ const TriggerDAGForm: React.FC<TriggerDAGFormProps> = ({
                 control={control}
                 name="dataIntervalStart"
                 render={({ field }) => (
-                  <Field.Root>
+                  <Field.Root invalid={Boolean(errors.date)}>
                     <Field.Label fontSize="md">
                       Data Interval Start Date
                     </Field.Label>
@@ -174,7 +166,7 @@ const TriggerDAGForm: React.FC<TriggerDAGFormProps> = ({
                 control={control}
                 name="dataIntervalEnd"
                 render={({ field }) => (
-                  <Field.Root mt={6}>
+                  <Field.Root invalid={Boolean(errors.date)} mt={6}>
                     <Field.Label fontSize="md">
                       Data Interval End Date
                     </Field.Label>
@@ -186,6 +178,9 @@ const TriggerDAGForm: React.FC<TriggerDAGFormProps> = ({
                       size="sm"
                       type="datetime-local"
                     />
+                    {Boolean(errors.date) ? (
+                      <Field.ErrorText>{errors.date}</Field.ErrorText>
+                    ) : undefined}
                   </Field.Root>
                 )}
               />
@@ -258,11 +253,6 @@ const TriggerDAGForm: React.FC<TriggerDAGFormProps> = ({
           </Accordion.ItemContent>
         </Accordion.Item>
       </Accordion.Root>
-      {Boolean(errors.date) && (
-        <Text color="red.500" fontSize="sm" mt={2}>
-          {errors.date}
-        </Text>
-      )}
       <Box as="footer" display="flex" justifyContent="flex-end" mt={4}>
         <HStack w="full">
           {isDirty ? (

--- a/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -16,7 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Input, Button, Box, Text, Spacer, HStack } from "@chakra-ui/react";
+import {
+  Input,
+  Button,
+  Box,
+  Text,
+  Spacer,
+  HStack,
+  Field,
+} from "@chakra-ui/react";
 import { json } from "@codemirror/lang-json";
 import { githubLight, githubDark } from "@uiw/codemirror-themes-all";
 import CodeMirror from "@uiw/react-codemirror";
@@ -142,65 +150,67 @@ const TriggerDAGForm: React.FC<TriggerDAGFormProps> = ({
           </Accordion.ItemTrigger>
           <Accordion.ItemContent>
             <Box p={5}>
-              <Text fontSize="md" mb={2}>
-                Data Interval Start Date
-              </Text>
               <Controller
                 control={control}
                 name="dataIntervalStart"
                 render={({ field }) => (
-                  <Input
-                    {...field}
-                    max={dataIntervalEnd || undefined}
-                    onBlur={() => validateDates("dataIntervalStart")}
-                    placeholder="yyyy-mm-ddThh:mm"
-                    size="sm"
-                    type="datetime-local"
-                  />
+                  <Field.Root>
+                    <Field.Label fontSize="md">
+                      Data Interval Start Date
+                    </Field.Label>
+                    <Input
+                      {...field}
+                      max={dataIntervalEnd || undefined}
+                      onBlur={() => validateDates("dataIntervalStart")}
+                      placeholder="yyyy-mm-ddThh:mm"
+                      size="sm"
+                      type="datetime-local"
+                    />
+                  </Field.Root>
                 )}
               />
 
-              <Text fontSize="md" mb={2} mt={6}>
-                Data Interval End Date
-              </Text>
               <Controller
                 control={control}
                 name="dataIntervalEnd"
                 render={({ field }) => (
-                  <Input
-                    {...field}
-                    min={dataIntervalStart || undefined}
-                    onBlur={() => validateDates("dataIntervalEnd")}
-                    placeholder="yyyy-mm-ddThh:mm"
-                    size="sm"
-                    type="datetime-local"
-                  />
+                  <Field.Root mt={6}>
+                    <Field.Label fontSize="md">
+                      Data Interval End Date
+                    </Field.Label>
+                    <Input
+                      {...field}
+                      min={dataIntervalStart || undefined}
+                      onBlur={() => validateDates("dataIntervalEnd")}
+                      placeholder="yyyy-mm-ddThh:mm"
+                      size="sm"
+                      type="datetime-local"
+                    />
+                  </Field.Root>
                 )}
               />
 
-              <Text fontSize="md" mb={2} mt={6}>
-                Run ID
-              </Text>
               <Controller
                 control={control}
                 name="dagRunId"
                 render={({ field }) => (
-                  <Input
-                    {...field}
-                    placeholder="Run Id, optional - will be generated if not provided"
-                    size="sm"
-                  />
+                  <Field.Root mt={6}>
+                    <Field.Label fontSize="md">Run ID</Field.Label>
+                    <Input
+                      {...field}
+                      placeholder="Run Id, optional - will be generated if not provided"
+                      size="sm"
+                    />
+                  </Field.Root>
                 )}
               />
 
-              <Text fontSize="md" mb={2} mt={6}>
-                Configuration JSON
-              </Text>
               <Controller
                 control={control}
                 name="conf"
                 render={({ field }) => (
-                  <Box mb={4}>
+                  <Field.Root invalid={Boolean(errors.conf)} mt={6}>
+                    <Field.Label fontSize="md">Configuration JSON</Field.Label>
                     <CodeMirror
                       {...field}
                       basicSetup={{
@@ -225,24 +235,23 @@ const TriggerDAGForm: React.FC<TriggerDAGFormProps> = ({
                         padding: "2px",
                       }}
                       theme={colorMode === "dark" ? githubDark : githubLight}
+                      width="765px"
                     />
-                    {Boolean(errors.conf) && (
-                      <Text color="red.500" fontSize="sm" mt={2}>
-                        {errors.conf}
-                      </Text>
-                    )}
-                  </Box>
+                    {Boolean(errors.conf) ? (
+                      <Field.ErrorText>{errors.conf}</Field.ErrorText>
+                    ) : undefined}
+                  </Field.Root>
                 )}
               />
 
-              <Text fontSize="md" mb={2} mt={6}>
-                Dag Run Notes
-              </Text>
               <Controller
                 control={control}
                 name="note"
                 render={({ field }) => (
-                  <Input {...field} placeholder="Optional" size="sm" />
+                  <Field.Root mt={6}>
+                    <Field.Label fontSize="md">Dag Run Notes</Field.Label>
+                    <Input {...field} placeholder="Optional" size="sm" />
+                  </Field.Root>
                 )}
               />
             </Box>

--- a/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -227,9 +227,9 @@ const TriggerDAGForm: React.FC<TriggerDAGFormProps> = ({
                         borderRadius: "8px",
                         outline: "none",
                         padding: "2px",
+                        width: "100%",
                       }}
                       theme={colorMode === "dark" ? githubDark : githubLight}
-                      width="765px"
                     />
                     {Boolean(errors.conf) ? (
                       <Field.ErrorText>{errors.conf}</Field.ErrorText>

--- a/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -32,9 +32,9 @@ import { ErrorAlert } from "../ErrorAlert";
 import { Accordion } from "../ui";
 
 type TriggerDAGFormProps = {
-  dagId: string;
-  onClose: () => void;
-  open: boolean;
+  readonly dagId: string;
+  readonly onClose: () => void;
+  readonly open: boolean;
 };
 
 export type DagRunTriggerParams = {
@@ -45,11 +45,7 @@ export type DagRunTriggerParams = {
   note: string;
 };
 
-const TriggerDAGForm: React.FC<TriggerDAGFormProps> = ({
-  dagId,
-  onClose,
-  open,
-}) => {
+const TriggerDAGForm = ({ dagId, onClose, open }: TriggerDAGFormProps) => {
   const [errors, setErrors] = useState<{ conf?: string; date?: unknown }>({});
   const conf = useDagParams(dagId, open);
   const { error: errorTrigger, isPending, triggerDagRun } = useTrigger(onClose);

--- a/airflow/ui/src/queries/useTrigger.ts
+++ b/airflow/ui/src/queries/useTrigger.ts
@@ -43,15 +43,14 @@ export const useTrigger = (onClose: () => void) => {
       queryKeys.map((key) =>
         queryClient.invalidateQueries({ queryKey: [key] }),
       ),
-    );
-
-    toaster.create({
-      description: "DAG run has been successfully triggered.",
-      title: "DAG Run Request Submitted",
-      type: "success",
+    ).then(() => {
+      toaster.create({
+        description: "DAG run has been successfully triggered.",
+        title: "DAG Run Request Submitted",
+        type: "success",
+      });
+      onClose();
     });
-
-    onClose();
   };
 
   const onError = (_error: unknown) => {


### PR DESCRIPTION
Note:

This PR refactors the TriggerDAGForm component for some bugs and code refactors.
1. Reset was not removing the error until the values are filled again. 
2. We have used field now instead of using the text.
3. Used the inbuilt field error.
4. Set the date validation check alert under ErrorAlert component.
5. Close the form on once the query has been invalidated.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
