### PR TITLE
Deferrable support for HttpOperator

### DIFF
--- a/providers/src/airflow/providers/http/exceptions.py
+++ b/providers/src/airflow/providers/http/exceptions.py
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow.exceptions import AirflowException
+
+
+class HttpMethodException(AirflowException):
+    """Exception raised for invalid HTTP methods in Http hook."""

--- a/providers/src/airflow/providers/http/exceptions.py
+++ b/providers/src/airflow/providers/http/exceptions.py
@@ -14,12 +14,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 from airflow.exceptions import AirflowException
 
 
 class HttpErrorException(AirflowException):
     """Exception raised for HTTP error in Http hook."""
+
 
 class HttpMethodException(AirflowException):
     """Exception raised for invalid HTTP methods in Http hook."""

--- a/providers/src/airflow/providers/http/exceptions.py
+++ b/providers/src/airflow/providers/http/exceptions.py
@@ -18,5 +18,8 @@
 from airflow.exceptions import AirflowException
 
 
+class HttpErrorException(AirflowException):
+    """Exception raised for HTTP error in Http hook."""
+
 class HttpMethodException(AirflowException):
     """Exception raised for invalid HTTP methods in Http hook."""

--- a/providers/src/airflow/providers/http/hooks/http.py
+++ b/providers/src/airflow/providers/http/hooks/http.py
@@ -457,8 +457,8 @@ class HttpAsyncHook(BaseHook):
                 await asyncio.sleep(self.retry_delay)
             else:
                 return response
-        else:
-            raise NotImplementedError  # should not reach this, but makes mypy happy
+
+        raise NotImplementedError  # should not reach this, but makes mypy happy
 
     @classmethod
     def _process_extra_options_from_connection(cls, conn: Connection, extra_options: dict) -> dict:

