### PR TITLE
More controls for pgbouncer secrets configuration

### DIFF
--- a/chart/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -67,8 +67,8 @@ spec:
         tier: airflow
         component: pgbouncer
         release: {{ .Release.Name }}
-        {{- with .Values.labels }}
-          {{- toYaml . | nindent 8 }}
+        {{- if or (.Values.labels) (.Values.pgbouncer.labels) }}
+          {{- mustMerge .Values.pgbouncer.labels .Values.labels | toYaml | nindent 8 }}
         {{- end }}
       annotations:
         checksum/pgbouncer-config-secret: {{ include (print $.Template.BasePath "/secrets/pgbouncer-config-secret.yaml") . | sha256sum }}
@@ -118,7 +118,9 @@ spec:
           readinessProbe:
             tcpSocket:
               port: {{ .Values.ports.pgbouncer }}
+          {{- if or .Values.pgbouncer.mountConfigSecret .Values.pgbouncer.ssl.ca .Values.pgbouncer.ssl.cert .Values.pgbouncer.ssl.key .Values.volumeMounts .Values.pgbouncer.extraVolumeMounts }}
           volumeMounts:
+            {{- if .Values.pgbouncer.mountConfigSecret }}
             - name: pgbouncer-config
               subPath: pgbouncer.ini
               mountPath: /etc/pgbouncer/pgbouncer.ini
@@ -127,6 +129,7 @@ spec:
               subPath: users.txt
               mountPath: /etc/pgbouncer/users.txt
               readOnly: true
+            {{- end}}
             {{- if .Values.pgbouncer.ssl.ca }}
             - name: pgbouncer-certificates
               subPath: root.crt
@@ -151,6 +154,7 @@ spec:
             {{- if .Values.pgbouncer.extraVolumeMounts }}
               {{- tpl (toYaml .Values.pgbouncer.extraVolumeMounts) . | nindent 12 }}
             {{- end }}
+          {{- end}}
           {{- if $containerLifecycleHooks }}
           lifecycle: {{- tpl (toYaml $containerLifecycleHooks) . | nindent 12 }}
           {{- end }}
@@ -191,14 +195,21 @@ spec:
           {{- if $containerLifecycleHooksMetricsExporter }}
           lifecycle: {{- tpl (toYaml $containerLifecycleHooksMetricsExporter) . | nindent 12 }}
           {{- end }}
+          {{- if .Values.pgbouncer.metricsExporterSidecar.extraVolumeMounts }}
+          volumeMounts:
+            {{- tpl (toYaml .Values.pgbouncer.metricsExporterSidecar.extraVolumeMounts) . | nindent 12 }}
+          {{- end}}
         {{- if .Values.pgbouncer.extraContainers }}
           {{- tpl (toYaml .Values.pgbouncer.extraContainers) . | nindent 8 }}
         {{- end }}
+      {{- if or .Values.pgbouncer.mountConfigSecret .Values.pgbouncer.ssl.ca .Values.pgbouncer.ssl.cert .Values.pgbouncer.ssl.key .Values.volumes .Values.pgbouncer.extraVolumes }}
       volumes:
+        {{- if .Values.pgbouncer.mountConfigSecret }}
         - name: pgbouncer-config
           secret:
             secretName: {{ template "pgbouncer_config_secret" . }}
-        {{- if or .Values.pgbouncer.ssl.ca  .Values.pgbouncer.ssl.cert .Values.pgbouncer.ssl.key }}
+        {{- end}}
+        {{- if or .Values.pgbouncer.ssl.ca .Values.pgbouncer.ssl.cert .Values.pgbouncer.ssl.key }}
         - name: pgbouncer-certificates
           secret:
             secretName: {{ template "pgbouncer_certificates_secret" . }}
@@ -209,4 +220,5 @@ spec:
         {{- if .Values.pgbouncer.extraVolumes }}
           {{- tpl (toYaml .Values.pgbouncer.extraVolumes) . | nindent 8 }}
         {{- end }}
+      {{- end }}
 {{- end }}

--- a/chart/templates/pgbouncer/pgbouncer-ingress.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-ingress.yaml
@@ -31,8 +31,8 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    {{- with .Values.labels }}
-      {{- toYaml . | nindent 4 }}
+    {{- if or (.Values.labels) (.Values.pgbouncer.labels) }}
+      {{- mustMerge .Values.pgbouncer.labels .Values.labels | toYaml | nindent 4 }}
     {{- end }}
   {{- with .Values.ingress.pgbouncer.annotations }}
   annotations: {{- toYaml . | nindent 4 }}

