### PR TITLE
Temporarily remove support for `dags reserialize` command

### DIFF
--- a/airflow/cli/commands/remote_commands/dag_command.py
+++ b/airflow/cli/commands/remote_commands/dag_command.py
@@ -537,5 +537,7 @@ def dag_test(args, dag: DAG | None = None, session: Session = NEW_SESSION) -> No
 @provide_session
 def dag_reserialize(args, session: Session = NEW_SESSION) -> None:
     """Serialize a DAG instance."""
-    dagbag = DagBag(process_subdir(args.subdir))
-    dagbag.sync_to_db(session=session)
+    # TODO: AIP-66 bundle centric reserialize
+    raise NotImplementedError(
+        "AIP-66: This command is not implemented yet - use `dag-processor --num-runs 1` in the meantime."
+    )

--- a/tests/cli/commands/remote_commands/test_dag_command.py
+++ b/tests/cli/commands/remote_commands/test_dag_command.py
@@ -80,6 +80,7 @@ class TestCliDags:
     def setup_method(self):
         clear_db_runs()  # clean-up all dag run before start each test
 
+    @pytest.mark.skip("AIP-66: reserialize is not implemented yet")
     def test_reserialize(self, session):
         # Assert that there are serialized Dags
         serialized_dags_before_command = session.query(SerializedDagModel).all()
@@ -99,6 +100,7 @@ class TestCliDags:
         dag_version_after_command = session.query(DagVersion).all()
         assert len(dag_version_after_command)
 
+    @pytest.mark.skip("AIP-66: reserialize is not implemented yet")
     def test_reserialize_should_support_subdir_argument(self, session):
         # Run clear of serialized dags
         session.query(DagVersion).delete()


### PR DESCRIPTION
As we work toward getting bundle parsing support in main (#42289), it'll be easier for reviewers to review the new `dags reserialize` command separate from the rest of the parsing changes (that PR will be rather large already). But in the meantime, simply using DagBag on a single directory won't continue working.

Tracking issue to add it back: #45336