### PR TITLE
Workaround problems after release of pytest-asyncio 0.25.1 with Python 3.12

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -258,7 +258,7 @@ DEVEL_EXTRAS: dict[str, list[str]] = {
         "deepdiff>=8.1.1",
         "jmespath>=0.7.0",
         "kgb>=7.0.0",
-        "pytest-asyncio>=0.23.6",
+        "pytest-asyncio>=0.23.6,!=0.25.1",
         "pytest-cov>=4.1.0",
         "pytest-custom-exit-code>=0.3.0",
         "pytest-icdiff>=0.9",

--- a/task_sdk/pyproject.toml
+++ b/task_sdk/pyproject.toml
@@ -79,7 +79,7 @@ namespace-packages = ["src/airflow"]
 [tool.uv]
 dev-dependencies = [
     "kgb>=7.1.1",
-    "pytest-asyncio>=0.24.0",
+    "pytest-asyncio>=0.24.0,!=0.25.1",
     "pytest-mock>=3.14.0",
     "pytest-unordered>=0.6.1",
     "pytest>=8.3.3",


### PR DESCRIPTION
Fixes broken canary after release of pytest-asyncio 0.25.1
see https://github.com/apache/airflow/actions/runs/12579028168
As well https://github.com/apache/airflow/actions/runs/12579028168