--- a/chart/templates/pgbouncer/pgbouncer-networkpolicy.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-networkpolicy.yaml
@@ -34,8 +34,8 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    {{- with .Values.labels }}
-      {{- toYaml . | nindent 4 }}
+    {{- if or (.Values.labels) (.Values.pgbouncer.labels) }}
+      {{- mustMerge .Values.pgbouncer.labels .Values.labels | toYaml | nindent 4 }}
     {{- end }}
 spec:
   podSelector:

--- a/chart/templates/pgbouncer/pgbouncer-poddisruptionbudget.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-poddisruptionbudget.yaml
@@ -31,8 +31,8 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    {{- with .Values.labels }}
-      {{- toYaml . | nindent 4 }}
+    {{- if or (.Values.labels) (.Values.pgbouncer.labels) }}
+      {{- mustMerge .Values.pgbouncer.labels .Values.labels | toYaml | nindent 4 }}
     {{- end }}
 spec:
   selector:

--- a/chart/templates/pgbouncer/pgbouncer-service.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-service.yaml
@@ -31,8 +31,8 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    {{- with .Values.labels }}
-      {{- toYaml . | nindent 4 }}
+    {{- if or (.Values.labels) (.Values.pgbouncer.labels) }}
+      {{- mustMerge .Values.pgbouncer.labels .Values.labels | toYaml | nindent 4 }}
     {{- end }}
   annotations:
     prometheus.io/scrape: "true"

--- a/chart/templates/pgbouncer/pgbouncer-serviceaccount.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-serviceaccount.yaml
@@ -32,8 +32,8 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    {{- with .Values.labels }}
-      {{- toYaml . | nindent 4 }}
+    {{- if or (.Values.labels) (.Values.pgbouncer.labels) }}
+      {{- mustMerge .Values.pgbouncer.labels .Values.labels | toYaml | nindent 4 }}
     {{- end }}
   {{- with .Values.pgbouncer.serviceAccount.annotations }}
   annotations: {{- toYaml . | nindent 4 }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -7026,6 +7026,14 @@
                         "additionalProperties": false
                     }
                 },
+                "labels": {
+                    "description": "Labels to add to the PgBouncer objects and pods.",
+                    "type": "object",
+                    "default": {},
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "enabled": {
                     "description": "Enable PgBouncer.",
                     "type": "boolean",
@@ -7080,6 +7088,12 @@
                         "type": "string"
                     },
                     "default": null
+                },
+                "mountConfigSecret": {
+                    "description": "Whether to mount the config secret files under `/etc/pgbouncer/` by default.",
+                    "type": "boolean",
+                    "x-docsSection": "Common",
+                    "default": true
                 },
                 "extraNetworkPolicies": {
                     "description": "Additional NetworkPolicies as needed.",
@@ -7618,6 +7632,14 @@
                                     "type": "integer",
                                     "default": 1
                                 }
+                            }
+                        },
+                        "extraVolumeMounts": {
+                            "description": "Mount additional volumes into PgBouncer Metrics Exporter.",
+                            "type": "array",
+                            "default": [],
+                            "items": {
+                                "$ref": "#/definitions/io.k8s.api.core.v1.VolumeMount"
                             }
                         }
                     }

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2173,6 +2173,10 @@ pgbouncer:
   auth_type: scram-sha-256
   auth_file: /etc/pgbouncer/users.txt
 
+  # Whether to mount the config secret files at a default location (/etc/pgbouncer/*).
+  # Can be skipped to allow for other means to get the values, e.g. secrets provider class.
+  mountConfigSecret: true
+
   # annotations to be added to the PgBouncer deployment
   annotations: {}
 
@@ -2279,6 +2283,8 @@ pgbouncer:
   #     - name: my-templated-extra-volume
   #       mountPath: "{{ .Values.my_custom_path }}"
   #       readOnly: true
+  # Volumes apply to all pgbouncer containers, while volume mounts apply to the pgbouncer
+  # container itself. Metrics exporter container has its own mounts.
   extraVolumes: []
   extraVolumeMounts: []
 
@@ -2352,6 +2358,15 @@ pgbouncer:
       periodSeconds: 10
       timeoutSeconds: 1
 
+    # Mount additional volumes into the metrics exporter. It can be templated like in the following example:
+    #   extraVolumeMounts:
+    #     - name: my-templated-extra-volume
+    #       mountPath: "{{ .Values.my_custom_path }}"
+    #       readOnly: true
+    extraVolumeMounts: []
+
+  # Labels specific to pgbouncer objects and pods
+  labels: {}
   # Environment variables to add to pgbouncer container
   env: []
 


### PR DESCRIPTION
closes: #45171

Allow to disable adding default secret mounts for pgbouncer configs as well as metrics exported database url env variable. This can be useful for cases, where the value is retrieved other way, e.g. secrets provider class.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
