### PR TITLE
feat: automatically inject OL transport info into spark jobs

### DIFF
--- a/docs/apache-airflow-providers-openlineage/guides/user.rst
+++ b/docs/apache-airflow-providers-openlineage/guides/user.rst
@@ -451,6 +451,33 @@ You can enable this automation by setting ``spark_inject_parent_job_info`` optio
   AIRFLOW__OPENLINEAGE__SPARK_INJECT_PARENT_JOB_INFO=true
 
 
+Passing transport information to Spark jobs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+OpenLineage integration can automatically inject Airflow's transport information into Spark application properties,
+for :ref:`supported Operators <supported_classes:openlineage>`.
+It allows Spark integration to send events to the same backend as Airflow integration without manual configuration.
+See `Scheduling from Airflow <https://openlineage.io/docs/integrations/spark/configuration/airflow>`_.
+
+.. note::
+
+  If any of the ``spark.openlineage.transport*`` properties are manually specified in the Spark job configuration, the integration will refrain from injecting transport properties to ensure that manually provided values are preserved.
+
+You can enable this automation by setting ``spark_inject_transport_info`` option to ``true`` in Airflow configuration.
+
+.. code-block:: ini
+
+    [openlineage]
+    transport = {"type": "http", "url": "http://example.com:5000", "endpoint": "api/v1/lineage"}
+    spark_inject_transport_info = true
+
+``AIRFLOW__OPENLINEAGE__SPARK_INJECT_TRANSPORT_INFO`` environment variable is an equivalent.
+
+.. code-block:: ini
+
+  AIRFLOW__OPENLINEAGE__SPARK_INJECT_TRANSPORT_INFO=true
+
+
 Troubleshooting
 ===============
 

