### PR TITLE
Fix update issues for object and advanced-arrays fields when empty default

### DIFF
--- a/airflow/www/static/js/trigger.js
+++ b/airflow/www/static/js/trigger.js
@@ -59,8 +59,6 @@ function updateJSONconf() {
           }
         }
         params[keyName] = values.length === 0 ? null : values;
-      } else if (elements[i].value.length === 0) {
-        params[keyName] = null;
       } else if (
         elements[i].attributes.valuetype &&
         (elements[i].attributes.valuetype.value === "object" ||
@@ -81,6 +79,8 @@ function updateJSONconf() {
           // ignore JSON parsing errors
           // we don't want to bother users during entry, error will be displayed before submit
         }
+      } else if (elements[i].value.length === 0) {
+        params[keyName] = null;
       } else if (Number.isNaN(elements[i].value)) {
         params[keyName] = elements[i].value;
       } else if (

--- a/airflow/www/templates/airflow/trigger.html
+++ b/airflow/www/templates/airflow/trigger.html
@@ -118,7 +118,9 @@
     {% elif form_details.schema and "object" in form_details.schema.type %}
       <textarea class="form-control" name="element_{{ form_key }}" id="element_{{ form_key }}" valuetype="object" rows="6"
         {%- if not "null" in form_details.schema.type %} required=""{% endif -%}>
-        {{- form_details.value | tojson() -}}
+        {%- if form_details.value %}
+          {{- form_details.value | tojson() -}}
+        {% endif -%}
       </textarea>
     {% elif form_details.schema and ("integer" in form_details.schema.type or "number" in form_details.schema.type) %}
       <input class="form-control" name="element_{{ form_key }}" id="element_{{ form_key }}"


### PR DESCRIPTION
As reported in #45032 the CodeMirror entry boxes are not working.

This is caused by how CodeMirror implements the entry: It is shadowing the original `<textarea>` fields in HTML. Unfortunately only via JavaScript the content of CodeMirror and HTML is in sync.
...and unfortunately my hand-written JavaScript checked for NULL/empty value _before_ getting to the fields from CodeMirror. So if an object or advanced array was initialized with an empty value, it never reached the onBlur() update action.
Moved the check for empty _after_ the CodeMirror field check.

Alongside figured out that the same as reported for advancedArray was also happening for object, just that the object field was never correctly initialized on empty value. Fixed this as well if a field is `type=["object", "null"]`.

closes: #45032
