### PR TITLE
Change UI source formatting to 110 chars

### DIFF
--- a/airflow/ui/.prettierrc
+++ b/airflow/ui/.prettierrc
@@ -5,7 +5,7 @@
   "importOrderSeparation": true,
   "jsxSingleQuote": false,
   "plugins": ["@trivago/prettier-plugin-sort-imports"],
-  "printWidth": 80,
+  "printWidth": 110,
   "singleQuote": false,
   "tabWidth": 2,
   "trailingComma": "all",

--- a/airflow/ui/dev/index.html
+++ b/airflow/ui/dev/index.html
@@ -3,11 +3,7 @@
 <html lang="en" style="height: 100%">
   <head>
     <meta charset="UTF-8" />
-    <link
-      rel="icon"
-      type="image/png"
-      href="http://localhost:5173/public/pin_32.png"
-    />
+    <link rel="icon" type="image/png" href="http://localhost:5173/public/pin_32.png" />
     <script type="module" src="http://localhost:5173/@vite/client"></script>
     <script type="module">
       import RefreshRuntime from "http://localhost:5173/@react-refresh";

--- a/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow/ui/openapi-gen/queries/common.ts
@@ -32,9 +32,7 @@ import {
 } from "../requests/services.gen";
 import { DagRunState, DagWarningType } from "../requests/types.gen";
 
-export type AssetServiceNextRunAssetsDefaultResponse = Awaited<
-  ReturnType<typeof AssetService.nextRunAssets>
->;
+export type AssetServiceNextRunAssetsDefaultResponse = Awaited<ReturnType<typeof AssetService.nextRunAssets>>;
 export type AssetServiceNextRunAssetsQueryResult<
   TData = AssetServiceNextRunAssetsDefaultResponse,
   TError = unknown,
@@ -48,9 +46,7 @@ export const UseAssetServiceNextRunAssetsKeyFn = (
   },
   queryKey?: Array<unknown>,
 ) => [useAssetServiceNextRunAssetsKey, ...(queryKey ?? [{ dagId }])];
-export type AssetServiceGetAssetsDefaultResponse = Awaited<
-  ReturnType<typeof AssetService.getAssets>
->;
+export type AssetServiceGetAssetsDefaultResponse = Awaited<ReturnType<typeof AssetService.getAssets>>;
 export type AssetServiceGetAssetsQueryResult<
   TData = AssetServiceGetAssetsDefaultResponse,
   TError = unknown,
@@ -75,9 +71,7 @@ export const UseAssetServiceGetAssetsKeyFn = (
   queryKey?: Array<unknown>,
 ) => [
   useAssetServiceGetAssetsKey,
-  ...(queryKey ?? [
-    { dagIds, limit, namePattern, offset, orderBy, uriPattern },
-  ]),
+  ...(queryKey ?? [{ dagIds, limit, namePattern, offset, orderBy, uriPattern }]),
 ];
 export type AssetServiceGetAssetAliasesDefaultResponse = Awaited<
   ReturnType<typeof AssetService.getAssetAliases>
@@ -100,13 +94,8 @@ export const UseAssetServiceGetAssetAliasesKeyFn = (
     orderBy?: string;
   } = {},
   queryKey?: Array<unknown>,
-) => [
-  useAssetServiceGetAssetAliasesKey,
-  ...(queryKey ?? [{ limit, namePattern, offset, orderBy }]),
-];
-export type AssetServiceGetAssetAliasDefaultResponse = Awaited<
-  ReturnType<typeof AssetService.getAssetAlias>
->;
+) => [useAssetServiceGetAssetAliasesKey, ...(queryKey ?? [{ limit, namePattern, offset, orderBy }])];
+export type AssetServiceGetAssetAliasDefaultResponse = Awaited<ReturnType<typeof AssetService.getAssetAlias>>;
 export type AssetServiceGetAssetAliasQueryResult<
   TData = AssetServiceGetAssetAliasDefaultResponse,
   TError = unknown,
@@ -177,8 +166,7 @@ export type AssetServiceGetAssetQueuedEventsQueryResult<
   TData = AssetServiceGetAssetQueuedEventsDefaultResponse,
   TError = unknown,
 > = UseQueryResult<TData, TError>;
-export const useAssetServiceGetAssetQueuedEventsKey =
-  "AssetServiceGetAssetQueuedEvents";
+export const useAssetServiceGetAssetQueuedEventsKey = "AssetServiceGetAssetQueuedEvents";
 export const UseAssetServiceGetAssetQueuedEventsKeyFn = (
   {
     assetId,
@@ -188,13 +176,8 @@ export const UseAssetServiceGetAssetQueuedEventsKeyFn = (
     before?: string;
   },
   queryKey?: Array<unknown>,
-) => [
-  useAssetServiceGetAssetQueuedEventsKey,
-  ...(queryKey ?? [{ assetId, before }]),
-];
-export type AssetServiceGetAssetDefaultResponse = Awaited<
-  ReturnType<typeof AssetService.getAsset>
->;
+) => [useAssetServiceGetAssetQueuedEventsKey, ...(queryKey ?? [{ assetId, before }])];
+export type AssetServiceGetAssetDefaultResponse = Awaited<ReturnType<typeof AssetService.getAsset>>;
 export type AssetServiceGetAssetQueryResult<
   TData = AssetServiceGetAssetDefaultResponse,
   TError = unknown,
@@ -215,8 +198,7 @@ export type AssetServiceGetDagAssetQueuedEventsQueryResult<
   TData = AssetServiceGetDagAssetQueuedEventsDefaultResponse,
   TError = unknown,
 > = UseQueryResult<TData, TError>;
-export const useAssetServiceGetDagAssetQueuedEventsKey =
-  "AssetServiceGetDagAssetQueuedEvents";
+export const useAssetServiceGetDagAssetQueuedEventsKey = "AssetServiceGetDagAssetQueuedEvents";
 export const UseAssetServiceGetDagAssetQueuedEventsKeyFn = (
   {
     before,
@@ -226,10 +208,7 @@ export const UseAssetServiceGetDagAssetQueuedEventsKeyFn = (
     dagId: string;
   },
   queryKey?: Array<unknown>,
-) => [
-  useAssetServiceGetDagAssetQueuedEventsKey,
-  ...(queryKey ?? [{ before, dagId }]),
-];
+) => [useAssetServiceGetDagAssetQueuedEventsKey, ...(queryKey ?? [{ before, dagId }])];
 export type AssetServiceGetDagAssetQueuedEventDefaultResponse = Awaited<
   ReturnType<typeof AssetService.getDagAssetQueuedEvent>
 >;
@@ -237,8 +216,7 @@ export type AssetServiceGetDagAssetQueuedEventQueryResult<
   TData = AssetServiceGetDagAssetQueuedEventDefaultResponse,
   TError = unknown,
 > = UseQueryResult<TData, TError>;
-export const useAssetServiceGetDagAssetQueuedEventKey =
-  "AssetServiceGetDagAssetQueuedEvent";
+export const useAssetServiceGetDagAssetQueuedEventKey = "AssetServiceGetDagAssetQueuedEvent";
 export const UseAssetServiceGetDagAssetQueuedEventKeyFn = (
   {
     assetId,
@@ -250,13 +228,8 @@ export const UseAssetServiceGetDagAssetQueuedEventKeyFn = (
     dagId: string;
   },
   queryKey?: Array<unknown>,
-) => [
-  useAssetServiceGetDagAssetQueuedEventKey,
-  ...(queryKey ?? [{ assetId, before, dagId }]),
-];
-export type ConfigServiceGetConfigsDefaultResponse = Awaited<
-  ReturnType<typeof ConfigService.getConfigs>
->;
+) => [useAssetServiceGetDagAssetQueuedEventKey, ...(queryKey ?? [{ assetId, before, dagId }])];
+export type ConfigServiceGetConfigsDefaultResponse = Awaited<ReturnType<typeof ConfigService.getConfigs>>;
 export type ConfigServiceGetConfigsQueryResult<
   TData = ConfigServiceGetConfigsDefaultResponse,
   TError = unknown,
@@ -266,9 +239,7 @@ export const UseConfigServiceGetConfigsKeyFn = (queryKey?: Array<unknown>) => [
   useConfigServiceGetConfigsKey,
   ...(queryKey ?? []),
 ];
-export type ConfigServiceGetConfigDefaultResponse = Awaited<
-  ReturnType<typeof ConfigService.getConfig>
->;
+export type ConfigServiceGetConfigDefaultResponse = Awaited<ReturnType<typeof ConfigService.getConfig>>;
 export type ConfigServiceGetConfigQueryResult<
   TData = ConfigServiceGetConfigDefaultResponse,
   TError = unknown,
@@ -303,13 +274,8 @@ export const UseConfigServiceGetConfigValueKeyFn = (
     section: string;
   },
   queryKey?: Array<unknown>,
-) => [
-  useConfigServiceGetConfigValueKey,
-  ...(queryKey ?? [{ accept, option, section }]),
-];
-export type DagsServiceRecentDagRunsDefaultResponse = Awaited<
-  ReturnType<typeof DagsService.recentDagRuns>
->;
+) => [useConfigServiceGetConfigValueKey, ...(queryKey ?? [{ accept, option, section }])];
+export type DagsServiceRecentDagRunsDefaultResponse = Awaited<ReturnType<typeof DagsService.recentDagRuns>>;
 export type DagsServiceRecentDagRunsQueryResult<
   TData = DagsServiceRecentDagRunsDefaultResponse,
   TError = unknown,
@@ -367,8 +333,7 @@ export type DashboardServiceHistoricalMetricsQueryResult<
   TData = DashboardServiceHistoricalMetricsDefaultResponse,
   TError = unknown,
 > = UseQueryResult<TData, TError>;
-export const useDashboardServiceHistoricalMetricsKey =
-  "DashboardServiceHistoricalMetrics";
+export const useDashboardServiceHistoricalMetricsKey = "DashboardServiceHistoricalMetrics";
 export const UseDashboardServiceHistoricalMetricsKeyFn = (
   {
     endDate,
@@ -378,10 +343,7 @@ export const UseDashboardServiceHistoricalMetricsKeyFn = (
     startDate: string;
   },
   queryKey?: Array<unknown>,
-) => [
-  useDashboardServiceHistoricalMetricsKey,
-  ...(queryKey ?? [{ endDate, startDate }]),
-];
+) => [useDashboardServiceHistoricalMetricsKey, ...(queryKey ?? [{ endDate, startDate }])];
 export type StructureServiceStructureDataDefaultResponse = Awaited<
   ReturnType<typeof StructureService.structureData>
 >;
@@ -389,8 +351,7 @@ export type StructureServiceStructureDataQueryResult<
   TData = StructureServiceStructureDataDefaultResponse,
   TError = unknown,
 > = UseQueryResult<TData, TError>;
-export const useStructureServiceStructureDataKey =
-  "StructureServiceStructureData";
+export const useStructureServiceStructureDataKey = "StructureServiceStructureData";
 export const UseStructureServiceStructureDataKeyFn = (
   {
     dagId,
@@ -408,9 +369,7 @@ export const UseStructureServiceStructureDataKeyFn = (
   queryKey?: Array<unknown>,
 ) => [
   useStructureServiceStructureDataKey,
-  ...(queryKey ?? [
-    { dagId, externalDependencies, includeDownstream, includeUpstream, root },
-  ]),
+  ...(queryKey ?? [{ dagId, externalDependencies, includeDownstream, includeUpstream, root }]),
 ];
 export type BackfillServiceListBackfillsDefaultResponse = Awaited<
   ReturnType<typeof BackfillService.listBackfills>
@@ -419,8 +378,7 @@ export type BackfillServiceListBackfillsQueryResult<
   TData = BackfillServiceListBackfillsDefaultResponse,
   TError = unknown,
 > = UseQueryResult<TData, TError>;
-export const useBackfillServiceListBackfillsKey =
-  "BackfillServiceListBackfills";
+export const useBackfillServiceListBackfillsKey = "BackfillServiceListBackfills";
 export const UseBackfillServiceListBackfillsKeyFn = (
   {
     active,
@@ -436,10 +394,7 @@ export const UseBackfillServiceListBackfillsKeyFn = (
     orderBy?: string;
   } = {},
   queryKey?: Array<unknown>,
-) => [
-  useBackfillServiceListBackfillsKey,
-  ...(queryKey ?? [{ active, dagId, limit, offset, orderBy }]),
-];
+) => [useBackfillServiceListBackfillsKey, ...(queryKey ?? [{ active, dagId, limit, offset, orderBy }])];
 export type BackfillServiceListBackfills1DefaultResponse = Awaited<
   ReturnType<typeof BackfillService.listBackfills1>
 >;
@@ -447,8 +402,7 @@ export type BackfillServiceListBackfills1QueryResult<
   TData = BackfillServiceListBackfills1DefaultResponse,
   TError = unknown,
 > = UseQueryResult<TData, TError>;
-export const useBackfillServiceListBackfills1Key =
-  "BackfillServiceListBackfills1";
+export const useBackfillServiceListBackfills1Key = "BackfillServiceListBackfills1";
 export const UseBackfillServiceListBackfills1KeyFn = (
   {
     dagId,
@@ -462,10 +416,7 @@ export const UseBackfillServiceListBackfills1KeyFn = (
     orderBy?: string;
   },
   queryKey?: Array<unknown>,
-) => [
-  useBackfillServiceListBackfills1Key,
-  ...(queryKey ?? [{ dagId, limit, offset, orderBy }]),
-];
+) => [useBackfillServiceListBackfills1Key, ...(queryKey ?? [{ dagId, limit, offset, orderBy }])];
 export type BackfillServiceGetBackfillDefaultResponse = Awaited<
   ReturnType<typeof BackfillService.getBackfill>
 >;
@@ -482,9 +433,7 @@ export const UseBackfillServiceGetBackfillKeyFn = (
   },
   queryKey?: Array<unknown>,
 ) => [useBackfillServiceGetBackfillKey, ...(queryKey ?? [{ backfillId }])];
-export type GridServiceGridDataDefaultResponse = Awaited<
-  ReturnType<typeof GridService.gridData>
->;
+export type GridServiceGridDataDefaultResponse = Awaited<ReturnType<typeof GridService.gridData>>;
 export type GridServiceGridDataQueryResult<
   TData = GridServiceGridDataDefaultResponse,
   TError = unknown,
@@ -542,8 +491,7 @@ export type ConnectionServiceGetConnectionQueryResult<
   TData = ConnectionServiceGetConnectionDefaultResponse,
   TError = unknown,
 > = UseQueryResult<TData, TError>;
-export const useConnectionServiceGetConnectionKey =
-  "ConnectionServiceGetConnection";
+export const useConnectionServiceGetConnectionKey = "ConnectionServiceGetConnection";
 export const UseConnectionServiceGetConnectionKeyFn = (
   {
     connectionId,
@@ -551,10 +499,7 @@ export const UseConnectionServiceGetConnectionKeyFn = (
     connectionId: string;
   },
   queryKey?: Array<unknown>,
-) => [
-  useConnectionServiceGetConnectionKey,
-  ...(queryKey ?? [{ connectionId }]),
-];
+) => [useConnectionServiceGetConnectionKey, ...(queryKey ?? [{ connectionId }])];
 export type ConnectionServiceGetConnectionsDefaultResponse = Awaited<
   ReturnType<typeof ConnectionService.getConnections>
 >;
@@ -562,8 +507,7 @@ export type ConnectionServiceGetConnectionsQueryResult<
   TData = ConnectionServiceGetConnectionsDefaultResponse,
   TError = unknown,
 > = UseQueryResult<TData, TError>;
-export const useConnectionServiceGetConnectionsKey =
-  "ConnectionServiceGetConnections";
+export const useConnectionServiceGetConnectionsKey = "ConnectionServiceGetConnections";
 export const UseConnectionServiceGetConnectionsKeyFn = (
   {
     limit,
@@ -575,13 +519,8 @@ export const UseConnectionServiceGetConnectionsKeyFn = (
     orderBy?: string;
   } = {},
   queryKey?: Array<unknown>,
-) => [
-  useConnectionServiceGetConnectionsKey,
-  ...(queryKey ?? [{ limit, offset, orderBy }]),
-];
-export type DagRunServiceGetDagRunDefaultResponse = Awaited<
-  ReturnType<typeof DagRunService.getDagRun>
->;
+) => [useConnectionServiceGetConnectionsKey, ...(queryKey ?? [{ limit, offset, orderBy }])];
+export type DagRunServiceGetDagRunDefaultResponse = Awaited<ReturnType<typeof DagRunService.getDagRun>>;
 export type DagRunServiceGetDagRunQueryResult<
   TData = DagRunServiceGetDagRunDefaultResponse,
   TError = unknown,
@@ -604,8 +543,7 @@ export type DagRunServiceGetUpstreamAssetEventsQueryResult<
   TData = DagRunServiceGetUpstreamAssetEventsDefaultResponse,
   TError = unknown,
 > = UseQueryResult<TData, TError>;
-export const useDagRunServiceGetUpstreamAssetEventsKey =
-  "DagRunServiceGetUpstreamAssetEvents";
+export const useDagRunServiceGetUpstreamAssetEventsKey = "DagRunServiceGetUpstreamAssetEvents";
 export const UseDagRunServiceGetUpstreamAssetEventsKeyFn = (
   {
     dagId,
@@ -615,13 +553,8 @@ export const UseDagRunServiceGetUpstreamAssetEventsKeyFn = (
     dagRunId: string;
   },
   queryKey?: Array<unknown>,
-) => [
-  useDagRunServiceGetUpstreamAssetEventsKey,
-  ...(queryKey ?? [{ dagId, dagRunId }]),
-];
-export type DagRunServiceGetDagRunsDefaultResponse = Awaited<
-  ReturnType<typeof DagRunService.getDagRuns>
->;
+) => [useDagRunServiceGetUpstreamAssetEventsKey, ...(queryKey ?? [{ dagId, dagRunId }])];
+export type DagRunServiceGetDagRunsDefaultResponse = Awaited<ReturnType<typeof DagRunService.getDagRuns>>;
 export type DagRunServiceGetDagRunsQueryResult<
   TData = DagRunServiceGetDagRunsDefaultResponse,
   TError = unknown,
@@ -685,8 +618,7 @@ export type DagSourceServiceGetDagSourceQueryResult<
   TData = DagSourceServiceGetDagSourceDefaultResponse,
   TError = unknown,
 > = UseQueryResult<TData, TError>;
-export const useDagSourceServiceGetDagSourceKey =
-  "DagSourceServiceGetDagSource";
+export const useDagSourceServiceGetDagSourceKey = "DagSourceServiceGetDagSource";
 export const UseDagSourceServiceGetDagSourceKeyFn = (
   {
     accept,
@@ -698,10 +630,7 @@ export const UseDagSourceServiceGetDagSourceKeyFn = (
     versionNumber?: number;
   },
   queryKey?: Array<unknown>,
-) => [
-  useDagSourceServiceGetDagSourceKey,
-  ...(queryKey ?? [{ accept, dagId, versionNumber }]),
-];
+) => [useDagSourceServiceGetDagSourceKey, ...(queryKey ?? [{ accept, dagId, versionNumber }])];
 export type DagStatsServiceGetDagStatsDefaultResponse = Awaited<
   ReturnType<typeof DagStatsService.getDagStats>
 >;
@@ -725,8 +654,7 @@ export type DagWarningServiceListDagWarningsQueryResult<
   TData = DagWarningServiceListDagWarningsDefaultResponse,
   TError = unknown,
 > = UseQueryResult<TData, TError>;
-export const useDagWarningServiceListDagWarningsKey =
-  "DagWarningServiceListDagWarnings";
+export const useDagWarningServiceListDagWarningsKey = "DagWarningServiceListDagWarnings";
 export const UseDagWarningServiceListDagWarningsKeyFn = (
   {
     dagId,
@@ -746,9 +674,7 @@ export const UseDagWarningServiceListDagWarningsKeyFn = (
   useDagWarningServiceListDagWarningsKey,
   ...(queryKey ?? [{ dagId, limit, offset, orderBy, warningType }]),
 ];
-export type DagServiceGetDagsDefaultResponse = Awaited<
-  ReturnType<typeof DagService.getDags>
->;
+export type DagServiceGetDagsDefaultResponse = Awaited<ReturnType<typeof DagService.getDags>>;
 export type DagServiceGetDagsQueryResult<
   TData = DagServiceGetDagsDefaultResponse,
   TError = unknown,
@@ -796,9 +722,7 @@ export const UseDagServiceGetDagsKeyFn = (
     },
   ]),
 ];
-export type DagServiceGetDagDefaultResponse = Awaited<
-  ReturnType<typeof DagService.getDag>
->;
+export type DagServiceGetDagDefaultResponse = Awaited<ReturnType<typeof DagService.getDag>>;
 export type DagServiceGetDagQueryResult<
   TData = DagServiceGetDagDefaultResponse,
   TError = unknown,
@@ -812,9 +736,7 @@ export const UseDagServiceGetDagKeyFn = (
   },
   queryKey?: Array<unknown>,
 ) => [useDagServiceGetDagKey, ...(queryKey ?? [{ dagId }])];
-export type DagServiceGetDagDetailsDefaultResponse = Awaited<
-  ReturnType<typeof DagService.getDagDetails>
->;
+export type DagServiceGetDagDetailsDefaultResponse = Awaited<ReturnType<typeof DagService.getDagDetails>>;
 export type DagServiceGetDagDetailsQueryResult<
   TData = DagServiceGetDagDetailsDefaultResponse,
   TError = unknown,
@@ -828,9 +750,7 @@ export const UseDagServiceGetDagDetailsKeyFn = (
   },
   queryKey?: Array<unknown>,
 ) => [useDagServiceGetDagDetailsKey, ...(queryKey ?? [{ dagId }])];
-export type DagServiceGetDagTagsDefaultResponse = Awaited<
-  ReturnType<typeof DagService.getDagTags>
->;
+export type DagServiceGetDagTagsDefaultResponse = Awaited<ReturnType<typeof DagService.getDagTags>>;
 export type DagServiceGetDagTagsQueryResult<
   TData = DagServiceGetDagTagsDefaultResponse,
   TError = unknown,
@@ -849,10 +769,7 @@ export const UseDagServiceGetDagTagsKeyFn = (
     tagNamePattern?: string;
   } = {},
   queryKey?: Array<unknown>,
-) => [
-  useDagServiceGetDagTagsKey,
-  ...(queryKey ?? [{ limit, offset, orderBy, tagNamePattern }]),
-];
+) => [useDagServiceGetDagTagsKey, ...(queryKey ?? [{ limit, offset, orderBy, tagNamePattern }])];
 export type EventLogServiceGetEventLogDefaultResponse = Awaited<
   ReturnType<typeof EventLogService.getEventLog>
 >;
@@ -938,8 +855,7 @@ export type ExtraLinksServiceGetExtraLinksQueryResult<
   TData = ExtraLinksServiceGetExtraLinksDefaultResponse,
   TError = unknown,
 > = UseQueryResult<TData, TError>;
-export const useExtraLinksServiceGetExtraLinksKey =
-  "ExtraLinksServiceGetExtraLinks";
+export const useExtraLinksServiceGetExtraLinksKey = "ExtraLinksServiceGetExtraLinks";
 export const UseExtraLinksServiceGetExtraLinksKeyFn = (
   {
     dagId,
@@ -951,10 +867,7 @@ export const UseExtraLinksServiceGetExtraLinksKeyFn = (
     taskId: string;
   },
   queryKey?: Array<unknown>,
-) => [
-  useExtraLinksServiceGetExtraLinksKey,
-  ...(queryKey ?? [{ dagId, dagRunId, taskId }]),
-];
+) => [useExtraLinksServiceGetExtraLinksKey, ...(queryKey ?? [{ dagId, dagRunId, taskId }])];
 export type TaskInstanceServiceGetExtraLinksDefaultResponse = Awaited<
   ReturnType<typeof TaskInstanceService.getExtraLinks>
 >;
@@ -962,8 +875,7 @@ export type TaskInstanceServiceGetExtraLinksQueryResult<
   TData = TaskInstanceServiceGetExtraLinksDefaultResponse,
   TError = unknown,
 > = UseQueryResult<TData, TError>;
-export const useTaskInstanceServiceGetExtraLinksKey =
-  "TaskInstanceServiceGetExtraLinks";
+export const useTaskInstanceServiceGetExtraLinksKey = "TaskInstanceServiceGetExtraLinks";
 export const UseTaskInstanceServiceGetExtraLinksKeyFn = (
   {
     dagId,
@@ -975,10 +887,7 @@ export const UseTaskInstanceServiceGetExtraLinksKeyFn = (
     taskId: string;
   },
   queryKey?: Array<unknown>,
-) => [
-  useTaskInstanceServiceGetExtraLinksKey,
-  ...(queryKey ?? [{ dagId, dagRunId, taskId }]),
-];
+) => [useTaskInstanceServiceGetExtraLinksKey, ...(queryKey ?? [{ dagId, dagRunId, taskId }])];
 export type TaskInstanceServiceGetTaskInstanceDefaultResponse = Awaited<
   ReturnType<typeof TaskInstanceService.getTaskInstance>
 >;
@@ -986,8 +895,7 @@ export type TaskInstanceServiceGetTaskInstanceQueryResult<
   TData = TaskInstanceServiceGetTaskInstanceDefaultResponse,
   TError = unknown,
 > = UseQueryResult<TData, TError>;
-export const useTaskInstanceServiceGetTaskInstanceKey =
-  "TaskInstanceServiceGetTaskInstance";
+export const useTaskInstanceServiceGetTaskInstanceKey = "TaskInstanceServiceGetTaskInstance";
 export const UseTaskInstanceServiceGetTaskInstanceKeyFn = (
   {
     dagId,
@@ -999,10 +907,7 @@ export const UseTaskInstanceServiceGetTaskInstanceKeyFn = (
     taskId: string;
   },
   queryKey?: Array<unknown>,
-) => [
-  useTaskInstanceServiceGetTaskInstanceKey,
-  ...(queryKey ?? [{ dagId, dagRunId, taskId }]),
-];
+) => [useTaskInstanceServiceGetTaskInstanceKey, ...(queryKey ?? [{ dagId, dagRunId, taskId }])];
 export type TaskInstanceServiceGetMappedTaskInstancesDefaultResponse = Awaited<
   ReturnType<typeof TaskInstanceService.getMappedTaskInstances>
 >;
@@ -1010,8 +915,7 @@ export type TaskInstanceServiceGetMappedTaskInstancesQueryResult<
   TData = TaskInstanceServiceGetMappedTaskInstancesDefaultResponse,
   TError = unknown,
 > = UseQueryResult<TData, TError>;
-export const useTaskInstanceServiceGetMappedTaskInstancesKey =
-  "TaskInstanceServiceGetMappedTaskInstances";
+export const useTaskInstanceServiceGetMappedTaskInstancesKey = "TaskInstanceServiceGetMappedTaskInstances";
 export const UseTaskInstanceServiceGetMappedTaskInstancesKeyFn = (
   {
     dagId,
@@ -1084,8 +988,9 @@ export const UseTaskInstanceServiceGetMappedTaskInstancesKeyFn = (
     },
   ]),
 ];
-export type TaskInstanceServiceGetTaskInstanceDependenciesDefaultResponse =
-  Awaited<ReturnType<typeof TaskInstanceService.getTaskInstanceDependencies>>;
+export type TaskInstanceServiceGetTaskInstanceDependenciesDefaultResponse = Awaited<
+  ReturnType<typeof TaskInstanceService.getTaskInstanceDependencies>
+>;
 export type TaskInstanceServiceGetTaskInstanceDependenciesQueryResult<
   TData = TaskInstanceServiceGetTaskInstanceDependenciesDefaultResponse,
   TError = unknown,
@@ -1109,8 +1014,9 @@ export const UseTaskInstanceServiceGetTaskInstanceDependenciesKeyFn = (
   useTaskInstanceServiceGetTaskInstanceDependenciesKey,
   ...(queryKey ?? [{ dagId, dagRunId, mapIndex, taskId }]),
 ];
-export type TaskInstanceServiceGetTaskInstanceDependencies1DefaultResponse =
-  Awaited<ReturnType<typeof TaskInstanceService.getTaskInstanceDependencies1>>;
+export type TaskInstanceServiceGetTaskInstanceDependencies1DefaultResponse = Awaited<
+  ReturnType<typeof TaskInstanceService.getTaskInstanceDependencies1>
+>;
 export type TaskInstanceServiceGetTaskInstanceDependencies1QueryResult<
   TData = TaskInstanceServiceGetTaskInstanceDependencies1DefaultResponse,
   TError = unknown,
@@ -1141,8 +1047,7 @@ export type TaskInstanceServiceGetTaskInstanceTriesQueryResult<
   TData = TaskInstanceServiceGetTaskInstanceTriesDefaultResponse,
   TError = unknown,
 > = UseQueryResult<TData, TError>;
-export const useTaskInstanceServiceGetTaskInstanceTriesKey =
-  "TaskInstanceServiceGetTaskInstanceTries";
+export const useTaskInstanceServiceGetTaskInstanceTriesKey = "TaskInstanceServiceGetTaskInstanceTries";
 export const UseTaskInstanceServiceGetTaskInstanceTriesKeyFn = (
   {
     dagId,
@@ -1160,8 +1065,9 @@ export const UseTaskInstanceServiceGetTaskInstanceTriesKeyFn = (
   useTaskInstanceServiceGetTaskInstanceTriesKey,
   ...(queryKey ?? [{ dagId, dagRunId, mapIndex, taskId }]),
 ];
-export type TaskInstanceServiceGetMappedTaskInstanceTriesDefaultResponse =
-  Awaited<ReturnType<typeof TaskInstanceService.getMappedTaskInstanceTries>>;
+export type TaskInstanceServiceGetMappedTaskInstanceTriesDefaultResponse = Awaited<
+  ReturnType<typeof TaskInstanceService.getMappedTaskInstanceTries>
+>;
 export type TaskInstanceServiceGetMappedTaskInstanceTriesQueryResult<
   TData = TaskInstanceServiceGetMappedTaskInstanceTriesDefaultResponse,
   TError = unknown,
@@ -1192,8 +1098,7 @@ export type TaskInstanceServiceGetMappedTaskInstanceQueryResult<
   TData = TaskInstanceServiceGetMappedTaskInstanceDefaultResponse,
   TError = unknown,
 > = UseQueryResult<TData, TError>;
-export const useTaskInstanceServiceGetMappedTaskInstanceKey =
-  "TaskInstanceServiceGetMappedTaskInstance";
+export const useTaskInstanceServiceGetMappedTaskInstanceKey = "TaskInstanceServiceGetMappedTaskInstance";
 export const UseTaskInstanceServiceGetMappedTaskInstanceKeyFn = (
   {
     dagId,
@@ -1218,8 +1123,7 @@ export type TaskInstanceServiceGetTaskInstancesQueryResult<
   TData = TaskInstanceServiceGetTaskInstancesDefaultResponse,
   TError = unknown,
 > = UseQueryResult<TData, TError>;
-export const useTaskInstanceServiceGetTaskInstancesKey =
-  "TaskInstanceServiceGetTaskInstances";
+export const useTaskInstanceServiceGetTaskInstancesKey = "TaskInstanceServiceGetTaskInstances";
 export const UseTaskInstanceServiceGetTaskInstancesKeyFn = (
   {
     dagId,
@@ -1295,8 +1199,9 @@ export const UseTaskInstanceServiceGetTaskInstancesKeyFn = (
     },
   ]),
 ];
-export type TaskInstanceServiceGetTaskInstanceTryDetailsDefaultResponse =
-  Awaited<ReturnType<typeof TaskInstanceService.getTaskInstanceTryDetails>>;
+export type TaskInstanceServiceGetTaskInstanceTryDetailsDefaultResponse = Awaited<
+  ReturnType<typeof TaskInstanceService.getTaskInstanceTryDetails>
+>;
 export type TaskInstanceServiceGetTaskInstanceTryDetailsQueryResult<
   TData = TaskInstanceServiceGetTaskInstanceTryDetailsDefaultResponse,
   TError = unknown,
@@ -1322,10 +1227,9 @@ export const UseTaskInstanceServiceGetTaskInstanceTryDetailsKeyFn = (
   useTaskInstanceServiceGetTaskInstanceTryDetailsKey,
   ...(queryKey ?? [{ dagId, dagRunId, mapIndex, taskId, taskTryNumber }]),
 ];
-export type TaskInstanceServiceGetMappedTaskInstanceTryDetailsDefaultResponse =
-  Awaited<
-    ReturnType<typeof TaskInstanceService.getMappedTaskInstanceTryDetails>
-  >;
+export type TaskInstanceServiceGetMappedTaskInstanceTryDetailsDefaultResponse = Awaited<
+  ReturnType<typeof TaskInstanceService.getMappedTaskInstanceTryDetails>
+>;
 export type TaskInstanceServiceGetMappedTaskInstanceTryDetailsQueryResult<
   TData = TaskInstanceServiceGetMappedTaskInstanceTryDetailsDefaultResponse,
   TError = unknown,
@@ -1351,9 +1255,7 @@ export const UseTaskInstanceServiceGetMappedTaskInstanceTryDetailsKeyFn = (
   useTaskInstanceServiceGetMappedTaskInstanceTryDetailsKey,
   ...(queryKey ?? [{ dagId, dagRunId, mapIndex, taskId, taskTryNumber }]),
 ];
-export type TaskInstanceServiceGetLogDefaultResponse = Awaited<
-  ReturnType<typeof TaskInstanceService.getLog>
->;
+export type TaskInstanceServiceGetLogDefaultResponse = Awaited<ReturnType<typeof TaskInstanceService.getLog>>;
 export type TaskInstanceServiceGetLogQueryResult<
   TData = TaskInstanceServiceGetLogDefaultResponse,
   TError = unknown,
@@ -1382,18 +1284,7 @@ export const UseTaskInstanceServiceGetLogKeyFn = (
   queryKey?: Array<unknown>,
 ) => [
   useTaskInstanceServiceGetLogKey,
-  ...(queryKey ?? [
-    {
-      accept,
-      dagId,
-      dagRunId,
-      fullContent,
-      mapIndex,
-      taskId,
-      token,
-      tryNumber,
-    },
-  ]),
+  ...(queryKey ?? [{ accept, dagId, dagRunId, fullContent, mapIndex, taskId, token, tryNumber }]),
 ];
 export type ImportErrorServiceGetImportErrorDefaultResponse = Awaited<
   ReturnType<typeof ImportErrorService.getImportError>
@@ -1402,8 +1293,7 @@ export type ImportErrorServiceGetImportErrorQueryResult<
   TData = ImportErrorServiceGetImportErrorDefaultResponse,
   TError = unknown,
 > = UseQueryResult<TData, TError>;
-export const useImportErrorServiceGetImportErrorKey =
-  "ImportErrorServiceGetImportError";
+export const useImportErrorServiceGetImportErrorKey = "ImportErrorServiceGetImportError";
 export const UseImportErrorServiceGetImportErrorKeyFn = (
   {
     importErrorId,
@@ -1411,10 +1301,7 @@ export const UseImportErrorServiceGetImportErrorKeyFn = (
     importErrorId: number;
   },
   queryKey?: Array<unknown>,
-) => [
-  useImportErrorServiceGetImportErrorKey,
-  ...(queryKey ?? [{ importErrorId }]),
-];
+) => [useImportErrorServiceGetImportErrorKey, ...(queryKey ?? [{ importErrorId }])];
 export type ImportErrorServiceGetImportErrorsDefaultResponse = Awaited<
   ReturnType<typeof ImportErrorService.getImportErrors>
 >;
@@ -1422,8 +1309,7 @@ export type ImportErrorServiceGetImportErrorsQueryResult<
   TData = ImportErrorServiceGetImportErrorsDefaultResponse,
   TError = unknown,
 > = UseQueryResult<TData, TError>;
-export const useImportErrorServiceGetImportErrorsKey =
-  "ImportErrorServiceGetImportErrors";
+export const useImportErrorServiceGetImportErrorsKey = "ImportErrorServiceGetImportErrors";
 export const UseImportErrorServiceGetImportErrorsKeyFn = (
   {
     limit,
@@ -1435,13 +1321,8 @@ export const UseImportErrorServiceGetImportErrorsKeyFn = (
     orderBy?: string;
   } = {},
   queryKey?: Array<unknown>,
-) => [
-  useImportErrorServiceGetImportErrorsKey,
-  ...(queryKey ?? [{ limit, offset, orderBy }]),
-];
-export type JobServiceGetJobsDefaultResponse = Awaited<
-  ReturnType<typeof JobService.getJobs>
->;
+) => [useImportErrorServiceGetImportErrorsKey, ...(queryKey ?? [{ limit, offset, orderBy }])];
+export type JobServiceGetJobsDefaultResponse = Awaited<ReturnType<typeof JobService.getJobs>>;
 export type JobServiceGetJobsQueryResult<
   TData = JobServiceGetJobsDefaultResponse,
   TError = unknown,
@@ -1495,9 +1376,7 @@ export const UseJobServiceGetJobsKeyFn = (
     },
   ]),
 ];
-export type PluginServiceGetPluginsDefaultResponse = Awaited<
-  ReturnType<typeof PluginService.getPlugins>
->;
+export type PluginServiceGetPluginsDefaultResponse = Awaited<ReturnType<typeof PluginService.getPlugins>>;
 export type PluginServiceGetPluginsQueryResult<
   TData = PluginServiceGetPluginsDefaultResponse,
   TError = unknown,
@@ -1513,9 +1392,7 @@ export const UsePluginServiceGetPluginsKeyFn = (
   } = {},
   queryKey?: Array<unknown>,
 ) => [usePluginServiceGetPluginsKey, ...(queryKey ?? [{ limit, offset }])];
-export type PoolServiceGetPoolDefaultResponse = Awaited<
-  ReturnType<typeof PoolService.getPool>
->;
+export type PoolServiceGetPoolDefaultResponse = Awaited<ReturnType<typeof PoolService.getPool>>;
 export type PoolServiceGetPoolQueryResult<
   TData = PoolServiceGetPoolDefaultResponse,
   TError = unknown,
@@ -1529,9 +1406,7 @@ export const UsePoolServiceGetPoolKeyFn = (
   },
   queryKey?: Array<unknown>,
 ) => [usePoolServiceGetPoolKey, ...(queryKey ?? [{ poolName }])];
-export type PoolServiceGetPoolsDefaultResponse = Awaited<
-  ReturnType<typeof PoolService.getPools>
->;
+export type PoolServiceGetPoolsDefaultResponse = Awaited<ReturnType<typeof PoolService.getPools>>;
 export type PoolServiceGetPoolsQueryResult<
   TData = PoolServiceGetPoolsDefaultResponse,
   TError = unknown,
@@ -1567,9 +1442,7 @@ export const UseProviderServiceGetProvidersKeyFn = (
   } = {},
   queryKey?: Array<unknown>,
 ) => [useProviderServiceGetProvidersKey, ...(queryKey ?? [{ limit, offset }])];
-export type XcomServiceGetXcomEntryDefaultResponse = Awaited<
-  ReturnType<typeof XcomService.getXcomEntry>
->;
+export type XcomServiceGetXcomEntryDefaultResponse = Awaited<ReturnType<typeof XcomService.getXcomEntry>>;
 export type XcomServiceGetXcomEntryQueryResult<
   TData = XcomServiceGetXcomEntryDefaultResponse,
   TError = unknown,
@@ -1596,13 +1469,9 @@ export const UseXcomServiceGetXcomEntryKeyFn = (
   queryKey?: Array<unknown>,
 ) => [
   useXcomServiceGetXcomEntryKey,
-  ...(queryKey ?? [
-    { dagId, dagRunId, deserialize, mapIndex, stringify, taskId, xcomKey },
-  ]),
+  ...(queryKey ?? [{ dagId, dagRunId, deserialize, mapIndex, stringify, taskId, xcomKey }]),
 ];
-export type XcomServiceGetXcomEntriesDefaultResponse = Awaited<
-  ReturnType<typeof XcomService.getXcomEntries>
->;
+export type XcomServiceGetXcomEntriesDefaultResponse = Awaited<ReturnType<typeof XcomService.getXcomEntries>>;
 export type XcomServiceGetXcomEntriesQueryResult<
   TData = XcomServiceGetXcomEntriesDefaultResponse,
   TError = unknown,
@@ -1629,13 +1498,9 @@ export const UseXcomServiceGetXcomEntriesKeyFn = (
   queryKey?: Array<unknown>,
 ) => [
   useXcomServiceGetXcomEntriesKey,
-  ...(queryKey ?? [
-    { dagId, dagRunId, limit, mapIndex, offset, taskId, xcomKey },
-  ]),
+  ...(queryKey ?? [{ dagId, dagRunId, limit, mapIndex, offset, taskId, xcomKey }]),
 ];
-export type TaskServiceGetTasksDefaultResponse = Awaited<
-  ReturnType<typeof TaskService.getTasks>
->;
+export type TaskServiceGetTasksDefaultResponse = Awaited<ReturnType<typeof TaskService.getTasks>>;
 export type TaskServiceGetTasksQueryResult<
   TData = TaskServiceGetTasksDefaultResponse,
   TError = unknown,
@@ -1651,9 +1516,7 @@ export const UseTaskServiceGetTasksKeyFn = (
   },
   queryKey?: Array<unknown>,
 ) => [useTaskServiceGetTasksKey, ...(queryKey ?? [{ dagId, orderBy }])];
-export type TaskServiceGetTaskDefaultResponse = Awaited<
-  ReturnType<typeof TaskService.getTask>
->;
+export type TaskServiceGetTaskDefaultResponse = Awaited<ReturnType<typeof TaskService.getTask>>;
 export type TaskServiceGetTaskQueryResult<
   TData = TaskServiceGetTaskDefaultResponse,
   TError = unknown,
@@ -1706,13 +1569,8 @@ export const UseVariableServiceGetVariablesKeyFn = (
     variableKeyPattern?: string;
   } = {},
   queryKey?: Array<unknown>,
-) => [
-  useVariableServiceGetVariablesKey,
-  ...(queryKey ?? [{ limit, offset, orderBy, variableKeyPattern }]),
-];
-export type MonitorServiceGetHealthDefaultResponse = Awaited<
-  ReturnType<typeof MonitorService.getHealth>
->;
+) => [useVariableServiceGetVariablesKey, ...(queryKey ?? [{ limit, offset, orderBy, variableKeyPattern }])];
+export type MonitorServiceGetHealthDefaultResponse = Awaited<ReturnType<typeof MonitorService.getHealth>>;
 export type MonitorServiceGetHealthQueryResult<
   TData = MonitorServiceGetHealthDefaultResponse,
   TError = unknown,
@@ -1722,9 +1580,7 @@ export const UseMonitorServiceGetHealthKeyFn = (queryKey?: Array<unknown>) => [
   useMonitorServiceGetHealthKey,
   ...(queryKey ?? []),
 ];
-export type VersionServiceGetVersionDefaultResponse = Awaited<
-  ReturnType<typeof VersionService.getVersion>
->;
+export type VersionServiceGetVersionDefaultResponse = Awaited<ReturnType<typeof VersionService.getVersion>>;
 export type VersionServiceGetVersionQueryResult<
   TData = VersionServiceGetVersionDefaultResponse,
   TError = unknown,
@@ -1749,9 +1605,7 @@ export type ConnectionServicePostConnectionsMutationResult = Awaited<
 export type ConnectionServiceTestConnectionMutationResult = Awaited<
   ReturnType<typeof ConnectionService.testConnection>
 >;
-export type DagRunServiceClearDagRunMutationResult = Awaited<
-  ReturnType<typeof DagRunService.clearDagRun>
->;
+export type DagRunServiceClearDagRunMutationResult = Awaited<ReturnType<typeof DagRunService.clearDagRun>>;
 export type DagRunServiceTriggerDagRunMutationResult = Awaited<
   ReturnType<typeof DagRunService.triggerDagRun>
 >;
@@ -1764,12 +1618,8 @@ export type TaskInstanceServiceGetTaskInstancesBatchMutationResult = Awaited<
 export type TaskInstanceServicePostClearTaskInstancesMutationResult = Awaited<
   ReturnType<typeof TaskInstanceService.postClearTaskInstances>
 >;
-export type PoolServicePostPoolMutationResult = Awaited<
-  ReturnType<typeof PoolService.postPool>
->;
-export type PoolServicePostPoolsMutationResult = Awaited<
-  ReturnType<typeof PoolService.postPools>
->;
+export type PoolServicePostPoolMutationResult = Awaited<ReturnType<typeof PoolService.postPool>>;
+export type PoolServicePostPoolsMutationResult = Awaited<ReturnType<typeof PoolService.postPools>>;
 export type VariableServicePostVariableMutationResult = Awaited<
   ReturnType<typeof VariableService.postVariable>
 >;
@@ -1791,24 +1641,16 @@ export type DagParsingServiceReparseDagFileMutationResult = Awaited<
 export type ConnectionServicePatchConnectionMutationResult = Awaited<
   ReturnType<typeof ConnectionService.patchConnection>
 >;
-export type DagRunServicePatchDagRunMutationResult = Awaited<
-  ReturnType<typeof DagRunService.patchDagRun>
->;
-export type DagServicePatchDagsMutationResult = Awaited<
-  ReturnType<typeof DagService.patchDags>
->;
-export type DagServicePatchDagMutationResult = Awaited<
-  ReturnType<typeof DagService.patchDag>
->;
+export type DagRunServicePatchDagRunMutationResult = Awaited<ReturnType<typeof DagRunService.patchDagRun>>;
+export type DagServicePatchDagsMutationResult = Awaited<ReturnType<typeof DagService.patchDags>>;
+export type DagServicePatchDagMutationResult = Awaited<ReturnType<typeof DagService.patchDag>>;
 export type TaskInstanceServicePatchTaskInstanceMutationResult = Awaited<
   ReturnType<typeof TaskInstanceService.patchTaskInstance>
 >;
 export type TaskInstanceServicePatchTaskInstance1MutationResult = Awaited<
   ReturnType<typeof TaskInstanceService.patchTaskInstance1>
 >;
-export type PoolServicePatchPoolMutationResult = Awaited<
-  ReturnType<typeof PoolService.patchPool>
->;
+export type PoolServicePatchPoolMutationResult = Awaited<ReturnType<typeof PoolService.patchPool>>;
 export type VariableServicePatchVariableMutationResult = Awaited<
   ReturnType<typeof VariableService.patchVariable>
 >;
@@ -1824,15 +1666,9 @@ export type AssetServiceDeleteDagAssetQueuedEventMutationResult = Awaited<
 export type ConnectionServiceDeleteConnectionMutationResult = Awaited<
   ReturnType<typeof ConnectionService.deleteConnection>
 >;
-export type DagRunServiceDeleteDagRunMutationResult = Awaited<
-  ReturnType<typeof DagRunService.deleteDagRun>
->;
-export type DagServiceDeleteDagMutationResult = Awaited<
-  ReturnType<typeof DagService.deleteDag>
->;
-export type PoolServiceDeletePoolMutationResult = Awaited<
-  ReturnType<typeof PoolService.deletePool>
->;
+export type DagRunServiceDeleteDagRunMutationResult = Awaited<ReturnType<typeof DagRunService.deleteDagRun>>;
+export type DagServiceDeleteDagMutationResult = Awaited<ReturnType<typeof DagService.deleteDag>>;
+export type PoolServiceDeletePoolMutationResult = Awaited<ReturnType<typeof PoolService.deletePool>>;
 export type VariableServiceDeleteVariableMutationResult = Awaited<
   ReturnType<typeof VariableService.deleteVariable>
 >;

--- a/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -91,15 +91,7 @@ export const prefetchUseAssetServiceGetAssets = (
       orderBy,
       uriPattern,
     }),
-    queryFn: () =>
-      AssetService.getAssets({
-        dagIds,
-        limit,
-        namePattern,
-        offset,
-        orderBy,
-        uriPattern,
-      }),
+    queryFn: () => AssetService.getAssets({ dagIds, limit, namePattern, offset, orderBy, uriPattern }),
   });
 /**
  * Get Asset Aliases
@@ -127,14 +119,8 @@ export const prefetchUseAssetServiceGetAssetAliases = (
   } = {},
 ) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseAssetServiceGetAssetAliasesKeyFn({
-      limit,
-      namePattern,
-      offset,
-      orderBy,
-    }),
-    queryFn: () =>
-      AssetService.getAssetAliases({ limit, namePattern, offset, orderBy }),
+    queryKey: Common.UseAssetServiceGetAssetAliasesKeyFn({ limit, namePattern, offset, orderBy }),
+    queryFn: () => AssetService.getAssetAliases({ limit, namePattern, offset, orderBy }),
   });
 /**
  * Get Asset Alias
@@ -246,10 +232,7 @@ export const prefetchUseAssetServiceGetAssetQueuedEvents = (
   },
 ) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseAssetServiceGetAssetQueuedEventsKeyFn({
-      assetId,
-      before,
-    }),
+    queryKey: Common.UseAssetServiceGetAssetQueuedEventsKeyFn({ assetId, before }),
     queryFn: () => AssetService.getAssetQueuedEvents({ assetId, before }),
   });
 /**
@@ -292,10 +275,7 @@ export const prefetchUseAssetServiceGetDagAssetQueuedEvents = (
   },
 ) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseAssetServiceGetDagAssetQueuedEventsKeyFn({
-      before,
-      dagId,
-    }),
+    queryKey: Common.UseAssetServiceGetDagAssetQueuedEventsKeyFn({ before, dagId }),
     queryFn: () => AssetService.getDagAssetQueuedEvents({ before, dagId }),
   });
 /**
@@ -321,13 +301,8 @@ export const prefetchUseAssetServiceGetDagAssetQueuedEvent = (
   },
 ) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseAssetServiceGetDagAssetQueuedEventKeyFn({
-      assetId,
-      before,
-      dagId,
-    }),
-    queryFn: () =>
-      AssetService.getDagAssetQueuedEvent({ assetId, before, dagId }),
+    queryKey: Common.UseAssetServiceGetDagAssetQueuedEventKeyFn({ assetId, before, dagId }),
+    queryFn: () => AssetService.getDagAssetQueuedEvent({ assetId, before, dagId }),
   });
 /**
  * Get Configs
@@ -384,11 +359,7 @@ export const prefetchUseConfigServiceGetConfigValue = (
   },
 ) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseConfigServiceGetConfigValueKeyFn({
-      accept,
-      option,
-      section,
-    }),
+    queryKey: Common.UseConfigServiceGetConfigValueKeyFn({ accept, option, section }),
     queryFn: () => ConfigService.getConfigValue({ accept, option, section }),
   });
 /**
@@ -486,10 +457,7 @@ export const prefetchUseDashboardServiceHistoricalMetrics = (
   },
 ) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseDashboardServiceHistoricalMetricsKeyFn({
-      endDate,
-      startDate,
-    }),
+    queryKey: Common.UseDashboardServiceHistoricalMetricsKeyFn({ endDate, startDate }),
     queryFn: () => DashboardService.historicalMetrics({ endDate, startDate }),
   });
 /**
@@ -565,15 +533,8 @@ export const prefetchUseBackfillServiceListBackfills = (
   } = {},
 ) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseBackfillServiceListBackfillsKeyFn({
-      active,
-      dagId,
-      limit,
-      offset,
-      orderBy,
-    }),
-    queryFn: () =>
-      BackfillService.listBackfills({ active, dagId, limit, offset, orderBy }),
+    queryKey: Common.UseBackfillServiceListBackfillsKeyFn({ active, dagId, limit, offset, orderBy }),
+    queryFn: () => BackfillService.listBackfills({ active, dagId, limit, offset, orderBy }),
   });
 /**
  * List Backfills
@@ -600,14 +561,8 @@ export const prefetchUseBackfillServiceListBackfills1 = (
   },
 ) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseBackfillServiceListBackfills1KeyFn({
-      dagId,
-      limit,
-      offset,
-      orderBy,
-    }),
-    queryFn: () =>
-      BackfillService.listBackfills1({ dagId, limit, offset, orderBy }),
+    queryKey: Common.UseBackfillServiceListBackfills1KeyFn({ dagId, limit, offset, orderBy }),
+    queryFn: () => BackfillService.listBackfills1({ dagId, limit, offset, orderBy }),
   });
 /**
  * Get Backfill
@@ -746,11 +701,7 @@ export const prefetchUseConnectionServiceGetConnections = (
   } = {},
 ) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseConnectionServiceGetConnectionsKeyFn({
-      limit,
-      offset,
-      orderBy,
-    }),
+    queryKey: Common.UseConnectionServiceGetConnectionsKeyFn({ limit, offset, orderBy }),
     queryFn: () => ConnectionService.getConnections({ limit, offset, orderBy }),
   });
 /**
@@ -795,10 +746,7 @@ export const prefetchUseDagRunServiceGetUpstreamAssetEvents = (
   },
 ) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseDagRunServiceGetUpstreamAssetEventsKeyFn({
-      dagId,
-      dagRunId,
-    }),
+    queryKey: Common.UseDagRunServiceGetUpstreamAssetEventsKeyFn({ dagId, dagRunId }),
     queryFn: () => DagRunService.getUpstreamAssetEvents({ dagId, dagRunId }),
   });
 /**
@@ -911,13 +859,8 @@ export const prefetchUseDagSourceServiceGetDagSource = (
   },
 ) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseDagSourceServiceGetDagSourceKeyFn({
-      accept,
-      dagId,
-      versionNumber,
-    }),
-    queryFn: () =>
-      DagSourceService.getDagSource({ accept, dagId, versionNumber }),
+    queryKey: Common.UseDagSourceServiceGetDagSourceKeyFn({ accept, dagId, versionNumber }),
+    queryFn: () => DagSourceService.getDagSource({ accept, dagId, versionNumber }),
   });
 /**
  * Get Dag Stats
@@ -968,21 +911,8 @@ export const prefetchUseDagWarningServiceListDagWarnings = (
   } = {},
 ) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseDagWarningServiceListDagWarningsKeyFn({
-      dagId,
-      limit,
-      offset,
-      orderBy,
-      warningType,
-    }),
-    queryFn: () =>
-      DagWarningService.listDagWarnings({
-        dagId,
-        limit,
-        offset,
-        orderBy,
-        warningType,
-      }),
+    queryKey: Common.UseDagWarningServiceListDagWarningsKeyFn({ dagId, limit, offset, orderBy, warningType }),
+    queryFn: () => DagWarningService.listDagWarnings({ dagId, limit, offset, orderBy, warningType }),
   });
 /**
  * Get Dags
@@ -1120,14 +1050,8 @@ export const prefetchUseDagServiceGetDagTags = (
   } = {},
 ) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseDagServiceGetDagTagsKeyFn({
-      limit,
-      offset,
-      orderBy,
-      tagNamePattern,
-    }),
-    queryFn: () =>
-      DagService.getDagTags({ limit, offset, orderBy, tagNamePattern }),
+    queryKey: Common.UseDagServiceGetDagTagsKeyFn({ limit, offset, orderBy, tagNamePattern }),
+    queryFn: () => DagService.getDagTags({ limit, offset, orderBy, tagNamePattern }),
   });
 /**
  * Get Event Log
@@ -1261,11 +1185,7 @@ export const prefetchUseExtraLinksServiceGetExtraLinks = (
   },
 ) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseExtraLinksServiceGetExtraLinksKeyFn({
-      dagId,
-      dagRunId,
-      taskId,
-    }),
+    queryKey: Common.UseExtraLinksServiceGetExtraLinksKeyFn({ dagId, dagRunId, taskId }),
     queryFn: () => ExtraLinksService.getExtraLinks({ dagId, dagRunId, taskId }),
   });
 /**
@@ -1291,13 +1211,8 @@ export const prefetchUseTaskInstanceServiceGetExtraLinks = (
   },
 ) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseTaskInstanceServiceGetExtraLinksKeyFn({
-      dagId,
-      dagRunId,
-      taskId,
-    }),
-    queryFn: () =>
-      TaskInstanceService.getExtraLinks({ dagId, dagRunId, taskId }),
+    queryKey: Common.UseTaskInstanceServiceGetExtraLinksKeyFn({ dagId, dagRunId, taskId }),
+    queryFn: () => TaskInstanceService.getExtraLinks({ dagId, dagRunId, taskId }),
   });
 /**
  * Get Task Instance
@@ -1322,13 +1237,8 @@ export const prefetchUseTaskInstanceServiceGetTaskInstance = (
   },
 ) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseTaskInstanceServiceGetTaskInstanceKeyFn({
-      dagId,
-      dagRunId,
-      taskId,
-    }),
-    queryFn: () =>
-      TaskInstanceService.getTaskInstance({ dagId, dagRunId, taskId }),
+    queryKey: Common.UseTaskInstanceServiceGetTaskInstanceKeyFn({ dagId, dagRunId, taskId }),
+    queryFn: () => TaskInstanceService.getTaskInstance({ dagId, dagRunId, taskId }),
   });
 /**
  * Get Mapped Task Instances
@@ -1482,13 +1392,7 @@ export const prefetchUseTaskInstanceServiceGetTaskInstanceDependencies = (
       mapIndex,
       taskId,
     }),
-    queryFn: () =>
-      TaskInstanceService.getTaskInstanceDependencies({
-        dagId,
-        dagRunId,
-        mapIndex,
-        taskId,
-      }),
+    queryFn: () => TaskInstanceService.getTaskInstanceDependencies({ dagId, dagRunId, mapIndex, taskId }),
   });
 /**
  * Get Task Instance Dependencies
@@ -1522,13 +1426,7 @@ export const prefetchUseTaskInstanceServiceGetTaskInstanceDependencies1 = (
       mapIndex,
       taskId,
     }),
-    queryFn: () =>
-      TaskInstanceService.getTaskInstanceDependencies1({
-        dagId,
-        dagRunId,
-        mapIndex,
-        taskId,
-      }),
+    queryFn: () => TaskInstanceService.getTaskInstanceDependencies1({ dagId, dagRunId, mapIndex, taskId }),
   });
 /**
  * Get Task Instance Tries
@@ -1556,19 +1454,8 @@ export const prefetchUseTaskInstanceServiceGetTaskInstanceTries = (
   },
 ) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseTaskInstanceServiceGetTaskInstanceTriesKeyFn({
-      dagId,
-      dagRunId,
-      mapIndex,
-      taskId,
-    }),
-    queryFn: () =>
-      TaskInstanceService.getTaskInstanceTries({
-        dagId,
-        dagRunId,
-        mapIndex,
-        taskId,
-      }),
+    queryKey: Common.UseTaskInstanceServiceGetTaskInstanceTriesKeyFn({ dagId, dagRunId, mapIndex, taskId }),
+    queryFn: () => TaskInstanceService.getTaskInstanceTries({ dagId, dagRunId, mapIndex, taskId }),
   });
 /**
  * Get Mapped Task Instance Tries
@@ -1601,13 +1488,7 @@ export const prefetchUseTaskInstanceServiceGetMappedTaskInstanceTries = (
       mapIndex,
       taskId,
     }),
-    queryFn: () =>
-      TaskInstanceService.getMappedTaskInstanceTries({
-        dagId,
-        dagRunId,
-        mapIndex,
-        taskId,
-      }),
+    queryFn: () => TaskInstanceService.getMappedTaskInstanceTries({ dagId, dagRunId, mapIndex, taskId }),
   });
 /**
  * Get Mapped Task Instance
@@ -1635,19 +1516,8 @@ export const prefetchUseTaskInstanceServiceGetMappedTaskInstance = (
   },
 ) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseTaskInstanceServiceGetMappedTaskInstanceKeyFn({
-      dagId,
-      dagRunId,
-      mapIndex,
-      taskId,
-    }),
-    queryFn: () =>
-      TaskInstanceService.getMappedTaskInstance({
-        dagId,
-        dagRunId,
-        mapIndex,
-        taskId,
-      }),
+    queryKey: Common.UseTaskInstanceServiceGetMappedTaskInstanceKeyFn({ dagId, dagRunId, mapIndex, taskId }),
+    queryFn: () => TaskInstanceService.getMappedTaskInstance({ dagId, dagRunId, mapIndex, taskId }),
   });
 /**
  * Get Task Instances
@@ -1814,13 +1684,7 @@ export const prefetchUseTaskInstanceServiceGetTaskInstanceTryDetails = (
       taskTryNumber,
     }),
     queryFn: () =>
-      TaskInstanceService.getTaskInstanceTryDetails({
-        dagId,
-        dagRunId,
-        mapIndex,
-        taskId,
-        taskTryNumber,
-      }),
+      TaskInstanceService.getTaskInstanceTryDetails({ dagId, dagRunId, mapIndex, taskId, taskTryNumber }),
   });
 /**
  * Get Mapped Task Instance Try Details
@@ -1850,9 +1714,13 @@ export const prefetchUseTaskInstanceServiceGetMappedTaskInstanceTryDetails = (
   },
 ) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseTaskInstanceServiceGetMappedTaskInstanceTryDetailsKeyFn(
-      { dagId, dagRunId, mapIndex, taskId, taskTryNumber },
-    ),
+    queryKey: Common.UseTaskInstanceServiceGetMappedTaskInstanceTryDetailsKeyFn({
+      dagId,
+      dagRunId,
+      mapIndex,
+      taskId,
+      taskTryNumber,
+    }),
     queryFn: () =>
       TaskInstanceService.getMappedTaskInstanceTryDetails({
         dagId,
@@ -1939,9 +1807,7 @@ export const prefetchUseImportErrorServiceGetImportError = (
   },
 ) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseImportErrorServiceGetImportErrorKeyFn({
-      importErrorId,
-    }),
+    queryKey: Common.UseImportErrorServiceGetImportErrorKeyFn({ importErrorId }),
     queryFn: () => ImportErrorService.getImportError({ importErrorId }),
   });
 /**
@@ -1967,13 +1833,8 @@ export const prefetchUseImportErrorServiceGetImportErrors = (
   } = {},
 ) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseImportErrorServiceGetImportErrorsKeyFn({
-      limit,
-      offset,
-      orderBy,
-    }),
-    queryFn: () =>
-      ImportErrorService.getImportErrors({ limit, offset, orderBy }),
+    queryKey: Common.UseImportErrorServiceGetImportErrorsKeyFn({ limit, offset, orderBy }),
+    queryFn: () => ImportErrorService.getImportErrors({ limit, offset, orderBy }),
   });
 /**
  * Get Jobs
@@ -2191,15 +2052,7 @@ export const prefetchUseXcomServiceGetXcomEntry = (
       xcomKey,
     }),
     queryFn: () =>
-      XcomService.getXcomEntry({
-        dagId,
-        dagRunId,
-        deserialize,
-        mapIndex,
-        stringify,
-        taskId,
-        xcomKey,
-      }),
+      XcomService.getXcomEntry({ dagId, dagRunId, deserialize, mapIndex, stringify, taskId, xcomKey }),
   });
 /**
  * Get Xcom Entries
@@ -2247,16 +2100,7 @@ export const prefetchUseXcomServiceGetXcomEntries = (
       taskId,
       xcomKey,
     }),
-    queryFn: () =>
-      XcomService.getXcomEntries({
-        dagId,
-        dagRunId,
-        limit,
-        mapIndex,
-        offset,
-        taskId,
-        xcomKey,
-      }),
+    queryFn: () => XcomService.getXcomEntries({ dagId, dagRunId, limit, mapIndex, offset, taskId, xcomKey }),
   });
 /**
  * Get Tasks
@@ -2350,19 +2194,8 @@ export const prefetchUseVariableServiceGetVariables = (
   } = {},
 ) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseVariableServiceGetVariablesKeyFn({
-      limit,
-      offset,
-      orderBy,
-      variableKeyPattern,
-    }),
-    queryFn: () =>
-      VariableService.getVariables({
-        limit,
-        offset,
-        orderBy,
-        variableKeyPattern,
-      }),
+    queryKey: Common.UseVariableServiceGetVariablesKeyFn({ limit, offset, orderBy, variableKeyPattern }),
+    queryFn: () => VariableService.getVariables({ limit, offset, orderBy, variableKeyPattern }),
   });
 /**
  * Get Health

--- a/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow/ui/openapi-gen/queries/queries.ts
@@ -1,10 +1,5 @@
 // generated with @7nohe/openapi-react-query-codegen@1.6.0
-import {
-  UseMutationOptions,
-  UseQueryOptions,
-  useMutation,
-  useQuery,
-} from "@tanstack/react-query";
+import { UseMutationOptions, UseQueryOptions, useMutation, useQuery } from "@tanstack/react-query";
 
 import {
   AssetService,
@@ -125,14 +120,7 @@ export const useAssetServiceGetAssets = <
       queryKey,
     ),
     queryFn: () =>
-      AssetService.getAssets({
-        dagIds,
-        limit,
-        namePattern,
-        offset,
-        orderBy,
-        uriPattern,
-      }) as TData,
+      AssetService.getAssets({ dagIds, limit, namePattern, offset, orderBy, uriPattern }) as TData,
     ...options,
   });
 /**
@@ -166,17 +154,8 @@ export const useAssetServiceGetAssetAliases = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseAssetServiceGetAssetAliasesKeyFn(
-      { limit, namePattern, offset, orderBy },
-      queryKey,
-    ),
-    queryFn: () =>
-      AssetService.getAssetAliases({
-        limit,
-        namePattern,
-        offset,
-        orderBy,
-      }) as TData,
+    queryKey: Common.UseAssetServiceGetAssetAliasesKeyFn({ limit, namePattern, offset, orderBy }, queryKey),
+    queryFn: () => AssetService.getAssetAliases({ limit, namePattern, offset, orderBy }) as TData,
     ...options,
   });
 /**
@@ -201,10 +180,7 @@ export const useAssetServiceGetAssetAlias = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseAssetServiceGetAssetAliasKeyFn(
-      { assetAliasId },
-      queryKey,
-    ),
+    queryKey: Common.UseAssetServiceGetAssetAliasKeyFn({ assetAliasId }, queryKey),
     queryFn: () => AssetService.getAssetAlias({ assetAliasId }) as TData,
     ...options,
   });
@@ -312,12 +288,8 @@ export const useAssetServiceGetAssetQueuedEvents = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseAssetServiceGetAssetQueuedEventsKeyFn(
-      { assetId, before },
-      queryKey,
-    ),
-    queryFn: () =>
-      AssetService.getAssetQueuedEvents({ assetId, before }) as TData,
+    queryKey: Common.UseAssetServiceGetAssetQueuedEventsKeyFn({ assetId, before }, queryKey),
+    queryFn: () => AssetService.getAssetQueuedEvents({ assetId, before }) as TData,
     ...options,
   });
 /**
@@ -371,12 +343,8 @@ export const useAssetServiceGetDagAssetQueuedEvents = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseAssetServiceGetDagAssetQueuedEventsKeyFn(
-      { before, dagId },
-      queryKey,
-    ),
-    queryFn: () =>
-      AssetService.getDagAssetQueuedEvents({ before, dagId }) as TData,
+    queryKey: Common.UseAssetServiceGetDagAssetQueuedEventsKeyFn({ before, dagId }, queryKey),
+    queryFn: () => AssetService.getDagAssetQueuedEvents({ before, dagId }) as TData,
     ...options,
   });
 /**
@@ -407,12 +375,8 @@ export const useAssetServiceGetDagAssetQueuedEvent = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseAssetServiceGetDagAssetQueuedEventKeyFn(
-      { assetId, before, dagId },
-      queryKey,
-    ),
-    queryFn: () =>
-      AssetService.getDagAssetQueuedEvent({ assetId, before, dagId }) as TData,
+    queryKey: Common.UseAssetServiceGetDagAssetQueuedEventKeyFn({ assetId, before, dagId }, queryKey),
+    queryFn: () => AssetService.getDagAssetQueuedEvent({ assetId, before, dagId }) as TData,
     ...options,
   });
 /**
@@ -458,10 +422,7 @@ export const useConfigServiceGetConfig = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseConfigServiceGetConfigKeyFn(
-      { accept, section },
-      queryKey,
-    ),
+    queryKey: Common.UseConfigServiceGetConfigKeyFn({ accept, section }, queryKey),
     queryFn: () => ConfigService.getConfig({ accept, section }) as TData,
     ...options,
   });
@@ -492,12 +453,8 @@ export const useConfigServiceGetConfigValue = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseConfigServiceGetConfigValueKeyFn(
-      { accept, option, section },
-      queryKey,
-    ),
-    queryFn: () =>
-      ConfigService.getConfigValue({ accept, option, section }) as TData,
+    queryKey: Common.UseConfigServiceGetConfigValueKeyFn({ accept, option, section }, queryKey),
+    queryFn: () => ConfigService.getConfigValue({ accept, option, section }) as TData,
     ...options,
   });
 /**
@@ -609,12 +566,8 @@ export const useDashboardServiceHistoricalMetrics = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseDashboardServiceHistoricalMetricsKeyFn(
-      { endDate, startDate },
-      queryKey,
-    ),
-    queryFn: () =>
-      DashboardService.historicalMetrics({ endDate, startDate }) as TData,
+    queryKey: Common.UseDashboardServiceHistoricalMetricsKeyFn({ endDate, startDate }, queryKey),
+    queryFn: () => DashboardService.historicalMetrics({ endDate, startDate }) as TData,
     ...options,
   });
 /**
@@ -702,14 +655,7 @@ export const useBackfillServiceListBackfills = <
       { active, dagId, limit, offset, orderBy },
       queryKey,
     ),
-    queryFn: () =>
-      BackfillService.listBackfills({
-        active,
-        dagId,
-        limit,
-        offset,
-        orderBy,
-      }) as TData,
+    queryFn: () => BackfillService.listBackfills({ active, dagId, limit, offset, orderBy }) as TData,
     ...options,
   });
 /**
@@ -742,17 +688,8 @@ export const useBackfillServiceListBackfills1 = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseBackfillServiceListBackfills1KeyFn(
-      { dagId, limit, offset, orderBy },
-      queryKey,
-    ),
-    queryFn: () =>
-      BackfillService.listBackfills1({
-        dagId,
-        limit,
-        offset,
-        orderBy,
-      }) as TData,
+    queryKey: Common.UseBackfillServiceListBackfills1KeyFn({ dagId, limit, offset, orderBy }, queryKey),
+    queryFn: () => BackfillService.listBackfills1({ dagId, limit, offset, orderBy }) as TData,
     ...options,
   });
 /**
@@ -776,10 +713,7 @@ export const useBackfillServiceGetBackfill = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseBackfillServiceGetBackfillKeyFn(
-      { backfillId },
-      queryKey,
-    ),
+    queryKey: Common.UseBackfillServiceGetBackfillKeyFn({ backfillId }, queryKey),
     queryFn: () => BackfillService.getBackfill({ backfillId }) as TData,
     ...options,
   });
@@ -889,10 +823,7 @@ export const useConnectionServiceGetConnection = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseConnectionServiceGetConnectionKeyFn(
-      { connectionId },
-      queryKey,
-    ),
+    queryKey: Common.UseConnectionServiceGetConnectionKeyFn({ connectionId }, queryKey),
     queryFn: () => ConnectionService.getConnection({ connectionId }) as TData,
     ...options,
   });
@@ -924,12 +855,8 @@ export const useConnectionServiceGetConnections = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseConnectionServiceGetConnectionsKeyFn(
-      { limit, offset, orderBy },
-      queryKey,
-    ),
-    queryFn: () =>
-      ConnectionService.getConnections({ limit, offset, orderBy }) as TData,
+    queryKey: Common.UseConnectionServiceGetConnectionsKeyFn({ limit, offset, orderBy }, queryKey),
+    queryFn: () => ConnectionService.getConnections({ limit, offset, orderBy }) as TData,
     ...options,
   });
 /**
@@ -956,10 +883,7 @@ export const useDagRunServiceGetDagRun = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseDagRunServiceGetDagRunKeyFn(
-      { dagId, dagRunId },
-      queryKey,
-    ),
+    queryKey: Common.UseDagRunServiceGetDagRunKeyFn({ dagId, dagRunId }, queryKey),
     queryFn: () => DagRunService.getDagRun({ dagId, dagRunId }) as TData,
     ...options,
   });
@@ -988,12 +912,8 @@ export const useDagRunServiceGetUpstreamAssetEvents = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseDagRunServiceGetUpstreamAssetEventsKeyFn(
-      { dagId, dagRunId },
-      queryKey,
-    ),
-    queryFn: () =>
-      DagRunService.getUpstreamAssetEvents({ dagId, dagRunId }) as TData,
+    queryKey: Common.UseDagRunServiceGetUpstreamAssetEventsKeyFn({ dagId, dagRunId }, queryKey),
+    queryFn: () => DagRunService.getUpstreamAssetEvents({ dagId, dagRunId }) as TData,
     ...options,
   });
 /**
@@ -1120,12 +1040,8 @@ export const useDagSourceServiceGetDagSource = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseDagSourceServiceGetDagSourceKeyFn(
-      { accept, dagId, versionNumber },
-      queryKey,
-    ),
-    queryFn: () =>
-      DagSourceService.getDagSource({ accept, dagId, versionNumber }) as TData,
+    queryKey: Common.UseDagSourceServiceGetDagSourceKeyFn({ accept, dagId, versionNumber }, queryKey),
+    queryFn: () => DagSourceService.getDagSource({ accept, dagId, versionNumber }) as TData,
     ...options,
   });
 /**
@@ -1192,14 +1108,7 @@ export const useDagWarningServiceListDagWarnings = <
       { dagId, limit, offset, orderBy, warningType },
       queryKey,
     ),
-    queryFn: () =>
-      DagWarningService.listDagWarnings({
-        dagId,
-        limit,
-        offset,
-        orderBy,
-        warningType,
-      }) as TData,
+    queryFn: () => DagWarningService.listDagWarnings({ dagId, limit, offset, orderBy, warningType }) as TData,
     ...options,
   });
 /**
@@ -1364,17 +1273,8 @@ export const useDagServiceGetDagTags = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseDagServiceGetDagTagsKeyFn(
-      { limit, offset, orderBy, tagNamePattern },
-      queryKey,
-    ),
-    queryFn: () =>
-      DagService.getDagTags({
-        limit,
-        offset,
-        orderBy,
-        tagNamePattern,
-      }) as TData,
+    queryKey: Common.UseDagServiceGetDagTagsKeyFn({ limit, offset, orderBy, tagNamePattern }, queryKey),
+    queryFn: () => DagService.getDagTags({ limit, offset, orderBy, tagNamePattern }) as TData,
     ...options,
   });
 /**
@@ -1398,10 +1298,7 @@ export const useEventLogServiceGetEventLog = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseEventLogServiceGetEventLogKeyFn(
-      { eventLogId },
-      queryKey,
-    ),
+    queryKey: Common.UseEventLogServiceGetEventLogKeyFn({ eventLogId }, queryKey),
     queryFn: () => EventLogService.getEventLog({ eventLogId }) as TData,
     ...options,
   });
@@ -1532,12 +1429,8 @@ export const useExtraLinksServiceGetExtraLinks = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseExtraLinksServiceGetExtraLinksKeyFn(
-      { dagId, dagRunId, taskId },
-      queryKey,
-    ),
-    queryFn: () =>
-      ExtraLinksService.getExtraLinks({ dagId, dagRunId, taskId }) as TData,
+    queryKey: Common.UseExtraLinksServiceGetExtraLinksKeyFn({ dagId, dagRunId, taskId }, queryKey),
+    queryFn: () => ExtraLinksService.getExtraLinks({ dagId, dagRunId, taskId }) as TData,
     ...options,
   });
 /**
@@ -1568,12 +1461,8 @@ export const useTaskInstanceServiceGetExtraLinks = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseTaskInstanceServiceGetExtraLinksKeyFn(
-      { dagId, dagRunId, taskId },
-      queryKey,
-    ),
-    queryFn: () =>
-      TaskInstanceService.getExtraLinks({ dagId, dagRunId, taskId }) as TData,
+    queryKey: Common.UseTaskInstanceServiceGetExtraLinksKeyFn({ dagId, dagRunId, taskId }, queryKey),
+    queryFn: () => TaskInstanceService.getExtraLinks({ dagId, dagRunId, taskId }) as TData,
     ...options,
   });
 /**
@@ -1604,12 +1493,8 @@ export const useTaskInstanceServiceGetTaskInstance = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseTaskInstanceServiceGetTaskInstanceKeyFn(
-      { dagId, dagRunId, taskId },
-      queryKey,
-    ),
-    queryFn: () =>
-      TaskInstanceService.getTaskInstance({ dagId, dagRunId, taskId }) as TData,
+    queryKey: Common.UseTaskInstanceServiceGetTaskInstanceKeyFn({ dagId, dagRunId, taskId }, queryKey),
+    queryFn: () => TaskInstanceService.getTaskInstance({ dagId, dagRunId, taskId }) as TData,
     ...options,
   });
 /**
@@ -1777,12 +1662,7 @@ export const useTaskInstanceServiceGetTaskInstanceDependencies = <
       queryKey,
     ),
     queryFn: () =>
-      TaskInstanceService.getTaskInstanceDependencies({
-        dagId,
-        dagRunId,
-        mapIndex,
-        taskId,
-      }) as TData,
+      TaskInstanceService.getTaskInstanceDependencies({ dagId, dagRunId, mapIndex, taskId }) as TData,
     ...options,
   });
 /**
@@ -1821,12 +1701,7 @@ export const useTaskInstanceServiceGetTaskInstanceDependencies1 = <
       queryKey,
     ),
     queryFn: () =>
-      TaskInstanceService.getTaskInstanceDependencies1({
-        dagId,
-        dagRunId,
-        mapIndex,
-        taskId,
-      }) as TData,
+      TaskInstanceService.getTaskInstanceDependencies1({ dagId, dagRunId, mapIndex, taskId }) as TData,
     ...options,
   });
 /**
@@ -1864,13 +1739,7 @@ export const useTaskInstanceServiceGetTaskInstanceTries = <
       { dagId, dagRunId, mapIndex, taskId },
       queryKey,
     ),
-    queryFn: () =>
-      TaskInstanceService.getTaskInstanceTries({
-        dagId,
-        dagRunId,
-        mapIndex,
-        taskId,
-      }) as TData,
+    queryFn: () => TaskInstanceService.getTaskInstanceTries({ dagId, dagRunId, mapIndex, taskId }) as TData,
     ...options,
   });
 /**
@@ -1908,12 +1777,7 @@ export const useTaskInstanceServiceGetMappedTaskInstanceTries = <
       queryKey,
     ),
     queryFn: () =>
-      TaskInstanceService.getMappedTaskInstanceTries({
-        dagId,
-        dagRunId,
-        mapIndex,
-        taskId,
-      }) as TData,
+      TaskInstanceService.getMappedTaskInstanceTries({ dagId, dagRunId, mapIndex, taskId }) as TData,
     ...options,
   });
 /**
@@ -1951,13 +1815,7 @@ export const useTaskInstanceServiceGetMappedTaskInstance = <
       { dagId, dagRunId, mapIndex, taskId },
       queryKey,
     ),
-    queryFn: () =>
-      TaskInstanceService.getMappedTaskInstance({
-        dagId,
-        dagRunId,
-        mapIndex,
-        taskId,
-      }) as TData,
+    queryFn: () => TaskInstanceService.getMappedTaskInstance({ dagId, dagRunId, mapIndex, taskId }) as TData,
     ...options,
   });
 /**
@@ -2236,16 +2094,7 @@ export const useTaskInstanceServiceGetLog = <
 ) =>
   useQuery<TData, TError>({
     queryKey: Common.UseTaskInstanceServiceGetLogKeyFn(
-      {
-        accept,
-        dagId,
-        dagRunId,
-        fullContent,
-        mapIndex,
-        taskId,
-        token,
-        tryNumber,
-      },
+      { accept, dagId, dagRunId, fullContent, mapIndex, taskId, token, tryNumber },
       queryKey,
     ),
     queryFn: () =>
@@ -2283,12 +2132,8 @@ export const useImportErrorServiceGetImportError = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseImportErrorServiceGetImportErrorKeyFn(
-      { importErrorId },
-      queryKey,
-    ),
-    queryFn: () =>
-      ImportErrorService.getImportError({ importErrorId }) as TData,
+    queryKey: Common.UseImportErrorServiceGetImportErrorKeyFn({ importErrorId }, queryKey),
+    queryFn: () => ImportErrorService.getImportError({ importErrorId }) as TData,
     ...options,
   });
 /**
@@ -2319,12 +2164,8 @@ export const useImportErrorServiceGetImportErrors = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseImportErrorServiceGetImportErrorsKeyFn(
-      { limit, offset, orderBy },
-      queryKey,
-    ),
-    queryFn: () =>
-      ImportErrorService.getImportErrors({ limit, offset, orderBy }) as TData,
+    queryKey: Common.UseImportErrorServiceGetImportErrorsKeyFn({ limit, offset, orderBy }, queryKey),
+    queryFn: () => ImportErrorService.getImportErrors({ limit, offset, orderBy }) as TData,
     ...options,
   });
 /**
@@ -2440,10 +2281,7 @@ export const usePluginServiceGetPlugins = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UsePluginServiceGetPluginsKeyFn(
-      { limit, offset },
-      queryKey,
-    ),
+    queryKey: Common.UsePluginServiceGetPluginsKeyFn({ limit, offset }, queryKey),
     queryFn: () => PluginService.getPlugins({ limit, offset }) as TData,
     ...options,
   });
@@ -2501,10 +2339,7 @@ export const usePoolServiceGetPools = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UsePoolServiceGetPoolsKeyFn(
-      { limit, offset, orderBy },
-      queryKey,
-    ),
+    queryKey: Common.UsePoolServiceGetPoolsKeyFn({ limit, offset, orderBy }, queryKey),
     queryFn: () => PoolService.getPools({ limit, offset, orderBy }) as TData,
     ...options,
   });
@@ -2533,10 +2368,7 @@ export const useProviderServiceGetProviders = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseProviderServiceGetProvidersKeyFn(
-      { limit, offset },
-      queryKey,
-    ),
+    queryKey: Common.UseProviderServiceGetProvidersKeyFn({ limit, offset }, queryKey),
     queryFn: () => ProviderService.getProviders({ limit, offset }) as TData,
     ...options,
   });
@@ -2643,15 +2475,7 @@ export const useXcomServiceGetXcomEntries = <
       queryKey,
     ),
     queryFn: () =>
-      XcomService.getXcomEntries({
-        dagId,
-        dagRunId,
-        limit,
-        mapIndex,
-        offset,
-        taskId,
-        xcomKey,
-      }) as TData,
+      XcomService.getXcomEntries({ dagId, dagRunId, limit, mapIndex, offset, taskId, xcomKey }) as TData,
     ...options,
   });
 /**
@@ -2734,10 +2558,7 @@ export const useVariableServiceGetVariable = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseVariableServiceGetVariableKeyFn(
-      { variableKey },
-      queryKey,
-    ),
+    queryKey: Common.UseVariableServiceGetVariableKeyFn({ variableKey }, queryKey),
     queryFn: () => VariableService.getVariable({ variableKey }) as TData,
     ...options,
   });
@@ -2776,13 +2597,7 @@ export const useVariableServiceGetVariables = <
       { limit, offset, orderBy, variableKeyPattern },
       queryKey,
     ),
-    queryFn: () =>
-      VariableService.getVariables({
-        limit,
-        offset,
-        orderBy,
-        variableKeyPattern,
-      }) as TData,
+    queryFn: () => VariableService.getVariables({ limit, offset, orderBy, variableKeyPattern }) as TData,
     ...options,
   });
 /**
@@ -2856,9 +2671,7 @@ export const useAssetServiceCreateAssetEvent = <
     TContext
   >({
     mutationFn: ({ requestBody }) =>
-      AssetService.createAssetEvent({
-        requestBody,
-      }) as unknown as Promise<TData>,
+      AssetService.createAssetEvent({ requestBody }) as unknown as Promise<TData>,
     ...options,
   });
 /**
@@ -2894,9 +2707,7 @@ export const useBackfillServiceCreateBackfill = <
     TContext
   >({
     mutationFn: ({ requestBody }) =>
-      BackfillService.createBackfill({
-        requestBody,
-      }) as unknown as Promise<TData>,
+      BackfillService.createBackfill({ requestBody }) as unknown as Promise<TData>,
     ...options,
   });
 /**
@@ -2933,9 +2744,7 @@ export const useConnectionServicePostConnection = <
     TContext
   >({
     mutationFn: ({ requestBody }) =>
-      ConnectionService.postConnection({
-        requestBody,
-      }) as unknown as Promise<TData>,
+      ConnectionService.postConnection({ requestBody }) as unknown as Promise<TData>,
     ...options,
   });
 /**
@@ -2972,9 +2781,7 @@ export const useConnectionServicePostConnections = <
     TContext
   >({
     mutationFn: ({ requestBody }) =>
-      ConnectionService.postConnections({
-        requestBody,
-      }) as unknown as Promise<TData>,
+      ConnectionService.postConnections({ requestBody }) as unknown as Promise<TData>,
     ...options,
   });
 /**
@@ -3015,9 +2822,7 @@ export const useConnectionServiceTestConnection = <
     TContext
   >({
     mutationFn: ({ requestBody }) =>
-      ConnectionService.testConnection({
-        requestBody,
-      }) as unknown as Promise<TData>,
+      ConnectionService.testConnection({ requestBody }) as unknown as Promise<TData>,
     ...options,
   });
 /**
@@ -3059,11 +2864,7 @@ export const useDagRunServiceClearDagRun = <
     TContext
   >({
     mutationFn: ({ dagId, dagRunId, requestBody }) =>
-      DagRunService.clearDagRun({
-        dagId,
-        dagRunId,
-        requestBody,
-      }) as unknown as Promise<TData>,
+      DagRunService.clearDagRun({ dagId, dagRunId, requestBody }) as unknown as Promise<TData>,
     ...options,
   });
 /**
@@ -3103,10 +2904,7 @@ export const useDagRunServiceTriggerDagRun = <
     TContext
   >({
     mutationFn: ({ dagId, requestBody }) =>
-      DagRunService.triggerDagRun({
-        dagId,
-        requestBody,
-      }) as unknown as Promise<TData>,
+      DagRunService.triggerDagRun({ dagId, requestBody }) as unknown as Promise<TData>,
     ...options,
   });
 /**
@@ -3146,10 +2944,7 @@ export const useDagRunServiceGetListDagRunsBatch = <
     TContext
   >({
     mutationFn: ({ dagId, requestBody }) =>
-      DagRunService.getListDagRunsBatch({
-        dagId,
-        requestBody,
-      }) as unknown as Promise<TData>,
+      DagRunService.getListDagRunsBatch({ dagId, requestBody }) as unknown as Promise<TData>,
     ...options,
   });
 /**
@@ -3236,10 +3031,7 @@ export const useTaskInstanceServicePostClearTaskInstances = <
     TContext
   >({
     mutationFn: ({ dagId, requestBody }) =>
-      TaskInstanceService.postClearTaskInstances({
-        dagId,
-        requestBody,
-      }) as unknown as Promise<TData>,
+      TaskInstanceService.postClearTaskInstances({ dagId, requestBody }) as unknown as Promise<TData>,
     ...options,
   });
 /**
@@ -3275,8 +3067,7 @@ export const usePoolServicePostPool = <
     },
     TContext
   >({
-    mutationFn: ({ requestBody }) =>
-      PoolService.postPool({ requestBody }) as unknown as Promise<TData>,
+    mutationFn: ({ requestBody }) => PoolService.postPool({ requestBody }) as unknown as Promise<TData>,
     ...options,
   });
 /**
@@ -3312,8 +3103,7 @@ export const usePoolServicePostPools = <
     },
     TContext
   >({
-    mutationFn: ({ requestBody }) =>
-      PoolService.postPools({ requestBody }) as unknown as Promise<TData>,
+    mutationFn: ({ requestBody }) => PoolService.postPools({ requestBody }) as unknown as Promise<TData>,
     ...options,
   });
 /**
@@ -3350,9 +3140,7 @@ export const useVariableServicePostVariable = <
     TContext
   >({
     mutationFn: ({ requestBody }) =>
-      VariableService.postVariable({
-        requestBody,
-      }) as unknown as Promise<TData>,
+      VariableService.postVariable({ requestBody }) as unknown as Promise<TData>,
     ...options,
   });
 /**
@@ -3392,10 +3180,7 @@ export const useVariableServiceImportVariables = <
     TContext
   >({
     mutationFn: ({ actionIfExists, formData }) =>
-      VariableService.importVariables({
-        actionIfExists,
-        formData,
-      }) as unknown as Promise<TData>,
+      VariableService.importVariables({ actionIfExists, formData }) as unknown as Promise<TData>,
     ...options,
   });
 /**
@@ -3431,9 +3216,7 @@ export const useBackfillServicePauseBackfill = <
     TContext
   >({
     mutationFn: ({ backfillId }) =>
-      BackfillService.pauseBackfill({
-        backfillId,
-      }) as unknown as Promise<TData>,
+      BackfillService.pauseBackfill({ backfillId }) as unknown as Promise<TData>,
     ...options,
   });
 /**
@@ -3469,9 +3252,7 @@ export const useBackfillServiceUnpauseBackfill = <
     TContext
   >({
     mutationFn: ({ backfillId }) =>
-      BackfillService.unpauseBackfill({
-        backfillId,
-      }) as unknown as Promise<TData>,
+      BackfillService.unpauseBackfill({ backfillId }) as unknown as Promise<TData>,
     ...options,
   });
 /**
@@ -3507,9 +3288,7 @@ export const useBackfillServiceCancelBackfill = <
     TContext
   >({
     mutationFn: ({ backfillId }) =>
-      BackfillService.cancelBackfill({
-        backfillId,
-      }) as unknown as Promise<TData>,
+      BackfillService.cancelBackfill({ backfillId }) as unknown as Promise<TData>,
     ...options,
   });
 /**
@@ -3546,9 +3325,7 @@ export const useDagParsingServiceReparseDagFile = <
     TContext
   >({
     mutationFn: ({ fileToken }) =>
-      DagParsingService.reparseDagFile({
-        fileToken,
-      }) as unknown as Promise<TData>,
+      DagParsingService.reparseDagFile({ fileToken }) as unknown as Promise<TData>,
     ...options,
   });
 /**
@@ -3641,12 +3418,7 @@ export const useDagRunServicePatchDagRun = <
     TContext
   >({
     mutationFn: ({ dagId, dagRunId, requestBody, updateMask }) =>
-      DagRunService.patchDagRun({
-        dagId,
-        dagRunId,
-        requestBody,
-        updateMask,
-      }) as unknown as Promise<TData>,
+      DagRunService.patchDagRun({ dagId, dagRunId, requestBody, updateMask }) as unknown as Promise<TData>,
     ...options,
   });
 /**
@@ -3775,11 +3547,7 @@ export const useDagServicePatchDag = <
     TContext
   >({
     mutationFn: ({ dagId, requestBody, updateMask }) =>
-      DagService.patchDag({
-        dagId,
-        requestBody,
-        updateMask,
-      }) as unknown as Promise<TData>,
+      DagService.patchDag({ dagId, requestBody, updateMask }) as unknown as Promise<TData>,
     ...options,
   });
 /**
@@ -3830,14 +3598,7 @@ export const useTaskInstanceServicePatchTaskInstance = <
     },
     TContext
   >({
-    mutationFn: ({
-      dagId,
-      dagRunId,
-      mapIndex,
-      requestBody,
-      taskId,
-      updateMask,
-    }) =>
+    mutationFn: ({ dagId, dagRunId, mapIndex, requestBody, taskId, updateMask }) =>
       TaskInstanceService.patchTaskInstance({
         dagId,
         dagRunId,
@@ -3896,14 +3657,7 @@ export const useTaskInstanceServicePatchTaskInstance1 = <
     },
     TContext
   >({
-    mutationFn: ({
-      dagId,
-      dagRunId,
-      mapIndex,
-      requestBody,
-      taskId,
-      updateMask,
-    }) =>
+    mutationFn: ({ dagId, dagRunId, mapIndex, requestBody, taskId, updateMask }) =>
       TaskInstanceService.patchTaskInstance1({
         dagId,
         dagRunId,
@@ -3954,11 +3708,7 @@ export const usePoolServicePatchPool = <
     TContext
   >({
     mutationFn: ({ poolName, requestBody, updateMask }) =>
-      PoolService.patchPool({
-        poolName,
-        requestBody,
-        updateMask,
-      }) as unknown as Promise<TData>,
+      PoolService.patchPool({ poolName, requestBody, updateMask }) as unknown as Promise<TData>,
     ...options,
   });
 /**
@@ -4001,11 +3751,7 @@ export const useVariableServicePatchVariable = <
     TContext
   >({
     mutationFn: ({ requestBody, updateMask, variableKey }) =>
-      VariableService.patchVariable({
-        requestBody,
-        updateMask,
-        variableKey,
-      }) as unknown as Promise<TData>,
+      VariableService.patchVariable({ requestBody, updateMask, variableKey }) as unknown as Promise<TData>,
     ...options,
   });
 /**
@@ -4045,10 +3791,7 @@ export const useAssetServiceDeleteAssetQueuedEvents = <
     TContext
   >({
     mutationFn: ({ assetId, before }) =>
-      AssetService.deleteAssetQueuedEvents({
-        assetId,
-        before,
-      }) as unknown as Promise<TData>,
+      AssetService.deleteAssetQueuedEvents({ assetId, before }) as unknown as Promise<TData>,
     ...options,
   });
 /**
@@ -4087,10 +3830,7 @@ export const useAssetServiceDeleteDagAssetQueuedEvents = <
     TContext
   >({
     mutationFn: ({ before, dagId }) =>
-      AssetService.deleteDagAssetQueuedEvents({
-        before,
-        dagId,
-      }) as unknown as Promise<TData>,
+      AssetService.deleteDagAssetQueuedEvents({ before, dagId }) as unknown as Promise<TData>,
     ...options,
   });
 /**
@@ -4133,11 +3873,7 @@ export const useAssetServiceDeleteDagAssetQueuedEvent = <
     TContext
   >({
     mutationFn: ({ assetId, before, dagId }) =>
-      AssetService.deleteDagAssetQueuedEvent({
-        assetId,
-        before,
-        dagId,
-      }) as unknown as Promise<TData>,
+      AssetService.deleteDagAssetQueuedEvent({ assetId, before, dagId }) as unknown as Promise<TData>,
     ...options,
   });
 /**
@@ -4174,9 +3910,7 @@ export const useConnectionServiceDeleteConnection = <
     TContext
   >({
     mutationFn: ({ connectionId }) =>
-      ConnectionService.deleteConnection({
-        connectionId,
-      }) as unknown as Promise<TData>,
+      ConnectionService.deleteConnection({ connectionId }) as unknown as Promise<TData>,
     ...options,
   });
 /**
@@ -4216,10 +3950,7 @@ export const useDagRunServiceDeleteDagRun = <
     TContext
   >({
     mutationFn: ({ dagId, dagRunId }) =>
-      DagRunService.deleteDagRun({
-        dagId,
-        dagRunId,
-      }) as unknown as Promise<TData>,
+      DagRunService.deleteDagRun({ dagId, dagRunId }) as unknown as Promise<TData>,
     ...options,
   });
 /**
@@ -4254,11 +3985,7 @@ export const useDagServiceDeleteDag = <
       dagId: string;
     },
     TContext
-  >({
-    mutationFn: ({ dagId }) =>
-      DagService.deleteDag({ dagId }) as unknown as Promise<TData>,
-    ...options,
-  });
+  >({ mutationFn: ({ dagId }) => DagService.deleteDag({ dagId }) as unknown as Promise<TData>, ...options });
 /**
  * Delete Pool
  * Delete a pool entry.
@@ -4292,8 +4019,7 @@ export const usePoolServiceDeletePool = <
     },
     TContext
   >({
-    mutationFn: ({ poolName }) =>
-      PoolService.deletePool({ poolName }) as unknown as Promise<TData>,
+    mutationFn: ({ poolName }) => PoolService.deletePool({ poolName }) as unknown as Promise<TData>,
     ...options,
   });
 /**
@@ -4330,8 +4056,6 @@ export const useVariableServiceDeleteVariable = <
     TContext
   >({
     mutationFn: ({ variableKey }) =>
-      VariableService.deleteVariable({
-        variableKey,
-      }) as unknown as Promise<TData>,
+      VariableService.deleteVariable({ variableKey }) as unknown as Promise<TData>,
     ...options,
   });

--- a/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow/ui/openapi-gen/queries/suspense.ts
@@ -99,14 +99,7 @@ export const useAssetServiceGetAssetsSuspense = <
       queryKey,
     ),
     queryFn: () =>
-      AssetService.getAssets({
-        dagIds,
-        limit,
-        namePattern,
-        offset,
-        orderBy,
-        uriPattern,
-      }) as TData,
+      AssetService.getAssets({ dagIds, limit, namePattern, offset, orderBy, uriPattern }) as TData,
     ...options,
   });
 /**
@@ -140,17 +133,8 @@ export const useAssetServiceGetAssetAliasesSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseAssetServiceGetAssetAliasesKeyFn(
-      { limit, namePattern, offset, orderBy },
-      queryKey,
-    ),
-    queryFn: () =>
-      AssetService.getAssetAliases({
-        limit,
-        namePattern,
-        offset,
-        orderBy,
-      }) as TData,
+    queryKey: Common.UseAssetServiceGetAssetAliasesKeyFn({ limit, namePattern, offset, orderBy }, queryKey),
+    queryFn: () => AssetService.getAssetAliases({ limit, namePattern, offset, orderBy }) as TData,
     ...options,
   });
 /**
@@ -175,10 +159,7 @@ export const useAssetServiceGetAssetAliasSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseAssetServiceGetAssetAliasKeyFn(
-      { assetAliasId },
-      queryKey,
-    ),
+    queryKey: Common.UseAssetServiceGetAssetAliasKeyFn({ assetAliasId }, queryKey),
     queryFn: () => AssetService.getAssetAlias({ assetAliasId }) as TData,
     ...options,
   });
@@ -286,12 +267,8 @@ export const useAssetServiceGetAssetQueuedEventsSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseAssetServiceGetAssetQueuedEventsKeyFn(
-      { assetId, before },
-      queryKey,
-    ),
-    queryFn: () =>
-      AssetService.getAssetQueuedEvents({ assetId, before }) as TData,
+    queryKey: Common.UseAssetServiceGetAssetQueuedEventsKeyFn({ assetId, before }, queryKey),
+    queryFn: () => AssetService.getAssetQueuedEvents({ assetId, before }) as TData,
     ...options,
   });
 /**
@@ -345,12 +322,8 @@ export const useAssetServiceGetDagAssetQueuedEventsSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseAssetServiceGetDagAssetQueuedEventsKeyFn(
-      { before, dagId },
-      queryKey,
-    ),
-    queryFn: () =>
-      AssetService.getDagAssetQueuedEvents({ before, dagId }) as TData,
+    queryKey: Common.UseAssetServiceGetDagAssetQueuedEventsKeyFn({ before, dagId }, queryKey),
+    queryFn: () => AssetService.getDagAssetQueuedEvents({ before, dagId }) as TData,
     ...options,
   });
 /**
@@ -381,12 +354,8 @@ export const useAssetServiceGetDagAssetQueuedEventSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseAssetServiceGetDagAssetQueuedEventKeyFn(
-      { assetId, before, dagId },
-      queryKey,
-    ),
-    queryFn: () =>
-      AssetService.getDagAssetQueuedEvent({ assetId, before, dagId }) as TData,
+    queryKey: Common.UseAssetServiceGetDagAssetQueuedEventKeyFn({ assetId, before, dagId }, queryKey),
+    queryFn: () => AssetService.getDagAssetQueuedEvent({ assetId, before, dagId }) as TData,
     ...options,
   });
 /**
@@ -432,10 +401,7 @@ export const useConfigServiceGetConfigSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseConfigServiceGetConfigKeyFn(
-      { accept, section },
-      queryKey,
-    ),
+    queryKey: Common.UseConfigServiceGetConfigKeyFn({ accept, section }, queryKey),
     queryFn: () => ConfigService.getConfig({ accept, section }) as TData,
     ...options,
   });
@@ -466,12 +432,8 @@ export const useConfigServiceGetConfigValueSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseConfigServiceGetConfigValueKeyFn(
-      { accept, option, section },
-      queryKey,
-    ),
-    queryFn: () =>
-      ConfigService.getConfigValue({ accept, option, section }) as TData,
+    queryKey: Common.UseConfigServiceGetConfigValueKeyFn({ accept, option, section }, queryKey),
+    queryFn: () => ConfigService.getConfigValue({ accept, option, section }) as TData,
     ...options,
   });
 /**
@@ -583,12 +545,8 @@ export const useDashboardServiceHistoricalMetricsSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseDashboardServiceHistoricalMetricsKeyFn(
-      { endDate, startDate },
-      queryKey,
-    ),
-    queryFn: () =>
-      DashboardService.historicalMetrics({ endDate, startDate }) as TData,
+    queryKey: Common.UseDashboardServiceHistoricalMetricsKeyFn({ endDate, startDate }, queryKey),
+    queryFn: () => DashboardService.historicalMetrics({ endDate, startDate }) as TData,
     ...options,
   });
 /**
@@ -676,14 +634,7 @@ export const useBackfillServiceListBackfillsSuspense = <
       { active, dagId, limit, offset, orderBy },
       queryKey,
     ),
-    queryFn: () =>
-      BackfillService.listBackfills({
-        active,
-        dagId,
-        limit,
-        offset,
-        orderBy,
-      }) as TData,
+    queryFn: () => BackfillService.listBackfills({ active, dagId, limit, offset, orderBy }) as TData,
     ...options,
   });
 /**
@@ -716,17 +667,8 @@ export const useBackfillServiceListBackfills1Suspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseBackfillServiceListBackfills1KeyFn(
-      { dagId, limit, offset, orderBy },
-      queryKey,
-    ),
-    queryFn: () =>
-      BackfillService.listBackfills1({
-        dagId,
-        limit,
-        offset,
-        orderBy,
-      }) as TData,
+    queryKey: Common.UseBackfillServiceListBackfills1KeyFn({ dagId, limit, offset, orderBy }, queryKey),
+    queryFn: () => BackfillService.listBackfills1({ dagId, limit, offset, orderBy }) as TData,
     ...options,
   });
 /**
@@ -750,10 +692,7 @@ export const useBackfillServiceGetBackfillSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseBackfillServiceGetBackfillKeyFn(
-      { backfillId },
-      queryKey,
-    ),
+    queryKey: Common.UseBackfillServiceGetBackfillKeyFn({ backfillId }, queryKey),
     queryFn: () => BackfillService.getBackfill({ backfillId }) as TData,
     ...options,
   });
@@ -863,10 +802,7 @@ export const useConnectionServiceGetConnectionSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseConnectionServiceGetConnectionKeyFn(
-      { connectionId },
-      queryKey,
-    ),
+    queryKey: Common.UseConnectionServiceGetConnectionKeyFn({ connectionId }, queryKey),
     queryFn: () => ConnectionService.getConnection({ connectionId }) as TData,
     ...options,
   });
@@ -898,12 +834,8 @@ export const useConnectionServiceGetConnectionsSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseConnectionServiceGetConnectionsKeyFn(
-      { limit, offset, orderBy },
-      queryKey,
-    ),
-    queryFn: () =>
-      ConnectionService.getConnections({ limit, offset, orderBy }) as TData,
+    queryKey: Common.UseConnectionServiceGetConnectionsKeyFn({ limit, offset, orderBy }, queryKey),
+    queryFn: () => ConnectionService.getConnections({ limit, offset, orderBy }) as TData,
     ...options,
   });
 /**
@@ -930,10 +862,7 @@ export const useDagRunServiceGetDagRunSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseDagRunServiceGetDagRunKeyFn(
-      { dagId, dagRunId },
-      queryKey,
-    ),
+    queryKey: Common.UseDagRunServiceGetDagRunKeyFn({ dagId, dagRunId }, queryKey),
     queryFn: () => DagRunService.getDagRun({ dagId, dagRunId }) as TData,
     ...options,
   });
@@ -962,12 +891,8 @@ export const useDagRunServiceGetUpstreamAssetEventsSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseDagRunServiceGetUpstreamAssetEventsKeyFn(
-      { dagId, dagRunId },
-      queryKey,
-    ),
-    queryFn: () =>
-      DagRunService.getUpstreamAssetEvents({ dagId, dagRunId }) as TData,
+    queryKey: Common.UseDagRunServiceGetUpstreamAssetEventsKeyFn({ dagId, dagRunId }, queryKey),
+    queryFn: () => DagRunService.getUpstreamAssetEvents({ dagId, dagRunId }) as TData,
     ...options,
   });
 /**
@@ -1094,12 +1019,8 @@ export const useDagSourceServiceGetDagSourceSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseDagSourceServiceGetDagSourceKeyFn(
-      { accept, dagId, versionNumber },
-      queryKey,
-    ),
-    queryFn: () =>
-      DagSourceService.getDagSource({ accept, dagId, versionNumber }) as TData,
+    queryKey: Common.UseDagSourceServiceGetDagSourceKeyFn({ accept, dagId, versionNumber }, queryKey),
+    queryFn: () => DagSourceService.getDagSource({ accept, dagId, versionNumber }) as TData,
     ...options,
   });
 /**
@@ -1166,14 +1087,7 @@ export const useDagWarningServiceListDagWarningsSuspense = <
       { dagId, limit, offset, orderBy, warningType },
       queryKey,
     ),
-    queryFn: () =>
-      DagWarningService.listDagWarnings({
-        dagId,
-        limit,
-        offset,
-        orderBy,
-        warningType,
-      }) as TData,
+    queryFn: () => DagWarningService.listDagWarnings({ dagId, limit, offset, orderBy, warningType }) as TData,
     ...options,
   });
 /**
@@ -1338,17 +1252,8 @@ export const useDagServiceGetDagTagsSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseDagServiceGetDagTagsKeyFn(
-      { limit, offset, orderBy, tagNamePattern },
-      queryKey,
-    ),
-    queryFn: () =>
-      DagService.getDagTags({
-        limit,
-        offset,
-        orderBy,
-        tagNamePattern,
-      }) as TData,
+    queryKey: Common.UseDagServiceGetDagTagsKeyFn({ limit, offset, orderBy, tagNamePattern }, queryKey),
+    queryFn: () => DagService.getDagTags({ limit, offset, orderBy, tagNamePattern }) as TData,
     ...options,
   });
 /**
@@ -1372,10 +1277,7 @@ export const useEventLogServiceGetEventLogSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseEventLogServiceGetEventLogKeyFn(
-      { eventLogId },
-      queryKey,
-    ),
+    queryKey: Common.UseEventLogServiceGetEventLogKeyFn({ eventLogId }, queryKey),
     queryFn: () => EventLogService.getEventLog({ eventLogId }) as TData,
     ...options,
   });
@@ -1506,12 +1408,8 @@ export const useExtraLinksServiceGetExtraLinksSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseExtraLinksServiceGetExtraLinksKeyFn(
-      { dagId, dagRunId, taskId },
-      queryKey,
-    ),
-    queryFn: () =>
-      ExtraLinksService.getExtraLinks({ dagId, dagRunId, taskId }) as TData,
+    queryKey: Common.UseExtraLinksServiceGetExtraLinksKeyFn({ dagId, dagRunId, taskId }, queryKey),
+    queryFn: () => ExtraLinksService.getExtraLinks({ dagId, dagRunId, taskId }) as TData,
     ...options,
   });
 /**
@@ -1542,12 +1440,8 @@ export const useTaskInstanceServiceGetExtraLinksSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseTaskInstanceServiceGetExtraLinksKeyFn(
-      { dagId, dagRunId, taskId },
-      queryKey,
-    ),
-    queryFn: () =>
-      TaskInstanceService.getExtraLinks({ dagId, dagRunId, taskId }) as TData,
+    queryKey: Common.UseTaskInstanceServiceGetExtraLinksKeyFn({ dagId, dagRunId, taskId }, queryKey),
+    queryFn: () => TaskInstanceService.getExtraLinks({ dagId, dagRunId, taskId }) as TData,
     ...options,
   });
 /**
@@ -1578,12 +1472,8 @@ export const useTaskInstanceServiceGetTaskInstanceSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseTaskInstanceServiceGetTaskInstanceKeyFn(
-      { dagId, dagRunId, taskId },
-      queryKey,
-    ),
-    queryFn: () =>
-      TaskInstanceService.getTaskInstance({ dagId, dagRunId, taskId }) as TData,
+    queryKey: Common.UseTaskInstanceServiceGetTaskInstanceKeyFn({ dagId, dagRunId, taskId }, queryKey),
+    queryFn: () => TaskInstanceService.getTaskInstance({ dagId, dagRunId, taskId }) as TData,
     ...options,
   });
 /**
@@ -1751,12 +1641,7 @@ export const useTaskInstanceServiceGetTaskInstanceDependenciesSuspense = <
       queryKey,
     ),
     queryFn: () =>
-      TaskInstanceService.getTaskInstanceDependencies({
-        dagId,
-        dagRunId,
-        mapIndex,
-        taskId,
-      }) as TData,
+      TaskInstanceService.getTaskInstanceDependencies({ dagId, dagRunId, mapIndex, taskId }) as TData,
     ...options,
   });
 /**
@@ -1795,12 +1680,7 @@ export const useTaskInstanceServiceGetTaskInstanceDependencies1Suspense = <
       queryKey,
     ),
     queryFn: () =>
-      TaskInstanceService.getTaskInstanceDependencies1({
-        dagId,
-        dagRunId,
-        mapIndex,
-        taskId,
-      }) as TData,
+      TaskInstanceService.getTaskInstanceDependencies1({ dagId, dagRunId, mapIndex, taskId }) as TData,
     ...options,
   });
 /**
@@ -1838,13 +1718,7 @@ export const useTaskInstanceServiceGetTaskInstanceTriesSuspense = <
       { dagId, dagRunId, mapIndex, taskId },
       queryKey,
     ),
-    queryFn: () =>
-      TaskInstanceService.getTaskInstanceTries({
-        dagId,
-        dagRunId,
-        mapIndex,
-        taskId,
-      }) as TData,
+    queryFn: () => TaskInstanceService.getTaskInstanceTries({ dagId, dagRunId, mapIndex, taskId }) as TData,
     ...options,
   });
 /**
@@ -1882,12 +1756,7 @@ export const useTaskInstanceServiceGetMappedTaskInstanceTriesSuspense = <
       queryKey,
     ),
     queryFn: () =>
-      TaskInstanceService.getMappedTaskInstanceTries({
-        dagId,
-        dagRunId,
-        mapIndex,
-        taskId,
-      }) as TData,
+      TaskInstanceService.getMappedTaskInstanceTries({ dagId, dagRunId, mapIndex, taskId }) as TData,
     ...options,
   });
 /**
@@ -1925,13 +1794,7 @@ export const useTaskInstanceServiceGetMappedTaskInstanceSuspense = <
       { dagId, dagRunId, mapIndex, taskId },
       queryKey,
     ),
-    queryFn: () =>
-      TaskInstanceService.getMappedTaskInstance({
-        dagId,
-        dagRunId,
-        mapIndex,
-        taskId,
-      }) as TData,
+    queryFn: () => TaskInstanceService.getMappedTaskInstance({ dagId, dagRunId, mapIndex, taskId }) as TData,
     ...options,
   });
 /**
@@ -2210,16 +2073,7 @@ export const useTaskInstanceServiceGetLogSuspense = <
 ) =>
   useSuspenseQuery<TData, TError>({
     queryKey: Common.UseTaskInstanceServiceGetLogKeyFn(
-      {
-        accept,
-        dagId,
-        dagRunId,
-        fullContent,
-        mapIndex,
-        taskId,
-        token,
-        tryNumber,
-      },
+      { accept, dagId, dagRunId, fullContent, mapIndex, taskId, token, tryNumber },
       queryKey,
     ),
     queryFn: () =>
@@ -2257,12 +2111,8 @@ export const useImportErrorServiceGetImportErrorSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseImportErrorServiceGetImportErrorKeyFn(
-      { importErrorId },
-      queryKey,
-    ),
-    queryFn: () =>
-      ImportErrorService.getImportError({ importErrorId }) as TData,
+    queryKey: Common.UseImportErrorServiceGetImportErrorKeyFn({ importErrorId }, queryKey),
+    queryFn: () => ImportErrorService.getImportError({ importErrorId }) as TData,
     ...options,
   });
 /**
@@ -2293,12 +2143,8 @@ export const useImportErrorServiceGetImportErrorsSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseImportErrorServiceGetImportErrorsKeyFn(
-      { limit, offset, orderBy },
-      queryKey,
-    ),
-    queryFn: () =>
-      ImportErrorService.getImportErrors({ limit, offset, orderBy }) as TData,
+    queryKey: Common.UseImportErrorServiceGetImportErrorsKeyFn({ limit, offset, orderBy }, queryKey),
+    queryFn: () => ImportErrorService.getImportErrors({ limit, offset, orderBy }) as TData,
     ...options,
   });
 /**
@@ -2414,10 +2260,7 @@ export const usePluginServiceGetPluginsSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UsePluginServiceGetPluginsKeyFn(
-      { limit, offset },
-      queryKey,
-    ),
+    queryKey: Common.UsePluginServiceGetPluginsKeyFn({ limit, offset }, queryKey),
     queryFn: () => PluginService.getPlugins({ limit, offset }) as TData,
     ...options,
   });
@@ -2475,10 +2318,7 @@ export const usePoolServiceGetPoolsSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UsePoolServiceGetPoolsKeyFn(
-      { limit, offset, orderBy },
-      queryKey,
-    ),
+    queryKey: Common.UsePoolServiceGetPoolsKeyFn({ limit, offset, orderBy }, queryKey),
     queryFn: () => PoolService.getPools({ limit, offset, orderBy }) as TData,
     ...options,
   });
@@ -2507,10 +2347,7 @@ export const useProviderServiceGetProvidersSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseProviderServiceGetProvidersKeyFn(
-      { limit, offset },
-      queryKey,
-    ),
+    queryKey: Common.UseProviderServiceGetProvidersKeyFn({ limit, offset }, queryKey),
     queryFn: () => ProviderService.getProviders({ limit, offset }) as TData,
     ...options,
   });
@@ -2617,15 +2454,7 @@ export const useXcomServiceGetXcomEntriesSuspense = <
       queryKey,
     ),
     queryFn: () =>
-      XcomService.getXcomEntries({
-        dagId,
-        dagRunId,
-        limit,
-        mapIndex,
-        offset,
-        taskId,
-        xcomKey,
-      }) as TData,
+      XcomService.getXcomEntries({ dagId, dagRunId, limit, mapIndex, offset, taskId, xcomKey }) as TData,
     ...options,
   });
 /**
@@ -2708,10 +2537,7 @@ export const useVariableServiceGetVariableSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseVariableServiceGetVariableKeyFn(
-      { variableKey },
-      queryKey,
-    ),
+    queryKey: Common.UseVariableServiceGetVariableKeyFn({ variableKey }, queryKey),
     queryFn: () => VariableService.getVariable({ variableKey }) as TData,
     ...options,
   });
@@ -2750,13 +2576,7 @@ export const useVariableServiceGetVariablesSuspense = <
       { limit, offset, orderBy, variableKeyPattern },
       queryKey,
     ),
-    queryFn: () =>
-      VariableService.getVariables({
-        limit,
-        offset,
-        orderBy,
-        variableKeyPattern,
-      }) as TData,
+    queryFn: () => VariableService.getVariables({ limit, offset, orderBy, variableKeyPattern }) as TData,
     ...options,
   });
 /**

--- a/airflow/ui/openapi-gen/requests/core/ApiError.ts
+++ b/airflow/ui/openapi-gen/requests/core/ApiError.ts
@@ -8,11 +8,7 @@ export class ApiError extends Error {
   public readonly body: unknown;
   public readonly request: ApiRequestOptions;
 
-  constructor(
-    request: ApiRequestOptions,
-    response: ApiResult,
-    message: string,
-  ) {
+  constructor(request: ApiRequestOptions, response: ApiResult, message: string) {
     super(message);
 
     this.name = "ApiError";

--- a/airflow/ui/openapi-gen/requests/core/ApiRequestOptions.ts
+++ b/airflow/ui/openapi-gen/requests/core/ApiRequestOptions.ts
@@ -5,14 +5,7 @@ export type ApiRequestOptions<T = unknown> = {
   readonly formData?: Record<string, unknown> | any[] | Blob | File;
   readonly headers?: Record<string, unknown>;
   readonly mediaType?: string;
-  readonly method:
-    | "DELETE"
-    | "GET"
-    | "HEAD"
-    | "OPTIONS"
-    | "PATCH"
-    | "POST"
-    | "PUT";
+  readonly method: "DELETE" | "GET" | "HEAD" | "OPTIONS" | "PATCH" | "POST" | "PUT";
   readonly path?: Record<string, unknown>;
   readonly query?: Record<string, unknown>;
   readonly responseHeader?: string;

--- a/airflow/ui/openapi-gen/requests/core/request.ts
+++ b/airflow/ui/openapi-gen/requests/core/request.ts
@@ -1,10 +1,5 @@
 import axios from "axios";
-import type {
-  AxiosError,
-  AxiosRequestConfig,
-  AxiosResponse,
-  AxiosInstance,
-} from "axios";
+import type { AxiosError, AxiosRequestConfig, AxiosResponse, AxiosInstance } from "axios";
 
 import { ApiError } from "./ApiError";
 import type { ApiRequestOptions } from "./ApiRequestOptions";
@@ -86,9 +81,7 @@ const getUrl = (config: OpenAPIConfig, options: ApiRequestOptions): string => {
   return options.query ? url + getQueryString(options.query) : url;
 };
 
-export const getFormData = (
-  options: ApiRequestOptions,
-): FormData | undefined => {
+export const getFormData = (options: ApiRequestOptions): FormData | undefined => {
   if (options.formData) {
     const formData = new FormData();
 
@@ -249,10 +242,7 @@ export const getResponseBody = (response: AxiosResponse<unknown>): unknown => {
   return undefined;
 };
 
-export const catchErrorCodes = (
-  options: ApiRequestOptions,
-  result: ApiResult,
-): void => {
+export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void => {
   const errors: Record<number, string> = {
     400: "Bad Request",
     401: "Unauthorized",
@@ -358,10 +348,7 @@ export const request = <T>(
         }
 
         const responseBody = getResponseBody(response);
-        const responseHeader = getResponseHeader(
-          response,
-          options.responseHeader,
-        );
+        const responseHeader = getResponseHeader(response, options.responseHeader);
 
         let transformedBody = responseBody;
         if (options.responseTransformer && isSuccess(response.status)) {

--- a/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -242,13 +242,7 @@ export const $AssetEventResponse = {
     },
   },
   type: "object",
-  required: [
-    "id",
-    "asset_id",
-    "source_map_index",
-    "created_dagruns",
-    "timestamp",
-  ],
+  required: ["id", "asset_id", "source_map_index", "created_dagruns", "timestamp"],
   title: "AssetEventResponse",
   description: "Asset event serializer for responses.",
 } as const;
@@ -2516,16 +2510,7 @@ same name in TaskInstanceState.`,
 
 export const $DagRunTriggeredByType = {
   type: "string",
-  enum: [
-    "cli",
-    "operator",
-    "rest_api",
-    "ui",
-    "test",
-    "timetable",
-    "asset",
-    "backfill",
-  ],
+  enum: ["cli", "operator", "rest_api", "ui", "test", "timetable", "asset", "backfill"],
   title: "DagRunTriggeredByType",
   description: "Class with TriggeredBy types for DagRun.",
 } as const;
@@ -3446,16 +3431,7 @@ export const $NodeResponse = {
     },
     type: {
       type: "string",
-      enum: [
-        "join",
-        "task",
-        "asset-condition",
-        "asset",
-        "asset-alias",
-        "dag",
-        "sensor",
-        "trigger",
-      ],
+      enum: ["join", "task", "asset-condition", "asset", "asset-alias", "dag", "sensor", "trigger"],
       title: "Type",
     },
     operator: {
@@ -4037,8 +4013,7 @@ export const $TaskDependencyCollectionResponse = {
   type: "object",
   required: ["dependencies"],
   title: "TaskDependencyCollectionResponse",
-  description:
-    "Task scheduling dependencies collection serializer for responses.",
+  description: "Task scheduling dependencies collection serializer for responses.",
 } as const;
 
 export const $TaskDependencyResponse = {
@@ -5331,8 +5306,7 @@ export const $TimeDelta = {
   type: "object",
   required: ["days", "seconds", "microseconds"],
   title: "TimeDelta",
-  description:
-    "TimeDelta can be used to interact with datetime.timedelta objects.",
+  description: "TimeDelta can be used to interact with datetime.timedelta objects.",
 } as const;
 
 export const $TriggerDAGRunPostBody = {
@@ -5688,15 +5662,7 @@ export const $XComResponse = {
     },
   },
   type: "object",
-  required: [
-    "key",
-    "timestamp",
-    "logical_date",
-    "map_index",
-    "task_id",
-    "dag_id",
-    "run_id",
-  ],
+  required: ["key", "timestamp", "logical_date", "map_index", "task_id", "dag_id", "run_id"],
   title: "XComResponse",
   description: "Serializer for a xcom item.",
 } as const;
@@ -5738,16 +5704,7 @@ export const $XComResponseNative = {
     },
   },
   type: "object",
-  required: [
-    "key",
-    "timestamp",
-    "logical_date",
-    "map_index",
-    "task_id",
-    "dag_id",
-    "run_id",
-    "value",
-  ],
+  required: ["key", "timestamp", "logical_date", "map_index", "task_id", "dag_id", "run_id", "value"],
   title: "XComResponseNative",
   description: "XCom response serializer with native return type.",
 } as const;
@@ -5797,16 +5754,7 @@ export const $XComResponseString = {
     },
   },
   type: "object",
-  required: [
-    "key",
-    "timestamp",
-    "logical_date",
-    "map_index",
-    "task_id",
-    "dag_id",
-    "run_id",
-    "value",
-  ],
+  required: ["key", "timestamp", "logical_date", "map_index", "task_id", "dag_id", "run_id", "value"],
   title: "XComResponseString",
   description: "XCom response serializer with string return type.",
 } as const;

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -198,9 +198,7 @@ export class AssetService {
    * @returns unknown Successful Response
    * @throws ApiError
    */
-  public static nextRunAssets(
-    data: NextRunAssetsData,
-  ): CancelablePromise<NextRunAssetsResponse> {
+  public static nextRunAssets(data: NextRunAssetsData): CancelablePromise<NextRunAssetsResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/ui/next_run_assets/{dag_id}",
@@ -226,9 +224,7 @@ export class AssetService {
    * @returns AssetCollectionResponse Successful Response
    * @throws ApiError
    */
-  public static getAssets(
-    data: GetAssetsData = {},
-  ): CancelablePromise<GetAssetsResponse> {
+  public static getAssets(data: GetAssetsData = {}): CancelablePromise<GetAssetsResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/assets",
@@ -260,9 +256,7 @@ export class AssetService {
    * @returns AssetAliasCollectionResponse Successful Response
    * @throws ApiError
    */
-  public static getAssetAliases(
-    data: GetAssetAliasesData = {},
-  ): CancelablePromise<GetAssetAliasesResponse> {
+  public static getAssetAliases(data: GetAssetAliasesData = {}): CancelablePromise<GetAssetAliasesResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/assets/aliases",
@@ -289,9 +283,7 @@ export class AssetService {
    * @returns unknown Successful Response
    * @throws ApiError
    */
-  public static getAssetAlias(
-    data: GetAssetAliasData,
-  ): CancelablePromise<GetAssetAliasResponse> {
+  public static getAssetAlias(data: GetAssetAliasData): CancelablePromise<GetAssetAliasResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/assets/aliases/{asset_alias_id}",
@@ -324,9 +316,7 @@ export class AssetService {
    * @returns AssetEventCollectionResponse Successful Response
    * @throws ApiError
    */
-  public static getAssetEvents(
-    data: GetAssetEventsData = {},
-  ): CancelablePromise<GetAssetEventsResponse> {
+  public static getAssetEvents(data: GetAssetEventsData = {}): CancelablePromise<GetAssetEventsResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/assets/events",
@@ -359,9 +349,7 @@ export class AssetService {
    * @returns AssetEventResponse Successful Response
    * @throws ApiError
    */
-  public static createAssetEvent(
-    data: CreateAssetEventData,
-  ): CancelablePromise<CreateAssetEventResponse> {
+  public static createAssetEvent(data: CreateAssetEventData): CancelablePromise<CreateAssetEventResponse> {
     return __request(OpenAPI, {
       method: "POST",
       url: "/public/assets/events",
@@ -444,9 +432,7 @@ export class AssetService {
    * @returns AssetResponse Successful Response
    * @throws ApiError
    */
-  public static getAsset(
-    data: GetAssetData,
-  ): CancelablePromise<GetAssetResponse> {
+  public static getAsset(data: GetAssetData): CancelablePromise<GetAssetResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/assets/{asset_id}",
@@ -613,9 +599,7 @@ export class ConfigService {
    * @returns Config Successful Response
    * @throws ApiError
    */
-  public static getConfig(
-    data: GetConfigData = {},
-  ): CancelablePromise<GetConfigResponse> {
+  public static getConfig(data: GetConfigData = {}): CancelablePromise<GetConfigResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/config",
@@ -644,9 +628,7 @@ export class ConfigService {
    * @returns Config Successful Response
    * @throws ApiError
    */
-  public static getConfigValue(
-    data: GetConfigValueData,
-  ): CancelablePromise<GetConfigValueResponse> {
+  public static getConfigValue(data: GetConfigValueData): CancelablePromise<GetConfigValueResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/config/section/{section}/option/{option}",
@@ -687,9 +669,7 @@ export class DagsService {
    * @returns DAGWithLatestDagRunsCollectionResponse Successful Response
    * @throws ApiError
    */
-  public static recentDagRuns(
-    data: RecentDagRunsData = {},
-  ): CancelablePromise<RecentDagRunsResponse> {
+  public static recentDagRuns(data: RecentDagRunsData = {}): CancelablePromise<RecentDagRunsResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/ui/dags/recent_dag_runs",
@@ -723,9 +703,7 @@ export class DashboardService {
    * @returns HistoricalMetricDataResponse Successful Response
    * @throws ApiError
    */
-  public static historicalMetrics(
-    data: HistoricalMetricsData,
-  ): CancelablePromise<HistoricalMetricsResponse> {
+  public static historicalMetrics(data: HistoricalMetricsData): CancelablePromise<HistoricalMetricsResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/ui/dashboard/historical_metrics_data",
@@ -754,9 +732,7 @@ export class StructureService {
    * @returns StructureDataResponse Successful Response
    * @throws ApiError
    */
-  public static structureData(
-    data: StructureDataData,
-  ): CancelablePromise<StructureDataResponse2> {
+  public static structureData(data: StructureDataData): CancelablePromise<StructureDataResponse2> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/ui/structure/structure_data",
@@ -787,9 +763,7 @@ export class BackfillService {
    * @returns BackfillCollectionResponse Successful Response
    * @throws ApiError
    */
-  public static listBackfills(
-    data: ListBackfillsData = {},
-  ): CancelablePromise<ListBackfillsResponse> {
+  public static listBackfills(data: ListBackfillsData = {}): CancelablePromise<ListBackfillsResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/ui/backfills",
@@ -817,9 +791,7 @@ export class BackfillService {
    * @returns BackfillCollectionResponse Successful Response
    * @throws ApiError
    */
-  public static listBackfills1(
-    data: ListBackfills1Data,
-  ): CancelablePromise<ListBackfills1Response> {
+  public static listBackfills1(data: ListBackfills1Data): CancelablePromise<ListBackfills1Response> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/backfills",
@@ -844,9 +816,7 @@ export class BackfillService {
    * @returns BackfillResponse Successful Response
    * @throws ApiError
    */
-  public static createBackfill(
-    data: CreateBackfillData,
-  ): CancelablePromise<CreateBackfillResponse> {
+  public static createBackfill(data: CreateBackfillData): CancelablePromise<CreateBackfillResponse> {
     return __request(OpenAPI, {
       method: "POST",
       url: "/public/backfills",
@@ -869,9 +839,7 @@ export class BackfillService {
    * @returns BackfillResponse Successful Response
    * @throws ApiError
    */
-  public static getBackfill(
-    data: GetBackfillData,
-  ): CancelablePromise<GetBackfillResponse> {
+  public static getBackfill(data: GetBackfillData): CancelablePromise<GetBackfillResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/backfills/{backfill_id}",
@@ -894,9 +862,7 @@ export class BackfillService {
    * @returns BackfillResponse Successful Response
    * @throws ApiError
    */
-  public static pauseBackfill(
-    data: PauseBackfillData,
-  ): CancelablePromise<PauseBackfillResponse> {
+  public static pauseBackfill(data: PauseBackfillData): CancelablePromise<PauseBackfillResponse> {
     return __request(OpenAPI, {
       method: "PUT",
       url: "/public/backfills/{backfill_id}/pause",
@@ -920,9 +886,7 @@ export class BackfillService {
    * @returns BackfillResponse Successful Response
    * @throws ApiError
    */
-  public static unpauseBackfill(
-    data: UnpauseBackfillData,
-  ): CancelablePromise<UnpauseBackfillResponse> {
+  public static unpauseBackfill(data: UnpauseBackfillData): CancelablePromise<UnpauseBackfillResponse> {
     return __request(OpenAPI, {
       method: "PUT",
       url: "/public/backfills/{backfill_id}/unpause",
@@ -946,9 +910,7 @@ export class BackfillService {
    * @returns BackfillResponse Successful Response
    * @throws ApiError
    */
-  public static cancelBackfill(
-    data: CancelBackfillData,
-  ): CancelablePromise<CancelBackfillResponse> {
+  public static cancelBackfill(data: CancelBackfillData): CancelablePromise<CancelBackfillResponse> {
     return __request(OpenAPI, {
       method: "PUT",
       url: "/public/backfills/{backfill_id}/cancel",
@@ -985,9 +947,7 @@ export class GridService {
    * @returns GridResponse Successful Response
    * @throws ApiError
    */
-  public static gridData(
-    data: GridDataData,
-  ): CancelablePromise<GridDataResponse> {
+  public static gridData(data: GridDataData): CancelablePromise<GridDataResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/ui/grid/{dag_id}",
@@ -1024,9 +984,7 @@ export class ConnectionService {
    * @returns void Successful Response
    * @throws ApiError
    */
-  public static deleteConnection(
-    data: DeleteConnectionData,
-  ): CancelablePromise<DeleteConnectionResponse> {
+  public static deleteConnection(data: DeleteConnectionData): CancelablePromise<DeleteConnectionResponse> {
     return __request(OpenAPI, {
       method: "DELETE",
       url: "/public/connections/{connection_id}",
@@ -1050,9 +1008,7 @@ export class ConnectionService {
    * @returns ConnectionResponse Successful Response
    * @throws ApiError
    */
-  public static getConnection(
-    data: GetConnectionData,
-  ): CancelablePromise<GetConnectionResponse> {
+  public static getConnection(data: GetConnectionData): CancelablePromise<GetConnectionResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/connections/{connection_id}",
@@ -1078,9 +1034,7 @@ export class ConnectionService {
    * @returns ConnectionResponse Successful Response
    * @throws ApiError
    */
-  public static patchConnection(
-    data: PatchConnectionData,
-  ): CancelablePromise<PatchConnectionResponse> {
+  public static patchConnection(data: PatchConnectionData): CancelablePromise<PatchConnectionResponse> {
     return __request(OpenAPI, {
       method: "PATCH",
       url: "/public/connections/{connection_id}",
@@ -1112,9 +1066,7 @@ export class ConnectionService {
    * @returns ConnectionCollectionResponse Successful Response
    * @throws ApiError
    */
-  public static getConnections(
-    data: GetConnectionsData = {},
-  ): CancelablePromise<GetConnectionsResponse> {
+  public static getConnections(data: GetConnectionsData = {}): CancelablePromise<GetConnectionsResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/connections",
@@ -1140,9 +1092,7 @@ export class ConnectionService {
    * @returns ConnectionResponse Successful Response
    * @throws ApiError
    */
-  public static postConnection(
-    data: PostConnectionData,
-  ): CancelablePromise<PostConnectionResponse> {
+  public static postConnection(data: PostConnectionData): CancelablePromise<PostConnectionResponse> {
     return __request(OpenAPI, {
       method: "POST",
       url: "/public/connections",
@@ -1165,9 +1115,7 @@ export class ConnectionService {
    * @returns ConnectionCollectionResponse Successful Response
    * @throws ApiError
    */
-  public static postConnections(
-    data: PostConnectionsData,
-  ): CancelablePromise<PostConnectionsResponse> {
+  public static postConnections(data: PostConnectionsData): CancelablePromise<PostConnectionsResponse> {
     return __request(OpenAPI, {
       method: "POST",
       url: "/public/connections/bulk",
@@ -1194,9 +1142,7 @@ export class ConnectionService {
    * @returns ConnectionTestResponse Successful Response
    * @throws ApiError
    */
-  public static testConnection(
-    data: TestConnectionData,
-  ): CancelablePromise<TestConnectionResponse> {
+  public static testConnection(data: TestConnectionData): CancelablePromise<TestConnectionResponse> {
     return __request(OpenAPI, {
       method: "POST",
       url: "/public/connections/test",
@@ -1220,9 +1166,7 @@ export class DagRunService {
    * @returns DAGRunResponse Successful Response
    * @throws ApiError
    */
-  public static getDagRun(
-    data: GetDagRunData,
-  ): CancelablePromise<GetDagRunResponse> {
+  public static getDagRun(data: GetDagRunData): CancelablePromise<GetDagRunResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/dags/{dag_id}/dagRuns/{dag_run_id}",
@@ -1248,9 +1192,7 @@ export class DagRunService {
    * @returns void Successful Response
    * @throws ApiError
    */
-  public static deleteDagRun(
-    data: DeleteDagRunData,
-  ): CancelablePromise<DeleteDagRunResponse> {
+  public static deleteDagRun(data: DeleteDagRunData): CancelablePromise<DeleteDagRunResponse> {
     return __request(OpenAPI, {
       method: "DELETE",
       url: "/public/dags/{dag_id}/dagRuns/{dag_run_id}",
@@ -1279,9 +1221,7 @@ export class DagRunService {
    * @returns DAGRunResponse Successful Response
    * @throws ApiError
    */
-  public static patchDagRun(
-    data: PatchDagRunData,
-  ): CancelablePromise<PatchDagRunResponse> {
+  public static patchDagRun(data: PatchDagRunData): CancelablePromise<PatchDagRunResponse> {
     return __request(OpenAPI, {
       method: "PATCH",
       url: "/public/dags/{dag_id}/dagRuns/{dag_run_id}",
@@ -1341,9 +1281,7 @@ export class DagRunService {
    * @returns unknown Successful Response
    * @throws ApiError
    */
-  public static clearDagRun(
-    data: ClearDagRunData,
-  ): CancelablePromise<ClearDagRunResponse> {
+  public static clearDagRun(data: ClearDagRunData): CancelablePromise<ClearDagRunResponse> {
     return __request(OpenAPI, {
       method: "POST",
       url: "/public/dags/{dag_id}/dagRuns/{dag_run_id}/clear",
@@ -1384,9 +1322,7 @@ export class DagRunService {
    * @returns DAGRunCollectionResponse Successful Response
    * @throws ApiError
    */
-  public static getDagRuns(
-    data: GetDagRunsData,
-  ): CancelablePromise<GetDagRunsResponse> {
+  public static getDagRuns(data: GetDagRunsData): CancelablePromise<GetDagRunsResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/dags/{dag_id}/dagRuns",
@@ -1425,9 +1361,7 @@ export class DagRunService {
    * @returns DAGRunResponse Successful Response
    * @throws ApiError
    */
-  public static triggerDagRun(
-    data: TriggerDagRunData,
-  ): CancelablePromise<TriggerDagRunResponse> {
+  public static triggerDagRun(data: TriggerDagRunData): CancelablePromise<TriggerDagRunResponse> {
     return __request(OpenAPI, {
       method: "POST",
       url: "/public/dags/{dag_id}/dagRuns",
@@ -1488,9 +1422,7 @@ export class DagSourceService {
    * @returns DAGSourceResponse Successful Response
    * @throws ApiError
    */
-  public static getDagSource(
-    data: GetDagSourceData,
-  ): CancelablePromise<GetDagSourceResponse> {
+  public static getDagSource(data: GetDagSourceData): CancelablePromise<GetDagSourceResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/dagSources/{dag_id}",
@@ -1524,9 +1456,7 @@ export class DagStatsService {
    * @returns DagStatsCollectionResponse Successful Response
    * @throws ApiError
    */
-  public static getDagStats(
-    data: GetDagStatsData = {},
-  ): CancelablePromise<GetDagStatsResponse> {
+  public static getDagStats(data: GetDagStatsData = {}): CancelablePromise<GetDagStatsResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/dagStats",
@@ -1557,9 +1487,7 @@ export class DagWarningService {
    * @returns DAGWarningCollectionResponse Successful Response
    * @throws ApiError
    */
-  public static listDagWarnings(
-    data: ListDagWarningsData = {},
-  ): CancelablePromise<ListDagWarningsResponse> {
+  public static listDagWarnings(data: ListDagWarningsData = {}): CancelablePromise<ListDagWarningsResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/dagWarnings",
@@ -1597,9 +1525,7 @@ export class DagService {
    * @returns DAGCollectionResponse Successful Response
    * @throws ApiError
    */
-  public static getDags(
-    data: GetDagsData = {},
-  ): CancelablePromise<GetDagsResponse> {
+  public static getDags(data: GetDagsData = {}): CancelablePromise<GetDagsResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/dags",
@@ -1640,9 +1566,7 @@ export class DagService {
    * @returns DAGCollectionResponse Successful Response
    * @throws ApiError
    */
-  public static patchDags(
-    data: PatchDagsData,
-  ): CancelablePromise<PatchDagsResponse> {
+  public static patchDags(data: PatchDagsData): CancelablePromise<PatchDagsResponse> {
     return __request(OpenAPI, {
       method: "PATCH",
       url: "/public/dags",
@@ -1704,9 +1628,7 @@ export class DagService {
    * @returns DAGResponse Successful Response
    * @throws ApiError
    */
-  public static patchDag(
-    data: PatchDagData,
-  ): CancelablePromise<PatchDagResponse> {
+  public static patchDag(data: PatchDagData): CancelablePromise<PatchDagResponse> {
     return __request(OpenAPI, {
       method: "PATCH",
       url: "/public/dags/{dag_id}",
@@ -1736,9 +1658,7 @@ export class DagService {
    * @returns unknown Successful Response
    * @throws ApiError
    */
-  public static deleteDag(
-    data: DeleteDagData,
-  ): CancelablePromise<DeleteDagResponse> {
+  public static deleteDag(data: DeleteDagData): CancelablePromise<DeleteDagResponse> {
     return __request(OpenAPI, {
       method: "DELETE",
       url: "/public/dags/{dag_id}",
@@ -1763,9 +1683,7 @@ export class DagService {
    * @returns DAGDetailsResponse Successful Response
    * @throws ApiError
    */
-  public static getDagDetails(
-    data: GetDagDetailsData,
-  ): CancelablePromise<GetDagDetailsResponse> {
+  public static getDagDetails(data: GetDagDetailsData): CancelablePromise<GetDagDetailsResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/dags/{dag_id}/details",
@@ -1793,9 +1711,7 @@ export class DagService {
    * @returns DAGTagCollectionResponse Successful Response
    * @throws ApiError
    */
-  public static getDagTags(
-    data: GetDagTagsData = {},
-  ): CancelablePromise<GetDagTagsResponse> {
+  public static getDagTags(data: GetDagTagsData = {}): CancelablePromise<GetDagTagsResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/dagTags",
@@ -1822,9 +1738,7 @@ export class EventLogService {
    * @returns EventLogResponse Successful Response
    * @throws ApiError
    */
-  public static getEventLog(
-    data: GetEventLogData,
-  ): CancelablePromise<GetEventLogResponse> {
+  public static getEventLog(data: GetEventLogData): CancelablePromise<GetEventLogResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/eventLogs/{event_log_id}",
@@ -1861,9 +1775,7 @@ export class EventLogService {
    * @returns EventLogCollectionResponse Successful Response
    * @throws ApiError
    */
-  public static getEventLogs(
-    data: GetEventLogsData = {},
-  ): CancelablePromise<GetEventLogsResponse> {
+  public static getEventLogs(data: GetEventLogsData = {}): CancelablePromise<GetEventLogsResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/eventLogs",
@@ -1903,9 +1815,7 @@ export class ExtraLinksService {
    * @returns ExtraLinksResponse Successful Response
    * @throws ApiError
    */
-  public static getExtraLinks(
-    data: GetExtraLinksData,
-  ): CancelablePromise<GetExtraLinksResponse> {
+  public static getExtraLinks(data: GetExtraLinksData): CancelablePromise<GetExtraLinksResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}/links",
@@ -1935,9 +1845,7 @@ export class TaskInstanceService {
    * @returns ExtraLinksResponse Successful Response
    * @throws ApiError
    */
-  public static getExtraLinks(
-    data: GetExtraLinksData,
-  ): CancelablePromise<GetExtraLinksResponse> {
+  public static getExtraLinks(data: GetExtraLinksData): CancelablePromise<GetExtraLinksResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}/links",
@@ -1965,9 +1873,7 @@ export class TaskInstanceService {
    * @returns TaskInstanceResponse Successful Response
    * @throws ApiError
    */
-  public static getTaskInstance(
-    data: GetTaskInstanceData,
-  ): CancelablePromise<GetTaskInstanceResponse> {
+  public static getTaskInstance(data: GetTaskInstanceData): CancelablePromise<GetTaskInstanceResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}",
@@ -1998,9 +1904,7 @@ export class TaskInstanceService {
    * @returns TaskInstanceResponse Successful Response
    * @throws ApiError
    */
-  public static patchTaskInstance(
-    data: PatchTaskInstanceData,
-  ): CancelablePromise<PatchTaskInstanceResponse> {
+  public static patchTaskInstance(data: PatchTaskInstanceData): CancelablePromise<PatchTaskInstanceResponse> {
     return __request(OpenAPI, {
       method: "PATCH",
       url: "/public/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}",
@@ -2325,9 +2229,7 @@ export class TaskInstanceService {
    * @returns TaskInstanceCollectionResponse Successful Response
    * @throws ApiError
    */
-  public static getTaskInstances(
-    data: GetTaskInstancesData,
-  ): CancelablePromise<GetTaskInstancesResponse> {
+  public static getTaskInstances(data: GetTaskInstancesData): CancelablePromise<GetTaskInstancesResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances",
@@ -2546,9 +2448,7 @@ export class ImportErrorService {
    * @returns ImportErrorResponse Successful Response
    * @throws ApiError
    */
-  public static getImportError(
-    data: GetImportErrorData,
-  ): CancelablePromise<GetImportErrorResponse> {
+  public static getImportError(data: GetImportErrorData): CancelablePromise<GetImportErrorResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/importErrors/{import_error_id}",
@@ -2574,9 +2474,7 @@ export class ImportErrorService {
    * @returns ImportErrorCollectionResponse Successful Response
    * @throws ApiError
    */
-  public static getImportErrors(
-    data: GetImportErrorsData = {},
-  ): CancelablePromise<GetImportErrorsResponse> {
+  public static getImportErrors(data: GetImportErrorsData = {}): CancelablePromise<GetImportErrorsResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/importErrors",
@@ -2614,9 +2512,7 @@ export class JobService {
    * @returns JobCollectionResponse Successful Response
    * @throws ApiError
    */
-  public static getJobs(
-    data: GetJobsData = {},
-  ): CancelablePromise<GetJobsResponse> {
+  public static getJobs(data: GetJobsData = {}): CancelablePromise<GetJobsResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/jobs",
@@ -2653,9 +2549,7 @@ export class PluginService {
    * @returns PluginCollectionResponse Successful Response
    * @throws ApiError
    */
-  public static getPlugins(
-    data: GetPluginsData = {},
-  ): CancelablePromise<GetPluginsResponse> {
+  public static getPlugins(data: GetPluginsData = {}): CancelablePromise<GetPluginsResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/plugins",
@@ -2681,9 +2575,7 @@ export class PoolService {
    * @returns void Successful Response
    * @throws ApiError
    */
-  public static deletePool(
-    data: DeletePoolData,
-  ): CancelablePromise<DeletePoolResponse> {
+  public static deletePool(data: DeletePoolData): CancelablePromise<DeletePoolResponse> {
     return __request(OpenAPI, {
       method: "DELETE",
       url: "/public/pools/{pool_name}",
@@ -2734,9 +2626,7 @@ export class PoolService {
    * @returns PoolResponse Successful Response
    * @throws ApiError
    */
-  public static patchPool(
-    data: PatchPoolData,
-  ): CancelablePromise<PatchPoolResponse> {
+  public static patchPool(data: PatchPoolData): CancelablePromise<PatchPoolResponse> {
     return __request(OpenAPI, {
       method: "PATCH",
       url: "/public/pools/{pool_name}",
@@ -2768,9 +2658,7 @@ export class PoolService {
    * @returns PoolCollectionResponse Successful Response
    * @throws ApiError
    */
-  public static getPools(
-    data: GetPoolsData = {},
-  ): CancelablePromise<GetPoolsResponse> {
+  public static getPools(data: GetPoolsData = {}): CancelablePromise<GetPoolsResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/pools",
@@ -2796,9 +2684,7 @@ export class PoolService {
    * @returns PoolResponse Successful Response
    * @throws ApiError
    */
-  public static postPool(
-    data: PostPoolData,
-  ): CancelablePromise<PostPoolResponse> {
+  public static postPool(data: PostPoolData): CancelablePromise<PostPoolResponse> {
     return __request(OpenAPI, {
       method: "POST",
       url: "/public/pools",
@@ -2821,9 +2707,7 @@ export class PoolService {
    * @returns PoolCollectionResponse Successful Response
    * @throws ApiError
    */
-  public static postPools(
-    data: PostPoolsData,
-  ): CancelablePromise<PostPoolsResponse> {
+  public static postPools(data: PostPoolsData): CancelablePromise<PostPoolsResponse> {
     return __request(OpenAPI, {
       method: "POST",
       url: "/public/pools/bulk",
@@ -2849,9 +2733,7 @@ export class ProviderService {
    * @returns ProviderCollectionResponse Successful Response
    * @throws ApiError
    */
-  public static getProviders(
-    data: GetProvidersData = {},
-  ): CancelablePromise<GetProvidersResponse> {
+  public static getProviders(data: GetProvidersData = {}): CancelablePromise<GetProvidersResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/providers",
@@ -2883,9 +2765,7 @@ export class XcomService {
    * @returns unknown Successful Response
    * @throws ApiError
    */
-  public static getXcomEntry(
-    data: GetXcomEntryData,
-  ): CancelablePromise<GetXcomEntryResponse> {
+  public static getXcomEntry(data: GetXcomEntryData): CancelablePromise<GetXcomEntryResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}/xcomEntries/{xcom_key}",
@@ -2926,9 +2806,7 @@ export class XcomService {
    * @returns XComCollection Successful Response
    * @throws ApiError
    */
-  public static getXcomEntries(
-    data: GetXcomEntriesData,
-  ): CancelablePromise<GetXcomEntriesResponse> {
+  public static getXcomEntries(data: GetXcomEntriesData): CancelablePromise<GetXcomEntriesResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}/xcomEntries",
@@ -2964,9 +2842,7 @@ export class TaskService {
    * @returns TaskCollectionResponse Successful Response
    * @throws ApiError
    */
-  public static getTasks(
-    data: GetTasksData,
-  ): CancelablePromise<GetTasksResponse> {
+  public static getTasks(data: GetTasksData): CancelablePromise<GetTasksResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/dags/{dag_id}/tasks",
@@ -3023,9 +2899,7 @@ export class VariableService {
    * @returns void Successful Response
    * @throws ApiError
    */
-  public static deleteVariable(
-    data: DeleteVariableData,
-  ): CancelablePromise<DeleteVariableResponse> {
+  public static deleteVariable(data: DeleteVariableData): CancelablePromise<DeleteVariableResponse> {
     return __request(OpenAPI, {
       method: "DELETE",
       url: "/public/variables/{variable_key}",
@@ -3049,9 +2923,7 @@ export class VariableService {
    * @returns VariableResponse Successful Response
    * @throws ApiError
    */
-  public static getVariable(
-    data: GetVariableData,
-  ): CancelablePromise<GetVariableResponse> {
+  public static getVariable(data: GetVariableData): CancelablePromise<GetVariableResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/variables/{variable_key}",
@@ -3077,9 +2949,7 @@ export class VariableService {
    * @returns VariableResponse Successful Response
    * @throws ApiError
    */
-  public static patchVariable(
-    data: PatchVariableData,
-  ): CancelablePromise<PatchVariableResponse> {
+  public static patchVariable(data: PatchVariableData): CancelablePromise<PatchVariableResponse> {
     return __request(OpenAPI, {
       method: "PATCH",
       url: "/public/variables/{variable_key}",
@@ -3112,9 +2982,7 @@ export class VariableService {
    * @returns VariableCollectionResponse Successful Response
    * @throws ApiError
    */
-  public static getVariables(
-    data: GetVariablesData = {},
-  ): CancelablePromise<GetVariablesResponse> {
+  public static getVariables(data: GetVariablesData = {}): CancelablePromise<GetVariablesResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/variables",
@@ -3140,9 +3008,7 @@ export class VariableService {
    * @returns VariableResponse Successful Response
    * @throws ApiError
    */
-  public static postVariable(
-    data: PostVariableData,
-  ): CancelablePromise<PostVariableResponse> {
+  public static postVariable(data: PostVariableData): CancelablePromise<PostVariableResponse> {
     return __request(OpenAPI, {
       method: "POST",
       url: "/public/variables",
@@ -3166,9 +3032,7 @@ export class VariableService {
    * @returns VariablesImportResponse Successful Response
    * @throws ApiError
    */
-  public static importVariables(
-    data: ImportVariablesData,
-  ): CancelablePromise<ImportVariablesResponse> {
+  public static importVariables(data: ImportVariablesData): CancelablePromise<ImportVariablesResponse> {
     return __request(OpenAPI, {
       method: "POST",
       url: "/public/variables/import",
@@ -3197,9 +3061,7 @@ export class DagParsingService {
    * @returns null Successful Response
    * @throws ApiError
    */
-  public static reparseDagFile(
-    data: ReparseDagFileData,
-  ): CancelablePromise<ReparseDagFileResponse> {
+  public static reparseDagFile(data: ReparseDagFileData): CancelablePromise<ReparseDagFileResponse> {
     return __request(OpenAPI, {
       method: "PUT",
       url: "/public/parseDagFile/{file_token}",

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -585,11 +585,7 @@ export type DagRunTriggeredByType =
 /**
  * Class with DagRun types.
  */
-export type DagRunType =
-  | "backfill"
-  | "scheduled"
-  | "manual"
-  | "asset_triggered";
+export type DagRunType = "backfill" | "scheduled" | "manual" | "asset_triggered";
 
 /**
  * DAG schedule reference serializer for assets.
@@ -820,15 +816,7 @@ export type NodeResponse = {
   label: string;
   tooltip?: string | null;
   setup_teardown_type?: "setup" | "teardown" | null;
-  type:
-    | "join"
-    | "task"
-    | "asset-condition"
-    | "asset"
-    | "asset-alias"
-    | "dag"
-    | "sensor"
-    | "trigger";
+  type: "join" | "task" | "asset-condition" | "asset" | "asset-alias" | "dag" | "sensor" | "trigger";
   operator?: string | null;
   asset_condition_type?: "or-gate" | "and-gate" | null;
 };
@@ -1677,9 +1665,7 @@ export type ClearDagRunData = {
   requestBody: DAGRunClearBody;
 };
 
-export type ClearDagRunResponse =
-  | TaskInstanceCollectionResponse
-  | DAGRunResponse;
+export type ClearDagRunResponse = TaskInstanceCollectionResponse | DAGRunResponse;
 
 export type GetDagRunsData = {
   dagId: string;
@@ -1886,8 +1872,7 @@ export type GetTaskInstanceDependenciesData = {
   taskId: string;
 };
 
-export type GetTaskInstanceDependenciesResponse =
-  TaskDependencyCollectionResponse;
+export type GetTaskInstanceDependenciesResponse = TaskDependencyCollectionResponse;
 
 export type GetTaskInstanceDependencies1Data = {
   dagId: string;
@@ -1896,8 +1881,7 @@ export type GetTaskInstanceDependencies1Data = {
   taskId: string;
 };
 
-export type GetTaskInstanceDependencies1Response =
-  TaskDependencyCollectionResponse;
+export type GetTaskInstanceDependencies1Response = TaskDependencyCollectionResponse;
 
 export type GetTaskInstanceTriesData = {
   dagId: string;
@@ -1906,8 +1890,7 @@ export type GetTaskInstanceTriesData = {
   taskId: string;
 };
 
-export type GetTaskInstanceTriesResponse =
-  TaskInstanceHistoryCollectionResponse;
+export type GetTaskInstanceTriesResponse = TaskInstanceHistoryCollectionResponse;
 
 export type GetMappedTaskInstanceTriesData = {
   dagId: string;
@@ -1916,8 +1899,7 @@ export type GetMappedTaskInstanceTriesData = {
   taskId: string;
 };
 
-export type GetMappedTaskInstanceTriesResponse =
-  TaskInstanceHistoryCollectionResponse;
+export type GetMappedTaskInstanceTriesResponse = TaskInstanceHistoryCollectionResponse;
 
 export type GetMappedTaskInstanceData = {
   dagId: string;
@@ -1991,16 +1973,14 @@ export type GetMappedTaskInstanceTryDetailsData = {
   taskTryNumber: number;
 };
 
-export type GetMappedTaskInstanceTryDetailsResponse =
-  TaskInstanceHistoryResponse;
+export type GetMappedTaskInstanceTryDetailsResponse = TaskInstanceHistoryResponse;
 
 export type PostClearTaskInstancesData = {
   dagId: string;
   requestBody: ClearTaskInstancesBody;
 };
 
-export type PostClearTaskInstancesResponse =
-  TaskInstanceReferenceCollectionResponse;
+export type PostClearTaskInstancesResponse = TaskInstanceReferenceCollectionResponse;
 
 export type GetLogData = {
   accept?: "application/json" | "text/plain" | "*/*";

--- a/airflow/ui/rules/core.js
+++ b/airflow/ui/rules/core.js
@@ -279,10 +279,7 @@ export const coreRules = /** @type {const} @satisfies {FlatConfig.Config} */ ({
      *
      * @see [max-lines](https://eslint.org/docs/latest/rules/max-lines)
      */
-    "max-lines": [
-      ERROR,
-      { max: 250, skipBlankLines: true, skipComments: true },
-    ],
+    "max-lines": [ERROR, { max: 250, skipBlankLines: true, skipComments: true }],
 
     /**
      * Enforce a maximum depth that callbacks can be nested to 3.
@@ -869,10 +866,7 @@ export const coreRules = /** @type {const} @satisfies {FlatConfig.Config} */ ({
      *
      * @see [no-restricted-globals](https://eslint.org/docs/latest/rules/no-restricted-globals)
      */
-    "no-restricted-globals": [
-      ERROR,
-      { message: "Use `globalThis` instead.", name: "window" },
-    ],
+    "no-restricted-globals": [ERROR, { message: "Use `globalThis` instead.", name: "window" }],
 
     /**
      * Disallow assignment operators in `return` statements.

--- a/airflow/ui/rules/off.js
+++ b/airflow/ui/rules/off.js
@@ -26,6 +26,4 @@ import { OFF } from "./levels.js";
  * @returns Object with rules set to {@link OFF}.
  */
 export const off = (...rules) =>
-  /** @type {Readonly<Record<Rule, typeof OFF>>} */ (
-    Object.fromEntries(rules.map((rule) => [rule, OFF]))
-  );
+  /** @type {Readonly<Record<Rule, typeof OFF>>} */ (Object.fromEntries(rules.map((rule) => [rule, OFF])));

--- a/airflow/ui/rules/perfectionist.js
+++ b/airflow/ui/rules/perfectionist.js
@@ -34,107 +34,106 @@ export const perfectionistNamespace = "perfectionist";
  * ESLint `perfectionist` rules.
  * @see [perfectionist](https://perfectionist.dev/rules)
  */
-export const perfectionistRules =
-  /** @type {const} @satisfies {FlatConfig.Config} */ ({
-    plugins: {
-      [perfectionistNamespace]: perfectionist,
-    },
-    rules: {
-      /**
-       * Enforce sorted array values if the `includes` method is
-       * immediately called after the array is created.
-       *
-       * @see [perfectionist/sort-array-includes](https://perfectionist.dev/rules/sort-array-includes)
-       */
-      [`${perfectionistNamespace}/sort-array-includes`]: ERROR,
+export const perfectionistRules = /** @type {const} @satisfies {FlatConfig.Config} */ ({
+  plugins: {
+    [perfectionistNamespace]: perfectionist,
+  },
+  rules: {
+    /**
+     * Enforce sorted array values if the `includes` method is
+     * immediately called after the array is created.
+     *
+     * @see [perfectionist/sort-array-includes](https://perfectionist.dev/rules/sort-array-includes)
+     */
+    [`${perfectionistNamespace}/sort-array-includes`]: ERROR,
 
-      /**
-       * Enforce sorted class members.
-       *
-       * @see [perfectionist/sort-classes](https://perfectionist.dev/rules/sort-classes)
-       */
-      [`${perfectionistNamespace}/sort-classes`]: ERROR,
+    /**
+     * Enforce sorted class members.
+     *
+     * @see [perfectionist/sort-classes](https://perfectionist.dev/rules/sort-classes)
+     */
+    [`${perfectionistNamespace}/sort-classes`]: ERROR,
 
-      /**
-       * Enforce sorted TypeScript enum members.
-       *
-       * @see [perfectionist/sort-enums](https://perfectionist.dev/rules/sort-enums)
-       */
-      [`${perfectionistNamespace}/sort-enums`]: ERROR,
+    /**
+     * Enforce sorted TypeScript enum members.
+     *
+     * @see [perfectionist/sort-enums](https://perfectionist.dev/rules/sort-enums)
+     */
+    [`${perfectionistNamespace}/sort-enums`]: ERROR,
 
-      /**
-       * Enforce sorted TypeScript interface properties.
-       *
-       * @see [perfectionist/sort-interfaces](https://perfectionist.dev/rules/sort-interfaces)
-       */
-      [`${perfectionistNamespace}/sort-interfaces`]: ERROR,
+    /**
+     * Enforce sorted TypeScript interface properties.
+     *
+     * @see [perfectionist/sort-interfaces](https://perfectionist.dev/rules/sort-interfaces)
+     */
+    [`${perfectionistNamespace}/sort-interfaces`]: ERROR,
 
-      /**
-       * Enforce sorted intersection types in TypeScript.
-       *
-       * @see [perfectionist/sort-intersection-types](https://perfectionist.dev/rules/sort-intersection-types)
-       */
-      [`${perfectionistNamespace}/sort-intersection-types`]: ERROR,
+    /**
+     * Enforce sorted intersection types in TypeScript.
+     *
+     * @see [perfectionist/sort-intersection-types](https://perfectionist.dev/rules/sort-intersection-types)
+     */
+    [`${perfectionistNamespace}/sort-intersection-types`]: ERROR,
 
-      /**
-       * Enforce sorted JSX props within JSX elements.
-       *
-       * @see [perfectionist/sort-jsx-props](https://perfectionist.dev/rules/sort-jsx-props)
-       */
-      [`${perfectionistNamespace}/sort-jsx-props`]: ERROR,
+    /**
+     * Enforce sorted JSX props within JSX elements.
+     *
+     * @see [perfectionist/sort-jsx-props](https://perfectionist.dev/rules/sort-jsx-props)
+     */
+    [`${perfectionistNamespace}/sort-jsx-props`]: ERROR,
 
-      /**
-       * Enforce sorted elements within JavaScript Map object.
-       *
-       * @see [perfectionist/sort-maps](https://perfectionist.dev/rules/sort-maps)
-       */
-      [`${perfectionistNamespace}/sort-maps`]: ERROR,
+    /**
+     * Enforce sorted elements within JavaScript Map object.
+     *
+     * @see [perfectionist/sort-maps](https://perfectionist.dev/rules/sort-maps)
+     */
+    [`${perfectionistNamespace}/sort-maps`]: ERROR,
 
-      /**
-       * Enforce sorted object types.
-       *
-       * @see [perfectionist/sort-object-types](https://perfectionist.dev/rules/sort-object-types)
-       */
-      [`${perfectionistNamespace}/sort-object-types`]: ERROR,
+    /**
+     * Enforce sorted object types.
+     *
+     * @see [perfectionist/sort-object-types](https://perfectionist.dev/rules/sort-object-types)
+     */
+    [`${perfectionistNamespace}/sort-object-types`]: ERROR,
 
-      /**
-       * Enforce sorted object types.
-       *
-       * @see [perfectionist/sort-objects](https://perfectionist.dev/rules/sort-objects)
-       */
-      [`${perfectionistNamespace}/sort-objects`]: [
-        ERROR,
-        {
-          type: "natural",
-        },
-      ],
+    /**
+     * Enforce sorted object types.
+     *
+     * @see [perfectionist/sort-objects](https://perfectionist.dev/rules/sort-objects)
+     */
+    [`${perfectionistNamespace}/sort-objects`]: [
+      ERROR,
+      {
+        type: "natural",
+      },
+    ],
 
-      /**
-       * Enforce sorted switch case statements.
-       *
-       * @see [perfectionist/sort-switch-case](https://perfectionist.dev/rules/sort-switch-case)
-       */
-      [`${perfectionistNamespace}/sort-switch-case`]: ERROR,
+    /**
+     * Enforce sorted switch case statements.
+     *
+     * @see [perfectionist/sort-switch-case](https://perfectionist.dev/rules/sort-switch-case)
+     */
+    [`${perfectionistNamespace}/sort-switch-case`]: ERROR,
 
-      /**
-       * Enforce sorted TypeScript union types.
-       *
-       * nullish groups will leave null and undefined at the end
-       *
-       * @see [perfectionist/sort-union-types](https://perfectionist.dev/rules/sort-union-types)
-       */
-      [`${perfectionistNamespace}/sort-union-types`]: [
-        ERROR,
-        {
-          groups: [
-            ["conditional", "function", "import"],
-            ["intersection", "keyword", "named"],
-            ["literal", "object", "operator", "tuple", "union"],
-            "nullish",
-          ],
-        },
-      ],
+    /**
+     * Enforce sorted TypeScript union types.
+     *
+     * nullish groups will leave null and undefined at the end
+     *
+     * @see [perfectionist/sort-union-types](https://perfectionist.dev/rules/sort-union-types)
+     */
+    [`${perfectionistNamespace}/sort-union-types`]: [
+      ERROR,
+      {
+        groups: [
+          ["conditional", "function", "import"],
+          ["intersection", "keyword", "named"],
+          ["literal", "object", "operator", "tuple", "union"],
+          "nullish",
+        ],
+      },
+    ],
 
-      ...off("sort-keys"),
-    },
-  });
+    ...off("sort-keys"),
+  },
+});

--- a/airflow/ui/rules/prettier.js
+++ b/airflow/ui/rules/prettier.js
@@ -33,8 +33,7 @@ export const prettierNamespace = "prettier";
  * ESLint Prettier rules.
  * @see [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier)
  */
-export const prettierRules =
-  /** @type {const} @satisfies {FlatConfig.Config} */ ({
-    plugins: { [prettierNamespace]: prettier },
-    rules: off("no-irregular-whitespace", "no-unexpected-multiline"),
-  });
+export const prettierRules = /** @type {const} @satisfies {FlatConfig.Config} */ ({
+  plugins: { [prettierNamespace]: prettier },
+  rules: off("no-irregular-whitespace", "no-unexpected-multiline"),
+});

--- a/airflow/ui/rules/react.js
+++ b/airflow/ui/rules/react.js
@@ -257,8 +257,7 @@ export const reactRules = /** @type {const} @satisfies {FlatConfig.Config} */ ({
      *
      * @see [jsx-a11y/no-interactive-element-to-noninteractive-role](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-interactive-element-to-noninteractive-role.md)
      */
-    [`${jsxA11yNamespace}/no-interactive-element-to-noninteractive-role`]:
-      ERROR,
+    [`${jsxA11yNamespace}/no-interactive-element-to-noninteractive-role`]: ERROR,
 
     /**
      * Avoid adding interactivity to non-interactive elements (event
@@ -274,8 +273,7 @@ export const reactRules = /** @type {const} @satisfies {FlatConfig.Config} */ ({
      *
      * @see [jsx-a11y/no-noninteractive-element-to-interactive-role](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-noninteractive-element-to-interactive-role.md)
      */
-    [`${jsxA11yNamespace}/no-noninteractive-element-to-interactive-role`]:
-      ERROR,
+    [`${jsxA11yNamespace}/no-noninteractive-element-to-interactive-role`]: ERROR,
 
     /**
      * Avoid adding tabindex to non-interactive elements.
@@ -395,8 +393,7 @@ export const reactRules = /** @type {const} @satisfies {FlatConfig.Config} */ ({
           { element: "noframes", message: "Use <iframe> instead." },
           {
             element: "param",
-            message:
-              "Use the <object> element with a data attribute to set the URL of an external resource.",
+            message: "Use the <object> element with a data attribute to set the URL of an external resource.",
           },
           { element: "plaintext", message: "Use <pre> instead." },
           { element: "rb", message: "Use UTF-8 instead." },
@@ -620,10 +617,7 @@ export const reactRules = /** @type {const} @satisfies {FlatConfig.Config} */ ({
      *
      * @see [Allow constant export](https://github.com/ArnaudBarre/eslint-plugin-react-refresh?tab=readme-ov-file#allowconstantexport-v040)
      */
-    [`${reactRefreshNamespace}/only-export-components`]: [
-      WARN,
-      { allowConstantExport: true },
-    ],
+    [`${reactRefreshNamespace}/only-export-components`]: [WARN, { allowConstantExport: true }],
   },
   settings: { react: { version: "18" } },
 });

--- a/airflow/ui/rules/stylistic.js
+++ b/airflow/ui/rules/stylistic.js
@@ -33,64 +33,59 @@ export const stylisticESLintNamespace = "@stylistic";
  * ESLint `@stylistic/eslint-plugin` rules.
  * @see [@stylistic/eslint-plugin](https://eslint.style/packages/default#rules)
  */
-export const stylisticRules =
-  /** @type {const} @satisfies {FlatConfig.Config} */ ({
-    plugins: { [stylisticESLintNamespace]: stylistic },
-    rules: {
-      /**
-       * Require padding lines between statements:
-       *
-       * -   Always a new line before a `return` statement.
-       * -   Always a new line after an `import`, `const`, `let` or `var` statement.
-       * -   Indifferent if followed by same type (`const`, `let` or `var`).
-       * -   Indifferent in `import` followed by other `import`.
-       * -   Always a new line before an `export` statement.
-       *
-       * @see [padding-line-between-statements](https://eslint.style/rules/default/padding-line-between-statements)
-       */
-      [`${stylisticESLintNamespace}/padding-line-between-statements`]: [
-        ERROR,
-        {
-          blankLine: "always",
-          next: "return",
-          prev: "*",
-        },
-        {
-          blankLine: "always",
-          next: "*",
-          prev: ["import", "const", "let", "var"],
-        },
-        {
-          blankLine: "any",
-          next: ["const", "let", "var"],
-          prev: ["const", "let", "var"],
-        },
-        {
-          blankLine: "any",
-          next: "import",
-          prev: "import",
-        },
-        {
-          blankLine: "always",
-          next: "export",
-          prev: "*",
-        },
-        {
-          blankLine: "any",
-          next: "export",
-          prev: "export",
-        },
-      ],
+export const stylisticRules = /** @type {const} @satisfies {FlatConfig.Config} */ ({
+  plugins: { [stylisticESLintNamespace]: stylistic },
+  rules: {
+    /**
+     * Require padding lines between statements:
+     *
+     * -   Always a new line before a `return` statement.
+     * -   Always a new line after an `import`, `const`, `let` or `var` statement.
+     * -   Indifferent if followed by same type (`const`, `let` or `var`).
+     * -   Indifferent in `import` followed by other `import`.
+     * -   Always a new line before an `export` statement.
+     *
+     * @see [padding-line-between-statements](https://eslint.style/rules/default/padding-line-between-statements)
+     */
+    [`${stylisticESLintNamespace}/padding-line-between-statements`]: [
+      ERROR,
+      {
+        blankLine: "always",
+        next: "return",
+        prev: "*",
+      },
+      {
+        blankLine: "always",
+        next: "*",
+        prev: ["import", "const", "let", "var"],
+      },
+      {
+        blankLine: "any",
+        next: ["const", "let", "var"],
+        prev: ["const", "let", "var"],
+      },
+      {
+        blankLine: "any",
+        next: "import",
+        prev: "import",
+      },
+      {
+        blankLine: "always",
+        next: "export",
+        prev: "*",
+      },
+      {
+        blankLine: "any",
+        next: "export",
+        prev: "export",
+      },
+    ],
 
-      /**
-       * Requires a whitespace (space or tab) beginning a comment.
-       *
-       * @see [spaced-comment](https://eslint.style/rules/default/spaced-comment)
-       */
-      [`${stylisticESLintNamespace}/spaced-comment`]: [
-        ERROR,
-        "always",
-        { exceptions: ["!"] },
-      ],
-    },
-  });
+    /**
+     * Requires a whitespace (space or tab) beginning a comment.
+     *
+     * @see [spaced-comment](https://eslint.style/rules/default/spaced-comment)
+     */
+    [`${stylisticESLintNamespace}/spaced-comment`]: [ERROR, "always", { exceptions: ["!"] }],
+  },
+});

--- a/airflow/ui/rules/typescript.js
+++ b/airflow/ui/rules/typescript.js
@@ -37,1901 +37,1853 @@ export const typescriptNamespace = "@typescript-eslint";
  * ESLint TypeScript rules.
  * @see [@typescript-eslint/eslint-plugin](https://typescript-eslint.io/rules/)
  */
-export const typescriptRules =
-  /** @type {const} @satisfies {FlatConfig.Config} */ ({
-    languageOptions: {
-      parser: typescriptParser,
-      parserOptions: {
-        ecmaFeatures: {
-          /**
-           * Enable global strict mode.
-           */
-          impliedStrict: true,
-
-          /**
-           * JSX enabled by default (even if it's not a React project).
-           */
-          jsx: true,
-        },
+export const typescriptRules = /** @type {const} @satisfies {FlatConfig.Config} */ ({
+  languageOptions: {
+    parser: typescriptParser,
+    parserOptions: {
+      ecmaFeatures: {
         /**
-         * Self explanatory. Use the latest ECMAScript version.
+         * Enable global strict mode.
          */
-        ecmaVersion: "latest",
+        impliedStrict: true,
 
         /**
-         * Get `tsconfig.json` from the root directory.
+         * JSX enabled by default (even if it's not a React project).
          */
-        project: [
-          `${import.meta.dirname}/../tsconfig.app.json`,
-          `${import.meta.dirname}/../tsconfig.dev.json`,
-          `${import.meta.dirname}/../tsconfig.node.json`,
-        ],
-
-        /**
-         * Default to ESM.
-         */
-        sourceType: "module",
+        jsx: true,
       },
+      /**
+       * Self explanatory. Use the latest ECMAScript version.
+       */
+      ecmaVersion: "latest",
+
+      /**
+       * Get `tsconfig.json` from the root directory.
+       */
+      project: [
+        `${import.meta.dirname}/../tsconfig.app.json`,
+        `${import.meta.dirname}/../tsconfig.dev.json`,
+        `${import.meta.dirname}/../tsconfig.node.json`,
+      ],
+
+      /**
+       * Default to ESM.
+       */
+      sourceType: "module",
     },
-    plugins: { [typescriptNamespace]: typescript },
-    rules: {
-      /**
-       * Grouping overloaded members together to improve readability.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * type Foo = {
-       *   foo(s: string): void;
-       *   foo(n: number): void;
-       *   bar(): void;
-       *   foo(sn: string | number): void;
-       * };
-       *
-       * // ✅ Correct
-       * type Foo = {
-       *   foo(s: string): void;
-       *   foo(n: number): void;
-       *   foo(sn: string | number): void;
-       *   bar(): void;
-       * };
-       * ```
-       * @see [@typescript-eslint/adjacent-overload-signatures](https://typescript-eslint.io/rules/adjacent-overload-signatures/)
-       */
-      [`${typescriptNamespace}/adjacent-overload-signatures`]: ERROR,
+  },
+  plugins: { [typescriptNamespace]: typescript },
+  rules: {
+    /**
+     * Grouping overloaded members together to improve readability.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * type Foo = {
+     *   foo(s: string): void;
+     *   foo(n: number): void;
+     *   bar(): void;
+     *   foo(sn: string | number): void;
+     * };
+     *
+     * // ✅ Correct
+     * type Foo = {
+     *   foo(s: string): void;
+     *   foo(n: number): void;
+     *   foo(sn: string | number): void;
+     *   bar(): void;
+     * };
+     * ```
+     * @see [@typescript-eslint/adjacent-overload-signatures](https://typescript-eslint.io/rules/adjacent-overload-signatures/)
+     */
+    [`${typescriptNamespace}/adjacent-overload-signatures`]: ERROR,
 
-      /**
-       * Consistent array types using generics `Array` and `ReadonlyArray`.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo: string[] = [];
-       * const bar: readonly string[] = [];
-       *
-       * // ✅ Correct
-       * const foo: Array<string> = [];
-       * const bar: ReadonlyArray<string> = [];
-       * ```
-       * @see [@typescript-eslint/array-type](https://typescript-eslint.io/rules/array-type/)
-       */
-      [`${typescriptNamespace}/array-type`]: [ERROR, { default: "generic" }],
+    /**
+     * Consistent array types using generics `Array` and `ReadonlyArray`.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo: string[] = [];
+     * const bar: readonly string[] = [];
+     *
+     * // ✅ Correct
+     * const foo: Array<string> = [];
+     * const bar: ReadonlyArray<string> = [];
+     * ```
+     * @see [@typescript-eslint/array-type](https://typescript-eslint.io/rules/array-type/)
+     */
+    [`${typescriptNamespace}/array-type`]: [ERROR, { default: "generic" }],
 
-      /**
-       * Avoid await on non thenable values.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo = await 42;
-       *
-       * // ✅ Correct
-       * const bar = await Promise.resolve(42);
-       * ```
-       * @see [@typescript-eslint/await-thenable](https://typescript-eslint.io/rules/await-thenable/)
-       */
-      [`${typescriptNamespace}/await-thenable`]: ERROR,
+    /**
+     * Avoid await on non thenable values.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo = await 42;
+     *
+     * // ✅ Correct
+     * const bar = await Promise.resolve(42);
+     * ```
+     * @see [@typescript-eslint/await-thenable](https://typescript-eslint.io/rules/await-thenable/)
+     */
+    [`${typescriptNamespace}/await-thenable`]: ERROR,
 
-      /**
-       * `@ts-comment` rules:
-       *
-       * -   `@ts-check` is allowed.
-       * -   `@ts-expect-error` is allowed, but only with a description.
-       * -   `@ts-ignore` is not allowed.
-       * -   `@ts-nocheck` is not allowed.
-       *
-       * @see [@typescript-eslint/ban-ts-comment](https://typescript-eslint.io/rules/ban-ts-comment/)
-       */
-      [`${typescriptNamespace}/ban-ts-comment`]: [
-        ERROR,
-        {
-          minimumDescriptionLength: 10,
-          "ts-check": false,
-          "ts-expect-error": "allow-with-description",
-          "ts-ignore": true,
-          "ts-nocheck": true,
+    /**
+     * `@ts-comment` rules:
+     *
+     * -   `@ts-check` is allowed.
+     * -   `@ts-expect-error` is allowed, but only with a description.
+     * -   `@ts-ignore` is not allowed.
+     * -   `@ts-nocheck` is not allowed.
+     *
+     * @see [@typescript-eslint/ban-ts-comment](https://typescript-eslint.io/rules/ban-ts-comment/)
+     */
+    [`${typescriptNamespace}/ban-ts-comment`]: [
+      ERROR,
+      {
+        minimumDescriptionLength: 10,
+        "ts-check": false,
+        "ts-expect-error": "allow-with-description",
+        "ts-ignore": true,
+        "ts-nocheck": true,
+      },
+    ],
+
+    /**
+     * Enforce that literals on classes are exposed in a consistent style.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * class Example {
+     *   readonly myField1 = 1;
+     *   readonly myField2 = `hello world`;
+     *   private readonly myField3 = 'hello world';
+     * }
+     *
+     * // ✅ Correct
+     * class Example {
+     *   // no readonly modifier
+     *   public myField1 = 'hello';
+     *
+     *   // not a literal
+     *   public readonly myField2 = [1, 2, 3];
+     *
+     *   public static get myField3() {
+     *     return 1;
+     *   }
+     *
+     *   private get ['myField4']() {
+     *     return 'hello world';
+     *   }
+     * }
+     * ```
+     * @see [@typescript-eslint/class-literal-property-style](https://typescript-eslint.io/rules/class-literal-property-style/)
+     */
+    [`${typescriptNamespace}/class-literal-property-style`]: [ERROR, "getters"],
+
+    /**
+     * Enforce that class methods utilize `this`. If not then it should be a function.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * class Example {
+     *   private message = "Hello, world!";
+     *   public log() {
+     *     console.log(this.message);
+     *   }
+     *   public goodbye() {
+     *     console.log("Goodbye, world!");
+     *   }
+     * }
+     *
+     * // ✅ Correct
+     * const goodbye = () => console.log("Goodbye, world!");
+     *
+     * class Example {
+     *   private message = "Hello, world!";
+     *   public log() {
+     *     console.log(this.message);
+     *   }
+     * }
+     * ```
+     * @see [@typescript-eslint/class-methods-use-this](https://typescript-eslint.io/rules/class-methods-use-this/)
+     * @see [class-methods-use-this](https://eslint.org/docs/latest/rules/class-methods-use-this)
+     */
+    [`${typescriptNamespace}/class-methods-use-this`]: ERROR,
+
+    /**
+     * Enforce specifying generic type arguments on constructor name of
+     * a constructor call.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const map: Map<string, number> = new Map();
+     * const set: Set<string> = new Set();
+     *
+     * // ✅ Correct
+     * const map = new Map<string, number>();
+     * const set = new Set<string>();
+     * ```
+     * @see [@typescript-eslint/consistent-generic-constructors](https://typescript-eslint.io/rules/consistent-generic-constructors/)
+     */
+    [`${typescriptNamespace}/consistent-generic-constructors`]: [ERROR, "constructor"],
+
+    /**
+     * Use `Record` instead of index signature.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * type Foo = { [key: string]: string; };
+     * type Bar = { [key: string]: string; bar: string; };
+     *
+     * // ✅ Correct
+     * type Foo = Record<string, string>;
+     * type Bar = Record<string, string> & { bar: string; };
+     * ```
+     * @see [@typescript-eslint/consistent-indexed-object-style](https://typescript-eslint.io/rules/consistent-indexed-object-style/)
+     */
+    [`${typescriptNamespace}/consistent-indexed-object-style`]: [ERROR, "record"],
+
+    /**
+     * Require `return` statements to either always or never specify values.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo = (): undefined => {}
+     * const bar = (flag: boolean): undefined => {
+     *   if (flag) {
+     *     return foo()
+     *   }
+     *   return;
+     * }
+     * const baz = async (flag: boolean): Promise<undefined> {
+     *   if (flag) {
+     *     return;
+     *  }
+     *   return foo();
+     * }
+     *
+     * // ✅ Correct
+     * const foo = (): void => {}
+     * const bar = (flag: boolean): void => {
+     *   if (flag) {
+     *     return foo()
+     *   }
+     *   return;
+     * }
+     * const baz = async (flag: boolean): Promise<void | number> {
+     *   if (flag) {
+     *     return 42;
+     *  }
+     *   return;
+     * }
+     * ```
+     * @see [@typescript-eslint/consistent-return](https://typescript-eslint.io/rules/consistent-return)
+     * @see [consistent-return](https://eslint.org/docs/latest/rules/consistent-return)
+     */
+    [`${typescriptNamespace}/consistent-return`]: ERROR,
+
+    /**
+     * Use `as` assertion.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo = <string>bar;
+     *
+     * // ✅ Correct
+     * const foo = bar as string;
+     * ```
+     * @see [@typescript-eslint/consistent-type-assertions](https://typescript-eslint.io/rules/consistent-type-assertions/)
+     */
+    [`${typescriptNamespace}/consistent-type-assertions`]: [
+      ERROR,
+      { assertionStyle: "as", objectLiteralTypeAssertions: "allow" },
+    ],
+
+    /**
+     * Use `type` for type definitions (instead of interfaces).
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * interface Foo { bar: string; }
+     *
+     * // ✅ Correct
+     * type Foo = { bar: string; };
+     * ```
+     * @see [@typescript-eslint/consistent-type-definitions](https://typescript-eslint.io/rules/consistent-type-definitions/)
+     */
+    [`${typescriptNamespace}/consistent-type-definitions`]: [ERROR, "type"],
+
+    /**
+     * Enforce specifying generic type arguments on constructor name of
+     * a constructor call.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const x = 1;
+     * type T = number;
+     * export { x, T };
+     *
+     * // ✅ Correct
+     * const x = 1;
+     * type T = number;
+     * export { x, type T };
+     * ```
+     * @see [@typescript-eslint/consistent-type-exports](https://typescript-eslint.io/rules/consistent-type-exports/)
+     */
+    [`${typescriptNamespace}/consistent-type-exports`]: [
+      ERROR,
+      { fixMixedExportsWithInlineTypeSpecifier: true },
+    ],
+
+    /**
+     * Enforce "typed imports".
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * import { Foo } from "./types/Foo.js";
+     *
+     * // ✅ Correct
+     * import type { Foo } from "./types/Foo.js";
+     * import { type Foo } from "./types/Foo.js";
+     * ```
+     * @see [@typescript-eslint/consistent-type-imports](https://typescript-eslint.io/rules/consistent-type-imports/)
+     */
+    [`${typescriptNamespace}/consistent-type-imports`]: [ERROR, { fixStyle: "inline-type-imports" }],
+
+    /**
+     * Enforce `default` parameters to be last.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const example = (a = 1, b) => a + b;
+     *
+     * // ✅ Correct
+     * const example = (b, a = 1) => a + b;
+     * ```
+     * @see [@typescript-eslint/default-param-last](https://typescript-eslint.io/rules/default-param-last/)
+     * @see [default-param-last](https://eslint.org/docs/latest/rules/default-param-last)
+     */
+    [`${typescriptNamespace}/default-param-last`]: ERROR,
+
+    /**
+     * Enforce `dot.notation` instead of `square["bracket"]["notation"]`.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo = bar["baz"];
+     *
+     * // ✅ Correct
+     * const foo = bar.baz;
+     * const bar = foo[foo]; // Dynamic access is allowed.
+     * ```
+     * @see [@typescript-eslint/dot-notation](https://typescript-eslint.io/rules/dot-notation/)
+     */
+    [`${typescriptNamespace}/dot-notation`]: ERROR,
+
+    /**
+     * Rely on inference instead of making return type explicit.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo = (): string => "bar";
+     *
+     * // ✅ Correct
+     * const foo = () => "bar";
+     * ```
+     * @see [@typescript-eslint/explicit-function-return-type](https://typescript-eslint.io/rules/explicit-function-return-type/)
+     */
+    [`${typescriptNamespace}/explicit-function-return-type`]: OFF,
+
+    /**
+     * When working with classes, let's be explicit about accessibility.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * class Foo {
+     *   constructor() {}
+     * }
+     *
+     * // ✅ Correct
+     * class Foo {
+     *   public constructor() {}
+     * }
+     * @see [@typescript-eslint/explicit-member-accessibility](https://typescript-eslint.io/rules/explicit-member-accessibility/)
+     */
+    [`${typescriptNamespace}/explicit-member-accessibility`]: [
+      ERROR,
+      {
+        accessibility: "explicit",
+        overrides: {
+          accessors: "explicit",
+          constructors: "explicit",
         },
-      ],
+      },
+    ],
 
-      /**
-       * Enforce that literals on classes are exposed in a consistent style.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * class Example {
-       *   readonly myField1 = 1;
-       *   readonly myField2 = `hello world`;
-       *   private readonly myField3 = 'hello world';
-       * }
-       *
-       * // ✅ Correct
-       * class Example {
-       *   // no readonly modifier
-       *   public myField1 = 'hello';
-       *
-       *   // not a literal
-       *   public readonly myField2 = [1, 2, 3];
-       *
-       *   public static get myField3() {
-       *     return 1;
-       *   }
-       *
-       *   private get ['myField4']() {
-       *     return 'hello world';
-       *   }
-       * }
-       * ```
-       * @see [@typescript-eslint/class-literal-property-style](https://typescript-eslint.io/rules/class-literal-property-style/)
-       */
-      [`${typescriptNamespace}/class-literal-property-style`]: [
-        ERROR,
-        "getters",
-      ],
+    /**
+     * Rely on inference for boundary types as well.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo = (): string => "bar";
+     *
+     * // ✅ Correct
+     * const foo = () => "bar";
+     * ```
+     * @see [@typescript-eslint/explicit-module-boundary-types](https://typescript-eslint.io/rules/explicit-module-boundary-types/)
+     */
+    [`${typescriptNamespace}/explicit-module-boundary-types`]: OFF,
 
-      /**
-       * Enforce that class methods utilize `this`. If not then it should be a function.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * class Example {
-       *   private message = "Hello, world!";
-       *   public log() {
-       *     console.log(this.message);
-       *   }
-       *   public goodbye() {
-       *     console.log("Goodbye, world!");
-       *   }
-       * }
-       *
-       * // ✅ Correct
-       * const goodbye = () => console.log("Goodbye, world!");
-       *
-       * class Example {
-       *   private message = "Hello, world!";
-       *   public log() {
-       *     console.log(this.message);
-       *   }
-       * }
-       * ```
-       * @see [@typescript-eslint/class-methods-use-this](https://typescript-eslint.io/rules/class-methods-use-this/)
-       * @see [class-methods-use-this](https://eslint.org/docs/latest/rules/class-methods-use-this)
-       */
-      [`${typescriptNamespace}/class-methods-use-this`]: ERROR,
+    /**
+     * We allow declaring variables without values in favor of `no-useless-assignment`
+     *
+     * @see [@typescript-eslint/init-declarations](https://typescript-eslint.io/rules/init-declarations/)
+     * @see [init-declarations](https://eslint.org/docs/latest/rules/init-declarations)
+     * @see [no-useless-assignment](https://eslint.org/docs/latest/rules/no-useless-assignment)
+     */
+    [`${typescriptNamespace}/init-declarations`]: OFF,
 
-      /**
-       * Enforce specifying generic type arguments on constructor name of
-       * a constructor call.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const map: Map<string, number> = new Map();
-       * const set: Set<string> = new Set();
-       *
-       * // ✅ Correct
-       * const map = new Map<string, number>();
-       * const set = new Set<string>();
-       * ```
-       * @see [@typescript-eslint/consistent-generic-constructors](https://typescript-eslint.io/rules/consistent-generic-constructors/)
-       */
-      [`${typescriptNamespace}/consistent-generic-constructors`]: [
-        ERROR,
-        "constructor",
-      ],
+    /**
+     * Max amount of parameters set to 3. More than that is too much.
+     *
+     * @see [@typescript-eslint/max-params](https://typescript-eslint.io/rules/max-params/)
+     * @see [max-params](https://eslint.org/docs/latest/rules/max-params)
+     */
+    [`${typescriptNamespace}/max-params`]: [ERROR, { max: 3 }],
 
-      /**
-       * Use `Record` instead of index signature.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * type Foo = { [key: string]: string; };
-       * type Bar = { [key: string]: string; bar: string; };
-       *
-       * // ✅ Correct
-       * type Foo = Record<string, string>;
-       * type Bar = Record<string, string> & { bar: string; };
-       * ```
-       * @see [@typescript-eslint/consistent-indexed-object-style](https://typescript-eslint.io/rules/consistent-indexed-object-style/)
-       */
-      [`${typescriptNamespace}/consistent-indexed-object-style`]: [
-        ERROR,
-        "record",
-      ],
+    /**
+     * Classes? Well, let's make those methods look like arrow functions at least.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * class Foo {
+     *   public bar() {
+     *     return "baz";
+     *   }
+     * }
+     *
+     * // ✅ Correct
+     * class Foo {
+     *   public bar = () => "baz";
+     * }
+     * ```
+     * @see [@typescript-eslint/method-signature-style](https://typescript-eslint.io/rules/method-signature-style/)
+     */
+    [`${typescriptNamespace}/method-signature-style`]: [ERROR, "property"],
 
-      /**
-       * Require `return` statements to either always or never specify values.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo = (): undefined => {}
-       * const bar = (flag: boolean): undefined => {
-       *   if (flag) {
-       *     return foo()
-       *   }
-       *   return;
-       * }
-       * const baz = async (flag: boolean): Promise<undefined> {
-       *   if (flag) {
-       *     return;
-       *  }
-       *   return foo();
-       * }
-       *
-       * // ✅ Correct
-       * const foo = (): void => {}
-       * const bar = (flag: boolean): void => {
-       *   if (flag) {
-       *     return foo()
-       *   }
-       *   return;
-       * }
-       * const baz = async (flag: boolean): Promise<void | number> {
-       *   if (flag) {
-       *     return 42;
-       *  }
-       *   return;
-       * }
-       * ```
-       * @see [@typescript-eslint/consistent-return](https://typescript-eslint.io/rules/consistent-return)
-       * @see [consistent-return](https://eslint.org/docs/latest/rules/consistent-return)
-       */
-      [`${typescriptNamespace}/consistent-return`]: ERROR,
+    /**
+     * Consistent naming:
+     *
+     * -   `camelCase`, `PascalCase` and `UPPER_CASE` for variables and enum members.
+     * -   `camelCase` and `PascalCase` for functions.
+     * -   `camelCase` for parameters, class properties, and class methods.
+     * -   `PascalCase` for classes, enums, interfaces, type aliases, type literals and type parameters.
+     *
+     * @see [@typescript-eslint/naming-convention](https://typescript-eslint.io/rules/naming-convention/)
+     */
+    [`${typescriptNamespace}/naming-convention`]: [
+      ERROR,
+      {
+        format: null, // eslint-disable-line unicorn/no-null
+        leadingUnderscore: "allow",
+        selector: "default",
+        trailingUnderscore: "forbid",
+      },
+      {
+        format: ["camelCase", "PascalCase", "UPPER_CASE"],
+        selector: ["variable", "enumMember"],
+      },
+      {
+        format: ["camelCase", "PascalCase"],
+        selector: "function",
+      },
+      {
+        format: ["camelCase"],
+        leadingUnderscore: "allow",
+        selector: ["autoAccessor", "parameter", "classProperty", "classMethod"],
+        trailingUnderscore: "forbid",
+      },
+      {
+        format: ["PascalCase"],
+        leadingUnderscore: "allow",
+        selector: ["class", "enum", "interface", "typeAlias", "typeLike", "typeParameter"],
+      },
+    ],
 
-      /**
-       * Use `as` assertion.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo = <string>bar;
-       *
-       * // ✅ Correct
-       * const foo = bar as string;
-       * ```
-       * @see [@typescript-eslint/consistent-type-assertions](https://typescript-eslint.io/rules/consistent-type-assertions/)
-       */
-      [`${typescriptNamespace}/consistent-type-assertions`]: [
-        ERROR,
-        { assertionStyle: "as", objectLiteralTypeAssertions: "allow" },
-      ],
+    /**
+     * Just use `[]` instead of `new Array()`.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo = new Array<string>();
+     *
+     * // ✅ Correct
+     * const bar = [] as Array<string>;
+     * ```
+     * @see [@typescript-eslint/no-array-constructor](https://typescript-eslint.io/rules/no-array-constructor/)
+     */
+    [`${typescriptNamespace}/no-array-constructor`]: ERROR,
 
-      /**
-       * Use `type` for type definitions (instead of interfaces).
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * interface Foo { bar: string; }
-       *
-       * // ✅ Correct
-       * type Foo = { bar: string; };
-       * ```
-       * @see [@typescript-eslint/consistent-type-definitions](https://typescript-eslint.io/rules/consistent-type-definitions/)
-       */
-      [`${typescriptNamespace}/consistent-type-definitions`]: [ERROR, "type"],
+    /**
+     * Disallow using the `delete` operator on array values.
+     *
+     * @see [@typescript-eslint/no-array-delete](https://typescript-eslint.io/rules/no-array-delete/)
+     */
+    [`${typescriptNamespace}/no-array-delete`]: ERROR,
 
-      /**
-       * Enforce specifying generic type arguments on constructor name of
-       * a constructor call.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const x = 1;
-       * type T = number;
-       * export { x, T };
-       *
-       * // ✅ Correct
-       * const x = 1;
-       * type T = number;
-       * export { x, type T };
-       * ```
-       * @see [@typescript-eslint/consistent-type-exports](https://typescript-eslint.io/rules/consistent-type-exports/)
-       */
-      [`${typescriptNamespace}/consistent-type-exports`]: [
-        ERROR,
-        { fixMixedExportsWithInlineTypeSpecifier: true },
-      ],
+    /**
+     * Avoid `.toString()` without a useful return type.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo = ({}).toString();
+     *
+     * // ✅ Correct
+     * const foo = (42).toString();
+     * ```
+     * @see [@typescript-eslint/no-base-to-string](https://typescript-eslint.io/rules/no-base-to-string/)
+     */
+    [`${typescriptNamespace}/no-base-to-string`]: ERROR,
 
-      /**
-       * Enforce "typed imports".
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * import { Foo } from "./types/Foo.js";
-       *
-       * // ✅ Correct
-       * import type { Foo } from "./types/Foo.js";
-       * import { type Foo } from "./types/Foo.js";
-       * ```
-       * @see [@typescript-eslint/consistent-type-imports](https://typescript-eslint.io/rules/consistent-type-imports/)
-       */
-      [`${typescriptNamespace}/consistent-type-imports`]: [
-        ERROR,
-        { fixStyle: "inline-type-imports" },
-      ],
+    /**
+     * Require expressions of type void to appear in statement position.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const response = alert('Are you sure?');
+     * console.log(alert('Are you sure?'));
+     *
+     * // ✅ Correct
+     * alert('Hello, world!');
+     * ```
+     * @see [@typescript-eslint/no-confusing-void-expression](https://typescript-eslint.io/rules/no-confusing-void-expression/)
+     */
+    [`${typescriptNamespace}/no-confusing-void-expression`]: [
+      ERROR,
+      { ignoreArrowShorthand: true, ignoreVoidOperator: true },
+    ],
 
-      /**
-       * Enforce `default` parameters to be last.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const example = (a = 1, b) => a + b;
-       *
-       * // ✅ Correct
-       * const example = (b, a = 1) => a + b;
-       * ```
-       * @see [@typescript-eslint/default-param-last](https://typescript-eslint.io/rules/default-param-last/)
-       * @see [default-param-last](https://eslint.org/docs/latest/rules/default-param-last)
-       */
-      [`${typescriptNamespace}/default-param-last`]: ERROR,
+    /**
+     * Disallow duplicate enum member values.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const enum E {
+     *   A = 0,
+     *   B = 0,
+     * }
+     *
+     * // ✅ Correct
+     * const enum E {
+     *   A = 0,
+     *   B = 1,
+     * }
+     * ```
+     * @see [@typescript-eslint/no-duplicate-enum-values](https://typescript-eslint.io/rules/no-duplicate-enum-values/)
+     */
+    [`${typescriptNamespace}/no-duplicate-enum-values`]: ERROR,
 
-      /**
-       * Enforce `dot.notation` instead of `square["bracket"]["notation"]`.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo = bar["baz"];
-       *
-       * // ✅ Correct
-       * const foo = bar.baz;
-       * const bar = foo[foo]; // Dynamic access is allowed.
-       * ```
-       * @see [@typescript-eslint/dot-notation](https://typescript-eslint.io/rules/dot-notation/)
-       */
-      [`${typescriptNamespace}/dot-notation`]: ERROR,
+    /**
+     * Disallow duplicate constituents of union and intersection types.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * type StringOrNumber = string | string | number;
+     * type ThisOrThat = { that: string } & { that: string };
+     *
+     * // ✅ Correct
+     * type StringOrNumber = string | number;
+     * type ThisOrThat = { this: string } & { that: string };
+     * ```
+     * @see [@typescript-eslint/no-duplicate-type-constituents](https://typescript-eslint.io/rules/no-duplicate-type-constituents/)
+     */
+    [`${typescriptNamespace}/no-duplicate-type-constituents`]: ERROR,
 
-      /**
-       * Rely on inference instead of making return type explicit.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo = (): string => "bar";
-       *
-       * // ✅ Correct
-       * const foo = () => "bar";
-       * ```
-       * @see [@typescript-eslint/explicit-function-return-type](https://typescript-eslint.io/rules/explicit-function-return-type/)
-       */
-      [`${typescriptNamespace}/explicit-function-return-type`]: OFF,
+    /**
+     * Avoid `delete` of dynamic properties.
+     *
+     * @see [@typescript-eslint/no-dynamic-delete](https://typescript-eslint.io/rules/no-dynamic-delete/)
+     */
+    [`${typescriptNamespace}/no-dynamic-delete`]: ERROR,
 
-      /**
-       * When working with classes, let's be explicit about accessibility.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * class Foo {
-       *   constructor() {}
-       * }
-       *
-       * // ✅ Correct
-       * class Foo {
-       *   public constructor() {}
-       * }
-       * @see [@typescript-eslint/explicit-member-accessibility](https://typescript-eslint.io/rules/explicit-member-accessibility/)
-       */
-      [`${typescriptNamespace}/explicit-member-accessibility`]: [
-        ERROR,
-        {
-          accessibility: "explicit",
-          overrides: {
-            accessors: "explicit",
-            constructors: "explicit",
+    /**
+     * Empty functions don't make any sense, but still we should avoid confusing `() => {}`.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo = () => {};
+     * const bar = function() {};
+     *
+     * // ✅ Correct
+     * const foo = () => undefined;
+     * const bar = function() { return undefined; };
+     * ```
+     * @see [@typescript-eslint/no-empty-function](https://typescript-eslint.io/rules/no-empty-function/)
+     */
+    [`${typescriptNamespace}/no-empty-function`]: ERROR,
+
+    /**
+     * An empty interface is useless.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * let fooValue: {};
+     * interface FooInterface {}
+     * type FooType = {};
+     *
+     * // ✅ Correct
+     * let fooValue: object;
+     * interface FooInterface {}
+     * interface FooInterface {
+     *   bar: string;
+     * };
+     * type FooType = object;
+     * ```
+     * @see [@typescript-eslint/no-empty-object-type](https://typescript-eslint.io/rules/no-empty-object-type/)
+     */
+    [`${typescriptNamespace}/no-empty-object-type`]: ERROR,
+
+    /**
+     * `any` is a really bad abstraction. Use `unknown` instead.
+     *
+     * @see [@typescript-eslint/no-explicit-any](https://typescript-eslint.io/rules/no-explicit-any/)
+     */
+    [`${typescriptNamespace}/no-explicit-any`]: ERROR,
+
+    /**
+     * A class with all statics can be turned into an object.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * class Foo {
+     *   public static bar = "baz";
+     * }
+     *
+     * // ✅ Correct
+     * const Foo = {
+     *   bar: "baz",
+     * };
+     * @see [@typescript-eslint/no-extraneous-class](https://typescript-eslint.io/rules/no-extraneous-class/)
+     */
+    [`${typescriptNamespace}/no-extraneous-class`]: ERROR,
+
+    /**
+     * Let's avoid floating (unhandled) promises.
+     *
+     * @example
+     * ```typescript
+     * const example = async () => "foo";
+     *
+     * // ❌ Incorrect
+     * example();
+     *
+     * // ✅ Correct
+     * void example();
+     * example().then(console.log).catch(console.error);`
+     * ```
+     * @see [@typescript-eslint/no-floating-promises](https://typescript-eslint.io/rules/no-floating-promises/)
+     */
+    [`${typescriptNamespace}/no-floating-promises`]: ERROR,
+
+    /**
+     * Use `for/of`, or better yet `map` or `forEach`.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * for (const key in foo) {
+     *   console.log(key);
+     * }
+     *
+     * // ✅ Correct
+     * Object.keys(foo).forEach(console.log);
+     *
+     * for (const key of Object.keys(foo)) {
+     *   console.log(key);
+     * }
+     * ```
+     * @see [@typescript-eslint/no-for-in-array](https://typescript-eslint.io/rules/no-for-in-array/)
+     */
+    [`${typescriptNamespace}/no-for-in-array`]: ERROR,
+
+    /**
+     * This is super insecure, avoid it at all costs.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const timeout = setTimeout("alert(`Hi!`);", 100);
+     * const fn = new Function("a", "b", "return a + b");
+     *
+     * // ✅ Correct
+     * const timeout = setTimeout(() => alert(`Hi!`), 100);
+     * const fn = (a, b) => a + b;
+     * ```
+     * @see [@typescript-eslint/no-implied-eval](https://typescript-eslint.io/rules/no-implied-eval/)
+     */
+    [`${typescriptNamespace}/no-implied-eval`]: ERROR,
+
+    /**
+     * Enforce the use of top-level import type qualifier when an import only has specifiers with inline type qualifiers.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * import { type A, type B } from 'library';
+     *
+     * // ✅ Correct
+     * import type { A, B } from 'library';
+     * ```
+     * @see [@typescript-eslint/no-import-type-side-effects](https://typescript-eslint.io/rules/no-import-type-side-effects/)
+     */
+    [`${typescriptNamespace}/no-import-type-side-effects`]: ERROR,
+
+    /**
+     * We want to rely on inference.
+     *
+     * @see [@typescript-eslint/no-inferrable-types](https://typescript-eslint.io/rules/no-inferrable-types/)
+     */
+    [`${typescriptNamespace}/no-inferrable-types`]: OFF,
+
+    /**
+     * Avoid using `this` outside a class.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * function foo() {
+     *   console.log(this);
+     * }
+     *
+     * // ✅ Correct
+     * class Foo {
+     *   public bar() {
+     *     console.log(this);
+     *   }
+     * }
+     * ```
+     * @see [@typescript-eslint/no-invalid-this](https://typescript-eslint.io/rules/no-invalid-this/)
+     */
+    [`${typescriptNamespace}/no-invalid-this`]: ERROR,
+
+    /**
+     * Avoid `void` for types, use `undefined` instead.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo: number | void = undefined;
+     *
+     * // ✅ Correct
+     * const foo: number | undefined = undefined;
+     * ```
+     * @see [@typescript-eslint/no-invalid-void-type](https://typescript-eslint.io/rules/no-invalid-void-type/)
+     */
+    [`${typescriptNamespace}/no-invalid-void-type`]: ERROR,
+
+    /**
+     * Avoid defining functions inside loops.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * for (const i = 0; i < 10; i++) {
+     *     const add2 = (n: number) => n + 2;
+     *     console.log(add2(i));
+     * }
+     *
+     * // ✅ Correct
+     * const add2 = (n: number) => n + 2;
+     *
+     * for (const i = 0; i < 10; i++) {
+     *     console.log(add2(i));
+     * }
+     * ```
+     * @see [@typescript-eslint/no-loop-func](https://typescript-eslint.io/rules/no-loop-func/)
+     */
+    [`${typescriptNamespace}/no-loop-func`]: ERROR,
+
+    /**
+     * Disallow the `void` operator except when used to discard a value.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * void (() => undefined)();
+     *
+     * // ✅ Correct
+     * void (() => "value")();
+     * ```
+     * @see [@typescript-eslint/no-meaningless-void-operator](https://typescript-eslint.io/rules/no-meaningless-void-operator/)
+     */
+    [`${typescriptNamespace}/no-meaningless-void-operator`]: ERROR,
+
+    /**
+     * Avoid missuses of the `new` declaration.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * declare class Foo {
+     *   new(): Foo;
+     * }
+     *
+     * // ✅ Correct
+     * declare class Foo {
+     *   constructor();
+     * }
+     * ```
+     * @see [@typescript-eslint/no-misused-new](https://typescript-eslint.io/rules/no-misused-new/)
+     */
+    [`${typescriptNamespace}/no-misused-new`]: ERROR,
+
+    /**
+     * Avoid missuses of promises.
+     *
+     * @example
+     * ```typescript
+     * const aPromise = Promise.resolve("foo");
+     *
+     * // ❌ Incorrect
+     * aPromise ? "foo" : "bar";
+     *
+     * // ✅ Correct
+     * (await aPromise) ? "foo" : "bar";
+     * ```
+     * @see [@typescript-eslint/no-misused-promises](https://typescript-eslint.io/rules/no-misused-promises/)
+     */
+    [`${typescriptNamespace}/no-misused-promises`]: ERROR,
+
+    /**
+     * Disallow enums from having both number and string members.
+     *
+     * @example
+     * ```typescript
+     * const aPromise = Promise.resolve("foo");
+     *
+     * // ❌ Incorrect
+     * const enum Status {
+     *   Unknown,
+     *   Closed = 1,
+     *   Open = 'open',
+     * }
+     *
+     * // ✅ Correct
+     * const enum Status {
+     *   Unknown = 0,
+     *   Closed = 2,
+     *   Open = 4,
+     * }
+     * ```
+     * @see [@typescript-eslint/no-mixed-enums](https://typescript-eslint.io/rules/no-mixed-enums/)
+     */
+    [`${typescriptNamespace}/no-mixed-enums`]: ERROR,
+
+    /**
+     * Old TypeScript.
+     *
+     * @see [@typescript-eslint/no-namespace](https://typescript-eslint.io/rules/no-namespace/)
+     */
+    [`${typescriptNamespace}/no-namespace`]: ERROR,
+
+    /**
+     * Prevents using non-null assertion with nullish coalescing.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo = bar! ?? "foo";
+     *
+     * // ✅ Correct
+     * const foo = bar ?? "foo";
+     * ```
+     * @see [@typescript-eslint/no-non-null-asserted-nullish-coalescing](https://typescript-eslint.io/rules/no-non-null-asserted-nullish-coalescing/)
+     */
+    [`${typescriptNamespace}/no-non-null-asserted-nullish-coalescing`]: ERROR,
+
+    /**
+     * Avoid null assertion (`value!`), a really unsafe TypeScript operator.
+     *
+     * @see [@typescript-eslint/no-non-null-assertion](https://typescript-eslint.io/rules/no-non-null-assertion/)
+     */
+    [`${typescriptNamespace}/no-non-null-assertion`]: WARN,
+
+    /**
+     * Disallow members of unions and intersections that do nothing or override type information.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * type UnionAny = any | 'foo';
+     * type UnionUnknown = unknown | 'foo';
+     * type UnionNever = never | 'foo';
+     * type UnionBooleanLiteral = boolean | false;
+     * type UnionNumberLiteral = number | 1;
+     * type UnionStringLiteral = string | 'foo';
+     * type IntersectionAny = any & 'foo';
+     * type IntersectionUnknown = string & unknown;
+     * type IntersectionNever = string | never;
+     * type IntersectionBooleanLiteral = boolean & false;
+     * type IntersectionNumberLiteral = number & 1;
+     * type IntersectionStringLiteral = string & 'foo';
+     * ```
+     * @see [@typescript-eslint/no-redundant-type-constituents](https://typescript-eslint.io/rules/no-redundant-type-constituents/)
+     */
+    [`${typescriptNamespace}/no-redundant-type-constituents`]: ERROR,
+
+    /**
+     * Use ECMAScript `import` and `export` instead of `require` and `module.exports`.
+     *
+     * @see [@typescript-eslint/no-require-imports](https://typescript-eslint.io/rules/no-require-imports/)
+     */
+    [`${typescriptNamespace}/no-require-imports`]: ERROR,
+
+    /**
+     * Disallow specified modules when loaded by `import`. Disabled imports
+     * are:
+     * -   jQuery.
+     * -   jQuery UI.
+     * -   Lodash.
+     * -   Moment.
+     * -   Underscore.
+     *
+     * @see [@typescript-eslint/no-restricted-imports](https://typescript-eslint.io/rules/no-restricted-imports/)
+     * @see [no-restricted-imports](https://eslint.org/docs/latest/rules/no-restricted-imports)
+     */
+    [`${typescriptNamespace}/no-restricted-imports`]: [
+      ERROR,
+      {
+        patterns: [
+          {
+            group: ["jquery", "lodash", "lodash-es", "lodash.*", "lodash/*", "underscore"],
+            message: "Just use vanilla JavaScript.",
           },
-        },
-      ],
-
-      /**
-       * Rely on inference for boundary types as well.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo = (): string => "bar";
-       *
-       * // ✅ Correct
-       * const foo = () => "bar";
-       * ```
-       * @see [@typescript-eslint/explicit-module-boundary-types](https://typescript-eslint.io/rules/explicit-module-boundary-types/)
-       */
-      [`${typescriptNamespace}/explicit-module-boundary-types`]: OFF,
-
-      /**
-       * We allow declaring variables without values in favor of `no-useless-assignment`
-       *
-       * @see [@typescript-eslint/init-declarations](https://typescript-eslint.io/rules/init-declarations/)
-       * @see [init-declarations](https://eslint.org/docs/latest/rules/init-declarations)
-       * @see [no-useless-assignment](https://eslint.org/docs/latest/rules/no-useless-assignment)
-       */
-      [`${typescriptNamespace}/init-declarations`]: OFF,
-
-      /**
-       * Max amount of parameters set to 3. More than that is too much.
-       *
-       * @see [@typescript-eslint/max-params](https://typescript-eslint.io/rules/max-params/)
-       * @see [max-params](https://eslint.org/docs/latest/rules/max-params)
-       */
-      [`${typescriptNamespace}/max-params`]: [ERROR, { max: 3 }],
-
-      /**
-       * Classes? Well, let's make those methods look like arrow functions at least.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * class Foo {
-       *   public bar() {
-       *     return "baz";
-       *   }
-       * }
-       *
-       * // ✅ Correct
-       * class Foo {
-       *   public bar = () => "baz";
-       * }
-       * ```
-       * @see [@typescript-eslint/method-signature-style](https://typescript-eslint.io/rules/method-signature-style/)
-       */
-      [`${typescriptNamespace}/method-signature-style`]: [ERROR, "property"],
-
-      /**
-       * Consistent naming:
-       *
-       * -   `camelCase`, `PascalCase` and `UPPER_CASE` for variables and enum members.
-       * -   `camelCase` and `PascalCase` for functions.
-       * -   `camelCase` for parameters, class properties, and class methods.
-       * -   `PascalCase` for classes, enums, interfaces, type aliases, type literals and type parameters.
-       *
-       * @see [@typescript-eslint/naming-convention](https://typescript-eslint.io/rules/naming-convention/)
-       */
-      [`${typescriptNamespace}/naming-convention`]: [
-        ERROR,
-        {
-          format: null, // eslint-disable-line unicorn/no-null
-          leadingUnderscore: "allow",
-          selector: "default",
-          trailingUnderscore: "forbid",
-        },
-        {
-          format: ["camelCase", "PascalCase", "UPPER_CASE"],
-          selector: ["variable", "enumMember"],
-        },
-        {
-          format: ["camelCase", "PascalCase"],
-          selector: "function",
-        },
-        {
-          format: ["camelCase"],
-          leadingUnderscore: "allow",
-          selector: [
-            "autoAccessor",
-            "parameter",
-            "classProperty",
-            "classMethod",
-          ],
-          trailingUnderscore: "forbid",
-        },
-        {
-          format: ["PascalCase"],
-          leadingUnderscore: "allow",
-          selector: [
-            "class",
-            "enum",
-            "interface",
-            "typeAlias",
-            "typeLike",
-            "typeParameter",
-          ],
-        },
-      ],
-
-      /**
-       * Just use `[]` instead of `new Array()`.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo = new Array<string>();
-       *
-       * // ✅ Correct
-       * const bar = [] as Array<string>;
-       * ```
-       * @see [@typescript-eslint/no-array-constructor](https://typescript-eslint.io/rules/no-array-constructor/)
-       */
-      [`${typescriptNamespace}/no-array-constructor`]: ERROR,
-
-      /**
-       * Disallow using the `delete` operator on array values.
-       *
-       * @see [@typescript-eslint/no-array-delete](https://typescript-eslint.io/rules/no-array-delete/)
-       */
-      [`${typescriptNamespace}/no-array-delete`]: ERROR,
-
-      /**
-       * Avoid `.toString()` without a useful return type.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo = ({}).toString();
-       *
-       * // ✅ Correct
-       * const foo = (42).toString();
-       * ```
-       * @see [@typescript-eslint/no-base-to-string](https://typescript-eslint.io/rules/no-base-to-string/)
-       */
-      [`${typescriptNamespace}/no-base-to-string`]: ERROR,
-
-      /**
-       * Require expressions of type void to appear in statement position.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const response = alert('Are you sure?');
-       * console.log(alert('Are you sure?'));
-       *
-       * // ✅ Correct
-       * alert('Hello, world!');
-       * ```
-       * @see [@typescript-eslint/no-confusing-void-expression](https://typescript-eslint.io/rules/no-confusing-void-expression/)
-       */
-      [`${typescriptNamespace}/no-confusing-void-expression`]: [
-        ERROR,
-        { ignoreArrowShorthand: true, ignoreVoidOperator: true },
-      ],
-
-      /**
-       * Disallow duplicate enum member values.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const enum E {
-       *   A = 0,
-       *   B = 0,
-       * }
-       *
-       * // ✅ Correct
-       * const enum E {
-       *   A = 0,
-       *   B = 1,
-       * }
-       * ```
-       * @see [@typescript-eslint/no-duplicate-enum-values](https://typescript-eslint.io/rules/no-duplicate-enum-values/)
-       */
-      [`${typescriptNamespace}/no-duplicate-enum-values`]: ERROR,
-
-      /**
-       * Disallow duplicate constituents of union and intersection types.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * type StringOrNumber = string | string | number;
-       * type ThisOrThat = { that: string } & { that: string };
-       *
-       * // ✅ Correct
-       * type StringOrNumber = string | number;
-       * type ThisOrThat = { this: string } & { that: string };
-       * ```
-       * @see [@typescript-eslint/no-duplicate-type-constituents](https://typescript-eslint.io/rules/no-duplicate-type-constituents/)
-       */
-      [`${typescriptNamespace}/no-duplicate-type-constituents`]: ERROR,
-
-      /**
-       * Avoid `delete` of dynamic properties.
-       *
-       * @see [@typescript-eslint/no-dynamic-delete](https://typescript-eslint.io/rules/no-dynamic-delete/)
-       */
-      [`${typescriptNamespace}/no-dynamic-delete`]: ERROR,
-
-      /**
-       * Empty functions don't make any sense, but still we should avoid confusing `() => {}`.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo = () => {};
-       * const bar = function() {};
-       *
-       * // ✅ Correct
-       * const foo = () => undefined;
-       * const bar = function() { return undefined; };
-       * ```
-       * @see [@typescript-eslint/no-empty-function](https://typescript-eslint.io/rules/no-empty-function/)
-       */
-      [`${typescriptNamespace}/no-empty-function`]: ERROR,
-
-      /**
-       * An empty interface is useless.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * let fooValue: {};
-       * interface FooInterface {}
-       * type FooType = {};
-       *
-       * // ✅ Correct
-       * let fooValue: object;
-       * interface FooInterface {}
-       * interface FooInterface {
-       *   bar: string;
-       * };
-       * type FooType = object;
-       * ```
-       * @see [@typescript-eslint/no-empty-object-type](https://typescript-eslint.io/rules/no-empty-object-type/)
-       */
-      [`${typescriptNamespace}/no-empty-object-type`]: ERROR,
-
-      /**
-       * `any` is a really bad abstraction. Use `unknown` instead.
-       *
-       * @see [@typescript-eslint/no-explicit-any](https://typescript-eslint.io/rules/no-explicit-any/)
-       */
-      [`${typescriptNamespace}/no-explicit-any`]: ERROR,
-
-      /**
-       * A class with all statics can be turned into an object.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * class Foo {
-       *   public static bar = "baz";
-       * }
-       *
-       * // ✅ Correct
-       * const Foo = {
-       *   bar: "baz",
-       * };
-       * @see [@typescript-eslint/no-extraneous-class](https://typescript-eslint.io/rules/no-extraneous-class/)
-       */
-      [`${typescriptNamespace}/no-extraneous-class`]: ERROR,
-
-      /**
-       * Let's avoid floating (unhandled) promises.
-       *
-       * @example
-       * ```typescript
-       * const example = async () => "foo";
-       *
-       * // ❌ Incorrect
-       * example();
-       *
-       * // ✅ Correct
-       * void example();
-       * example().then(console.log).catch(console.error);`
-       * ```
-       * @see [@typescript-eslint/no-floating-promises](https://typescript-eslint.io/rules/no-floating-promises/)
-       */
-      [`${typescriptNamespace}/no-floating-promises`]: ERROR,
-
-      /**
-       * Use `for/of`, or better yet `map` or `forEach`.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * for (const key in foo) {
-       *   console.log(key);
-       * }
-       *
-       * // ✅ Correct
-       * Object.keys(foo).forEach(console.log);
-       *
-       * for (const key of Object.keys(foo)) {
-       *   console.log(key);
-       * }
-       * ```
-       * @see [@typescript-eslint/no-for-in-array](https://typescript-eslint.io/rules/no-for-in-array/)
-       */
-      [`${typescriptNamespace}/no-for-in-array`]: ERROR,
-
-      /**
-       * This is super insecure, avoid it at all costs.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const timeout = setTimeout("alert(`Hi!`);", 100);
-       * const fn = new Function("a", "b", "return a + b");
-       *
-       * // ✅ Correct
-       * const timeout = setTimeout(() => alert(`Hi!`), 100);
-       * const fn = (a, b) => a + b;
-       * ```
-       * @see [@typescript-eslint/no-implied-eval](https://typescript-eslint.io/rules/no-implied-eval/)
-       */
-      [`${typescriptNamespace}/no-implied-eval`]: ERROR,
-
-      /**
-       * Enforce the use of top-level import type qualifier when an import only has specifiers with inline type qualifiers.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * import { type A, type B } from 'library';
-       *
-       * // ✅ Correct
-       * import type { A, B } from 'library';
-       * ```
-       * @see [@typescript-eslint/no-import-type-side-effects](https://typescript-eslint.io/rules/no-import-type-side-effects/)
-       */
-      [`${typescriptNamespace}/no-import-type-side-effects`]: ERROR,
-
-      /**
-       * We want to rely on inference.
-       *
-       * @see [@typescript-eslint/no-inferrable-types](https://typescript-eslint.io/rules/no-inferrable-types/)
-       */
-      [`${typescriptNamespace}/no-inferrable-types`]: OFF,
-
-      /**
-       * Avoid using `this` outside a class.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * function foo() {
-       *   console.log(this);
-       * }
-       *
-       * // ✅ Correct
-       * class Foo {
-       *   public bar() {
-       *     console.log(this);
-       *   }
-       * }
-       * ```
-       * @see [@typescript-eslint/no-invalid-this](https://typescript-eslint.io/rules/no-invalid-this/)
-       */
-      [`${typescriptNamespace}/no-invalid-this`]: ERROR,
-
-      /**
-       * Avoid `void` for types, use `undefined` instead.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo: number | void = undefined;
-       *
-       * // ✅ Correct
-       * const foo: number | undefined = undefined;
-       * ```
-       * @see [@typescript-eslint/no-invalid-void-type](https://typescript-eslint.io/rules/no-invalid-void-type/)
-       */
-      [`${typescriptNamespace}/no-invalid-void-type`]: ERROR,
-
-      /**
-       * Avoid defining functions inside loops.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * for (const i = 0; i < 10; i++) {
-       *     const add2 = (n: number) => n + 2;
-       *     console.log(add2(i));
-       * }
-       *
-       * // ✅ Correct
-       * const add2 = (n: number) => n + 2;
-       *
-       * for (const i = 0; i < 10; i++) {
-       *     console.log(add2(i));
-       * }
-       * ```
-       * @see [@typescript-eslint/no-loop-func](https://typescript-eslint.io/rules/no-loop-func/)
-       */
-      [`${typescriptNamespace}/no-loop-func`]: ERROR,
-
-      /**
-       * Disallow the `void` operator except when used to discard a value.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * void (() => undefined)();
-       *
-       * // ✅ Correct
-       * void (() => "value")();
-       * ```
-       * @see [@typescript-eslint/no-meaningless-void-operator](https://typescript-eslint.io/rules/no-meaningless-void-operator/)
-       */
-      [`${typescriptNamespace}/no-meaningless-void-operator`]: ERROR,
-
-      /**
-       * Avoid missuses of the `new` declaration.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * declare class Foo {
-       *   new(): Foo;
-       * }
-       *
-       * // ✅ Correct
-       * declare class Foo {
-       *   constructor();
-       * }
-       * ```
-       * @see [@typescript-eslint/no-misused-new](https://typescript-eslint.io/rules/no-misused-new/)
-       */
-      [`${typescriptNamespace}/no-misused-new`]: ERROR,
-
-      /**
-       * Avoid missuses of promises.
-       *
-       * @example
-       * ```typescript
-       * const aPromise = Promise.resolve("foo");
-       *
-       * // ❌ Incorrect
-       * aPromise ? "foo" : "bar";
-       *
-       * // ✅ Correct
-       * (await aPromise) ? "foo" : "bar";
-       * ```
-       * @see [@typescript-eslint/no-misused-promises](https://typescript-eslint.io/rules/no-misused-promises/)
-       */
-      [`${typescriptNamespace}/no-misused-promises`]: ERROR,
-
-      /**
-       * Disallow enums from having both number and string members.
-       *
-       * @example
-       * ```typescript
-       * const aPromise = Promise.resolve("foo");
-       *
-       * // ❌ Incorrect
-       * const enum Status {
-       *   Unknown,
-       *   Closed = 1,
-       *   Open = 'open',
-       * }
-       *
-       * // ✅ Correct
-       * const enum Status {
-       *   Unknown = 0,
-       *   Closed = 2,
-       *   Open = 4,
-       * }
-       * ```
-       * @see [@typescript-eslint/no-mixed-enums](https://typescript-eslint.io/rules/no-mixed-enums/)
-       */
-      [`${typescriptNamespace}/no-mixed-enums`]: ERROR,
-
-      /**
-       * Old TypeScript.
-       *
-       * @see [@typescript-eslint/no-namespace](https://typescript-eslint.io/rules/no-namespace/)
-       */
-      [`${typescriptNamespace}/no-namespace`]: ERROR,
-
-      /**
-       * Prevents using non-null assertion with nullish coalescing.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo = bar! ?? "foo";
-       *
-       * // ✅ Correct
-       * const foo = bar ?? "foo";
-       * ```
-       * @see [@typescript-eslint/no-non-null-asserted-nullish-coalescing](https://typescript-eslint.io/rules/no-non-null-asserted-nullish-coalescing/)
-       */
-      [`${typescriptNamespace}/no-non-null-asserted-nullish-coalescing`]: ERROR,
-
-      /**
-       * Avoid null assertion (`value!`), a really unsafe TypeScript operator.
-       *
-       * @see [@typescript-eslint/no-non-null-assertion](https://typescript-eslint.io/rules/no-non-null-assertion/)
-       */
-      [`${typescriptNamespace}/no-non-null-assertion`]: WARN,
-
-      /**
-       * Disallow members of unions and intersections that do nothing or override type information.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * type UnionAny = any | 'foo';
-       * type UnionUnknown = unknown | 'foo';
-       * type UnionNever = never | 'foo';
-       * type UnionBooleanLiteral = boolean | false;
-       * type UnionNumberLiteral = number | 1;
-       * type UnionStringLiteral = string | 'foo';
-       * type IntersectionAny = any & 'foo';
-       * type IntersectionUnknown = string & unknown;
-       * type IntersectionNever = string | never;
-       * type IntersectionBooleanLiteral = boolean & false;
-       * type IntersectionNumberLiteral = number & 1;
-       * type IntersectionStringLiteral = string & 'foo';
-       * ```
-       * @see [@typescript-eslint/no-redundant-type-constituents](https://typescript-eslint.io/rules/no-redundant-type-constituents/)
-       */
-      [`${typescriptNamespace}/no-redundant-type-constituents`]: ERROR,
-
-      /**
-       * Use ECMAScript `import` and `export` instead of `require` and `module.exports`.
-       *
-       * @see [@typescript-eslint/no-require-imports](https://typescript-eslint.io/rules/no-require-imports/)
-       */
-      [`${typescriptNamespace}/no-require-imports`]: ERROR,
-
-      /**
-       * Disallow specified modules when loaded by `import`. Disabled imports
-       * are:
-       * -   jQuery.
-       * -   jQuery UI.
-       * -   Lodash.
-       * -   Moment.
-       * -   Underscore.
-       *
-       * @see [@typescript-eslint/no-restricted-imports](https://typescript-eslint.io/rules/no-restricted-imports/)
-       * @see [no-restricted-imports](https://eslint.org/docs/latest/rules/no-restricted-imports)
-       */
-      [`${typescriptNamespace}/no-restricted-imports`]: [
-        ERROR,
-        {
-          patterns: [
-            {
-              group: [
-                "jquery",
-                "lodash",
-                "lodash-es",
-                "lodash.*",
-                "lodash/*",
-                "underscore",
-              ],
-              message: "Just use vanilla JavaScript.",
-            },
-            {
-              group: ["jquery-ui", "moment"],
-              message: "Use a modern dependency instead.",
-            },
-          ],
-        },
-      ],
-
-      /**
-       * Avoid name shadowing (`_` is allowed).
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const bar = "foo";
-       * const foo = (bar: string) => bar;
-       *
-       * // ✅ Correct
-       * const bar = "foo";
-       * const foo = (baz: string) => baz;
-       * ```
-       * @see [@typescript-eslint/no-shadow](https://typescript-eslint.io/rules/no-shadow/)
-       */
-      [`${typescriptNamespace}/no-shadow`]: [
-        ERROR,
-        { allow: ["_"], hoist: "all" },
-      ],
-
-      /**
-       * Just use arrow functions, _this/that aliases are no longer needed.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo = function () {
-       *   const that = this;
-       *   return function() {
-       *     return that;
-       *   };
-       * }
-       *
-       * // ✅ Correct
-       * const foo = function() {
-       *   return () => this;
-       * };
-       * ```
-       * @see [@typescript-eslint/no-this-alias](https://typescript-eslint.io/rules/no-this-alias/)
-       */
-      [`${typescriptNamespace}/no-this-alias`]: ERROR,
-
-      /**
-       * If it's a `boolean`, use it as such.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * if (foo === true) // …
-       *
-       * // ✅ Correct
-       * if (foo) // …
-       * ```
-       * @see [@typescript-eslint/no-unnecessary-boolean-literal-compare](https://typescript-eslint.io/rules/no-unnecessary-boolean-literal-compare/)
-       */
-      [`${typescriptNamespace}/no-unnecessary-boolean-literal-compare`]: ERROR,
-
-      /**
-       * Avoid conditions with values that can't be falsy.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const check = (value: "foo" | "bar") => {
-       *   if (value) // value will never be falsy
-       * }
-       *
-       * // ✅ Correct
-       * const check = (value: string) => {
-       *   if (value) // Necessary, since value might be ""
-       * }
-       * ```
-       * @see [@typescript-eslint/no-unnecessary-condition](https://typescript-eslint.io/rules/no-unnecessary-condition/)
-       */
-      [`${typescriptNamespace}/no-unnecessary-condition`]: ERROR,
-
-      /**
-       * Disallow unnecessary assignment of constructor property parameter.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * class Foo {
-       *   constructor(public bar: string) {
-       *     this.bar = bar;
-       *   }
-       * }
-       *
-       * // ✅ Correct
-       * class Foo {
-       *   constructor(public bar: string) {}
-       * }
-       * ```
-       * @see [@typescript-eslint/no-unnecessary-parameter-property-assignment](https://typescript-eslint.io/rules/no-unnecessary-parameter-property-assignment/)
-       */
-      [`${typescriptNamespace}/no-unnecessary-parameter-property-assignment`]:
-        ERROR,
-
-      /**
-       * Disallow unnecessary namespace qualifiers.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * enum A {
-       *   B,
-       *   C = A.B,
-       * }
-       *
-       * // ✅ Correct
-       * enum A {
-       *   B,
-       *   C = B,
-       * }
-       * ```
-       * @see [@typescript-eslint/no-unnecessary-qualifier](https://typescript-eslint.io/rules/no-unnecessary-qualifier/)
-       */
-      [`${typescriptNamespace}/no-unnecessary-qualifier`]: ERROR,
-
-      /**
-       * Disallow unnecessary template expressions.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * `${'a'}${'b'}`
-       *
-       * // ✅ Correct
-       * "ab"
-       * ```
-       * @see [@typescript-eslint/no-unnecessary-template-expression](https://typescript-eslint.io/rules/no-unnecessary-template-expression/)
-       */
-      [`${typescriptNamespace}/no-unnecessary-template-expression`]: ERROR,
-
-      /**
-       * If the type assertion is the same, skip it.
-       *
-       * @example
-       * ```typescript
-       * const example = <Value = string>(value: Value) => value;
-       *
-       * // ❌ Incorrect
-       * example<string>("hello");
-       *
-       * // ✅ Correct
-       * example("hello");
-       * ```
-       * @see [@typescript-eslint/no-unnecessary-type-arguments](https://typescript-eslint.io/rules/no-unnecessary-type-arguments/)
-       */
-      [`${typescriptNamespace}/no-unnecessary-type-arguments`]: ERROR,
-
-      /**
-       * Don't assert something that doesn't need assertion.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo = "bar" as string;
-       * ```
-       * @see [@typescript-eslint/no-unnecessary-type-assertion](https://typescript-eslint.io/rules/no-unnecessary-type-assertion/)
-       */
-      [`${typescriptNamespace}/no-unnecessary-type-assertion`]: ERROR,
-
-      /**
-       * Don't do `extends any` or `extends unknown`. That's the default.
-       *
-       * @see [@typescript-eslint/no-unnecessary-type-constraint](https://typescript-eslint.io/rules/no-unnecessary-type-constraint/)
-       */
-      [`${typescriptNamespace}/no-unnecessary-type-constraint`]: ERROR,
-
-      /**
-       * Disallow type parameters that only appear once.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const second = <A, B>(a: A, b: B): B => b;
-       *
-       * // ✅ Correct
-       * const second = <B>(a: unknown, b: B): B => b;
-       * ```
-       * @see [@typescript-eslint/no-unnecessary-type-parameters](https://typescript-eslint.io/rules/no-unnecessary-type-parameters/)
-       */
-      [`${typescriptNamespace}/no-unnecessary-type-parameters`]: ERROR,
-
-      /**
-       * Disallows calling an function with an `any` type value.
-       *
-       * @see [@typescript-eslint/no-unsafe-argument](https://typescript-eslint.io/rules/no-unsafe-argument/)
-       */
-      [`${typescriptNamespace}/no-unsafe-argument`]: ERROR,
-
-      /**
-       * Avoid `any` assignments.
-       *
-       * @see [@typescript-eslint/no-unsafe-assignment](https://typescript-eslint.io/rules/no-unsafe-assignment/)
-       */
-      [`${typescriptNamespace}/no-unsafe-assignment`]: ERROR,
-
-      /**
-       * Avoid calling `any`.
-       *
-       * @see [@typescript-eslint/no-unsafe-call](https://typescript-eslint.io/rules/no-unsafe-call/)
-       */
-      [`${typescriptNamespace}/no-unsafe-call`]: ERROR,
-
-      /**
-       * Disallow unsafe declaration merging.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * interface Foo {}
-       * class Foo {}
-       * ```
-       * @see [@typescript-eslint/no-unsafe-declaration-merging](https://typescript-eslint.io/rules/no-unsafe-declaration-merging/)
-       */
-      [`${typescriptNamespace}/no-unsafe-declaration-merging`]: ERROR,
-
-      /**
-       * Disallow comparing an enum value with a non-enum value.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const enum Fruit {
-       *   Apple = 0,
-       * }
-       *
-       * declare let fruit: Fruit;
-       *
-       * fruit === 0;
-       *
-       * // ✅ Correct
-       * const enum Fruit {
-       *   Apple = 0,
-       * }
-       *
-       * declare let fruit: Fruit;
-       *
-       * fruit === Fruit.Apple;
-       * ```
-       * @see [@typescript-eslint/no-unsafe-enum-comparison](https://typescript-eslint.io/rules/no-unsafe-enum-comparison/)
-       */
-      [`${typescriptNamespace}/no-unsafe-enum-comparison`]: ERROR,
-
-      /**
-       * Avoid accessing `any` members.
-       *
-       * @see [@typescript-eslint/no-unsafe-member-access](https://typescript-eslint.io/rules/no-unsafe-member-access/)
-       */
-      [`${typescriptNamespace}/no-unsafe-member-access`]: ERROR,
-
-      /**
-       * Avoid returning `any`.
-       *
-       * @see [@typescript-eslint/no-unsafe-return](https://typescript-eslint.io/rules/no-unsafe-return/)
-       */
-      [`${typescriptNamespace}/no-unsafe-return`]: ERROR,
-
-      /**
-       * Require unary negation to take a number.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * declare const a: string;
-       * -a;
-       *
-       * // ✅ Correct
-       * declare const a: number;
-       * -a;
-       * ```
-       * @see [@typescript-eslint/no-unsafe-unary-minus](https://typescript-eslint.io/rules/no-unsafe-unary-minus/)
-       */
-      [`${typescriptNamespace}/no-unsafe-unary-minus`]: ERROR,
-
-      /**
-       * Don't just leave expressions lying around! Use them!
-       *
-       * @see [no-unused-expressions](https://eslint.org/docs/latest/rules/no-unused-expressions)
-       * @see [@typescript-eslint/no-unused-expressions](https://typescript-eslint.io/rules/no-unused-expressions/)
-       */
-      [`${typescriptNamespace}/no-unused-expressions`]: ERROR,
-
-      /**
-       * Avoid using something before is defined.
-       *
-       * @see [no-use-before-define](https://eslint.org/docs/latest/rules/no-use-before-define)
-       * @see [@typescript-eslint/no-use-before-define](https://typescript-eslint.io/rules/no-use-before-define/)
-       */
-      [`${typescriptNamespace}/no-use-before-define`]: ERROR,
-
-      /**
-       * When working with classes, let's not define useless constructors (constructors that only call `super`).
-       *
-       * @see [no-useless-constructor](https://eslint.org/docs/latest/rules/no-useless-constructor)
-       * @see [@typescript-eslint/no-useless-constructor](https://typescript-eslint.io/rules/no-useless-constructor/)
-       */
-      [`${typescriptNamespace}/no-useless-constructor`]: ERROR,
-
-      /**
-       * Disallow empty exports that don't change anything in a module file.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * export const value = 'Hello, world!';
-       * export {};
-       *
-       * // ✅ Correct
-       * export const value = 'Hello, world!';
-       * ```
-       * @see [@typescript-eslint/no-useless-empty-export](https://typescript-eslint.io/rules/no-useless-empty-export/)
-       */
-      [`${typescriptNamespace}/no-useless-empty-export`]: ERROR,
-
-      /**
-       * Disallow using confusing built-in primitive class wrappers.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * let myBigInt: BigInt;
-       * let myBoolean: Boolean;
-       * let myNumber: Number;
-       * let myString: String;
-       * let mySymbol: Symbol;
-       * let myObject: Object;
-       *
-       * // ✅ Correct
-       * let myBigInt: bigint;
-       * let myBoolean: boolean;
-       * let myNumber: number;
-       * let myString: string;
-       * let mySymbol: symbol;
-       * let myObject: object;
-       * ```
-       * @see [@typescript-eslint/no-wrapper-object-types](https://typescript-eslint.io/rules/no-wrapper-object-types/)
-       */
-      [`${typescriptNamespace}/no-wrapper-object-types`]: ERROR,
-
-      /**
-       * If you'll throw, throw errors, not literals.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * throw 'foo';
-       *
-       * // ✅ Correct
-       * throw new Error('foo');
-       * ```
-       * @see [@typescript-eslint/only-throw-error](https://typescript-eslint.io/rules/only-throw-error/)
-       * @see [no-throw-literal](https://eslint.org/docs/latest/rules/no-throw-literal)
-       */
-      [`${typescriptNamespace}/only-throw-error`]: ERROR,
-
-      /**
-       * Disallow parameter properties in class constructors.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * class Example {
-       *   constructor (private name: string) {}
-       * }
-       *
-       * // ✅ Correct
-       * class Example {
-       *   private name: string;
-       *   constructor (name: string) {
-       *     this.name = name;
-       *   }
-       * }
-       * ```
-       * @see [@typescript-eslint/parameter-properties](https://typescript-eslint.io/rules/parameter-properties/)
-       */
-      [`${typescriptNamespace}/parameter-properties`]: [
-        ERROR,
-        { prefer: "class-property" },
-      ],
-
-      /**
-       * Use `as const` instead of writing `"value" as "value"`.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo = "foo" as "foo";
-       * const bar: "bar" = "bar";
-       *
-       * // ✅ Correct
-       * const foo = "foo" as const;
-       * const bar = "bar" as const;
-       * ```
-       * @see [@typescript-eslint/prefer-as-const](https://typescript-eslint.io/rules/prefer-as-const/)
-       */
-      [`${typescriptNamespace}/prefer-as-const`]: ERROR,
-
-      /**
-       * Require destructuring from arrays and/or objects.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo = array[0];
-       * const bar = array[5];
-       *
-       * // ✅ Correct
-       * const { [0]: foo, [5]: bar } = array;
-       * ```
-       * @see [@typescript-eslint/prefer-destructuring](https://typescript-eslint.io/rules/prefer-destructuring/)
-       */
-      [`${typescriptNamespace}/prefer-destructuring`]: ERROR,
-
-      /**
-       * Require each enum member value to be explicitly initialized.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const enum Status {
-       *   Open = 1,
-       *   Close,
-       * }
-       *
-       * const enum Direction {
-       *   Up,
-       *   Down,
-       * }
-       *
-       * // ✅ Correct
-       * const enum Status {
-       *   Open = 0,
-       *   Close = 1,
-       * }
-       *
-       * const enum Direction {
-       *   Up = 0,
-       *   Down = 1,
-       * }
-       * ```
-       * @see [@typescript-eslint/prefer-enum-initializers](https://typescript-eslint.io/rules/prefer-enum-initializers/)
-       */
-      [`${typescriptNamespace}/prefer-enum-initializers`]: ERROR,
-
-      /**
-       * Enforce the use of `Array#find` over `Array#filter` followed by when looking for a single result.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * [1, 2, 3].filter(x => x > 1)[0];
-       *
-       * // ✅ Correct
-       * [1, 2, 3].find(x => x > 1);
-       * ```
-       * @see [@typescript-eslint/prefer-find](https://typescript-eslint.io/rules/prefer-find/)
-       */
-      [`${typescriptNamespace}/prefer-find`]: ERROR,
-
-      /**
-       * If you'll use a `for` loop on an array, use `for/of`.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * for (let i = 0; i < foo.length; i++) {
-       *   console.log(foo[i]);
-       * }
-       *
-       * // ✅ Correct
-       * for (const value of foo) {
-       *   console.log(value);
-       * }
-       * ```
-       * @see [@typescript-eslint/prefer-for-of](https://typescript-eslint.io/rules/prefer-for-of/)
-       */
-      [`${typescriptNamespace}/prefer-for-of`]: ERROR,
-
-      /**
-       * Use `() => Type` instead of other verbose alternatives.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * interface Foo {
-       *   (): string;
-       * }
-       *
-       * // ✅ Correct
-       * type Foo = () => string;
-       * ```
-       * @see [@typescript-eslint/prefer-function-type](https://typescript-eslint.io/rules/prefer-function-type/)
-       */
-      [`${typescriptNamespace}/prefer-function-type`]: ERROR,
-
-      /**
-       * Avoid `indexOf` and use `includes` instead.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * foo.indexOf("bar") !== -1;
-       *
-       * // ✅ Correct
-       * foo.includes("bar");
-       * ```
-       * @see [@typescript-eslint/prefer-includes](https://typescript-eslint.io/rules/prefer-includes/)
-       */
-      [`${typescriptNamespace}/prefer-includes`]: ERROR,
-
-      /**
-       * Require all enum members to be literal values.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const str = "Test";
-       * const enum Invalid {
-       *   A = str, // Variable assignment
-       *   B = {}, // Object assignment
-       *   C = `A template literal string`, // Template literal
-       *   D = new Set(1, 2, 3), // Constructor in assignment
-       *   E = 2 + 2, // Expression assignment
-       * }
-       *
-       * // ✅ Correct
-       * const enum Valid {
-       *   A,
-       *   B = "TestStr", // A regular string
-       *   C = 4, // A number
-       *   D = null,
-       *   E = /some_regex/,
-       * }
-       * ```
-       * @see [@typescript-eslint/prefer-includes](https://typescript-eslint.io/rules/prefer-includes/)
-       */
-      [`${typescriptNamespace}/prefer-literal-enum-member`]: [
-        ERROR,
-        { allowBitwiseExpressions: true },
-      ],
-
-      /**
-       * Old TypeScript. Use `namespace` instead of `module`.
-       *
-       * @see [@typescript-eslint/prefer-namespace-keyword](https://typescript-eslint.io/rules/prefer-namespace-keyword/)
-       */
-      [`${typescriptNamespace}/prefer-namespace-keyword`]: ERROR,
-
-      /**
-       * Use `??` instead of a ternary.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo = bar !== null && bar !== undefined ? bar : "baz";
-       *
-       * // ✅ Correct
-       * const foo = bar ?? "baz";
-       * ```
-       * @see [@typescript-eslint/prefer-nullish-coalescing](https://typescript-eslint.io/rules/prefer-nullish-coalescing/)
-       */
-      [`${typescriptNamespace}/prefer-nullish-coalescing`]: [
-        ERROR,
-        {
-          ignoreConditionalTests: false,
-          ignoreMixedLogicalExpressions: false,
-        },
-      ],
-
-      /**
-       * Use `?.` instead of checking every property.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo = bar && bar.baz && bar.baz.qux;
-       *
-       * // ✅ Correct
-       * const foo = bar?.baz?.qux;
-       * ```
-       * @see [@typescript-eslint/prefer-optional-chain](https://typescript-eslint.io/rules/prefer-optional-chain/)
-       */
-      [`${typescriptNamespace}/prefer-optional-chain`]: ERROR,
-
-      /**
-       * In classes, private members should be read only.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * class Foo {
-       *   private neverModified = "bar";
-       * }
-       *
-       * // ✅ Correct
-       * class Foo {
-       *   private readonly neverModified = "bar";
-       * }
-       * ```
-       * @see [@typescript-eslint/prefer-readonly](https://typescript-eslint.io/rules/prefer-readonly/)
-       */
-      [`${typescriptNamespace}/prefer-readonly`]: ERROR,
-
-      /**
-       * Enforce using type parameter when calling `Array#reduce` instead
-       * of casting.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * [1, 2, 3].reduce((array, item) => [...array, item * 2], [] as ReadonlyArray<number>);
-       *
-       * // ✅ Correct
-       * [1, 2, 3].reduce<ReadonlyArray<number>>((array, item) => [...array, item * 2], []);
-       * ```
-       * @see [@typescript-eslint/prefer-reduce-type-parameter](https://typescript-eslint.io/rules/prefer-reduce-type-parameter)
-       */
-      [`${typescriptNamespace}/prefer-reduce-type-parameter`]: ERROR,
-
-      /**
-       * Enforce `RegExp#exec` over `String#match` if no global flag is
-       * provided.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * 'something'.match(/thing/);
-       *
-       * // ✅ Correct
-       * /thing/.exec('something');
-       * ```
-       * @see [@typescript-eslint/prefer-regexp-exec](https://typescript-eslint.io/rules/prefer-regexp-exec)
-       */
-      [`${typescriptNamespace}/prefer-regexp-exec`]: ERROR,
-
-      /**
-       * Enforce that `this` is used when only `this` type is returned.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * class Example {
-       *   someMethod(): Example {
-       *     return this;
-       *   }
-       * }
-       *
-       * // ✅ Correct
-       * class Example {
-       *   someMethod(): this {
-       *     return this;
-       *   }
-       * }
-       * ```
-       * @see [@typescript-eslint/prefer-return-this-type](https://typescript-eslint.io/rules/prefer-return-this-type)
-       */
-      [`${typescriptNamespace}/prefer-return-this-type`]: ERROR,
-
-      /**
-       * Enforce using `String#startsWith` and `String#endsWith` over
-       * other equivalent methods of checking substrings.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * // starts with
-       * foo[0] === 'b';
-       * foo.charAt(0) === 'b';
-       * foo.indexOf('bar') === 0;
-       * foo.slice(0, 3) === 'bar';
-       * foo.substring(0, 3) === 'bar';
-       * foo.match(/^bar/) != null;
-       * /^bar/.test(foo);
-       *
-       * // ends with
-       * foo[foo.length - 1] === 'b';
-       * foo.charAt(foo.length - 1) === 'b';
-       * foo.lastIndexOf('bar') === foo.length - 3;
-       * foo.slice(-3) === 'bar';
-       * foo.substring(foo.length - 3) === 'bar';
-       * foo.match(/bar$/) != null;
-       * /bar$/.test(foo);
-       *
-       * // ✅ Correct
-       * // starts with
-       * foo.startsWith('bar');
-       *
-       * // ends with
-       * foo.endsWith('bar');
-       * ```
-       * @see [@typescript-eslint/prefer-string-starts-ends-with](https://typescript-eslint.io/rules/prefer-string-starts-ends-with)
-       */
-      [`${typescriptNamespace}/prefer-string-starts-ends-with`]: ERROR,
-
-      /**
-       * Always use `Array#sort` with a comparing function.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * foo.sort();
-       *
-       * // ✅ Correct
-       * foo.sort((a, z) => a - z);
-       * ```
-       * @see [@typescript-eslint/require-array-sort-compare](https://typescript-eslint.io/rules/require-array-sort-compare/)
-       */
-      [`${typescriptNamespace}/require-array-sort-compare`]: ERROR,
-
-      /**
-       * Use `await` if you are using `async`.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo = async () => "bar";
-       *
-       * // ✅ Correct
-       * const foo = async () => await "bar";
-       * ```
-       * @see [@typescript-eslint/require-await](https://typescript-eslint.io/rules/require-await/)
-       */
-      [`${typescriptNamespace}/require-await`]: ERROR,
-
-      /**
-       * Use `+` with the same type (`number` or `string`).
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo = "bar" + 42;
-       *
-       * // ✅ Correct
-       * const foo = "bar" + "baz";
-       * ```
-       * @see [@typescript-eslint/restrict-plus-operands](https://typescript-eslint.io/rules/restrict-plus-operands/)
-       */
-      [`${typescriptNamespace}/restrict-plus-operands`]: ERROR,
-
-      /**
-       * Only use strings or numbers inside template expressions.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo = `bar${true}`;
-       * const bar = `baz${undefined}`;
-       *
-       * // ✅ Correct
-       * const foo = `bar${42}`;
-       * const bar = `baz${"qux"}`;
-       * const baz = `qux${undefined ?? "default"}`;
-       * ```
-       * @see [@typescript-eslint/restrict-template-expressions](https://typescript-eslint.io/rules/restrict-template-expressions/)
-       */
-      [`${typescriptNamespace}/restrict-template-expressions`]: [
-        ERROR,
-        { allowNumber: true },
-      ],
-
-      /**
-       * Comparisons should be applied to booleans only (not
-       * falsy/truthy).
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * if (foo) // …
-       * if (!foo) // …
-       *
-       * // ✅ Correct
-       * if (foo !== "") // …
-       * if (foo === undefined) // …
-       * ```
-       * @see [@typescript-eslint/strict-boolean-expressions](https://typescript-eslint.io/rules/strict-boolean-expressions/)
-       */
-      [`${typescriptNamespace}/strict-boolean-expressions`]: [
-        ERROR,
-        { allowNullableBoolean: true },
-      ],
-
-      /**
-       * If you'll use switch, make sure to cover every possible value.
-       *
-       * @see [@typescript-eslint/switch-exhaustiveness-check](https://typescript-eslint.io/rules/switch-exhaustiveness-check/)
-       */
-      [`${typescriptNamespace}/switch-exhaustiveness-check`]: ERROR,
-
-      /**
-       * Old TypeScript.
-       *
-       * @see [@typescript-eslint/triple-slash-reference](https://typescript-eslint.io/rules/triple-slash-reference/)
-       */
-      [`${typescriptNamespace}/triple-slash-reference`]: ERROR,
-
-      /**
-       * Unify signatures instead of overloading.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * function x(x: number): void;
-       * function x(x: string): void;
-       *
-       * // ✅ Correct
-       * function x(x: number | string): void;
-       * ```
-       * @see [@typescript-eslint/unified-signatures](https://typescript-eslint.io/rules/unified-signatures/)
-       */
-      [`${typescriptNamespace}/unified-signatures`]: ERROR,
-
-      /**
-       * Enforce typing arguments in `.catch()` callbacks as `unknown`.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * Promise.reject(new Error('I will reject!')).catch(error => {
-       *   console.log(error);
-       * });
-       *
-       * Promise.reject(new Error('I will reject!')).catch((error: any) => {
-       *   console.log(error);
-       * });
-       *
-       * Promise.reject(new Error('I will reject!')).catch((error: Error) => {
-       *   console.log(error);
-       * });
-       *
-       * // ✅ Correct
-       * Promise.reject(new Error('I will reject!')).catch((error: unknown) => {
-       *   console.log(error);
-       * });
-       * ```
-       * @see [@typescript-eslint/use-unknown-in-catch-callback-variable](https://typescript-eslint.io/rules/use-unknown-in-catch-callback-variable/)
-       */
-      [`${typescriptNamespace}/use-unknown-in-catch-callback-variable`]: ERROR,
-
-      // Rules covered by `@typescript-eslint` or by the language itself.
-      ...off(
-        "camelcase",
-        "class-methods-use-this",
-        "consistent-return",
-        "constructor-super",
-        "default-param-last",
-        "dot-notation",
-        "getter-return",
-        "id-match",
-        "init-declarations",
-        "max-params",
-        "new-cap",
-        "no-array-constructor",
-        "no-async-promise-executor",
-        "no-case-declarations",
-        "no-class-assign",
-        "no-cond-assign",
-        "no-const-assign",
-        "no-constant-binary-expression",
-        "no-constant-condition",
-        "no-delete-var",
-        "no-dupe-args",
-        "no-dupe-class-members",
-        "no-dupe-else-if",
-        "no-dupe-keys",
-        "no-extra-boolean-cast",
-        "no-fallthrough",
-        "no-func-assign",
-        "no-global-assign",
-        "no-implicit-globals",
-        "no-implied-eval",
-        "no-invalid-this",
-        "no-loop-func",
-        "no-nonoctal-decimal-escape",
-        "no-obj-calls",
-        "no-octal-escape",
-        "no-promise-executor-return",
-        "no-redeclare",
-        "no-restricted-imports",
-        "no-setter-return",
-        "no-shadow",
-        "no-this-before-super",
-        "no-throw-literal",
-        "no-undef-init",
-        "no-undef",
-        "no-undefined",
-        "no-underscore-dangle",
-        "no-unreachable",
-        "no-unsafe-negation",
-        "no-unsafe-optional-chaining",
-        "no-unused-expressions",
-        "no-unused-labels",
-        "no-unused-private-class-members",
-        "no-unused-vars",
-        "no-use-before-define",
-        "no-useless-backreference",
-        "no-useless-constructor",
-        "no-with",
-        "prefer-destructuring",
-        "require-await",
-        "use-isnan",
-        "valid-typeof",
-        `${typescriptNamespace}/no-dupe-class-members`,
-        `${typescriptNamespace}/no-redeclare`,
-        `${typescriptNamespace}/no-unused-vars`,
-      ),
-    },
-  });
+          {
+            group: ["jquery-ui", "moment"],
+            message: "Use a modern dependency instead.",
+          },
+        ],
+      },
+    ],
+
+    /**
+     * Avoid name shadowing (`_` is allowed).
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const bar = "foo";
+     * const foo = (bar: string) => bar;
+     *
+     * // ✅ Correct
+     * const bar = "foo";
+     * const foo = (baz: string) => baz;
+     * ```
+     * @see [@typescript-eslint/no-shadow](https://typescript-eslint.io/rules/no-shadow/)
+     */
+    [`${typescriptNamespace}/no-shadow`]: [ERROR, { allow: ["_"], hoist: "all" }],
+
+    /**
+     * Just use arrow functions, _this/that aliases are no longer needed.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo = function () {
+     *   const that = this;
+     *   return function() {
+     *     return that;
+     *   };
+     * }
+     *
+     * // ✅ Correct
+     * const foo = function() {
+     *   return () => this;
+     * };
+     * ```
+     * @see [@typescript-eslint/no-this-alias](https://typescript-eslint.io/rules/no-this-alias/)
+     */
+    [`${typescriptNamespace}/no-this-alias`]: ERROR,
+
+    /**
+     * If it's a `boolean`, use it as such.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * if (foo === true) // …
+     *
+     * // ✅ Correct
+     * if (foo) // …
+     * ```
+     * @see [@typescript-eslint/no-unnecessary-boolean-literal-compare](https://typescript-eslint.io/rules/no-unnecessary-boolean-literal-compare/)
+     */
+    [`${typescriptNamespace}/no-unnecessary-boolean-literal-compare`]: ERROR,
+
+    /**
+     * Avoid conditions with values that can't be falsy.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const check = (value: "foo" | "bar") => {
+     *   if (value) // value will never be falsy
+     * }
+     *
+     * // ✅ Correct
+     * const check = (value: string) => {
+     *   if (value) // Necessary, since value might be ""
+     * }
+     * ```
+     * @see [@typescript-eslint/no-unnecessary-condition](https://typescript-eslint.io/rules/no-unnecessary-condition/)
+     */
+    [`${typescriptNamespace}/no-unnecessary-condition`]: ERROR,
+
+    /**
+     * Disallow unnecessary assignment of constructor property parameter.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * class Foo {
+     *   constructor(public bar: string) {
+     *     this.bar = bar;
+     *   }
+     * }
+     *
+     * // ✅ Correct
+     * class Foo {
+     *   constructor(public bar: string) {}
+     * }
+     * ```
+     * @see [@typescript-eslint/no-unnecessary-parameter-property-assignment](https://typescript-eslint.io/rules/no-unnecessary-parameter-property-assignment/)
+     */
+    [`${typescriptNamespace}/no-unnecessary-parameter-property-assignment`]: ERROR,
+
+    /**
+     * Disallow unnecessary namespace qualifiers.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * enum A {
+     *   B,
+     *   C = A.B,
+     * }
+     *
+     * // ✅ Correct
+     * enum A {
+     *   B,
+     *   C = B,
+     * }
+     * ```
+     * @see [@typescript-eslint/no-unnecessary-qualifier](https://typescript-eslint.io/rules/no-unnecessary-qualifier/)
+     */
+    [`${typescriptNamespace}/no-unnecessary-qualifier`]: ERROR,
+
+    /**
+     * Disallow unnecessary template expressions.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * `${'a'}${'b'}`
+     *
+     * // ✅ Correct
+     * "ab"
+     * ```
+     * @see [@typescript-eslint/no-unnecessary-template-expression](https://typescript-eslint.io/rules/no-unnecessary-template-expression/)
+     */
+    [`${typescriptNamespace}/no-unnecessary-template-expression`]: ERROR,
+
+    /**
+     * If the type assertion is the same, skip it.
+     *
+     * @example
+     * ```typescript
+     * const example = <Value = string>(value: Value) => value;
+     *
+     * // ❌ Incorrect
+     * example<string>("hello");
+     *
+     * // ✅ Correct
+     * example("hello");
+     * ```
+     * @see [@typescript-eslint/no-unnecessary-type-arguments](https://typescript-eslint.io/rules/no-unnecessary-type-arguments/)
+     */
+    [`${typescriptNamespace}/no-unnecessary-type-arguments`]: ERROR,
+
+    /**
+     * Don't assert something that doesn't need assertion.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo = "bar" as string;
+     * ```
+     * @see [@typescript-eslint/no-unnecessary-type-assertion](https://typescript-eslint.io/rules/no-unnecessary-type-assertion/)
+     */
+    [`${typescriptNamespace}/no-unnecessary-type-assertion`]: ERROR,
+
+    /**
+     * Don't do `extends any` or `extends unknown`. That's the default.
+     *
+     * @see [@typescript-eslint/no-unnecessary-type-constraint](https://typescript-eslint.io/rules/no-unnecessary-type-constraint/)
+     */
+    [`${typescriptNamespace}/no-unnecessary-type-constraint`]: ERROR,
+
+    /**
+     * Disallow type parameters that only appear once.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const second = <A, B>(a: A, b: B): B => b;
+     *
+     * // ✅ Correct
+     * const second = <B>(a: unknown, b: B): B => b;
+     * ```
+     * @see [@typescript-eslint/no-unnecessary-type-parameters](https://typescript-eslint.io/rules/no-unnecessary-type-parameters/)
+     */
+    [`${typescriptNamespace}/no-unnecessary-type-parameters`]: ERROR,
+
+    /**
+     * Disallows calling an function with an `any` type value.
+     *
+     * @see [@typescript-eslint/no-unsafe-argument](https://typescript-eslint.io/rules/no-unsafe-argument/)
+     */
+    [`${typescriptNamespace}/no-unsafe-argument`]: ERROR,
+
+    /**
+     * Avoid `any` assignments.
+     *
+     * @see [@typescript-eslint/no-unsafe-assignment](https://typescript-eslint.io/rules/no-unsafe-assignment/)
+     */
+    [`${typescriptNamespace}/no-unsafe-assignment`]: ERROR,
+
+    /**
+     * Avoid calling `any`.
+     *
+     * @see [@typescript-eslint/no-unsafe-call](https://typescript-eslint.io/rules/no-unsafe-call/)
+     */
+    [`${typescriptNamespace}/no-unsafe-call`]: ERROR,
+
+    /**
+     * Disallow unsafe declaration merging.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * interface Foo {}
+     * class Foo {}
+     * ```
+     * @see [@typescript-eslint/no-unsafe-declaration-merging](https://typescript-eslint.io/rules/no-unsafe-declaration-merging/)
+     */
+    [`${typescriptNamespace}/no-unsafe-declaration-merging`]: ERROR,
+
+    /**
+     * Disallow comparing an enum value with a non-enum value.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const enum Fruit {
+     *   Apple = 0,
+     * }
+     *
+     * declare let fruit: Fruit;
+     *
+     * fruit === 0;
+     *
+     * // ✅ Correct
+     * const enum Fruit {
+     *   Apple = 0,
+     * }
+     *
+     * declare let fruit: Fruit;
+     *
+     * fruit === Fruit.Apple;
+     * ```
+     * @see [@typescript-eslint/no-unsafe-enum-comparison](https://typescript-eslint.io/rules/no-unsafe-enum-comparison/)
+     */
+    [`${typescriptNamespace}/no-unsafe-enum-comparison`]: ERROR,
+
+    /**
+     * Avoid accessing `any` members.
+     *
+     * @see [@typescript-eslint/no-unsafe-member-access](https://typescript-eslint.io/rules/no-unsafe-member-access/)
+     */
+    [`${typescriptNamespace}/no-unsafe-member-access`]: ERROR,
+
+    /**
+     * Avoid returning `any`.
+     *
+     * @see [@typescript-eslint/no-unsafe-return](https://typescript-eslint.io/rules/no-unsafe-return/)
+     */
+    [`${typescriptNamespace}/no-unsafe-return`]: ERROR,
+
+    /**
+     * Require unary negation to take a number.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * declare const a: string;
+     * -a;
+     *
+     * // ✅ Correct
+     * declare const a: number;
+     * -a;
+     * ```
+     * @see [@typescript-eslint/no-unsafe-unary-minus](https://typescript-eslint.io/rules/no-unsafe-unary-minus/)
+     */
+    [`${typescriptNamespace}/no-unsafe-unary-minus`]: ERROR,
+
+    /**
+     * Don't just leave expressions lying around! Use them!
+     *
+     * @see [no-unused-expressions](https://eslint.org/docs/latest/rules/no-unused-expressions)
+     * @see [@typescript-eslint/no-unused-expressions](https://typescript-eslint.io/rules/no-unused-expressions/)
+     */
+    [`${typescriptNamespace}/no-unused-expressions`]: ERROR,
+
+    /**
+     * Avoid using something before is defined.
+     *
+     * @see [no-use-before-define](https://eslint.org/docs/latest/rules/no-use-before-define)
+     * @see [@typescript-eslint/no-use-before-define](https://typescript-eslint.io/rules/no-use-before-define/)
+     */
+    [`${typescriptNamespace}/no-use-before-define`]: ERROR,
+
+    /**
+     * When working with classes, let's not define useless constructors (constructors that only call `super`).
+     *
+     * @see [no-useless-constructor](https://eslint.org/docs/latest/rules/no-useless-constructor)
+     * @see [@typescript-eslint/no-useless-constructor](https://typescript-eslint.io/rules/no-useless-constructor/)
+     */
+    [`${typescriptNamespace}/no-useless-constructor`]: ERROR,
+
+    /**
+     * Disallow empty exports that don't change anything in a module file.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * export const value = 'Hello, world!';
+     * export {};
+     *
+     * // ✅ Correct
+     * export const value = 'Hello, world!';
+     * ```
+     * @see [@typescript-eslint/no-useless-empty-export](https://typescript-eslint.io/rules/no-useless-empty-export/)
+     */
+    [`${typescriptNamespace}/no-useless-empty-export`]: ERROR,
+
+    /**
+     * Disallow using confusing built-in primitive class wrappers.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * let myBigInt: BigInt;
+     * let myBoolean: Boolean;
+     * let myNumber: Number;
+     * let myString: String;
+     * let mySymbol: Symbol;
+     * let myObject: Object;
+     *
+     * // ✅ Correct
+     * let myBigInt: bigint;
+     * let myBoolean: boolean;
+     * let myNumber: number;
+     * let myString: string;
+     * let mySymbol: symbol;
+     * let myObject: object;
+     * ```
+     * @see [@typescript-eslint/no-wrapper-object-types](https://typescript-eslint.io/rules/no-wrapper-object-types/)
+     */
+    [`${typescriptNamespace}/no-wrapper-object-types`]: ERROR,
+
+    /**
+     * If you'll throw, throw errors, not literals.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * throw 'foo';
+     *
+     * // ✅ Correct
+     * throw new Error('foo');
+     * ```
+     * @see [@typescript-eslint/only-throw-error](https://typescript-eslint.io/rules/only-throw-error/)
+     * @see [no-throw-literal](https://eslint.org/docs/latest/rules/no-throw-literal)
+     */
+    [`${typescriptNamespace}/only-throw-error`]: ERROR,
+
+    /**
+     * Disallow parameter properties in class constructors.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * class Example {
+     *   constructor (private name: string) {}
+     * }
+     *
+     * // ✅ Correct
+     * class Example {
+     *   private name: string;
+     *   constructor (name: string) {
+     *     this.name = name;
+     *   }
+     * }
+     * ```
+     * @see [@typescript-eslint/parameter-properties](https://typescript-eslint.io/rules/parameter-properties/)
+     */
+    [`${typescriptNamespace}/parameter-properties`]: [ERROR, { prefer: "class-property" }],
+
+    /**
+     * Use `as const` instead of writing `"value" as "value"`.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo = "foo" as "foo";
+     * const bar: "bar" = "bar";
+     *
+     * // ✅ Correct
+     * const foo = "foo" as const;
+     * const bar = "bar" as const;
+     * ```
+     * @see [@typescript-eslint/prefer-as-const](https://typescript-eslint.io/rules/prefer-as-const/)
+     */
+    [`${typescriptNamespace}/prefer-as-const`]: ERROR,
+
+    /**
+     * Require destructuring from arrays and/or objects.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo = array[0];
+     * const bar = array[5];
+     *
+     * // ✅ Correct
+     * const { [0]: foo, [5]: bar } = array;
+     * ```
+     * @see [@typescript-eslint/prefer-destructuring](https://typescript-eslint.io/rules/prefer-destructuring/)
+     */
+    [`${typescriptNamespace}/prefer-destructuring`]: ERROR,
+
+    /**
+     * Require each enum member value to be explicitly initialized.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const enum Status {
+     *   Open = 1,
+     *   Close,
+     * }
+     *
+     * const enum Direction {
+     *   Up,
+     *   Down,
+     * }
+     *
+     * // ✅ Correct
+     * const enum Status {
+     *   Open = 0,
+     *   Close = 1,
+     * }
+     *
+     * const enum Direction {
+     *   Up = 0,
+     *   Down = 1,
+     * }
+     * ```
+     * @see [@typescript-eslint/prefer-enum-initializers](https://typescript-eslint.io/rules/prefer-enum-initializers/)
+     */
+    [`${typescriptNamespace}/prefer-enum-initializers`]: ERROR,
+
+    /**
+     * Enforce the use of `Array#find` over `Array#filter` followed by when looking for a single result.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * [1, 2, 3].filter(x => x > 1)[0];
+     *
+     * // ✅ Correct
+     * [1, 2, 3].find(x => x > 1);
+     * ```
+     * @see [@typescript-eslint/prefer-find](https://typescript-eslint.io/rules/prefer-find/)
+     */
+    [`${typescriptNamespace}/prefer-find`]: ERROR,
+
+    /**
+     * If you'll use a `for` loop on an array, use `for/of`.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * for (let i = 0; i < foo.length; i++) {
+     *   console.log(foo[i]);
+     * }
+     *
+     * // ✅ Correct
+     * for (const value of foo) {
+     *   console.log(value);
+     * }
+     * ```
+     * @see [@typescript-eslint/prefer-for-of](https://typescript-eslint.io/rules/prefer-for-of/)
+     */
+    [`${typescriptNamespace}/prefer-for-of`]: ERROR,
+
+    /**
+     * Use `() => Type` instead of other verbose alternatives.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * interface Foo {
+     *   (): string;
+     * }
+     *
+     * // ✅ Correct
+     * type Foo = () => string;
+     * ```
+     * @see [@typescript-eslint/prefer-function-type](https://typescript-eslint.io/rules/prefer-function-type/)
+     */
+    [`${typescriptNamespace}/prefer-function-type`]: ERROR,
+
+    /**
+     * Avoid `indexOf` and use `includes` instead.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * foo.indexOf("bar") !== -1;
+     *
+     * // ✅ Correct
+     * foo.includes("bar");
+     * ```
+     * @see [@typescript-eslint/prefer-includes](https://typescript-eslint.io/rules/prefer-includes/)
+     */
+    [`${typescriptNamespace}/prefer-includes`]: ERROR,
+
+    /**
+     * Require all enum members to be literal values.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const str = "Test";
+     * const enum Invalid {
+     *   A = str, // Variable assignment
+     *   B = {}, // Object assignment
+     *   C = `A template literal string`, // Template literal
+     *   D = new Set(1, 2, 3), // Constructor in assignment
+     *   E = 2 + 2, // Expression assignment
+     * }
+     *
+     * // ✅ Correct
+     * const enum Valid {
+     *   A,
+     *   B = "TestStr", // A regular string
+     *   C = 4, // A number
+     *   D = null,
+     *   E = /some_regex/,
+     * }
+     * ```
+     * @see [@typescript-eslint/prefer-includes](https://typescript-eslint.io/rules/prefer-includes/)
+     */
+    [`${typescriptNamespace}/prefer-literal-enum-member`]: [ERROR, { allowBitwiseExpressions: true }],
+
+    /**
+     * Old TypeScript. Use `namespace` instead of `module`.
+     *
+     * @see [@typescript-eslint/prefer-namespace-keyword](https://typescript-eslint.io/rules/prefer-namespace-keyword/)
+     */
+    [`${typescriptNamespace}/prefer-namespace-keyword`]: ERROR,
+
+    /**
+     * Use `??` instead of a ternary.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo = bar !== null && bar !== undefined ? bar : "baz";
+     *
+     * // ✅ Correct
+     * const foo = bar ?? "baz";
+     * ```
+     * @see [@typescript-eslint/prefer-nullish-coalescing](https://typescript-eslint.io/rules/prefer-nullish-coalescing/)
+     */
+    [`${typescriptNamespace}/prefer-nullish-coalescing`]: [
+      ERROR,
+      {
+        ignoreConditionalTests: false,
+        ignoreMixedLogicalExpressions: false,
+      },
+    ],
+
+    /**
+     * Use `?.` instead of checking every property.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo = bar && bar.baz && bar.baz.qux;
+     *
+     * // ✅ Correct
+     * const foo = bar?.baz?.qux;
+     * ```
+     * @see [@typescript-eslint/prefer-optional-chain](https://typescript-eslint.io/rules/prefer-optional-chain/)
+     */
+    [`${typescriptNamespace}/prefer-optional-chain`]: ERROR,
+
+    /**
+     * In classes, private members should be read only.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * class Foo {
+     *   private neverModified = "bar";
+     * }
+     *
+     * // ✅ Correct
+     * class Foo {
+     *   private readonly neverModified = "bar";
+     * }
+     * ```
+     * @see [@typescript-eslint/prefer-readonly](https://typescript-eslint.io/rules/prefer-readonly/)
+     */
+    [`${typescriptNamespace}/prefer-readonly`]: ERROR,
+
+    /**
+     * Enforce using type parameter when calling `Array#reduce` instead
+     * of casting.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * [1, 2, 3].reduce((array, item) => [...array, item * 2], [] as ReadonlyArray<number>);
+     *
+     * // ✅ Correct
+     * [1, 2, 3].reduce<ReadonlyArray<number>>((array, item) => [...array, item * 2], []);
+     * ```
+     * @see [@typescript-eslint/prefer-reduce-type-parameter](https://typescript-eslint.io/rules/prefer-reduce-type-parameter)
+     */
+    [`${typescriptNamespace}/prefer-reduce-type-parameter`]: ERROR,
+
+    /**
+     * Enforce `RegExp#exec` over `String#match` if no global flag is
+     * provided.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * 'something'.match(/thing/);
+     *
+     * // ✅ Correct
+     * /thing/.exec('something');
+     * ```
+     * @see [@typescript-eslint/prefer-regexp-exec](https://typescript-eslint.io/rules/prefer-regexp-exec)
+     */
+    [`${typescriptNamespace}/prefer-regexp-exec`]: ERROR,
+
+    /**
+     * Enforce that `this` is used when only `this` type is returned.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * class Example {
+     *   someMethod(): Example {
+     *     return this;
+     *   }
+     * }
+     *
+     * // ✅ Correct
+     * class Example {
+     *   someMethod(): this {
+     *     return this;
+     *   }
+     * }
+     * ```
+     * @see [@typescript-eslint/prefer-return-this-type](https://typescript-eslint.io/rules/prefer-return-this-type)
+     */
+    [`${typescriptNamespace}/prefer-return-this-type`]: ERROR,
+
+    /**
+     * Enforce using `String#startsWith` and `String#endsWith` over
+     * other equivalent methods of checking substrings.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * // starts with
+     * foo[0] === 'b';
+     * foo.charAt(0) === 'b';
+     * foo.indexOf('bar') === 0;
+     * foo.slice(0, 3) === 'bar';
+     * foo.substring(0, 3) === 'bar';
+     * foo.match(/^bar/) != null;
+     * /^bar/.test(foo);
+     *
+     * // ends with
+     * foo[foo.length - 1] === 'b';
+     * foo.charAt(foo.length - 1) === 'b';
+     * foo.lastIndexOf('bar') === foo.length - 3;
+     * foo.slice(-3) === 'bar';
+     * foo.substring(foo.length - 3) === 'bar';
+     * foo.match(/bar$/) != null;
+     * /bar$/.test(foo);
+     *
+     * // ✅ Correct
+     * // starts with
+     * foo.startsWith('bar');
+     *
+     * // ends with
+     * foo.endsWith('bar');
+     * ```
+     * @see [@typescript-eslint/prefer-string-starts-ends-with](https://typescript-eslint.io/rules/prefer-string-starts-ends-with)
+     */
+    [`${typescriptNamespace}/prefer-string-starts-ends-with`]: ERROR,
+
+    /**
+     * Always use `Array#sort` with a comparing function.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * foo.sort();
+     *
+     * // ✅ Correct
+     * foo.sort((a, z) => a - z);
+     * ```
+     * @see [@typescript-eslint/require-array-sort-compare](https://typescript-eslint.io/rules/require-array-sort-compare/)
+     */
+    [`${typescriptNamespace}/require-array-sort-compare`]: ERROR,
+
+    /**
+     * Use `await` if you are using `async`.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo = async () => "bar";
+     *
+     * // ✅ Correct
+     * const foo = async () => await "bar";
+     * ```
+     * @see [@typescript-eslint/require-await](https://typescript-eslint.io/rules/require-await/)
+     */
+    [`${typescriptNamespace}/require-await`]: ERROR,
+
+    /**
+     * Use `+` with the same type (`number` or `string`).
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo = "bar" + 42;
+     *
+     * // ✅ Correct
+     * const foo = "bar" + "baz";
+     * ```
+     * @see [@typescript-eslint/restrict-plus-operands](https://typescript-eslint.io/rules/restrict-plus-operands/)
+     */
+    [`${typescriptNamespace}/restrict-plus-operands`]: ERROR,
+
+    /**
+     * Only use strings or numbers inside template expressions.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo = `bar${true}`;
+     * const bar = `baz${undefined}`;
+     *
+     * // ✅ Correct
+     * const foo = `bar${42}`;
+     * const bar = `baz${"qux"}`;
+     * const baz = `qux${undefined ?? "default"}`;
+     * ```
+     * @see [@typescript-eslint/restrict-template-expressions](https://typescript-eslint.io/rules/restrict-template-expressions/)
+     */
+    [`${typescriptNamespace}/restrict-template-expressions`]: [ERROR, { allowNumber: true }],
+
+    /**
+     * Comparisons should be applied to booleans only (not
+     * falsy/truthy).
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * if (foo) // …
+     * if (!foo) // …
+     *
+     * // ✅ Correct
+     * if (foo !== "") // …
+     * if (foo === undefined) // …
+     * ```
+     * @see [@typescript-eslint/strict-boolean-expressions](https://typescript-eslint.io/rules/strict-boolean-expressions/)
+     */
+    [`${typescriptNamespace}/strict-boolean-expressions`]: [ERROR, { allowNullableBoolean: true }],
+
+    /**
+     * If you'll use switch, make sure to cover every possible value.
+     *
+     * @see [@typescript-eslint/switch-exhaustiveness-check](https://typescript-eslint.io/rules/switch-exhaustiveness-check/)
+     */
+    [`${typescriptNamespace}/switch-exhaustiveness-check`]: ERROR,
+
+    /**
+     * Old TypeScript.
+     *
+     * @see [@typescript-eslint/triple-slash-reference](https://typescript-eslint.io/rules/triple-slash-reference/)
+     */
+    [`${typescriptNamespace}/triple-slash-reference`]: ERROR,
+
+    /**
+     * Unify signatures instead of overloading.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * function x(x: number): void;
+     * function x(x: string): void;
+     *
+     * // ✅ Correct
+     * function x(x: number | string): void;
+     * ```
+     * @see [@typescript-eslint/unified-signatures](https://typescript-eslint.io/rules/unified-signatures/)
+     */
+    [`${typescriptNamespace}/unified-signatures`]: ERROR,
+
+    /**
+     * Enforce typing arguments in `.catch()` callbacks as `unknown`.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * Promise.reject(new Error('I will reject!')).catch(error => {
+     *   console.log(error);
+     * });
+     *
+     * Promise.reject(new Error('I will reject!')).catch((error: any) => {
+     *   console.log(error);
+     * });
+     *
+     * Promise.reject(new Error('I will reject!')).catch((error: Error) => {
+     *   console.log(error);
+     * });
+     *
+     * // ✅ Correct
+     * Promise.reject(new Error('I will reject!')).catch((error: unknown) => {
+     *   console.log(error);
+     * });
+     * ```
+     * @see [@typescript-eslint/use-unknown-in-catch-callback-variable](https://typescript-eslint.io/rules/use-unknown-in-catch-callback-variable/)
+     */
+    [`${typescriptNamespace}/use-unknown-in-catch-callback-variable`]: ERROR,
+
+    // Rules covered by `@typescript-eslint` or by the language itself.
+    ...off(
+      "camelcase",
+      "class-methods-use-this",
+      "consistent-return",
+      "constructor-super",
+      "default-param-last",
+      "dot-notation",
+      "getter-return",
+      "id-match",
+      "init-declarations",
+      "max-params",
+      "new-cap",
+      "no-array-constructor",
+      "no-async-promise-executor",
+      "no-case-declarations",
+      "no-class-assign",
+      "no-cond-assign",
+      "no-const-assign",
+      "no-constant-binary-expression",
+      "no-constant-condition",
+      "no-delete-var",
+      "no-dupe-args",
+      "no-dupe-class-members",
+      "no-dupe-else-if",
+      "no-dupe-keys",
+      "no-extra-boolean-cast",
+      "no-fallthrough",
+      "no-func-assign",
+      "no-global-assign",
+      "no-implicit-globals",
+      "no-implied-eval",
+      "no-invalid-this",
+      "no-loop-func",
+      "no-nonoctal-decimal-escape",
+      "no-obj-calls",
+      "no-octal-escape",
+      "no-promise-executor-return",
+      "no-redeclare",
+      "no-restricted-imports",
+      "no-setter-return",
+      "no-shadow",
+      "no-this-before-super",
+      "no-throw-literal",
+      "no-undef-init",
+      "no-undef",
+      "no-undefined",
+      "no-underscore-dangle",
+      "no-unreachable",
+      "no-unsafe-negation",
+      "no-unsafe-optional-chaining",
+      "no-unused-expressions",
+      "no-unused-labels",
+      "no-unused-private-class-members",
+      "no-unused-vars",
+      "no-use-before-define",
+      "no-useless-backreference",
+      "no-useless-constructor",
+      "no-with",
+      "prefer-destructuring",
+      "require-await",
+      "use-isnan",
+      "valid-typeof",
+      `${typescriptNamespace}/no-dupe-class-members`,
+      `${typescriptNamespace}/no-redeclare`,
+      `${typescriptNamespace}/no-unused-vars`,
+    ),
+  },
+});

--- a/airflow/ui/rules/unicorn.js
+++ b/airflow/ui/rules/unicorn.js
@@ -33,1250 +33,1249 @@ export const unicornNamespace = "unicorn";
  * ESLint `unicorn` rules.
  * @see [eslint-plugin-unicorn](https://github.com/sindresorhus/eslint-plugin-unicorn#rules)
  */
-export const unicornRules =
-  /** @type {const} @satisfies {FlatConfig.Config} */ ({
-    plugins: { [unicornNamespace]: unicorn },
-    rules: {
-      /**
-       * Improve regexes by making them shorter, consistent, and safer.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const regex = /[0-9]/;
-       * const regex = /[^0-9]/;
-       * const regex = /[a-zA-Z0-9_]/;
-       * const regex = /[a-z0-9_]/i;
-       * const regex = /[^a-zA-Z0-9_]/;
-       * const regex = /[^a-z0-9_]/i;
-       * const regex = /[0-9]\.[a-zA-Z0-9_]\-[^0-9]/i;
-       *
-       * // ✅ Correct
-       * const regex = /\d/;
-       * const regex = /\D/;
-       * const regex = /\w/;
-       * const regex = /\w/i;
-       * const regex = /\W/;
-       * const regex = /\W/i;
-       * const regex = /\d\.\w\-\D/i;
-       * ```
-       * @see [unicorn/better-regex](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/better-regex.md)
-       */
-      [`${unicornNamespace}/better-regex`]: ERROR,
+export const unicornRules = /** @type {const} @satisfies {FlatConfig.Config} */ ({
+  plugins: { [unicornNamespace]: unicorn },
+  rules: {
+    /**
+     * Improve regexes by making them shorter, consistent, and safer.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const regex = /[0-9]/;
+     * const regex = /[^0-9]/;
+     * const regex = /[a-zA-Z0-9_]/;
+     * const regex = /[a-z0-9_]/i;
+     * const regex = /[^a-zA-Z0-9_]/;
+     * const regex = /[^a-z0-9_]/i;
+     * const regex = /[0-9]\.[a-zA-Z0-9_]\-[^0-9]/i;
+     *
+     * // ✅ Correct
+     * const regex = /\d/;
+     * const regex = /\D/;
+     * const regex = /\w/;
+     * const regex = /\w/i;
+     * const regex = /\W/;
+     * const regex = /\W/i;
+     * const regex = /\d\.\w\-\D/i;
+     * ```
+     * @see [unicorn/better-regex](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/better-regex.md)
+     */
+    [`${unicornNamespace}/better-regex`]: ERROR,
 
-      /**
-       * Catch error must be named `error` or `somethingError` (`_` is allowed unless is used).
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * try {} catch (badName) {}
-       * try {} catch (_) { console.log(_); } // `_` is not allowed if it's used
-       * promise.catch(badName => {});
-       * promise.then(undefined, badName => {});
-       *
-       * // ✅ Correct
-       * try {} catch (error) {}
-       * promise.catch(error => {});
-       * promise.then(undefined, error => {});
-       * try {} catch (_) { console.log(foo); } // `_` is allowed when it's not used
-       * try {} catch (fsError) {}
-       * ```
-       * @see [unicorn/catch-error-name](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/catch-error-name.md)
-       */
-      [`${unicornNamespace}/catch-error-name`]: ERROR,
+    /**
+     * Catch error must be named `error` or `somethingError` (`_` is allowed unless is used).
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * try {} catch (badName) {}
+     * try {} catch (_) { console.log(_); } // `_` is not allowed if it's used
+     * promise.catch(badName => {});
+     * promise.then(undefined, badName => {});
+     *
+     * // ✅ Correct
+     * try {} catch (error) {}
+     * promise.catch(error => {});
+     * promise.then(undefined, error => {});
+     * try {} catch (_) { console.log(foo); } // `_` is allowed when it's not used
+     * try {} catch (fsError) {}
+     * ```
+     * @see [unicorn/catch-error-name](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/catch-error-name.md)
+     */
+    [`${unicornNamespace}/catch-error-name`]: ERROR,
 
-      /**
-       * Use destructured variables over properties.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const { a } = foo;
-       * console.log(a, foo.b);
-       * console.log(foo.a);
-       *
-       * const { a: { b } } = foo;
-       * console.log(foo.a.c);
-       *
-       * const { bar } = foo;
-       * const { a } = foo.bar;
-       *
-       * // ✅ Correct
-       * const { a } = foo;
-       * console.log(a);
-       * console.log(foo.a, foo.b);
-       * console.log(a, foo.b());
-       *
-       * const { a } = foo.bar;
-       * console.log(foo.bar);
-       * ```
-       * @see [unicorn/consistent-destructuring](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/consistent-destructuring.md)
-       */
-      [`${unicornNamespace}/consistent-destructuring`]: ERROR,
+    /**
+     * Use destructured variables over properties.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const { a } = foo;
+     * console.log(a, foo.b);
+     * console.log(foo.a);
+     *
+     * const { a: { b } } = foo;
+     * console.log(foo.a.c);
+     *
+     * const { bar } = foo;
+     * const { a } = foo.bar;
+     *
+     * // ✅ Correct
+     * const { a } = foo;
+     * console.log(a);
+     * console.log(foo.a, foo.b);
+     * console.log(a, foo.b());
+     *
+     * const { a } = foo.bar;
+     * console.log(foo.bar);
+     * ```
+     * @see [unicorn/consistent-destructuring](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/consistent-destructuring.md)
+     */
+    [`${unicornNamespace}/consistent-destructuring`]: ERROR,
 
-      /**
-       * Prefer consistent types when spreading a ternary in an array literal.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const array = [a, ...(foo ? [b, c] : """)];
-       * const array = [a, ...(foo ? "bc" : [])];
-       *
-       * // ✅ Correct
-       * const array = [a, ...(foo ? [b, c] : [])];
-       * const array = [a, ...(foo ? "bc" : "")];
-       * ```
-       * @see [unicorn/consistent-empty-array-spread](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/consistent-empty-array-spread.md)
-       */
-      [`${unicornNamespace}/consistent-empty-array-spread`]: ERROR,
+    /**
+     * Prefer consistent types when spreading a ternary in an array literal.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const array = [a, ...(foo ? [b, c] : """)];
+     * const array = [a, ...(foo ? "bc" : [])];
+     *
+     * // ✅ Correct
+     * const array = [a, ...(foo ? [b, c] : [])];
+     * const array = [a, ...(foo ? "bc" : "")];
+     * ```
+     * @see [unicorn/consistent-empty-array-spread](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/consistent-empty-array-spread.md)
+     */
+    [`${unicornNamespace}/consistent-empty-array-spread`]: ERROR,
 
-      /**
-       * Move function definitions to the highest possible scope.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const doFoo = foo => bar => bar === "bar";
-       *
-       * // ✅ Correct
-       * const doBar = bar => bar === "bar";
-       * const doFoo = foo => doBar;
-       * ```
-       * @see [unicorn/consistent-function-scoping](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/consistent-function-scoping.md)
-       */
-      [`${unicornNamespace}/consistent-function-scoping`]: ERROR,
+    /**
+     * Move function definitions to the highest possible scope.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const doFoo = foo => bar => bar === "bar";
+     *
+     * // ✅ Correct
+     * const doBar = bar => bar === "bar";
+     * const doFoo = foo => doBar;
+     * ```
+     * @see [unicorn/consistent-function-scoping](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/consistent-function-scoping.md)
+     */
+    [`${unicornNamespace}/consistent-function-scoping`]: ERROR,
 
-      /**
-       * Enforce passing a message value when creating a built-in error.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * throw Error();
-       * throw Error("");
-       * throw new TypeError();
-       * const error = new AggregateError(errors);
-       *
-       * // ✅ Correct
-       * throw Error("Unexpected property.");
-       * throw new TypeError("Array expected.");
-       * const error = new AggregateError(errors, "Promises rejected.");
-       * ```
-       * @see [unicorn/error-message](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/error-message.md)
-       */
-      [`${unicornNamespace}/error-message`]: ERROR,
+    /**
+     * Enforce passing a message value when creating a built-in error.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * throw Error();
+     * throw Error("");
+     * throw new TypeError();
+     * const error = new AggregateError(errors);
+     *
+     * // ✅ Correct
+     * throw Error("Unexpected property.");
+     * throw new TypeError("Array expected.");
+     * const error = new AggregateError(errors, "Promises rejected.");
+     * ```
+     * @see [unicorn/error-message](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/error-message.md)
+     */
+    [`${unicornNamespace}/error-message`]: ERROR,
 
-      /**
-       * Require escape sequences to use uppercase values.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo = "\xa9";
-       * const foo = "\ud834";
-       * const foo = "\u{1d306}";
-       * const foo = "\ca";
-       *
-       * // ✅ Correct
-       * const foo = "\xA9";
-       * const foo = "\uD834";
-       * const foo = "\u{1D306}";
-       * const foo = "\cA";
-       * ```
-       * @see [unicorn/escape-case](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/escape-case.md)
-       */
-      [`${unicornNamespace}/escape-case`]: ERROR,
+    /**
+     * Require escape sequences to use uppercase values.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo = "\xa9";
+     * const foo = "\ud834";
+     * const foo = "\u{1d306}";
+     * const foo = "\ca";
+     *
+     * // ✅ Correct
+     * const foo = "\xA9";
+     * const foo = "\uD834";
+     * const foo = "\u{1D306}";
+     * const foo = "\cA";
+     * ```
+     * @see [unicorn/escape-case](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/escape-case.md)
+     */
+    [`${unicornNamespace}/escape-case`]: ERROR,
 
-      /**
-       * Enforce specifying rules to disable in eslint-disable comments.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * console.log(message); // eslint-disable-line
-       * // eslint-disable-next-line
-       * console.log(message);
-       *
-       * // ✅ Correct
-       * console.log(message); // eslint-disable-line no-console
-       * // eslint-disable-next-line no-console
-       * console.log(message);
-       * ```
-       * @see [unicorn/no-abusive-eslint-disable](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-abusive-eslint-disable.md)
-       */
-      [`${unicornNamespace}/no-abusive-eslint-disable`]: ERROR,
+    /**
+     * Enforce specifying rules to disable in eslint-disable comments.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * console.log(message); // eslint-disable-line
+     * // eslint-disable-next-line
+     * console.log(message);
+     *
+     * // ✅ Correct
+     * console.log(message); // eslint-disable-line no-console
+     * // eslint-disable-next-line no-console
+     * console.log(message);
+     * ```
+     * @see [unicorn/no-abusive-eslint-disable](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-abusive-eslint-disable.md)
+     */
+    [`${unicornNamespace}/no-abusive-eslint-disable`]: ERROR,
 
-      /**
-       * Disallow anonymous functions and classes as the default export.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * export default class {}
-       * export default function () {}
-       * export default () => {};
-       *
-       * // ✅ Correct
-       * export default class Foo {}
-       * export default function foo () {}
-       * const foo = () => {};
-       * export default foo;
-       * ```
-       * @see [unicorn/no-anonymous-default-export](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-anonymous-default-export.md)
-       */
-      [`${unicornNamespace}/no-anonymous-default-export`]: ERROR,
+    /**
+     * Disallow anonymous functions and classes as the default export.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * export default class {}
+     * export default function () {}
+     * export default () => {};
+     *
+     * // ✅ Correct
+     * export default class Foo {}
+     * export default function foo () {}
+     * const foo = () => {};
+     * export default foo;
+     * ```
+     * @see [unicorn/no-anonymous-default-export](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-anonymous-default-export.md)
+     */
+    [`${unicornNamespace}/no-anonymous-default-export`]: ERROR,
 
-      /**
-       * Disallow using await in Promise method parameters.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * Promise.all([await promise, anotherPromise]);
-       * Promise.allSettled([await promise, anotherPromise]);
-       * Promise.any([await promise, anotherPromise]);
-       * Promise.race([await promise, anotherPromise]);
-       *
-       * // ✅ Correct
-       * Promise.all([promise, anotherPromise]);
-       * Promise.allSettled([promise, anotherPromise]);
-       * Promise.any([promise, anotherPromise]);
-       * Promise.race([promise, anotherPromise]);
-       * ```
-       * @see [unicorn/no-await-in-promise-methods](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-await-in-promise-methods.md)
-       */
-      [`${unicornNamespace}/no-await-in-promise-methods`]: ERROR,
+    /**
+     * Disallow using await in Promise method parameters.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * Promise.all([await promise, anotherPromise]);
+     * Promise.allSettled([await promise, anotherPromise]);
+     * Promise.any([await promise, anotherPromise]);
+     * Promise.race([await promise, anotherPromise]);
+     *
+     * // ✅ Correct
+     * Promise.all([promise, anotherPromise]);
+     * Promise.allSettled([promise, anotherPromise]);
+     * Promise.any([promise, anotherPromise]);
+     * Promise.race([promise, anotherPromise]);
+     * ```
+     * @see [unicorn/no-await-in-promise-methods](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-await-in-promise-methods.md)
+     */
+    [`${unicornNamespace}/no-await-in-promise-methods`]: ERROR,
 
-      /**
-       * Do not use leading/trailing space between `console.log` parameters.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * console.log("abc ", "def");
-       * console.log("abc", " def");
-       *
-       * // ✅ Correct
-       * console.log("abc", "def");
-       * ```
-       * @see [unicorn/no-console-spaces](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-console-spaces.md)
-       */
-      [`${unicornNamespace}/no-console-spaces`]: ERROR,
+    /**
+     * Do not use leading/trailing space between `console.log` parameters.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * console.log("abc ", "def");
+     * console.log("abc", " def");
+     *
+     * // ✅ Correct
+     * console.log("abc", "def");
+     * ```
+     * @see [unicorn/no-console-spaces](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-console-spaces.md)
+     */
+    [`${unicornNamespace}/no-console-spaces`]: ERROR,
 
-      /**
-       * Enforce the use of Unicode escapes instead of hexadecimal escapes.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo = "\x1B";
-       *
-       * // ✅ Correct
-       * const foo = "\u001B";
-       * ```
-       * @see [unicorn/no-hex-escape](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-hex-escape.md)
-       */
-      [`${unicornNamespace}/no-hex-escape`]: ERROR,
+    /**
+     * Enforce the use of Unicode escapes instead of hexadecimal escapes.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo = "\x1B";
+     *
+     * // ✅ Correct
+     * const foo = "\u001B";
+     * ```
+     * @see [unicorn/no-hex-escape](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-hex-escape.md)
+     */
+    [`${unicornNamespace}/no-hex-escape`]: ERROR,
 
-      /**
-       * Require `Array.isArray` instead of `instanceof Array`.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * [1, 2, 3] instanceof Array;
-       *
-       * // ✅ Correct
-       * Array.isArray([1, 2, 3]);
-       * ```
-       * @see [unicorn/no-instanceof-array](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-instanceof-array.md)
-       */
-      [`${unicornNamespace}/no-instanceof-array`]: ERROR,
+    /**
+     * Require `Array.isArray` instead of `instanceof Array`.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * [1, 2, 3] instanceof Array;
+     *
+     * // ✅ Correct
+     * Array.isArray([1, 2, 3]);
+     * ```
+     * @see [unicorn/no-instanceof-array](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-instanceof-array.md)
+     */
+    [`${unicornNamespace}/no-instanceof-array`]: ERROR,
 
-      /**
-       * Disallow invalid options in `fetch()` and new `Request()`.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const response = await fetch("/", { body: "foo=bar" });
-       * const request = new Request("/", { body: "foo=bar" });
-       * const response = await fetch("/", { method: "GET", body: "foo=bar" });
-       * const request = new Request("/", { method: "GET", body: "foo=bar" });
-       *
-       * // ✅ Correct
-       * const response = await fetch("/", { method: "POST", body: "foo=bar" });
-       * const request = new Request("/", { method: "POST", body: "foo=bar" });
-       * ```
-       * @see [unicorn/no-invalid-fetch-options](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-invalid-fetch-options.md)
-       */
-      [`${unicornNamespace}/no-invalid-fetch-options`]: ERROR,
+    /**
+     * Disallow invalid options in `fetch()` and new `Request()`.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const response = await fetch("/", { body: "foo=bar" });
+     * const request = new Request("/", { body: "foo=bar" });
+     * const response = await fetch("/", { method: "GET", body: "foo=bar" });
+     * const request = new Request("/", { method: "GET", body: "foo=bar" });
+     *
+     * // ✅ Correct
+     * const response = await fetch("/", { method: "POST", body: "foo=bar" });
+     * const request = new Request("/", { method: "POST", body: "foo=bar" });
+     * ```
+     * @see [unicorn/no-invalid-fetch-options](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-invalid-fetch-options.md)
+     */
+    [`${unicornNamespace}/no-invalid-fetch-options`]: ERROR,
 
-      /**
-       * Prevent calling `EventTarget#removeEventListener` with the result of an expression.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * window.removeEventListener("click", fn.bind(window));
-       * window.removeEventListener("click", () => {});
-       * window.removeEventListener("click", function () {});
-       *
-       * // ✅ Correct
-       * window.removeEventListener("click", listener);
-       * window.removeEventListener("click", getListener());
-       * ```
-       * @see [unicorn/no-invalid-remove-event-listener](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-invalid-remove-event-listener.md)
-       */
-      [`${unicornNamespace}/no-invalid-remove-event-listener`]: ERROR,
+    /**
+     * Prevent calling `EventTarget#removeEventListener` with the result of an expression.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * window.removeEventListener("click", fn.bind(window));
+     * window.removeEventListener("click", () => {});
+     * window.removeEventListener("click", function () {});
+     *
+     * // ✅ Correct
+     * window.removeEventListener("click", listener);
+     * window.removeEventListener("click", getListener());
+     * ```
+     * @see [unicorn/no-invalid-remove-event-listener](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-invalid-remove-event-listener.md)
+     */
+    [`${unicornNamespace}/no-invalid-remove-event-listener`]: ERROR,
 
-      /**
-       * Disallow using `.length` as the end argument of
-       * `{Array,String,TypedArray}#slice()`.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo = string.slice(1, string.length);
-       * const foo = array.slice(1, array.length);
-       *
-       * // ✅ Correct
-       * const foo = string.slice(1);
-       * const foo = bar.slice(1, baz.length);
-       * ```
-       * @see [unicorn/no-length-as-slice-end](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-length-as-slice-end.md)
-       */
-      [`${unicornNamespace}/no-length-as-slice-end`]: ERROR,
+    /**
+     * Disallow using `.length` as the end argument of
+     * `{Array,String,TypedArray}#slice()`.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo = string.slice(1, string.length);
+     * const foo = array.slice(1, array.length);
+     *
+     * // ✅ Correct
+     * const foo = string.slice(1);
+     * const foo = bar.slice(1, baz.length);
+     * ```
+     * @see [unicorn/no-length-as-slice-end](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-length-as-slice-end.md)
+     */
+    [`${unicornNamespace}/no-length-as-slice-end`]: ERROR,
 
-      /**
-       * Disallow a magic number as the `depth` argument in `Array#flat`.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo = array.flat(2);
-       * const foo = array.flat(99);
-       *
-       * // ✅ Correct
-       * const foo = array.flat();
-       * const foo = array.flat(Number.POSITIVE_INFINITY);
-       * const foo = array.flat(Infinity);
-       * const foo = array.flat(depth);
-       * ```
-       * @see [unicorn/no-magic-array-flat-depth](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-magic-array-flat-depth.md)
-       */
-      [`${unicornNamespace}/no-magic-array-flat-depth`]: ERROR,
+    /**
+     * Disallow a magic number as the `depth` argument in `Array#flat`.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo = array.flat(2);
+     * const foo = array.flat(99);
+     *
+     * // ✅ Correct
+     * const foo = array.flat();
+     * const foo = array.flat(Number.POSITIVE_INFINITY);
+     * const foo = array.flat(Infinity);
+     * const foo = array.flat(depth);
+     * ```
+     * @see [unicorn/no-magic-array-flat-depth](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-magic-array-flat-depth.md)
+     */
+    [`${unicornNamespace}/no-magic-array-flat-depth`]: ERROR,
 
-      /**
-       * Disallow negated conditions.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * !a ? c : b;
-       *
-       * // ✅ Correct
-       * a ? b : c;
-       * ```
-       * @see [unicorn/no-negated-condition](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-negated-condition.md)
-       */
-      [`${unicornNamespace}/no-negated-condition`]: ERROR,
+    /**
+     * Disallow negated conditions.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * !a ? c : b;
+     *
+     * // ✅ Correct
+     * a ? b : c;
+     * ```
+     * @see [unicorn/no-negated-condition](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-negated-condition.md)
+     */
+    [`${unicornNamespace}/no-negated-condition`]: ERROR,
 
-      /**
-       * Disallow negated expression in equality check.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * if (!foo === bar) {}
-       * if (!foo !== bar) {}
-       *
-       * // ✅ Correct
-       * if (foo !== bar) {}
-       * if (!(foo === bar)) {}
-       * ```
-       * @see [unicorn/no-negation-in-equality-check](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-negation-in-equality-check.md)
-       */
-      [`${unicornNamespace}/no-negation-in-equality-check`]: ERROR,
+    /**
+     * Disallow negated expression in equality check.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * if (!foo === bar) {}
+     * if (!foo !== bar) {}
+     *
+     * // ✅ Correct
+     * if (foo !== bar) {}
+     * if (!(foo === bar)) {}
+     * ```
+     * @see [unicorn/no-negation-in-equality-check](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-negation-in-equality-check.md)
+     */
+    [`${unicornNamespace}/no-negation-in-equality-check`]: ERROR,
 
-      /**
-       * Disallow `new Array()`.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const array = new Array(length);
-       * const array = new Array(onlyElement);
-       * const array = new Array(...unknownArgumentsList);
-       *
-       * // ✅ Correct
-       * const array = Array.from({ length });
-       * const array = [onlyElement];
-       * const array = [...items];
-       * ```
-       * @see [unicorn/no-new-array](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-new-array.md)
-       */
-      [`${unicornNamespace}/no-new-array`]: ERROR,
+    /**
+     * Disallow `new Array()`.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const array = new Array(length);
+     * const array = new Array(onlyElement);
+     * const array = new Array(...unknownArgumentsList);
+     *
+     * // ✅ Correct
+     * const array = Array.from({ length });
+     * const array = [onlyElement];
+     * const array = [...items];
+     * ```
+     * @see [unicorn/no-new-array](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-new-array.md)
+     */
+    [`${unicornNamespace}/no-new-array`]: ERROR,
 
-      /**
-       * Enforce the use of `Buffer.from` and `Buffer.alloc` instead of the deprecated `new Buffer()`.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const buffer = new Buffer("7468697320697320612074c3a97374", "hex");
-       * const buffer = new Buffer([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
-       * const buffer = new Buffer(10);
-       *
-       * // ✅ Correct
-       * const buffer = Buffer.from("7468697320697320612074c3a97374", "hex");
-       * const buffer = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
-       * const buffer = Buffer.alloc(10);
-       * ```
-       * @see [unicorn/no-new-buffer](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-new-buffer.md)
-       */
-      [`${unicornNamespace}/no-new-buffer`]: ERROR,
+    /**
+     * Enforce the use of `Buffer.from` and `Buffer.alloc` instead of the deprecated `new Buffer()`.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const buffer = new Buffer("7468697320697320612074c3a97374", "hex");
+     * const buffer = new Buffer([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
+     * const buffer = new Buffer(10);
+     *
+     * // ✅ Correct
+     * const buffer = Buffer.from("7468697320697320612074c3a97374", "hex");
+     * const buffer = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
+     * const buffer = Buffer.alloc(10);
+     * ```
+     * @see [unicorn/no-new-buffer](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-new-buffer.md)
+     */
+    [`${unicornNamespace}/no-new-buffer`]: ERROR,
 
-      /**
-       * Disallow the use of the null literal.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * let foo = null;
-       * if (bar == null) {}
-       *
-       * // ✅ Correct
-       * let foo;
-       * const foo = Object.create(null);
-       * if (foo === null) {}
-       * ```
-       * @see [Reasoning](https://lou.cx/articles/we-don-t-need-null/)
-       * @see [unicorn/no-null](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-null.md)
-       */
-      [`${unicornNamespace}/no-null`]: WARN,
+    /**
+     * Disallow the use of the null literal.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * let foo = null;
+     * if (bar == null) {}
+     *
+     * // ✅ Correct
+     * let foo;
+     * const foo = Object.create(null);
+     * if (foo === null) {}
+     * ```
+     * @see [Reasoning](https://lou.cx/articles/we-don-t-need-null/)
+     * @see [unicorn/no-null](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-null.md)
+     */
+    [`${unicornNamespace}/no-null`]: WARN,
 
-      /**
-       * Disallow passing single-element arrays to Promise methods.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo = await Promise.all([promise]);
-       * const foo = await Promise.any([promise]);
-       * const foo = await Promise.race([promise]);
-       * const promise = Promise.all([nonPromise]);
-       *
-       * // ✅ Correct
-       * const foo = await promise;
-       * const promise = Promise.resolve(nonPromise);
-       * const foo = await Promise.all(promises);
-       * const foo = await Promise.any([promise, anotherPromise]);
-       * const [{ value: foo, reason: error }] = await Promise.allSettled([promise]);
-       * ```
-       * @see [unicorn/no-single-promise-in-promise-methods](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-single-promise-in-promise-methods.md)
-       */
-      [`${unicornNamespace}/no-single-promise-in-promise-methods`]: ERROR,
+    /**
+     * Disallow passing single-element arrays to Promise methods.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo = await Promise.all([promise]);
+     * const foo = await Promise.any([promise]);
+     * const foo = await Promise.race([promise]);
+     * const promise = Promise.all([nonPromise]);
+     *
+     * // ✅ Correct
+     * const foo = await promise;
+     * const promise = Promise.resolve(nonPromise);
+     * const foo = await Promise.all(promises);
+     * const foo = await Promise.any([promise, anotherPromise]);
+     * const [{ value: foo, reason: error }] = await Promise.allSettled([promise]);
+     * ```
+     * @see [unicorn/no-single-promise-in-promise-methods](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-single-promise-in-promise-methods.md)
+     */
+    [`${unicornNamespace}/no-single-promise-in-promise-methods`]: ERROR,
 
-      /**
-       * Enforce the use of built-in methods instead of unnecessary polyfills.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const assign = require("object-assign");
-       * ```
-       * @see [unicorn/no-unnecessary-polyfills](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-unnecessary-polyfills.md)
-       */
-      [`${unicornNamespace}/no-unnecessary-polyfills`]: ERROR,
+    /**
+     * Enforce the use of built-in methods instead of unnecessary polyfills.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const assign = require("object-assign");
+     * ```
+     * @see [unicorn/no-unnecessary-polyfills](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-unnecessary-polyfills.md)
+     */
+    [`${unicornNamespace}/no-unnecessary-polyfills`]: ERROR,
 
-      /**
-       * Disallow useless fallback when spreading in object literals.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const object = { ...(foo || {}) };
-       * const object = { ...(foo ?? {}) };
-       *
-       * // ✅ Correct
-       * const object = { ...foo };
-       * const object = { ...(foo && {}) };
-       * const array = [...(foo || [])];
-       * ```
-       * @see [unicorn/no-useless-fallback-in-spread](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-useless-fallback-in-spread.md)
-       */
-      [`${unicornNamespace}/no-useless-fallback-in-spread`]: ERROR,
+    /**
+     * Disallow useless fallback when spreading in object literals.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const object = { ...(foo || {}) };
+     * const object = { ...(foo ?? {}) };
+     *
+     * // ✅ Correct
+     * const object = { ...foo };
+     * const object = { ...(foo && {}) };
+     * const array = [...(foo || [])];
+     * ```
+     * @see [unicorn/no-useless-fallback-in-spread](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-useless-fallback-in-spread.md)
+     */
+    [`${unicornNamespace}/no-useless-fallback-in-spread`]: ERROR,
 
-      /**
-       * Disallow useless array length check.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * if (array.length === 0 || array.every(Boolean));
-       * if (array.length !== 0 && array.some(Boolean));
-       * if (array.length > 0 && array.some(Boolean));
-       * const isAllTrulyOrEmpty = array.length === 0 || array.every(Boolean);
-       *
-       * // ✅ Correct
-       * if (array.every(Boolean));
-       * if (array.some(Boolean));
-       * const isAllTrulyOrEmpty = array.every(Boolean);
-       * if (array.length === 0 || anotherCheck() || array.every(Boolean));
-       * const isNonEmptyAllTrulyArray = array.length > 0 && array.every(Boolean);
-       * const isEmptyArrayOrAllTruly = array.length === 0 || array.some(Boolean);
-       * ```
-       * @see [unicorn/no-useless-length-check](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-useless-length-check.md)
-       */
-      [`${unicornNamespace}/no-useless-length-check`]: ERROR,
+    /**
+     * Disallow useless array length check.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * if (array.length === 0 || array.every(Boolean));
+     * if (array.length !== 0 && array.some(Boolean));
+     * if (array.length > 0 && array.some(Boolean));
+     * const isAllTrulyOrEmpty = array.length === 0 || array.every(Boolean);
+     *
+     * // ✅ Correct
+     * if (array.every(Boolean));
+     * if (array.some(Boolean));
+     * const isAllTrulyOrEmpty = array.every(Boolean);
+     * if (array.length === 0 || anotherCheck() || array.every(Boolean));
+     * const isNonEmptyAllTrulyArray = array.length > 0 && array.every(Boolean);
+     * const isEmptyArrayOrAllTruly = array.length === 0 || array.some(Boolean);
+     * ```
+     * @see [unicorn/no-useless-length-check](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-useless-length-check.md)
+     */
+    [`${unicornNamespace}/no-useless-length-check`]: ERROR,
 
-      /**
-       * Disallow unnecessary spread.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const array = [firstElement, ...[secondElement], thirdElement];
-       * const object = { firstProperty, ...{ secondProperty }, thirdProperty };
-       * foo(firstArgument, ...[secondArgument], thirdArgument);
-       * const object = new Foo(firstArgument, ...[secondArgument], thirdArgument);
-       * const set = new Set([...iterable]);
-       * const results = await Promise.all([...iterable]);
-       * for (const foo of [...set]);
-       * const foo = function* () { yield* [...anotherGenerator()]; };
-       * const foo = bar => [...bar.map(x => x * 2)];
-       *
-       * // ✅ Correct
-       * const array = [firstElement, secondElement, thirdElement];
-       * const object = { firstProperty, secondProperty, thirdProperty };
-       * foo(firstArgument, secondArgument, thirdArgument);
-       * const object = new Foo(firstArgument, secondArgument, thirdArgument);
-       * const set = new Set(iterable);
-       * const results = await Promise.all(iterable);
-       * for (const foo of set);
-       * const foo = function* () { yield* anotherGenerator; };
-       * const foo = bar => bar.map(x => x * 2);
-       * ```
-       * @see [unicorn/no-useless-spread](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-useless-spread.md)
-       */
-      [`${unicornNamespace}/no-useless-spread`]: ERROR,
+    /**
+     * Disallow unnecessary spread.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const array = [firstElement, ...[secondElement], thirdElement];
+     * const object = { firstProperty, ...{ secondProperty }, thirdProperty };
+     * foo(firstArgument, ...[secondArgument], thirdArgument);
+     * const object = new Foo(firstArgument, ...[secondArgument], thirdArgument);
+     * const set = new Set([...iterable]);
+     * const results = await Promise.all([...iterable]);
+     * for (const foo of [...set]);
+     * const foo = function* () { yield* [...anotherGenerator()]; };
+     * const foo = bar => [...bar.map(x => x * 2)];
+     *
+     * // ✅ Correct
+     * const array = [firstElement, secondElement, thirdElement];
+     * const object = { firstProperty, secondProperty, thirdProperty };
+     * foo(firstArgument, secondArgument, thirdArgument);
+     * const object = new Foo(firstArgument, secondArgument, thirdArgument);
+     * const set = new Set(iterable);
+     * const results = await Promise.all(iterable);
+     * for (const foo of set);
+     * const foo = function* () { yield* anotherGenerator; };
+     * const foo = bar => bar.map(x => x * 2);
+     * ```
+     * @see [unicorn/no-useless-spread](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-useless-spread.md)
+     */
+    [`${unicornNamespace}/no-useless-spread`]: ERROR,
 
-      /**
-       * Disallow useless case in switch statements.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       *
-       * // ✅ Correct
-       * ```
-       * @see [unicorn/no-useless-switch-case](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-useless-switch-case.md)
-       */
-      [`${unicornNamespace}/no-useless-switch-case`]: ERROR,
+    /**
+     * Disallow useless case in switch statements.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     *
+     * // ✅ Correct
+     * ```
+     * @see [unicorn/no-useless-switch-case](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-useless-switch-case.md)
+     */
+    [`${unicornNamespace}/no-useless-switch-case`]: ERROR,
 
-      /**
-       * Enforce the style of numeric separators by correctly grouping digits.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * switch (foo) {
-       *   case 1:
-       *   default:
-       *     handleDefaultCase();
-       *     break;
-       * }
-       *
-       * // ✅ Correct
-       * switch (foo) {
-       *   case 1:
-       *   case 2:
-       *     handleDefaultCase();
-       *     break;
-       * }
-       *
-       *
-       * switch (foo) {
-       *   case 1:
-       *     handleCase1();
-       *   default:
-       *     handleDefaultCase();
-       *     break;
-       * }
-       * ```
-       * @see [unicorn/numeric-separators-style](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/numeric-separators-style.md)
-       */
-      [`${unicornNamespace}/numeric-separators-style`]: ERROR,
+    /**
+     * Enforce the style of numeric separators by correctly grouping digits.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * switch (foo) {
+     *   case 1:
+     *   default:
+     *     handleDefaultCase();
+     *     break;
+     * }
+     *
+     * // ✅ Correct
+     * switch (foo) {
+     *   case 1:
+     *   case 2:
+     *     handleDefaultCase();
+     *     break;
+     * }
+     *
+     *
+     * switch (foo) {
+     *   case 1:
+     *     handleCase1();
+     *   default:
+     *     handleDefaultCase();
+     *     break;
+     * }
+     * ```
+     * @see [unicorn/numeric-separators-style](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/numeric-separators-style.md)
+     */
+    [`${unicornNamespace}/numeric-separators-style`]: ERROR,
 
-      /**
-       * Prefer `Element#addEventListener` and `Element#removeEventListener` over on-functions.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * foo.onclick = () => {};
-       * foo.onkeydown = () => {};
-       * foo.bar.onclick = onClick;
-       * foo.onclick = null;
-       *
-       * // ✅ Correct
-       * foo.addEventListener("click", () => {});
-       * foo.addEventListener("keydown", () => {});
-       * foo.bar.addEventListener("click", onClick);
-       * foo.removeEventListener("click", onClick);
-       * ```
-       * @see [unicorn/prefer-add-event-listener](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-add-event-listener.md)
-       */
-      [`${unicornNamespace}/prefer-add-event-listener`]: ERROR,
+    /**
+     * Prefer `Element#addEventListener` and `Element#removeEventListener` over on-functions.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * foo.onclick = () => {};
+     * foo.onkeydown = () => {};
+     * foo.bar.onclick = onClick;
+     * foo.onclick = null;
+     *
+     * // ✅ Correct
+     * foo.addEventListener("click", () => {});
+     * foo.addEventListener("keydown", () => {});
+     * foo.bar.addEventListener("click", onClick);
+     * foo.removeEventListener("click", onClick);
+     * ```
+     * @see [unicorn/prefer-add-event-listener](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-add-event-listener.md)
+     */
+    [`${unicornNamespace}/prefer-add-event-listener`]: ERROR,
 
-      /**
-       * Prefer `Array#find` and `Array#findLast` over the first or last element from `Array#filter`.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const item = array.filter(isUnicorn)[0];
-       * const item = array.filter(isUnicorn).at(-1);
-       * const item = array.filter(isUnicorn).shift();
-       * const item = array.filter(isUnicorn).pop();
-       * const [item] = array.filter(isUnicorn);
-       * [item] = array.filter(isUnicorn);
-       *
-       * // ✅ Correct
-       * const item = array.find(isUnicorn);
-       * item = array.find(isUnicorn);
-       * const item = array.findLast(isUnicorn);
-       * ```
-       * @see [unicorn/prefer-array-find](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-array-find.md)
-       */
-      [`${unicornNamespace}/prefer-array-find`]: ERROR,
+    /**
+     * Prefer `Array#find` and `Array#findLast` over the first or last element from `Array#filter`.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const item = array.filter(isUnicorn)[0];
+     * const item = array.filter(isUnicorn).at(-1);
+     * const item = array.filter(isUnicorn).shift();
+     * const item = array.filter(isUnicorn).pop();
+     * const [item] = array.filter(isUnicorn);
+     * [item] = array.filter(isUnicorn);
+     *
+     * // ✅ Correct
+     * const item = array.find(isUnicorn);
+     * item = array.find(isUnicorn);
+     * const item = array.findLast(isUnicorn);
+     * ```
+     * @see [unicorn/prefer-array-find](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-array-find.md)
+     */
+    [`${unicornNamespace}/prefer-array-find`]: ERROR,
 
-      /**
-       * Prefer `Array#flat` over legacy techniques to flatten arrays.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo = array.flatMap(x => x);
-       * const foo = array.reduce((a, b) => a.concat(b), []);
-       * const foo = array.reduce((a, b) => [...a, ...b], []);
-       * const foo = [].concat(maybeArray);
-       * const foo = [].concat(...array);
-       * const foo = [].concat.apply([], array);
-       * const foo = Array.prototype.concat.apply([], array);
-       * const foo = Array.prototype.concat.call([], maybeArray);
-       * const foo = Array.prototype.concat.call([], ...array);
-       * const foo = _.flatten(array);
-       * const foo = lodash.flatten(array);
-       * const foo = underscore.flatten(array);
-       *
-       * // ✅ Correct
-       * const foo = array.flat();
-       * const foo = [maybeArray].flat();
-       * ```
-       * @see [unicorn/prefer-array-flat](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-array-flat.md)
-       */
-      [`${unicornNamespace}/prefer-array-flat`]: ERROR,
+    /**
+     * Prefer `Array#flat` over legacy techniques to flatten arrays.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo = array.flatMap(x => x);
+     * const foo = array.reduce((a, b) => a.concat(b), []);
+     * const foo = array.reduce((a, b) => [...a, ...b], []);
+     * const foo = [].concat(maybeArray);
+     * const foo = [].concat(...array);
+     * const foo = [].concat.apply([], array);
+     * const foo = Array.prototype.concat.apply([], array);
+     * const foo = Array.prototype.concat.call([], maybeArray);
+     * const foo = Array.prototype.concat.call([], ...array);
+     * const foo = _.flatten(array);
+     * const foo = lodash.flatten(array);
+     * const foo = underscore.flatten(array);
+     *
+     * // ✅ Correct
+     * const foo = array.flat();
+     * const foo = [maybeArray].flat();
+     * ```
+     * @see [unicorn/prefer-array-flat](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-array-flat.md)
+     */
+    [`${unicornNamespace}/prefer-array-flat`]: ERROR,
 
-      /**
-       * Prefer `Array#flatMap` over `Array#map(…).flat()`.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo = bar.map(unicorn).flat();
-       * const foo = bar.map(unicorn).flat(1);
-       *
-       * // ✅ Correct
-       * const foo = bar.flatMap(unicorn);
-       * const foo = bar.map(unicorn).flat(2);
-       * const foo = bar.map(unicorn).foo().flat();
-       * const foo = bar.flat().map(unicorn);
-       * ```
-       * @see [unicorn/prefer-array-flat-map](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-array-flat-map.md)
-       */
-      [`${unicornNamespace}/prefer-array-flat-map`]: ERROR,
+    /**
+     * Prefer `Array#flatMap` over `Array#map(…).flat()`.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo = bar.map(unicorn).flat();
+     * const foo = bar.map(unicorn).flat(1);
+     *
+     * // ✅ Correct
+     * const foo = bar.flatMap(unicorn);
+     * const foo = bar.map(unicorn).flat(2);
+     * const foo = bar.map(unicorn).foo().flat();
+     * const foo = bar.flat().map(unicorn);
+     * ```
+     * @see [unicorn/prefer-array-flat-map](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-array-flat-map.md)
+     */
+    [`${unicornNamespace}/prefer-array-flat-map`]: ERROR,
 
-      /**
-       * Prefer `Array#indexOf` and `Array#lastIndexOf` over `Array#findIndex` and `Array#findLastIndex` when looking for the index of an item.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const index = foo.findIndex(x => x === "foo");
-       * const index = foo.findIndex(x => "foo" === x);
-       * const index = foo.findLastIndex(x => x === "foo");
-       * const index = foo.findLastIndex(x => "foo" === x);
-       *
-       * // ✅ Correct
-       * const index = foo.indexOf("foo");
-       * const index = foo.findIndex(x => x === undefined);
-       * const index = foo.findIndex(x => x !== "foo");
-       * const index = foo.findIndex((x, index) => x === index);
-       * const index = foo.findIndex(x => (x === "foo") && isValid());
-       * const index = foo.findIndex(x => y === "foo");
-       * const index = foo.findIndex(x => y.x === "foo");
-       * const index = foo.lastIndexOf("foo");
-       * const index = foo.findLastIndex(x => x == undefined);
-       * const index = foo.findLastIndex(x => x !== "foo");
-       * const index = foo.findLastIndex((x, index) => x === index);
-       * const index = foo.findLastIndex(x => (x === "foo") && isValid());
-       * const index = foo.findLastIndex(x => y === "foo");
-       * const index = foo.findLastIndex(x => y.x === "foo");
-       * ```
-       * @see [unicorn/prefer-array-index-of](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-array-index-of.md)
-       */
-      [`${unicornNamespace}/prefer-array-index-of`]: ERROR,
+    /**
+     * Prefer `Array#indexOf` and `Array#lastIndexOf` over `Array#findIndex` and `Array#findLastIndex` when looking for the index of an item.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const index = foo.findIndex(x => x === "foo");
+     * const index = foo.findIndex(x => "foo" === x);
+     * const index = foo.findLastIndex(x => x === "foo");
+     * const index = foo.findLastIndex(x => "foo" === x);
+     *
+     * // ✅ Correct
+     * const index = foo.indexOf("foo");
+     * const index = foo.findIndex(x => x === undefined);
+     * const index = foo.findIndex(x => x !== "foo");
+     * const index = foo.findIndex((x, index) => x === index);
+     * const index = foo.findIndex(x => (x === "foo") && isValid());
+     * const index = foo.findIndex(x => y === "foo");
+     * const index = foo.findIndex(x => y.x === "foo");
+     * const index = foo.lastIndexOf("foo");
+     * const index = foo.findLastIndex(x => x == undefined);
+     * const index = foo.findLastIndex(x => x !== "foo");
+     * const index = foo.findLastIndex((x, index) => x === index);
+     * const index = foo.findLastIndex(x => (x === "foo") && isValid());
+     * const index = foo.findLastIndex(x => y === "foo");
+     * const index = foo.findLastIndex(x => y.x === "foo");
+     * ```
+     * @see [unicorn/prefer-array-index-of](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-array-index-of.md)
+     */
+    [`${unicornNamespace}/prefer-array-index-of`]: ERROR,
 
-      /**
-       * Prefer `Array#some` over `Array#filter(…).length` check and `Array#find` or `Array#findLast`.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const hasUnicorn = array.filter(isUnicorn).length > 0;
-       * const hasUnicorn = array.filter(isUnicorn).length !== 0;
-       * const hasUnicorn = array.filter(isUnicorn).length >= 1;
-       * const foo = array.find(isUnicorn) ? bar : baz;
-       * const hasUnicorn = array.find(isUnicorn) !== undefined;
-       * const hasUnicorn = array.find(isUnicorn) != null;
-       * const foo = array.findLast(isUnicorn) ? bar : baz;
-       * const hasUnicorn = array.findLast(isUnicorn) !== undefined;
-       * const hasUnicorn = array.findLast(isUnicorn) != null;
-       * const hasUnicorn = array.findIndex(isUnicorn) !== -1;
-       * const hasUnicorn = array.findLastIndex(isUnicorn) !== -1;
-       *
-       * // ✅ Correct
-       * const hasUnicorn = array.some(isUnicorn);
-       * ```
-       * @see [unicorn/prefer-array-some](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-array-some.md)
-       */
-      [`${unicornNamespace}/prefer-array-some`]: ERROR,
+    /**
+     * Prefer `Array#some` over `Array#filter(…).length` check and `Array#find` or `Array#findLast`.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const hasUnicorn = array.filter(isUnicorn).length > 0;
+     * const hasUnicorn = array.filter(isUnicorn).length !== 0;
+     * const hasUnicorn = array.filter(isUnicorn).length >= 1;
+     * const foo = array.find(isUnicorn) ? bar : baz;
+     * const hasUnicorn = array.find(isUnicorn) !== undefined;
+     * const hasUnicorn = array.find(isUnicorn) != null;
+     * const foo = array.findLast(isUnicorn) ? bar : baz;
+     * const hasUnicorn = array.findLast(isUnicorn) !== undefined;
+     * const hasUnicorn = array.findLast(isUnicorn) != null;
+     * const hasUnicorn = array.findIndex(isUnicorn) !== -1;
+     * const hasUnicorn = array.findLastIndex(isUnicorn) !== -1;
+     *
+     * // ✅ Correct
+     * const hasUnicorn = array.some(isUnicorn);
+     * ```
+     * @see [unicorn/prefer-array-some](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-array-some.md)
+     */
+    [`${unicornNamespace}/prefer-array-some`]: ERROR,
 
-      /**
-       * Prefer `Date.now` to get the number of milliseconds since the Unix Epoch.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo = new Date().getTime();
-       * const foo = new Date().valueOf();
-       * const foo = +new Date;
-       * const foo = Number(new Date());
-       *
-       * // ✅ Correct
-       * const foo = Date.now();
-       * ```
-       * @see [unicorn/prefer-date-now](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-date-now.md)
-       */
-      [`${unicornNamespace}/prefer-date-now`]: ERROR,
+    /**
+     * Prefer `Date.now` to get the number of milliseconds since the Unix Epoch.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo = new Date().getTime();
+     * const foo = new Date().valueOf();
+     * const foo = +new Date;
+     * const foo = Number(new Date());
+     *
+     * // ✅ Correct
+     * const foo = Date.now();
+     * ```
+     * @see [unicorn/prefer-date-now](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-date-now.md)
+     */
+    [`${unicornNamespace}/prefer-date-now`]: ERROR,
 
-      /**
-       * Prefer default parameters over reassignment.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * function abc(foo) {
-       *   foo ||= "bar";
-       * }
-       *
-       * // ✅ Correct
-       * function abc(foo = "bar") {}
-       * ```
-       * @see [unicorn/prefer-default-parameters](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-default-parameters.md)
-       */
-      [`${unicornNamespace}/prefer-default-parameters`]: ERROR,
+    /**
+     * Prefer default parameters over reassignment.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * function abc(foo) {
+     *   foo ||= "bar";
+     * }
+     *
+     * // ✅ Correct
+     * function abc(foo = "bar") {}
+     * ```
+     * @see [unicorn/prefer-default-parameters](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-default-parameters.md)
+     */
+    [`${unicornNamespace}/prefer-default-parameters`]: ERROR,
 
-      /**
-       * Prefer `Node#append` over `Node#appendChild`.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * foo.appendChild(bar);
-       *
-       * // ✅ Correct
-       * foo.append(bar);
-       * foo.append("bar");
-       * foo.append(bar, "baz");
-       * ```
-       * @see [unicorn/prefer-dom-node-append](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-dom-node-append.md)
-       */
-      [`${unicornNamespace}/prefer-dom-node-append`]: ERROR,
+    /**
+     * Prefer `Node#append` over `Node#appendChild`.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * foo.appendChild(bar);
+     *
+     * // ✅ Correct
+     * foo.append(bar);
+     * foo.append("bar");
+     * foo.append(bar, "baz");
+     * ```
+     * @see [unicorn/prefer-dom-node-append](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-dom-node-append.md)
+     */
+    [`${unicornNamespace}/prefer-dom-node-append`]: ERROR,
 
-      /**
-       * Prefer using `Element.dataset` on DOM elements over calling attribute methods.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const unicorn = element.getAttribute("data-unicorn");
-       * element.setAttribute("data-unicorn", "🦄");
-       * element.removeAttribute("data-unicorn");
-       * const hasUnicorn = element.hasAttribute("data-unicorn");
-       *
-       * // ✅ Correct
-       * const { unicorn } = element.dataset;
-       * element.dataset.unicorn = "🦄";
-       * delete element.dataset.unicorn;
-       * const hasUnicorn = Object.hasOwn(element.dataset, "unicorn");
-       * ```
-       * @see [unicorn/prefer-dom-node-dataset](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-dom-node-dataset.md)
-       */
-      [`${unicornNamespace}/prefer-dom-node-dataset`]: ERROR,
+    /**
+     * Prefer using `Element.dataset` on DOM elements over calling attribute methods.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const unicorn = element.getAttribute("data-unicorn");
+     * element.setAttribute("data-unicorn", "🦄");
+     * element.removeAttribute("data-unicorn");
+     * const hasUnicorn = element.hasAttribute("data-unicorn");
+     *
+     * // ✅ Correct
+     * const { unicorn } = element.dataset;
+     * element.dataset.unicorn = "🦄";
+     * delete element.dataset.unicorn;
+     * const hasUnicorn = Object.hasOwn(element.dataset, "unicorn");
+     * ```
+     * @see [unicorn/prefer-dom-node-dataset](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-dom-node-dataset.md)
+     */
+    [`${unicornNamespace}/prefer-dom-node-dataset`]: ERROR,
 
-      /**
-       * Prefer `ChildNode#remove` over `ParentNode#removeChild(childNode)`.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * parentNode.removeChild(foo);
-       * parentNode.removeChild(this);
-       *
-       * // ✅ Correct
-       * foo.remove();
-       * this.remove();
-       * ```
-       * @see [unicorn/prefer-dom-node-remove](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-dom-node-remove.md)
-       */
-      [`${unicornNamespace}/prefer-dom-node-remove`]: ERROR,
+    /**
+     * Prefer `ChildNode#remove` over `ParentNode#removeChild(childNode)`.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * parentNode.removeChild(foo);
+     * parentNode.removeChild(this);
+     *
+     * // ✅ Correct
+     * foo.remove();
+     * this.remove();
+     * ```
+     * @see [unicorn/prefer-dom-node-remove](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-dom-node-remove.md)
+     */
+    [`${unicornNamespace}/prefer-dom-node-remove`]: ERROR,
 
-      /**
-       * Prefer `Element#textContent` over `Element#innerText`.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const text = foo.innerText;
-       * const { innerText } = foo;
-       * foo.innerText = "🦄";
-       *
-       * // ✅ Correct
-       * const text = foo.textContent;
-       * const { textContent } = foo;
-       * foo.textContent = "🦄";
-       * ```
-       * @see [unicorn/prefer-dom-node-text-content](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-dom-node-text-content.md)
-       */
-      [`${unicornNamespace}/prefer-dom-node-text-content`]: ERROR,
+    /**
+     * Prefer `Element#textContent` over `Element#innerText`.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const text = foo.innerText;
+     * const { innerText } = foo;
+     * foo.innerText = "🦄";
+     *
+     * // ✅ Correct
+     * const text = foo.textContent;
+     * const { textContent } = foo;
+     * foo.textContent = "🦄";
+     * ```
+     * @see [unicorn/prefer-dom-node-text-content](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-dom-node-text-content.md)
+     */
+    [`${unicornNamespace}/prefer-dom-node-text-content`]: ERROR,
 
-      /**
-       * Prefer `EventTarget` over `EventEmitter`.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * import { EventEmitter } from "node:event";
-       *
-       * class Foo extends EventEmitter {}
-       * const emitter = new EventEmitter();
-       *
-       * // ✅ Correct
-       * class Foo extends EventTarget {}
-       * const target = new EventTarget();
-       * ```
-       * @see [unicorn/prefer-event-target](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-event-target.md)
-       */
-      [`${unicornNamespace}/prefer-event-target`]: ERROR,
+    /**
+     * Prefer `EventTarget` over `EventEmitter`.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * import { EventEmitter } from "node:event";
+     *
+     * class Foo extends EventEmitter {}
+     * const emitter = new EventEmitter();
+     *
+     * // ✅ Correct
+     * class Foo extends EventTarget {}
+     * const target = new EventTarget();
+     * ```
+     * @see [unicorn/prefer-event-target](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-event-target.md)
+     */
+    [`${unicornNamespace}/prefer-event-target`]: ERROR,
 
-      /**
-       * Prefer `export…from` when re-exporting.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * import defaultExport from "./foo.js";
-       * export default defaultExport;
-       *
-       * import { named } from "./foo.js";
-       * export { named };
-       *
-       * // ✅ Correct
-       * export { default } from "./foo.js";
-       * export { named } from "./foo.js";
-       * ```
-       * @see [unicorn/prefer-export-from](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-export-from.md)
-       */
-      [`${unicornNamespace}/prefer-export-from`]: ERROR,
+    /**
+     * Prefer `export…from` when re-exporting.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * import defaultExport from "./foo.js";
+     * export default defaultExport;
+     *
+     * import { named } from "./foo.js";
+     * export { named };
+     *
+     * // ✅ Correct
+     * export { default } from "./foo.js";
+     * export { named } from "./foo.js";
+     * ```
+     * @see [unicorn/prefer-export-from](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-export-from.md)
+     */
+    [`${unicornNamespace}/prefer-export-from`]: ERROR,
 
-      /**
-       * Prefer `Array#includes` over `Array.indexOf` and `Array#some` when checking for existence or non-existence.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * array.indexOf("foo") !== -1;
-       * string.indexOf("foo") !== -1;
-       * array.lastIndexOf("foo") !== -1;
-       * string.lastIndexOf("foo") !== -1;
-       *
-       * // ✅ Correct
-       * array.includes("foo");
-       * string.includes("foo");
-       * array.includes("foo");
-       * string.includes("foo");
-       * ```
-       * @see [unicorn/prefer-includes](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-includes.md)
-       */
-      [`${unicornNamespace}/prefer-includes`]: ERROR,
+    /**
+     * Prefer `Array#includes` over `Array.indexOf` and `Array#some` when checking for existence or non-existence.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * array.indexOf("foo") !== -1;
+     * string.indexOf("foo") !== -1;
+     * array.lastIndexOf("foo") !== -1;
+     * string.lastIndexOf("foo") !== -1;
+     *
+     * // ✅ Correct
+     * array.includes("foo");
+     * string.includes("foo");
+     * array.includes("foo");
+     * string.includes("foo");
+     * ```
+     * @see [unicorn/prefer-includes](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-includes.md)
+     */
+    [`${unicornNamespace}/prefer-includes`]: ERROR,
 
-      /**
-       * Prefer `KeyboardEvent#key` over `KeyboardEvent#keyCode`.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * window.addEventListener("keydown", event => {
-       *   console.log(event.keyCode);
-       * });
-       *
-       * // ✅ Correct
-       * window.addEventListener("click", event => {
-       *   console.log(event.key);
-       * });
-       * ```
-       * @see [unicorn/prefer-keyboard-event-key](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-keyboard-event-key.md)
-       */
-      [`${unicornNamespace}/prefer-keyboard-event-key`]: ERROR,
+    /**
+     * Prefer `KeyboardEvent#key` over `KeyboardEvent#keyCode`.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * window.addEventListener("keydown", event => {
+     *   console.log(event.keyCode);
+     * });
+     *
+     * // ✅ Correct
+     * window.addEventListener("click", event => {
+     *   console.log(event.key);
+     * });
+     * ```
+     * @see [unicorn/prefer-keyboard-event-key](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-keyboard-event-key.md)
+     */
+    [`${unicornNamespace}/prefer-keyboard-event-key`]: ERROR,
 
-      /**
-       * Prefer using a logical operator over a ternary.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * foo ? foo : bar;
-       *
-       * // ✅ Correct
-       * foo ?? bar;
-       * ```
-       * @see [unicorn/prefer-logical-operator-over-ternary](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-logical-operator-over-ternary.md)
-       */
-      [`${unicornNamespace}/prefer-logical-operator-over-ternary`]: ERROR,
+    /**
+     * Prefer using a logical operator over a ternary.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * foo ? foo : bar;
+     *
+     * // ✅ Correct
+     * foo ?? bar;
+     * ```
+     * @see [unicorn/prefer-logical-operator-over-ternary](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-logical-operator-over-ternary.md)
+     */
+    [`${unicornNamespace}/prefer-logical-operator-over-ternary`]: ERROR,
 
-      /**
-       * Modern DOM APIs enforcement:
-       *
-       * | Prefer…                                                                  | over…                                                              |
-       * | ------------------------------------------------------------------------ | ------------------------------------------------------------------ |
-       * | `Element#before`                                                         | `Element#insertBefore`                                             |
-       * | `Element#replaceWith`                                                    | `Element#replaceChild`                                             |
-       * | `Element#before`, `Element#after`, `Element#append` or `Element#prepend` | `Element#insertAdjacentText`() and `Element#insertAdjacentElement` |
-       *
-       * @see [unicorn/prefer-modern-dom-apis](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-modern-dom-apis.md)
-       */
-      [`${unicornNamespace}/prefer-modern-dom-apis`]: ERROR,
+    /**
+     * Modern DOM APIs enforcement:
+     *
+     * | Prefer…                                                                  | over…                                                              |
+     * | ------------------------------------------------------------------------ | ------------------------------------------------------------------ |
+     * | `Element#before`                                                         | `Element#insertBefore`                                             |
+     * | `Element#replaceWith`                                                    | `Element#replaceChild`                                             |
+     * | `Element#before`, `Element#after`, `Element#append` or `Element#prepend` | `Element#insertAdjacentText`() and `Element#insertAdjacentElement` |
+     *
+     * @see [unicorn/prefer-modern-dom-apis](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-modern-dom-apis.md)
+     */
+    [`${unicornNamespace}/prefer-modern-dom-apis`]: ERROR,
 
-      /**
-       * Prefer modern Math APIs over legacy patterns.
-       *
-       * | Prefer…         | over…                       |
-       * | --------------- | --------------------------- |
-       * | `Math.log10(x)` | `Math.log(x) * Math.LOG10E` |
-       * | `Math.log2(x)`  | `Math.log(x) * Math.LOG2E`  |
-       * | `Math.hypot(…)` | `Math.sqrt(a * a + b * b)`  |
-       *
-       * @see [unicorn/prefer-modern-math-apis](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-modern-math-apis.md)
-       */
-      [`${unicornNamespace}/prefer-modern-math-apis`]: ERROR,
+    /**
+     * Prefer modern Math APIs over legacy patterns.
+     *
+     * | Prefer…         | over…                       |
+     * | --------------- | --------------------------- |
+     * | `Math.log10(x)` | `Math.log(x) * Math.LOG10E` |
+     * | `Math.log2(x)`  | `Math.log(x) * Math.LOG2E`  |
+     * | `Math.hypot(…)` | `Math.sqrt(a * a + b * b)`  |
+     *
+     * @see [unicorn/prefer-modern-math-apis](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-modern-math-apis.md)
+     */
+    [`${unicornNamespace}/prefer-modern-math-apis`]: ERROR,
 
-      /**
-       * Prefer using the `node:` protocol when importing Node.js builtin modules.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * import fs from "fs/promises";
-       * export { strict as default } from "assert";
-       *
-       * // ✅ Correct
-       * import fs from "node:fs/promises";
-       * export { strict as default } from "node:assert";
-       * ```
-       * @see [unicorn/prefer-node-protocol](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-node-protocol.md)
-       */
-      [`${unicornNamespace}/prefer-node-protocol`]: ERROR,
+    /**
+     * Prefer using the `node:` protocol when importing Node.js builtin modules.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * import fs from "fs/promises";
+     * export { strict as default } from "assert";
+     *
+     * // ✅ Correct
+     * import fs from "node:fs/promises";
+     * export { strict as default } from "node:assert";
+     * ```
+     * @see [unicorn/prefer-node-protocol](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-node-protocol.md)
+     */
+    [`${unicornNamespace}/prefer-node-protocol`]: ERROR,
 
-      /**
-       * Prefer using `Object.fromEntries` to transform a list of key-value pairs into an object.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const object = pairs.reduce(
-       *   (object, [key, value]) => ({...object, [key]: value}),
-       *   {}
-       * );
-       * const object = _.fromPairs(pairs);
-       *
-       * // ✅ Correct
-       * const object = Object.fromEntries(pairs);
-       * const object = new Map(pairs);
-       * ```
-       * @see [unicorn/prefer-object-from-entries](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-object-from-entries.md)
-       */
-      [`${unicornNamespace}/prefer-object-from-entries`]: ERROR,
+    /**
+     * Prefer using `Object.fromEntries` to transform a list of key-value pairs into an object.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const object = pairs.reduce(
+     *   (object, [key, value]) => ({...object, [key]: value}),
+     *   {}
+     * );
+     * const object = _.fromPairs(pairs);
+     *
+     * // ✅ Correct
+     * const object = Object.fromEntries(pairs);
+     * const object = new Map(pairs);
+     * ```
+     * @see [unicorn/prefer-object-from-entries](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-object-from-entries.md)
+     */
+    [`${unicornNamespace}/prefer-object-from-entries`]: ERROR,
 
-      /**
-       * Prefer omitting the catch binding parameter.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * try {} catch (notUsedError) {}
-       * try {} catch ({ message }) {}
-       *
-       * // ✅ Correct
-       * try {} catch {}
-       *
-       * try {} catch (error) {
-       *   console.error(error);
-       * }
-       * ```
-       * @see [unicorn/prefer-optional-catch-binding](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-optional-catch-binding.md)
-       */
-      [`${unicornNamespace}/prefer-optional-catch-binding`]: ERROR,
+    /**
+     * Prefer omitting the catch binding parameter.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * try {} catch (notUsedError) {}
+     * try {} catch ({ message }) {}
+     *
+     * // ✅ Correct
+     * try {} catch {}
+     *
+     * try {} catch (error) {
+     *   console.error(error);
+     * }
+     * ```
+     * @see [unicorn/prefer-optional-catch-binding](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-optional-catch-binding.md)
+     */
+    [`${unicornNamespace}/prefer-optional-catch-binding`]: ERROR,
 
-      /**
-       * Query selector preference:
-       *
-       * | Prefer…                    | over…                                                               |
-       * | -------------------------- | ------------------------------------------------------------------- |
-       * | `Element#querySelector`    | `Element#getElementById`                                            |
-       * | `Element#querySelectorAll` | `Element#getElementsByClassName` and `Element#getElementsByTagName` |
-       *
-       * @see [unicorn/prefer-query-selector](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-query-selector.md)
-       */
-      [`${unicornNamespace}/prefer-query-selector`]: ERROR,
+    /**
+     * Query selector preference:
+     *
+     * | Prefer…                    | over…                                                               |
+     * | -------------------------- | ------------------------------------------------------------------- |
+     * | `Element#querySelector`    | `Element#getElementById`                                            |
+     * | `Element#querySelectorAll` | `Element#getElementsByClassName` and `Element#getElementsByTagName` |
+     *
+     * @see [unicorn/prefer-query-selector](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-query-selector.md)
+     */
+    [`${unicornNamespace}/prefer-query-selector`]: ERROR,
 
-      /**
-       * Prefer the spread operator over `Array.from`, `Array#concat`, `Array#slice`, `Array#toSpliced` and `String#split`.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * Array.from(set).map(element => foo(element));
-       * const array = array1.concat(array2);
-       * const copy = array.slice();
-       * const copy = array.slice(0);
-       * const copy = array.toSpliced();
-       * const characters = string.split("");
-       *
-       * // ✅ Correct
-       * [...set].map(element => foo(element));
-       * const array = [...array1, ...array2];
-       * const tail = array.slice(1);
-       * const copy = [...array];
-       * const characters = [...string];
-       * ```
-       * @see [unicorn/prefer-spread](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-spread.md)
-       */
-      [`${unicornNamespace}/prefer-spread`]: ERROR,
+    /**
+     * Prefer the spread operator over `Array.from`, `Array#concat`, `Array#slice`, `Array#toSpliced` and `String#split`.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * Array.from(set).map(element => foo(element));
+     * const array = array1.concat(array2);
+     * const copy = array.slice();
+     * const copy = array.slice(0);
+     * const copy = array.toSpliced();
+     * const characters = string.split("");
+     *
+     * // ✅ Correct
+     * [...set].map(element => foo(element));
+     * const array = [...array1, ...array2];
+     * const tail = array.slice(1);
+     * const copy = [...array];
+     * const characters = [...string];
+     * ```
+     * @see [unicorn/prefer-spread](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-spread.md)
+     */
+    [`${unicornNamespace}/prefer-spread`]: ERROR,
 
-      /**
-       * Prefer `String#replaceAll` over regex searches with the global flag.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * string.replace(/RegExp with global flag/igu, ");
-       * string.replace(/RegExp without special symbols/g, ");
-       *
-       * // ✅ Correct
-       * string.replace(/Non-global regexp/iu, ");
-       * string.replace("Not a regex expression", ")
-       * string.replaceAll("string", ");
-       * ```
-       * @see [unicorn/prefer-string-replace-all](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-string-replace-all.md)
-       */
-      [`${unicornNamespace}/prefer-string-replace-all`]: ERROR,
+    /**
+     * Prefer `String#replaceAll` over regex searches with the global flag.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * string.replace(/RegExp with global flag/igu, ");
+     * string.replace(/RegExp without special symbols/g, ");
+     *
+     * // ✅ Correct
+     * string.replace(/Non-global regexp/iu, ");
+     * string.replace("Not a regex expression", ")
+     * string.replaceAll("string", ");
+     * ```
+     * @see [unicorn/prefer-string-replace-all](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-string-replace-all.md)
+     */
+    [`${unicornNamespace}/prefer-string-replace-all`]: ERROR,
 
-      /**
-       * Prefer `String#slice` over `String#substr` and `String#substring`.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * foo.substr(start, length);
-       * foo.substring(indexStart, indexEnd);
-       *
-       * // ✅ Correct
-       * foo.slice(beginIndex, endIndex);
-       * ```
-       * @see [unicorn/prefer-string-slice](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-string-slice.md)
-       */
-      [`${unicornNamespace}/prefer-string-slice`]: ERROR,
+    /**
+     * Prefer `String#slice` over `String#substr` and `String#substring`.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * foo.substr(start, length);
+     * foo.substring(indexStart, indexEnd);
+     *
+     * // ✅ Correct
+     * foo.slice(beginIndex, endIndex);
+     * ```
+     * @see [unicorn/prefer-string-slice](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-string-slice.md)
+     */
+    [`${unicornNamespace}/prefer-string-slice`]: ERROR,
 
-      /**
-       * Prefer `String#startsWith` & `String#endsWith` over `RegExp#test`.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo = /^bar/.test(baz);
-       * const foo = /bar$/.test(baz);
-       *
-       * // ✅ Correct
-       * const foo = baz.startsWith("bar");
-       * const foo = baz.endsWith("bar");
-       * ```
-       * @see [unicorn/prefer-string-starts-ends-with](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-string-starts-ends-with.md)
-       */
-      [`${unicornNamespace}/prefer-string-starts-ends-with`]: ERROR,
+    /**
+     * Prefer `String#startsWith` & `String#endsWith` over `RegExp#test`.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo = /^bar/.test(baz);
+     * const foo = /bar$/.test(baz);
+     *
+     * // ✅ Correct
+     * const foo = baz.startsWith("bar");
+     * const foo = baz.endsWith("bar");
+     * ```
+     * @see [unicorn/prefer-string-starts-ends-with](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-string-starts-ends-with.md)
+     */
+    [`${unicornNamespace}/prefer-string-starts-ends-with`]: ERROR,
 
-      /**
-       * Prefer `String#trimStart` and `String#trimEnd` over `String#trimLeft` and `String#trimRight`.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const foo = bar.trimLeft();
-       * const foo = bar.trimRight();
-       *
-       * // ✅ Correct
-       * const foo = bar.trimStart();
-       * const foo = bar.trimEnd();
-       * ```
-       * @see [unicorn/prefer-string-trim-start-end](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-string-trim-start-end.md)
-       */
-      [`${unicornNamespace}/prefer-string-trim-start-end`]: ERROR,
+    /**
+     * Prefer `String#trimStart` and `String#trimEnd` over `String#trimLeft` and `String#trimRight`.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const foo = bar.trimLeft();
+     * const foo = bar.trimRight();
+     *
+     * // ✅ Correct
+     * const foo = bar.trimStart();
+     * const foo = bar.trimEnd();
+     * ```
+     * @see [unicorn/prefer-string-trim-start-end](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-string-trim-start-end.md)
+     */
+    [`${unicornNamespace}/prefer-string-trim-start-end`]: ERROR,
 
-      /**
-       * Prefer using `structuredClone` to create a deep clone.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const clone = JSON.parse(JSON.stringify(foo));
-       * const clone = _.cloneDeep(foo);
-       *
-       * // ✅ Correct
-       * const clone = structuredClone(foo);
-       * ```
-       * @see [unicorn/prefer-structured-clone](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-structured-clone.md)
-       */
-      [`${unicornNamespace}/prefer-structured-clone`]: ERROR,
+    /**
+     * Prefer using `structuredClone` to create a deep clone.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const clone = JSON.parse(JSON.stringify(foo));
+     * const clone = _.cloneDeep(foo);
+     *
+     * // ✅ Correct
+     * const clone = structuredClone(foo);
+     * ```
+     * @see [unicorn/prefer-structured-clone](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-structured-clone.md)
+     */
+    [`${unicornNamespace}/prefer-structured-clone`]: ERROR,
 
-      /**
-       * Prefer ternary expressions over simple if-else statements.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const unicorn = () => {
-       *   if (test) {
-       *     return a;
-       *   } else {
-       *     return b;
-       *   }
-       * };
-       *
-       *
-       * const unicorn = function* () {
-       *   if (test) {
-       *     yield a;
-       *   } else {
-       *     yield b;
-       *   }
-       * };
-       *
-       * const unicorn = async () => {
-       *   if (test) {
-       *     await a();
-       *   } else {
-       *     await b();
-       *   }
-       * };
-       *
-       * if (test) {
-       *   throw new Error("foo");
-       * } else {
-       *   throw new Error("bar");
-       * }
-       *
-       * let foo;
-       * if (test) {
-       *   foo = 1;
-       * } else {
-       *   foo = 2;
-       * }
-       *
-       * // ✅ Correct
-       * const unicorn = () => test ? a : b;
-       *
-       *
-       * const unicorn = function* () {
-       *   yield (test ? a : b);
-       * };
-       *
-       * const unicorn = async () => {
-       *   await (test ? a : b)();
-       * };
-       *
-       * throw new Error(test ? "foo" : "bar");
-       *
-       * const foo = test ? 1 : 2;
-       * ```
-       * @see [unicorn/prefer-ternary](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-ternary.md)
-       */
-      [`${unicornNamespace}/prefer-ternary`]: ERROR,
+    /**
+     * Prefer ternary expressions over simple if-else statements.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const unicorn = () => {
+     *   if (test) {
+     *     return a;
+     *   } else {
+     *     return b;
+     *   }
+     * };
+     *
+     *
+     * const unicorn = function* () {
+     *   if (test) {
+     *     yield a;
+     *   } else {
+     *     yield b;
+     *   }
+     * };
+     *
+     * const unicorn = async () => {
+     *   if (test) {
+     *     await a();
+     *   } else {
+     *     await b();
+     *   }
+     * };
+     *
+     * if (test) {
+     *   throw new Error("foo");
+     * } else {
+     *   throw new Error("bar");
+     * }
+     *
+     * let foo;
+     * if (test) {
+     *   foo = 1;
+     * } else {
+     *   foo = 2;
+     * }
+     *
+     * // ✅ Correct
+     * const unicorn = () => test ? a : b;
+     *
+     *
+     * const unicorn = function* () {
+     *   yield (test ? a : b);
+     * };
+     *
+     * const unicorn = async () => {
+     *   await (test ? a : b)();
+     * };
+     *
+     * throw new Error(test ? "foo" : "bar");
+     *
+     * const foo = test ? 1 : 2;
+     * ```
+     * @see [unicorn/prefer-ternary](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-ternary.md)
+     */
+    [`${unicornNamespace}/prefer-ternary`]: ERROR,
 
-      /**
-       * Enforce throwing TypeError in type checking conditions.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * if (Array.isArray(foo) === false) {
-       *   throw new Error("Array expected");
-       * }
-       *
-       * // ✅ Correct
-       * if (Array.isArray(foo) === false) {
-       *   throw new TypeError("Array expected");
-       * }
-       * ```
-       * @see [unicorn/prefer-type-error](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-type-error.md)
-       */
-      [`${unicornNamespace}/prefer-type-error`]: ERROR,
+    /**
+     * Enforce throwing TypeError in type checking conditions.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * if (Array.isArray(foo) === false) {
+     *   throw new Error("Array expected");
+     * }
+     *
+     * // ✅ Correct
+     * if (Array.isArray(foo) === false) {
+     *   throw new TypeError("Array expected");
+     * }
+     * ```
+     * @see [unicorn/prefer-type-error](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-type-error.md)
+     */
+    [`${unicornNamespace}/prefer-type-error`]: ERROR,
 
-      /**
-       * Enforce using the separator argument with `Array#join`.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * const string = array.join();
-       *
-       * // ✅ Correct
-       * const string = array.join(",");
-       * ```
-       * @see [unicorn/require-array-join-separator](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/require-array-join-separator.md)
-       */
-      [`${unicornNamespace}/require-array-join-separator`]: ERROR,
+    /**
+     * Enforce using the separator argument with `Array#join`.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * const string = array.join();
+     *
+     * // ✅ Correct
+     * const string = array.join(",");
+     * ```
+     * @see [unicorn/require-array-join-separator](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/require-array-join-separator.md)
+     */
+    [`${unicornNamespace}/require-array-join-separator`]: ERROR,
 
-      /**
-       * Enforce consistent case for text encoding identifiers.
-       *
-       * @example
-       * ```typescript
-       * // ❌ Incorrect
-       * await fs.readFile(file, "UTF-8");
-       * await fs.readFile(file, "ASCII");
-       * const string = buffer.toString("utf-8");
-       *
-       * // ✅ Correct
-       * await fs.readFile(file, "utf8");
-       * await fs.readFile(file, "ascii");
-       * const string = buffer.toString("utf8");
-       * ```
-       * @see [unicorn/text-encoding-identifier-case](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/text-encoding-identifier-case.md)
-       */
-      [`${unicornNamespace}/text-encoding-identifier-case`]: ERROR,
-    },
-  });
+    /**
+     * Enforce consistent case for text encoding identifiers.
+     *
+     * @example
+     * ```typescript
+     * // ❌ Incorrect
+     * await fs.readFile(file, "UTF-8");
+     * await fs.readFile(file, "ASCII");
+     * const string = buffer.toString("utf-8");
+     *
+     * // ✅ Correct
+     * await fs.readFile(file, "utf8");
+     * await fs.readFile(file, "ascii");
+     * const string = buffer.toString("utf8");
+     * ```
+     * @see [unicorn/text-encoding-identifier-case](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/text-encoding-identifier-case.md)
+     */
+    [`${unicornNamespace}/text-encoding-identifier-case`]: ERROR,
+  },
+});

--- a/airflow/ui/src/components/ClearRun/ClearRunButton.tsx
+++ b/airflow/ui/src/components/ClearRun/ClearRunButton.tsx
@@ -37,11 +37,10 @@ const ClearRunButton = ({ dagId, dagRunId, withText = true }: Props) => {
 
   const [onlyFailed, setOnlyFailed] = useState(false);
 
-  const [affectedTasks, setAffectedTasks] =
-    useState<TaskInstanceCollectionResponse>({
-      task_instances: [],
-      total_entries: 0,
-    });
+  const [affectedTasks, setAffectedTasks] = useState<TaskInstanceCollectionResponse>({
+    task_instances: [],
+    total_entries: 0,
+  });
 
   const { isPending, mutate } = useClearDagRun({
     dagId,

--- a/airflow/ui/src/components/ClearRun/ClearRunDialog.tsx
+++ b/airflow/ui/src/components/ClearRun/ClearRunDialog.tsx
@@ -19,10 +19,7 @@
 import { Flex, Heading, VStack } from "@chakra-ui/react";
 import { FiRefreshCw } from "react-icons/fi";
 
-import type {
-  DAGRunClearBody,
-  TaskInstanceCollectionResponse,
-} from "openapi/requests/types.gen";
+import type { DAGRunClearBody, TaskInstanceCollectionResponse } from "openapi/requests/types.gen";
 import { Button, Dialog } from "src/components/ui";
 
 import SegmentedControl from "../ui/SegmentedControl";

--- a/airflow/ui/src/components/ClearRun/ClearRunTaskAccordion.tsx
+++ b/airflow/ui/src/components/ClearRun/ClearRunTaskAccordion.tsx
@@ -21,10 +21,7 @@ import { Link } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
 import { Link as RouterLink } from "react-router-dom";
 
-import type {
-  TaskInstanceCollectionResponse,
-  TaskInstanceResponse,
-} from "openapi/requests/types.gen";
+import type { TaskInstanceCollectionResponse, TaskInstanceResponse } from "openapi/requests/types.gen";
 import { DataTable } from "src/components/DataTable";
 import { Status } from "src/components/ui";
 import { getTaskInstanceLink } from "src/utils/links";
@@ -36,9 +33,7 @@ const columns: Array<ColumnDef<TaskInstanceResponse>> = [
     accessorKey: "task_display_name",
     cell: ({ row: { original } }) => (
       <Link asChild color="fg.info" fontWeight="bold">
-        <RouterLink to={getTaskInstanceLink(original)}>
-          {original.task_display_name}
-        </RouterLink>
+        <RouterLink to={getTaskInstanceLink(original)}>{original.task_display_name}</RouterLink>
       </Link>
     ),
     enableSorting: false,
@@ -55,8 +50,7 @@ const columns: Array<ColumnDef<TaskInstanceResponse>> = [
     header: () => "State",
   },
   {
-    accessorFn: (row: TaskInstanceResponse) =>
-      row.rendered_map_index ?? row.map_index,
+    accessorFn: (row: TaskInstanceResponse) => row.rendered_map_index ?? row.map_index,
     enableSorting: false,
     header: "Map Index",
   },
@@ -78,9 +72,7 @@ const ClearRunTasksAccordion = ({ affectedTasks }: Props) => (
   <Accordion.Root collapsible variant="enclosed">
     <Accordion.Item key="tasks" value="tasks">
       <Accordion.ItemTrigger>
-        <Text fontWeight="bold">
-          Affected Tasks: {affectedTasks?.total_entries ?? 0}
-        </Text>
+        <Text fontWeight="bold">Affected Tasks: {affectedTasks?.total_entries ?? 0}</Text>
       </Accordion.ItemTrigger>
       <Accordion.ItemContent>
         <Box maxH="400px" overflowY="scroll">

--- a/airflow/ui/src/components/ConfirmationModal.tsx
+++ b/airflow/ui/src/components/ConfirmationModal.tsx
@@ -29,13 +29,7 @@ type Props = {
   readonly open: boolean;
 };
 
-export const ConfirmationModal = ({
-  children,
-  header,
-  onConfirm,
-  onOpenChange,
-  open,
-}: Props) => (
+export const ConfirmationModal = ({ children, header, onConfirm, onOpenChange, open }: Props) => (
   <Dialog.Root onOpenChange={onOpenChange} open={open}>
     <Dialog.Content backdrop>
       <Dialog.Header>

--- a/airflow/ui/src/components/DagRunInfo.tsx
+++ b/airflow/ui/src/components/DagRunInfo.tsx
@@ -61,10 +61,7 @@ const DagRunInfo = ({
             </Text>
           ) : undefined}
           {Boolean(startDate) ? (
-            <Text>
-              Duration:{" "}
-              {dayjs.duration(dayjs(endDate).diff(startDate)).asSeconds()}s
-            </Text>
+            <Text>Duration: {dayjs.duration(dayjs(endDate).diff(startDate)).asSeconds()}s</Text>
           ) : undefined}
           <Text>
             Data Interval Start: <Time datetime={dataIntervalStart} />
@@ -78,9 +75,7 @@ const DagRunInfo = ({
     >
       <HStack fontSize="sm">
         <Time datetime={dataIntervalStart} showTooltip={false} />
-        {state === undefined ? undefined : (
-          <Status state={state}>{state}</Status>
-        )}
+        {state === undefined ? undefined : <Status state={state}>{state}</Status>}
       </HStack>
     </Tooltip>
   ) : undefined;

--- a/airflow/ui/src/components/DataTable/CardList.tsx
+++ b/airflow/ui/src/components/DataTable/CardList.tsx
@@ -27,25 +27,13 @@ type DataTableProps<TData> = {
   readonly table: TanStackTable<TData>;
 };
 
-export const CardList = <TData,>({
-  cardDef,
-  isLoading,
-  table,
-}: DataTableProps<TData>) => (
-  <SimpleGrid
-    data-testid="card-list"
-    {...{ column: { base: 1 }, gap: 2, ...cardDef.gridProps }}
-  >
+export const CardList = <TData,>({ cardDef, isLoading, table }: DataTableProps<TData>) => (
+  <SimpleGrid data-testid="card-list" {...{ column: { base: 1 }, gap: 2, ...cardDef.gridProps }}>
     {table.getRowModel().rows.map((row) => (
       <Box key={row.id}>
         {Boolean(isLoading) &&
           (cardDef.meta?.customSkeleton ?? (
-            <Skeleton
-              data-testid="skeleton"
-              display="inline-block"
-              height={80}
-              width="100%"
-            />
+            <Skeleton data-testid="skeleton" display="inline-block" height={80} width="100%" />
           ))}
         {!Boolean(isLoading) && flexRender(cardDef.card, { row: row.original })}
       </Box>

--- a/airflow/ui/src/components/DataTable/DataTable.test.tsx
+++ b/airflow/ui/src/components/DataTable/DataTable.test.tsx
@@ -117,17 +117,9 @@ describe("DataTable", () => {
   });
 
   it("displays cards if mode is card and there is cardDef", () => {
-    render(
-      <DataTable
-        cardDef={cardDef}
-        columns={columns}
-        data={data}
-        displayMode="card"
-      />,
-      {
-        wrapper: ChakraWrapper,
-      },
-    );
+    render(<DataTable cardDef={cardDef} columns={columns} data={data} displayMode="card" />, {
+      wrapper: ChakraWrapper,
+    });
 
     expect(screen.getByText("My name is John Doe.")).toBeInTheDocument();
   });

--- a/airflow/ui/src/components/DataTable/DataTable.tsx
+++ b/airflow/ui/src/components/DataTable/DataTable.tsx
@@ -49,9 +49,7 @@ type DataTableProps<TData> = {
   readonly modelName?: string;
   readonly noRowsMessage?: ReactNode;
   readonly onStateChange?: (state: TableState) => void;
-  readonly renderSubComponent?: (props: {
-    row: Row<TData>;
-  }) => React.ReactElement;
+  readonly renderSubComponent?: (props: { row: Row<TData> }) => React.ReactElement;
   readonly skeletonCount?: number;
   readonly total?: number;
 };
@@ -95,9 +93,7 @@ export const DataTable = <TData,>({
     [onStateChange],
   );
 
-  const rest = Boolean(isLoading)
-    ? createSkeletonMock(displayMode, skeletonCount, columns)
-    : {};
+  const rest = Boolean(isLoading) ? createSkeletonMock(displayMode, skeletonCount, columns) : {};
 
   const table = useReactTable({
     columns,
@@ -122,12 +118,7 @@ export const DataTable = <TData,>({
 
   return (
     <>
-      <ProgressBar
-        size="xs"
-        visibility={
-          Boolean(isFetching) && !Boolean(isLoading) ? "visible" : "hidden"
-        }
-      />
+      <ProgressBar size="xs" visibility={Boolean(isFetching) && !Boolean(isLoading) ? "visible" : "hidden"} />
       <Toaster />
       {errorMessage}
       {display === "table" && <TableList table={table} />}

--- a/airflow/ui/src/components/DataTable/TableList.tsx
+++ b/airflow/ui/src/components/DataTable/TableList.tsx
@@ -17,84 +17,59 @@
  * under the License.
  */
 import { Button, Table } from "@chakra-ui/react";
-import {
-  flexRender,
-  type Row,
-  type Table as TanStackTable,
-} from "@tanstack/react-table";
+import { flexRender, type Row, type Table as TanStackTable } from "@tanstack/react-table";
 import React, { Fragment } from "react";
-import {
-  TiArrowSortedDown,
-  TiArrowSortedUp,
-  TiArrowUnsorted,
-} from "react-icons/ti";
+import { TiArrowSortedDown, TiArrowSortedUp, TiArrowUnsorted } from "react-icons/ti";
 
 type DataTableProps<TData> = {
-  readonly renderSubComponent?: (props: {
-    row: Row<TData>;
-  }) => React.ReactElement;
+  readonly renderSubComponent?: (props: { row: Row<TData> }) => React.ReactElement;
   readonly table: TanStackTable<TData>;
 };
 
-export const TableList = <TData,>({
-  renderSubComponent,
-  table,
-}: DataTableProps<TData>) => (
+export const TableList = <TData,>({ renderSubComponent, table }: DataTableProps<TData>) => (
   <Table.Root data-testid="table-list" striped>
     <Table.Header bg="chakra-body-bg" position="sticky" top={0} zIndex={1}>
       {table.getHeaderGroups().map((headerGroup) => (
         <Table.Row key={headerGroup.id}>
-          {headerGroup.headers.map(
-            ({ colSpan, column, getContext, id, isPlaceholder }) => {
-              const sort = column.getIsSorted();
-              const canSort = column.getCanSort();
-              const text = flexRender(column.columnDef.header, getContext());
+          {headerGroup.headers.map(({ colSpan, column, getContext, id, isPlaceholder }) => {
+            const sort = column.getIsSorted();
+            const canSort = column.getCanSort();
+            const text = flexRender(column.columnDef.header, getContext());
 
-              let rightIcon;
+            let rightIcon;
 
-              if (canSort) {
-                if (sort === "desc") {
-                  rightIcon = (
-                    <TiArrowSortedDown aria-label="sorted descending" />
-                  );
-                } else if (sort === "asc") {
-                  rightIcon = <TiArrowSortedUp aria-label="sorted ascending" />;
-                } else {
-                  rightIcon = <TiArrowUnsorted aria-label="unsorted" />;
-                }
-
-                return (
-                  <Table.ColumnHeader
-                    colSpan={colSpan}
-                    key={id}
-                    whiteSpace="nowrap"
-                  >
-                    {isPlaceholder ? undefined : (
-                      <Button
-                        aria-label="sort"
-                        disabled={!canSort}
-                        onClick={column.getToggleSortingHandler()}
-                        variant="plain"
-                      >
-                        {text}
-                        {rightIcon}
-                      </Button>
-                    )}
-                  </Table.ColumnHeader>
-                );
+            if (canSort) {
+              if (sort === "desc") {
+                rightIcon = <TiArrowSortedDown aria-label="sorted descending" />;
+              } else if (sort === "asc") {
+                rightIcon = <TiArrowSortedUp aria-label="sorted ascending" />;
+              } else {
+                rightIcon = <TiArrowUnsorted aria-label="unsorted" />;
               }
 
               return (
-                <Table.ColumnHeader
-                  colSpan={colSpan}
-                  key={id}
-                  whiteSpace="nowrap"
-                >
-                  {isPlaceholder ? undefined : text}
+                <Table.ColumnHeader colSpan={colSpan} key={id} whiteSpace="nowrap">
+                  {isPlaceholder ? undefined : (
+                    <Button
+                      aria-label="sort"
+                      disabled={!canSort}
+                      onClick={column.getToggleSortingHandler()}
+                      variant="plain"
+                    >
+                      {text}
+                      {rightIcon}
+                    </Button>
+                  )}
                 </Table.ColumnHeader>
               );
-            },
-          )}
+            }
+
+            return (
+              <Table.ColumnHeader colSpan={colSpan} key={id} whiteSpace="nowrap">
+                {isPlaceholder ? undefined : text}
+              </Table.ColumnHeader>
+            );
+          })}
         </Table.Row>
       ))}
     </Table.Header>
@@ -112,9 +87,7 @@ export const TableList = <TData,>({
           {row.getIsExpanded() && (
             <Table.Row>
               {/* 2nd row is a custom 1 cell row */}
-              <Table.Cell colSpan={row.getVisibleCells().length}>
-                {renderSubComponent?.({ row })}
-              </Table.Cell>
+              <Table.Cell colSpan={row.getVisibleCells().length}>{renderSubComponent?.({ row })}</Table.Cell>
             </Table.Row>
           )}
         </Fragment>

--- a/airflow/ui/src/components/DataTable/searchParams.test.ts
+++ b/airflow/ui/src/components/DataTable/searchParams.test.ts
@@ -32,25 +32,20 @@ describe("searchParams", () => {
         sorting: [{ desc: false, id: "name" }],
       };
 
-      expect(stateToSearchParams(state).toString()).toEqual(
-        "limit=20&offset=1&sort=name",
-      );
+      expect(stateToSearchParams(state).toString()).toEqual("limit=20&offset=1&sort=name");
     });
   });
 
   describe("searchParamsToState", () => {
     it("can parse search params back to table state", () => {
       expect(
-        searchParamsToState(
-          new URLSearchParams("limit=20&offset=0&sort=name&sort=-age"),
-          {
-            pagination: {
-              pageIndex: 1,
-              pageSize: 5,
-            },
-            sorting: [],
+        searchParamsToState(new URLSearchParams("limit=20&offset=0&sort=name&sort=-age"), {
+          pagination: {
+            pageIndex: 1,
+            pageSize: 5,
           },
-        ),
+          sorting: [],
+        }),
       ).toEqual({
         pagination: {
           pageIndex: 0,

--- a/airflow/ui/src/components/DataTable/searchParams.ts
+++ b/airflow/ui/src/components/DataTable/searchParams.ts
@@ -18,23 +18,13 @@
  */
 import type { SortingState } from "@tanstack/react-table";
 
-import {
-  SearchParamsKeys,
-  type SearchParamsKeysType,
-} from "src/constants/searchParams";
+import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
 
 import type { TableState } from "./types";
 
-const {
-  LIMIT: LIMIT_PARAM,
-  OFFSET: OFFSET_PARAM,
-  SORT: SORT_PARAM,
-}: SearchParamsKeysType = SearchParamsKeys;
+const { LIMIT: LIMIT_PARAM, OFFSET: OFFSET_PARAM, SORT: SORT_PARAM }: SearchParamsKeysType = SearchParamsKeys;
 
-export const stateToSearchParams = (
-  state: TableState,
-  defaultTableState?: TableState,
-): URLSearchParams => {
+export const stateToSearchParams = (state: TableState, defaultTableState?: TableState): URLSearchParams => {
   const queryParams = new URLSearchParams(globalThis.location.search);
 
   if (state.pagination.pageSize === defaultTableState?.pagination.pageSize) {
@@ -51,11 +41,7 @@ export const stateToSearchParams = (
 
   if (state.sorting.length) {
     state.sorting.forEach(({ desc, id }) => {
-      if (
-        defaultTableState?.sorting.find(
-          (sort) => sort.id === id && sort.desc === desc,
-        )
-      ) {
+      if (defaultTableState?.sorting.find((sort) => sort.id === id && sort.desc === desc)) {
         queryParams.delete(SORT_PARAM, `${desc ? "-" : ""}${id}`);
       } else {
         queryParams.set(SORT_PARAM, `${desc ? "-" : ""}${id}`);
@@ -68,10 +54,7 @@ export const stateToSearchParams = (
   return queryParams;
 };
 
-export const searchParamsToState = (
-  searchParams: URLSearchParams,
-  defaultState: TableState,
-) => {
+export const searchParamsToState = (searchParams: URLSearchParams, defaultState: TableState) => {
   let urlState: Partial<TableState> = {};
   const pageIndex = searchParams.get(OFFSET_PARAM) ?? "";
   const pageSize = searchParams.get(LIMIT_PARAM) ?? "";
@@ -81,10 +64,7 @@ export const searchParamsToState = (
       ...urlState,
       pagination: {
         pageIndex: parseInt(pageIndex, 10),
-        pageSize:
-          pageSize === ""
-            ? defaultState.pagination.pageSize
-            : parseInt(pageSize, 10),
+        pageSize: pageSize === "" ? defaultState.pagination.pageSize : parseInt(pageSize, 10),
       },
     };
   }

--- a/airflow/ui/src/components/DataTable/types.ts
+++ b/airflow/ui/src/components/DataTable/types.ts
@@ -17,11 +17,7 @@
  * under the License.
  */
 import type { SimpleGridProps } from "@chakra-ui/react";
-import type {
-  ColumnDef,
-  PaginationState,
-  SortingState,
-} from "@tanstack/react-table";
+import type { ColumnDef, PaginationState, SortingState } from "@tanstack/react-table";
 import type { ReactNode } from "react";
 
 export type TableState = {

--- a/airflow/ui/src/components/DocumentationModal.tsx
+++ b/airflow/ui/src/components/DocumentationModal.tsx
@@ -24,13 +24,7 @@ import remarkGfm from "remark-gfm";
 
 import { Button, Dialog } from "src/components/ui";
 
-const DocumentationModal = ({
-  docMd,
-  docType,
-}: {
-  readonly docMd: string;
-  readonly docType: string;
-}) => {
+const DocumentationModal = ({ docMd, docType }: { readonly docMd: string; readonly docType: string }) => {
   const [isDocsOpen, setIsDocsOpen] = useState(false);
 
   return (
@@ -39,11 +33,7 @@ const DocumentationModal = ({
         <FiBookOpen height={5} width={5} />
         {docType} Docs
       </Button>
-      <Dialog.Root
-        onOpenChange={() => setIsDocsOpen(false)}
-        open={isDocsOpen}
-        size="md"
-      >
+      <Dialog.Root onOpenChange={() => setIsDocsOpen(false)} open={isDocsOpen} size="md">
         <Dialog.Content backdrop>
           <Dialog.Header bg="blue.muted">
             <Heading size="xl">{docType} Documentation</Heading>

--- a/airflow/ui/src/components/ErrorAlert.tsx
+++ b/airflow/ui/src/components/ErrorAlert.tsx
@@ -18,10 +18,7 @@
  */
 import { HStack } from "@chakra-ui/react";
 import type { ApiError } from "openapi-gen/requests/core/ApiError";
-import type {
-  HTTPExceptionResponse,
-  HTTPValidationError,
-} from "openapi-gen/requests/types.gen";
+import type { HTTPExceptionResponse, HTTPValidationError } from "openapi-gen/requests/types.gen";
 
 import { Alert } from "./ui";
 
@@ -52,9 +49,7 @@ export const ErrorAlert = ({ error: err }: Props) => {
           ${detail.loc.join(".")} ${detail.msg}`,
       );
     } else {
-      detailMessage = Object.keys(details).map(
-        (key) => `${key}: ${details[key] as string}`,
-      );
+      detailMessage = Object.keys(details).map((key) => `${key}: ${details[key] as string}`);
     }
   }
 

--- a/airflow/ui/src/components/MetricsBadge.tsx
+++ b/airflow/ui/src/components/MetricsBadge.tsx
@@ -24,21 +24,8 @@ type MetricBadgeProps = {
   readonly runs?: number;
 } & BadgeProps;
 
-export const MetricsBadge = ({
-  backgroundColor,
-  color = "fg.inverted",
-  runs,
-}: MetricBadgeProps) => (
-  <Badge
-    bg={backgroundColor}
-    borderRadius={15}
-    color={color}
-    minWidth={10}
-    mr={1}
-    px={4}
-    py={1}
-    size="md"
-  >
+export const MetricsBadge = ({ backgroundColor, color = "fg.inverted", runs }: MetricBadgeProps) => (
+  <Badge bg={backgroundColor} borderRadius={15} color={color} minWidth={10} mr={1} px={4} py={1} size="md">
     {runs}
   </Badge>
 );

--- a/airflow/ui/src/components/ParseDag.tsx
+++ b/airflow/ui/src/components/ParseDag.tsx
@@ -30,11 +30,7 @@ const ParseDag = ({ dagId, fileToken }: Props) => {
   const { isPending, mutate } = useDagParsing({ dagId });
 
   return (
-    <Button
-      loading={isPending}
-      onClick={() => mutate({ fileToken })}
-      variant="outline"
-    >
+    <Button loading={isPending} onClick={() => mutate({ fileToken })} variant="outline">
       <FiRefreshCw height={5} width={5} />
       Reparse Dag
     </Button>

--- a/airflow/ui/src/components/QuickFilterButton.tsx
+++ b/airflow/ui/src/components/QuickFilterButton.tsx
@@ -22,11 +22,7 @@ type QuickFilterButtonProps = {
   readonly isActive: boolean;
 } & ButtonProps;
 
-export const QuickFilterButton = ({
-  children,
-  isActive,
-  ...rest
-}: QuickFilterButtonProps) => (
+export const QuickFilterButton = ({ children, isActive, ...rest }: QuickFilterButtonProps) => (
   <Button
     _hover={{ bg: "colorPalette.subtle" }}
     bg={isActive ? "colorPalette.muted" : undefined}

--- a/airflow/ui/src/components/SearchBar.test.tsx
+++ b/airflow/ui/src/components/SearchBar.test.tsx
@@ -25,16 +25,9 @@ import { SearchBar } from "./SearchBar";
 
 describe("Test SearchBar", () => {
   it("Renders and clear button works", async () => {
-    render(
-      <SearchBar
-        defaultValue=""
-        onChange={vi.fn()}
-        placeHolder="Search Dags"
-      />,
-      {
-        wrapper: Wrapper,
-      },
-    );
+    render(<SearchBar defaultValue="" onChange={vi.fn()} placeHolder="Search Dags" />, {
+      wrapper: Wrapper,
+    });
 
     const input = screen.getByTestId("search-dags");
 
@@ -43,9 +36,7 @@ describe("Test SearchBar", () => {
 
     fireEvent.change(input, { target: { value: "search" } });
 
-    await waitFor(() =>
-      expect((input as HTMLInputElement).value).toBe("search"),
-    );
+    await waitFor(() => expect((input as HTMLInputElement).value).toBe("search"));
 
     const clearButton = screen.getByTestId("clear-search");
 

--- a/airflow/ui/src/components/SearchBar.tsx
+++ b/airflow/ui/src/components/SearchBar.tsx
@@ -33,17 +33,8 @@ type Props = {
   readonly placeHolder: string;
 };
 
-export const SearchBar = ({
-  buttonProps,
-  defaultValue,
-  groupProps,
-  onChange,
-  placeHolder,
-}: Props) => {
-  const handleSearchChange = useDebouncedCallback(
-    (val: string) => onChange(val),
-    debounceDelay,
-  );
+export const SearchBar = ({ buttonProps, defaultValue, groupProps, onChange, placeHolder }: Props) => {
+  const handleSearchChange = useDebouncedCallback((val: string) => onChange(val), debounceDelay);
 
   const [value, setValue] = useState(defaultValue);
 
@@ -70,13 +61,7 @@ export const SearchBar = ({
               size="xs"
             />
           ) : undefined}
-          <Button
-            fontWeight="normal"
-            height="1.75rem"
-            variant="ghost"
-            width={140}
-            {...buttonProps}
-          >
+          <Button fontWeight="normal" height="1.75rem" variant="ghost" width={140} {...buttonProps}>
             Advanced Search
           </Button>
         </>

--- a/airflow/ui/src/components/TaskInstanceTooltip.tsx
+++ b/airflow/ui/src/components/TaskInstanceTooltip.tsx
@@ -18,10 +18,7 @@
  */
 import { Box, Text } from "@chakra-ui/react";
 
-import type {
-  TaskInstanceHistoryResponse,
-  TaskInstanceResponse,
-} from "openapi/requests/types.gen";
+import type { TaskInstanceHistoryResponse, TaskInstanceResponse } from "openapi/requests/types.gen";
 import Time from "src/components/Time";
 import { Tooltip, type TooltipProps } from "src/components/ui";
 
@@ -40,9 +37,7 @@ const TaskInstanceTooltip = ({ children, taskInstance }: Props) => (
         <Text>
           End Date: <Time datetime={taskInstance.end_date} />
         </Text>
-        {taskInstance.try_number > 1 && (
-          <Text>Try Number: {taskInstance.try_number}</Text>
-        )}
+        {taskInstance.try_number > 1 && <Text>Try Number: {taskInstance.try_number}</Text>}
         <Text>Duration: {taskInstance.duration?.toFixed(2) ?? 0}s</Text>
         <Text>State: {taskInstance.state}</Text>
       </Box>

--- a/airflow/ui/src/components/TaskTrySelect.tsx
+++ b/airflow/ui/src/components/TaskTrySelect.tsx
@@ -16,19 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  Button,
-  createListCollection,
-  HStack,
-  VStack,
-  Heading,
-} from "@chakra-ui/react";
+import { Button, createListCollection, HStack, VStack, Heading } from "@chakra-ui/react";
 
 import { useTaskInstanceServiceGetMappedTaskInstanceTries } from "openapi/queries";
-import type {
-  TaskInstanceHistoryResponse,
-  TaskInstanceResponse,
-} from "openapi/requests/types.gen";
+import type { TaskInstanceHistoryResponse, TaskInstanceResponse } from "openapi/requests/types.gen";
 
 import TaskInstanceTooltip from "./TaskInstanceTooltip";
 import { Select, Status } from "./ui";
@@ -39,11 +30,7 @@ type Props = {
   readonly taskInstance: TaskInstanceResponse;
 };
 
-export const TaskTrySelect = ({
-  onSelectTryNumber,
-  selectedTryNumber,
-  taskInstance,
-}: Props) => {
+export const TaskTrySelect = ({ onSelectTryNumber, selectedTryNumber, taskInstance }: Props) => {
   const {
     dag_id: dagId,
     dag_run_id: dagRunId,
@@ -90,9 +77,7 @@ export const TaskTrySelect = ({
           onValueChange={(details) => {
             if (onSelectTryNumber) {
               onSelectTryNumber(
-                details.value[0] === undefined
-                  ? finalTryNumber
-                  : parseInt(details.value[0], 10),
+                details.value[0] === undefined ? finalTryNumber : parseInt(details.value[0], 10),
               );
             }
           }}
@@ -141,9 +126,7 @@ export const TaskTrySelect = ({
                     onSelectTryNumber(ti.try_number);
                   }
                 }}
-                variant={
-                  selectedTryNumber === ti.try_number ? "surface" : "outline"
-                }
+                variant={selectedTryNumber === ti.try_number ? "surface" : "outline"}
               >
                 {ti.try_number}
                 <Status state={ti.state} />

--- a/airflow/ui/src/components/Time.test.tsx
+++ b/airflow/ui/src/components/Time.test.tsx
@@ -44,9 +44,7 @@ describe("Test Time and TimezoneProvider", () => {
     const tz = "US/Samoa";
 
     render(
-      <TimezoneContext.Provider
-        value={{ selectedTimezone: tz, setSelectedTimezone: vi.fn() }}
-      >
+      <TimezoneContext.Provider value={{ selectedTimezone: tz, setSelectedTimezone: vi.fn() }}>
         <Time datetime={now.toISOString()} />
       </TimezoneContext.Provider>,
       {
@@ -58,8 +56,6 @@ describe("Test Time and TimezoneProvider", () => {
     const samoaTime = screen.getByText(nowTime.tz(tz).format(defaultFormat));
 
     expect(samoaTime).toBeDefined();
-    expect(samoaTime.title).toEqual(
-      nowTime.tz("UTC").format(defaultFormatWithTZ),
-    );
+    expect(samoaTime.title).toEqual(nowTime.tz("UTC").format(defaultFormatWithTZ));
   });
 });

--- a/airflow/ui/src/components/Time.tsx
+++ b/airflow/ui/src/components/Time.tsx
@@ -37,11 +37,7 @@ type Props = {
   readonly showTooltip?: boolean;
 };
 
-const Time = ({
-  datetime,
-  format = defaultFormat,
-  showTooltip = true,
-}: Props) => {
+const Time = ({ datetime, format = defaultFormat, showTooltip = true }: Props) => {
   const { selectedTimezone } = useTimezone();
   const time = dayjs(datetime);
 
@@ -56,11 +52,7 @@ const Time = ({
     <time
       dateTime={datetime}
       // show title if date is not UTC
-      title={
-        selectedTimezone.toUpperCase() !== "UTC" && showTooltip
-          ? utcTime
-          : undefined
-      }
+      title={selectedTimezone.toUpperCase() !== "UTC" && showTooltip ? utcTime : undefined}
     >
       {formattedTime}
     </time>

--- a/airflow/ui/src/components/TimeRangeSelector.tsx
+++ b/airflow/ui/src/components/TimeRangeSelector.tsx
@@ -17,10 +17,7 @@
  * under the License.
  */
 import { HStack, Text, type SelectValueChangeDetails } from "@chakra-ui/react";
-import {
-  createListCollection,
-  type ListCollection,
-} from "@chakra-ui/react/collection";
+import { createListCollection, type ListCollection } from "@chakra-ui/react/collection";
 import dayjs from "dayjs";
 import { FiCalendar } from "react-icons/fi";
 
@@ -53,9 +50,7 @@ const TimeRangeSelector = ({
   startDate,
   timeOptions = defaultTimeOptions,
 }: Props) => {
-  const handleTimeChange = ({
-    value,
-  }: SelectValueChangeDetails<Array<string>>) => {
+  const handleTimeChange = ({ value }: SelectValueChangeDetails<Array<string>>) => {
     const cnow = dayjs();
 
     setStartDate(cnow.subtract(Number(value[0]), "hour").toISOString());

--- a/airflow/ui/src/components/TogglePause.tsx
+++ b/airflow/ui/src/components/TogglePause.tsx
@@ -37,12 +37,7 @@ type Props = {
   readonly skipConfirm?: boolean;
 };
 
-export const TogglePause = ({
-  dagDisplayName,
-  dagId,
-  isPaused,
-  skipConfirm,
-}: Props) => {
+export const TogglePause = ({ dagDisplayName, dagId, isPaused, skipConfirm }: Props) => {
   const queryClient = useQueryClient();
   const { onClose, onOpen, open } = useDisclosure();
 
@@ -60,9 +55,7 @@ export const TogglePause = ({
     onSuccess,
   });
 
-  const showConfirmation = Boolean(
-    useConfig("require_confirmation_dag_change"),
-  );
+  const showConfirmation = Boolean(useConfig("require_confirmation_dag_change"));
 
   const onToggle = useCallback(() => {
     mutate({
@@ -83,12 +76,7 @@ export const TogglePause = ({
 
   return (
     <>
-      <Switch
-        checked={!isPaused}
-        colorPalette="blue"
-        onCheckedChange={onChange}
-        size="sm"
-      />
+      <Switch checked={!isPaused} colorPalette="blue" onCheckedChange={onChange} size="sm" />
       <ConfirmationModal
         header={`${isPaused ? "Unpause" : "Pause"} ${dagDisplayName ?? dagId}?`}
         onConfirm={onToggle}

--- a/airflow/ui/src/components/TrendCountButton.tsx
+++ b/airflow/ui/src/components/TrendCountButton.tsx
@@ -59,11 +59,7 @@ export const TrendCountButton = ({
         <Text fontSize="sm" fontWeight="bold">
           {pluralize(label, count, undefined, true)}
         </Text>
-        <TrendCountChart
-          endDate={endDate}
-          events={events}
-          startDate={startDate}
-        />
+        <TrendCountChart endDate={endDate} events={events} startDate={startDate} />
       </HStack>
     </Link>
   );

--- a/airflow/ui/src/components/TrendCountChart.tsx
+++ b/airflow/ui/src/components/TrendCountChart.tsx
@@ -33,32 +33,18 @@ import { Line } from "react-chartjs-2";
 
 import { useColorMode } from "src/context/colorMode";
 
-ChartJS.register(
-  CategoryScale,
-  LinearScale,
-  PointElement,
-  LineElement,
-  Filler,
-  Tooltip,
-);
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Filler, Tooltip);
 
 export type ChartEvent = { timestamp: string };
 
-const aggregateEventsIntoIntervals = (
-  events: Array<ChartEvent>,
-  startDate: string,
-  endDate: string,
-) => {
+const aggregateEventsIntoIntervals = (events: Array<ChartEvent>, startDate: string, endDate: string) => {
   const totalMinutes = dayjs(endDate).diff(startDate, "minutes");
   const intervalSize = Math.floor(totalMinutes / 10);
   const intervals = Array.from({ length: 10 }).fill(0) as Array<number>;
 
   events.forEach((event) => {
     const minutesSinceStart = dayjs(event.timestamp).diff(startDate, "minutes");
-    const intervalIndex = Math.min(
-      Math.floor(minutesSinceStart / intervalSize),
-      9,
-    );
+    const intervalIndex = Math.min(Math.floor(minutesSinceStart / intervalSize), 9);
 
     if (intervals[intervalIndex] !== undefined) {
       intervals[intervalIndex] += 1;

--- a/airflow/ui/src/components/TriggerDag/TriggerDAGButton.tsx
+++ b/airflow/ui/src/components/TriggerDag/TriggerDAGButton.tsx
@@ -20,10 +20,7 @@ import { Box } from "@chakra-ui/react";
 import { useDisclosure } from "@chakra-ui/react";
 import { FiPlay } from "react-icons/fi";
 
-import type {
-  DAGResponse,
-  DAGWithLatestDagRunsResponse,
-} from "openapi/requests/types.gen";
+import type { DAGResponse, DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
 
 import ActionButton from "../ui/ActionButton";
 import TriggerDAGModal from "./TriggerDAGModal";

--- a/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -110,8 +110,7 @@ const TriggerDAGForm = ({ dagId, onClose, open }: TriggerDAGFormProps) => {
 
       return JSON.stringify(parsedJson, undefined, 2);
     } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : "Unknown error occurred.";
+      const errorMessage = error instanceof Error ? error.message : "Unknown error occurred.";
 
       setErrors((prev) => ({
         ...prev,
@@ -132,9 +131,7 @@ const TriggerDAGForm = ({ dagId, onClose, open }: TriggerDAGFormProps) => {
     <>
       <Accordion.Root collapsible mb={4} mt={4} size="lg" variant="enclosed">
         <Accordion.Item key="advancedOptions" value="advancedOptions">
-          <Accordion.ItemTrigger cursor="button">
-            Advanced Options
-          </Accordion.ItemTrigger>
+          <Accordion.ItemTrigger cursor="button">Advanced Options</Accordion.ItemTrigger>
           <Accordion.ItemContent>
             <Box p={5}>
               <Controller
@@ -142,9 +139,7 @@ const TriggerDAGForm = ({ dagId, onClose, open }: TriggerDAGFormProps) => {
                 name="dataIntervalStart"
                 render={({ field }) => (
                   <Field.Root invalid={Boolean(errors.date)}>
-                    <Field.Label fontSize="md">
-                      Data Interval Start Date
-                    </Field.Label>
+                    <Field.Label fontSize="md">Data Interval Start Date</Field.Label>
                     <Input
                       {...field}
                       max={dataIntervalEnd || undefined}
@@ -162,9 +157,7 @@ const TriggerDAGForm = ({ dagId, onClose, open }: TriggerDAGFormProps) => {
                 name="dataIntervalEnd"
                 render={({ field }) => (
                   <Field.Root invalid={Boolean(errors.date)} mt={6}>
-                    <Field.Label fontSize="md">
-                      Data Interval End Date
-                    </Field.Label>
+                    <Field.Label fontSize="md">Data Interval End Date</Field.Label>
                     <Input
                       {...field}
                       min={dataIntervalStart || undefined}
@@ -220,9 +213,7 @@ const TriggerDAGForm = ({ dagId, onClose, open }: TriggerDAGFormProps) => {
                       }}
                       theme={colorMode === "dark" ? githubDark : githubLight}
                     />
-                    {Boolean(errors.conf) ? (
-                      <Field.ErrorText>{errors.conf}</Field.ErrorText>
-                    ) : undefined}
+                    {Boolean(errors.conf) ? <Field.ErrorText>{errors.conf}</Field.ErrorText> : undefined}
                   </Field.Root>
                 )}
               />

--- a/airflow/ui/src/components/TriggerDag/TriggerDAGModal.tsx
+++ b/airflow/ui/src/components/TriggerDag/TriggerDAGModal.tsx
@@ -39,24 +39,16 @@ const TriggerDAGModal: React.FC<TriggerDAGModalProps> = ({
   onClose,
   open,
 }) => (
-  <Dialog.Root
-    lazyMount
-    onOpenChange={onClose}
-    open={open}
-    size="xl"
-    unmountOnExit
-  >
+  <Dialog.Root lazyMount onOpenChange={onClose} open={open} size="xl" unmountOnExit>
     <Dialog.Content backdrop>
       <Dialog.Header>
         <VStack align="start" gap={4}>
           <Heading size="xl">
-            Trigger Dag - {dagDisplayName}{" "}
-            <TogglePause dagId={dagId} isPaused={isPaused} skipConfirm />
+            Trigger Dag - {dagDisplayName} <TogglePause dagId={dagId} isPaused={isPaused} skipConfirm />
           </Heading>
           {isPaused ? (
             <Alert status="warning" title="Paused DAG">
-              Triggering will create a DAG run, but it will not start until the
-              Dag is unpaused.
+              Triggering will create a DAG run, but it will not start until the Dag is unpaused.
             </Alert>
           ) : undefined}
         </VStack>

--- a/airflow/ui/src/components/ui/Accordion/ItemContent.tsx
+++ b/airflow/ui/src/components/ui/Accordion/ItemContent.tsx
@@ -21,10 +21,7 @@ import { forwardRef } from "react";
 
 type AccordionItemContentProps = {} & Accordion.ItemContentProps;
 
-export const ItemContent = forwardRef<
-  HTMLDivElement,
-  AccordionItemContentProps
->((props, ref) => (
+export const ItemContent = forwardRef<HTMLDivElement, AccordionItemContentProps>((props, ref) => (
   <Accordion.ItemContent>
     <Accordion.ItemBody {...props} ref={ref} />
   </Accordion.ItemContent>

--- a/airflow/ui/src/components/ui/Accordion/ItemTrigger.tsx
+++ b/airflow/ui/src/components/ui/Accordion/ItemTrigger.tsx
@@ -24,10 +24,7 @@ type AccordionItemTriggerProps = {
   indicatorPlacement?: "end" | "start";
 } & Accordion.ItemTriggerProps;
 
-export const ItemTrigger = forwardRef<
-  HTMLButtonElement,
-  AccordionItemTriggerProps
->((props, ref) => {
+export const ItemTrigger = forwardRef<HTMLButtonElement, AccordionItemTriggerProps>((props, ref) => {
   const { children, indicatorPlacement = "end", ...rest } = props;
 
   return (

--- a/airflow/ui/src/components/ui/Alert.tsx
+++ b/airflow/ui/src/components/ui/Alert.tsx
@@ -31,16 +31,7 @@ export type AlertProps = {
 } & Omit<ChakraAlert.RootProps, "title">;
 
 export const Alert = forwardRef<HTMLDivElement, AlertProps>((props, ref) => {
-  const {
-    children,
-    closable,
-    endElement,
-    icon,
-    onClose,
-    startElement,
-    title,
-    ...rest
-  } = props;
+  const { children, closable, endElement, icon, onClose, startElement, title, ...rest } = props;
 
   return (
     <ChakraAlert.Root ref={ref} {...rest}>

--- a/airflow/ui/src/components/ui/Breadcrumb/Root.tsx
+++ b/airflow/ui/src/components/ui/Breadcrumb/Root.tsx
@@ -24,32 +24,26 @@ export type BreadcrumbRootProps = {
   separatorGap?: SystemStyleObject["gap"];
 } & Breadcrumb.RootProps;
 
-export const Root = React.forwardRef<HTMLDivElement, BreadcrumbRootProps>(
-  (props, ref) => {
-    const { children, separator, separatorGap, ...rest } = props;
+export const Root = React.forwardRef<HTMLDivElement, BreadcrumbRootProps>((props, ref) => {
+  const { children, separator, separatorGap, ...rest } = props;
 
-    const validChildren = React.Children.toArray(children).filter(
-      React.isValidElement,
-    );
+  const validChildren = React.Children.toArray(children).filter(React.isValidElement);
 
-    return (
-      <Breadcrumb.Root ref={ref} {...rest}>
-        <Breadcrumb.List gap={separatorGap}>
-          {validChildren.map((child, index) => {
-            const last = index === validChildren.length - 1;
+  return (
+    <Breadcrumb.Root ref={ref} {...rest}>
+      <Breadcrumb.List gap={separatorGap}>
+        {validChildren.map((child, index) => {
+          const last = index === validChildren.length - 1;
 
-            return (
-              // eslint-disable-next-line react/no-array-index-key
-              <React.Fragment key={index}>
-                <Breadcrumb.Item>{child}</Breadcrumb.Item>
-                {!last && (
-                  <Breadcrumb.Separator>{separator}</Breadcrumb.Separator>
-                )}
-              </React.Fragment>
-            );
-          })}
-        </Breadcrumb.List>
-      </Breadcrumb.Root>
-    );
-  },
-);
+          return (
+            // eslint-disable-next-line react/no-array-index-key
+            <React.Fragment key={index}>
+              <Breadcrumb.Item>{child}</Breadcrumb.Item>
+              {!last && <Breadcrumb.Separator>{separator}</Breadcrumb.Separator>}
+            </React.Fragment>
+          );
+        })}
+      </Breadcrumb.List>
+    </Breadcrumb.Root>
+  );
+});

--- a/airflow/ui/src/components/ui/Button.tsx
+++ b/airflow/ui/src/components/ui/Button.tsx
@@ -17,12 +17,7 @@
  * under the License.
  */
 import type { ButtonProps as ChakraButtonProps } from "@chakra-ui/react";
-import {
-  AbsoluteCenter,
-  Button as ChakraButton,
-  Span,
-  Spinner,
-} from "@chakra-ui/react";
+import { AbsoluteCenter, Button as ChakraButton, Span, Spinner } from "@chakra-ui/react";
 import * as React from "react";
 
 type ButtonLoadingProps = {
@@ -32,28 +27,26 @@ type ButtonLoadingProps = {
 
 export type ButtonProps = {} & ButtonLoadingProps & ChakraButtonProps;
 
-export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  (props, ref) => {
-    const { children, disabled, loading, loadingText, ...rest } = props;
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
+  const { children, disabled, loading, loadingText, ...rest } = props;
 
-    return (
-      <ChakraButton disabled={loading ?? disabled} ref={ref} {...rest}>
-        {loading && !Boolean(loadingText) ? (
-          <>
-            <AbsoluteCenter display="inline-flex">
-              <Spinner color="inherit" size="inherit" />
-            </AbsoluteCenter>
-            <Span opacity={0}>{children}</Span>
-          </>
-        ) : loading && Boolean(loadingText) ? (
-          <>
+  return (
+    <ChakraButton disabled={loading ?? disabled} ref={ref} {...rest}>
+      {loading && !Boolean(loadingText) ? (
+        <>
+          <AbsoluteCenter display="inline-flex">
             <Spinner color="inherit" size="inherit" />
-            {loadingText}
-          </>
-        ) : (
-          children
-        )}
-      </ChakraButton>
-    );
-  },
-);
+          </AbsoluteCenter>
+          <Span opacity={0}>{children}</Span>
+        </>
+      ) : loading && Boolean(loadingText) ? (
+        <>
+          <Spinner color="inherit" size="inherit" />
+          {loadingText}
+        </>
+      ) : (
+        children
+      )}
+    </ChakraButton>
+  );
+});

--- a/airflow/ui/src/components/ui/Checkbox.tsx
+++ b/airflow/ui/src/components/ui/Checkbox.tsx
@@ -25,20 +25,14 @@ export type CheckboxProps = {
   rootRef?: React.Ref<HTMLLabelElement>;
 } & ChakraCheckbox.RootProps;
 
-export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
-  (props, ref) => {
-    const { children, icon, inputProps, rootRef, ...rest } = props;
+export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>((props, ref) => {
+  const { children, icon, inputProps, rootRef, ...rest } = props;
 
-    return (
-      <ChakraCheckbox.Root ref={rootRef} {...rest}>
-        <ChakraCheckbox.HiddenInput ref={ref} {...inputProps} />
-        <ChakraCheckbox.Control>
-          {icon ?? <ChakraCheckbox.Indicator />}
-        </ChakraCheckbox.Control>
-        {children !== undefined && (
-          <ChakraCheckbox.Label>{children}</ChakraCheckbox.Label>
-        )}
-      </ChakraCheckbox.Root>
-    );
-  },
-);
+  return (
+    <ChakraCheckbox.Root ref={rootRef} {...rest}>
+      <ChakraCheckbox.HiddenInput ref={ref} {...inputProps} />
+      <ChakraCheckbox.Control>{icon ?? <ChakraCheckbox.Indicator />}</ChakraCheckbox.Control>
+      {children !== undefined && <ChakraCheckbox.Label>{children}</ChakraCheckbox.Label>}
+    </ChakraCheckbox.Root>
+  );
+});

--- a/airflow/ui/src/components/ui/Clipboard.tsx
+++ b/airflow/ui/src/components/ui/Clipboard.tsx
@@ -17,37 +17,23 @@
  * under the License.
  */
 import type { ButtonProps, InputProps } from "@chakra-ui/react";
-import {
-  Button,
-  Clipboard as ChakraClipboard,
-  IconButton,
-  Input,
-} from "@chakra-ui/react";
+import { Button, Clipboard as ChakraClipboard, IconButton, Input } from "@chakra-ui/react";
 import * as React from "react";
 import { LuCheck, LuClipboard, LuLink } from "react-icons/lu";
 
-const ClipboardIcon = React.forwardRef<
-  HTMLDivElement,
-  ChakraClipboard.IndicatorProps
->((props, ref) => (
+const ClipboardIcon = React.forwardRef<HTMLDivElement, ChakraClipboard.IndicatorProps>((props, ref) => (
   <ChakraClipboard.Indicator copied={<LuCheck />} {...props} ref={ref}>
     <LuClipboard />
   </ChakraClipboard.Indicator>
 ));
 
-const ClipboardCopyText = React.forwardRef<
-  HTMLDivElement,
-  ChakraClipboard.IndicatorProps
->((props, ref) => (
+const ClipboardCopyText = React.forwardRef<HTMLDivElement, ChakraClipboard.IndicatorProps>((props, ref) => (
   <ChakraClipboard.Indicator copied="Copied" {...props} ref={ref}>
     Copy
   </ChakraClipboard.Indicator>
 ));
 
-export const ClipboardLabel = React.forwardRef<
-  HTMLLabelElement,
-  ChakraClipboard.LabelProps
->((props, ref) => (
+export const ClipboardLabel = React.forwardRef<HTMLLabelElement, ChakraClipboard.LabelProps>((props, ref) => (
   <ChakraClipboard.Label
     display="inline-block"
     fontWeight="medium"
@@ -58,41 +44,34 @@ export const ClipboardLabel = React.forwardRef<
   />
 ));
 
-export const ClipboardButton = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  (props, ref) => (
-    <ChakraClipboard.Trigger asChild>
-      <Button ref={ref} size="sm" variant="surface" {...props}>
-        <ClipboardIcon />
-        <ClipboardCopyText />
-      </Button>
-    </ChakraClipboard.Trigger>
-  ),
-);
+export const ClipboardButton = React.forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => (
+  <ChakraClipboard.Trigger asChild>
+    <Button ref={ref} size="sm" variant="surface" {...props}>
+      <ClipboardIcon />
+      <ClipboardCopyText />
+    </Button>
+  </ChakraClipboard.Trigger>
+));
 
-export const ClipboardLink = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  (props, ref) => (
-    <ChakraClipboard.Trigger asChild>
-      <Button
-        alignItems="center"
-        display="inline-flex"
-        gap="2"
-        ref={ref}
-        size="xs"
-        unstyled
-        variant="plain"
-        {...props}
-      >
-        <LuLink />
-        <ClipboardCopyText />
-      </Button>
-    </ChakraClipboard.Trigger>
-  ),
-);
+export const ClipboardLink = React.forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => (
+  <ChakraClipboard.Trigger asChild>
+    <Button
+      alignItems="center"
+      display="inline-flex"
+      gap="2"
+      ref={ref}
+      size="xs"
+      unstyled
+      variant="plain"
+      {...props}
+    >
+      <LuLink />
+      <ClipboardCopyText />
+    </Button>
+  </ChakraClipboard.Trigger>
+));
 
-export const ClipboardIconButton = React.forwardRef<
-  HTMLButtonElement,
-  ButtonProps
->((props, ref) => (
+export const ClipboardIconButton = React.forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => (
   <ChakraClipboard.Trigger asChild>
     <IconButton ref={ref} size="xs" variant="subtle" {...props}>
       <ClipboardIcon />
@@ -101,12 +80,10 @@ export const ClipboardIconButton = React.forwardRef<
   </ChakraClipboard.Trigger>
 ));
 
-export const ClipboardInput = React.forwardRef<HTMLInputElement, InputProps>(
-  (props, ref) => (
-    <ChakraClipboard.Input asChild>
-      <Input ref={ref} {...props} />
-    </ChakraClipboard.Input>
-  ),
-);
+export const ClipboardInput = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => (
+  <ChakraClipboard.Input asChild>
+    <Input ref={ref} {...props} />
+  </ChakraClipboard.Input>
+));
 
 export const ClipboardRoot = ChakraClipboard.Root;

--- a/airflow/ui/src/components/ui/CloseButton.tsx
+++ b/airflow/ui/src/components/ui/CloseButton.tsx
@@ -23,10 +23,8 @@ import { LuX } from "react-icons/lu";
 
 export type CloseButtonProps = {} & ChakraCloseButtonProps;
 
-export const CloseButton = forwardRef<HTMLButtonElement, CloseButtonProps>(
-  (props, ref) => (
-    <ChakraIconButton aria-label="Close" ref={ref} variant="ghost" {...props}>
-      {props.children ?? <LuX />}
-    </ChakraIconButton>
-  ),
-);
+export const CloseButton = forwardRef<HTMLButtonElement, CloseButtonProps>((props, ref) => (
+  <ChakraIconButton aria-label="Close" ref={ref} variant="ghost" {...props}>
+    {props.children ?? <LuX />}
+  </ChakraIconButton>
+));

--- a/airflow/ui/src/components/ui/Dialog/CloseTrigger.tsx
+++ b/airflow/ui/src/components/ui/Dialog/CloseTrigger.tsx
@@ -27,13 +27,7 @@ type Props = {
 
 export const CloseTrigger = forwardRef<HTMLButtonElement, Props>(
   ({ children, closeButtonProps, ...rest }, ref) => (
-    <ChakraDialog.CloseTrigger
-      insetEnd="2"
-      position="absolute"
-      top="2"
-      {...rest}
-      asChild
-    >
+    <ChakraDialog.CloseTrigger insetEnd="2" position="absolute" top="2" {...rest} asChild>
       <CloseButton ref={ref} size="sm" {...closeButtonProps}>
         {children}
       </CloseButton>

--- a/airflow/ui/src/components/ui/Dialog/Content.tsx
+++ b/airflow/ui/src/components/ui/Dialog/Content.tsx
@@ -25,25 +25,17 @@ type ContentProps = {
   portalRef?: React.RefObject<HTMLElement>;
 } & ChakraDialog.ContentProps;
 
-export const Content = forwardRef<HTMLDivElement, ContentProps>(
-  (props, ref) => {
-    const {
-      backdrop = true,
-      children,
-      portalled = true,
-      portalRef,
-      ...rest
-    } = props;
+export const Content = forwardRef<HTMLDivElement, ContentProps>((props, ref) => {
+  const { backdrop = true, children, portalled = true, portalRef, ...rest } = props;
 
-    return (
-      <Portal container={portalRef} disabled={!portalled}>
-        {backdrop ? <ChakraDialog.Backdrop /> : undefined}
-        <ChakraDialog.Positioner>
-          <ChakraDialog.Content ref={ref} {...rest}>
-            {children}
-          </ChakraDialog.Content>
-        </ChakraDialog.Positioner>
-      </Portal>
-    );
-  },
-);
+  return (
+    <Portal container={portalRef} disabled={!portalled}>
+      {backdrop ? <ChakraDialog.Backdrop /> : undefined}
+      <ChakraDialog.Positioner>
+        <ChakraDialog.Content ref={ref} {...rest}>
+          {children}
+        </ChakraDialog.Content>
+      </ChakraDialog.Positioner>
+    </Portal>
+  );
+});

--- a/airflow/ui/src/components/ui/FileUpload/Dropzone.tsx
+++ b/airflow/ui/src/components/ui/FileUpload/Dropzone.tsx
@@ -25,21 +25,19 @@ export type FileUploadDropzoneProps = {
   label: React.ReactNode;
 } & ChakraFileUpload.DropzoneProps;
 
-export const Dropzone = forwardRef<HTMLInputElement, FileUploadDropzoneProps>(
-  (props, ref) => {
-    const { children, description, label, ...rest } = props;
+export const Dropzone = forwardRef<HTMLInputElement, FileUploadDropzoneProps>((props, ref) => {
+  const { children, description, label, ...rest } = props;
 
-    return (
-      <ChakraFileUpload.Dropzone ref={ref} {...rest}>
-        <Icon color="fg.muted" fontSize="xl">
-          <LuUpload />
-        </Icon>
-        <ChakraFileUpload.DropzoneContent>
-          <div>{label}</div>
-          {description ?? <Text color="fg.muted">{description}</Text>}
-        </ChakraFileUpload.DropzoneContent>
-        {children}
-      </ChakraFileUpload.Dropzone>
-    );
-  },
-);
+  return (
+    <ChakraFileUpload.Dropzone ref={ref} {...rest}>
+      <Icon color="fg.muted" fontSize="xl">
+        <LuUpload />
+      </Icon>
+      <ChakraFileUpload.DropzoneContent>
+        <div>{label}</div>
+        {description ?? <Text color="fg.muted">{description}</Text>}
+      </ChakraFileUpload.DropzoneContent>
+      {children}
+    </ChakraFileUpload.Dropzone>
+  );
+});

--- a/airflow/ui/src/components/ui/FileUpload/FileInput.tsx
+++ b/airflow/ui/src/components/ui/FileUpload/FileInput.tsx
@@ -17,12 +17,7 @@
  * under the License.
  */
 import type { ButtonProps, RecipeProps } from "@chakra-ui/react";
-import {
-  Button,
-  FileUpload as ChakraFileUpload,
-  Span,
-  useRecipe,
-} from "@chakra-ui/react";
+import { Button, FileUpload as ChakraFileUpload, Span, useRecipe } from "@chakra-ui/react";
 import { forwardRef } from "react";
 
 type Assign<T, U> = Omit<T, keyof U> & U;
@@ -31,35 +26,27 @@ type FileInputProps = {
   placeholder?: React.ReactNode;
 } & Assign<ButtonProps, RecipeProps<"input">>;
 
-export const FileInput = forwardRef<HTMLButtonElement, FileInputProps>(
-  (props, ref) => {
-    const inputRecipe = useRecipe({ key: "input" });
-    const [recipeProps, restProps] = inputRecipe.splitVariantProps(props);
-    const { placeholder = "Select file(s)", ...rest } = restProps;
+export const FileInput = forwardRef<HTMLButtonElement, FileInputProps>((props, ref) => {
+  const inputRecipe = useRecipe({ key: "input" });
+  const [recipeProps, restProps] = inputRecipe.splitVariantProps(props);
+  const { placeholder = "Select file(s)", ...rest } = restProps;
 
-    return (
-      <ChakraFileUpload.Trigger asChild>
-        <Button
-          py="0"
-          ref={ref}
-          unstyled
-          {...rest}
-          css={[inputRecipe(recipeProps), props.css]}
-        >
-          <ChakraFileUpload.Context>
-            {({ acceptedFiles }) => {
-              if (acceptedFiles.length === 1) {
-                return <span>{acceptedFiles[0]?.name}</span>;
-              }
-              if (acceptedFiles.length > 1) {
-                return <span>{acceptedFiles.length} files</span>;
-              }
+  return (
+    <ChakraFileUpload.Trigger asChild>
+      <Button py="0" ref={ref} unstyled {...rest} css={[inputRecipe(recipeProps), props.css]}>
+        <ChakraFileUpload.Context>
+          {({ acceptedFiles }) => {
+            if (acceptedFiles.length === 1) {
+              return <span>{acceptedFiles[0]?.name}</span>;
+            }
+            if (acceptedFiles.length > 1) {
+              return <span>{acceptedFiles.length} files</span>;
+            }
 
-              return <Span color="fg.subtle">{placeholder}</Span>;
-            }}
-          </ChakraFileUpload.Context>
-        </Button>
-      </ChakraFileUpload.Trigger>
-    );
-  },
-);
+            return <Span color="fg.subtle">{placeholder}</Span>;
+          }}
+        </ChakraFileUpload.Context>
+      </Button>
+    </ChakraFileUpload.Trigger>
+  );
+});

--- a/airflow/ui/src/components/ui/FileUpload/Item.tsx
+++ b/airflow/ui/src/components/ui/FileUpload/Item.tsx
@@ -16,11 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  FileUpload as ChakraFileUpload,
-  Icon,
-  IconButton,
-} from "@chakra-ui/react";
+import { FileUpload as ChakraFileUpload, Icon, IconButton } from "@chakra-ui/react";
 import { forwardRef } from "react";
 import { LuFile, LuX } from "react-icons/lu";
 
@@ -33,35 +29,33 @@ type FileUploadItemProps = {
   file: File;
 } & VisibilityProps;
 
-export const Item = forwardRef<HTMLLIElement, FileUploadItemProps>(
-  (props, ref) => {
-    const { clearable, file, showSize } = props;
+export const Item = forwardRef<HTMLLIElement, FileUploadItemProps>((props, ref) => {
+  const { clearable, file, showSize } = props;
 
-    return (
-      <ChakraFileUpload.Item file={file} ref={ref}>
-        <ChakraFileUpload.ItemPreview asChild>
-          <Icon color="fg.muted" fontSize="lg">
-            <LuFile />
-          </Icon>
-        </ChakraFileUpload.ItemPreview>
+  return (
+    <ChakraFileUpload.Item file={file} ref={ref}>
+      <ChakraFileUpload.ItemPreview asChild>
+        <Icon color="fg.muted" fontSize="lg">
+          <LuFile />
+        </Icon>
+      </ChakraFileUpload.ItemPreview>
 
-        {showSize ? (
-          <ChakraFileUpload.ItemContent>
-            <ChakraFileUpload.ItemName />
-            <ChakraFileUpload.ItemSizeText />
-          </ChakraFileUpload.ItemContent>
-        ) : (
-          <ChakraFileUpload.ItemName flex="1" />
-        )}
+      {showSize ? (
+        <ChakraFileUpload.ItemContent>
+          <ChakraFileUpload.ItemName />
+          <ChakraFileUpload.ItemSizeText />
+        </ChakraFileUpload.ItemContent>
+      ) : (
+        <ChakraFileUpload.ItemName flex="1" />
+      )}
 
-        {clearable ? (
-          <ChakraFileUpload.ItemDeleteTrigger asChild>
-            <IconButton color="fg.muted" size="xs" variant="ghost">
-              <LuX />
-            </IconButton>
-          </ChakraFileUpload.ItemDeleteTrigger>
-        ) : undefined}
-      </ChakraFileUpload.Item>
-    );
-  },
-);
+      {clearable ? (
+        <ChakraFileUpload.ItemDeleteTrigger asChild>
+          <IconButton color="fg.muted" size="xs" variant="ghost">
+            <LuX />
+          </IconButton>
+        </ChakraFileUpload.ItemDeleteTrigger>
+      ) : undefined}
+    </ChakraFileUpload.Item>
+  );
+});

--- a/airflow/ui/src/components/ui/FileUpload/List.tsx
+++ b/airflow/ui/src/components/ui/FileUpload/List.tsx
@@ -16,10 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  FileUpload as ChakraFileUpload,
-  useFileUploadContext,
-} from "@chakra-ui/react";
+import { FileUpload as ChakraFileUpload, useFileUploadContext } from "@chakra-ui/react";
 import { forwardRef } from "react";
 
 import { Item } from "./Item";
@@ -34,28 +31,21 @@ type FileUploadListProps = {
 } & ChakraFileUpload.ItemGroupProps &
   VisibilityProps;
 
-export const List = forwardRef<HTMLUListElement, FileUploadListProps>(
-  (props, ref) => {
-    const { clearable, files, showSize, ...rest } = props;
+export const List = forwardRef<HTMLUListElement, FileUploadListProps>((props, ref) => {
+  const { clearable, files, showSize, ...rest } = props;
 
-    const fileUpload = useFileUploadContext();
-    const acceptedFiles = files ?? fileUpload.acceptedFiles;
+  const fileUpload = useFileUploadContext();
+  const acceptedFiles = files ?? fileUpload.acceptedFiles;
 
-    if (acceptedFiles.length === 0) {
-      return undefined;
-    }
+  if (acceptedFiles.length === 0) {
+    return undefined;
+  }
 
-    return (
-      <ChakraFileUpload.ItemGroup ref={ref} {...rest}>
-        {acceptedFiles.map((file) => (
-          <Item
-            clearable={clearable}
-            file={file}
-            key={file.name}
-            showSize={showSize}
-          />
-        ))}
-      </ChakraFileUpload.ItemGroup>
-    );
-  },
-);
+  return (
+    <ChakraFileUpload.ItemGroup ref={ref} {...rest}>
+      {acceptedFiles.map((file) => (
+        <Item clearable={clearable} file={file} key={file.name} showSize={showSize} />
+      ))}
+    </ChakraFileUpload.ItemGroup>
+  );
+});

--- a/airflow/ui/src/components/ui/FileUpload/Root.tsx
+++ b/airflow/ui/src/components/ui/FileUpload/Root.tsx
@@ -23,15 +23,13 @@ export type FileUploadRootProps = {
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
 } & ChakraFileUpload.RootProps;
 
-export const Root = forwardRef<HTMLInputElement, FileUploadRootProps>(
-  (props, ref) => {
-    const { children, inputProps, ...rest } = props;
+export const Root = forwardRef<HTMLInputElement, FileUploadRootProps>((props, ref) => {
+  const { children, inputProps, ...rest } = props;
 
-    return (
-      <ChakraFileUpload.Root {...rest}>
-        <ChakraFileUpload.HiddenInput ref={ref} {...inputProps} />
-        {children}
-      </ChakraFileUpload.Root>
-    );
-  },
-);
+  return (
+    <ChakraFileUpload.Root {...rest}>
+      <ChakraFileUpload.HiddenInput ref={ref} {...inputProps} />
+      {children}
+    </ChakraFileUpload.Root>
+  );
+});

--- a/airflow/ui/src/components/ui/InputGroup.tsx
+++ b/airflow/ui/src/components/ui/InputGroup.tsx
@@ -32,35 +32,26 @@ export type InputGroupProps = {
   startElementProps?: InputElementProps;
 } & BoxProps;
 
-export const InputGroup = forwardRef<HTMLDivElement, InputGroupProps>(
-  (props, ref) => {
-    const {
-      children,
-      endElement,
-      endElementProps,
-      startElement,
-      startElementProps,
-      ...rest
-    } = props;
+export const InputGroup = forwardRef<HTMLDivElement, InputGroupProps>((props, ref) => {
+  const { children, endElement, endElementProps, startElement, startElementProps, ...rest } = props;
 
-    return (
-      <Group ref={ref} {...rest}>
-        {startElement ? (
-          <InputElement pointerEvents="none" {...startElementProps}>
-            {startElement}
-          </InputElement>
-        ) : undefined}
-        {cloneElement(children, {
-          ...(startElement && { ps: "calc(var(--input-height) - 6px)" }),
-          ...(endElement && { pe: "calc(var(--input-height) - 6px)" }),
-          ...children.props,
-        })}
-        {endElement ? (
-          <InputElement placement="end" {...endElementProps}>
-            {endElement}
-          </InputElement>
-        ) : undefined}
-      </Group>
-    );
-  },
-);
+  return (
+    <Group ref={ref} {...rest}>
+      {startElement ? (
+        <InputElement pointerEvents="none" {...startElementProps}>
+          {startElement}
+        </InputElement>
+      ) : undefined}
+      {cloneElement(children, {
+        ...(startElement && { ps: "calc(var(--input-height) - 6px)" }),
+        ...(endElement && { pe: "calc(var(--input-height) - 6px)" }),
+        ...children.props,
+      })}
+      {endElement ? (
+        <InputElement placement="end" {...endElementProps}>
+          {endElement}
+        </InputElement>
+      ) : undefined}
+    </Group>
+  );
+});

--- a/airflow/ui/src/components/ui/Pagination/Ellipsis.tsx
+++ b/airflow/ui/src/components/ui/Pagination/Ellipsis.tsx
@@ -24,10 +24,7 @@ import { paginationContext } from "./context";
 
 const [, useRootProps] = paginationContext;
 
-export const Ellipsis = forwardRef<
-  HTMLDivElement,
-  ChakraPagination.EllipsisProps
->((props, ref) => {
+export const Ellipsis = forwardRef<HTMLDivElement, ChakraPagination.EllipsisProps>((props, ref) => {
   const { size, variantMap } = useRootProps();
 
   return (

--- a/airflow/ui/src/components/ui/Pagination/Item.tsx
+++ b/airflow/ui/src/components/ui/Pagination/Item.tsx
@@ -17,11 +17,7 @@
  * under the License.
  */
 import type { ButtonProps } from "@chakra-ui/react";
-import {
-  Button,
-  Pagination as ChakraPagination,
-  usePaginationContext,
-} from "@chakra-ui/react";
+import { Button, Pagination as ChakraPagination, usePaginationContext } from "@chakra-ui/react";
 import { forwardRef } from "react";
 
 import { paginationContext } from "./context";
@@ -35,20 +31,18 @@ export type PaginationRootProps = {
   variant?: PaginationVariant;
 } & Omit<ChakraPagination.RootProps, "type">;
 
-export const Item = forwardRef<HTMLButtonElement, ChakraPagination.ItemProps>(
-  (props, ref) => {
-    const { page } = usePaginationContext();
-    const { size, variantMap } = useRootProps();
+export const Item = forwardRef<HTMLButtonElement, ChakraPagination.ItemProps>((props, ref) => {
+  const { page } = usePaginationContext();
+  const { size, variantMap } = useRootProps();
 
-    const current = page === props.value;
-    const variant = current ? variantMap.current : variantMap.default;
+  const current = page === props.value;
+  const variant = current ? variantMap.current : variantMap.default;
 
-    return (
-      <ChakraPagination.Item ref={ref} {...props} asChild>
-        <Button size={size} variant={variant}>
-          {props.value}
-        </Button>
-      </ChakraPagination.Item>
-    );
-  },
-);
+  return (
+    <ChakraPagination.Item ref={ref} {...props} asChild>
+      <Button size={size} variant={variant}>
+        {props.value}
+      </Button>
+    </ChakraPagination.Item>
+  );
+});

--- a/airflow/ui/src/components/ui/Pagination/NextTrigger.tsx
+++ b/airflow/ui/src/components/ui/Pagination/NextTrigger.tsx
@@ -24,10 +24,7 @@ import { paginationContext } from "./context";
 
 const [, useRootProps] = paginationContext;
 
-export const NextTrigger = forwardRef<
-  HTMLButtonElement,
-  ChakraPagination.NextTriggerProps
->((props, ref) => {
+export const NextTrigger = forwardRef<HTMLButtonElement, ChakraPagination.NextTriggerProps>((props, ref) => {
   const { size, variantMap } = useRootProps();
 
   return (

--- a/airflow/ui/src/components/ui/Pagination/PageText.tsx
+++ b/airflow/ui/src/components/ui/Pagination/PageText.tsx
@@ -24,25 +24,23 @@ type PageTextProps = {
   format?: "compact" | "long" | "short";
 } & TextProps;
 
-export const PageText = forwardRef<HTMLParagraphElement, PageTextProps>(
-  (props, ref) => {
-    const { format = "compact", ...rest } = props;
-    const { count, page, pageRange, pages } = usePaginationContext();
-    const content = useMemo(() => {
-      if (format === "short") {
-        return `${page} / ${pages.length}`;
-      }
-      if (format === "compact") {
-        return `${page} of ${pages.length}`;
-      }
+export const PageText = forwardRef<HTMLParagraphElement, PageTextProps>((props, ref) => {
+  const { format = "compact", ...rest } = props;
+  const { count, page, pageRange, pages } = usePaginationContext();
+  const content = useMemo(() => {
+    if (format === "short") {
+      return `${page} / ${pages.length}`;
+    }
+    if (format === "compact") {
+      return `${page} of ${pages.length}`;
+    }
 
-      return `${pageRange.start + 1} - ${pageRange.end} of ${count}`;
-    }, [format, page, pages.length, pageRange, count]);
+    return `${pageRange.start + 1} - ${pageRange.end} of ${count}`;
+  }, [format, page, pages.length, pageRange, count]);
 
-    return (
-      <Text fontWeight="medium" ref={ref} {...rest}>
-        {content}
-      </Text>
-    );
-  },
-);
+  return (
+    <Text fontWeight="medium" ref={ref} {...rest}>
+      {content}
+    </Text>
+  );
+});

--- a/airflow/ui/src/components/ui/Pagination/PrevTrigger.tsx
+++ b/airflow/ui/src/components/ui/Pagination/PrevTrigger.tsx
@@ -24,10 +24,7 @@ import { paginationContext } from "./context";
 
 const [, useRootProps] = paginationContext;
 
-export const PrevTrigger = forwardRef<
-  HTMLButtonElement,
-  ChakraPagination.PrevTriggerProps
->((props, ref) => {
+export const PrevTrigger = forwardRef<HTMLButtonElement, ChakraPagination.PrevTriggerProps>((props, ref) => {
   const { size, variantMap } = useRootProps();
 
   return (

--- a/airflow/ui/src/components/ui/Pagination/Root.tsx
+++ b/airflow/ui/src/components/ui/Pagination/Root.tsx
@@ -43,14 +43,12 @@ const VARIANT_MAP: Record<PaginationVariant, ButtonVariantMap> = {
   subtle: { current: "subtle", default: "ghost", ellipsis: "plain" },
 };
 
-export const Root = forwardRef<HTMLDivElement, PaginationRootProps>(
-  (props, ref) => {
-    const { size = "sm", variant = "outline", ...rest } = props;
+export const Root = forwardRef<HTMLDivElement, PaginationRootProps>((props, ref) => {
+  const { size = "sm", variant = "outline", ...rest } = props;
 
-    return (
-      <RootPropsProvider value={{ size, variantMap: VARIANT_MAP[variant] }}>
-        <ChakraPagination.Root ref={ref} type="button" {...rest} />
-      </RootPropsProvider>
-    );
-  },
-);
+  return (
+    <RootPropsProvider value={{ size, variantMap: VARIANT_MAP[variant] }}>
+      <ChakraPagination.Root ref={ref} type="button" {...rest} />
+    </RootPropsProvider>
+  );
+});

--- a/airflow/ui/src/components/ui/ProgressBar.tsx
+++ b/airflow/ui/src/components/ui/ProgressBar.tsx
@@ -19,12 +19,10 @@
 import { Progress as ChakraProgress } from "@chakra-ui/react";
 import { forwardRef } from "react";
 
-export const ProgressBar = forwardRef<HTMLDivElement, ChakraProgress.RootProps>(
-  (props, ref) => (
-    <ChakraProgress.Root {...props} ref={ref}>
-      <ChakraProgress.Track>
-        <ChakraProgress.Range />
-      </ChakraProgress.Track>
-    </ChakraProgress.Root>
-  ),
-);
+export const ProgressBar = forwardRef<HTMLDivElement, ChakraProgress.RootProps>((props, ref) => (
+  <ChakraProgress.Root {...props} ref={ref}>
+    <ChakraProgress.Track>
+      <ChakraProgress.Range />
+    </ChakraProgress.Track>
+  </ChakraProgress.Root>
+));

--- a/airflow/ui/src/components/ui/RadioCard.tsx
+++ b/airflow/ui/src/components/ui/RadioCard.tsx
@@ -29,65 +29,53 @@ type RadioCardItemProps = {
   label?: React.ReactNode;
 } & RadioCard.ItemProps;
 
-export const RadioCardItem = forwardRef<HTMLInputElement, RadioCardItemProps>(
-  (props, ref) => {
-    const {
-      addon,
-      description,
-      icon,
-      indicator = <RadioCard.ItemIndicator />,
-      indicatorPlacement = "end",
-      inputProps,
-      label,
-      ...rest
-    } = props;
+export const RadioCardItem = forwardRef<HTMLInputElement, RadioCardItemProps>((props, ref) => {
+  const {
+    addon,
+    description,
+    icon,
+    indicator = <RadioCard.ItemIndicator />,
+    indicatorPlacement = "end",
+    inputProps,
+    label,
+    ...rest
+  } = props;
 
-    const hasContent = label ?? description ?? icon;
-    const shouldWrapContent = Boolean(indicator);
+  const hasContent = label ?? description ?? icon;
+  const shouldWrapContent = Boolean(indicator);
 
-    return (
-      <RadioCard.Item {...rest}>
-        <RadioCard.ItemHiddenInput ref={ref} {...inputProps} />
-        <RadioCard.ItemControl>
-          {indicatorPlacement === "start" && indicator}
-          {Boolean(hasContent) ? (
-            shouldWrapContent ? (
-              <RadioCard.ItemContent>
-                {icon}
-                {Boolean(label) ? (
-                  <RadioCard.ItemText>{label}</RadioCard.ItemText>
-                ) : undefined}
-                {Boolean(description) ? (
-                  <RadioCard.ItemDescription>
-                    {description}
-                  </RadioCard.ItemDescription>
-                ) : undefined}
-                {indicatorPlacement === "inside" && indicator}
-              </RadioCard.ItemContent>
-            ) : (
-              <>
-                {icon}
-                {Boolean(label) ? (
-                  <RadioCard.ItemText>{label}</RadioCard.ItemText>
-                ) : undefined}
-                {Boolean(description) ? (
-                  <RadioCard.ItemDescription>
-                    {description}
-                  </RadioCard.ItemDescription>
-                ) : undefined}
-                {indicatorPlacement === "inside" && indicator}
-              </>
-            )
-          ) : undefined}
-          {indicatorPlacement === "end" && indicator}
-        </RadioCard.ItemControl>
-        {Boolean(addon) ? (
-          <RadioCard.ItemAddon>{addon}</RadioCard.ItemAddon>
+  return (
+    <RadioCard.Item {...rest}>
+      <RadioCard.ItemHiddenInput ref={ref} {...inputProps} />
+      <RadioCard.ItemControl>
+        {indicatorPlacement === "start" && indicator}
+        {Boolean(hasContent) ? (
+          shouldWrapContent ? (
+            <RadioCard.ItemContent>
+              {icon}
+              {Boolean(label) ? <RadioCard.ItemText>{label}</RadioCard.ItemText> : undefined}
+              {Boolean(description) ? (
+                <RadioCard.ItemDescription>{description}</RadioCard.ItemDescription>
+              ) : undefined}
+              {indicatorPlacement === "inside" && indicator}
+            </RadioCard.ItemContent>
+          ) : (
+            <>
+              {icon}
+              {Boolean(label) ? <RadioCard.ItemText>{label}</RadioCard.ItemText> : undefined}
+              {Boolean(description) ? (
+                <RadioCard.ItemDescription>{description}</RadioCard.ItemDescription>
+              ) : undefined}
+              {indicatorPlacement === "inside" && indicator}
+            </>
+          )
         ) : undefined}
-      </RadioCard.Item>
-    );
-  },
-);
+        {indicatorPlacement === "end" && indicator}
+      </RadioCard.ItemControl>
+      {Boolean(addon) ? <RadioCard.ItemAddon>{addon}</RadioCard.ItemAddon> : undefined}
+    </RadioCard.Item>
+  );
+});
 
 export const RadioCardRoot = RadioCard.Root;
 export const RadioCardLabel = RadioCard.Label;

--- a/airflow/ui/src/components/ui/SegmentedControl.tsx
+++ b/airflow/ui/src/components/ui/SegmentedControl.tsx
@@ -30,12 +30,7 @@ type SegmentedControlProps = {
   readonly value: string;
 } & Omit<TabsRootProps, "onValueChange">;
 
-const SegmentedControl = ({
-  onValueChange,
-  options,
-  value,
-  ...rest
-}: SegmentedControlProps) => (
+const SegmentedControl = ({ onValueChange, options, value, ...rest }: SegmentedControlProps) => (
   <Tabs.Root
     defaultValue={value}
     onValueChange={(option) => onValueChange(option.value)}
@@ -45,11 +40,7 @@ const SegmentedControl = ({
     <Tabs.List>
       <For each={options}>
         {(option) => (
-          <Tabs.Trigger
-            disabled={option.disabled}
-            key={option.value}
-            value={option.value}
-          >
+          <Tabs.Trigger disabled={option.disabled} key={option.value} value={option.value}>
             {option.label}
           </Tabs.Trigger>
         )}

--- a/airflow/ui/src/components/ui/Select/Content.tsx
+++ b/airflow/ui/src/components/ui/Select/Content.tsx
@@ -24,16 +24,14 @@ type ContentProps = {
   portalRef?: React.RefObject<HTMLElement>;
 } & ChakraSelect.ContentProps;
 
-export const Content = forwardRef<HTMLDivElement, ContentProps>(
-  (props, ref) => {
-    const { portalled = true, portalRef, ...rest } = props;
+export const Content = forwardRef<HTMLDivElement, ContentProps>((props, ref) => {
+  const { portalled = true, portalRef, ...rest } = props;
 
-    return (
-      <Portal container={portalRef} disabled={!portalled}>
-        <ChakraSelect.Positioner>
-          <ChakraSelect.Content {...rest} ref={ref} />
-        </ChakraSelect.Positioner>
-      </Portal>
-    );
-  },
-);
+  return (
+    <Portal container={portalRef} disabled={!portalled}>
+      <ChakraSelect.Positioner>
+        <ChakraSelect.Content {...rest} ref={ref} />
+      </ChakraSelect.Positioner>
+    </Portal>
+  );
+});

--- a/airflow/ui/src/components/ui/Select/Item.tsx
+++ b/airflow/ui/src/components/ui/Select/Item.tsx
@@ -21,16 +21,14 @@
 import { Select as ChakraSelect } from "@chakra-ui/react";
 import { forwardRef } from "react";
 
-export const Item = forwardRef<HTMLDivElement, ChakraSelect.ItemProps>(
-  (props, ref) => {
-    const { children, item, ...rest } = props;
+export const Item = forwardRef<HTMLDivElement, ChakraSelect.ItemProps>((props, ref) => {
+  const { children, item, ...rest } = props;
 
-    return (
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      <ChakraSelect.Item item={item} key={item.value} {...rest} ref={ref}>
-        {children}
-        <ChakraSelect.ItemIndicator />
-      </ChakraSelect.Item>
-    );
-  },
-);
+  return (
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    <ChakraSelect.Item item={item} key={item.value} {...rest} ref={ref}>
+      {children}
+      <ChakraSelect.ItemIndicator />
+    </ChakraSelect.Item>
+  );
+});

--- a/airflow/ui/src/components/ui/Select/ItemGroup.tsx
+++ b/airflow/ui/src/components/ui/Select/ItemGroup.tsx
@@ -23,15 +23,13 @@ type ItemGroupProps = {
   label: React.ReactNode;
 } & ChakraSelect.ItemGroupProps;
 
-export const ItemGroup = forwardRef<HTMLDivElement, ItemGroupProps>(
-  (props, ref) => {
-    const { children, label, ...rest } = props;
+export const ItemGroup = forwardRef<HTMLDivElement, ItemGroupProps>((props, ref) => {
+  const { children, label, ...rest } = props;
 
-    return (
-      <ChakraSelect.ItemGroup {...rest} ref={ref}>
-        <ChakraSelect.ItemGroupLabel>{label}</ChakraSelect.ItemGroupLabel>
-        {children}
-      </ChakraSelect.ItemGroup>
-    );
-  },
-);
+  return (
+    <ChakraSelect.ItemGroup {...rest} ref={ref}>
+      <ChakraSelect.ItemGroupLabel>{label}</ChakraSelect.ItemGroupLabel>
+      {children}
+    </ChakraSelect.ItemGroup>
+  );
+});

--- a/airflow/ui/src/components/ui/Select/Root.tsx
+++ b/airflow/ui/src/components/ui/Select/Root.tsx
@@ -19,12 +19,6 @@
 import { Select as ChakraSelect } from "@chakra-ui/react";
 import { forwardRef } from "react";
 
-export const Root = forwardRef<HTMLDivElement, ChakraSelect.RootProps>(
-  (props, ref) => (
-    <ChakraSelect.Root
-      {...props}
-      positioning={{ sameWidth: true, ...props.positioning }}
-      ref={ref}
-    />
-  ),
-);
+export const Root = forwardRef<HTMLDivElement, ChakraSelect.RootProps>((props, ref) => (
+  <ChakraSelect.Root {...props} positioning={{ sameWidth: true, ...props.positioning }} ref={ref} />
+));

--- a/airflow/ui/src/components/ui/Select/ValueText.tsx
+++ b/airflow/ui/src/components/ui/Select/ValueText.tsx
@@ -24,30 +24,28 @@ type ValueTextProps = {
   children?: (items: Array<CollectionItem>) => React.ReactNode;
 } & Omit<ChakraSelect.ValueTextProps, "children">;
 
-export const ValueText = forwardRef<HTMLSpanElement, ValueTextProps>(
-  (props, ref) => {
-    const { children, ...rest } = props;
+export const ValueText = forwardRef<HTMLSpanElement, ValueTextProps>((props, ref) => {
+  const { children, ...rest } = props;
 
-    return (
-      <ChakraSelect.ValueText {...rest} ref={ref}>
-        <ChakraSelect.Context>
-          {(select) => {
-            const items = select.selectedItems;
+  return (
+    <ChakraSelect.ValueText {...rest} ref={ref}>
+      <ChakraSelect.Context>
+        {(select) => {
+          const items = select.selectedItems;
 
-            if (items.length === 0) {
-              return props.placeholder;
-            }
-            if (children) {
-              return children(items);
-            }
-            if (items.length === 1) {
-              return select.collection.stringifyItem(items[0]);
-            }
+          if (items.length === 0) {
+            return props.placeholder;
+          }
+          if (children) {
+            return children(items);
+          }
+          if (items.length === 1) {
+            return select.collection.stringifyItem(items[0]);
+          }
 
-            return `${items.length} selected`;
-          }}
-        </ChakraSelect.Context>
-      </ChakraSelect.ValueText>
-    );
-  },
-);
+          return `${items.length} selected`;
+        }}
+      </ChakraSelect.Context>
+    </ChakraSelect.ValueText>
+  );
+});

--- a/airflow/ui/src/components/ui/Status.tsx
+++ b/airflow/ui/src/components/ui/Status.tsx
@@ -19,10 +19,7 @@
 import { Status as ChakraStatus } from "@chakra-ui/react";
 import * as React from "react";
 
-import type {
-  DagRunState,
-  TaskInstanceState,
-} from "openapi/requests/types.gen";
+import type { DagRunState, TaskInstanceState } from "openapi/requests/types.gen";
 import { stateColor } from "src/utils/stateColor";
 
 type StatusValue = DagRunState | TaskInstanceState;
@@ -31,16 +28,14 @@ export type StatusProps = {
   state: StatusValue | null;
 } & ChakraStatus.RootProps;
 
-export const Status = React.forwardRef<HTMLDivElement, StatusProps>(
-  ({ children, state, ...rest }, ref) => {
-    // "null" is actually a string on stateColor
-    const colorPalette = stateColor[state ?? "null"];
+export const Status = React.forwardRef<HTMLDivElement, StatusProps>(({ children, state, ...rest }, ref) => {
+  // "null" is actually a string on stateColor
+  const colorPalette = stateColor[state ?? "null"];
 
-    return (
-      <ChakraStatus.Root ref={ref} {...rest}>
-        <ChakraStatus.Indicator bg={colorPalette} />
-        {children}
-      </ChakraStatus.Root>
-    );
-  },
-);
+  return (
+    <ChakraStatus.Root ref={ref} {...rest}>
+      <ChakraStatus.Indicator bg={colorPalette} />
+      {children}
+    </ChakraStatus.Root>
+  );
+});

--- a/airflow/ui/src/components/ui/Switch.tsx
+++ b/airflow/ui/src/components/ui/Switch.tsx
@@ -26,32 +26,25 @@ export type SwitchProps = {
   trackLabel?: { off: React.ReactNode; on: React.ReactNode };
 } & ChakraSwitch.RootProps;
 
-export const Switch = forwardRef<HTMLInputElement, SwitchProps>(
-  (props, ref) => {
-    const { children, inputProps, rootRef, thumbLabel, trackLabel, ...rest } =
-      props;
+export const Switch = forwardRef<HTMLInputElement, SwitchProps>((props, ref) => {
+  const { children, inputProps, rootRef, thumbLabel, trackLabel, ...rest } = props;
 
-    return (
-      <ChakraSwitch.Root ref={rootRef} {...rest}>
-        <ChakraSwitch.HiddenInput ref={ref} {...inputProps} />
-        <ChakraSwitch.Control>
-          <ChakraSwitch.Thumb>
-            {thumbLabel ? (
-              <ChakraSwitch.ThumbIndicator fallback={thumbLabel.off}>
-                {thumbLabel.on}
-              </ChakraSwitch.ThumbIndicator>
-            ) : undefined}
-          </ChakraSwitch.Thumb>
-          {trackLabel ? (
-            <ChakraSwitch.Indicator fallback={trackLabel.off}>
-              {trackLabel.on}
-            </ChakraSwitch.Indicator>
+  return (
+    <ChakraSwitch.Root ref={rootRef} {...rest}>
+      <ChakraSwitch.HiddenInput ref={ref} {...inputProps} />
+      <ChakraSwitch.Control>
+        <ChakraSwitch.Thumb>
+          {thumbLabel ? (
+            <ChakraSwitch.ThumbIndicator fallback={thumbLabel.off}>
+              {thumbLabel.on}
+            </ChakraSwitch.ThumbIndicator>
           ) : undefined}
-        </ChakraSwitch.Control>
-        {Boolean(children) && (
-          <ChakraSwitch.Label>{children}</ChakraSwitch.Label>
-        )}
-      </ChakraSwitch.Root>
-    );
-  },
-);
+        </ChakraSwitch.Thumb>
+        {trackLabel ? (
+          <ChakraSwitch.Indicator fallback={trackLabel.off}>{trackLabel.on}</ChakraSwitch.Indicator>
+        ) : undefined}
+      </ChakraSwitch.Control>
+      {Boolean(children) && <ChakraSwitch.Label>{children}</ChakraSwitch.Label>}
+    </ChakraSwitch.Root>
+  );
+});

--- a/airflow/ui/src/components/ui/Tag.tsx
+++ b/airflow/ui/src/components/ui/Tag.tsx
@@ -27,24 +27,13 @@ export type TagProps = {
 } & ChakraTag.RootProps;
 
 export const Tag = forwardRef<HTMLSpanElement, TagProps>((props, ref) => {
-  const {
-    children,
-    onClose,
-    closable = Boolean(onClose),
-    endElement,
-    startElement,
-    ...rest
-  } = props;
+  const { children, onClose, closable = Boolean(onClose), endElement, startElement, ...rest } = props;
 
   return (
     <ChakraTag.Root ref={ref} {...rest}>
-      {Boolean(startElement) ? (
-        <ChakraTag.StartElement>{startElement}</ChakraTag.StartElement>
-      ) : undefined}
+      {Boolean(startElement) ? <ChakraTag.StartElement>{startElement}</ChakraTag.StartElement> : undefined}
       <ChakraTag.Label>{children}</ChakraTag.Label>
-      {Boolean(endElement) ? (
-        <ChakraTag.EndElement>{endElement}</ChakraTag.EndElement>
-      ) : undefined}
+      {Boolean(endElement) ? <ChakraTag.EndElement>{endElement}</ChakraTag.EndElement> : undefined}
       {Boolean(closable) ? (
         <ChakraTag.EndElement>
           <ChakraTag.CloseTrigger onClick={onClose} />

--- a/airflow/ui/src/components/ui/Toaster.tsx
+++ b/airflow/ui/src/components/ui/Toaster.tsx
@@ -16,14 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  Toaster as ChakraToaster,
-  Portal,
-  Spinner,
-  Stack,
-  Toast,
-  createToaster,
-} from "@chakra-ui/react";
+import { Toaster as ChakraToaster, Portal, Spinner, Stack, Toast, createToaster } from "@chakra-ui/react";
 
 export const toaster = createToaster({
   pauseOnPageIdle: true,
@@ -35,22 +28,14 @@ export const Toaster = () => (
     <ChakraToaster insetInline={{ mdDown: "4" }} toaster={toaster}>
       {(toast) => (
         <Toast.Root width={{ md: "sm" }}>
-          {toast.type === "loading" ? (
-            <Spinner color="blue.solid" size="sm" />
-          ) : (
-            <Toast.Indicator />
-          )}
+          {toast.type === "loading" ? <Spinner color="blue.solid" size="sm" /> : <Toast.Indicator />}
           <Stack flex="1" gap="1" maxWidth="100%">
-            {Boolean(toast.title) ? (
-              <Toast.Title>{toast.title}</Toast.Title>
-            ) : undefined}
+            {Boolean(toast.title) ? <Toast.Title>{toast.title}</Toast.Title> : undefined}
             {Boolean(toast.description) ? (
               <Toast.Description>{toast.description}</Toast.Description>
             ) : undefined}
           </Stack>
-          {toast.action ? (
-            <Toast.ActionTrigger>{toast.action.label}</Toast.ActionTrigger>
-          ) : undefined}
+          {toast.action ? <Toast.ActionTrigger>{toast.action.label}</Toast.ActionTrigger> : undefined}
           {Boolean(toast.meta?.closable) ? <Toast.CloseTrigger /> : undefined}
         </Toast.Root>
       )}

--- a/airflow/ui/src/components/ui/Tooltip.tsx
+++ b/airflow/ui/src/components/ui/Tooltip.tsx
@@ -28,39 +28,28 @@ export type TooltipProps = {
   showArrow?: boolean;
 } & ChakraTooltip.RootProps;
 
-export const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(
-  (props, ref) => {
-    const {
-      children,
-      content,
-      contentProps,
-      disabled,
-      portalled,
-      portalRef,
-      showArrow,
-      ...rest
-    } = props;
+export const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>((props, ref) => {
+  const { children, content, contentProps, disabled, portalled, portalRef, showArrow, ...rest } = props;
 
-    if (disabled) {
-      return children;
-    }
+  if (disabled) {
+    return children;
+  }
 
-    return (
-      <ChakraTooltip.Root {...rest}>
-        <ChakraTooltip.Trigger asChild>{children}</ChakraTooltip.Trigger>
-        <Portal container={portalRef} disabled={!portalled}>
-          <ChakraTooltip.Positioner>
-            <ChakraTooltip.Content ref={ref} {...contentProps}>
-              {showArrow ? (
-                <ChakraTooltip.Arrow>
-                  <ChakraTooltip.ArrowTip />
-                </ChakraTooltip.Arrow>
-              ) : undefined}
-              {content}
-            </ChakraTooltip.Content>
-          </ChakraTooltip.Positioner>
-        </Portal>
-      </ChakraTooltip.Root>
-    );
-  },
-);
+  return (
+    <ChakraTooltip.Root {...rest}>
+      <ChakraTooltip.Trigger asChild>{children}</ChakraTooltip.Trigger>
+      <Portal container={portalRef} disabled={!portalled}>
+        <ChakraTooltip.Positioner>
+          <ChakraTooltip.Content ref={ref} {...contentProps}>
+            {showArrow ? (
+              <ChakraTooltip.Arrow>
+                <ChakraTooltip.ArrowTip />
+              </ChakraTooltip.Arrow>
+            ) : undefined}
+            {content}
+          </ChakraTooltip.Content>
+        </ChakraTooltip.Positioner>
+      </Portal>
+    </ChakraTooltip.Root>
+  );
+});

--- a/airflow/ui/src/constants/searchParams.ts
+++ b/airflow/ui/src/constants/searchParams.ts
@@ -26,7 +26,4 @@ export enum SearchParamsKeys {
   TAGS = "tags",
 }
 
-export type SearchParamsKeysType = Record<
-  keyof typeof SearchParamsKeys,
-  string
->;
+export type SearchParamsKeysType = Record<keyof typeof SearchParamsKeys, string>;

--- a/airflow/ui/src/context/openGroups/OpenGroupsProvider.tsx
+++ b/airflow/ui/src/context/openGroups/OpenGroupsProvider.tsx
@@ -16,12 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  createContext,
-  useCallback,
-  useMemo,
-  type PropsWithChildren,
-} from "react";
+import { createContext, useCallback, useMemo, type PropsWithChildren } from "react";
 import { useLocalStorage } from "usehooks-ts";
 
 export type OpenGroupsContextType = {
@@ -30,9 +25,7 @@ export type OpenGroupsContextType = {
   toggleGroupId: (groupId: string) => void;
 };
 
-export const OpenGroupsContext = createContext<
-  OpenGroupsContextType | undefined
->(undefined);
+export const OpenGroupsContext = createContext<OpenGroupsContextType | undefined>(undefined);
 
 type Props = {
   readonly dagId: string;
@@ -40,10 +33,7 @@ type Props = {
 
 export const OpenGroupsProvider = ({ children, dagId }: Props) => {
   const openGroupsKey = `${dagId}/open-groups`;
-  const [openGroupIds, setOpenGroupIds] = useLocalStorage<Array<string>>(
-    openGroupsKey,
-    [],
-  );
+  const [openGroupIds, setOpenGroupIds] = useLocalStorage<Array<string>>(openGroupsKey, []);
 
   const toggleGroupId = useCallback(
     (groupId: string) => {
@@ -61,9 +51,5 @@ export const OpenGroupsProvider = ({ children, dagId }: Props) => {
     [openGroupIds, setOpenGroupIds, toggleGroupId],
   );
 
-  return (
-    <OpenGroupsContext.Provider value={value}>
-      {children}
-    </OpenGroupsContext.Provider>
-  );
+  return <OpenGroupsContext.Provider value={value}>{children}</OpenGroupsContext.Provider>;
 };

--- a/airflow/ui/src/context/openGroups/useOpenGroups.ts
+++ b/airflow/ui/src/context/openGroups/useOpenGroups.ts
@@ -18,10 +18,7 @@
  */
 import { useContext } from "react";
 
-import {
-  OpenGroupsContext,
-  type OpenGroupsContextType,
-} from "./OpenGroupsProvider";
+import { OpenGroupsContext, type OpenGroupsContextType } from "./OpenGroupsProvider";
 
 export const useOpenGroups = (): OpenGroupsContextType => {
   const context = useContext(OpenGroupsContext);

--- a/airflow/ui/src/context/timezone/TimezoneProvider.tsx
+++ b/airflow/ui/src/context/timezone/TimezoneProvider.tsx
@@ -26,9 +26,7 @@ export type TimezoneContextType = {
   setSelectedTimezone: (timezone: string) => void;
 };
 
-export const TimezoneContext = createContext<TimezoneContextType | undefined>(
-  undefined,
-);
+export const TimezoneContext = createContext<TimezoneContextType | undefined>(undefined);
 
 const TIMEZONE_KEY = "timezone";
 
@@ -45,9 +43,5 @@ export const TimezoneProvider = ({ children }: PropsWithChildren) => {
     [selectedTimezone, setSelectedTimezone],
   );
 
-  return (
-    <TimezoneContext.Provider value={value}>
-      {children}
-    </TimezoneContext.Provider>
-  );
+  return <TimezoneContext.Provider value={value}>{children}</TimezoneContext.Provider>;
 };

--- a/airflow/ui/src/layouts/Details/DagVizModal.tsx
+++ b/airflow/ui/src/layouts/Details/DagVizModal.tsx
@@ -51,12 +51,7 @@ const visualizationOptions = [
   { component: <Grid />, icon: <FiGrid height={5} width={5} />, value: "grid" },
 ];
 
-export const DagVizModal: React.FC<TriggerDAGModalProps> = ({
-  dagDisplayName,
-  dagId,
-  onClose,
-  open,
-}) => {
+export const DagVizModal: React.FC<TriggerDAGModalProps> = ({ dagDisplayName, dagId, onClose, open }) => {
   const [searchParams] = useSearchParams();
 
   const activeViz = searchParams.get("modal") ?? "graph";
@@ -96,8 +91,7 @@ export const DagVizModal: React.FC<TriggerDAGModalProps> = ({
         <Dialog.Body display="flex">
           {dagId === undefined
             ? undefined
-            : visualizationOptions.find((viz) => viz.value === activeViz)
-                ?.component}
+            : visualizationOptions.find((viz) => viz.value === activeViz)?.component}
         </Dialog.Body>
       </Dialog.Content>
     </Dialog.Root>

--- a/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -19,12 +19,7 @@
 import { Box, Button } from "@chakra-ui/react";
 import type { PropsWithChildren } from "react";
 import { FiChevronsLeft } from "react-icons/fi";
-import {
-  Outlet,
-  Link as RouterLink,
-  useParams,
-  useSearchParams,
-} from "react-router-dom";
+import { Outlet, Link as RouterLink, useParams, useSearchParams } from "react-router-dom";
 
 import type { DAGResponse } from "openapi/requests/types.gen";
 import { ErrorAlert } from "src/components/ErrorAlert";
@@ -42,13 +37,7 @@ type Props = {
   readonly tabs: Array<{ label: string; value: string }>;
 } & PropsWithChildren;
 
-export const DetailsLayout = ({
-  children,
-  dag,
-  error,
-  isLoading,
-  tabs,
-}: Props) => {
+export const DetailsLayout = ({ children, dag, error, isLoading, tabs }: Props) => {
   const { dagId = "" } = useParams();
 
   const [searchParams, setSearchParams] = useSearchParams();

--- a/airflow/ui/src/layouts/Details/Graph/Edge.tsx
+++ b/airflow/ui/src/layouts/Details/Graph/Edge.tsx
@@ -61,11 +61,7 @@ const CustomEdge = ({ data }: Props) => {
       })}
       {(rest.sections ?? []).map((section) => (
         <LinePath
-          data={[
-            section.startPoint,
-            ...(section.bendPoints ?? []),
-            section.endPoint,
-          ]}
+          data={[section.startPoint, ...(section.bendPoints ?? []), section.endPoint]}
           key={section.id}
           stroke={colorMode === "dark" ? darkStroke : lightStroke}
           strokeDasharray={rest.isSetupTeardown ? "10,5" : undefined}

--- a/airflow/ui/src/layouts/Details/Graph/Graph.tsx
+++ b/airflow/ui/src/layouts/Details/Graph/Graph.tsx
@@ -42,10 +42,9 @@ export const Graph = () => {
 
   const { openGroupIds } = useOpenGroups();
 
-  const { data: graphData = { arrange: "LR", edges: [], nodes: [] } } =
-    useStructureServiceStructureData({
-      dagId,
-    });
+  const { data: graphData = { arrange: "LR", edges: [], nodes: [] } } = useStructureServiceStructureData({
+    dagId,
+  });
 
   const { data } = useGraphLayout({
     ...graphData,

--- a/airflow/ui/src/layouts/Details/Graph/JoinNode.tsx
+++ b/airflow/ui/src/layouts/Details/Graph/JoinNode.tsx
@@ -22,15 +22,8 @@ import type { NodeProps, Node as NodeType } from "@xyflow/react";
 import { NodeWrapper } from "./NodeWrapper";
 import type { CustomNodeProps } from "./reactflowUtils";
 
-export const JoinNode = ({
-  data,
-}: NodeProps<NodeType<CustomNodeProps, "join">>) => (
+export const JoinNode = ({ data }: NodeProps<NodeType<CustomNodeProps, "join">>) => (
   <NodeWrapper>
-    <Box
-      bg="fg"
-      borderRadius={`${data.width}px`}
-      height={`${data.height}px`}
-      width={`${data.width}px`}
-    />
+    <Box bg="fg" borderRadius={`${data.width}px`} height={`${data.height}px`} width={`${data.width}px`} />
   </NodeWrapper>
 );

--- a/airflow/ui/src/layouts/Details/Graph/NodeWrapper.tsx
+++ b/airflow/ui/src/layouts/Details/Graph/NodeWrapper.tsx
@@ -21,16 +21,8 @@ import type { PropsWithChildren } from "react";
 
 export const NodeWrapper = ({ children }: PropsWithChildren) => (
   <>
-    <Handle
-      position={Position.Top}
-      style={{ visibility: "hidden" }}
-      type="target"
-    />
+    <Handle position={Position.Top} style={{ visibility: "hidden" }} type="target" />
     {children}
-    <Handle
-      position={Position.Bottom}
-      style={{ visibility: "hidden" }}
-      type="source"
-    />
+    <Handle position={Position.Bottom} style={{ visibility: "hidden" }} type="source" />
   </>
 );

--- a/airflow/ui/src/layouts/Details/Graph/TaskName.tsx
+++ b/airflow/ui/src/layouts/Details/Graph/TaskName.tsx
@@ -52,9 +52,7 @@ export const TaskName = ({
     <Text data-testid={id} fontSize={isZoomedOut ? 24 : undefined} {...rest}>
       {label}
       {isMapped ? " [ ]" : undefined}
-      {setupTeardownType === "setup" && (
-        <FiArrowUpRight size={isZoomedOut ? 24 : 15} style={iconStyle} />
-      )}
+      {setupTeardownType === "setup" && <FiArrowUpRight size={isZoomedOut ? 24 : 15} style={iconStyle} />}
       {setupTeardownType === "teardown" && (
         <FiArrowDownRight size={isZoomedOut ? 24 : 15} style={iconStyle} />
       )}

--- a/airflow/ui/src/layouts/Details/Graph/TaskNode.tsx
+++ b/airflow/ui/src/layouts/Details/Graph/TaskNode.tsx
@@ -80,12 +80,7 @@ export const TaskNode = ({
           </Box>
           <Box>
             {isGroup ? (
-              <Button
-                colorPalette="blue"
-                onClick={onClick}
-                p={0}
-                variant="plain"
-              >
+              <Button colorPalette="blue" onClick={onClick} p={0} variant="plain">
                 {isOpen ? "- " : "+ "}
                 {pluralize("task", childCount, undefined, false)}
               </Button>

--- a/airflow/ui/src/layouts/Details/Graph/reactflowUtils.ts
+++ b/airflow/ui/src/layouts/Details/Graph/reactflowUtils.ts
@@ -129,11 +129,7 @@ export type EdgeData = {
   rest: { isSetupTeardown?: boolean } & ElkExtendedEdge;
 };
 
-export const formatFlowEdges = ({
-  edges,
-}: {
-  edges: Array<Edge>;
-}): Array<FlowEdgeType<EdgeData>> =>
+export const formatFlowEdges = ({ edges }: { edges: Array<Edge> }): Array<FlowEdgeType<EdgeData>> =>
   edges.map((edge) => ({
     data: { rest: edge },
     id: edge.id,

--- a/airflow/ui/src/layouts/Details/Graph/useGraphLayout.ts
+++ b/airflow/ui/src/layouts/Details/Graph/useGraphLayout.ts
@@ -81,14 +81,9 @@ const getDirection = (arrange: string) => {
   }
 };
 
-const formatElkEdge = (
-  edge: EdgeResponse,
-  font: string,
-  node?: NodeResponse,
-): FormattedEdge => ({
+const formatElkEdge = (edge: EdgeResponse, font: string, node?: NodeResponse): FormattedEdge => ({
   id: `${edge.source_id}-${edge.target_id}`,
-  isSetupTeardown:
-    edge.is_setup_teardown === null ? undefined : edge.is_setup_teardown,
+  isSetupTeardown: edge.is_setup_teardown === null ? undefined : edge.is_setup_teardown,
   // isSourceAsset: e.isSourceAsset,
   labels:
     edge.label === undefined || edge.label === null
@@ -142,12 +137,9 @@ const generateElkGraph = ({
   const formatChildNode = (node: NodeResponse): FormattedNode => {
     const isOpen = openGroupIds?.includes(node.id);
 
-    const childCount =
-      node.children?.filter((child) => child.type !== "join").length ?? 0;
+    const childCount = node.children?.filter((child) => child.type !== "join").length ?? 0;
     const childIds =
-      node.children === null || node.children === undefined
-        ? []
-        : getNestedChildIds(node.children);
+      node.children === null || node.children === undefined ? [] : getNestedChildIds(node.children);
 
     if (isOpen && node.children !== null && node.children !== undefined) {
       return {
@@ -156,17 +148,10 @@ const generateElkGraph = ({
         children: node.children.map(formatChildNode),
         edges: filteredEdges
           .filter((edge) => {
-            if (
-              childIds.includes(edge.source_id) &&
-              childIds.includes(edge.target_id)
-            ) {
+            if (childIds.includes(edge.source_id) && childIds.includes(edge.target_id)) {
               // Remove edge from array when we add it here
               filteredEdges = filteredEdges.filter(
-                (fe) =>
-                  !(
-                    fe.source_id === edge.source_id &&
-                    fe.target_id === edge.target_id
-                  ),
+                (fe) => !(fe.source_id === edge.source_id && fe.target_id === edge.target_id),
               );
 
               return true;
@@ -188,12 +173,7 @@ const generateElkGraph = ({
     if (!Boolean(isOpen) && node.children !== undefined) {
       filteredEdges = filteredEdges
         // Filter out internal group edges
-        .filter(
-          (fe) =>
-            !(
-              childIds.includes(fe.source_id) && childIds.includes(fe.target_id)
-            ),
-        )
+        .filter((fe) => !(childIds.includes(fe.source_id) && childIds.includes(fe.target_id)))
         // For external group edges, point to the group itself instead of a child node
         .map((fe) => ({
           ...fe,
@@ -252,18 +232,10 @@ type LayoutProps = {
   openGroupIds: Array<string>;
 } & StructureDataResponse;
 
-export const useGraphLayout = ({
-  arrange = "LR",
-  dagId,
-  edges,
-  nodes,
-  openGroupIds = [],
-}: LayoutProps) =>
+export const useGraphLayout = ({ arrange = "LR", dagId, edges, nodes, openGroupIds = [] }: LayoutProps) =>
   useQuery({
     queryFn: async () => {
-      const font = `bold 16px ${
-        globalThis.getComputedStyle(document.body).fontFamily
-      }`;
+      const font = `bold 16px ${globalThis.getComputedStyle(document.body).fontFamily}`;
       const elk = new ELK();
 
       // 1. Format graph data to pass for elk to process
@@ -285,8 +257,7 @@ export const useGraphLayout = ({
 
       // merge & dedupe edges
       const flatEdges = [...(data.edges ?? []), ...flattenedData.edges].filter(
-        (value, index, self) =>
-          index === self.findIndex((edge) => edge.id === value.id),
+        (value, index, self) => index === self.findIndex((edge) => edge.id === value.id),
       );
 
       const formattedEdges = formatFlowEdges({ edges: flatEdges });

--- a/airflow/ui/src/layouts/Details/NavTabs.tsx
+++ b/airflow/ui/src/layouts/Details/NavTabs.tsx
@@ -31,11 +31,7 @@ export const NavTabs = ({ tabs }: Props) => {
   const [searchParams] = useSearchParams();
 
   return (
-    <Flex
-      alignItems="center"
-      borderBottomWidth={1}
-      justifyContent="space-between"
-    >
+    <Flex alignItems="center" borderBottomWidth={1} justifyContent="space-between">
       <Flex>
         {tabs.map(({ label, value }) => (
           <NavLink

--- a/airflow/ui/src/layouts/Nav/DocsButton.tsx
+++ b/airflow/ui/src/layouts/Nav/DocsButton.tsx
@@ -52,12 +52,7 @@ export const DocsButton = () => {
           .filter((link) => !(!showAPIDocs && link.href === "/docs"))
           .map((link) => (
             <Menu.Item asChild key={link.title} value={link.title}>
-              <Link
-                aria-label={link.title}
-                href={link.href}
-                rel="noopener noreferrer"
-                target="_blank"
-              >
+              <Link aria-label={link.title} href={link.href} rel="noopener noreferrer" target="_blank">
                 {link.title}
               </Link>
             </Menu.Item>

--- a/airflow/ui/src/layouts/Nav/Nav.tsx
+++ b/airflow/ui/src/layouts/Nav/Nav.tsx
@@ -50,17 +50,8 @@ export const Nav = () => {
           <AirflowPin height="35px" width="35px" />
         </Box>
         <NavButton icon={<FiHome size="1.75rem" />} title="Home" to="/" />
-        <NavButton
-          icon={<DagIcon height="1.75rem" width="1.75rem" />}
-          title="Dags"
-          to="dags"
-        />
-        <NavButton
-          disabled
-          icon={<FiDatabase size="1.75rem" />}
-          title="Assets"
-          to="assets"
-        />
+        <NavButton icon={<DagIcon height="1.75rem" width="1.75rem" />} title="Dags" to="dags" />
+        <NavButton disabled icon={<FiDatabase size="1.75rem" />} title="Assets" to="assets" />
         <BrowseButton />
         <AdminButton />
       </Flex>

--- a/airflow/ui/src/layouts/Nav/TimezoneSelector.tsx
+++ b/airflow/ui/src/layouts/Nav/TimezoneSelector.tsx
@@ -38,11 +38,7 @@ const TimezoneSelector: React.FC = () => {
   const timezones = useMemo<Array<string>>(() => {
     const tzList = Intl.supportedValuesOf("timeZone");
     const guessedTz = dayjs.tz.guess();
-    const uniqueTimezones = new Set([
-      "UTC",
-      ...(guessedTz ? [guessedTz] : []),
-      ...tzList,
-    ]);
+    const uniqueTimezones = new Set(["UTC", ...(guessedTz ? [guessedTz] : []), ...tzList]);
 
     return [...uniqueTimezones];
   }, []);
@@ -56,17 +52,13 @@ const TimezoneSelector: React.FC = () => {
     [timezones],
   );
 
-  const handleTimezoneChange = (
-    selectedOption: SingleValue<TimezoneOption>,
-  ) => {
+  const handleTimezoneChange = (selectedOption: SingleValue<TimezoneOption>) => {
     if (selectedOption) {
       setSelectedTimezone(selectedOption.value);
     }
   };
 
-  const currentTime = dayjs()
-    .tz(selectedTimezone)
-    .format("YYYY-MM-DD HH:mm:ss");
+  const currentTime = dayjs().tz(selectedTimezone).format("YYYY-MM-DD HH:mm:ss");
 
   return (
     <VStack align="stretch" gap={6}>

--- a/airflow/ui/src/main.tsx
+++ b/airflow/ui/src/main.tsx
@@ -37,9 +37,7 @@ axios.interceptors.response.use(
       const params = new URLSearchParams();
 
       params.set("next", globalThis.location.href);
-      globalThis.location.replace(
-        `${import.meta.env.VITE_LEGACY_API_URL}/login?${params.toString()}`,
-      );
+      globalThis.location.replace(`${import.meta.env.VITE_LEGACY_API_URL}/login?${params.toString()}`);
     }
 
     return Promise.reject(error);

--- a/airflow/ui/src/pages/Dag/Code/Code.tsx
+++ b/airflow/ui/src/pages/Dag/Code/Code.tsx
@@ -19,20 +19,11 @@
 import { Box, Button, Heading, HStack } from "@chakra-ui/react";
 import { useState } from "react";
 import { useParams } from "react-router-dom";
-import {
-  createElement,
-  PrismLight as SyntaxHighlighter,
-} from "react-syntax-highlighter";
+import { createElement, PrismLight as SyntaxHighlighter } from "react-syntax-highlighter";
 import python from "react-syntax-highlighter/dist/esm/languages/prism/python";
-import {
-  oneLight,
-  oneDark,
-} from "react-syntax-highlighter/dist/esm/styles/prism";
+import { oneLight, oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
 
-import {
-  useDagServiceGetDagDetails,
-  useDagSourceServiceGetDagSource,
-} from "openapi/queries";
+import { useDagServiceGetDagDetails, useDagSourceServiceGetDagSource } from "openapi/queries";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import Time from "src/components/Time";
 import { ProgressBar } from "src/components/ui";
@@ -82,20 +73,12 @@ export const Code = () => {
             Parsed at: <Time datetime={dag.last_parsed_time} />
           </Heading>
         )}
-        <Button
-          aria-label={wrap ? "Unwrap" : "Wrap"}
-          bg="bg.panel"
-          onClick={toggleWrap}
-          variant="outline"
-        >
+        <Button aria-label={wrap ? "Unwrap" : "Wrap"} bg="bg.panel" onClick={toggleWrap} variant="outline">
           {wrap ? "Unwrap" : "Wrap"}
         </Button>
       </HStack>
       <ErrorAlert error={error ?? codeError} />
-      <ProgressBar
-        size="xs"
-        visibility={isLoading || isCodeLoading ? "visible" : "hidden"}
-      />
+      <ProgressBar size="xs" visibility={isLoading || isCodeLoading ? "visible" : "hidden"} />
       <div
         style={{
           fontSize: "14px",

--- a/airflow/ui/src/pages/Dag/Dag.tsx
+++ b/airflow/ui/src/pages/Dag/Dag.tsx
@@ -18,10 +18,7 @@
  */
 import { useParams } from "react-router-dom";
 
-import {
-  useDagServiceGetDagDetails,
-  useDagsServiceRecentDagRuns,
-} from "openapi/queries";
+import { useDagServiceGetDagDetails, useDagsServiceRecentDagRuns } from "openapi/queries";
 import { DetailsLayout } from "src/layouts/Details/DetailsLayout";
 
 import { Header } from "./Header";
@@ -54,17 +51,10 @@ export const Dag = () => {
     enabled: Boolean(dagId),
   });
 
-  const runs =
-    runsData?.dags.find((dagWithRuns) => dagWithRuns.dag_id === dagId)
-      ?.latest_dag_runs ?? [];
+  const runs = runsData?.dags.find((dagWithRuns) => dagWithRuns.dag_id === dagId)?.latest_dag_runs ?? [];
 
   return (
-    <DetailsLayout
-      dag={dag}
-      error={error ?? runsError}
-      isLoading={isLoading || isLoadingRuns}
-      tabs={tabs}
-    >
+    <DetailsLayout dag={dag} error={error ?? runsError} isLoading={isLoading || isLoadingRuns} tabs={tabs}>
       <Header dag={dag} dagId={dagId} latestRun={runs[0]} />
     </DetailsLayout>
   );

--- a/airflow/ui/src/pages/Dag/Header.tsx
+++ b/airflow/ui/src/pages/Dag/Header.tsx
@@ -19,10 +19,7 @@
 import { Box, Flex, Heading, HStack, SimpleGrid, Text } from "@chakra-ui/react";
 import { FiCalendar } from "react-icons/fi";
 
-import type {
-  DAGDetailsResponse,
-  DAGRunResponse,
-} from "openapi/requests/types.gen";
+import type { DAGDetailsResponse, DAGRunResponse } from "openapi/requests/types.gen";
 import { DagIcon } from "src/assets/DagIcon";
 import DagRunInfo from "src/components/DagRunInfo";
 import DocumentationModal from "src/components/DocumentationModal";
@@ -50,19 +47,13 @@ export const Header = ({
           <DagIcon height={8} width={8} />
           <Heading size="lg">{dag?.dag_display_name ?? dagId}</Heading>
           {dag !== undefined && (
-            <TogglePause
-              dagDisplayName={dag.dag_display_name}
-              dagId={dag.dag_id}
-              isPaused={dag.is_paused}
-            />
+            <TogglePause dagDisplayName={dag.dag_display_name} dagId={dag.dag_id} isPaused={dag.is_paused} />
           )}
         </HStack>
         <Flex>
           {dag ? (
             <HStack>
-              {dag.doc_md === null ? undefined : (
-                <DocumentationModal docMd={dag.doc_md} docType="Dag" />
-              )}
+              {dag.doc_md === null ? undefined : <DocumentationModal docMd={dag.doc_md} docType="Dag" />}
               <ParseDag dagId={dag.dag_id} fileToken={dag.file_token} />
               <TriggerDAGButton dag={dag} />
             </HStack>
@@ -74,8 +65,7 @@ export const Header = ({
           {Boolean(dag?.timetable_summary) ? (
             <Tooltip content={dag?.timetable_description} showArrow>
               <Text fontSize="sm">
-                <FiCalendar style={{ display: "inline" }} />{" "}
-                {dag?.timetable_summary}
+                <FiCalendar style={{ display: "inline" }} /> {dag?.timetable_summary}
               </Text>
             </Tooltip>
           ) : undefined}

--- a/airflow/ui/src/pages/Dag/Overview/Overview.tsx
+++ b/airflow/ui/src/pages/Dag/Overview/Overview.tsx
@@ -21,10 +21,7 @@ import dayjs from "dayjs";
 import { useState } from "react";
 import { useParams } from "react-router-dom";
 
-import {
-  useDagRunServiceGetDagRuns,
-  useTaskInstanceServiceGetTaskInstances,
-} from "openapi/queries";
+import { useDagRunServiceGetDagRuns, useTaskInstanceServiceGetTaskInstances } from "openapi/queries";
 import TimeRangeSelector from "src/components/TimeRangeSelector";
 import { TrendCountButton } from "src/components/TrendCountButton";
 import { stateColor } from "src/utils/stateColor";
@@ -35,27 +32,23 @@ export const Overview = () => {
   const { dagId } = useParams();
 
   const now = dayjs();
-  const [startDate, setStartDate] = useState(
-    now.subtract(Number(defaultHour), "hour").toISOString(),
-  );
+  const [startDate, setStartDate] = useState(now.subtract(Number(defaultHour), "hour").toISOString());
   const [endDate, setEndDate] = useState(now.toISOString());
 
-  const { data: failedTasks, isLoading } =
-    useTaskInstanceServiceGetTaskInstances({
-      dagId: dagId ?? "",
-      dagRunId: "~",
-      logicalDateGte: startDate,
-      logicalDateLte: endDate,
-      state: ["failed"],
-    });
+  const { data: failedTasks, isLoading } = useTaskInstanceServiceGetTaskInstances({
+    dagId: dagId ?? "",
+    dagRunId: "~",
+    logicalDateGte: startDate,
+    logicalDateLte: endDate,
+    state: ["failed"],
+  });
 
-  const { data: failedRuns, isLoading: isLoadingRuns } =
-    useDagRunServiceGetDagRuns({
-      dagId: dagId ?? "",
-      logicalDateGte: startDate,
-      logicalDateLte: endDate,
-      state: ["failed"],
-    });
+  const { data: failedRuns, isLoading: isLoadingRuns } = useDagRunServiceGetDagRuns({
+    dagId: dagId ?? "",
+    logicalDateGte: startDate,
+    logicalDateLte: endDate,
+    state: ["failed"],
+  });
 
   // TODO actually link to task instances list
   return (

--- a/airflow/ui/src/pages/Dag/Runs/Runs.tsx
+++ b/airflow/ui/src/pages/Dag/Runs/Runs.tsx
@@ -27,11 +27,7 @@ import {
 } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useCallback } from "react";
-import {
-  useParams,
-  Link as RouterLink,
-  useSearchParams,
-} from "react-router-dom";
+import { useParams, Link as RouterLink, useSearchParams } from "react-router-dom";
 
 import { useDagRunServiceGetDagRuns } from "openapi/queries";
 import type { DAGRunResponse, DagRunState } from "openapi/requests/types.gen";
@@ -88,19 +84,14 @@ const columns: Array<ColumnDef<DAGRunResponse>> = [
     header: "End Date",
   },
   {
-    cell: ({ row: { original } }) =>
-      getDuration(original.start_date, original.end_date),
+    cell: ({ row: { original } }) => getDuration(original.start_date, original.end_date),
     header: "Duration",
   },
   {
     accessorKey: "clear_dag_run",
     cell: ({ row }) => (
       <Flex justifyContent="end">
-        <ClearRunButton
-          dagId={row.original.dag_id}
-          dagRunId={row.original.dag_run_id}
-          withText={false}
-        />
+        <ClearRunButton dagId={row.original.dag_id} dagRunId={row.original.dag_run_id} withText={false} />
       </Flex>
     ),
     enableSorting: false,
@@ -177,9 +168,7 @@ export const Runs = () => {
                 filteredState === null ? (
                   "All States"
                 ) : (
-                  <Status state={filteredState as DagRunState}>
-                    {capitalize(filteredState)}
-                  </Status>
+                  <Status state={filteredState as DagRunState}>{capitalize(filteredState)}</Status>
                 )
               }
             </Select.ValueText>
@@ -190,9 +179,7 @@ export const Runs = () => {
                 {option.value === "all" ? (
                   option.label
                 ) : (
-                  <Status state={option.value as DagRunState}>
-                    {option.label}
-                  </Status>
+                  <Status state={option.value as DagRunState}>{option.label}</Status>
                 )}
               </Select.Item>
             ))}

--- a/airflow/ui/src/pages/Dag/Tasks/TaskCard.tsx
+++ b/airflow/ui/src/pages/Dag/Tasks/TaskCard.tsx
@@ -19,10 +19,7 @@
 import { Heading, VStack, Box, SimpleGrid, Text, Link } from "@chakra-ui/react";
 import { Link as RouterLink } from "react-router-dom";
 
-import type {
-  TaskResponse,
-  TaskInstanceResponse,
-} from "openapi/requests/types.gen";
+import type { TaskResponse, TaskInstanceResponse } from "openapi/requests/types.gen";
 import TaskInstanceTooltip from "src/components/TaskInstanceTooltip";
 import Time from "src/components/Time";
 import { Status } from "src/components/ui";
@@ -37,14 +34,7 @@ type Props = {
 };
 
 export const TaskCard = ({ dagId, task, taskInstances }: Props) => (
-  <Box
-    borderColor="border.emphasized"
-    borderRadius={8}
-    borderWidth={1}
-    overflow="hidden"
-    px={3}
-    py={2}
-  >
+  <Box borderColor="border.emphasized" borderRadius={8} borderWidth={1} overflow="hidden" px={3} py={2}>
     <Link asChild color="fg.info" fontWeight="bold">
       <RouterLink to={`/dags/${dagId}/tasks/${task.task_id}`}>
         {task.task_display_name ?? task.task_id}
@@ -74,9 +64,7 @@ export const TaskCard = ({ dagId, task, taskInstances }: Props) => (
               <RouterLink to={getTaskInstanceLink(taskInstances[0])}>
                 <Time datetime={taskInstances[0].start_date} />
                 {taskInstances[0].state === null ? undefined : (
-                  <Status state={taskInstances[0].state}>
-                    {taskInstances[0].state}
-                  </Status>
+                  <Status state={taskInstances[0].state}>{taskInstances[0].state}</Status>
                 )}
               </RouterLink>
             </Link>

--- a/airflow/ui/src/pages/Dag/Tasks/TaskRecentRuns.tsx
+++ b/airflow/ui/src/pages/Dag/Tasks/TaskRecentRuns.tsx
@@ -42,11 +42,7 @@ export const TaskRecentRuns = ({
   const taskInstancesWithDuration = taskInstances.map((taskInstance) => ({
     ...taskInstance,
     duration:
-      dayjs
-        .duration(
-          dayjs(taskInstance.end_date ?? dayjs()).diff(taskInstance.start_date),
-        )
-        .asSeconds() || 0,
+      dayjs.duration(dayjs(taskInstance.end_date ?? dayjs()).diff(taskInstance.start_date)).asSeconds() || 0,
   }));
 
   const max = Math.max.apply(
@@ -58,10 +54,7 @@ export const TaskRecentRuns = ({
     <Flex alignItems="flex-end" flexDirection="row-reverse">
       {taskInstancesWithDuration.map((taskInstance) =>
         taskInstance.state === null ? undefined : (
-          <TaskInstanceTooltip
-            key={taskInstance.dag_run_id}
-            taskInstance={taskInstance}
-          >
+          <TaskInstanceTooltip key={taskInstance.dag_run_id} taskInstance={taskInstance}>
             <Link to={getTaskInstanceLink(taskInstance)}>
               <Box p={1}>
                 <Box

--- a/airflow/ui/src/pages/Dag/Tasks/Tasks.tsx
+++ b/airflow/ui/src/pages/Dag/Tasks/Tasks.tsx
@@ -24,10 +24,7 @@ import {
   useTaskInstanceServiceGetTaskInstances,
   useDagsServiceRecentDagRuns,
 } from "openapi/queries";
-import type {
-  TaskResponse,
-  TaskInstanceResponse,
-} from "openapi/requests/types.gen";
+import type { TaskResponse, TaskInstanceResponse } from "openapi/requests/types.gen";
 import { DataTable } from "src/components/DataTable";
 import type { CardDef } from "src/components/DataTable/types";
 import { ErrorAlert } from "src/components/ErrorAlert";
@@ -35,20 +32,14 @@ import { pluralize } from "src/utils";
 
 import { TaskCard } from "./TaskCard";
 
-const cardDef = (
-  dagId: string,
-  taskInstances?: Array<TaskInstanceResponse>,
-): CardDef<TaskResponse> => ({
+const cardDef = (dagId: string, taskInstances?: Array<TaskInstanceResponse>): CardDef<TaskResponse> => ({
   card: ({ row }) => (
     <TaskCard
       dagId={dagId}
       task={row}
       taskInstances={
         taskInstances
-          ? taskInstances.filter(
-              (instance: TaskInstanceResponse) =>
-                instance.task_id === row.task_id,
-            )
+          ? taskInstances.filter((instance: TaskInstanceResponse) => instance.task_id === row.task_id)
           : []
       }
     />
@@ -69,31 +60,24 @@ export const Tasks = () => {
     dagId,
   });
 
-  const { data: runsData } = useDagsServiceRecentDagRuns(
-    { dagIds: [dagId], dagRunsLimit: 14 },
-    undefined,
-    {
-      enabled: Boolean(dagId),
-    },
-  );
+  const { data: runsData } = useDagsServiceRecentDagRuns({ dagIds: [dagId], dagRunsLimit: 14 }, undefined, {
+    enabled: Boolean(dagId),
+  });
 
-  const runs =
-    runsData?.dags.find((dagWithRuns) => dagWithRuns.dag_id === dagId)
-      ?.latest_dag_runs ?? [];
+  const runs = runsData?.dags.find((dagWithRuns) => dagWithRuns.dag_id === dagId)?.latest_dag_runs ?? [];
 
   // TODO: Revisit this endpoint since only 100 task instances are returned and
   // only duration is calculated with other attributes unused.
-  const { data: taskInstancesResponse } =
-    useTaskInstanceServiceGetTaskInstances(
-      {
-        dagId,
-        dagRunId: "~",
-        logicalDateGte: runs.at(-1)?.logical_date ?? "",
-        orderBy: "-start_date",
-      },
-      undefined,
-      { enabled: Boolean(runs[0]?.dag_run_id) },
-    );
+  const { data: taskInstancesResponse } = useTaskInstanceServiceGetTaskInstances(
+    {
+      dagId,
+      dagRunId: "~",
+      logicalDateGte: runs.at(-1)?.logical_date ?? "",
+      orderBy: "-start_date",
+    },
+    undefined,
+    { enabled: Boolean(runs[0]?.dag_run_id) },
+  );
 
   return (
     <Box>

--- a/airflow/ui/src/pages/DagsList/DagCard.test.tsx
+++ b/airflow/ui/src/pages/DagsList/DagCard.test.tsx
@@ -19,10 +19,7 @@
  * under the License.
  */
 import { render, screen } from "@testing-library/react";
-import type {
-  DagTagResponse,
-  DAGWithLatestDagRunsResponse,
-} from "openapi-gen/requests/types.gen";
+import type { DagTagResponse, DAGWithLatestDagRunsResponse } from "openapi-gen/requests/types.gen";
 import { afterEach, describe, it, vi, expect } from "vitest";
 
 import { Wrapper } from "src/utils/Wrapper";
@@ -34,8 +31,7 @@ const mockDag = {
   dag_id: "nested_groups",
   default_view: "grid",
   description: null,
-  file_token:
-    "Ii9maWxlcy9kYWdzL25lc3RlZF90YXNrX2dyb3Vwcy5weSI.G3EkdxmDUDQsVb7AIZww1TSGlFE",
+  file_token: "Ii9maWxlcy9kYWdzL25lc3RlZF90YXNrX2dyb3Vwcy5weSI.G3EkdxmDUDQsVb7AIZww1TSGlFE",
   fileloc: "/files/dags/nested_task_groups.py",
   has_import_errors: false,
   has_task_concurrency_limits: false,

--- a/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -38,39 +38,18 @@ export const DagCard = ({ dag }: Props) => {
   const [latestRun] = dag.latest_dag_runs;
 
   return (
-    <Box
-      borderColor="border.emphasized"
-      borderRadius={8}
-      borderWidth={1}
-      overflow="hidden"
-    >
-      <Flex
-        alignItems="center"
-        bg="bg.muted"
-        justifyContent="space-between"
-        px={3}
-        py={2}
-      >
+    <Box borderColor="border.emphasized" borderRadius={8} borderWidth={1} overflow="hidden">
+      <Flex alignItems="center" bg="bg.muted" justifyContent="space-between" px={3} py={2}>
         <HStack>
-          <Tooltip
-            content={dag.description}
-            disabled={!Boolean(dag.description)}
-            showArrow
-          >
+          <Tooltip content={dag.description} disabled={!Boolean(dag.description)} showArrow>
             <Link asChild color="fg.info" fontWeight="bold">
-              <RouterLink to={`/dags/${dag.dag_id}`}>
-                {dag.dag_display_name}
-              </RouterLink>
+              <RouterLink to={`/dags/${dag.dag_id}`}>{dag.dag_display_name}</RouterLink>
             </Link>
           </Tooltip>
           <DagTags tags={dag.tags} />
         </HStack>
         <HStack>
-          <TogglePause
-            dagDisplayName={dag.dag_display_name}
-            dagId={dag.dag_id}
-            isPaused={dag.is_paused}
-          />
+          <TogglePause dagDisplayName={dag.dag_display_name} dagId={dag.dag_id} isPaused={dag.is_paused} />
           <TriggerDAGButton dag={dag} withText={false} />
         </HStack>
       </Flex>
@@ -81,9 +60,7 @@ export const DagCard = ({ dag }: Props) => {
         <Stat label="Latest Run">
           {latestRun ? (
             <Link asChild color="fg.info" fontSize="sm">
-              <RouterLink
-                to={`/dags/${latestRun.dag_id}/runs/${latestRun.dag_run_id}`}
-              >
+              <RouterLink to={`/dags/${latestRun.dag_id}/runs/${latestRun.dag_run_id}`}>
                 <DagRunInfo
                   dataIntervalEnd={latestRun.data_interval_end}
                   dataIntervalStart={latestRun.data_interval_start}

--- a/airflow/ui/src/pages/DagsList/DagsFilters.tsx
+++ b/airflow/ui/src/pages/DagsList/DagsFilters.tsx
@@ -33,10 +33,7 @@ import { useDagServiceGetDagTags } from "openapi/queries";
 import { useTableURLState } from "src/components/DataTable/useTableUrlState";
 import { QuickFilterButton } from "src/components/QuickFilterButton";
 import { Select, Status } from "src/components/ui";
-import {
-  SearchParamsKeys,
-  type SearchParamsKeysType,
-} from "src/constants/searchParams";
+import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
 import { useConfig } from "src/queries/useConfig";
 import { pluralize } from "src/utils";
 
@@ -69,9 +66,7 @@ export const DagsFilters = () => {
     orderBy: "name",
   });
 
-  const hidePausedDagsByDefault = Boolean(
-    useConfig("hide_paused_dags_by_default"),
-  );
+  const hidePausedDagsByDefault = Boolean(useConfig("hide_paused_dags_by_default"));
   const defaultShowPaused = hidePausedDagsByDefault ? "false" : "all";
 
   const { setTableURLState, tableURLState } = useTableURLState();
@@ -95,22 +90,21 @@ export const DagsFilters = () => {
     [pagination, searchParams, setSearchParams, setTableURLState, sorting],
   );
 
-  const handleStateChange: React.MouseEventHandler<HTMLButtonElement> =
-    useCallback(
-      ({ currentTarget: { value } }) => {
-        if (value === "all") {
-          searchParams.delete(LAST_DAG_RUN_STATE_PARAM);
-        } else {
-          searchParams.set(LAST_DAG_RUN_STATE_PARAM, value);
-        }
-        setSearchParams(searchParams);
-        setTableURLState({
-          pagination: { ...pagination, pageIndex: 0 },
-          sorting,
-        });
-      },
-      [pagination, searchParams, setSearchParams, setTableURLState, sorting],
-    );
+  const handleStateChange: React.MouseEventHandler<HTMLButtonElement> = useCallback(
+    ({ currentTarget: { value } }) => {
+      if (value === "all") {
+        searchParams.delete(LAST_DAG_RUN_STATE_PARAM);
+      } else {
+        searchParams.set(LAST_DAG_RUN_STATE_PARAM, value);
+      }
+      setSearchParams(searchParams);
+      setTableURLState({
+        pagination: { ...pagination, pageIndex: 0 },
+        sorting,
+      });
+    },
+    [pagination, searchParams, setSearchParams, setTableURLState, sorting],
+  );
   const handleSelectTagsChange = useCallback(
     (
       tags: MultiValue<{
@@ -151,32 +145,16 @@ export const DagsFilters = () => {
     <HStack justifyContent="space-between">
       <HStack gap={4}>
         <HStack>
-          <QuickFilterButton
-            isActive={isAll}
-            onClick={handleStateChange}
-            value="all"
-          >
+          <QuickFilterButton isActive={isAll} onClick={handleStateChange} value="all">
             All
           </QuickFilterButton>
-          <QuickFilterButton
-            isActive={isFailed}
-            onClick={handleStateChange}
-            value="failed"
-          >
+          <QuickFilterButton isActive={isFailed} onClick={handleStateChange} value="failed">
             <Status state="failed">Failed</Status>
           </QuickFilterButton>
-          <QuickFilterButton
-            isActive={isRunning}
-            onClick={handleStateChange}
-            value="running"
-          >
+          <QuickFilterButton isActive={isRunning} onClick={handleStateChange} value="running">
             <Status state="running">Running</Status>
           </QuickFilterButton>
-          <QuickFilterButton
-            isActive={isSuccess}
-            onClick={handleStateChange}
-            value="success"
-          >
+          <QuickFilterButton isActive={isSuccess} onClick={handleStateChange} value="success">
             <Status state="success">Success</Status>
           </QuickFilterButton>
         </HStack>

--- a/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -30,10 +30,7 @@ import { useCallback, useState } from "react";
 import { Link as RouterLink, useSearchParams } from "react-router-dom";
 import { useLocalStorage } from "usehooks-ts";
 
-import type {
-  DagRunState,
-  DAGWithLatestDagRunsResponse,
-} from "openapi/requests/types.gen";
+import type { DagRunState, DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
 import DagRunInfo from "src/components/DagRunInfo";
 import { DataTable } from "src/components/DataTable";
 import { ToggleTableDisplay } from "src/components/DataTable/ToggleTableDisplay";
@@ -43,10 +40,7 @@ import { ErrorAlert } from "src/components/ErrorAlert";
 import { SearchBar } from "src/components/SearchBar";
 import { TogglePause } from "src/components/TogglePause";
 import TriggerDAGButton from "src/components/TriggerDag/TriggerDAGButton";
-import {
-  SearchParamsKeys,
-  type SearchParamsKeysType,
-} from "src/constants/searchParams";
+import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
 import { useConfig } from "src/queries/useConfig";
 import { useDags } from "src/queries/useDags";
 import { pluralize } from "src/utils";
@@ -77,9 +71,7 @@ const columns: Array<ColumnDef<DAGWithLatestDagRunsResponse>> = [
     accessorKey: "dag_id",
     cell: ({ row: { original } }) => (
       <Link asChild color="fg.info" fontWeight="bold">
-        <RouterLink to={`/dags/${original.dag_id}`}>
-          {original.dag_display_name}
-        </RouterLink>
+        <RouterLink to={`/dags/${original.dag_id}`}>{original.dag_display_name}</RouterLink>
       </Link>
     ),
     header: "Dag",
@@ -152,21 +144,14 @@ const DAGS_LIST_DISPLAY = "dags_list_display";
 
 export const DagsList = () => {
   const [searchParams, setSearchParams] = useSearchParams();
-  const [display, setDisplay] = useLocalStorage<"card" | "table">(
-    DAGS_LIST_DISPLAY,
-    "card",
-  );
+  const [display, setDisplay] = useLocalStorage<"card" | "table">(DAGS_LIST_DISPLAY, "card");
 
-  const hidePausedDagsByDefault = Boolean(
-    useConfig("hide_paused_dags_by_default"),
-  );
+  const hidePausedDagsByDefault = Boolean(useConfig("hide_paused_dags_by_default"));
   const defaultShowPaused = hidePausedDagsByDefault ? false : undefined;
 
   const showPaused = searchParams.get(PAUSED_PARAM);
 
-  const lastDagRunState = searchParams.get(
-    LAST_DAG_RUN_STATE_PARAM,
-  ) as DagRunState;
+  const lastDagRunState = searchParams.get(LAST_DAG_RUN_STATE_PARAM) as DagRunState;
   const selectedTags = searchParams.getAll(TAGS_PARAM);
 
   const { setTableURLState, tableURLState } = useTableURLState();
@@ -177,9 +162,7 @@ export const DagsList = () => {
   );
 
   const [sort] = sorting;
-  const orderBy = sort
-    ? `${sort.desc ? "-" : ""}${sort.id}`
-    : "-last_run_start_date";
+  const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : "-last_run_start_date";
 
   const handleSearchChange = (value: string) => {
     if (value) {
@@ -206,9 +189,7 @@ export const DagsList = () => {
   }
 
   const { data, error, isFetching, isLoading } = useDags({
-    dagDisplayNamePattern: Boolean(dagDisplayNamePattern)
-      ? `${dagDisplayNamePattern}`
-      : undefined,
+    dagDisplayNamePattern: Boolean(dagDisplayNamePattern) ? `${dagDisplayNamePattern}` : undefined,
     lastDagRunState,
     limit: pagination.pageSize,
     offset: pagination.pageIndex * pagination.pageSize,

--- a/airflow/ui/src/pages/DagsList/RecentRuns.tsx
+++ b/airflow/ui/src/pages/DagsList/RecentRuns.tsx
@@ -41,9 +41,7 @@ export const RecentRuns = ({
 
   const runsWithDuration = latestRuns.map((run) => ({
     ...run,
-    duration: dayjs
-      .duration(dayjs(run.end_date).diff(run.start_date))
-      .asSeconds(),
+    duration: dayjs.duration(dayjs(run.end_date).diff(run.start_date)).asSeconds(),
   }));
 
   const max = Math.max.apply(

--- a/airflow/ui/src/pages/DagsList/Schedule.tsx
+++ b/airflow/ui/src/pages/DagsList/Schedule.tsx
@@ -27,8 +27,7 @@ type Props = {
 };
 
 export const Schedule = ({ dag }: Props) =>
-  Boolean(dag.timetable_summary) &&
-  dag.timetable_description !== "Never, external triggers only" ? (
+  Boolean(dag.timetable_summary) && dag.timetable_description !== "Never, external triggers only" ? (
     <Tooltip content={dag.timetable_description} showArrow>
       <Text fontSize="sm">
         <FiCalendar style={{ display: "inline" }} /> {dag.timetable_summary}

--- a/airflow/ui/src/pages/DagsList/SortSelect.tsx
+++ b/airflow/ui/src/pages/DagsList/SortSelect.tsx
@@ -22,9 +22,7 @@ import { Select } from "src/components/ui";
 import { dagSortOptions } from "src/constants/sortParams";
 
 type Props = {
-  readonly handleSortChange: ({
-    value,
-  }: SelectValueChangeDetails<Array<string>>) => void;
+  readonly handleSortChange: ({ value }: SelectValueChangeDetails<Array<string>>) => void;
   readonly orderBy?: string;
 };
 

--- a/airflow/ui/src/pages/Dashboard/Health/Health.tsx
+++ b/airflow/ui/src/pages/Dashboard/Health/Health.tsx
@@ -37,11 +37,7 @@ export const Health = () => {
       </Flex>
       <ErrorAlert error={error} />
       <HStack alignItems="center" gap={2}>
-        <HealthTag
-          isLoading={isLoading}
-          status={data?.metadatabase.status}
-          title="MetaDatabase"
-        />
+        <HealthTag isLoading={isLoading} status={data?.metadatabase.status} title="MetaDatabase" />
         <HealthTag
           isLoading={isLoading}
           latestHeartbeat={data?.scheduler.latest_scheduler_heartbeat}

--- a/airflow/ui/src/pages/Dashboard/Health/HealthTag.tsx
+++ b/airflow/ui/src/pages/Dashboard/Health/HealthTag.tsx
@@ -50,11 +50,7 @@ export const HealthTag = ({
       disabled={!Boolean(latestHeartbeat)}
       showArrow
     >
-      <Tag
-        borderRadius="full"
-        colorPalette={status === "healthy" ? "green" : "red"}
-        size="lg"
-      >
+      <Tag borderRadius="full" colorPalette={status === "healthy" ? "green" : "red"} size="lg">
         <TagLabel>{title}</TagLabel>
       </Tag>
     </Tooltip>

--- a/airflow/ui/src/pages/Dashboard/HistoricalMetrics/DagRunMetrics.tsx
+++ b/airflow/ui/src/pages/Dashboard/HistoricalMetrics/DagRunMetrics.tsx
@@ -28,12 +28,7 @@ type DagRunMetricsProps = {
   readonly total: number;
 };
 
-const DAGRUN_STATES: Array<keyof DAGRunStates> = [
-  "queued",
-  "running",
-  "success",
-  "failed",
-];
+const DAGRUN_STATES: Array<keyof DAGRunStates> = ["queued", "running", "success", "failed"];
 
 export const DagRunMetrics = ({ dagRunStates, total }: DagRunMetricsProps) => (
   <Box borderRadius={5} borderWidth={1} p={2}>
@@ -42,12 +37,7 @@ export const DagRunMetrics = ({ dagRunStates, total }: DagRunMetricsProps) => (
       <Heading size="md">Dag Runs</Heading>
     </HStack>
     {DAGRUN_STATES.map((state) => (
-      <MetricSection
-        key={state}
-        runs={dagRunStates[state]}
-        state={state}
-        total={total}
-      />
+      <MetricSection key={state} runs={dagRunStates[state]} state={state} total={total} />
     ))}
   </Box>
 );

--- a/airflow/ui/src/pages/Dashboard/HistoricalMetrics/HistoricalMetrics.tsx
+++ b/airflow/ui/src/pages/Dashboard/HistoricalMetrics/HistoricalMetrics.tsx
@@ -32,9 +32,7 @@ const defaultHour = "168";
 
 export const HistoricalMetrics = () => {
   const now = dayjs();
-  const [startDate, setStartDate] = useState(
-    now.subtract(Number(defaultHour), "hour").toISOString(),
-  );
+  const [startDate, setStartDate] = useState(now.subtract(Number(defaultHour), "hour").toISOString());
   const [endDate, setEndDate] = useState(now.toISOString());
 
   const { data, error, isLoading } = useDashboardServiceHistoricalMetrics({
@@ -43,17 +41,11 @@ export const HistoricalMetrics = () => {
   });
 
   const dagRunTotal = data
-    ? Object.values(data.dag_run_states).reduce(
-        (partialSum, value) => partialSum + value,
-        0,
-      )
+    ? Object.values(data.dag_run_states).reduce((partialSum, value) => partialSum + value, 0)
     : 0;
 
   const taskRunTotal = data
-    ? Object.values(data.task_instance_states).reduce(
-        (partialSum, value) => partialSum + value,
-        0,
-      )
+    ? Object.values(data.task_instance_states).reduce((partialSum, value) => partialSum + value, 0)
     : 0;
 
   return (
@@ -70,14 +62,8 @@ export const HistoricalMetrics = () => {
         {isLoading ? <MetricSectionSkeleton /> : undefined}
         {!isLoading && data !== undefined && (
           <Box>
-            <DagRunMetrics
-              dagRunStates={data.dag_run_states}
-              total={dagRunTotal}
-            />
-            <TaskInstanceMetrics
-              taskInstanceStates={data.task_instance_states}
-              total={taskRunTotal}
-            />
+            <DagRunMetrics dagRunStates={data.dag_run_states} total={dagRunTotal} />
+            <TaskInstanceMetrics taskInstanceStates={data.task_instance_states} total={taskRunTotal} />
           </Box>
         )}
       </VStack>

--- a/airflow/ui/src/pages/Dashboard/HistoricalMetrics/MetricSection.tsx
+++ b/airflow/ui/src/pages/Dashboard/HistoricalMetrics/MetricSection.tsx
@@ -42,10 +42,7 @@ export const MetricSection = ({ runs, state, total }: MetricSectionProps) => {
     <VStack align="left" gap={1} mb={4} ml={0} pl={0}>
       <Flex justify="space-between">
         <HStack>
-          <MetricsBadge
-            backgroundColor={stateColor[state as keyof typeof stateColor]}
-            runs={runs}
-          />
+          <MetricsBadge backgroundColor={stateColor[state as keyof typeof stateColor]} runs={runs} />
           <Text> {capitalize(state)} </Text>
         </HStack>
         <Text color="fg.muted"> {statePercent}% </Text>

--- a/airflow/ui/src/pages/Dashboard/HistoricalMetrics/TaskInstanceMetrics.tsx
+++ b/airflow/ui/src/pages/Dashboard/HistoricalMetrics/TaskInstanceMetrics.tsx
@@ -36,10 +36,7 @@ const TASK_STATES: Array<keyof TaskInstanceStateCount> = [
   "skipped",
 ];
 
-export const TaskInstanceMetrics = ({
-  taskInstanceStates,
-  total,
-}: TaskInstanceMetricsProps) => (
+export const TaskInstanceMetrics = ({ taskInstanceStates, total }: TaskInstanceMetricsProps) => (
   <Box borderRadius={5} borderWidth={1} mt={2} p={2}>
     <HStack mb={4}>
       <MetricsBadge backgroundColor="blue.solid" runs={total} />
@@ -47,12 +44,7 @@ export const TaskInstanceMetrics = ({
     </HStack>
 
     {TASK_STATES.map((state) => (
-      <MetricSection
-        key={state}
-        runs={taskInstanceStates[state]}
-        state={state}
-        total={total}
-      />
+      <MetricSection key={state} runs={taskInstanceStates[state]} state={state} total={total} />
     ))}
   </Box>
 );

--- a/airflow/ui/src/pages/Dashboard/Stats/DAGImportErrors.tsx
+++ b/airflow/ui/src/pages/Dashboard/Stats/DAGImportErrors.tsx
@@ -49,21 +49,14 @@ export const DAGImportErrors = () => {
           onClick={onOpen}
           variant="outline"
         >
-          <MetricsBadge
-            backgroundColor={stateColor.failed}
-            runs={importErrorsCount}
-          />
+          <MetricsBadge backgroundColor={stateColor.failed} runs={importErrorsCount} />
           <Box alignItems="center" display="flex" gap={1}>
             <Text fontWeight="bold">Dag Import Errors</Text>
             <FiChevronRight />
           </Box>
         </Button>
       )}
-      <DAGImportErrorsModal
-        importErrors={importErrors}
-        onClose={onClose}
-        open={open}
-      />
+      <DAGImportErrorsModal importErrors={importErrors} onClose={onClose} open={open} />
     </Box>
   );
 };

--- a/airflow/ui/src/pages/Dashboard/Stats/DAGImportErrorsModal.tsx
+++ b/airflow/ui/src/pages/Dashboard/Stats/DAGImportErrorsModal.tsx
@@ -33,11 +33,7 @@ type ImportDAGErrorModalProps = {
 
 const PAGE_LIMIT = 15;
 
-export const DAGImportErrorsModal: React.FC<ImportDAGErrorModalProps> = ({
-  importErrors,
-  onClose,
-  open,
-}) => {
+export const DAGImportErrorsModal: React.FC<ImportDAGErrorModalProps> = ({ importErrors, onClose, open }) => {
   const [page, setPage] = useState(1);
   const [searchQuery, setSearchQuery] = useState("");
   const [filteredErrors, setFilteredErrors] = useState(importErrors);
@@ -54,21 +50,14 @@ export const DAGImportErrorsModal: React.FC<ImportDAGErrorModalProps> = ({
 
   useEffect(() => {
     const query = searchQuery.toLowerCase();
-    const filtered = importErrors.filter((error) =>
-      error.filename.toLowerCase().includes(query),
-    );
+    const filtered = importErrors.filter((error) => error.filename.toLowerCase().includes(query));
 
     setFilteredErrors(filtered);
     setPage(1);
   }, [searchQuery, importErrors]);
 
   return (
-    <Dialog.Root
-      onOpenChange={onOpenChange}
-      open={open}
-      scrollBehavior="inside"
-      size="xl"
-    >
+    <Dialog.Root onOpenChange={onOpenChange} open={open} scrollBehavior="inside" size="xl">
       <Dialog.Content backdrop>
         <Dialog.Header>
           <Heading size="xl">Dag Import Errors</Heading>
@@ -85,10 +74,7 @@ export const DAGImportErrorsModal: React.FC<ImportDAGErrorModalProps> = ({
         <Dialog.Body>
           <Accordion.Root collapsible multiple size="md" variant="enclosed">
             {visibleItems.map((importError) => (
-              <Accordion.Item
-                key={importError.import_error_id}
-                value={importError.filename}
-              >
+              <Accordion.Item key={importError.import_error_id} value={importError.filename}>
                 <Accordion.ItemTrigger cursor="pointer">
                   <PiFilePy />
                   {importError.filename}

--- a/airflow/ui/src/pages/Dashboard/Stats/DagFilterButton.tsx
+++ b/airflow/ui/src/pages/Dashboard/Stats/DagFilterButton.tsx
@@ -35,13 +35,7 @@ export const DagFilterButton = ({
   readonly link: string;
 }) => (
   <RouterLink to={link}>
-    <Button
-      alignItems="center"
-      borderRadius="md"
-      display="flex"
-      gap={2}
-      variant="outline"
-    >
+    <Button alignItems="center" borderRadius="md" display="flex" gap={2} variant="outline">
       <Box alignItems="center" display="flex" gap={1}>
         <MetricsBadge backgroundColor={badgeColor} />
         <Text fontWeight="bold">{capitalize(filter)} Dags</Text>

--- a/airflow/ui/src/pages/Dashboard/Stats/Stats.tsx
+++ b/airflow/ui/src/pages/Dashboard/Stats/Stats.tsx
@@ -33,22 +33,14 @@ export const Stats = () => (
       </Heading>
     </Flex>
     <HStack>
-      <DagFilterButton
-        badgeColor={stateColor.failed}
-        filter="failed"
-        link="dags?last_dag_run_state=failed"
-      />
+      <DagFilterButton badgeColor={stateColor.failed} filter="failed" link="dags?last_dag_run_state=failed" />
       <DAGImportErrors />
       <DagFilterButton
         badgeColor={stateColor.running}
         filter="running"
         link="dags?last_dag_run_state=running"
       />
-      <DagFilterButton
-        badgeColor="blue.solid"
-        filter="active"
-        link="dags?paused=false"
-      />
+      <DagFilterButton badgeColor="blue.solid" filter="active" link="dags?paused=false" />
     </HStack>
   </Box>
 );

--- a/airflow/ui/src/pages/Error.tsx
+++ b/airflow/ui/src/pages/Error.tsx
@@ -16,21 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  Box,
-  VStack,
-  Heading,
-  Text,
-  Button,
-  Container,
-  HStack,
-  Code,
-} from "@chakra-ui/react";
-import {
-  useNavigate,
-  useRouteError,
-  isRouteErrorResponse,
-} from "react-router-dom";
+import { Box, VStack, Heading, Text, Button, Container, HStack, Code } from "@chakra-ui/react";
+import { useNavigate, useRouteError, isRouteErrorResponse } from "react-router-dom";
 
 import { AirflowPin } from "src/assets/AirflowPin";
 
@@ -44,8 +31,7 @@ export const ErrorPage = () => {
   if (isRouteErrorResponse(error)) {
     statusCode = String(error.status);
     errorMessage =
-      ((error as unknown as Error).message ||
-        (error as { statusText?: string }).statusText) ??
+      ((error as unknown as Error).message || (error as { statusText?: string }).statusText) ??
       "Page Not Found";
   } else if (error instanceof Error) {
     errorMessage = error.message;
@@ -57,13 +43,7 @@ export const ErrorPage = () => {
   const isDev = import.meta.env.DEV;
 
   return (
-    <Box
-      alignItems="center"
-      display="flex"
-      justifyContent="center"
-      pt={36}
-      px={4}
-    >
+    <Box alignItems="center" display="flex" justifyContent="center" pt={36} px={4}>
       <Container maxW="lg">
         <VStack gap={8} textAlign="center">
           <AirflowPin height="50px" width="50px" />
@@ -82,12 +62,7 @@ export const ErrorPage = () => {
             <Button colorPalette="blue" onClick={() => navigate(-1)} size="lg">
               Back
             </Button>
-            <Button
-              colorPalette="blue"
-              onClick={() => navigate("/")}
-              size="lg"
-              variant="outline"
-            >
+            <Button colorPalette="blue" onClick={() => navigate("/")} size="lg" variant="outline">
               Home
             </Button>
           </HStack>

--- a/airflow/ui/src/pages/Run/Header.tsx
+++ b/airflow/ui/src/pages/Run/Header.tsx
@@ -67,9 +67,7 @@ export const Header = ({ dagRun }: { readonly dagRun: DAGRunResponse }) => (
       <Stat label="End">
         <Time datetime={dagRun.end_date} />
       </Stat>
-      <Stat label="Duration">
-        {getDuration(dagRun.start_date, dagRun.end_date)}s
-      </Stat>
+      <Stat label="Duration">{getDuration(dagRun.start_date, dagRun.end_date)}s</Stat>
     </SimpleGrid>
   </Box>
 );

--- a/airflow/ui/src/pages/Run/Run.tsx
+++ b/airflow/ui/src/pages/Run/Run.tsx
@@ -19,10 +19,7 @@
 import { LiaSlashSolid } from "react-icons/lia";
 import { useParams, Link as RouterLink } from "react-router-dom";
 
-import {
-  useDagRunServiceGetDagRun,
-  useDagServiceGetDagDetails,
-} from "openapi/queries";
+import { useDagRunServiceGetDagRun, useDagServiceGetDagDetails } from "openapi/queries";
 import { Breadcrumb } from "src/components/ui";
 import { DetailsLayout } from "src/layouts/Details/DetailsLayout";
 
@@ -55,20 +52,13 @@ export const Run = () => {
   });
 
   return (
-    <DetailsLayout
-      dag={dag}
-      error={error ?? dagError}
-      isLoading={isLoading || isLoadinDag}
-      tabs={tabs}
-    >
+    <DetailsLayout dag={dag} error={error ?? dagError} isLoading={isLoading || isLoadinDag} tabs={tabs}>
       <Breadcrumb.Root mb={3} separator={<LiaSlashSolid />}>
         <Breadcrumb.Link asChild color="fg.info">
           <RouterLink to="/dags">Dags</RouterLink>
         </Breadcrumb.Link>
         <Breadcrumb.Link asChild color="fg.info">
-          <RouterLink to={`/dags/${dagId}`}>
-            {dag?.dag_display_name ?? dagId}
-          </RouterLink>
+          <RouterLink to={`/dags/${dagId}`}>{dag?.dag_display_name ?? dagId}</RouterLink>
         </Breadcrumb.Link>
         <Breadcrumb.CurrentLink>{runId}</Breadcrumb.CurrentLink>
       </Breadcrumb.Root>

--- a/airflow/ui/src/pages/Run/TaskInstances.tsx
+++ b/airflow/ui/src/pages/Run/TaskInstances.tsx
@@ -35,9 +35,7 @@ const columns: Array<ColumnDef<TaskInstanceResponse>> = [
     accessorKey: "task_display_name",
     cell: ({ row: { original } }) => (
       <Link asChild color="fg.info" fontWeight="bold">
-        <RouterLink to={getTaskInstanceLink(original)}>
-          {original.task_display_name}
-        </RouterLink>
+        <RouterLink to={getTaskInstanceLink(original)}>{original.task_display_name}</RouterLink>
       </Link>
     ),
     enableSorting: false,
@@ -63,8 +61,7 @@ const columns: Array<ColumnDef<TaskInstanceResponse>> = [
     header: "End Date",
   },
   {
-    accessorFn: (row: TaskInstanceResponse) =>
-      row.rendered_map_index ?? row.map_index,
+    accessorFn: (row: TaskInstanceResponse) => row.rendered_map_index ?? row.map_index,
     header: "Map Index",
   },
 
@@ -80,8 +77,7 @@ const columns: Array<ColumnDef<TaskInstanceResponse>> = [
   },
 
   {
-    cell: ({ row: { original } }) =>
-      `${getDuration(original.start_date, original.end_date)}s`,
+    cell: ({ row: { original } }) => `${getDuration(original.start_date, original.end_date)}s`,
     header: "Duration",
   },
 ];
@@ -93,18 +89,17 @@ export const TaskInstances = () => {
   const [sort] = sorting;
   const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : "-start_date";
 
-  const { data, error, isFetching, isLoading } =
-    useTaskInstanceServiceGetTaskInstances(
-      {
-        dagId,
-        dagRunId: runId,
-        limit: pagination.pageSize,
-        offset: pagination.pageIndex * pagination.pageSize,
-        orderBy,
-      },
-      undefined,
-      { enabled: !isNaN(pagination.pageSize) },
-    );
+  const { data, error, isFetching, isLoading } = useTaskInstanceServiceGetTaskInstances(
+    {
+      dagId,
+      dagRunId: runId,
+      limit: pagination.pageSize,
+      offset: pagination.pageIndex * pagination.pageSize,
+      orderBy,
+    },
+    undefined,
+    { enabled: !isNaN(pagination.pageSize) },
+  );
 
   return (
     <Box>

--- a/airflow/ui/src/pages/Task/Header.tsx
+++ b/airflow/ui/src/pages/Task/Header.tsx
@@ -37,9 +37,7 @@ export const Header = ({ task }: { readonly task: TaskResponse }) => (
           <div />
         </Flex>
       </HStack>
-      {task.doc_md === null ? undefined : (
-        <DocumentationModal docMd={task.doc_md} docType="Task" />
-      )}
+      {task.doc_md === null ? undefined : <DocumentationModal docMd={task.doc_md} docType="Task" />}
     </Flex>
     <SimpleGrid columns={4} gap={4}>
       <Stat label="Operator">

--- a/airflow/ui/src/pages/Task/Instances.tsx
+++ b/airflow/ui/src/pages/Task/Instances.tsx
@@ -20,10 +20,7 @@ import { Box, Link } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
 import { Link as RouterLink, useParams } from "react-router-dom";
 
-import {
-  useTaskInstanceServiceGetTaskInstances,
-  useTaskServiceGetTask,
-} from "openapi/queries";
+import { useTaskInstanceServiceGetTaskInstances, useTaskServiceGetTask } from "openapi/queries";
 import type { TaskInstanceResponse } from "openapi/requests/types.gen";
 import { DataTable } from "src/components/DataTable";
 import { useTableURLState } from "src/components/DataTable/useTableUrlState";
@@ -33,16 +30,12 @@ import { Status } from "src/components/ui";
 import { getDuration } from "src/utils";
 import { getTaskInstanceLink } from "src/utils/links";
 
-const columns = (
-  isMapped?: boolean,
-): Array<ColumnDef<TaskInstanceResponse>> => [
+const columns = (isMapped?: boolean): Array<ColumnDef<TaskInstanceResponse>> => [
   {
     accessorKey: "dag_run_id",
     cell: ({ row: { original } }) => (
       <Link asChild color="fg.info" fontWeight="bold">
-        <RouterLink to={getTaskInstanceLink(original)}>
-          {original.dag_run_id}
-        </RouterLink>
+        <RouterLink to={getTaskInstanceLink(original)}>{original.dag_run_id}</RouterLink>
       </Link>
     ),
     enableSorting: false,
@@ -70,8 +63,7 @@ const columns = (
   ...(isMapped
     ? [
         {
-          accessorFn: (row: TaskInstanceResponse) =>
-            row.rendered_map_index ?? row.map_index,
+          accessorFn: (row: TaskInstanceResponse) => row.rendered_map_index ?? row.map_index,
           header: "Map Index",
         },
       ]
@@ -82,8 +74,7 @@ const columns = (
     header: "Try Number",
   },
   {
-    cell: ({ row: { original } }) =>
-      `${getDuration(original.start_date, original.end_date)}s`,
+    cell: ({ row: { original } }) => `${getDuration(original.start_date, original.end_date)}s`,
     header: "Duration",
   },
 ];
@@ -95,21 +86,16 @@ export const Instances = () => {
   const [sort] = sorting;
   const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : "-start_date";
 
-  const {
-    data: task,
-    error: taskError,
-    isLoading: isTaskLoading,
-  } = useTaskServiceGetTask({ dagId, taskId });
+  const { data: task, error: taskError, isLoading: isTaskLoading } = useTaskServiceGetTask({ dagId, taskId });
 
-  const { data, error, isFetching, isLoading } =
-    useTaskInstanceServiceGetTaskInstances({
-      dagId,
-      dagRunId: "~",
-      limit: pagination.pageSize,
-      offset: pagination.pageIndex * pagination.pageSize,
-      orderBy,
-      taskId,
-    });
+  const { data, error, isFetching, isLoading } = useTaskInstanceServiceGetTaskInstances({
+    dagId,
+    dagRunId: "~",
+    limit: pagination.pageSize,
+    offset: pagination.pageIndex * pagination.pageSize,
+    orderBy,
+    taskId,
+  });
 
   return (
     <Box>

--- a/airflow/ui/src/pages/Task/Task.tsx
+++ b/airflow/ui/src/pages/Task/Task.tsx
@@ -19,10 +19,7 @@
 import { LiaSlashSolid } from "react-icons/lia";
 import { useParams, Link as RouterLink } from "react-router-dom";
 
-import {
-  useDagServiceGetDagDetails,
-  useTaskServiceGetTask,
-} from "openapi/queries";
+import { useDagServiceGetDagDetails, useTaskServiceGetTask } from "openapi/queries";
 import { Breadcrumb } from "src/components/ui";
 import { DetailsLayout } from "src/layouts/Details/DetailsLayout";
 
@@ -36,11 +33,7 @@ const tabs = [
 export const Task = () => {
   const { dagId = "", taskId = "" } = useParams();
 
-  const {
-    data: task,
-    error,
-    isLoading,
-  } = useTaskServiceGetTask({ dagId, taskId });
+  const { data: task, error, isLoading } = useTaskServiceGetTask({ dagId, taskId });
 
   const {
     data: dag,
@@ -57,20 +50,11 @@ export const Task = () => {
   ];
 
   return (
-    <DetailsLayout
-      dag={dag}
-      error={error ?? dagError}
-      isLoading={isLoading || isDagLoading}
-      tabs={tabs}
-    >
+    <DetailsLayout dag={dag} error={error ?? dagError} isLoading={isLoading || isDagLoading} tabs={tabs}>
       <Breadcrumb.Root mb={3} separator={<LiaSlashSolid />}>
         {links.map((link, index) => {
           if (index === links.length - 1) {
-            return (
-              <Breadcrumb.CurrentLink key={link.label}>
-                {link.label}
-              </Breadcrumb.CurrentLink>
-            );
+            return <Breadcrumb.CurrentLink key={link.label}>{link.label}</Breadcrumb.CurrentLink>;
           }
 
           return link.value === undefined ? (

--- a/airflow/ui/src/pages/TaskInstance/Header.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Header.tsx
@@ -25,19 +25,14 @@ import Time from "src/components/Time";
 import { Status } from "src/components/ui";
 import { getDuration } from "src/utils";
 
-export const Header = ({
-  taskInstance,
-}: {
-  readonly taskInstance: TaskInstanceResponse;
-}) => (
+export const Header = ({ taskInstance }: { readonly taskInstance: TaskInstanceResponse }) => (
   <Box borderColor="border" borderRadius={8} borderWidth={1} p={2}>
     <Flex alignItems="center" justifyContent="space-between" mb={2}>
       <HStack alignItems="center" gap={2}>
         <MdOutlineTask size="1.75rem" />
         <Heading size="lg">
           <strong>Task Instance: </strong>
-          {taskInstance.task_display_name}{" "}
-          <Time datetime={taskInstance.start_date} />
+          {taskInstance.task_display_name} <Time datetime={taskInstance.start_date} />
         </Heading>
         <Status state={taskInstance.state}>{taskInstance.state}</Status>
         <Flex>
@@ -45,8 +40,7 @@ export const Header = ({
         </Flex>
       </HStack>
     </Flex>
-    {taskInstance.note === null ||
-    taskInstance.note.length === 0 ? undefined : (
+    {taskInstance.note === null || taskInstance.note.length === 0 ? undefined : (
       <Flex alignItems="flex-start" justifyContent="space-between" mr={16}>
         <MdOutlineModeComment size="3rem" />
         <Text fontSize="sm" ml={3}>
@@ -57,22 +51,16 @@ export const Header = ({
     <SimpleGrid columns={6} gap={4} my={2}>
       <Stat label="Operator">{taskInstance.operator}</Stat>
       {taskInstance.map_index > -1 ? (
-        <Stat label="Map Index">
-          {taskInstance.rendered_map_index ?? taskInstance.map_index}
-        </Stat>
+        <Stat label="Map Index">{taskInstance.rendered_map_index ?? taskInstance.map_index}</Stat>
       ) : undefined}
-      {taskInstance.try_number > 1 ? (
-        <Stat label="Try Number">{taskInstance.try_number}</Stat>
-      ) : undefined}
+      {taskInstance.try_number > 1 ? <Stat label="Try Number">{taskInstance.try_number}</Stat> : undefined}
       <Stat label="Start">
         <Time datetime={taskInstance.start_date} />
       </Stat>
       <Stat label="End">
         <Time datetime={taskInstance.end_date} />
       </Stat>
-      <Stat label="Duration">
-        {getDuration(taskInstance.start_date, taskInstance.end_date)}s
-      </Stat>
+      <Stat label="Duration">{getDuration(taskInstance.start_date, taskInstance.end_date)}s</Stat>
     </SimpleGrid>
   </Box>
 );

--- a/airflow/ui/src/pages/TaskInstance/Logs.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Logs.tsx
@@ -55,10 +55,7 @@ export const Logs = () => {
     setSearchParams(searchParams);
   };
 
-  const tryNumber =
-    tryNumberParam === null
-      ? taskInstance?.try_number
-      : parseInt(tryNumberParam, 10);
+  const tryNumber = tryNumberParam === null ? taskInstance?.try_number : parseInt(tryNumberParam, 10);
 
   const defaultWrap = Boolean(useConfig("default_wrap"));
 
@@ -81,9 +78,7 @@ export const Logs = () => {
   return (
     <Box p={2}>
       <HStack justifyContent="space-between" mb={2}>
-        {taskInstance === undefined ||
-        tryNumber === undefined ||
-        taskInstance.try_number <= 1 ? (
+        {taskInstance === undefined || tryNumber === undefined || taskInstance.try_number <= 1 ? (
           <div />
         ) : (
           <TaskTrySelect
@@ -92,21 +87,13 @@ export const Logs = () => {
             taskInstance={taskInstance}
           />
         )}
-        <Button
-          aria-label={wrap ? "Unwrap" : "Wrap"}
-          bg="bg.panel"
-          onClick={toggleWrap}
-          variant="outline"
-        >
+        <Button aria-label={wrap ? "Unwrap" : "Wrap"} bg="bg.panel" onClick={toggleWrap} variant="outline">
           {wrap ? "Unwrap" : "Wrap"}
         </Button>
       </HStack>
       <ErrorAlert error={error ?? logError} />
       <Skeleton />
-      <ProgressBar
-        size="xs"
-        visibility={isLoading || isLoadingLogs ? "visible" : "hidden"}
-      />
+      <ProgressBar size="xs" visibility={isLoading || isLoadingLogs ? "visible" : "hidden"} />
       <Code overflow="auto" py={3} textWrap={wrap ? "pre" : "nowrap"}>
         <VStack alignItems="flex-start">{data.parsedLogs}</VStack>
       </Code>

--- a/airflow/ui/src/pages/TaskInstance/TaskInstance.tsx
+++ b/airflow/ui/src/pages/TaskInstance/TaskInstance.tsx
@@ -17,16 +17,9 @@
  * under the License.
  */
 import { LiaSlashSolid } from "react-icons/lia";
-import {
-  useParams,
-  Link as RouterLink,
-  useSearchParams,
-} from "react-router-dom";
+import { useParams, Link as RouterLink, useSearchParams } from "react-router-dom";
 
-import {
-  useDagServiceGetDagDetails,
-  useTaskInstanceServiceGetMappedTaskInstance,
-} from "openapi/queries";
+import { useDagServiceGetDagDetails, useTaskInstanceServiceGetMappedTaskInstance } from "openapi/queries";
 import { Breadcrumb } from "src/components/ui";
 import { DetailsLayout } from "src/layouts/Details/DetailsLayout";
 
@@ -78,20 +71,11 @@ export const TaskInstance = () => {
   }
 
   return (
-    <DetailsLayout
-      dag={dag}
-      error={error ?? dagError}
-      isLoading={isLoading || isDagLoading}
-      tabs={tabs}
-    >
+    <DetailsLayout dag={dag} error={error ?? dagError} isLoading={isLoading || isDagLoading} tabs={tabs}>
       <Breadcrumb.Root mb={3} separator={<LiaSlashSolid />}>
         {links.map((link, index) => {
           if (index === links.length - 1) {
-            return (
-              <Breadcrumb.CurrentLink key={link.label}>
-                {link.label}
-              </Breadcrumb.CurrentLink>
-            );
+            return <Breadcrumb.CurrentLink key={link.label}>{link.label}</Breadcrumb.CurrentLink>;
           }
 
           return link.value === undefined ? (
@@ -105,9 +89,7 @@ export const TaskInstance = () => {
           );
         })}
       </Breadcrumb.Root>
-      {taskInstance === undefined ? undefined : (
-        <Header taskInstance={taskInstance} />
-      )}
+      {taskInstance === undefined ? undefined : <Header taskInstance={taskInstance} />}
     </DetailsLayout>
   );
 };

--- a/airflow/ui/src/pages/Variables/ImportVariablesForm.tsx
+++ b/airflow/ui/src/pages/Variables/ImportVariablesForm.tsx
@@ -25,11 +25,7 @@ import { ErrorAlert } from "src/components/ErrorAlert";
 import { Button, CloseButton, InputGroup } from "src/components/ui";
 import { FileUpload } from "src/components/ui/FileUpload";
 import { FileInput } from "src/components/ui/FileUpload/FileInput";
-import {
-  RadioCardItem,
-  RadioCardLabel,
-  RadioCardRoot,
-} from "src/components/ui/RadioCard";
+import { RadioCardItem, RadioCardLabel, RadioCardRoot } from "src/components/ui/RadioCard";
 import { useImportVariables } from "src/queries/useImportVariables";
 
 type ImportVariablesFormProps = {
@@ -59,12 +55,8 @@ const ImportVariablesForm = ({ onClose }: ImportVariablesFormProps) => {
     onSuccessConfirm: onClose,
   });
 
-  const [selectedFile, setSelectedFile] = useState<Blob | File | undefined>(
-    undefined,
-  );
-  const [actionIfExists, setActionIfExists] = useState<
-    "fail" | "overwrite" | "skip" | undefined
-  >("fail");
+  const [selectedFile, setSelectedFile] = useState<Blob | File | undefined>(undefined);
+  const [actionIfExists, setActionIfExists] = useState<"fail" | "overwrite" | "skip" | undefined>("fail");
 
   const onSubmit = () => {
     setError(undefined);
@@ -153,11 +145,7 @@ const ImportVariablesForm = ({ onClose }: ImportVariablesFormProps) => {
             </Center>
           </Box>
         ) : undefined}
-        <Button
-          colorPalette="blue"
-          disabled={!selectedFile || isPending}
-          onClick={onSubmit}
-        >
+        <Button colorPalette="blue" disabled={!selectedFile || isPending} onClick={onSubmit}>
           <FiUploadCloud /> Import
         </Button>
       </Box>

--- a/airflow/ui/src/pages/Variables/ManageVariable/DeleteVariableButton.tsx
+++ b/airflow/ui/src/pages/Variables/ManageVariable/DeleteVariableButton.tsx
@@ -70,9 +70,7 @@ const DeleteVariableButton = ({ deleteKey: variableKey }: Props) => {
           <Dialog.CloseTrigger />
 
           <Dialog.Body width="full">
-            <Text>
-              Are you sure you want to delete the variable key: `{variableKey}`?
-            </Text>
+            <Text>Are you sure you want to delete the variable key: `{variableKey}`?</Text>
             <Flex justifyContent="end" mt={3}>
               {renderDeleteButton()}
             </Flex>

--- a/airflow/ui/src/pages/Variables/ManageVariable/EditVariableButton.tsx
+++ b/airflow/ui/src/pages/Variables/ManageVariable/EditVariableButton.tsx
@@ -38,10 +38,9 @@ const EditVariableButton = ({ variable }: Props) => {
     key: variable.key,
     value: variable.value ?? "",
   };
-  const { editVariable, error, isPending, setError } = useEditVariable(
-    initialVariableValue,
-    { onSuccessConfirm: onClose },
-  );
+  const { editVariable, error, isPending, setError } = useEditVariable(initialVariableValue, {
+    onSuccessConfirm: onClose,
+  });
 
   const handleClose = () => {
     setError(undefined);

--- a/airflow/ui/src/pages/Variables/ManageVariable/VariableForm.tsx
+++ b/airflow/ui/src/pages/Variables/ManageVariable/VariableForm.tsx
@@ -37,13 +37,7 @@ type VariableFormProps = {
   readonly setError: (error: unknown) => void;
 };
 
-const VariableForm = ({
-  error,
-  initialVariable,
-  isPending,
-  manageMutate,
-  setError,
-}: VariableFormProps) => {
+const VariableForm = ({ error, initialVariable, isPending, manageMutate, setError }: VariableFormProps) => {
   const {
     control,
     formState: { isDirty, isValid },
@@ -73,22 +67,13 @@ const VariableForm = ({
             <Field.Label fontSize="md">
               Key <Field.RequiredIndicator />
             </Field.Label>
-            <Input
-              {...field}
-              disabled={Boolean(initialVariable.key)}
-              required
-              size="sm"
-            />
-            {fieldState.error ? (
-              <Field.ErrorText>{fieldState.error.message}</Field.ErrorText>
-            ) : undefined}
+            <Input {...field} disabled={Boolean(initialVariable.key)} required size="sm" />
+            {fieldState.error ? <Field.ErrorText>{fieldState.error.message}</Field.ErrorText> : undefined}
           </Field.Root>
         )}
         rules={{
           required: "Key is required",
-          validate: (_value) =>
-            _value.length <= 250 ||
-            "Key can contain a maximum of 250 characters",
+          validate: (_value) => _value.length <= 250 || "Key can contain a maximum of 250 characters",
         }}
       />
 
@@ -101,9 +86,7 @@ const VariableForm = ({
               Value <Field.RequiredIndicator />
             </Field.Label>
             <Textarea {...field} required size="sm" />
-            {fieldState.error ? (
-              <Field.ErrorText>{fieldState.error.message}</Field.ErrorText>
-            ) : undefined}
+            {fieldState.error ? <Field.ErrorText>{fieldState.error.message}</Field.ErrorText> : undefined}
           </Field.Root>
         )}
         rules={{

--- a/airflow/ui/src/pages/Variables/Variables.tsx
+++ b/airflow/ui/src/pages/Variables/Variables.tsx
@@ -27,10 +27,7 @@ import { DataTable } from "src/components/DataTable";
 import { useTableURLState } from "src/components/DataTable/useTableUrlState";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import { SearchBar } from "src/components/SearchBar";
-import {
-  SearchParamsKeys,
-  type SearchParamsKeysType,
-} from "src/constants/searchParams";
+import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
 
 import ImportVariablesButton from "./ImportVariablesButton";
 import AddVariableButton from "./ManageVariable/AddVariableButton";
@@ -70,27 +67,20 @@ const columns: Array<ColumnDef<VariableResponse>> = [
 export const Variables = () => {
   const { setTableURLState, tableURLState } = useTableURLState();
   const [searchParams, setSearchParams] = useSearchParams();
-  const { NAME_PATTERN: NAME_PATTERN_PARAM }: SearchParamsKeysType =
-    SearchParamsKeys;
+  const { NAME_PATTERN: NAME_PATTERN_PARAM }: SearchParamsKeysType = SearchParamsKeys;
   const [variableKeyPattern, setVariableKeyPattern] = useState(
     searchParams.get(NAME_PATTERN_PARAM) ?? undefined,
   );
   const { pagination, sorting } = tableURLState;
   const [sort] = sorting;
-  const orderBy = sort
-    ? `${sort.desc ? "-" : ""}${sort.id === "value" ? "_val" : sort.id}`
-    : "-key";
+  const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id === "value" ? "_val" : sort.id}` : "-key";
 
-  const { data, error, isFetching, isLoading } = useVariableServiceGetVariables(
-    {
-      limit: pagination.pageSize,
-      offset: pagination.pageIndex * pagination.pageSize,
-      orderBy,
-      variableKeyPattern: Boolean(variableKeyPattern)
-        ? `${variableKeyPattern}`
-        : undefined,
-    },
-  );
+  const { data, error, isFetching, isLoading } = useVariableServiceGetVariables({
+    limit: pagination.pageSize,
+    offset: pagination.pageIndex * pagination.pageSize,
+    orderBy,
+    variableKeyPattern: Boolean(variableKeyPattern) ? `${variableKeyPattern}` : undefined,
+  });
 
   const handleSearchChange = (value: string) => {
     if (value) {

--- a/airflow/ui/src/pages/XCom/XComEntry.tsx
+++ b/airflow/ui/src/pages/XCom/XComEntry.tsx
@@ -30,13 +30,7 @@ type XComEntryProps = {
   readonly xcomKey: string;
 };
 
-export const XComEntry = ({
-  dagId,
-  mapIndex,
-  runId,
-  taskId,
-  xcomKey,
-}: XComEntryProps) => {
+export const XComEntry = ({ dagId, mapIndex, runId, taskId, xcomKey }: XComEntryProps) => {
   const { data, isLoading } = useXcomServiceGetXcomEntry<XComResponseString>({
     dagId,
     dagRunId: runId,

--- a/airflow/ui/src/queries/useAddVariable.ts
+++ b/airflow/ui/src/queries/useAddVariable.ts
@@ -19,18 +19,11 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
-import {
-  useVariableServiceGetVariablesKey,
-  useVariableServicePostVariable,
-} from "openapi/queries";
+import { useVariableServiceGetVariablesKey, useVariableServicePostVariable } from "openapi/queries";
 import { toaster } from "src/components/ui";
 import type { VariableBody } from "src/pages/Variables/ManageVariable/VariableForm";
 
-export const useAddVariable = ({
-  onSuccessConfirm,
-}: {
-  onSuccessConfirm: () => void;
-}) => {
+export const useAddVariable = ({ onSuccessConfirm }: { onSuccessConfirm: () => void }) => {
   const queryClient = useQueryClient();
   const [error, setError] = useState<unknown>(undefined);
 
@@ -59,9 +52,7 @@ export const useAddVariable = ({
 
   const addVariable = (variableRequestBody: VariableBody) => {
     const parsedDescription =
-      variableRequestBody.description === ""
-        ? undefined
-        : variableRequestBody.description;
+      variableRequestBody.description === "" ? undefined : variableRequestBody.description;
 
     mutate({
       requestBody: {

--- a/airflow/ui/src/queries/useClearRun.ts
+++ b/airflow/ui/src/queries/useClearRun.ts
@@ -25,10 +25,7 @@ import {
   UseDagServiceGetDagDetailsKeyFn,
   useTaskInstanceServiceGetTaskInstancesKey,
 } from "openapi/queries";
-import type {
-  DAGRunClearBody,
-  TaskInstanceCollectionResponse,
-} from "openapi/requests/types.gen";
+import type { DAGRunClearBody, TaskInstanceCollectionResponse } from "openapi/requests/types.gen";
 import { toaster } from "src/components/ui";
 
 const onError = () => {
@@ -70,11 +67,7 @@ export const useClearDagRun = ({
         [useDagRunServiceGetDagRunsKey],
       ];
 
-      await Promise.all(
-        queryKeys.map((key) =>
-          queryClient.invalidateQueries({ queryKey: key }),
-        ),
-      );
+      await Promise.all(queryKeys.map((key) => queryClient.invalidateQueries({ queryKey: key })));
 
       onSuccessConfirm();
     }

--- a/airflow/ui/src/queries/useDagParams.ts
+++ b/airflow/ui/src/queries/useDagParams.ts
@@ -39,10 +39,7 @@ export const useDagParams = (dagId: string, open: boolean) => {
 
   const transformedParams = data?.params
     ? Object.fromEntries(
-        Object.entries(data.params).map(([key, param]) => [
-          key,
-          (param as { value: unknown }).value,
-        ]),
+        Object.entries(data.params).map(([key, param]) => [key, (param as { value: unknown }).value]),
       )
     : {};
 

--- a/airflow/ui/src/queries/useDagParsing.ts
+++ b/airflow/ui/src/queries/useDagParsing.ts
@@ -27,8 +27,7 @@ import { toaster } from "src/components/ui";
 
 const onError = () => {
   toaster.create({
-    description:
-      "Dag parsing request failed. There could be pending parsing requests yet to be processed.",
+    description: "Dag parsing request failed. There could be pending parsing requests yet to be processed.",
     title: "Dag Failed to Reparse",
     type: "error",
   });

--- a/airflow/ui/src/queries/useDags.tsx
+++ b/airflow/ui/src/queries/useDags.tsx
@@ -16,14 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  useDagServiceGetDags,
-  useDagsServiceRecentDagRuns,
-} from "openapi/queries";
-import type {
-  DagRunState,
-  DAGWithLatestDagRunsResponse,
-} from "openapi/requests/types.gen";
+import { useDagServiceGetDags, useDagsServiceRecentDagRuns } from "openapi/queries";
+import type { DagRunState, DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
 
 export type DagWithLatest = {
   last_run_start_date: string;
@@ -43,8 +37,7 @@ export const useDags = (
     tags?: Array<string>;
   } = {},
 ) => {
-  const { data, error, isFetching, isLoading } =
-    useDagServiceGetDags(searchParams);
+  const { data, error, isFetching, isLoading } = useDagServiceGetDags(searchParams);
 
   const { orderBy, ...runsParams } = searchParams;
   const {
@@ -58,9 +51,7 @@ export const useDags = (
   });
 
   const dags = (data?.dags ?? []).map((dag) => {
-    const dagWithRuns = runsData?.dags.find(
-      (runsDag) => runsDag.dag_id === dag.dag_id,
-    );
+    const dagWithRuns = runsData?.dags.find((runsDag) => runsDag.dag_id === dag.dag_id);
 
     return {
       latest_dag_runs: [],

--- a/airflow/ui/src/queries/useDeleteVariable.ts
+++ b/airflow/ui/src/queries/useDeleteVariable.ts
@@ -18,10 +18,7 @@
  */
 import { useQueryClient } from "@tanstack/react-query";
 
-import {
-  useVariableServiceDeleteVariable,
-  useVariableServiceGetVariablesKey,
-} from "openapi/queries";
+import { useVariableServiceDeleteVariable, useVariableServiceGetVariablesKey } from "openapi/queries";
 import { toaster } from "src/components/ui";
 
 const onError = () => {
@@ -32,11 +29,7 @@ const onError = () => {
   });
 };
 
-export const useDeleteVariable = ({
-  onSuccessConfirm,
-}: {
-  onSuccessConfirm: () => void;
-}) => {
+export const useDeleteVariable = ({ onSuccessConfirm }: { onSuccessConfirm: () => void }) => {
   const queryClient = useQueryClient();
 
   const onSuccess = async () => {

--- a/airflow/ui/src/queries/useEditVariable.ts
+++ b/airflow/ui/src/queries/useEditVariable.ts
@@ -19,10 +19,7 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
-import {
-  useVariableServiceGetVariablesKey,
-  useVariableServicePatchVariable,
-} from "openapi/queries";
+import { useVariableServiceGetVariablesKey, useVariableServicePatchVariable } from "openapi/queries";
 import { toaster } from "src/components/ui";
 import type { VariableBody } from "src/pages/Variables/ManageVariable/VariableForm";
 
@@ -71,9 +68,7 @@ export const useEditVariable = (
     }
 
     const parsedDescription =
-      addVariableRequestBody.description === ""
-        ? undefined
-        : addVariableRequestBody.description;
+      addVariableRequestBody.description === "" ? undefined : addVariableRequestBody.description;
 
     mutate({
       requestBody: {

--- a/airflow/ui/src/queries/useImportVariables.ts
+++ b/airflow/ui/src/queries/useImportVariables.ts
@@ -19,17 +19,10 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
-import {
-  useVariableServiceGetVariablesKey,
-  useVariableServiceImportVariables,
-} from "openapi/queries";
+import { useVariableServiceGetVariablesKey, useVariableServiceImportVariables } from "openapi/queries";
 import { toaster } from "src/components/ui";
 
-export const useImportVariables = ({
-  onSuccessConfirm,
-}: {
-  onSuccessConfirm: () => void;
-}) => {
+export const useImportVariables = ({ onSuccessConfirm }: { onSuccessConfirm: () => void }) => {
   const queryClient = useQueryClient();
   const [error, setError] = useState<unknown>(undefined);
 

--- a/airflow/ui/src/queries/useLogs.tsx
+++ b/airflow/ui/src/queries/useLogs.tsx
@@ -57,13 +57,7 @@ const parseLogs = ({ data }: ParseLogsProps) => {
   };
 };
 
-export const useLogs = ({
-  dagId,
-  mapIndex = -1,
-  runId,
-  taskId,
-  tryNumber = 1,
-}: Props) => {
+export const useLogs = ({ dagId, mapIndex = -1, runId, taskId, tryNumber = 1 }: Props) => {
   const { data, ...rest } = useTaskInstanceServiceGetLog({
     dagId,
     dagRunId: runId,

--- a/airflow/ui/src/queries/useTrigger.ts
+++ b/airflow/ui/src/queries/useTrigger.ts
@@ -28,16 +28,11 @@ import {
 import type { DagRunTriggerParams } from "src/components/TriggerDag/TriggerDAGForm";
 import { toaster } from "src/components/ui";
 
-export const useTrigger = ({
-  onSuccessConfirm,
-}: {
-  onSuccessConfirm: () => void;
-}) => {
+export const useTrigger = ({ onSuccessConfirm }: { onSuccessConfirm: () => void }) => {
   const queryClient = useQueryClient();
   const [error, setError] = useState<unknown>(undefined);
 
-  const [dateValidationError, setDateValidationError] =
-    useState<unknown>(undefined);
+  const [dateValidationError, setDateValidationError] = useState<unknown>(undefined);
 
   const onSuccess = async () => {
     const queryKeys = [
@@ -46,11 +41,7 @@ export const useTrigger = ({
       useDagRunServiceGetDagRunsKey,
     ];
 
-    await Promise.all(
-      queryKeys.map((key) =>
-        queryClient.invalidateQueries({ queryKey: [key] }),
-      ),
-    );
+    await Promise.all(queryKeys.map((key) => queryClient.invalidateQueries({ queryKey: [key] })));
     toaster.create({
       description: "DAG run has been successfully triggered.",
       title: "DAG Run Request Submitted",
@@ -68,14 +59,8 @@ export const useTrigger = ({
     onSuccess,
   });
 
-  const triggerDagRun = (
-    dagId: string,
-    dagRunRequestBody: DagRunTriggerParams,
-  ) => {
-    const parsedConfig = JSON.parse(dagRunRequestBody.conf) as Record<
-      string,
-      unknown
-    >;
+  const triggerDagRun = (dagId: string, dagRunRequestBody: DagRunTriggerParams) => {
+    const parsedConfig = JSON.parse(dagRunRequestBody.conf) as Record<string, unknown>;
 
     const DataIntervalStart = dagRunRequestBody.dataIntervalStart
       ? new Date(dagRunRequestBody.dataIntervalStart)
@@ -99,8 +84,7 @@ export const useTrigger = ({
       if (DataIntervalStart > DataIntervalEnd) {
         setDateValidationError({
           body: {
-            detail:
-              "Data Interval Start Date must be less than or equal to Data Interval End Date.",
+            detail: "Data Interval Start Date must be less than or equal to Data Interval End Date.",
           },
         });
 
@@ -108,17 +92,11 @@ export const useTrigger = ({
       }
     }
 
-    const formattedDataIntervalStart =
-      DataIntervalStart?.toISOString() ?? undefined;
-    const formattedDataIntervalEnd =
-      DataIntervalEnd?.toISOString() ?? undefined;
+    const formattedDataIntervalStart = DataIntervalStart?.toISOString() ?? undefined;
+    const formattedDataIntervalEnd = DataIntervalEnd?.toISOString() ?? undefined;
 
-    const checkDagRunId =
-      dagRunRequestBody.dagRunId === ""
-        ? undefined
-        : dagRunRequestBody.dagRunId;
-    const checkNote =
-      dagRunRequestBody.note === "" ? undefined : dagRunRequestBody.note;
+    const checkDagRunId = dagRunRequestBody.dagRunId === "" ? undefined : dagRunRequestBody.dagRunId;
+    const checkNote = dagRunRequestBody.note === "" ? undefined : dagRunRequestBody.note;
 
     mutate({
       dagId,

--- a/airflow/ui/src/utils/RouterWrapper.tsx
+++ b/airflow/ui/src/utils/RouterWrapper.tsx
@@ -19,6 +19,4 @@
 import type { PropsWithChildren } from "react";
 import { MemoryRouter } from "react-router-dom";
 
-export const RouterWrapper = ({ children }: PropsWithChildren) => (
-  <MemoryRouter>{children}</MemoryRouter>
-);
+export const RouterWrapper = ({ children }: PropsWithChildren) => <MemoryRouter>{children}</MemoryRouter>;

--- a/airflow/ui/src/utils/pluralize.test.ts
+++ b/airflow/ui/src/utils/pluralize.test.ts
@@ -71,14 +71,7 @@ const pluralizeTestCases = [
 describe("pluralize", () => {
   it("case", () => {
     pluralizeTestCases.forEach((testCase) =>
-      expect(
-        pluralize(
-          testCase.in[0],
-          testCase.in[1],
-          testCase.in[2],
-          testCase.in[3],
-        ),
-      ).toEqual(testCase.out),
+      expect(pluralize(testCase.in[0], testCase.in[1], testCase.in[2], testCase.in[3])).toEqual(testCase.out),
     );
   });
 });

--- a/airflow/ui/vite.config.ts
+++ b/airflow/ui/vite.config.ts
@@ -29,9 +29,7 @@ export default defineConfig({
     {
       name: "transform-url-src",
       transformIndexHtml: (html) =>
-        html
-          .replace(`src="/assets/`, `src="/static/assets/`)
-          .replace(`href="/`, `href="/webapp/`),
+        html.replace(`src="/assets/`, `src="/static/assets/`).replace(`href="/`, `href="/webapp/`),
     },
     cssInjectedByJsPlugin(),
   ],


### PR DESCRIPTION
(Note: I know this PR fails in pre-commit checks but wanted to raise it anyway... based on discussion I'd make it clean)

I noticed that in pre-commit we format all text to 110 chars... for Python code and tooling. Also there was a bit of discussion on the devlist about to change it for smaller screens.

NOTE: The big diff is mainly the re-formatting of all UI source. The impact is caused by the one line change in https://github.com/apache/airflow/pull/45312/files#diff-14e4a70ab8ce4057d209267e534689fe0c3f48658095289169b396cd0c37be51R8

Nevertheless I was wondering why we format the (new) UI code to 80 chars? Is there a reason for this? I'd propose (with this PR) to make it common with the test of the codebase.