--- a/providers/src/airflow/providers/http/hooks/http.py
+++ b/providers/src/airflow/providers/http/hooks/http.py
@@ -359,6 +359,7 @@ class HttpAsyncHook(BaseHook):
 
     async def run(
         self,
+        session: aiohttp.ClientSession,
         endpoint: str | None = None,
         data: dict[str, Any] | str | None = None,
         json: dict[str, Any] | str | None = None,
@@ -410,54 +411,53 @@ class HttpAsyncHook(BaseHook):
 
         url = _url_from_endpoint(self.base_url, endpoint)
 
-        async with aiohttp.ClientSession() as session:
-            if self.method == "GET":
-                request_func = session.get
-            elif self.method == "POST":
-                request_func = session.post
-            elif self.method == "PATCH":
-                request_func = session.patch
-            elif self.method == "HEAD":
-                request_func = session.head
-            elif self.method == "PUT":
-                request_func = session.put
-            elif self.method == "DELETE":
-                request_func = session.delete
-            elif self.method == "OPTIONS":
-                request_func = session.options
-            else:
-                raise AirflowException(f"Unexpected HTTP Method: {self.method}")
+        if self.method == "GET":
+            request_func = session.get
+        elif self.method == "POST":
+            request_func = session.post
+        elif self.method == "PATCH":
+            request_func = session.patch
+        elif self.method == "HEAD":
+            request_func = session.head
+        elif self.method == "PUT":
+            request_func = session.put
+        elif self.method == "DELETE":
+            request_func = session.delete
+        elif self.method == "OPTIONS":
+            request_func = session.options
+        else:
+            raise AirflowException(f"Unexpected HTTP Method: {self.method}")
 
-            for attempt in range(1, 1 + self.retry_limit):
-                response = await request_func(
+        for attempt in range(1, 1 + self.retry_limit):
+            response = await request_func(
+                url,
+                params=data if self.method == "GET" else None,
+                data=data if self.method in ("POST", "PUT", "PATCH") else None,
+                json=json,
+                headers=_headers,
+                auth=auth,
+                **extra_options,
+            )
+            try:
+                response.raise_for_status()
+            except ClientResponseError as e:
+                self.log.warning(
+                    "[Try %d of %d] Request to %s failed.",
+                    attempt,
+                    self.retry_limit,
                     url,
-                    params=data if self.method == "GET" else None,
-                    data=data if self.method in ("POST", "PUT", "PATCH") else None,
-                    json=json,
-                    headers=_headers,
-                    auth=auth,
-                    **extra_options,
                 )
-                try:
-                    response.raise_for_status()
-                except ClientResponseError as e:
-                    self.log.warning(
-                        "[Try %d of %d] Request to %s failed.",
-                        attempt,
-                        self.retry_limit,
-                        url,
-                    )
-                    if not self._retryable_error_async(e) or attempt == self.retry_limit:
-                        self.log.exception("HTTP error with status: %s", e.status)
-                        # In this case, the user probably made a mistake.
-                        # Don't retry.
-                        raise AirflowException(f"{e.status}:{e.message}")
-                    else:
-                        await asyncio.sleep(self.retry_delay)
+                if not self._retryable_error_async(e) or attempt == self.retry_limit:
+                    self.log.exception("HTTP error with status: %s", e.status)
+                    # In this case, the user probably made a mistake.
+                    # Don't retry.
+                    raise AirflowException(f"{e.status}:{e.message}")
                 else:
-                    return response
+                    await asyncio.sleep(self.retry_delay)
             else:
-                raise NotImplementedError  # should not reach this, but makes mypy happy
+                return response
+        else:
+            raise NotImplementedError  # should not reach this, but makes mypy happy
 
     @classmethod
     def _process_extra_options_from_connection(cls, conn: Connection, extra_options: dict) -> dict:

--- a/providers/src/airflow/providers/http/hooks/http.py
+++ b/providers/src/airflow/providers/http/hooks/http.py
@@ -32,6 +32,7 @@ from requests_toolbelt.adapters.socket_options import TCPKeepAliveAdapter
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
+from airflow.providers.http.exceptions import HttpMethodException
 
 if TYPE_CHECKING:
     from aiohttp.client_reqrep import ClientResponse
@@ -426,7 +427,7 @@ class HttpAsyncHook(BaseHook):
         elif self.method == "OPTIONS":
             request_func = session.options
         else:
-            raise AirflowException(f"Unexpected HTTP Method: {self.method}")
+            raise HttpMethodException(f"Unexpected HTTP Method: {self.method}")
 
         for attempt in range(1, 1 + self.retry_limit):
             response = await request_func(

--- a/providers/src/airflow/providers/http/hooks/http.py
+++ b/providers/src/airflow/providers/http/hooks/http.py
@@ -32,7 +32,7 @@ from requests_toolbelt.adapters.socket_options import TCPKeepAliveAdapter
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
-from airflow.providers.http.exceptions import HttpMethodException
+from airflow.providers.http.exceptions import HttpErrorException, HttpMethodException
 
 if TYPE_CHECKING:
     from aiohttp.client_reqrep import ClientResponse
@@ -452,9 +452,7 @@ class HttpAsyncHook(BaseHook):
                     self.log.exception("HTTP error with status: %s", e.status)
                     # In this case, the user probably made a mistake.
                     # Don't retry.
-                    raise AirflowException(f"{e.status}:{e.message}")
-                else:
-                await asyncio.sleep(self.retry_delay)
+                    raise HttpErrorException(f"{e.status}:{e.message}")
             else:
                 return response
 

--- a/providers/src/airflow/providers/http/hooks/http.py
+++ b/providers/src/airflow/providers/http/hooks/http.py
@@ -454,7 +454,7 @@ class HttpAsyncHook(BaseHook):
                     # Don't retry.
                     raise AirflowException(f"{e.status}:{e.message}")
                 else:
-                    await asyncio.sleep(self.retry_delay)
+                await asyncio.sleep(self.retry_delay)
             else:
                 return response
         else:

--- a/providers/src/airflow/providers/http/hooks/http.py
+++ b/providers/src/airflow/providers/http/hooks/http.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import asyncio
 from typing import TYPE_CHECKING, Any, Callable
 from urllib.parse import urlparse
 

--- a/providers/src/airflow/providers/http/triggers/http.py
+++ b/providers/src/airflow/providers/http/triggers/http.py
@@ -16,13 +16,13 @@
 # under the License.
 from __future__ import annotations
 
-import aiohttp
 import asyncio
 import base64
 import pickle
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any
 
+import aiohttp
 import requests
 from requests.cookies import RequestsCookieJar
 from requests.structures import CaseInsensitiveDict

--- a/providers/src/airflow/providers/http/triggers/http.py
+++ b/providers/src/airflow/providers/http/triggers/http.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import aiohttp
 import asyncio
 import base64
 import pickle
@@ -94,13 +95,15 @@ class HttpTrigger(BaseTrigger):
             auth_type=self.auth_type,
         )
         try:
-            client_response = await hook.run(
-                endpoint=self.endpoint,
-                data=self.data,
-                headers=self.headers,
-                extra_options=self.extra_options,
-            )
-            response = await self._convert_response(client_response)
+            async with aiohttp.ClientSession() as session:
+                client_response = await hook.run(
+                    session=session,
+                    endpoint=self.endpoint,
+                    data=self.data,
+                    headers=self.headers,
+                    extra_options=self.extra_options,
+                )
+                response = await self._convert_response(client_response)
             yield TriggerEvent(
                 {
                     "status": "success",
@@ -181,12 +184,14 @@ class HttpSensorTrigger(BaseTrigger):
         hook = self._get_async_hook()
         while True:
             try:
-                await hook.run(
-                    endpoint=self.endpoint,
-                    data=self.data,
-                    headers=self.headers,
-                    extra_options=self.extra_options,
-                )
+                async with aiohttp.ClientSession() as session:
+                    await hook.run(
+                        session=session,
+                        endpoint=self.endpoint,
+                        data=self.data,
+                        headers=self.headers,
+                        extra_options=self.extra_options,
+                    )
                 yield TriggerEvent(True)
                 return
             except AirflowException as exc:

--- a/providers/tests/http/hooks/test_http.py
+++ b/providers/tests/http/hooks/test_http.py
@@ -656,7 +656,8 @@ class TestHttpAsyncHook:
                         await hook.run(session=session, endpoint="v1/test")
                         headers = mocked_function.call_args.kwargs.get("headers")
                         assert all(
-                            key in headers and headers[key] == value for key, value in connection_extra.items()
+                            key in headers and headers[key] == value
+                            for key, value in connection_extra.items()
                         )
 
     @pytest.mark.asyncio
@@ -694,7 +695,8 @@ class TestHttpAsyncHook:
                         await hook.run(session=session, endpoint="v1/test")
                         headers = mocked_function.call_args.kwargs.get("headers")
                         assert all(
-                            key in headers and headers[key] == value for key, value in connection_extra.items()
+                            key in headers and headers[key] == value
+                            for key, value in connection_extra.items()
                         )
                         assert mocked_function.call_args.kwargs.get("proxy") == proxy
                         assert mocked_function.call_args.kwargs.get("timeout") == 60
@@ -760,11 +762,14 @@ class TestHttpAsyncHook:
         hook = HttpAsyncHook()
 
         with aioresponses() as m:
-            m.post("http://test.com:8080/v1/test", status=200, payload='{"status":{"status": 200}}', reason="OK")
+            m.post(
+                "http://test.com:8080/v1/test", status=200, payload='{"status":{"status": 200}}', reason="OK"
+            )
 
-            with mock.patch("airflow.hooks.base.BaseHook.get_connection", side_effect=get_empty_conn), mock.patch(
-                "aiohttp.ClientSession.post", new_callable=mock.AsyncMock
-            ) as mocked_function:
+            with (
+                mock.patch("airflow.hooks.base.BaseHook.get_connection", side_effect=get_empty_conn),
+                mock.patch("aiohttp.ClientSession.post", new_callable=mock.AsyncMock) as mocked_function,
+            ):
                 async with aiohttp.ClientSession() as session:
                     await hook.run(session=session, endpoint="test.com:8080/v1/test")
                     assert mocked_function.call_args.args[0] == "http://test.com:8080/v1/test"

--- a/providers/tests/http/hooks/test_http.py
+++ b/providers/tests/http/hooks/test_http.py
@@ -25,6 +25,7 @@ import os
 from http import HTTPStatus
 from unittest import mock
 
+import aiohttp
 import pytest
 import requests
 import tenacity
@@ -565,7 +566,8 @@ class TestHttpAsyncHook:
                 AIRFLOW_CONN_HTTP_DEFAULT="http://httpbin.org/",
             ),
         ):
-            await hook.run(endpoint="non_existent_endpoint")
+            async with aiohttp.ClientSession() as session:
+                await hook.run(session=session, endpoint="non_existent_endpoint")
 
     @pytest.mark.asyncio
     async def test_do_api_call_async_retryable_error(self, caplog, aioresponse):
@@ -581,7 +583,8 @@ class TestHttpAsyncHook:
                 AIRFLOW_CONN_HTTP_DEFAULT="http://httpbin.org/",
             ),
         ):
