### PR TITLE
Extending task sdk loggers to handle non ascii characters

### DIFF
--- a/task_sdk/src/airflow/sdk/log.py
+++ b/task_sdk/src/airflow/sdk/log.py
@@ -109,7 +109,7 @@ class StdBinaryStreamHandler(logging.StreamHandler):
     def emit(self, record: logging.LogRecord):
         try:
             msg = self.format(record)
-            buffer = bytearray(msg, "ascii", "backslashreplace")
+            buffer = bytearray(msg, "utf-8", "backslashreplace")
 
             buffer += b"\n"
 
@@ -202,7 +202,7 @@ def logging_processors(
             return encoder.encode(msg)
 
         def json_processor(logger: Any, method_name: Any, event_dict: EventDict) -> str:
-            return encoder.encode(event_dict).decode("ascii")
+            return encoder.encode(event_dict).decode("utf-8")
 
         json = structlog.processors.JSONRenderer(serializer=json_dumps)
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

If we run a dag that emits non ascii characters in the task logs, the logger in task sdk runs into an exception that looks like this:
```
{"logger":"airflow.task.hooks.airflow.providers.standard.hooks.subprocess.SubprocessHook","timestamp":"2024-12-27T06:56:12.072210","event":"","level":"info"}
{"chan":"stderr","event":"--- Logging error ---","timestamp":"2024-12-27T06:56:12.072312Z","level":"error","logger":"task"}
{"chan":"stderr","event":"Traceback (most recent call last):","timestamp":"2024-12-27T06:56:12.073263Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/usr/local/lib/python3.12/site-packages/airflow/sdk/log.py\", line 111, in emit","timestamp":"2024-12-27T06:56:12.074470Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    msg = self.format(record)","timestamp":"2024-12-27T06:56:12.074516Z","level":"error","logger":"task"}
{"chan":"stderr","event":"          ^^^^^^^^^^^^^^^^^^^","timestamp":"2024-12-27T06:56:12.074527Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/usr/local/lib/python3.12/logging/__init__.py\", line 999, in format","timestamp":"2024-12-27T06:56:12.074535Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    return fmt.format(record)","timestamp":"2024-12-27T06:56:12.074542Z","level":"error","logger":"task"}
{"chan":"stderr","event":"           ^^^^^^^^^^^^^^^^^^","timestamp":"2024-12-27T06:56:12.074549Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/usr/local/lib/python3.12/site-packages/structlog/stdlib.py\", line 1098, in format","timestamp":"2024-12-27T06:56:12.074555Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    ed = p(logger, meth_name, cast(EventDict, ed))","timestamp":"2024-12-27T06:56:12.074562Z","level":"error","logger":"task"}
{"chan":"stderr","event":"         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^","timestamp":"2024-12-27T06:56:12.074577Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/usr/local/lib/python3.12/site-packages/airflow/sdk/log.py\", line 205, in json_processor","timestamp":"2024-12-27T06:56:12.074584Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    return encoder.encode(event_dict).decode(\"ascii\")","timestamp":"2024-12-27T06:56:12.074590Z","level":"error","logger":"task"}
{"chan":"stderr","event":"           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^","timestamp":"2024-12-27T06:56:12.074596Z","level":"error","logger":"task"}
{"chan":"stderr","event":"UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 10: ordinal not in range(128)","timestamp":"2024-12-27T06:56:12.074601Z","level":"error","logger":"task"}
```

### Internals:
- We use the `msgspec.json.Encoder()` encoder internally for task sdk log encoding.
```
In [5]: x
Out[5]: '→ Get DAGs'
```

```
In [7]: encoder = msgspec.json.Encoder()

In [8]: encoder.encode(x)
Out[8]: b'"\xe2\x86\x92 Get DAGs"'
```

So, we just instead update the decode to `utf-8`.

### Testing:
Example DAG:
```
from airflow import DAG
from airflow.providers.standard.operators.bash import BashOperator

with DAG(
    "unicode_logging_test",
    schedule=None,
    catchup=False,
    tags=["test", "unicode", "logging"],
) as dag:

    generate_unicode_logs = BashOperator(
        task_id="generate_unicode_logs",
        bash_command='echo "This is a test log with non-ASCII characters: é, ü, 漢字, 😊"',
    )

    generate_unicode_logs

```

Without changes, logs:
```
{"logger":"airflow.models.dagbag.DagBag","timestamp":"2024-12-30T08:29:01.614531","event":"Filling up the DagBag from /files/dags/non-ascii.py","level":"info"}
{"logger":"airflow.models.dagbag.DagBag","timestamp":"2024-12-30T08:29:01.615191","event":"Importing /files/dags/non-ascii.py","level":"debug"}
{"logger":"airflow.models.dagbag.DagBag","timestamp":"2024-12-30T08:29:01.624665","event":"Loaded DAG <DAG: unicode_logging_test>","level":"debug"}
{"file":"/files/dags/non-ascii.py","timestamp":"2024-12-30T08:29:01.624924","logger":"task","event":"DAG file parsed","level":"debug"}
{"json":"{\"rendered_fields\":{\"bash_command\":\"echo \\\"This is a test log with non-ASCII characters: é, ü, 漢字, 😊\\\"\",\"env\":null,\"cwd\":null},\"type\":\"SetRenderedFields\"}\n","timestamp":"2024-12-30T08:29:01.625635","logger":"task","event":"Sending request","level":"debug"}
{"logger":"airflow.task.operators.airflow.providers.standard.operators.bash.BashOperator","timestamp":"2024-12-30T08:29:01.656412","event":"BashOperator.execute cannot be called outside TaskInstance!","level":"warning"}
{"logger":"airflow.task.operators.airflow.providers.standard.operators.bash.BashOperator","timestamp":"2024-12-30T08:29:01.656968","event":"Exporting env vars: AIRFLOW_CTX_DAG_OWNER='airflow' AIRFLOW_CTX_DAG_ID='unicode_logging_test' AIRFLOW_CTX_TASK_ID='generate_unicode_logs' AIRFLOW_CTX_TRY_NUMBER='1' AIRFLOW_CTX_DAG_RUN_ID='manual__2024-12-30T08:29:01.038634+00:00'","level":"debug"}
{"logger":"airflow.task.hooks.airflow.providers.standard.hooks.subprocess.SubprocessHook","timestamp":"2024-12-30T08:29:01.657464","event":"Tmp dir root location: /tmp","level":"info"}
{"chan":"stderr","event":"--- Logging error ---","timestamp":"2024-12-30T08:29:01.657838Z","level":"error","logger":"task"}
{"chan":"stderr","event":"Traceback (most recent call last):","timestamp":"2024-12-30T08:29:01.658815Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/task_sdk/src/airflow/sdk/log.py\", line 111, in emit","timestamp":"2024-12-30T08:29:01.658911Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    msg = self.format(record)","timestamp":"2024-12-30T08:29:01.658965Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/usr/local/lib/python3.9/logging/__init__.py\", line 927, in format","timestamp":"2024-12-30T08:29:01.659051Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    return fmt.format(record)","timestamp":"2024-12-30T08:29:01.659112Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/usr/local/lib/python3.9/site-packages/structlog/stdlib.py\", line 1098, in format","timestamp":"2024-12-30T08:29:01.659217Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    ed = p(logger, meth_name, cast(EventDict, ed))","timestamp":"2024-12-30T08:29:01.659314Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/task_sdk/src/airflow/sdk/log.py\", line 205, in json_processor","timestamp":"2024-12-30T08:29:01.659344Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    return encoder.encode(event_dict).decode(\"ascii\")","timestamp":"2024-12-30T08:29:01.659403Z","level":"error","logger":"task"}
{"chan":"stderr","event":"UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 105: ordinal not in range(128)","timestamp":"2024-12-30T08:29:01.659473Z","level":"error","logger":"task"}
{"chan":"stderr","event":"Call stack:","timestamp":"2024-12-30T08:29:01.659534Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/usr/local/bin/airflow\", line 8, in <module>","timestamp":"2024-12-30T08:29:01.663849Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    sys.exit(main())","timestamp":"2024-12-30T08:29:01.663979Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/__main__.py\", line 58, in main","timestamp":"2024-12-30T08:29:01.664052Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    args.func(args)","timestamp":"2024-12-30T08:29:01.664108Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/cli/cli_config.py\", line 49, in command","timestamp":"2024-12-30T08:29:01.664234Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    return func(*args, **kwargs)","timestamp":"2024-12-30T08:29:01.664305Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/utils/cli.py\", line 111, in wrapper","timestamp":"2024-12-30T08:29:01.664366Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    return f(*args, **kwargs)","timestamp":"2024-12-30T08:29:01.664432Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/utils/providers_configuration_loader.py\", line 55, in wrapped_function","timestamp":"2024-12-30T08:29:01.664496Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    return func(*args, **kwargs)","timestamp":"2024-12-30T08:29:01.664557Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/cli/commands/local_commands/scheduler_command.py\", line 56, in scheduler","timestamp":"2024-12-30T08:29:01.664623Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    run_command_with_daemon_option(","timestamp":"2024-12-30T08:29:01.664682Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/cli/commands/local_commands/daemon_utils.py\", line 86, in run_command_with_daemon_option","timestamp":"2024-12-30T08:29:01.664747Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    callback()","timestamp":"2024-12-30T08:29:01.664800Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/cli/commands/local_commands/scheduler_command.py\", line 59, in <lambda>","timestamp":"2024-12-30T08:29:01.664883Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    callback=lambda: _run_scheduler_job(args),","timestamp":"2024-12-30T08:29:01.664934Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/cli/commands/local_commands/scheduler_command.py\", line 45, in _run_scheduler_job","timestamp":"2024-12-30T08:29:01.664972Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    run_job(job=job_runner.job, execute_callable=job_runner._execute)","timestamp":"2024-12-30T08:29:01.665047Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/utils/session.py\", line 101, in wrapper","timestamp":"2024-12-30T08:29:01.665151Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    return func(*args, session=session, **kwargs)","timestamp":"2024-12-30T08:29:01.665205Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/jobs/job.py\", line 342, in run_job","timestamp":"2024-12-30T08:29:01.665244Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    return execute_job(job, execute_callable=execute_callable)","timestamp":"2024-12-30T08:29:01.665325Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/jobs/job.py\", line 371, in execute_job","timestamp":"2024-12-30T08:29:01.665388Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    ret = execute_callable()","timestamp":"2024-12-30T08:29:01.665415Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/jobs/scheduler_job_runner.py\", line 953, in _execute","timestamp":"2024-12-30T08:29:01.665449Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    self._run_scheduler_loop()","timestamp":"2024-12-30T08:29:01.665524Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/jobs/scheduler_job_runner.py\", line 1093, in _run_scheduler_loop","timestamp":"2024-12-30T08:29:01.665588Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    num_queued_tis = self._do_scheduling(session)","timestamp":"2024-12-30T08:29:01.665638Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/jobs/scheduler_job_runner.py\", line 1241, in _do_scheduling","timestamp":"2024-12-30T08:29:01.665685Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    num_queued_tis = self._critical_section_enqueue_task_instances(session=session)","timestamp":"2024-12-30T08:29:01.665808Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/jobs/scheduler_job_runner.py\", line 724, in _critical_section_enqueue_task_instances","timestamp":"2024-12-30T08:29:01.665884Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    self._enqueue_task_instances_with_queued_state(queued_tis_per_executor, executor, session=session)","timestamp":"2024-12-30T08:29:01.665934Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/jobs/scheduler_job_runner.py\", line 653, in _enqueue_task_instances_with_queued_state","timestamp":"2024-12-30T08:29:01.665968Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    executor.queue_workload(workload)","timestamp":"2024-12-30T08:29:01.666038Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/executors/local_executor.py\", line 246, in queue_workload","timestamp":"2024-12-30T08:29:01.666109Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    self._check_workers()","timestamp":"2024-12-30T08:29:01.666148Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/executors/local_executor.py\", line 185, in _check_workers","timestamp":"2024-12-30T08:29:01.666195Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    self._spawn_worker()","timestamp":"2024-12-30T08:29:01.666275Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/executors/local_executor.py\", line 197, in _spawn_worker","timestamp":"2024-12-30T08:29:01.666364Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    p.start()","timestamp":"2024-12-30T08:29:01.666406Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/usr/local/lib/python3.9/multiprocessing/process.py\", line 121, in start","timestamp":"2024-12-30T08:29:01.666440Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    self._popen = self._Popen(self)","timestamp":"2024-12-30T08:29:01.666509Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/usr/local/lib/python3.9/multiprocessing/context.py\", line 224, in _Popen","timestamp":"2024-12-30T08:29:01.666596Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    return _default_context.get_context().Process._Popen(process_obj)","timestamp":"2024-12-30T08:29:01.666646Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/usr/local/lib/python3.9/multiprocessing/context.py\", line 277, in _Popen","timestamp":"2024-12-30T08:29:01.666675Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    return Popen(process_obj)","timestamp":"2024-12-30T08:29:01.666704Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/usr/local/lib/python3.9/multiprocessing/popen_fork.py\", line 19, in __init__","timestamp":"2024-12-30T08:29:01.666755Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    self._launch(process_obj)","timestamp":"2024-12-30T08:29:01.666855Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/usr/local/lib/python3.9/multiprocessing/popen_fork.py\", line 71, in _launch","timestamp":"2024-12-30T08:29:01.666902Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    code = process_obj._bootstrap(parent_sentinel=child_r)","timestamp":"2024-12-30T08:29:01.666957Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/usr/local/lib/python3.9/multiprocessing/process.py\", line 315, in _bootstrap","timestamp":"2024-12-30T08:29:01.667024Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    self.run()","timestamp":"2024-12-30T08:29:01.667090Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/usr/local/lib/python3.9/multiprocessing/process.py\", line 108, in run","timestamp":"2024-12-30T08:29:01.667152Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    self._target(*self._args, **self._kwargs)","timestamp":"2024-12-30T08:29:01.667303Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/executors/local_executor.py\", line 92, in _run_worker","timestamp":"2024-12-30T08:29:01.667380Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    _execute_work(log, workload)","timestamp":"2024-12-30T08:29:01.667428Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/executors/local_executor.py\", line 113, in _execute_work","timestamp":"2024-12-30T08:29:01.667471Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    supervise(","timestamp":"2024-12-30T08:29:01.667552Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/task_sdk/src/airflow/sdk/execution_time/supervisor.py\", line 896, in supervise","timestamp":"2024-12-30T08:29:01.667638Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    process = WatchedSubprocess.start(dag_path, ti, client=client, logger=logger)","timestamp":"2024-12-30T08:29:01.667675Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/task_sdk/src/airflow/sdk/execution_time/supervisor.py\", line 345, in start","timestamp":"2024-12-30T08:29:01.667721Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    _fork_main(child_stdin, child_stdout, child_stderr, child_logs.fileno(), target)","timestamp":"2024-12-30T08:29:01.667787Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/task_sdk/src/airflow/sdk/execution_time/supervisor.py\", line 252, in _fork_main","timestamp":"2024-12-30T08:29:01.667919Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    target()","timestamp":"2024-12-30T08:29:01.667981Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/task_sdk/src/airflow/sdk/execution_time/supervisor.py\", line 134, in _subprocess_main","timestamp":"2024-12-30T08:29:01.668052Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    main()","timestamp":"2024-12-30T08:29:01.668120Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/task_sdk/src/airflow/sdk/execution_time/task_runner.py\", line 490, in main","timestamp":"2024-12-30T08:29:01.668165Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    run(ti, log)","timestamp":"2024-12-30T08:29:01.668194Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/task_sdk/src/airflow/sdk/execution_time/task_runner.py\", line 393, in run","timestamp":"2024-12-30T08:29:01.668227Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    result = ti.task.execute(context)  # type: ignore[attr-defined]","timestamp":"2024-12-30T08:29:01.668284Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/models/baseoperator.py\", line 377, in wrapper","timestamp":"2024-12-30T08:29:01.668354Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    return func(self, *args, **kwargs)","timestamp":"2024-12-30T08:29:01.668404Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/providers/src/airflow/providers/standard/operators/bash.py\", line 265, in execute","timestamp":"2024-12-30T08:29:01.668430Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    result = self._run_inline_command(bash_path=bash_path, env=env)","timestamp":"2024-12-30T08:29:01.668464Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/providers/src/airflow/providers/standard/operators/bash.py\", line 280, in _run_inline_command","timestamp":"2024-12-30T08:29:01.668514Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    return self.subprocess_hook.run_command(","timestamp":"2024-12-30T08:29:01.668581Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/providers/src/airflow/providers/standard/hooks/subprocess.py\", line 88, in run_command","timestamp":"2024-12-30T08:29:01.668627Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    self.log.info(\"Running command: %s\", command)","timestamp":"2024-12-30T08:29:01.668693Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/usr/local/lib/python3.9/logging/__init__.py\", line 1446, in info","timestamp":"2024-12-30T08:29:01.668739Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    self._log(INFO, msg, args, **kwargs)","timestamp":"2024-12-30T08:29:01.668852Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/usr/local/lib/python3.9/logging/__init__.py\", line 1589, in _log","timestamp":"2024-12-30T08:29:01.668903Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    self.handle(record)","timestamp":"2024-12-30T08:29:01.668934Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/usr/local/lib/python3.9/logging/__init__.py\", line 1599, in handle","timestamp":"2024-12-30T08:29:01.668969Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    self.callHandlers(record)","timestamp":"2024-12-30T08:29:01.669020Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/usr/local/lib/python3.9/logging/__init__.py\", line 1661, in callHandlers","timestamp":"2024-12-30T08:29:01.669124Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    hdlr.handle(record)","timestamp":"2024-12-30T08:29:01.669180Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/usr/local/lib/python3.9/logging/__init__.py\", line 952, in handle","timestamp":"2024-12-30T08:29:01.669223Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    self.emit(record)","timestamp":"2024-12-30T08:29:01.669302Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/task_sdk/src/airflow/sdk/log.py\", line 122, in emit","timestamp":"2024-12-30T08:29:01.669371Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    self.handleError(record)","timestamp":"2024-12-30T08:29:01.669418Z","level":"error","logger":"task"}
{"chan":"stderr","event":"Message: 'Running command: %s'","timestamp":"2024-12-30T08:29:01.669445Z","level":"error","logger":"task"}
{"chan":"stderr","event":"Arguments: (['/usr/bin/bash', '-c', 'echo \"This is a test log with non-ASCII characters: é, ü, 漢字, 😊\"'],)","timestamp":"2024-12-30T08:29:01.669481Z","level":"error","logger":"task"}
{"logger":"airflow.task.hooks.airflow.providers.standard.hooks.subprocess.SubprocessHook","timestamp":"2024-12-30T08:29:01.670357","event":"Output:","level":"info"}
{"chan":"stderr","event":"--- Logging error ---","timestamp":"2024-12-30T08:29:01.672321Z","level":"error","logger":"task"}
{"chan":"stderr","event":"Traceback (most recent call last):","timestamp":"2024-12-30T08:29:01.672481Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/task_sdk/src/airflow/sdk/log.py\", line 111, in emit","timestamp":"2024-12-30T08:29:01.672544Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    msg = self.format(record)","timestamp":"2024-12-30T08:29:01.672597Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/usr/local/lib/python3.9/logging/__init__.py\", line 927, in format","timestamp":"2024-12-30T08:29:01.672670Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    return fmt.format(record)","timestamp":"2024-12-30T08:29:01.672744Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/usr/local/lib/python3.9/site-packages/structlog/stdlib.py\", line 1098, in format","timestamp":"2024-12-30T08:29:01.672791Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    ed = p(logger, meth_name, cast(EventDict, ed))","timestamp":"2024-12-30T08:29:01.672838Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/task_sdk/src/airflow/sdk/log.py\", line 205, in json_processor","timestamp":"2024-12-30T08:29:01.672897Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    return encoder.encode(event_dict).decode(\"ascii\")","timestamp":"2024-12-30T08:29:01.673016Z","level":"error","logger":"task"}
{"chan":"stderr","event":"UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 56: ordinal not in range(128)","timestamp":"2024-12-30T08:29:01.673073Z","level":"error","logger":"task"}
{"chan":"stderr","event":"Call stack:","timestamp":"2024-12-30T08:29:01.673128Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/usr/local/bin/airflow\", line 8, in <module>","timestamp":"2024-12-30T08:29:01.673205Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    sys.exit(main())","timestamp":"2024-12-30T08:29:01.673293Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/__main__.py\", line 58, in main","timestamp":"2024-12-30T08:29:01.673478Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    args.func(args)","timestamp":"2024-12-30T08:29:01.673818Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/cli/cli_config.py\", line 49, in command","timestamp":"2024-12-30T08:29:01.674222Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    return func(*args, **kwargs)","timestamp":"2024-12-30T08:29:01.674334Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/utils/cli.py\", line 111, in wrapper","timestamp":"2024-12-30T08:29:01.674514Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    return f(*args, **kwargs)","timestamp":"2024-12-30T08:29:01.674679Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/utils/providers_configuration_loader.py\", line 55, in wrapped_function","timestamp":"2024-12-30T08:29:01.674918Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    return func(*args, **kwargs)","timestamp":"2024-12-30T08:29:01.674972Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/cli/commands/local_commands/scheduler_command.py\", line 56, in scheduler","timestamp":"2024-12-30T08:29:01.675059Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    run_command_with_daemon_option(","timestamp":"2024-12-30T08:29:01.675459Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/cli/commands/local_commands/daemon_utils.py\", line 86, in run_command_with_daemon_option","timestamp":"2024-12-30T08:29:01.675508Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    callback()","timestamp":"2024-12-30T08:29:01.675645Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/cli/commands/local_commands/scheduler_command.py\", line 59, in <lambda>","timestamp":"2024-12-30T08:29:01.675680Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    callback=lambda: _run_scheduler_job(args),","timestamp":"2024-12-30T08:29:01.675720Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/cli/commands/local_commands/scheduler_command.py\", line 45, in _run_scheduler_job","timestamp":"2024-12-30T08:29:01.675842Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    run_job(job=job_runner.job, execute_callable=job_runner._execute)","timestamp":"2024-12-30T08:29:01.675907Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/utils/session.py\", line 101, in wrapper","timestamp":"2024-12-30T08:29:01.675972Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    return func(*args, session=session, **kwargs)","timestamp":"2024-12-30T08:29:01.676137Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/jobs/job.py\", line 342, in run_job","timestamp":"2024-12-30T08:29:01.676246Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    return execute_job(job, execute_callable=execute_callable)","timestamp":"2024-12-30T08:29:01.676371Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/jobs/job.py\", line 371, in execute_job","timestamp":"2024-12-30T08:29:01.676424Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    ret = execute_callable()","timestamp":"2024-12-30T08:29:01.676507Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/jobs/scheduler_job_runner.py\", line 953, in _execute","timestamp":"2024-12-30T08:29:01.676574Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    self._run_scheduler_loop()","timestamp":"2024-12-30T08:29:01.676663Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/jobs/scheduler_job_runner.py\", line 1093, in _run_scheduler_loop","timestamp":"2024-12-30T08:29:01.676708Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    num_queued_tis = self._do_scheduling(session)","timestamp":"2024-12-30T08:29:01.676748Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/jobs/scheduler_job_runner.py\", line 1241, in _do_scheduling","timestamp":"2024-12-30T08:29:01.676813Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    num_queued_tis = self._critical_section_enqueue_task_instances(session=session)","timestamp":"2024-12-30T08:29:01.676886Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/jobs/scheduler_job_runner.py\", line 724, in _critical_section_enqueue_task_instances","timestamp":"2024-12-30T08:29:01.676928Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    self._enqueue_task_instances_with_queued_state(queued_tis_per_executor, executor, session=session)","timestamp":"2024-12-30T08:29:01.676958Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/jobs/scheduler_job_runner.py\", line 653, in _enqueue_task_instances_with_queued_state","timestamp":"2024-12-30T08:29:01.677029Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    executor.queue_workload(workload)","timestamp":"2024-12-30T08:29:01.677093Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/executors/local_executor.py\", line 246, in queue_workload","timestamp":"2024-12-30T08:29:01.677131Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    self._check_workers()","timestamp":"2024-12-30T08:29:01.677180Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/executors/local_executor.py\", line 185, in _check_workers","timestamp":"2024-12-30T08:29:01.677255Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    self._spawn_worker()","timestamp":"2024-12-30T08:29:01.677424Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/executors/local_executor.py\", line 197, in _spawn_worker","timestamp":"2024-12-30T08:29:01.677494Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    p.start()","timestamp":"2024-12-30T08:29:01.677553Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/usr/local/lib/python3.9/multiprocessing/process.py\", line 121, in start","timestamp":"2024-12-30T08:29:01.677596Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    self._popen = self._Popen(self)","timestamp":"2024-12-30T08:29:01.677652Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/usr/local/lib/python3.9/multiprocessing/context.py\", line 224, in _Popen","timestamp":"2024-12-30T08:29:01.677737Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    return _default_context.get_context().Process._Popen(process_obj)","timestamp":"2024-12-30T08:29:01.677779Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/usr/local/lib/python3.9/multiprocessing/context.py\", line 277, in _Popen","timestamp":"2024-12-30T08:29:01.677824Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    return Popen(process_obj)","timestamp":"2024-12-30T08:29:01.677892Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/usr/local/lib/python3.9/multiprocessing/popen_fork.py\", line 19, in __init__","timestamp":"2024-12-30T08:29:01.677965Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    self._launch(process_obj)","timestamp":"2024-12-30T08:29:01.678050Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/usr/local/lib/python3.9/multiprocessing/popen_fork.py\", line 71, in _launch","timestamp":"2024-12-30T08:29:01.678129Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    code = process_obj._bootstrap(parent_sentinel=child_r)","timestamp":"2024-12-30T08:29:01.678238Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/usr/local/lib/python3.9/multiprocessing/process.py\", line 315, in _bootstrap","timestamp":"2024-12-30T08:29:01.678345Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    self.run()","timestamp":"2024-12-30T08:29:01.678389Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/usr/local/lib/python3.9/multiprocessing/process.py\", line 108, in run","timestamp":"2024-12-30T08:29:01.678462Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    self._target(*self._args, **self._kwargs)","timestamp":"2024-12-30T08:29:01.678535Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/executors/local_executor.py\", line 92, in _run_worker","timestamp":"2024-12-30T08:29:01.678572Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    _execute_work(log, workload)","timestamp":"2024-12-30T08:29:01.678625Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/airflow/executors/local_executor.py\", line 113, in _execute_work","timestamp":"2024-12-30T08:29:01.678693Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    supervise(","timestamp":"2024-12-30T08:29:01.678776Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/task_sdk/src/airflow/sdk/execution_time/supervisor.py\", line 896, in supervise","timestamp":"2024-12-30T08:29:01.678830Z","level":"error","logger":"task"}
{"chan":"stderr","event":"    process = WatchedSubprocess.start(dag_path, ti, client=client, logger=logger)","timestamp":"2024-12-30T08:29:01.678874Z","level":"error","logger":"task"}
{"chan":"stderr","event":"  File \"/opt/airflow/task_sdk/src/airflow/sdk/execution_time/supervisor.py\", line 345, in start","timestamp":"2024-12-30T08:29:01.678947Z","level":"error","logger":"task"}
{"logger":"airflow.task.hooks.airflow.providers.standard.hooks.subprocess.SubprocessHook","timestamp":"2024-12-30T08:29:01.673033","event":"Command exited with return code 0","level":"info"}
{"json":"{\"key\":\"return_value\",\"value\":\"\\\"This is a test log with non-ASCII characters: \\\\u00e9, \\\\u00fc, \\\\u6f22\\\\u5b57, \\\\ud83d\\\\ude0a\\\"\",\"dag_id\":\"unicode_logging_test\",\"run_id\":\"manual__2024-12-30T08:29:01.038634+00:00\",\"task_id\":\"generate_unicode_logs\",\"map_index\":null,\"type\":\"SetXCom\"}\n","timestamp":"2024-12-30T08:29:01.673960","logger":"task","event":"Sending request","level":"debug"}
{"json":"{\"state\":\"success\",\"end_date\":\"2024-12-30T08:29:01.674161Z\",\"type\":\"TaskState\"}\n","timestamp":"2024-12-30T08:29:01.674351","logger":"task","event":"Sending request","level":"debug"}
```

With changes, logs:
```
{"logger":"airflow.models.dagbag.DagBag","timestamp":"2024-12-30T08:26:02.798717","event":"Filling up the DagBag from /files/dags/non-ascii.py","level":"info"}
{"logger":"airflow.models.dagbag.DagBag","timestamp":"2024-12-30T08:26:02.799734","event":"Importing /files/dags/non-ascii.py","level":"debug"}
{"logger":"airflow.models.dagbag.DagBag","timestamp":"2024-12-30T08:26:02.815459","event":"Loaded DAG <DAG: unicode_logging_test>","level":"debug"}
{"file":"/files/dags/non-ascii.py","timestamp":"2024-12-30T08:26:02.815916","logger":"task","event":"DAG file parsed","level":"debug"}
{"json":"{\"rendered_fields\":{\"bash_command\":\"echo \\\"This is a test log with non-ASCII characters: é, ü, 漢字, 😊\\\"\",\"env\":null,\"cwd\":null},\"type\":\"SetRenderedFields\"}\n","timestamp":"2024-12-30T08:26:02.816578","logger":"task","event":"Sending request","level":"debug"}
{"logger":"airflow.task.operators.airflow.providers.standard.operators.bash.BashOperator","timestamp":"2024-12-30T08:26:02.841691","event":"BashOperator.execute cannot be called outside TaskInstance!","level":"warning"}
{"logger":"airflow.task.operators.airflow.providers.standard.operators.bash.BashOperator","timestamp":"2024-12-30T08:26:02.842139","event":"Exporting env vars: AIRFLOW_CTX_DAG_OWNER='airflow' AIRFLOW_CTX_DAG_ID='unicode_logging_test' AIRFLOW_CTX_TASK_ID='generate_unicode_logs' AIRFLOW_CTX_TRY_NUMBER='1' AIRFLOW_CTX_DAG_RUN_ID='manual__2024-12-30T08:25:13.497632+00:00'","level":"debug"}
{"logger":"airflow.task.hooks.airflow.providers.standard.hooks.subprocess.SubprocessHook","timestamp":"2024-12-30T08:26:02.842428","event":"Tmp dir root location: /tmp","level":"info"}
{"logger":"airflow.task.hooks.airflow.providers.standard.hooks.subprocess.SubprocessHook","timestamp":"2024-12-30T08:26:02.842670","event":"Running command: ['/usr/bin/bash', '-c', 'echo \"This is a test log with non-ASCII characters: é, ü, 漢字, 😊\"']","level":"info"}
{"logger":"airflow.task.hooks.airflow.providers.standard.hooks.subprocess.SubprocessHook","timestamp":"2024-12-30T08:26:02.848839","event":"Output:","level":"info"}
{"logger":"airflow.task.hooks.airflow.providers.standard.hooks.subprocess.SubprocessHook","timestamp":"2024-12-30T08:26:02.849667","event":"This is a test log with non-ASCII characters: é, ü, 漢字, 😊","level":"info"}
{"logger":"airflow.task.hooks.airflow.providers.standard.hooks.subprocess.SubprocessHook","timestamp":"2024-12-30T08:26:02.849786","event":"Command exited with return code 0","level":"info"}
{"json":"{\"key\":\"return_value\",\"value\":\"\\\"This is a test log with non-ASCII characters: \\\\u00e9, \\\\u00fc, \\\\u6f22\\\\u5b57, \\\\ud83d\\\\ude0a\\\"\",\"dag_id\":\"unicode_logging_test\",\"run_id\":\"manual__2024-12-30T08:25:13.497632+00:00\",\"task_id\":\"generate_unicode_logs\",\"map_index\":null,\"type\":\"SetXCom\"}\n","timestamp":"2024-12-30T08:26:02.850431","logger":"task","event":"Sending request","level":"debug"}
{"json":"{\"state\":\"success\",\"end_date\":\"2024-12-30T08:26:02.850521Z\",\"type\":\"TaskState\"}\n","timestamp":"2024-12-30T08:26:02.850626","logger":"task","event":"Sending request","level":"debug"}
```


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
