### PR TITLE
fix: spark operator label

### DIFF
--- a/providers/src/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
+++ b/providers/src/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from functools import cached_property
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from kubernetes.client import CoreV1Api, CustomObjectsApi, models as k8s
 
@@ -188,7 +188,7 @@ class SparkKubernetesOperator(KubernetesPodOperator):
         if not context:
             return {}
 
-        context_dict = cast(Dict, context)
+        context_dict = cast(dict, context)
         ti = context_dict["ti"]
         run_id = context_dict["run_id"]
 

--- a/providers/src/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
+++ b/providers/src/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
@@ -177,7 +177,7 @@ class SparkKubernetesOperator(KubernetesPodOperator):
         return self._set_name(updated_name)
 
     @staticmethod
-    def _get_pod_identifying_label_string(labels) -> str:
+    def _build_find_pod_label_selector(labels) -> str:
         filtered_labels = {label_id: label for label_id, label in labels.items() if label_id != "try_number"}
         return ",".join([label_id + "=" + label for label_id, label in sorted(filtered_labels.items())])
 
@@ -238,7 +238,7 @@ class SparkKubernetesOperator(KubernetesPodOperator):
 
     def find_spark_job(self, context):
         labels = self._get_ti_pod_labels(context, include_try_number=False)
-        label_selector = self._get_pod_identifying_label_string(labels) + ",spark-role=driver"
+        label_selector = self._build_find_pod_label_selector(labels) + ",spark-role=driver"
         pod_list = self.client.list_namespaced_pod(self.namespace, label_selector=label_selector).items
 
         pod = None

--- a/providers/src/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
+++ b/providers/src/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
@@ -177,12 +177,6 @@ class SparkKubernetesOperator(KubernetesPodOperator):
         return self._set_name(updated_name)
 
     @staticmethod
-    def _build_find_pod_label_selector(labels) -> str:
-        filtered_labels = {label_id: label for label_id, label in labels.items() if label_id != "try_number"}
-        return ",".join([label_id + "=" + label for label_id, label in sorted(filtered_labels.items())])
-
-
-    @staticmethod
     def _get_ti_pod_labels(context: Context | None = None, include_try_number: bool = True) -> dict[str, str]:
         """
         Generate labels for the pod to track the pod in case of Operator crash.
@@ -236,9 +230,8 @@ class SparkKubernetesOperator(KubernetesPodOperator):
         """Templated body for CustomObjectLauncher."""
         return self.manage_template_specs()
 
-    def find_spark_job(self, context):
-        labels = self._get_ti_pod_labels(context, include_try_number=False)
-        label_selector = self._build_find_pod_label_selector(labels) + ",spark-role=driver"
+    def find_spark_job(self, context, exclude_checked: bool = True):
+        label_selector = self._build_find_pod_label_selector(context, exclude_checked=exclude_checked) + ",spark-role=driver"
         pod_list = self.client.list_namespaced_pod(self.namespace, label_selector=label_selector).items
 
         pod = None

--- a/providers/src/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
+++ b/providers/src/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
@@ -181,8 +181,9 @@ class SparkKubernetesOperator(KubernetesPodOperator):
         filtered_labels = {label_id: label for label_id, label in labels.items() if label_id != "try_number"}
         return ",".join([label_id + "=" + label for label_id, label in sorted(filtered_labels.items())])
 
+
     @staticmethod
-    def create_labels_for_pod(context: dict | None = None, include_try_number: bool = True) -> dict:
+    def _get_ti_pod_labels(context: Context | None = None, include_try_number: bool = True) -> dict[str, str]:
         """
         Generate labels for the pod to track the pod in case of Operator crash.
 
@@ -236,7 +237,7 @@ class SparkKubernetesOperator(KubernetesPodOperator):
         return self.manage_template_specs()
 
     def find_spark_job(self, context):
-        labels = self.create_labels_for_pod(context, include_try_number=False)
+        labels = self._get_ti_pod_labels(context, include_try_number=False)
         label_selector = self._get_pod_identifying_label_string(labels) + ",spark-role=driver"
         pod_list = self.client.list_namespaced_pod(self.namespace, label_selector=label_selector).items
 

--- a/providers/tests/cncf/kubernetes/operators/test_spark_kubernetes.py
+++ b/providers/tests/cncf/kubernetes/operators/test_spark_kubernetes.py
@@ -711,7 +711,8 @@ class TestSparkKubernetesOperator:
         mock_await_pod_start,
         mock_await_pod_completion,
         mock_fetch_requested_container_logs,
-        data_file,):
+        data_file,
+    ):
         task_name = "test_find_custom_pod_labels"
         job_spec = yaml.safe_load(data_file("spark/application_template.yaml").read_text())
 
@@ -724,14 +725,9 @@ class TestSparkKubernetesOperator:
         )
         context = create_context(op)
         op.execute(context)
-        label_selector = (
-            op._build_find_pod_label_selector(context)
-            + ",spark-role=driver"
-        )
+        label_selector = op._build_find_pod_label_selector(context) + ",spark-role=driver"
         op.find_spark_job(context)
-        mock_get_kube_client.list_namespaced_pod.assert_called_with(
-            'default', label_selector=label_selector
-        )
+        mock_get_kube_client.list_namespaced_pod.assert_called_with("default", label_selector=label_selector)
 
 
 @pytest.mark.db_test

--- a/providers/tests/cncf/kubernetes/operators/test_spark_kubernetes.py
+++ b/providers/tests/cncf/kubernetes/operators/test_spark_kubernetes.py
@@ -700,6 +700,40 @@ class TestSparkKubernetesOperator:
         )
 
 
+    def test_find_custom_pod_labels(
+        self,
+        mock_create_namespaced_crd,
+        mock_get_namespaced_custom_object_status,
+        mock_cleanup,
+        mock_create_job_name,
+        mock_get_kube_client,
+        mock_create_pod,
+        mock_await_pod_start,
+        mock_await_pod_completion,
+        mock_fetch_requested_container_logs,
+        data_file,):
+        task_name = "test_find_custom_pod_labels"
+        job_spec = yaml.safe_load(data_file("spark/application_template.yaml").read_text())
+
+        mock_create_job_name.return_value = task_name
+        op = SparkKubernetesOperator(
+            template_spec=job_spec,
+            kubernetes_conn_id="kubernetes_default_kube_config",
+            task_id=task_name,
+            get_logs=True,
+        )
+        context = create_context(op)
+        op.execute(context)
+        label_selector = (
+            op._build_find_pod_label_selector(context)
+            + ",spark-role=driver"
+        )
+        op.find_spark_job(context)
+        mock_get_kube_client.list_namespaced_pod.assert_called_with(
+            'default', label_selector=label_selector
+        )
+
+
 @pytest.mark.db_test
 def test_template_body_templating(create_task_instance_of_operator, session):
     ti = create_task_instance_of_operator(

--- a/providers/tests/cncf/kubernetes/operators/test_spark_kubernetes.py
+++ b/providers/tests/cncf/kubernetes/operators/test_spark_kubernetes.py
@@ -699,7 +699,6 @@ class TestSparkKubernetesOperator:
             follow_logs=True,
         )
 
-
     def test_find_custom_pod_labels(
         self,
         mock_create_namespaced_crd,


### PR DESCRIPTION
KubernetesPodOperator renamed create_labels_for_pod, _get_pod_identifying_label_string, but it seems that SparkKubernetesOperator hasn't changed them.