-            await hook.run(endpoint="non_existent_endpoint")
+            async with aiohttp.ClientSession() as session:
+                await hook.run(session=session, endpoint="non_existent_endpoint")
 
         assert "[Try 3 of 3] Request to http://httpbin.org/non_existent_endpoint failed" in caplog.text
 
@@ -593,61 +596,68 @@ class TestHttpAsyncHook:
         json = {"existing_cluster_id": "xxxx-xxxxxx-xxxxxx"}
 
         with pytest.raises(AirflowException, match="Unexpected HTTP Method: NOPE"):
-            await hook.run(endpoint="non_existent_endpoint", data=json)
+            async with aiohttp.ClientSession() as session:
+                await hook.run(session=session, endpoint="non_existent_endpoint", data=json)
 
     @pytest.mark.asyncio
-    async def test_async_post_request(self, aioresponse):
+    async def test_async_post_request(self):
         """Test api call asynchronously for POST request."""
         hook = HttpAsyncHook()
 
-        aioresponse.post(
-            "http://test:8080/v1/test",
-            status=200,
-            payload='{"status":{"status": 200}}',
-            reason="OK",
-        )
+        with aioresponses() as m:
+            m.post(
+                "http://test:8080/v1/test",
+                status=200,
+                payload='{"status":{"status": 200}}',
+                reason="OK",
+            )
 