--- a/docs/exts/templates/openlineage.rst.jinja2
+++ b/docs/exts/templates/openlineage.rst.jinja2
@@ -34,12 +34,15 @@ See :ref:`automatic injection of parent job information <options:spark_inject_pa
 apache-airflow-providers-google
 """""""""""""""""""""""""""""""
 
-- :class:`~airflow.providers.google.cloud.operators.dataproc.DataprocSubmitJobOperator`
-    - Parent Job Information
 - :class:`~airflow.providers.google.cloud.operators.dataproc.DataprocCreateBatchOperator`
     - Parent Job Information
+    - Transport Information (only HTTP transport is supported for now (with api_key auth, if any))
 - :class:`~airflow.providers.google.cloud.operators.dataproc.DataprocInstantiateInlineWorkflowTemplateOperator`
     - Parent Job Information
+    - Transport Information (only HTTP transport is supported for now (with api_key auth, if any))
+- :class:`~airflow.providers.google.cloud.operators.dataproc.DataprocSubmitJobOperator`
+    - Parent Job Information
+    - Transport Information (only HTTP transport is supported for now (with api_key auth, if any))
 
 
 :class:`~airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`

--- a/providers/src/airflow/providers/common/compat/openlineage/utils/spark.py
+++ b/providers/src/airflow/providers/common/compat/openlineage/utils/spark.py
@@ -23,11 +23,15 @@ from typing import TYPE_CHECKING
 log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from airflow.providers.openlineage.utils.spark import inject_parent_job_information_into_spark_properties
+    from airflow.providers.openlineage.utils.spark import (
+        inject_parent_job_information_into_spark_properties,
+        inject_transport_information_into_spark_properties,
+    )
 else:
     try:
         from airflow.providers.openlineage.utils.spark import (
             inject_parent_job_information_into_spark_properties,
+            inject_transport_information_into_spark_properties,
         )
     except ImportError:
         try:
@@ -64,5 +68,63 @@ else:
                 }
                 return {**properties, **ol_parent_job_properties}
 
+        try:
+            from airflow.providers.openlineage.plugins.listener import get_openlineage_listener
+        except ImportError:
 
-__all__ = ["inject_parent_job_information_into_spark_properties"]
+            def inject_transport_information_into_spark_properties(properties: dict, context) -> dict:
+                log.warning(
+                    "Could not import `airflow.providers.openlineage.plugins.listener`."
+                    "Skipping the injection of OpenLineage transport information into Spark properties."
+                )
+                return properties
+
+        else:
+
+            def inject_transport_information_into_spark_properties(properties: dict, context) -> dict:
+                if any(str(key).startswith("spark.openlineage.transport") for key in properties):
+                    log.info(
+                        "Some OpenLineage properties with transport information are already present "
+                        "in Spark properties. Skipping the injection of OpenLineage "
+                        "transport information into Spark properties."
+                    )
+                    return properties
+
+                transport = get_openlineage_listener().adapter.get_or_create_openlineage_client().transport
+                if transport.kind != "http":
+                    log.info(
+                        "OpenLineage transport type `%s` does not support automatic "
+                        "injection of OpenLineage transport information into Spark properties.",
+                        transport.kind,
+                    )
+                    return {}
+
+                transport_properties = {
+                    "spark.openlineage.transport.type": "http",
+                    "spark.openlineage.transport.url": transport.url,
+                    "spark.openlineage.transport.endpoint": transport.endpoint,
+                    # Timeout is converted to milliseconds, as required by Spark integration,
+                    "spark.openlineage.transport.timeoutInMillis": str(int(transport.timeout * 1000)),
+                }
+                if transport.compression:
+                    transport_properties["spark.openlineage.transport.compression"] = str(
+                        transport.compression
+                    )
+
+                if hasattr(transport.config.auth, "api_key") and transport.config.auth.get_bearer():
+                    transport_properties["spark.openlineage.transport.auth.type"] = "api_key"
+                    transport_properties["spark.openlineage.transport.auth.apiKey"] = (
+                        transport.config.auth.get_bearer()
+                    )
+
+                if hasattr(transport.config, "custom_headers") and transport.config.custom_headers:
+                    for key, value in transport.config.custom_headers.items():
+                        transport_properties[f"spark.openlineage.transport.headers.{key}"] = value
+
+                return {**properties, **transport_properties}
+
+
+__all__ = [
+    "inject_parent_job_information_into_spark_properties",
+    "inject_transport_information_into_spark_properties",
+]

--- a/providers/src/airflow/providers/openlineage/conf.py
+++ b/providers/src/airflow/providers/openlineage/conf.py
@@ -84,6 +84,12 @@ def spark_inject_parent_job_info() -> bool:
 
 
 @cache
+def spark_inject_transport_info() -> bool:
+    """[openlineage] spark_inject_transport_info."""
+    return conf.getboolean(_CONFIG_SECTION, "spark_inject_transport_info", fallback="False")
+
+
+@cache
 def custom_extractors() -> set[str]:
     """[openlineage] extractors."""
     option = conf.get(_CONFIG_SECTION, "extractors", fallback="")

--- a/providers/src/airflow/providers/openlineage/provider.yaml
+++ b/providers/src/airflow/providers/openlineage/provider.yaml
@@ -192,4 +192,12 @@ config:
         type: boolean
         default: "False"
         example: ~
-        version_added: 1.15.0
+        version_added: 2.0.0
+      spark_inject_transport_info:
+        description: |
+          Automatically inject OpenLineage's transport information into Spark application properties
+          for supported Operators.
+        type: boolean
+        default: "False"
+        example: ~
+        version_added: 2.1.0

--- a/providers/src/airflow/providers/openlineage/utils/spark.py
+++ b/providers/src/airflow/providers/openlineage/utils/spark.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from airflow.providers.openlineage.plugins.listener import get_openlineage_listener
 from airflow.providers.openlineage.plugins.macros import (
     lineage_job_name,
     lineage_job_namespace,
@@ -50,6 +51,39 @@ def _get_parent_job_information_as_spark_properties(context: Context) -> dict:
     }
 
 
+def _get_transport_information_as_spark_properties() -> dict:
+    """Retrieve transport information as Spark properties."""
+    transport = get_openlineage_listener().adapter.get_or_create_openlineage_client().transport
+    if transport.kind != "http":
+        log.info(
+            "OpenLineage transport type `%s` does not support automatic "
+            "injection of OpenLineage transport information into Spark properties.",
+            transport.kind,
+        )
+        return {}
+
+    properties = {
+        "spark.openlineage.transport.type": transport.kind,
+        "spark.openlineage.transport.url": transport.url,
+        "spark.openlineage.transport.endpoint": transport.endpoint,
+        "spark.openlineage.transport.timeoutInMillis": str(
+            int(transport.timeout * 1000)  # convert to milliseconds, as required by Spark integration
+        ),
+    }
+    if transport.compression:
+        properties["spark.openlineage.transport.compression"] = str(transport.compression)
+
+    if hasattr(transport.config.auth, "api_key") and transport.config.auth.get_bearer():
+        properties["spark.openlineage.transport.auth.type"] = "api_key"
+        properties["spark.openlineage.transport.auth.apiKey"] = transport.config.auth.get_bearer()
+
+    if hasattr(transport.config, "custom_headers") and transport.config.custom_headers:
+        for key, value in transport.config.custom_headers.items():
+            properties[f"spark.openlineage.transport.headers.{key}"] = value
+
+    return properties
+
+
 def _is_parent_job_information_present_in_spark_properties(properties: dict) -> bool:
     """
     Check if any parent job information is present in Spark properties.
@@ -61,6 +95,19 @@ def _is_parent_job_information_present_in_spark_properties(properties: dict) -> 
         True if parent job information is present, False otherwise.
     """
     return any(str(key).startswith("spark.openlineage.parent") for key in properties)
+
+
+def _is_transport_information_present_in_spark_properties(properties: dict) -> bool:
+    """
+    Check if any transport information is present in Spark properties.
+
+    Args:
+        properties: Spark properties.
+
+    Returns:
+        True if transport information is present, False otherwise.
+    """
+    return any(str(key).startswith("spark.openlineage.transport") for key in properties)
 
 
 def inject_parent_job_information_into_spark_properties(properties: dict, context: Context) -> dict:
@@ -82,5 +129,26 @@ def inject_parent_job_information_into_spark_properties(properties: dict, contex
         )
         return properties
 
-    ol_parent_job_properties = _get_parent_job_information_as_spark_properties(context)
-    return {**properties, **ol_parent_job_properties}
+    return {**properties, **_get_parent_job_information_as_spark_properties(context)}
+
+
+def inject_transport_information_into_spark_properties(properties: dict, context: Context) -> dict:
+    """
+    Inject transport information into Spark properties if not already present.
+
+    Args:
+        properties: Spark properties.
+        context: The context containing task instance information.
+
+    Returns:
+        Modified Spark properties with OpenLineage transport information properties injected, if applicable.
+    """
+    if _is_transport_information_present_in_spark_properties(properties):
+        log.info(
+            "Some OpenLineage properties with transport information are already present "
+            "in Spark properties. Skipping the injection of OpenLineage "
+            "transport information into Spark properties."
+        )
+        return properties
+
+    return {**properties, **_get_transport_information_as_spark_properties()}

--- a/providers/tests/openlineage/test_conf.py
+++ b/providers/tests/openlineage/test_conf.py
@@ -37,6 +37,7 @@ from airflow.providers.openlineage.conf import (
     namespace,
     selective_enable,
     spark_inject_parent_job_info,
+    spark_inject_transport_info,
     transport,
 )
 
@@ -63,6 +64,7 @@ _CONFIG_OPTION_DAG_STATE_CHANGE_PROCESS_POOL_SIZE = "dag_state_change_process_po
 _CONFIG_OPTION_INCLUDE_FULL_TASK_INFO = "include_full_task_info"
 _CONFIG_OPTION_DEBUG_MODE = "debug_mode"
 _CONFIG_OPTION_SPARK_INJECT_PARENT_JOB_INFO = "spark_inject_parent_job_info"
+_CONFIG_OPTION_SPARK_INJECT_TRANSPORT_INFO = "spark_inject_transport_info"
 
 _BOOL_PARAMS = (
     ("1", True),
@@ -641,3 +643,30 @@ def test_spark_inject_parent_job_info_empty_conf_option():
 @conf_vars({(_CONFIG_SECTION, _CONFIG_OPTION_SPARK_INJECT_PARENT_JOB_INFO): None})
 def test_spark_inject_parent_job_info_do_not_fail_if_conf_option_missing():
     assert spark_inject_parent_job_info() is False
+
+
+@pytest.mark.parametrize(
+    ("var_string", "expected"),
+    _BOOL_PARAMS,
+)
+def test_spark_inject_transport_info(var_string, expected):
+    with conf_vars({(_CONFIG_SECTION, _CONFIG_OPTION_SPARK_INJECT_TRANSPORT_INFO): var_string}):
+        result = spark_inject_transport_info()
+        assert result is expected
+
+
+@conf_vars({(_CONFIG_SECTION, _CONFIG_OPTION_SPARK_INJECT_TRANSPORT_INFO): "asdadawlaksnd"})
+def test_spark_inject_transport_info_not_working_for_random_string():
+    with pytest.raises(AirflowConfigException):
+        spark_inject_transport_info()
+
+
+@conf_vars({(_CONFIG_SECTION, _CONFIG_OPTION_SPARK_INJECT_TRANSPORT_INFO): ""})
+def test_spark_inject_transport_info_empty_conf_option():
+    with pytest.raises(AirflowConfigException):
+        spark_inject_transport_info()
+
+
+@conf_vars({(_CONFIG_SECTION, _CONFIG_OPTION_SPARK_INJECT_TRANSPORT_INFO): None})
+def test_spark_inject_transport_info_do_not_fail_if_conf_option_missing():
+    assert spark_inject_transport_info() is False

--- a/providers/tests/openlineage/utils/test_spark.py
+++ b/providers/tests/openlineage/utils/test_spark.py
@@ -18,14 +18,18 @@
 from __future__ import annotations
 
 import datetime as dt
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
+from openlineage.client.transport import HttpConfig, HttpTransport, KafkaConfig, KafkaTransport
 
 from airflow.providers.openlineage.utils.spark import (
     _get_parent_job_information_as_spark_properties,
+    _get_transport_information_as_spark_properties,
     _is_parent_job_information_present_in_spark_properties,
+    _is_transport_information_present_in_spark_properties,
     inject_parent_job_information_into_spark_properties,
+    inject_transport_information_into_spark_properties,
 )
 
 EXAMPLE_CONTEXT = {
@@ -37,16 +41,69 @@ EXAMPLE_CONTEXT = {
         logical_date=dt.datetime(2024, 11, 11),
     )
 }
+EXAMPLE_HTTP_TRANSPORT_CONFIG = {
+    "url": "https://some-custom.url",
+    "endpoint": "/api/custom",
+    "timeout": 123,
+    "compression": "gzip",
+    "custom_headers": {
+        "key1": "val1",
+        "key2": "val2",
+    },
+    "auth": {
+        "type": "api_key",
+        "apiKey": "secret_123",
+    },
+}
 EXAMPLE_PARENT_JOB_SPARK_PROPERTIES = {
     "spark.openlineage.parentJobName": "dag_id.task_id",
     "spark.openlineage.parentJobNamespace": "default",
     "spark.openlineage.parentRunId": "01931885-2800-7be7-aa8d-aaa15c337267",
+}
+EXAMPLE_TRANSPORT_SPARK_PROPERTIES = {
+    "spark.openlineage.transport.type": "http",
+    "spark.openlineage.transport.url": "https://some-custom.url",
+    "spark.openlineage.transport.endpoint": "/api/custom",
+    "spark.openlineage.transport.auth.type": "api_key",
+    "spark.openlineage.transport.auth.apiKey": "Bearer secret_123",
+    "spark.openlineage.transport.compression": "gzip",
+    "spark.openlineage.transport.headers.key1": "val1",
+    "spark.openlineage.transport.headers.key2": "val2",
+    "spark.openlineage.transport.timeoutInMillis": "123000",
 }
 
 
 def test_get_parent_job_information_as_spark_properties():
     result = _get_parent_job_information_as_spark_properties(EXAMPLE_CONTEXT)
     assert result == EXAMPLE_PARENT_JOB_SPARK_PROPERTIES
+
+
+@patch("airflow.providers.openlineage.plugins.listener._openlineage_listener")
+def test_get_transport_information_as_spark_properties(mock_ol_listener):
+    mock_ol_listener.adapter.get_or_create_openlineage_client.return_value.transport = HttpTransport(
+        HttpConfig.from_dict(EXAMPLE_HTTP_TRANSPORT_CONFIG)
+    )
+    result = _get_transport_information_as_spark_properties()
+    assert result == EXAMPLE_TRANSPORT_SPARK_PROPERTIES
+
+
+@patch("airflow.providers.openlineage.plugins.listener._openlineage_listener")
+def test_get_transport_information_as_spark_properties_unsupported_transport_type(mock_ol_listener):
+    kafka_config = KafkaConfig(
+        topic="my_topic",
+        config={
+            "bootstrap.servers": "localhost:9092,another.host:9092",
+            "acks": "all",
+            "retries": "3",
+        },
+        flush=True,
+        messageKey="some",
+    )
+    mock_ol_listener.adapter.get_or_create_openlineage_client.return_value.transport = KafkaTransport(
+        kafka_config
+    )
+    result = _get_transport_information_as_spark_properties()
+    assert result == {}
 
 
 @pytest.mark.parametrize(
@@ -80,10 +137,47 @@ def test_get_parent_job_information_as_spark_properties():
             },
             True,
         ),
+        (
+            {},
+            False,
+        ),
     ],
 )
 def test_is_parent_job_information_present_in_spark_properties(properties, expected):
     assert _is_parent_job_information_present_in_spark_properties(properties) is expected
+
+
+@pytest.mark.parametrize(
+    "properties, expected",
+    [
+        (
+            {"spark.openlineage.transport": "example_namespace"},
+            True,
+        ),
+        (
+            {"spark.openlineage.transport.type": "some_job_name"},
+            True,
+        ),
+        (
+            {"spark.openlineage.transport.urlParams.value1": "some_run_id"},
+            True,
+        ),
+        (
+            {"spark.openlineage.transportWhatever": "some_value", "some.other.property": "value"},
+            True,
+        ),
+        (
+            {"some.other.property": "value"},
+            False,
+        ),
+        (
+            {},
+            False,
+        ),
+    ],
+)
+def test_is_transport_information_present_in_spark_properties(properties, expected):
+    assert _is_transport_information_present_in_spark_properties(properties) is expected
 
 
 @pytest.mark.parametrize(
@@ -126,4 +220,43 @@ def test_is_parent_job_information_present_in_spark_properties(properties, expec
 def test_inject_parent_job_information_into_spark_properties(properties, should_inject):
     result = inject_parent_job_information_into_spark_properties(properties, EXAMPLE_CONTEXT)
     expected = {**properties, **EXAMPLE_PARENT_JOB_SPARK_PROPERTIES} if should_inject else properties
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "properties, should_inject",
+    [
+        (
+            {"spark.openlineage.transport": "example_namespace"},
+            False,
+        ),
+        (
+            {"spark.openlineage.transport.type": "some_job_name"},
+            False,
+        ),
+        (
+            {"spark.openlineage.transport.url": "some_run_id"},
+            False,
+        ),
+        (
+            {"spark.openlineage.transportWhatever": "some_value", "some.other.property": "value"},
+            False,
+        ),
+        (
+            {"some.other.property": "value"},
+            True,
+        ),
+        (
+            {},
+            True,
+        ),
+    ],
+)
+@patch("airflow.providers.openlineage.plugins.listener._openlineage_listener")
+def test_inject_transport_information_into_spark_properties(mock_ol_listener, properties, should_inject):
+    mock_ol_listener.adapter.get_or_create_openlineage_client.return_value.transport = HttpTransport(
+        HttpConfig.from_dict(EXAMPLE_HTTP_TRANSPORT_CONFIG)
+    )
+    result = inject_transport_information_into_spark_properties(properties, EXAMPLE_CONTEXT)
+    expected = {**properties, **EXAMPLE_TRANSPORT_SPARK_PROPERTIES} if should_inject else properties
     assert result == expected


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Similar to #44477 , this PR introduces a new feature to OpenLineage integration. **It will NOT impact users that are not using OpenLineage or have not explicitly enabled this feature (False by default).**

## TLDR; 
When explicitly enabled by the user for supported operators, we will automatically inject transport information into the Spark job properties. For example, when submitting a Spark job using the DataprocSubmitJobOperator, we will configure  Spark/OpenLineage integration to use the same transport configuration that Airflow integration uses.

## Why ?

Currently, this process requires manual configuration by the user, as described [here](https://openlineage.io/docs/integrations/spark/configuration/airflow/). E.g.:
```
DataprocSubmitJobOperator(
    task_id="my_task", 
    # ... 
    job={ 
        # ...
        "spark.openlineage.transport.type": "http",
        "spark.openlineage.transport.url": openlineage_url,
        "spark.openlineage.transport.compression": "gzip",
        "spark.openlineage.transport.auth.apiKey": api_key,
        "spark.openlineage.transport.auth.type": "apiKey",
    } 
)

