### PR TITLE
AIP-72: Handling AirflowException in task sdk

### DIFF
--- a/task_sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task_sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -425,9 +425,17 @@ def run(ti: RuntimeTaskInstance, log: Logger):
         )
 
         # TODO: Run task failure callbacks here
-    except (AirflowTaskTimeout, AirflowException):
+    except AirflowTaskTimeout:
         # TODO: handle the case of up_for_retry here
+        # TODO: coagulate this exception handling with AirflowException
+        # once https://github.com/apache/airflow/issues/45307 is handled
         ...
+    except AirflowException:
+        # TODO: handle the case of up_for_retry here
+        msg = TaskState(
+            state=TerminalTIState.FAILED,
+            end_date=datetime.now(tz=timezone.utc),
+        )
     except AirflowTaskTerminated:
         # External state updates are already handled with `ti_heartbeat` and will be
         # updated already be another UI API. So, these exceptions should ideally never be thrown.

--- a/task_sdk/tests/execution_time/test_task_runner.py
+++ b/task_sdk/tests/execution_time/test_task_runner.py
@@ -27,6 +27,7 @@ import pytest
 from uuid6 import uuid7
 
 from airflow.exceptions import (
+    AirflowException,
     AirflowFailException,
     AirflowSensorTimeout,
     AirflowSkipException,
@@ -315,6 +316,46 @@ def test_run_raises_system_exit(time_machine, mocked_parse, make_ti_context, moc
     )
 
     ti = mocked_parse(what, "basic_dag_system_exit", task)
+
+    instant = timezone.datetime(2024, 12, 3, 10, 0)
+    time_machine.move_to(instant, tick=False)
+
+    run(ti, log=mock.MagicMock())
+
+    mock_supervisor_comms.send_request.assert_called_once_with(
+        msg=TaskState(
+            state=TerminalTIState.FAILED,
+            end_date=instant,
+        ),
+        log=mock.ANY,
+    )
+
+
+def test_run_raises_airflow_exception(time_machine, mocked_parse, make_ti_context, mock_supervisor_comms):
+    """Test running a basic task that exits with AirflowException."""
+    from airflow.providers.standard.operators.python import PythonOperator
+
+    task = PythonOperator(
+        task_id="af_exception_task",
+        python_callable=lambda: (_ for _ in ()).throw(
+            AirflowException("Oops! I am failing with AirflowException!"),
+        ),
+    )
+
+    what = StartupDetails(
+        ti=TaskInstance(
+            id=uuid7(),
+            task_id="af_exception_task",
+            dag_id="basic_dag_af_exception",
+            run_id="c",
+            try_number=1,
+        ),
+        file="",
+        requests_fd=0,
+        ti_context=make_ti_context(),
+    )
+
+    ti = mocked_parse(what, "basic_dag_af_exception", task)
 
     instant = timezone.datetime(2024, 12, 3, 10, 0)
     time_machine.move_to(instant, tick=False)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


PR: https://github.com/apache/airflow/pull/45106 provides a machinery to handle "failure" / "retry" states in the execution API server itself.

This PR handles the AirflowException if thrown by tasks.

### Testing results
DAG:
```
from airflow import DAG
from airflow.exceptions import AirflowException
from airflow.providers.standard.operators.python import PythonOperator


def print_hello():
    raise AirflowException("hi i am AirflowException!")

with DAG(
    dag_id="afexception",
    schedule=None,
    catchup=False,
) as dag:
    hello_task = PythonOperator(
        task_id="afexception_task",
        retries=2,
        python_callable=print_hello,
    )

```

#### Legacy

1. With retries
![image (12)](https://github.com/user-attachments/assets/88251c7a-ef2d-444b-9592-e88f538983d2)

2. Without retries
![image (13)](https://github.com/user-attachments/assets/b77b93b8-7443-4e7a-b3a8-6b65fdb67690)



#### Task SDK
1. With retries
<img width="1725" alt="image" src="https://github.com/user-attachments/assets/d4c2fed8-340a-4609-b806-7640539ebee3" />

2. Without retries
<img width="1725" alt="image" src="https://github.com/user-attachments/assets/303c8e39-e1b2-4a54-85b7-df72d43ac0ca" />



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