-        with mock.patch("airflow.hooks.base.BaseHook.get_connection", side_effect=get_airflow_connection):
-            resp = await hook.run("v1/test")
-            assert resp.status == 200
+            with mock.patch("airflow.hooks.base.BaseHook.get_connection", side_effect=get_airflow_connection):
+                async with aiohttp.ClientSession() as session:
+                    resp = await hook.run(session=session, endpoint="v1/test")
+                    assert resp.status == 200
 
     @pytest.mark.asyncio
-    async def test_async_post_request_with_error_code(self, aioresponse):
+    async def test_async_post_request_with_error_code(self):
         """Test api call asynchronously for POST request with error."""
         hook = HttpAsyncHook()
 
-        aioresponse.post(
-            "http://test:8080/v1/test",
-            status=418,
-            payload='{"status":{"status": 418}}',
-            reason="I am teapot",
-        )
+        with aioresponses() as m:
+            m.post(
+                "http://test:8080/v1/test",
+                status=418,
+                payload='{"status":{"status": 418}}',
+                reason="I am teapot",
+            )
 
-        with mock.patch("airflow.hooks.base.BaseHook.get_connection", side_effect=get_airflow_connection):
-            with pytest.raises(AirflowException):
-                await hook.run("v1/test")
+            with mock.patch("airflow.hooks.base.BaseHook.get_connection", side_effect=get_airflow_connection):
+                async with aiohttp.ClientSession() as session:
+                    with pytest.raises(AirflowException):
+                        await hook.run(session=session, endpoint="v1/test")
 
     @pytest.mark.asyncio
-    async def test_async_request_uses_connection_extra(self, aioresponse):
+    async def test_async_request_uses_connection_extra(self):
         """Test api call asynchronously with a connection that has extra field."""
 
         connection_extra = {"bearer": "test"}
 
-        aioresponse.post(
-            "http://test:8080/v1/test",
-            status=200,
-            payload='{"status":{"status": 200}}',
-            reason="OK",
-        )
+        with aioresponses() as m:
+            m.post(
+                "http://test:8080/v1/test",
+                status=200,
+                payload='{"status":{"status": 200}}',
+                reason="OK",
+            )
 
