### PR TITLE
AIP-72: Handling SystemExit from task sdk

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -1203,11 +1203,7 @@ class SelectiveChecks:
 
     @cached_property
     def docker_cache(self) -> str:
-        return (
-            "disabled"
-            if DISABLE_IMAGE_CACHE_LABEL in self._pr_labels
-            else "registry"
-        )
+        return "disabled" if DISABLE_IMAGE_CACHE_LABEL in self._pr_labels else "registry"
 
     @cached_property
     def debug_resources(self) -> bool:

--- a/task_sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task_sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -438,7 +438,12 @@ def run(ti: RuntimeTaskInstance, log: Logger):
         )
         # TODO: Run task failure callbacks here
     except SystemExit:
-        ...
+        # SystemExit needs to be retried if they are eligible.
+        msg = TaskState(
+            state=TerminalTIState.FAILED,
+            end_date=datetime.now(tz=timezone.utc),
+        )
+        # TODO: Run task failure callbacks here
     except BaseException:
         # TODO: Run task failure callbacks here
         msg = TaskState(state=TerminalTIState.FAILED, end_date=datetime.now(tz=timezone.utc))

--- a/task_sdk/tests/execution_time/test_task_runner.py
+++ b/task_sdk/tests/execution_time/test_task_runner.py
@@ -295,6 +295,47 @@ def test_run_raises_base_exception(time_machine, mocked_parse, make_ti_context):
         )
 
 
+def test_run_raises_system_exit(time_machine, mocked_parse, make_ti_context):
+    """Test running a basic task that exits with SystemExit exception."""
+    from airflow.providers.standard.operators.python import PythonOperator
+
+    task = PythonOperator(
+        task_id="system_exit_task",
+        python_callable=lambda: exit(10),
+    )
+
+    what = StartupDetails(
+        ti=TaskInstance(
+            id=uuid7(),
+            task_id="system_exit_task",
+            dag_id="basic_dag_system_exit",
+            run_id="c",
+            try_number=1,
+        ),
+        file="",
+        requests_fd=0,
+        ti_context=make_ti_context(),
+    )
+
+    ti = mocked_parse(what, "basic_dag_system_exit", task)
+
+    instant = timezone.datetime(2024, 12, 3, 10, 0)
+    time_machine.move_to(instant, tick=False)
+
+    with mock.patch(
+        "airflow.sdk.execution_time.task_runner.SUPERVISOR_COMMS", create=True
+    ) as mock_supervisor_comms:
+        run(ti, log=mock.MagicMock())
+
+        mock_supervisor_comms.send_request.assert_called_once_with(
+            msg=TaskState(
+                state=TerminalTIState.FAILED,
+                end_date=instant,
+            ),
+            log=mock.ANY,
+        )
+
+
 def test_startup_basic_templated_dag(mocked_parse, make_ti_context):
     """Test running a DAG with templated task."""
     from airflow.providers.standard.operators.bash import BashOperator

--- a/task_sdk/tests/execution_time/test_task_runner.py
+++ b/task_sdk/tests/execution_time/test_task_runner.py
@@ -295,7 +295,7 @@ def test_run_raises_base_exception(time_machine, mocked_parse, make_ti_context):
         )
 
 
-def test_run_raises_system_exit(time_machine, mocked_parse, make_ti_context):
+def test_run_raises_system_exit(time_machine, mocked_parse, make_ti_context, mock_supervisor_comms):
     """Test running a basic task that exits with SystemExit exception."""
     from airflow.providers.standard.operators.python import PythonOperator
 
@@ -322,18 +322,15 @@ def test_run_raises_system_exit(time_machine, mocked_parse, make_ti_context):
     instant = timezone.datetime(2024, 12, 3, 10, 0)
     time_machine.move_to(instant, tick=False)
 
-    with mock.patch(
-        "airflow.sdk.execution_time.task_runner.SUPERVISOR_COMMS", create=True
-    ) as mock_supervisor_comms:
-        run(ti, log=mock.MagicMock())
+    run(ti, log=mock.MagicMock())
 
-        mock_supervisor_comms.send_request.assert_called_once_with(
-            msg=TaskState(
-                state=TerminalTIState.FAILED,
-                end_date=instant,
-            ),
-            log=mock.ANY,
-        )
+    mock_supervisor_comms.send_request.assert_called_once_with(
+        msg=TaskState(
+            state=TerminalTIState.FAILED,
+            end_date=instant,
+        ),
+        log=mock.ANY,
+    )
 
 
 def test_startup_basic_templated_dag(mocked_parse, make_ti_context):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


PR: #45106 provides a machinery to handle "failure" / "retry" states in the execution API server itself.

The aim of this PR is to extend to the "SystemExit" exception if thrown by tasks.


## Testing results

### DAG used (with and without retries):
```
import sys
from time import sleep

from airflow import DAG
from airflow.providers.standard.operators.python import PythonOperator


def print_hello():
    sleep(10)
    print("exiting with code 10")
    exit(10)

with DAG(
    dag_id="exitcode",
    schedule=None,
    catchup=False,
    tags=["demo"],
) as dag:
    hello_task = PythonOperator(
        task_id="exitcode-task",
        retries=2,
        python_callable=print_hello,
    )
```

### Behaviour in legacy (non task sdk):

With retries configured
![image (8)](https://github.com/user-attachments/assets/ca7c1e6f-a1bc-479a-a1dd-3acaba3ead4d)
![image (9)](https://github.com/user-attachments/assets/3646f612-4410-47fe-a690-2ea2613ed5f8)

Without retries configured
<img width="1719" alt="image" src="https://github.com/user-attachments/assets/76657e18-a3ec-47ef-b32f-eca351f8b7a3" />
<img width="1719" alt="image" src="https://github.com/user-attachments/assets/e66d4cb9-dbf0-468f-98cd-584128bd72ab" />


### Behaviour in task sdk:

With retries configured
![image (10)](https://github.com/user-attachments/assets/15f98a5a-1d11-40fd-981f-e2f8876acc18)
![image (11)](https://github.com/user-attachments/assets/e58ef04e-ab53-4769-9507-47cffaf4efb7)

Without retries configured
<img width="1719" alt="image" src="https://github.com/user-attachments/assets/b94be24e-75c4-4cbc-8aab-f020a4dc0a45" />
<img width="1719" alt="image" src="https://github.com/user-attachments/assets/00797a5a-5954-418b-b6b4-dcc5f9f61ff0" />





<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
