### PR TITLE
AIP-72: Gracefully handle 'not-found' XCOMs in task sdk API client

### DIFF
--- a/task_sdk/src/airflow/sdk/api/client.py
+++ b/task_sdk/src/airflow/sdk/api/client.py
@@ -237,6 +237,7 @@ class XComOperations:
                 # Hence returning with key as `key` and value as `None`, so that the message is sent back to task runner
                 # and the default value of None in xcom_pull is used.
                 return XComResponse(key=key, value=None)
+            raise
         return XComResponse.model_validate_json(resp.read())
 
     def set(

--- a/task_sdk/src/airflow/sdk/api/client.py
+++ b/task_sdk/src/airflow/sdk/api/client.py
@@ -219,7 +219,24 @@ class XComOperations:
         params = {}
         if map_index is not None:
             params.update({"map_index": map_index})
-        resp = self.client.get(f"xcoms/{dag_id}/{run_id}/{task_id}/{key}", params=params)
+        try:
+            resp = self.client.get(f"xcoms/{dag_id}/{run_id}/{task_id}/{key}", params=params)
+        except ServerResponseError as e:
+            if e.response.status_code == HTTPStatus.NOT_FOUND:
+                log.error(
+                    "XCom not found",
+                    dag_id=dag_id,
+                    run_id=run_id,
+                    task_id=task_id,
+                    key=key,
+                    map_index=map_index,
+                    detail=e.detail,
+                    status_code=e.response.status_code,
+                )
+                # Airflow 2.x just ignores the absence of an XCom and moves on with a return value of None
+                # Hence returning with key as `key` and value as `None`, so that the message is sent back to task runner
+                # and the default value of None in xcom_pull is used.
+                return XComResponse(key=key, value=None)
         return XComResponse.model_validate_json(resp.read())
 
     def set(

--- a/task_sdk/tests/api/test_client.py
+++ b/task_sdk/tests/api/test_client.py
@@ -460,6 +460,30 @@ class TestXCOMOperations:
         assert result.key == "test_key"
         assert result.value == "test_value"
 
+    @mock.patch("time.sleep", return_value=None)
+    def test_xcom_get_500_error(self, mock_sleep):
+        # Simulate a successful response from the server returning a 500 error
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/xcoms/dag_id/run_id/task_id/key":
+                return httpx.Response(
+                    status_code=500,
+                    headers=[("content-Type", "application/json")],
+                    json={
+                        "reason": "invalid_format",
+                        "message": "XCom value is not a valid JSON",
+                    },
+                )
+            return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+
+        client = make_client(transport=httpx.MockTransport(handle_request))
+        with pytest.raises(ServerResponseError):
+            client.xcoms.get(
+                dag_id="dag_id",
+                run_id="run_id",
+                task_id="task_id",
+                key="key",
+            )
+
     @pytest.mark.parametrize(
         "values",
         [

--- a/task_sdk/tests/execution_time/test_supervisor.py
+++ b/task_sdk/tests/execution_time/test_supervisor.py
@@ -832,6 +832,14 @@ class TestHandleRequest:
                 id="get_xcom_map_index",
             ),
             pytest.param(
+                GetXCom(dag_id="test_dag", run_id="test_run", task_id="test_task", key="test_key"),
+                b'{"key":"test_key","value":null,"type":"XComResult"}\n',
+                "xcoms.get",
+                ("test_dag", "test_run", "test_task", "test_key", None),
+                XComResult(key="test_key", value=None, type="XComResult"),
+                id="get_xcom_not_found",
+            ),
+            pytest.param(
                 SetXCom(
                     dag_id="test_dag",
                     run_id="test_run",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #45341 

### Testing results
DAG used:
```
from airflow import DAG
from airflow.providers.standard.operators.python import PythonOperator

def push_to_xcom(**kwargs):
    value = "Hello, XCom!"
    return value


def pull_from_xcom(**kwargs):
    ti = kwargs['ti']
    xcom_value = ti.xcom_pull(task_ids='invalid_id')
    print(f"Retrieved XCom Value: {xcom_value}")


with DAG(
    'xcom_example',
    schedule=None,
    catchup=False,
) as dag:

    push_xcom_task = PythonOperator(
        task_id='push_xcom_task',
        python_callable=push_to_xcom,
    )

    pull_xcom_task = PythonOperator(
        task_id='pull_xcom_task',
        python_callable=pull_from_xcom,
    )

    push_xcom_task >> pull_xcom_task
```

#### Legacy
Task 1 XCom pushed:
<img width="1727" alt="image" src="https://github.com/user-attachments/assets/b4ab2d7a-72e4-4e13-ba0d-2b3faa7aee7f" />

Task 2 XCom consumed as None when absent:
<img width="1727" alt="image" src="https://github.com/user-attachments/assets/461744d5-6c77-4630-b98f-87d7d0942b67" />



#### Task SDK
Task 1 XCom pushed:
<img width="1727" alt="image" src="https://github.com/user-attachments/assets/c3967e43-8c56-4779-ab00-c724c2d18ab3" />

Task 2 XCom consumed as None when absent:
<img width="1727" alt="image" src="https://github.com/user-attachments/assets/1a3c30ca-e0e8-47d4-a555-c4311b4ca094" />


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