-        with mock.patch("airflow.hooks.base.BaseHook.get_connection", side_effect=get_airflow_connection):
-            hook = HttpAsyncHook()
-            with mock.patch("aiohttp.ClientSession.post", new_callable=mock.AsyncMock) as mocked_function:
-                await hook.run("v1/test")
-                headers = mocked_function.call_args.kwargs.get("headers")
-                assert all(
-                    key in headers and headers[key] == value for key, value in connection_extra.items()
-                )
+            with mock.patch("airflow.hooks.base.BaseHook.get_connection", side_effect=get_airflow_connection):
+                hook = HttpAsyncHook()
+                with mock.patch("aiohttp.ClientSession.post", new_callable=mock.AsyncMock) as mocked_function:
+                    async with aiohttp.ClientSession() as session:
+                        await hook.run(session=session, endpoint="v1/test")
+                        headers = mocked_function.call_args.kwargs.get("headers")
+                        assert all(
+                            key in headers and headers[key] == value for key, value in connection_extra.items()
+                        )
 
     @pytest.mark.asyncio
     async def test_async_request_uses_connection_extra_with_requests_parameters(self):
@@ -670,18 +680,28 @@ class TestHttpAsyncHook:
 
         with mock.patch("airflow.hooks.base.BaseHook.get_connection", side_effect=airflow_connection):
             hook = HttpAsyncHook()
