### PR TITLE
fix deserializing callbacks to proper types

### DIFF
--- a/airflow/callbacks/callback_requests.py
+++ b/airflow/callbacks/callback_requests.py
@@ -16,9 +16,9 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated, Literal, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from airflow.api_fastapi.execution_api.datamodels import taskinstance as ti_datamodel  # noqa: TC001
 from airflow.utils.state import TaskInstanceState
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from airflow.typing_compat import Self
 
 
-class CallbackRequest(BaseModel):
+class BaseCallbackRequest(BaseModel):
     """
     Base Class with information about the callback to be executed.
 
@@ -47,7 +47,7 @@ class CallbackRequest(BaseModel):
         return self.model_dump_json(**kwargs)
 
 
-class TaskCallbackRequest(CallbackRequest):
+class TaskCallbackRequest(BaseCallbackRequest):
     """
     Task callback status information.
 
@@ -59,6 +59,7 @@ class TaskCallbackRequest(CallbackRequest):
     """Simplified Task Instance representation"""
     task_callback_type: TaskInstanceState | None = None
     """Whether on success, on failure, on retry"""
+    type: Literal["TaskCallbackRequest"] = "TaskCallbackRequest"
 
     @property
     def is_failure_callback(self) -> bool:
@@ -72,10 +73,17 @@ class TaskCallbackRequest(CallbackRequest):
         }
 
 
-class DagCallbackRequest(CallbackRequest):
+class DagCallbackRequest(BaseCallbackRequest):
     """A Class with information about the success/failure DAG callback to be executed."""
 
     dag_id: str
     run_id: str
     is_failure_callback: bool | None = True
     """Flag to determine whether it is a Failure Callback or Success Callback"""
+    type: Literal["DagCallbackRequest"] = "DagCallbackRequest"
+
+
+CallbackRequest = Annotated[
+    Union[DagCallbackRequest, TaskCallbackRequest],
+    Field(discriminator="type"),
+]

--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -45,7 +45,7 @@ from tabulate import tabulate
 from uuid6 import uuid7
 
 import airflow.models
-from airflow.callbacks.callback_requests import CallbackRequest
+from airflow.callbacks.callback_requests import CallbackRequest, DagCallbackRequest, TaskCallbackRequest
 from airflow.configuration import conf
 from airflow.dag_processing.collection import update_dag_parsing_results_in_db
 from airflow.dag_processing.processor import DagFileParsingResult, DagFileProcessorProcess
@@ -561,7 +561,7 @@ class DagFileProcessorManager:
             sys.exit(os.EX_OK)
 
         self.log.debug("Received %s signal from DagFileProcessorAgent", agent_signal)
-        if isinstance(agent_signal, CallbackRequest):
+        if isinstance(agent_signal, (TaskCallbackRequest, DagCallbackRequest)):
             self._add_callback_to_queue(agent_signal)
         elif agent_signal is None:
             self.terminate()

--- a/airflow/dag_processing/processor.py
+++ b/airflow/dag_processing/processor.py
@@ -111,7 +111,7 @@ def _execute_callbacks(
     dagbag: DagBag, callback_requests: list[CallbackRequest], log: FilteringBoundLogger
 ) -> None:
     for request in callback_requests:
