### PR TITLE
Fix test collection for Connection and Variables for non-db tests

### DIFF
--- a/contributing-docs/testing/unit_tests.rst
+++ b/contributing-docs/testing/unit_tests.rst
@@ -359,6 +359,13 @@ For selected test types (example - the tests will run for Providers/API/CLI code
 
      breeze testing providers-tests --skip-db-tests --parallel-test-types "Providers[google] Providers[amazon]"
 
+You can also enter interactive shell with ``--skip-db-tests`` flag and run the tests iteratively
+
+  .. code-block:: bash
+
+     breeze shell --skip-db-tests
+     > pytest tests/your_test.py
+
 
 How to make your test not depend on DB
 ......................................

--- a/providers/tests/microsoft/azure/fs/test_adls.py
+++ b/providers/tests/microsoft/azure/fs/test_adls.py
@@ -17,12 +17,20 @@
 
 from __future__ import annotations
 
+import os
 from unittest import mock
 
 import pytest
 
 from airflow.models import Connection
 from airflow.providers.microsoft.azure.fs.adls import get_fs
+
+if os.environ.get("_AIRFLOW_SKIP_DB_TESTS") == "true":
+    # Handle collection of the test by non-db case
+    Connection = mock.MagicMock()  # type: ignore[misc]
+
+
+pytestmark = pytest.mark.db_test
 
 
 @pytest.fixture

--- a/providers/tests/microsoft/azure/hooks/test_adx.py
+++ b/providers/tests/microsoft/azure/hooks/test_adx.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import os
 from unittest import mock
 
 import pytest
@@ -30,6 +31,10 @@ from airflow.providers.microsoft.azure.hooks.adx import AzureDataExplorerHook
 ADX_TEST_CONN_ID = "adx_test_connection_id"
 
 pytestmark = pytest.mark.db_test
+
+if os.environ.get("_AIRFLOW_SKIP_DB_TESTS") == "true":
+    # Handle collection of the test by non-db case
+    Connection = mock.MagicMock()  # type: ignore[misc]
 
 
 class TestAzureDataExplorerHook:

--- a/providers/tests/microsoft/azure/hooks/test_base_azure.py
+++ b/providers/tests/microsoft/azure/hooks/test_base_azure.py
@@ -16,7 +16,8 @@
 # under the License.
 from __future__ import annotations
 
-from unittest.mock import Mock, patch
+import os
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
@@ -24,6 +25,10 @@ from airflow.models import Connection
 from airflow.providers.microsoft.azure.hooks.base_azure import AzureBaseHook
 
 pytestmark = pytest.mark.db_test
+
+if os.environ.get("_AIRFLOW_SKIP_DB_TESTS") == "true":
+    # Handle collection of the test by non-db case
+    Connection = MagicMock()  # type: ignore[misc]
 
 MODULE = "airflow.providers.microsoft.azure.hooks.base_azure"
 

--- a/providers/tests/microsoft/azure/hooks/test_container_registry.py
+++ b/providers/tests/microsoft/azure/hooks/test_container_registry.py
@@ -17,12 +17,19 @@
 # under the License.
 from __future__ import annotations
 
+import os
 from unittest import mock
 
 import pytest
 
 from airflow.models import Connection
 from airflow.providers.microsoft.azure.hooks.container_registry import AzureContainerRegistryHook
+
+pytestmark = pytest.mark.db_test
+
+if os.environ.get("_AIRFLOW_SKIP_DB_TESTS") == "true":
+    # Handle collection of the test by non-db case
+    Connection = mock.MagicMock()  # type: ignore[misc]
 
 
 class TestAzureContainerRegistryHook:

--- a/providers/tests/microsoft/azure/hooks/test_container_volume.py
+++ b/providers/tests/microsoft/azure/hooks/test_container_volume.py
@@ -17,12 +17,19 @@
 # under the License.
 from __future__ import annotations
 
+import os
 from unittest import mock
 
 import pytest
 
 from airflow.models import Connection
 from airflow.providers.microsoft.azure.hooks.container_volume import AzureContainerVolumeHook
+
+pytestmark = pytest.mark.db_test
+
+if os.environ.get("_AIRFLOW_SKIP_DB_TESTS") == "true":
+    # Handle collection of the test by non-db case
+    Connection = mock.MagicMock()  # type: ignore[misc]
 
 
 class TestAzureContainerVolumeHook:

--- a/providers/tests/microsoft/azure/hooks/test_cosmos.py
+++ b/providers/tests/microsoft/azure/hooks/test_cosmos.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import uuid
 from unittest import mock
 from unittest.mock import PropertyMock
@@ -30,7 +31,13 @@ from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.providers.microsoft.azure.hooks.cosmos import AzureCosmosDBHook
 
+pytestmark = pytest.mark.db_test
+
 MODULE = "airflow.providers.microsoft.azure.hooks.cosmos"
+
+if os.environ.get("_AIRFLOW_SKIP_DB_TESTS") == "true":
+    # Handle collection of the test by non-db case
+    Connection = mock.MagicMock()  # type: ignore[misc]
 
 
 class TestAzureCosmosDbHook:

--- a/providers/tests/microsoft/azure/hooks/test_data_factory.py
+++ b/providers/tests/microsoft/azure/hooks/test_data_factory.py
@@ -59,6 +59,12 @@ MODULE = "airflow.providers.microsoft.azure.hooks.data_factory"
 # TODO: FIXME: the tests here have tricky issues with typing and need a bit more thought to fix them
 # mypy: disable-error-code="union-attr,call-overload"
 
+pytestmark = pytest.mark.db_test
+
+if os.environ.get("_AIRFLOW_SKIP_DB_TESTS") == "true":
+    # Handle collection of the test by non-db case
+    Connection = mock.MagicMock()  # type: ignore[misc]
+
 
 @pytest.fixture(autouse=True)
 def setup_connections(create_mock_connections):

--- a/providers/tests/microsoft/azure/hooks/test_wasb.py
+++ b/providers/tests/microsoft/azure/hooks/test_wasb.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import os
 import re
 from unittest import mock
 
@@ -31,6 +32,9 @@ from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
 
 pytestmark = pytest.mark.db_test
 
+if os.environ.get("_AIRFLOW_SKIP_DB_TESTS") == "true":
+    # Handle collection of the test by non-db case
+    Connection = mock.MagicMock()  # type: ignore[misc]
 
 # connection_string has a format
 CONN_STRING = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -372,6 +372,7 @@ testing = ["dev", "providers.tests", "task_sdk.tests", "tests_common", "tests"]
 
 # Test compat imports banned imports to allow testing against older airflow versions
 "tests_common/test_utils/compat.py" = ["TID251", "F401"]
+"tests_common/pytest_plugin.py" = ["F811"]
 
 [tool.ruff.lint.flake8-tidy-imports]
 # Disallow all relative imports.


### PR DESCRIPTION
When Tests were collected for microsoft provider alone for non-db tests, Connection were used in "parametrized" to perameterize the tests. This was only working accidentally so far because all ORM models were loaded before in other tests - including Triggers -and then the connection objects did not trigger any DB operations. But when microsoft provider tests were run first (and in separation), the Triggers were not imported and Connection creation caused error:

> When initializing mapper mapped class AssetModel->asset, expression
  'Trigger' failed to locate a name ('Trigger') # Please enter the commit
  message for your changes. Lines starting

This can be mitigated (as already advised in unit tests documentation) by replacing Connections with MagicMock.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