-            with mock.patch("aiohttp.ClientSession.post", new_callable=mock.AsyncMock) as mocked_function:
-                await hook.run("v1/test")
-                headers = mocked_function.call_args.kwargs.get("headers")
-                assert all(
-                    key in headers and headers[key] == value for key, value in connection_extra.items()
+
+            with aioresponses() as m:
+                m.post(
+                    "http://test:8080/v1/test",
+                    status=200,
+                    payload='{"status":{"status": 200}}',
+                    reason="OK",
                 )
-                assert mocked_function.call_args.kwargs.get("proxy") == proxy
-                assert mocked_function.call_args.kwargs.get("timeout") == 60
-                assert mocked_function.call_args.kwargs.get("verify_ssl") is False
-                assert mocked_function.call_args.kwargs.get("allow_redirects") is False
-                assert mocked_function.call_args.kwargs.get("max_redirects") == 3
-                assert mocked_function.call_args.kwargs.get("trust_env") is False
+
+                with mock.patch("aiohttp.ClientSession.post", new_callable=mock.AsyncMock) as mocked_function:
+                    async with aiohttp.ClientSession() as session:
+                        await hook.run(session=session, endpoint="v1/test")
+                        headers = mocked_function.call_args.kwargs.get("headers")
+                        assert all(
+                            key in headers and headers[key] == value for key, value in connection_extra.items()
+                        )
+                        assert mocked_function.call_args.kwargs.get("proxy") == proxy
+                        assert mocked_function.call_args.kwargs.get("timeout") == 60
+                        assert mocked_function.call_args.kwargs.get("verify_ssl") is False
+                        assert mocked_function.call_args.kwargs.get("allow_redirects") is False
+                        assert mocked_function.call_args.kwargs.get("max_redirects") == 3
+                        assert mocked_function.call_args.kwargs.get("trust_env") is False
 
     def test_process_extra_options_from_connection(self):
         extra_options = {}
@@ -718,9 +738,19 @@ class TestHttpAsyncHook:
         schema = conn.schema or "http"  # default to http
         with mock.patch("airflow.hooks.base.BaseHook.get_connection", side_effect=get_airflow_connection):
             hook = HttpAsyncHook()
+
+            with aioresponses() as m:
+                m.post(
+                    f"{schema}://test:8080/v1/test",
+                    status=200,
+                    payload='{"status":{"status": 200}}',
+                    reason="OK",
+                )
+
             with mock.patch("aiohttp.ClientSession.post", new_callable=mock.AsyncMock) as mocked_function:
-                await hook.run("v1/test")
-                assert mocked_function.call_args.args[0] == f"{schema}://{conn.host}v1/test"
+                async with aiohttp.ClientSession() as session:
+                    await hook.run(session=session, endpoint="v1/test")
+                    assert mocked_function.call_args.args[0] == f"{schema}://{conn.host}v1/test"
 
     @pytest.mark.asyncio
     async def test_build_request_url_from_endpoint_param(self):
@@ -728,9 +758,13 @@ class TestHttpAsyncHook:
             return Connection(conn_id=conn_id, conn_type="http")
 
         hook = HttpAsyncHook()
-        with (
-            mock.patch("airflow.hooks.base.BaseHook.get_connection", side_effect=get_empty_conn),
-            mock.patch("aiohttp.ClientSession.post", new_callable=mock.AsyncMock) as mocked_function,
-        ):
-            await hook.run("test.com:8080/v1/test")
-            assert mocked_function.call_args.args[0] == "http://test.com:8080/v1/test"
+
+        with aioresponses() as m:
+            m.post("http://test.com:8080/v1/test", status=200, payload='{"status":{"status": 200}}', reason="OK")
+
+            with mock.patch("airflow.hooks.base.BaseHook.get_connection", side_effect=get_empty_conn), mock.patch(
+                "aiohttp.ClientSession.post", new_callable=mock.AsyncMock
+            ) as mocked_function:
+                async with aiohttp.ClientSession() as session:
+                    await hook.run(session=session, endpoint="test.com:8080/v1/test")
+                    assert mocked_function.call_args.args[0] == "http://test.com:8080/v1/test"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Enabling deferrable for HttpOperator causes an error.
The minimum test case is as follows
```
import datetime

from airflow import DAG
from airflow.operators.empty import EmptyOperator
from airflow.providers.http.operators.http import HttpOperator

with DAG(
    dag_id="my_dag_name",
    catchup=False,
) as dag:

    test = HttpOperator(
        task_id="test",
        method="GET",
        http_conn_id="google_http_default",
        endpoint="search?q=airflow",
        log_response=True,
        deferrable=True,
    )

    EmptyOperator(task_id="start") >> test >> EmptyOperator(task_id="end")
```

For connections, set Connection Id to “google_http_default”, Connection Type to “HTTP” and HOST to “https://www.google.com”.

If you place it in airflow/files/dags/ and run it you will get the following error

```
[2024-12-27, 01:53:21 UTC] {taskinstance.py:3311} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/opt/airflow/airflow/models/taskinstance.py", line 767, in _execute_task
    result = _execute_callable(context=context, **execute_callable_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/airflow/airflow/models/taskinstance.py", line 733, in _execute_callable
    return ExecutionCallableRunner(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/airflow/airflow/utils/operator_helpers.py", line 252, in run
    return self.func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/airflow/airflow/models/baseoperator.py", line 1814, in resume_execution
    return execute_callable(context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/airflow/airflow/providers/http/operators/http.py", line 261, in execute_complete
    raise AirflowException(f"Unexpected error in the operation: {event['message']}")
airflow.exceptions.AirflowException: Unexpected error in the operation: Connection closed.
```

Causes:.

https://github.com/apache/airflow/blob/9178f8f0b1ffd80b8eacf4d02b732528fde218e5/providers/src/airflow/providers/http/triggers/http .py#L97
A session object is created by the above caller.

It is at the following link
https://github.com/apache/airflow/blob/9178f8f0b1ffd80b8eacf4d02b732528fde218e5/providers/src/airflow/providers/http/hooks/http.py #L413

The following is then called.
https://github.com/apache/airflow/blob/9178f8f0b1ffd80b8eacf4d02b732528fde218e5/providers/src/airflow/providers/http/triggers/http .py#L103

https://github.com/apache/airflow/blob/9178f8f0b1ffd80b8eacf4d02b732528fde218e5/providers/src/airflow/providers/http/triggers/http .py#L117
It is expected that the ClientSession is alive at this point, but it is already out of scope and disconnected.

To properly correct this, we changed the configuration to the following Previously, the opposite was the case, which caused the bug.

Correct.
ClientSession scope {
  ClientResponse scope{
    response.read
  }
}

Incorrect
ClientResponse scope {
  ClientSession scope {
  }
  response.read expect session living (error)
}

With the interface changes, we modified the required tests, re-ran the required tests, and verified that they completed successfully. I would be happy to check and review! Best regards.

Takayuki Tanabe

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