```
Understanding how various Airflow operators configure Spark allows us to automatically inject transport information.

## Controlling the Behavior

We provide users with a flexible control mechanism to manage this injection, combining per-operator enablement with a global fallback configuration. This design is inspired by the `deferrable` argument in Airflow.

```python
ol_inject_transport_info: bool = conf.getboolean(
    "openlineage", "spark_inject_transport_info", fallback=False
)
```
Each supported operator will include an argument like `ol_inject_transport_info`, which defaults to the global configuration value of `openlineage.spark_inject_transport_info`. This approach allows users to:

1. Control behavior on a per-job basis by explicitly setting the argument.
2. Rely on a consistent default configuration for all jobs if the argument is not set.

This design ensures both flexibility and ease of use, enabling users to fine-tune their workflows while minimizing repetitive configuration. I am aware that adding an OpenLineage-related argument to the operator will affect all users, even those not using OpenLineage, but since it defaults to False and can be ignored, I hope this will not pose any issues.

## How?
The implementation is divided into three parts for better organization and clarity:

1. **Operator's Code (including the `execute` method):**  
   Contains minimal logic to avoid overwhelming users who are not actively working with OpenLineage.

2. **Google's Provider OpenLineage Utils File:**  
   Handles the logic for accessing Spark properties specific to a given operator or job.

3. **OpenLineage Provider's Utils:**  
   Responsible for creating / extracting all necessary information in a format compatible with the OpenLineage Spark integration. We are also performing modifications to the Spark properties here.

For some operators parts 1 and 2 may be in the operator's code. In general, the specific operator / provider will know how to get the spark properties and the OL will know what to inject and do the injection itself.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