-        log.debug("Processing Callback Request", request=request)
+        log.debug("Processing Callback Request", request=request.to_json())
         if isinstance(request, TaskCallbackRequest):
             raise NotImplementedError(
                 "Haven't coded Task callback yet - https://github.com/apache/airflow/issues/44354!"
@@ -137,7 +137,6 @@ def _execute_dag_callbacks(dagbag: DagBag, request: DagCallbackRequest, log: Fil
         log.info(
             "Executing on_%s dag callback",
             "failure" if request.is_failure_callback else "success",
-            fn=callback,
             dag_id=request.dag_id,
         )
         try:

--- a/tests/callbacks/test_callback_requests.py
+++ b/tests/callbacks/test_callback_requests.py
@@ -21,7 +21,6 @@ from datetime import datetime
 import pytest
 
 from airflow.callbacks.callback_requests import (
-    CallbackRequest,
     DagCallbackRequest,
     TaskCallbackRequest,
 )
@@ -38,7 +37,6 @@ class TestCallbackRequest:
     @pytest.mark.parametrize(
         "input,request_class",
         [
-            (CallbackRequest(full_filepath="filepath", msg="task_failure"), CallbackRequest),
             (
                 None,  # to be generated when test is run
                 TaskCallbackRequest,

--- a/tests/dag_processing/test_manager.py
+++ b/tests/dag_processing/test_manager.py
@@ -41,7 +41,7 @@ import time_machine
 from sqlalchemy import func
 from uuid6 import uuid7
 
-from airflow.callbacks.callback_requests import CallbackRequest, DagCallbackRequest
+from airflow.callbacks.callback_requests import DagCallbackRequest
 from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
 from airflow.dag_processing.manager import (
     DagFileProcessorAgent,
@@ -526,6 +526,42 @@ class TestDagFileProcessorManager:
             manager._kill_timed_out_processors()
         mock_kill.assert_not_called()
 
+    @pytest.mark.parametrize(
+        ["callbacks", "path", "child_comms_fd", "expected_buffer"],
+        [
+            pytest.param(
+                [],
+                "/opt/airflow/dags/test_dag.py",
+                123,
+                b'{"file":"/opt/airflow/dags/test_dag.py","requests_fd":123,"callback_requests":[],'
+                b'"type":"DagFileParseRequest"}\n',
+            ),
+            pytest.param(
+                [
+                    DagCallbackRequest(
+                        full_filepath="/opt/airflow/dags/dag_callback_dag.py",
+                        dag_id="dag_id",
+                        run_id="run_id",
+                        is_failure_callback=False,
+                    )
+                ],
+                "/opt/airflow/dags/dag_callback_dag.py",
+                123,
+                b'{"file":"/opt/airflow/dags/dag_callback_dag.py","requests_fd":123,"callback_requests":'
+                b'[{"full_filepath":"/opt/airflow/dags/dag_callback_dag.py","msg":null,"dag_id":"dag_id",'
+                b'"run_id":"run_id","is_failure_callback":false,"type":"DagCallbackRequest"}],'
+                b'"type":"DagFileParseRequest"}\n',
+            ),
+        ],
+    )
+    def test_serialize_callback_requests(self, callbacks, path, child_comms_fd, expected_buffer):
+        processor = self.mock_processor()
+        processor._on_child_started(callbacks, path, child_comms_fd)
+
+        # Verify the response was added to the buffer
+        val = processor.stdin.getvalue()
+        assert val == expected_buffer
+
     @conf_vars({("core", "load_examples"): "False"})
     @pytest.mark.execution_timeout(10)
     def test_dag_with_system_exit(self):
@@ -573,8 +609,10 @@ class TestDagFileProcessorManager:
                 if exit_event.is_set():
                     break
 
-                req = CallbackRequest(full_filepath=dag_filepath.as_posix())
-                logger.info("Sending CallbackRequests %d", n)
+                req = DagCallbackRequest(
+                    full_filepath=dag_filepath.as_posix(), dag_id="test_dag", run_id="run_id"
+                )
+                logger.info("Sending DagCallbackRequests %d", n)
                 try:
                     pipe.send(req)
                 except TypeError:
@@ -583,7 +621,7 @@ class TestDagFileProcessorManager:
                     break
                 except OSError:
                     break
-                logger.debug("   Sent %d CallbackRequests", n)
+                logger.debug("   Sent %d DagCallbackRequests", n)
 
         thread = threading.Thread(target=keep_pipe_full, args=(parent_pipe, exit_event))
 


### PR DESCRIPTION
Without this fix, the callback requests are deserialized as a base class `CallbackRequest` and are not executed - they are silently failing through this check.

```
def _execute_callbacks(
    dagbag: DagBag, callback_requests: list[CallbackRequest], log: FilteringBoundLogger
) -> None:
    for request in callback_requests:
        log.debug("Processing Callback Request", request=request.to_json())
        if isinstance(request, TaskCallbackRequest):
            raise NotImplementedError(
                "Haven't coded Task callback yet - https://github.com/apache/airflow/issues/44354!"
            )
            # _execute_task_callbacks(dagbag, request)
        elif isinstance(request, DagCallbackRequest):
            _execute_dag_callbacks(dagbag, request, log)
```