### PR TITLE
Refactor DAG.create_dagrun() arguments

### DIFF
--- a/airflow/api/common/trigger_dag.py
+++ b/airflow/api/common/trigger_dag.py
@@ -101,12 +101,13 @@ def _trigger_dag(
     dag_run = dag.create_dagrun(
         run_id=run_id,
         logical_date=logical_date,
-        state=DagRunState.QUEUED,
+        data_interval=data_interval,
         conf=run_conf,
+        run_type=DagRunType.MANUAL,
+        triggered_by=triggered_by,
         external_trigger=True,
         dag_version=dag_version,
-        data_interval=data_interval,
-        triggered_by=triggered_by,
+        state=DagRunState.QUEUED,
         session=session,
     )
 

--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -347,18 +347,17 @@ def post_dag_run(*, dag_id: str, session: Session = NEW_SESSION) -> APIResponse:
                 )
             else:
                 data_interval = dag.timetable.infer_manual_data_interval(run_after=logical_date)
-            dag_version = DagVersion.get_latest_version(dag.dag_id)
             dag_run = dag.create_dagrun(
-                run_type=DagRunType.MANUAL,
                 run_id=run_id,
                 logical_date=logical_date,
                 data_interval=data_interval,
-                state=DagRunState.QUEUED,
                 conf=post_body.get("conf"),
-                external_trigger=True,
-                dag_version=dag_version,
-                session=session,
+                run_type=DagRunType.MANUAL,
                 triggered_by=DagRunTriggeredByType.REST_API,
+                external_trigger=True,
+                dag_version=DagVersion.get_latest_version(dag.dag_id),
+                state=DagRunState.QUEUED,
+                session=session,
             )
             dag_run_note = post_body.get("note")
             if dag_run_note:

--- a/airflow/cli/commands/remote_commands/task_command.py
+++ b/airflow/cli/commands/remote_commands/task_command.py
@@ -66,7 +66,7 @@ from airflow.utils.providers_configuration_loader import providers_configuration
 from airflow.utils.session import NEW_SESSION, create_session, provide_session
 from airflow.utils.state import DagRunState
 from airflow.utils.task_instance_session import set_current_task_instance_session
-from airflow.utils.types import DagRunTriggeredByType
+from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 if TYPE_CHECKING:
     from typing import Literal
@@ -180,12 +180,14 @@ def _get_dag_run(
         return dag_run, True
     elif create_if_necessary == "db":
         dag_run = dag.create_dagrun(
-            state=DagRunState.QUEUED,
-            logical_date=dag_run_logical_date,
             run_id=_generate_temporary_run_id(),
+            logical_date=dag_run_logical_date,
             data_interval=dag.timetable.infer_manual_data_interval(run_after=dag_run_logical_date),
-            session=session,
+            run_type=DagRunType.MANUAL,
             triggered_by=DagRunTriggeredByType.CLI,
+            dag_version=None,
+            state=DagRunState.QUEUED,
+            session=session,
         )
         return dag_run, True
     raise ValueError(f"unknown create_if_necessary value: {create_if_necessary!r}")

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1775,6 +1775,14 @@ class DAG(TaskSDKDag, LoggingMixin):
                 f"the configured pattern: {regex!r} or the built-in pattern: {RUN_ID_REGEX!r}"
             )
 
+        # Prevent a manual run from using an ID that looks like a scheduled run.
+        if run_type == DagRunType.MANUAL:
+            if (inferred_run_type := DagRunType.from_run_id(run_id)) != DagRunType.MANUAL:
+                raise ValueError(
+                    f"A {run_type.value} DAG run cannot use ID {run_id!r} since it "
+                    f"is reserved for {inferred_run_type.value} runs"
+                )
+
         # todo: AIP-78 add verification that if run type is backfill then we have a backfill id
 
         if TYPE_CHECKING:

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1758,7 +1758,7 @@ class DAG(TaskSDKDag, LoggingMixin):
         """
         logical_date = timezone.coerce_datetime(logical_date)
 
-        if data_interval and not isinstance(data_interval, DataInterval):
+        if not isinstance(data_interval, DataInterval):
             data_interval = DataInterval(*map(timezone.coerce_datetime, data_interval))
 
         if isinstance(run_type, DagRunType):
@@ -1767,6 +1767,9 @@ class DAG(TaskSDKDag, LoggingMixin):
             run_type = DagRunType(run_type)
         else:
             raise ValueError(f"run_type should be a DagRunType, not {type(run_type)}")
+
+        if not isinstance(run_id, str):
+            raise ValueError(f"`run_id` should be a str, not {type(run_id)}")
 
         # Prevent a manual run from using an ID that looks like a scheduled run.
         if run_type == DagRunType.MANUAL:
@@ -1791,7 +1794,7 @@ class DAG(TaskSDKDag, LoggingMixin):
             dag=self,
             run_id=run_id,
             logical_date=logical_date,
-            start_date=start_date,
+            start_date=timezone.coerce_datetime(start_date),
             external_trigger=external_trigger,
             conf=conf,
             state=state,

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -83,7 +83,7 @@ from airflow.models.asset import (
 from airflow.models.base import Base, StringID
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.dag_version import DagVersion
-from airflow.models.dagrun import RUN_ID_REGEX, DagRun
+from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import (
     Context,
     TaskInstance,
@@ -1767,13 +1767,6 @@ class DAG(TaskSDKDag, LoggingMixin):
             run_type = DagRunType(run_type)
         else:
             raise ValueError(f"run_type should be a DagRunType, not {type(run_type)}")
-
-        regex = airflow_conf.get("scheduler", "allowed_run_id_pattern").strip()
-        if not re2.match(RUN_ID_REGEX, run_id) and not (regex or re2.match(regex, run_id)):
-            raise AirflowException(
-                f"The provided run ID {run_id!r} is invalid. It does not match either "
-                f"the configured pattern: {regex!r} or the built-in pattern: {RUN_ID_REGEX!r}"
-            )
 
         # Prevent a manual run from using an ID that looks like a scheduled run.
         if run_type == DagRunType.MANUAL:

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1758,7 +1758,7 @@ class DAG(TaskSDKDag, LoggingMixin):
         """
         logical_date = timezone.coerce_datetime(logical_date)
 
-        if not isinstance(data_interval, DataInterval):
+        if data_interval and not isinstance(data_interval, DataInterval):
             data_interval = DataInterval(*map(timezone.coerce_datetime, data_interval))
 
         if isinstance(run_type, DagRunType):

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -246,31 +246,24 @@ def _triggerer_is_healthy():
 
 @provide_session
 def _create_orm_dagrun(
-    dag,
-    dag_id,
-    run_id,
-    logical_date,
-    start_date,
-    external_trigger,
-    conf,
-    state,
-    run_type,
-    dag_version,
-    creating_job_id,
-    data_interval,
-    backfill_id,
-    session,
-    triggered_by,
-):
-    bundle_version = session.scalar(
-        select(
-            DagModel.latest_bundle_version,
-        ).where(
-            DagModel.dag_id == dag.dag_id,
-        )
-    )
+    *,
+    dag: DAG,
+    run_id: str,
+    logical_date: datetime | None,
+    data_interval: DataInterval | None,
+    start_date: datetime | None,
+    external_trigger: bool,
+    conf: Any,
+    state: DagRunState | None,
+    run_type: DagRunType,
+    dag_version: DagVersion | None,
+    creating_job_id: int | None,
+    backfill_id: int | None,
+    triggered_by: DagRunTriggeredByType,
+    session: Session = NEW_SESSION,
+) -> DagRun:
     run = DagRun(
-        dag_id=dag_id,
+        dag_id=dag.dag_id,
         run_id=run_id,
         logical_date=logical_date,
         start_date=start_date,
@@ -283,7 +276,9 @@ def _create_orm_dagrun(
         data_interval=data_interval,
         triggered_by=triggered_by,
         backfill_id=backfill_id,
-        bundle_version=bundle_version,
+        bundle_version=session.scalar(
+            select(DagModel.latest_bundle_version).where(DagModel.dag_id == dag.dag_id)
+        ),
     )
     # Load defaults into the following two fields to ensure result can be serialized detached
     run.log_template_id = int(session.scalar(select(func.max(LogTemplate.__table__.c.id))))
@@ -1735,87 +1730,50 @@ class DAG(TaskSDKDag, LoggingMixin):
     @provide_session
     def create_dagrun(
         self,
-        state: DagRunState,
         *,
-        triggered_by: DagRunTriggeredByType | None,
-        logical_date: datetime | None = None,
-        run_id: str | None = None,
-        start_date: datetime | None = None,
-        external_trigger: bool | None = False,
+        run_id: str,
+        logical_date: datetime,
+        data_interval: tuple[datetime, datetime],
         conf: dict | None = None,
-        run_type: DagRunType | None = None,
-        session: Session = NEW_SESSION,
-        dag_version: DagVersion | None = None,
+        run_type: DagRunType,
+        triggered_by: DagRunTriggeredByType,
+        external_trigger: bool = False,
+        dag_version: DagVersion | None,
+        state: DagRunState,
+        start_date: datetime | None = None,
         creating_job_id: int | None = None,
-        data_interval: tuple[datetime, datetime] | None = None,
         backfill_id: int | None = None,
-    ):
+        session: Session = NEW_SESSION,
+    ) -> DagRun:
         """
-        Create a dag run from this dag including the tasks associated with this dag.
+        Create a run for this DAG to run its tasks.
 
-        Returns the dag run.
-
-        :param state: the state of the dag run
-        :param triggered_by: The entity which triggers the DagRun
-        :param run_id: defines the run id for this dag run
-        :param run_type: type of DagRun
-        :param logical_date: the logical date of this dag run
         :param start_date: the date this dag run should be evaluated
-        :param external_trigger: whether this dag run is externally triggered
         :param conf: Dict containing configuration/parameters to pass to the DAG
-        :param creating_job_id: id of the job creating this DagRun
-        :param session: database session
-        :param dag_version: The DagVersion object for this run
-        :param data_interval: Data interval of the DagRun
-        :param backfill_id: id of the backfill run if one exists
+        :param creating_job_id: ID of the job creating this DagRun
+        :param backfill_id: ID of the backfill run if one exists
+        :return: The created DAG run.
+
+        :meta private:
         """
         logical_date = timezone.coerce_datetime(logical_date)
 
         if data_interval and not isinstance(data_interval, DataInterval):
             data_interval = DataInterval(*map(timezone.coerce_datetime, data_interval))
 
-        if data_interval is None and logical_date is not None:
-            raise ValueError(
-                "Calling `DAG.create_dagrun()` without an explicit data interval is not supported."
-            )
-
-        if run_type is None or isinstance(run_type, DagRunType):
+        if isinstance(run_type, DagRunType):
             pass
-        elif isinstance(run_type, str):  # Compatibility: run_type used to be a str.
+        elif isinstance(run_type, str):  # Ensure the input value is valid.
             run_type = DagRunType(run_type)
         else:
-            raise ValueError(f"`run_type` should be a DagRunType, not {type(run_type)}")
+            raise ValueError(f"run_type should be a DagRunType, not {type(run_type)}")
 
-        if run_id:  # Infer run_type from run_id if needed.
-            if not isinstance(run_id, str):
-                raise ValueError(f"`run_id` should be a str, not {type(run_id)}")
-            inferred_run_type = DagRunType.from_run_id(run_id)
-            if run_type is None:
-                # No explicit type given, use the inferred type.
-                run_type = inferred_run_type
-            elif run_type == DagRunType.MANUAL and inferred_run_type != DagRunType.MANUAL:
-                # Prevent a manual run from using an ID that looks like a scheduled run.
-                raise ValueError(
-                    f"A {run_type.value} DAG run cannot use ID {run_id!r} since it "
-                    f"is reserved for {inferred_run_type.value} runs"
-                )
-        elif run_type and logical_date is not None:  # Generate run_id from run_type and logical_date.
-            run_id = self.timetable.generate_run_id(
-                run_type=run_type, logical_date=logical_date, data_interval=data_interval
-            )
-        else:
+        regex = airflow_conf.get("scheduler", "allowed_run_id_pattern").strip()
+        if not re2.match(RUN_ID_REGEX, run_id) and not (regex or re2.match(regex, run_id)):
             raise AirflowException(
-                "Creating DagRun needs either `run_id` or both `run_type` and `logical_date`"
+                f"The provided run ID {run_id!r} is invalid. It does not match either "
+                f"the configured pattern: {regex!r} or the built-in pattern: {RUN_ID_REGEX!r}"
             )
-
-        regex = airflow_conf.get("scheduler", "allowed_run_id_pattern")
-
-        if run_id and not re2.match(RUN_ID_REGEX, run_id):
-            if not regex.strip() or not re2.match(regex.strip(), run_id):
-                raise AirflowException(
-                    f"The provided run ID '{run_id}' is invalid. It does not match either "
-                    f"the configured pattern: '{regex}' or the built-in pattern: '{RUN_ID_REGEX}'"
-                )
 
         # todo: AIP-78 add verification that if run type is backfill then we have a backfill id
 
@@ -1824,12 +1782,12 @@ class DAG(TaskSDKDag, LoggingMixin):
             assert self.params
         # create a copy of params before validating
         copied_params = copy.deepcopy(self.params)
-        copied_params.update(conf or {})
+        if conf:
+            copied_params.update(conf)
         copied_params.validate()
 
-        run = _create_orm_dagrun(
+        return _create_orm_dagrun(
             dag=self,
-            dag_id=self.dag_id,
             run_id=run_id,
             logical_date=logical_date,
             start_date=start_date,
@@ -1841,10 +1799,9 @@ class DAG(TaskSDKDag, LoggingMixin):
             creating_job_id=creating_job_id,
             backfill_id=backfill_id,
             data_interval=data_interval,
-            session=session,
             triggered_by=triggered_by,
+            session=session,
         )
-        return run
 
     @classmethod
     @provide_session
@@ -2487,14 +2444,15 @@ def _run_task(
 
 
 def _get_or_create_dagrun(
+    *,
     dag: DAG,
-    conf: dict[Any, Any] | None,
-    start_date: datetime,
-    logical_date: datetime,
     run_id: str,
-    session: Session,
+    logical_date: datetime,
+    data_interval: tuple[datetime, datetime],
+    conf: dict | None,
     triggered_by: DagRunTriggeredByType,
-    data_interval: tuple[datetime, datetime] | None = None,
+    start_date: datetime,
+    session: Session,
 ) -> DagRun:
     """
     Create a DAG run, replacing an existing instance if needed to prevent collisions.
@@ -2510,24 +2468,23 @@ def _get_or_create_dagrun(
 
     :return: The newly created DAG run.
     """
-    log.info("dagrun id: %s", dag.dag_id)
     dr: DagRun = session.scalar(
         select(DagRun).where(DagRun.dag_id == dag.dag_id, DagRun.logical_date == logical_date)
     )
     if dr:
         session.delete(dr)
         session.commit()
-    dag_version = DagVersion.get_latest_version(dag.dag_id, session=session)
     dr = dag.create_dagrun(
-        state=DagRunState.RUNNING,
-        logical_date=logical_date,
         run_id=run_id,
+        logical_date=logical_date,
+        data_interval=data_interval,
+        conf=conf,
+        run_type=DagRunType.MANUAL,
+        state=DagRunState.RUNNING,
+        triggered_by=triggered_by,
+        dag_version=DagVersion.get_latest_version(dag.dag_id, session=session),
         start_date=start_date or logical_date,
         session=session,
-        conf=conf,
-        data_interval=data_interval,
-        triggered_by=triggered_by,
-        dag_version=dag_version,
     )
     log.info("created dagrun %s", dr)
     return dr

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1738,7 +1738,7 @@ class DAG(TaskSDKDag, LoggingMixin):
         run_type: DagRunType,
         triggered_by: DagRunTriggeredByType,
         external_trigger: bool = False,
-        dag_version: DagVersion | None,
+        dag_version: DagVersion | None = None,
         state: DagRunState,
         start_date: datetime | None = None,
         creating_job_id: int | None = None,

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -278,12 +278,14 @@ class DagRun(Base, LoggingMixin):
     def validate_run_id(self, key: str, run_id: str) -> str | None:
         if not run_id:
             return None
-        regex = airflow_conf.get("scheduler", "allowed_run_id_pattern")
-        if not re2.match(regex, run_id) and not re2.match(RUN_ID_REGEX, run_id):
-            raise ValueError(
-                f"The run_id provided '{run_id}' does not match the pattern '{regex}' or '{RUN_ID_REGEX}'"
-            )
-        return run_id
+        if re2.match(RUN_ID_REGEX, run_id):
+            return run_id
+        regex = airflow_conf.get("scheduler", "allowed_run_id_pattern").strip()
+        if regex and re2.match(regex, run_id):
+            return run_id
+        raise ValueError(
+            f"The run_id provided '{run_id}' does not match the pattern '{regex}' or '{RUN_ID_REGEX}'"
+        )
 
     @property
     def stats_tags(self) -> dict[str, str]:

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -284,7 +284,7 @@ class DagRun(Base, LoggingMixin):
         if regex and re2.match(regex, run_id):
             return run_id
         raise ValueError(
-            f"The run_id provided '{run_id}' does not match the pattern '{regex}' or '{RUN_ID_REGEX}'"
+            f"The run_id provided '{run_id}' does not match regex pattern '{regex}' or '{RUN_ID_REGEX}'"
         )
 
     @property

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2221,11 +2221,19 @@ class Airflow(AirflowBaseView):
                     "warning",
                 )
 
+        data_interval = dag.timetable.infer_manual_data_interval(run_after=logical_date)
+        if not run_id:
+            run_id = dag.timetable.generate_run_id(
+                logical_date=logical_date,
+                data_interval=data_interval,
+                run_type=DagRunType.MANUAL,
+            )
+
         try:
             dag_run = dag.create_dagrun(
                 run_id=run_id,
                 logical_date=logical_date,
-                data_interval=dag.timetable.infer_manual_data_interval(run_after=logical_date),
+                data_interval=data_interval,
                 conf=run_conf,
                 run_type=DagRunType.MANUAL,
                 triggered_by=DagRunTriggeredByType.UI,

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2222,17 +2222,17 @@ class Airflow(AirflowBaseView):
                 )
 
         try:
-            dag_version = DagVersion.get_latest_version(dag.dag_id)
             dag_run = dag.create_dagrun(
-                run_type=DagRunType.MANUAL,
+                run_id=run_id,
                 logical_date=logical_date,
                 data_interval=dag.timetable.infer_manual_data_interval(run_after=logical_date),
-                state=DagRunState.QUEUED,
                 conf=run_conf,
-                external_trigger=True,
-                dag_version=dag_version,
-                run_id=run_id,
+                run_type=DagRunType.MANUAL,
                 triggered_by=DagRunTriggeredByType.UI,
+                external_trigger=True,
+                dag_version=DagVersion.get_latest_version(dag.dag_id),
+                state=DagRunState.QUEUED,
+                session=session,
             )
         except (ValueError, ParamValidationError) as ve:
             flash(f"{ve}", "error")

--- a/dev/perf/scheduler_dag_execution_timing.py
+++ b/dev/perf/scheduler_dag_execution_timing.py
@@ -172,11 +172,14 @@ def create_dag_runs(dag, num_runs, session):
         dag.create_dagrun(
             run_id=f"{id_prefix}{logical_date.isoformat()}",
             logical_date=logical_date,
-            start_date=timezone.utcnow(),
-            state=DagRunState.RUNNING,
-            external_trigger=False,
-            session=session,
+            data_interval=(logical_date, logical_date),
+            run_type=DagRunType.MANUAL,
             triggered_by=DagRunTriggeredByType.TEST,
+            external_trigger=False,
+            dag_version=None,
+            state=DagRunState.RUNNING,
+            start_date=timezone.utcnow(),
+            session=session,
         )
         last_dagrun_data_interval = next_info.data_interval
 
@@ -292,7 +295,8 @@ def main(num_runs, repeat, pre_create_dag_runs, executor_class, dag_ids):
 
     # Need a lambda to refer to the _latest_ value for scheduler_job, not just
     # the initial one
-    code_to_test = lambda: run_job(job=job_runner.job, execute_callable=job_runner._execute)
+    def code_to_test():
+        run_job(job=job_runner.job, execute_callable=job_runner._execute)
 
     for count in range(repeat):
         if not count:

--- a/docs/apache-airflow/best-practices.rst
+++ b/docs/apache-airflow/best-practices.rst
@@ -732,7 +732,7 @@ This is an example test want to verify the structure of a code-generated DAG aga
 
     TEST_DAG_ID = "my_custom_operator_dag"
     TEST_TASK_ID = "my_custom_operator_task"
-    TEST_RUN_ID = "my_custom_oeprator_dag_run"
+    TEST_RUN_ID = "my_custom_operator_dag_run"
 
 
     @pytest.fixture()

--- a/docs/apache-airflow/best-practices.rst
+++ b/docs/apache-airflow/best-practices.rst
@@ -725,13 +725,14 @@ This is an example test want to verify the structure of a code-generated DAG aga
 
     from airflow import DAG
     from airflow.utils.state import DagRunState, TaskInstanceState
-    from airflow.utils.types import DagRunType
+    from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
     DATA_INTERVAL_START = pendulum.datetime(2021, 9, 13, tz="UTC")
     DATA_INTERVAL_END = DATA_INTERVAL_START + datetime.timedelta(days=1)
 
     TEST_DAG_ID = "my_custom_operator_dag"
     TEST_TASK_ID = "my_custom_operator_task"
+    TEST_RUN_ID = "my_custom_oeprator_dag_run"
 
 
     @pytest.fixture()
@@ -750,11 +751,13 @@ This is an example test want to verify the structure of a code-generated DAG aga
 
     def test_my_custom_operator_execute_no_trigger(dag):
         dagrun = dag.create_dagrun(
-            state=DagRunState.RUNNING,
-            execution_date=DATA_INTERVAL_START,
+            run_id=TEST_RUN_ID,
+            logical_date=DATA_INTERVAL_START,
             data_interval=(DATA_INTERVAL_START, DATA_INTERVAL_END),
-            start_date=DATA_INTERVAL_END,
             run_type=DagRunType.MANUAL,
+            triggered_by=DagRunTriggeredByType.TIMETABLE,
+            state=DagRunState.RUNNING,
+            start_date=DATA_INTERVAL_END,
         )
         ti = dagrun.get_task_instance(task_id=TEST_TASK_ID)
         ti.task = dag.get_task(task_id=TEST_TASK_ID)

--- a/providers/tests/common/sql/operators/test_sql.py
+++ b/providers/tests/common/sql/operators/test_sql.py
@@ -44,6 +44,7 @@ from airflow.providers.postgres.hooks.postgres import PostgresHook
 from airflow.utils import timezone
 from airflow.utils.session import create_session
 from airflow.utils.state import State
+from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.providers import get_provider_min_airflow_version
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
@@ -1158,26 +1159,23 @@ class TestSqlBranch:
         self.branch_1.set_upstream(branch_op)
         self.branch_2.set_upstream(branch_op)
         self.dag.clear()
-        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
 
         if AIRFLOW_V_3_0_PLUS:
-            dr = self.dag.create_dagrun(
-                run_id="manual__",
-                start_date=timezone.utcnow(),
-                logical_date=DEFAULT_DATE,
-                state=State.RUNNING,
-                data_interval=(DEFAULT_DATE, DEFAULT_DATE),
-                **triggered_by_kwargs,
-            )
+            dagrun_kwargs = {
+                "logical_date": DEFAULT_DATE,
+                "triggered_by": DagRunTriggeredByType.TEST,
+            }
         else:
-            dr = self.dag.create_dagrun(
-                run_id="manual__",
-                start_date=timezone.utcnow(),
-                execution_date=DEFAULT_DATE,
-                state=State.RUNNING,
-                data_interval=(DEFAULT_DATE, DEFAULT_DATE),
-                **triggered_by_kwargs,
-            )
+            dagrun_kwargs = {"execution_date": DEFAULT_DATE}
+
+        dr = self.dag.create_dagrun(
+            run_id="manual__",
+            run_type=DagRunType.MANUAL,
+            start_date=timezone.utcnow(),
+            state=State.RUNNING,
+            data_interval=(DEFAULT_DATE, DEFAULT_DATE),
+            **dagrun_kwargs,
+        )
 
         mock_get_records = mock_get_db_hook.return_value.get_first
 
@@ -1211,25 +1209,22 @@ class TestSqlBranch:
         self.branch_1.set_upstream(branch_op)
         self.branch_2.set_upstream(branch_op)
         self.dag.clear()
-        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
+
         if AIRFLOW_V_3_0_PLUS:
-            dr = self.dag.create_dagrun(
-                run_id="manual__",
-                start_date=timezone.utcnow(),
-                logical_date=DEFAULT_DATE,
-                state=State.RUNNING,
-                data_interval=(DEFAULT_DATE, DEFAULT_DATE),
-                **triggered_by_kwargs,
-            )
+            dagrun_kwargs = {
+                "logical_date": DEFAULT_DATE,
+                "triggered_by": DagRunTriggeredByType.TEST,
+            }
         else:
-            dr = self.dag.create_dagrun(
-                run_id="manual__",
-                start_date=timezone.utcnow(),
-                execution_date=DEFAULT_DATE,
-                state=State.RUNNING,
-                data_interval=(DEFAULT_DATE, DEFAULT_DATE),
-                **triggered_by_kwargs,
-            )
+            dagrun_kwargs = {"execution_date": DEFAULT_DATE}
+        dr = self.dag.create_dagrun(
+            run_id="manual__",
+            run_type=DagRunType.MANUAL,
+            start_date=timezone.utcnow(),
+            state=State.RUNNING,
+            data_interval=(DEFAULT_DATE, DEFAULT_DATE),
+            **dagrun_kwargs,
+        )
 
         mock_get_records = mock_get_db_hook.return_value.get_first
 
@@ -1264,26 +1259,22 @@ class TestSqlBranch:
         self.branch_1.set_upstream(branch_op)
         self.branch_2.set_upstream(branch_op)
         self.dag.clear()
-        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
 
         if AIRFLOW_V_3_0_PLUS:
-            dr = self.dag.create_dagrun(
-                run_id="manual__",
-                start_date=timezone.utcnow(),
-                logical_date=DEFAULT_DATE,
-                state=State.RUNNING,
-                data_interval=(DEFAULT_DATE, DEFAULT_DATE),
-                **triggered_by_kwargs,
-            )
+            dagrun_kwargs = {
+                "logical_date": DEFAULT_DATE,
+                "triggered_by": DagRunTriggeredByType.TEST,
+            }
         else:
-            dr = self.dag.create_dagrun(
-                run_id="manual__",
-                start_date=timezone.utcnow(),
-                execution_date=DEFAULT_DATE,
-                state=State.RUNNING,
-                data_interval=(DEFAULT_DATE, DEFAULT_DATE),
-                **triggered_by_kwargs,
-            )
+            dagrun_kwargs = {"execution_date": DEFAULT_DATE}
+        dr = self.dag.create_dagrun(
+            run_id="manual__",
+            run_type=DagRunType.MANUAL,
+            start_date=timezone.utcnow(),
+            state=State.RUNNING,
+            data_interval=(DEFAULT_DATE, DEFAULT_DATE),
+            **dagrun_kwargs,
+        )
 
         mock_get_records = mock_get_db_hook.return_value.get_first
 
@@ -1319,26 +1310,22 @@ class TestSqlBranch:
         self.branch_3 = EmptyOperator(task_id="branch_3", dag=self.dag)
         self.branch_3.set_upstream(branch_op)
         self.dag.clear()
-        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
 
         if AIRFLOW_V_3_0_PLUS:
-            dr = self.dag.create_dagrun(
-                run_id="manual__",
-                start_date=timezone.utcnow(),
-                logical_date=DEFAULT_DATE,
-                state=State.RUNNING,
-                data_interval=(DEFAULT_DATE, DEFAULT_DATE),
-                **triggered_by_kwargs,
-            )
+            dagrun_kwargs = {
+                "logical_date": DEFAULT_DATE,
+                "triggered_by": DagRunTriggeredByType.TEST,
+            }
         else:
-            dr = self.dag.create_dagrun(
-                run_id="manual__",
-                start_date=timezone.utcnow(),
-                execution_date=DEFAULT_DATE,
-                state=State.RUNNING,
-                data_interval=(DEFAULT_DATE, DEFAULT_DATE),
-                **triggered_by_kwargs,
-            )
+            dagrun_kwargs = {"execution_date": DEFAULT_DATE}
+        dr = self.dag.create_dagrun(
+            run_id="manual__",
+            run_type=DagRunType.MANUAL,
+            start_date=timezone.utcnow(),
+            state=State.RUNNING,
+            data_interval=(DEFAULT_DATE, DEFAULT_DATE),
+            **dagrun_kwargs,
+        )
 
         mock_get_records = mock_get_db_hook.return_value.get_first
         mock_get_records.return_value = [["1"]]
@@ -1371,26 +1358,22 @@ class TestSqlBranch:
         self.branch_1.set_upstream(branch_op)
         self.branch_2.set_upstream(branch_op)
         self.dag.clear()
-        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
 
         if AIRFLOW_V_3_0_PLUS:
-            self.dag.create_dagrun(
-                run_id="manual__",
-                start_date=timezone.utcnow(),
-                logical_date=DEFAULT_DATE,
-                state=State.RUNNING,
-                data_interval=(DEFAULT_DATE, DEFAULT_DATE),
-                **triggered_by_kwargs,
-            )
+            dagrun_kwargs = {
+                "logical_date": DEFAULT_DATE,
+                "triggered_by": DagRunTriggeredByType.TEST,
+            }
         else:
-            self.dag.create_dagrun(
-                run_id="manual__",
-                start_date=timezone.utcnow(),
-                execution_date=DEFAULT_DATE,
-                state=State.RUNNING,
-                data_interval=(DEFAULT_DATE, DEFAULT_DATE),
-                **triggered_by_kwargs,
-            )
+            dagrun_kwargs = {"execution_date": DEFAULT_DATE}
+        self.dag.create_dagrun(
+            run_id="manual__",
+            run_type=DagRunType.MANUAL,
+            start_date=timezone.utcnow(),
+            state=State.RUNNING,
+            data_interval=(DEFAULT_DATE, DEFAULT_DATE),
+            **dagrun_kwargs,
+        )
 
         mock_get_records = mock_get_db_hook.return_value.get_first
 
@@ -1414,25 +1397,22 @@ class TestSqlBranch:
         branch_op >> self.branch_1 >> self.branch_2
         branch_op >> self.branch_2
         self.dag.clear()
-        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
+
         if AIRFLOW_V_3_0_PLUS:
-            dr = self.dag.create_dagrun(
-                run_id="manual__",
-                start_date=timezone.utcnow(),
-                logical_date=DEFAULT_DATE,
-                state=State.RUNNING,
-                data_interval=(DEFAULT_DATE, DEFAULT_DATE),
-                **triggered_by_kwargs,
-            )
+            dagrun_kwargs = {
+                "logical_date": DEFAULT_DATE,
+                "triggered_by": DagRunTriggeredByType.TEST,
+            }
         else:
-            dr = self.dag.create_dagrun(
-                run_id="manual__",
-                start_date=timezone.utcnow(),
-                execution_date=DEFAULT_DATE,
-                state=State.RUNNING,
-                data_interval=(DEFAULT_DATE, DEFAULT_DATE),
-                **triggered_by_kwargs,
-            )
+            dagrun_kwargs = {"execution_date": DEFAULT_DATE}
+        dr = self.dag.create_dagrun(
+            run_id="manual__",
+            run_type=DagRunType.MANUAL,
+            start_date=timezone.utcnow(),
+            state=State.RUNNING,
+            data_interval=(DEFAULT_DATE, DEFAULT_DATE),
+            **dagrun_kwargs,
+        )
 
         mock_get_records = mock_get_db_hook.return_value.get_first
 
@@ -1465,25 +1445,22 @@ class TestSqlBranch:
         branch_op >> self.branch_1 >> self.branch_2
         branch_op >> self.branch_2
         self.dag.clear()
-        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
+
         if AIRFLOW_V_3_0_PLUS:
-            dr = self.dag.create_dagrun(
-                run_id="manual__",
-                start_date=timezone.utcnow(),
-                logical_date=DEFAULT_DATE,
-                state=State.RUNNING,
-                data_interval=(DEFAULT_DATE, DEFAULT_DATE),
-                **triggered_by_kwargs,
-            )
+            dagrun_kwargs = {
+                "logical_date": DEFAULT_DATE,
+                "triggered_by": DagRunTriggeredByType.TEST,
+            }
         else:
-            dr = self.dag.create_dagrun(
-                run_id="manual__",
-                start_date=timezone.utcnow(),
-                execution_date=DEFAULT_DATE,
-                state=State.RUNNING,
-                data_interval=(DEFAULT_DATE, DEFAULT_DATE),
-                **triggered_by_kwargs,
-            )
+            dagrun_kwargs = {"execution_date": DEFAULT_DATE}
+        dr = self.dag.create_dagrun(
+            run_id="manual__",
+            run_type=DagRunType.MANUAL,
+            start_date=timezone.utcnow(),
+            state=State.RUNNING,
+            data_interval=(DEFAULT_DATE, DEFAULT_DATE),
+            **dagrun_kwargs,
+        )
 
         mock_get_records = mock_get_db_hook.return_value.get_first
 

--- a/providers/tests/openlineage/plugins/test_execution.py
+++ b/providers/tests/openlineage/plugins/test_execution.py
@@ -37,6 +37,7 @@ from airflow.utils.state import State
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.db import clear_db_runs
 from tests_common.test_utils.version_compat import AIRFLOW_V_2_10_PLUS, AIRFLOW_V_3_0_PLUS
 
 if AIRFLOW_V_3_0_PLUS:
@@ -73,6 +74,9 @@ with tempfile.TemporaryDirectory(prefix="venv") as tmp_dir:
     @pytest.mark.skipif(not AIRFLOW_V_2_10_PLUS, reason="Test requires Airflow 2.10+")
     @pytest.mark.usefixtures("reset_logging_config")
     class TestOpenLineageExecution:
+        def teardown_method(self):
+            clear_db_runs()
+
         @pytest.fixture(autouse=True)
         def clean_listener_manager(self):
             get_listener_manager().clear()

--- a/providers/tests/openlineage/plugins/test_listener.py
+++ b/providers/tests/openlineage/plugins/test_listener.py
@@ -20,7 +20,7 @@ import datetime as dt
 import uuid
 from concurrent.futures import Future
 from contextlib import suppress
-from typing import Callable
+from typing import Any, Callable
 from unittest import mock
 from unittest.mock import ANY, MagicMock, patch
 
@@ -174,7 +174,7 @@ def _create_test_dag_and_task(python_callable: Callable, scenario_name: str) -> 
     )
     t = PythonOperator(task_id=f"test_task_{scenario_name}", dag=dag, python_callable=python_callable)
     run_id = str(uuid.uuid1())
-    v3_kwargs = (
+    v3_kwargs: dict[str, Any] = (
         {
             "dag_version": None,
             "triggered_by": types.DagRunTriggeredByType.TEST,
@@ -709,14 +709,14 @@ class TestOpenLineageSelectiveEnable:
         v3_kwargs = (
             {
                 "dag_version": None,
+                "logical_date": date,
                 "triggered_by": types.DagRunTriggeredByType.TEST,
             }
             if AIRFLOW_V_3_0_PLUS
-            else {}
+            else {"execution_date": date}
         )
         self.dagrun = self.dag.create_dagrun(
             run_id=run_id,
-            logical_date=date,
             data_interval=(date, date),
             run_type=types.DagRunType.MANUAL,
             state=DagRunState.QUEUED,

--- a/tests/cli/commands/remote_commands/test_task_command.py
+++ b/tests/cli/commands/remote_commands/test_task_command.py
@@ -656,11 +656,7 @@ class TestCliTasks:
             else {}
         )
         dagrun = dag2.create_dagrun(
-            run_id=dag2.timetable.generate_run_id(
-                run_type=DagRunType.MANUAL,
-                logical_date=default_date2,
-                data_interval=data_interval,
-            ),
+            run_id="test",
             state=State.RUNNING,
             logical_date=default_date2,
             data_interval=data_interval,

--- a/tests/cli/commands/remote_commands/test_task_command.py
+++ b/tests/cli/commands/remote_commands/test_task_command.py
@@ -104,14 +104,21 @@ class TestCliTasks:
         cls.dagbag = DagBag(read_dags_from_db=True)
         cls.dag = cls.dagbag.get_dag(cls.dag_id)
         data_interval = cls.dag.timetable.infer_manual_data_interval(run_after=DEFAULT_DATE)
-        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.CLI} if AIRFLOW_V_3_0_PLUS else {}
+        v3_kwargs = (
+            {
+                "dag_version": None,
+                "triggered_by": DagRunTriggeredByType.TEST,
+            }
+            if AIRFLOW_V_3_0_PLUS
+            else {}
+        )
         cls.dag_run = cls.dag.create_dagrun(
             state=State.NONE,
             run_id=cls.run_id,
             run_type=DagRunType.MANUAL,
             logical_date=DEFAULT_DATE,
             data_interval=data_interval,
-            **triggered_by_kwargs,
+            **v3_kwargs,
         )
 
     @classmethod
@@ -168,7 +175,14 @@ class TestCliTasks:
 
         logical_date = pendulum.now("UTC")
         data_interval = dag.timetable.infer_manual_data_interval(run_after=logical_date)
-        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
+        v3_kwargs = (
+            {
+                "dag_version": None,
+                "triggered_by": DagRunTriggeredByType.TEST,
+            }
+            if AIRFLOW_V_3_0_PLUS
+            else {}
+        )
         dag.create_dagrun(
             state=State.NONE,
             run_id="abc123",
@@ -176,7 +190,7 @@ class TestCliTasks:
             logical_date=logical_date,
             data_interval=data_interval,
             session=session,
-            **triggered_by_kwargs,
+            **v3_kwargs,
         )
         session.commit()
 
@@ -633,14 +647,26 @@ class TestCliTasks:
         default_date2 = timezone.datetime(2016, 1, 9)
         dag2.clear()
         data_interval = dag2.timetable.infer_manual_data_interval(run_after=default_date2)
-        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.CLI} if AIRFLOW_V_3_0_PLUS else {}
+        v3_kwargs = (
+            {
+                "dag_version": None,
+                "triggered_by": DagRunTriggeredByType.CLI,
+            }
+            if AIRFLOW_V_3_0_PLUS
+            else {}
+        )
         dagrun = dag2.create_dagrun(
+            run_id=dag2.timetable.generate_run_id(
+                run_type=DagRunType.MANUAL,
+                logical_date=default_date2,
+                data_interval=data_interval,
+            ),
             state=State.RUNNING,
             logical_date=default_date2,
             data_interval=data_interval,
             run_type=DagRunType.MANUAL,
             external_trigger=True,
-            **triggered_by_kwargs,
+            **v3_kwargs,
         )
         ti2 = TaskInstance(task2, run_id=dagrun.run_id)
         ti2.set_state(State.SUCCESS)
@@ -714,7 +740,14 @@ class TestLogsfromTaskRunCommand:
 
         dag = DagBag().get_dag(self.dag_id)
         data_interval = dag.timetable.infer_manual_data_interval(run_after=self.logical_date)
-        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
+        v3_kwargs = (
+            {
+                "dag_version": None,
+                "triggered_by": DagRunTriggeredByType.TEST,
+            }
+            if AIRFLOW_V_3_0_PLUS
+            else {}
+        )
         self.dr = dag.create_dagrun(
             run_id=self.run_id,
             logical_date=self.logical_date,
@@ -722,7 +755,7 @@ class TestLogsfromTaskRunCommand:
             start_date=timezone.utcnow(),
             state=State.RUNNING,
             run_type=DagRunType.MANUAL,
-            **triggered_by_kwargs,
+            **v3_kwargs,
         )
         self.tis = self.dr.get_task_instances()
         assert len(self.tis) == 1
@@ -1019,7 +1052,15 @@ def test_context_with_run():
 
     dag = DagBag().get_dag(dag_id)
     data_interval = dag.timetable.infer_manual_data_interval(run_after=logical_date)
-    triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
+
+    v3_kwargs = (
+        {
+            "dag_version": None,
+            "triggered_by": DagRunTriggeredByType.TEST,
+        }
+        if AIRFLOW_V_3_0_PLUS
+        else {}
+    )
     dag.create_dagrun(
         run_id=run_id,
         logical_date=logical_date,
@@ -1027,7 +1068,7 @@ def test_context_with_run():
         start_date=timezone.utcnow(),
         state=State.RUNNING,
         run_type=DagRunType.MANUAL,
-        **triggered_by_kwargs,
+        **v3_kwargs,
     )
     with conf_vars({("core", "dags_folder"): dag_path}):
         task_command.task_run(parser.parse_args(task_args))

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -444,7 +444,8 @@ class TestAirflowTaskDecorator(BasePythonTest):
 
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
         dr = self.dag_non_serialized.create_dagrun(
-            run_id=DagRunType.MANUAL,
+            run_id="test",
+            run_type=DagRunType.MANUAL,
             start_date=timezone.utcnow(),
             logical_date=DEFAULT_DATE,
             state=State.RUNNING,
@@ -508,7 +509,8 @@ class TestAirflowTaskDecorator(BasePythonTest):
 
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
         dr = self.dag_non_serialized.create_dagrun(
-            run_id=DagRunType.MANUAL,
+            run_id="test",
+            run_type=DagRunType.MANUAL,
             start_date=timezone.utcnow(),
             logical_date=DEFAULT_DATE,
             state=State.RUNNING,

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -310,6 +310,7 @@ class TestLocalTaskJob:
             triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
             dr = dag.create_dagrun(
                 run_id="test_heartbeat_failed_fast_run",
+                run_type=DagRunType.MANUAL,
                 state=State.RUNNING,
                 logical_date=DEFAULT_DATE,
                 start_date=DEFAULT_DATE,
@@ -347,6 +348,7 @@ class TestLocalTaskJob:
         data_interval = dag.infer_automated_data_interval(DEFAULT_LOGICAL_DATE)
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
         dr = dag.create_dagrun(
+            run_id="test",
             state=State.RUNNING,
             logical_date=DEFAULT_DATE,
             run_type=DagRunType.SCHEDULED,
@@ -382,6 +384,7 @@ class TestLocalTaskJob:
         dag.clear()
         dr = dag.create_dagrun(
             run_id="test",
+            run_type=DagRunType.MANUAL,
             state=State.SUCCESS,
             logical_date=DEFAULT_DATE,
             start_date=DEFAULT_DATE,
@@ -485,6 +488,7 @@ class TestLocalTaskJob:
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
         with create_session() as session:
             dr = dag.create_dagrun(
+                run_id="test",
                 state=State.RUNNING,
                 logical_date=DEFAULT_DATE,
                 run_type=DagRunType.SCHEDULED,
@@ -520,6 +524,7 @@ class TestLocalTaskJob:
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
         with create_session() as session:
             dr = dag.create_dagrun(
+                run_id="test",
                 state=State.RUNNING,
                 start_date=DEFAULT_DATE,
                 logical_date=DEFAULT_DATE,
@@ -555,6 +560,7 @@ class TestLocalTaskJob:
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
         with create_session() as session:
             dr = dag.create_dagrun(
+                run_id="test",
                 state=State.RUNNING,
                 logical_date=DEFAULT_DATE,
                 run_type=DagRunType.SCHEDULED,
@@ -591,6 +597,7 @@ class TestLocalTaskJob:
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
         with create_session() as session:
             dr = dag.create_dagrun(
+                run_id="test",
                 state=State.RUNNING,
                 logical_date=DEFAULT_DATE,
                 run_type=DagRunType.SCHEDULED,
@@ -627,6 +634,7 @@ class TestLocalTaskJob:
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
         with create_session() as session:
             dr = dag.create_dagrun(
+                run_id="test",
                 state=State.RUNNING,
                 logical_date=DEFAULT_DATE,
                 run_type=DagRunType.SCHEDULED,
@@ -666,6 +674,7 @@ class TestLocalTaskJob:
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
         with create_session() as session:
             dr = dag.create_dagrun(
+                run_id="test",
                 state=State.RUNNING,
                 logical_date=DEFAULT_DATE,
                 run_type=DagRunType.SCHEDULED,
@@ -705,6 +714,7 @@ class TestLocalTaskJob:
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
         with create_session() as session:
             dr = dag.create_dagrun(
+                run_id="test",
                 state=State.RUNNING,
                 logical_date=DEFAULT_DATE,
                 run_type=DagRunType.SCHEDULED,
@@ -748,6 +758,7 @@ class TestLocalTaskJob:
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
         with create_session() as session:
             dag.create_dagrun(
+                run_id="test",
                 state=State.RUNNING,
                 logical_date=DEFAULT_DATE,
                 run_type=DagRunType.SCHEDULED,
@@ -1007,6 +1018,7 @@ class TestSigtermOnRunner:
         data_interval = dag.infer_automated_data_interval(DEFAULT_LOGICAL_DATE)
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
         dag_run = dag.create_dagrun(
+            run_type=DagRunType.MANUAL,
             state=State.RUNNING,
             run_id=run_id,
             logical_date=logical_date,

--- a/tests/models/test_cleartasks.py
+++ b/tests/models/test_cleartasks.py
@@ -644,6 +644,7 @@ class TestClearTasks:
 
             triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
             dr = dag.create_dagrun(
+                run_id=f"scheduled_{i}",
                 logical_date=DEFAULT_DATE,
                 state=State.RUNNING,
                 run_type=DagRunType.SCHEDULED,

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -112,6 +112,7 @@ if AIRFLOW_V_3_0_PLUS:
     from airflow.utils.types import DagRunTriggeredByType
 
 if TYPE_CHECKING:
+    from pendulum import DateTime
     from sqlalchemy.orm import Session
 
 pytestmark = pytest.mark.db_test
@@ -135,6 +136,32 @@ def clear_assets():
     clear_db_assets()
     yield
     clear_db_assets()
+
+
+def _create_dagrun(
+    dag: DAG,
+    *,
+    logical_date: DateTime,
+    data_interval: DataInterval,
+    run_type: DagRunType,
+    state: DagRunState = DagRunState.RUNNING,
+    start_date: datetime.datetime | None = None,
+) -> DagRun:
+    triggered_by_kwargs: dict = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
+    run_id = dag.timetable.generate_run_id(
+        run_type=run_type,
+        logical_date=logical_date,
+        data_interval=data_interval,
+    )
+    return dag.create_dagrun(
+        run_id=run_id,
+        logical_date=logical_date,
+        data_interval=data_interval,
+        run_type=run_type,
+        state=state,
+        start_date=start_date,
+        **triggered_by_kwargs,
+    )
 
 
 class TestDag:
@@ -282,13 +309,11 @@ class TestDag:
                 task_id="empty_task",
                 weight_rule=cls(),
             )
-        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
-        dr = dag.create_dagrun(
-            state=None,
-            run_id="test",
+        dr = _create_dagrun(
+            dag,
             logical_date=DEFAULT_DATE,
             data_interval=(DEFAULT_DATE, DEFAULT_DATE),
-            **triggered_by_kwargs,
+            run_type=DagRunType.MANUAL,
         )
         ti = dr.get_task_instance(task.task_id)
         assert ti.priority_weight == expected
@@ -299,44 +324,39 @@ class TestDag:
 
         test_dag = DAG(dag_id=test_dag_id, schedule=None, start_date=DEFAULT_DATE)
         test_task = EmptyOperator(task_id=test_task_id, dag=test_dag)
-        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
 
-        dr1 = test_dag.create_dagrun(
-            state=None,
-            run_id="test1",
+        dr1 = _create_dagrun(
+            test_dag,
+            run_type=DagRunType.MANUAL,
             logical_date=DEFAULT_DATE,
             data_interval=(DEFAULT_DATE, DEFAULT_DATE),
-            **triggered_by_kwargs,
         )
-        dr2 = test_dag.create_dagrun(
-            state=None,
-            run_id="test2",
+        dr2 = _create_dagrun(
+            test_dag,
+            run_type=DagRunType.MANUAL,
             logical_date=DEFAULT_DATE + datetime.timedelta(days=1),
             data_interval=(
                 DEFAULT_DATE + datetime.timedelta(days=1),
                 DEFAULT_DATE + datetime.timedelta(days=1),
             ),
-            **triggered_by_kwargs,
         )
-        dr3 = test_dag.create_dagrun(
-            state=None,
-            run_id="test3",
+        dr3 = _create_dagrun(
+            test_dag,
+            run_type=DagRunType.MANUAL,
             logical_date=DEFAULT_DATE + datetime.timedelta(days=2),
             data_interval=(
                 DEFAULT_DATE + datetime.timedelta(days=2),
                 DEFAULT_DATE + datetime.timedelta(days=2),
             ),
-            **triggered_by_kwargs,
         )
-        dr4 = test_dag.create_dagrun(
-            state=None,
-            run_id="test4",
+        dr4 = _create_dagrun(
+            test_dag,
+            run_type=DagRunType.MANUAL,
             logical_date=DEFAULT_DATE + datetime.timedelta(days=3),
             data_interval=(
                 DEFAULT_DATE + datetime.timedelta(days=2),
                 DEFAULT_DATE + datetime.timedelta(days=2),
             ),
-            **triggered_by_kwargs,
         )
 
         ti1 = TI(task=test_task, run_id=dr1.run_id)
@@ -407,6 +427,8 @@ class TestDag:
                 state=State.SUCCESS,
                 run_type=type,
                 run_id=f"test_{delta_h}",
+                logical_date=None,
+                data_interval=None,
                 session=session,
                 **triggered_by_kwargs,
             )
@@ -606,6 +628,7 @@ class TestDag:
         dag.add_task(BaseOperator(task_id="task_without_start_date"))
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
         dagrun = dag.create_dagrun(
+            run_id="test",
             state=State.RUNNING,
             run_type=DagRunType.MANUAL,
             logical_date=DEFAULT_DATE,
@@ -802,6 +825,7 @@ class TestDag:
 
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
         dr = dag.create_dagrun(
+            run_id="test",
             state=state,
             logical_date=model.next_dagrun,
             run_type=DagRunType.SCHEDULED,
@@ -1089,6 +1113,7 @@ class TestDag:
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
 
         dag_run = dag.create_dagrun(
+            run_id="test",
             run_type=DagRunType.SCHEDULED,
             logical_date=TEST_DATE,
             state=State.RUNNING,
@@ -1128,6 +1153,7 @@ class TestDag:
 
         with create_session() as session:
             dag_run = dag.create_dagrun(
+                run_id="test",
                 state=State.RUNNING,
                 logical_date=when,
                 run_type=DagRunType.MANUAL,
@@ -1166,6 +1192,7 @@ class TestDag:
         with create_session() as session:
             triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
             dag_run = dag.create_dagrun(
+                run_id="test",
                 state=State.RUNNING,
                 logical_date=TEST_DATE,
                 run_type=DagRunType.MANUAL,
@@ -1194,15 +1221,13 @@ class TestDag:
         dag_id = "test_schedule_dag_fake_scheduled_previous"
         dag = DAG(dag_id=dag_id, schedule=delta, start_date=DEFAULT_DATE)
         dag.add_task(BaseOperator(task_id="faketastic", owner="Also fake", start_date=DEFAULT_DATE))
-        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
 
-        dag.create_dagrun(
+        _create_dagrun(
+            dag,
             run_type=DagRunType.SCHEDULED,
             logical_date=DEFAULT_DATE,
             state=State.SUCCESS,
-            external_trigger=True,
             data_interval=(DEFAULT_DATE, DEFAULT_DATE),
-            **triggered_by_kwargs,
         )
         dag.sync_to_db()
         with create_session() as session:
@@ -1228,13 +1253,12 @@ class TestDag:
         # Sync once to create the DagModel
         dag.sync_to_db()
 
-        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
-        dag.create_dagrun(
+        _create_dagrun(
+            dag,
             run_type=DagRunType.SCHEDULED,
             logical_date=TEST_DATE,
             state=State.SUCCESS,
             data_interval=(TEST_DATE, TEST_DATE),
-            **triggered_by_kwargs,
         )
 
         # Then sync again after creating the dag run -- this should update next_dagrun
@@ -1256,15 +1280,13 @@ class TestDag:
 
         start_date = timezone.utcnow()
 
-        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
-        run = dag.create_dagrun(
-            run_id="test_" + start_date.isoformat(),
+        run = _create_dagrun(
+            dag,
+            run_type=DagRunType.MANUAL,
             logical_date=start_date,
             start_date=start_date,
             state=State.RUNNING,
-            external_trigger=False,
             data_interval=(start_date, start_date),
-            **triggered_by_kwargs,
         )
 
         run.refresh_from_db()
@@ -1389,37 +1411,15 @@ class TestDag:
         assert dag.timetable == timetable
         assert dag.timetable.description == expected_description
 
-    def test_create_dagrun_run_id_is_generated(self):
-        dag = DAG(dag_id="run_id_is_generated", schedule=None)
-        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
-        dr = dag.create_dagrun(
-            run_type=DagRunType.MANUAL,
-            logical_date=DEFAULT_DATE,
-            state=State.NONE,
-            data_interval=(DEFAULT_DATE, DEFAULT_DATE),
-            **triggered_by_kwargs,
-        )
-        assert dr.run_id == f"manual__{DEFAULT_DATE.isoformat()}"
-
-    def test_create_dagrun_run_type_is_obtained_from_run_id(self):
-        dag = DAG(dag_id="run_type_is_obtained_from_run_id", schedule=None)
-        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
-        dr = dag.create_dagrun(run_id="scheduled__", state=State.NONE, **triggered_by_kwargs)
-        assert dr.run_type == DagRunType.SCHEDULED
-
-        dr = dag.create_dagrun(
-            run_id="custom_is_set_to_manual",
-            state=State.NONE,
-            **triggered_by_kwargs,
-        )
-        assert dr.run_type == DagRunType.MANUAL
-
     def test_create_dagrun_job_id_is_set(self):
         job_id = 42
         dag = DAG(dag_id="test_create_dagrun_job_id_is_set", schedule=None)
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
         dr = dag.create_dagrun(
             run_id="test_create_dagrun_job_id_is_set",
+            logical_date=DEFAULT_DATE,
+            data_interval=(DEFAULT_DATE, DEFAULT_DATE),
+            run_type=DagRunType.MANUAL,
             state=State.NONE,
             creating_job_id=job_id,
             **triggered_by_kwargs,
@@ -1485,14 +1485,13 @@ class TestDag:
         t_1 = EmptyOperator(task_id=task_id, dag=dag)
 
         session = settings.Session()
-        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
-        dagrun_1 = dag.create_dagrun(
+        dagrun_1 = _create_dagrun(
+            dag,
             run_type=DagRunType.BACKFILL_JOB,
             state=State.FAILED,
             start_date=DEFAULT_DATE,
             logical_date=DEFAULT_DATE,
             data_interval=(DEFAULT_DATE, DEFAULT_DATE),
-            **triggered_by_kwargs,
         )
         session.merge(dagrun_1)
 
@@ -1536,6 +1535,7 @@ class TestDag:
         session = settings.Session()
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
         dagrun_1 = dag.create_dagrun(
+            run_id="backfill",
             run_type=DagRunType.BACKFILL_JOB,
             state=State.FAILED,
             start_date=DEFAULT_DATE,
@@ -1723,6 +1723,7 @@ my_postgres_conn:
         session = settings.Session()  # type: ignore
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
         dagrun_1 = dag.create_dagrun(
+            run_id="backfill",
             run_type=DagRunType.BACKFILL_JOB,
             state=DagRunState.RUNNING,
             start_date=DEFAULT_DATE,
@@ -2039,6 +2040,7 @@ my_postgres_conn:
         with pytest.raises(ParamValidationError, match="No value passed and Param has no default value"):
             dag.create_dagrun(
                 run_id="test_dagrun_missing_param",
+                run_type=DagRunType.MANUAL,
                 state=State.RUNNING,
                 logical_date=TEST_DATE,
                 data_interval=(TEST_DATE, TEST_DATE),
@@ -2051,6 +2053,7 @@ my_postgres_conn:
         ):
             dag.create_dagrun(
                 run_id="test_dagrun_missing_param",
+                run_type=DagRunType.MANUAL,
                 state=State.RUNNING,
                 logical_date=TEST_DATE,
                 conf={"param1": None},
@@ -2061,6 +2064,7 @@ my_postgres_conn:
         dag = DAG("dummy-dag", schedule=None, params={"param1": Param(type="string")})
         dag.create_dagrun(
             run_id="test_dagrun_missing_param",
+            run_type=DagRunType.MANUAL,
             state=State.RUNNING,
             logical_date=TEST_DATE,
             conf={"param1": "hello"},
@@ -2523,6 +2527,7 @@ class TestQueries:
         with assert_queries_count(4):
             dag.create_dagrun(
                 run_id="test_dagrun_query_count",
+                run_type=DagRunType.MANUAL,
                 state=State.RUNNING,
                 logical_date=TEST_DATE,
                 data_interval=(TEST_DATE, TEST_DATE),
@@ -2597,7 +2602,8 @@ class TestDagDecorator:
 
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
         dr = dag.create_dagrun(
-            run_id=DagRunType.MANUAL.value,
+            run_id="test",
+            run_type=DagRunType.MANUAL,
             start_date=timezone.utcnow(),
             logical_date=self.DEFAULT_DATE,
             data_interval=(self.DEFAULT_DATE, self.DEFAULT_DATE),
@@ -2627,7 +2633,8 @@ class TestDagDecorator:
         new_value = 52
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
         dr = dag.create_dagrun(
-            run_id=DagRunType.MANUAL.value,
+            run_id="test",
+            run_type=DagRunType.MANUAL,
             start_date=timezone.utcnow(),
             logical_date=self.DEFAULT_DATE,
             data_interval=(self.DEFAULT_DATE, self.DEFAULT_DATE),
@@ -3119,25 +3126,6 @@ def test_get_asset_triggered_next_run_info_with_unresolved_asset_alias(dag_maker
 
     dag1_model = DagModel.get_dagmodel(dag1.dag_id)
     assert dag1_model.get_asset_triggered_next_run_info(session=session) is None
-
-
-def test_dag_uses_timetable_for_run_id(session):
-    class CustomRunIdTimetable(Timetable):
-        def generate_run_id(self, *, run_type, logical_date, data_interval, **extra) -> str:
-            return "abc"
-
-    dag = DAG(dag_id="test", start_date=DEFAULT_DATE, schedule=CustomRunIdTimetable())
-    triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
-
-    dag_run = dag.create_dagrun(
-        run_type=DagRunType.MANUAL,
-        state=DagRunState.QUEUED,
-        logical_date=DEFAULT_DATE,
-        data_interval=(DEFAULT_DATE, DEFAULT_DATE),
-        **triggered_by_kwargs,
-    )
-
-    assert dag_run.run_id == "abc"
 
 
 @pytest.mark.parametrize(

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -1733,6 +1733,8 @@ my_postgres_conn:
         session.merge(dagrun_1)
 
         task_instance_1 = dagrun_1.get_task_instance(task_id)
+        if TYPE_CHECKING:
+            assert task_instance_1
         task_instance_1.state = ti_state_begin
         task_instance_1.job_id = 123
         session.merge(task_instance_1)

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -30,7 +30,6 @@ import pytest
 from airflow import settings
 from airflow.callbacks.callback_requests import DagCallbackRequest
 from airflow.decorators import setup, task, task_group, teardown
-from airflow.exceptions import AirflowException
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.dag import DAG, DagModel
 from airflow.models.dagrun import DagRun, DagRunNote
@@ -111,6 +110,11 @@ class TestDagRun:
             run_type = DagRunType.MANUAL
             data_interval = dag.timetable.infer_manual_data_interval(run_after=logical_date)
         dag_run = dag.create_dagrun(
+            run_id=dag.timetable.generate_run_id(
+                run_type=run_type,
+                logical_date=logical_date,
+                data_interval=data_interval,
+            ),
             run_type=run_type,
             logical_date=logical_date,
             data_interval=data_interval,
@@ -281,18 +285,11 @@ class TestDagRun:
         dag_run.update_state()
         assert dag_run.state == DagRunState.SUCCESS
 
-    def test_dagrun_success_conditions(self, session):
-        dag = DAG(
-            "test_dagrun_success_conditions",
-            schedule=datetime.timedelta(days=1),
-            start_date=DEFAULT_DATE,
-            default_args={"owner": "owner1"},
-        )
-
+    def test_dagrun_success_conditions(self, dag_maker, session):
         # A -> B
         # A -> C -> D
         # ordered: B, D, C, A or D, B, C, A or D, C, B, A
-        with dag:
+        with dag_maker(schedule=datetime.timedelta(days=1), session=session):
             op1 = EmptyOperator(task_id="A")
             op2 = EmptyOperator(task_id="B")
             op3 = EmptyOperator(task_id="C")
@@ -300,18 +297,7 @@ class TestDagRun:
             op1.set_upstream([op2, op3])
             op3.set_upstream(op4)
 
-        dag.clear()
-
-        now = pendulum.now("UTC")
-        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
-        dr = dag.create_dagrun(
-            run_id="test_dagrun_success_conditions",
-            state=DagRunState.RUNNING,
-            logical_date=now,
-            data_interval=dag.timetable.infer_manual_data_interval(run_after=now),
-            start_date=now,
-            **triggered_by_kwargs,
-        )
+        dr = dag_maker.create_dagrun()
 
         # op1 = root
         ti_op1 = dr.get_task_instance(task_id=op1.task_id)
@@ -332,32 +318,14 @@ class TestDagRun:
         dr.update_state()
         assert dr.state == DagRunState.SUCCESS
 
-    def test_dagrun_deadlock(self, session):
-        dag = DAG(
-            "text_dagrun_deadlock",
-            schedule=datetime.timedelta(days=1),
-            start_date=DEFAULT_DATE,
-            default_args={"owner": "owner1"},
-        )
-
-        with dag:
+    def test_dagrun_deadlock(self, dag_maker, session):
+        with dag_maker(schedule=datetime.timedelta(days=1), session=session):
             op1 = EmptyOperator(task_id="A")
             op2 = EmptyOperator(task_id="B")
             op2.trigger_rule = TriggerRule.ONE_FAILED
             op2.set_upstream(op1)
 
-        dag.clear()
-        now = pendulum.now("UTC")
-        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
-        dr = dag.create_dagrun(
-            run_id="test_dagrun_deadlock",
-            state=DagRunState.RUNNING,
-            logical_date=now,
-            data_interval=dag.timetable.infer_manual_data_interval(run_after=now),
-            start_date=now,
-            session=session,
-            **triggered_by_kwargs,
-        )
+        dr = dag_maker.create_dagrun()
 
         ti_op1: TI = dr.get_task_instance(task_id=op1.task_id, session=session)
         ti_op2: TI = dr.get_task_instance(task_id=op2.task_id, session=session)
@@ -372,56 +340,32 @@ class TestDagRun:
         dr.update_state(session=session)
         assert dr.state == DagRunState.FAILED
 
-    def test_dagrun_no_deadlock_with_restarting(self, session):
-        dag = DAG(
-            "test_dagrun_no_deadlock_with_restarting",
-            schedule=datetime.timedelta(days=1),
-            start_date=DEFAULT_DATE,
-        )
-        with dag:
+    def test_dagrun_no_deadlock_with_restarting(self, dag_maker, session):
+        with dag_maker(schedule=datetime.timedelta(days=1)):
             op1 = EmptyOperator(task_id="upstream_task")
             op2 = EmptyOperator(task_id="downstream_task")
             op2.set_upstream(op1)
 
-        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
-        dr = dag.create_dagrun(
-            run_id="test_dagrun_no_deadlock_with_shutdown",
-            state=DagRunState.RUNNING,
-            logical_date=DEFAULT_DATE,
-            data_interval=dag.timetable.infer_manual_data_interval(run_after=DEFAULT_DATE),
-            start_date=DEFAULT_DATE,
-            **triggered_by_kwargs,
-        )
+        dr = dag_maker.create_dagrun()
         upstream_ti = dr.get_task_instance(task_id="upstream_task")
         upstream_ti.set_state(TaskInstanceState.RESTARTING, session=session)
 
         dr.update_state()
         assert dr.state == DagRunState.RUNNING
 
-    def test_dagrun_no_deadlock_with_depends_on_past(self, session):
-        dag = DAG("test_dagrun_no_deadlock", schedule=datetime.timedelta(days=1), start_date=DEFAULT_DATE)
-        with dag:
+    def test_dagrun_no_deadlock_with_depends_on_past(self, dag_maker, session):
+        with dag_maker(schedule=datetime.timedelta(days=1)):
             EmptyOperator(task_id="dop", depends_on_past=True)
             EmptyOperator(task_id="tc", max_active_tis_per_dag=1)
 
-        dag.clear()
-        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
-        dr = dag.create_dagrun(
+        dr = dag_maker.create_dagrun(
             run_id="test_dagrun_no_deadlock_1",
-            state=DagRunState.RUNNING,
-            logical_date=DEFAULT_DATE,
-            data_interval=dag.timetable.infer_manual_data_interval(run_after=DEFAULT_DATE),
             start_date=DEFAULT_DATE,
-            **triggered_by_kwargs,
         )
-        next_date = DEFAULT_DATE + datetime.timedelta(days=1)
-        dr2 = dag.create_dagrun(
+        dr2 = dag_maker.create_dagrun_after(
+            dr,
             run_id="test_dagrun_no_deadlock_2",
-            state=DagRunState.RUNNING,
-            logical_date=next_date,
-            data_interval=dag.timetable.infer_manual_data_interval(run_after=next_date),
-            start_date=next_date,
-            **triggered_by_kwargs,
+            start_date=DEFAULT_DATE + datetime.timedelta(days=1),
         )
         ti1_op1 = dr.get_task_instance(task_id="dop")
         dr2.get_task_instance(task_id="dop")
@@ -596,26 +540,11 @@ class TestDagRun:
             msg="task_failure",
         )
 
-    def test_dagrun_set_state_end_date(self, session):
-        dag = DAG(
-            "test_dagrun_set_state_end_date",
-            schedule=datetime.timedelta(days=1),
-            start_date=DEFAULT_DATE,
-            default_args={"owner": "owner1"},
-        )
+    def test_dagrun_set_state_end_date(self, dag_maker, session):
+        with dag_maker(schedule=datetime.timedelta(days=1), start_date=DEFAULT_DATE):
+            pass
 
-        dag.clear()
-
-        now = pendulum.now("UTC")
-        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
-        dr = dag.create_dagrun(
-            run_id="test_dagrun_set_state_end_date",
-            state=DagRunState.RUNNING,
-            logical_date=now,
-            data_interval=dag.timetable.infer_manual_data_interval(now),
-            start_date=now,
-            **triggered_by_kwargs,
-        )
+        dr = dag_maker.create_dagrun()
 
         # Initial end_date should be NULL
         # DagRunState.SUCCESS and DagRunState.FAILED are all ending state and should set end_date
@@ -628,7 +557,7 @@ class TestDagRun:
         session.merge(dr)
         session.commit()
 
-        dr_database = session.query(DagRun).filter(DagRun.run_id == "test_dagrun_set_state_end_date").one()
+        dr_database = session.query(DagRun).filter(DagRun.run_id == dr.run_id).one()
         assert dr_database.end_date is not None
         assert dr.end_date == dr_database.end_date
 
@@ -636,44 +565,26 @@ class TestDagRun:
         session.merge(dr)
         session.commit()
 
-        dr_database = session.query(DagRun).filter(DagRun.run_id == "test_dagrun_set_state_end_date").one()
+        dr_database = session.query(DagRun).filter(DagRun.run_id == dr.run_id).one()
 
         assert dr_database.end_date is None
 
         dr.set_state(DagRunState.FAILED)
         session.merge(dr)
         session.commit()
-        dr_database = session.query(DagRun).filter(DagRun.run_id == "test_dagrun_set_state_end_date").one()
+        dr_database = session.query(DagRun).filter(DagRun.run_id == dr.run_id).one()
 
         assert dr_database.end_date is not None
         assert dr.end_date == dr_database.end_date
 
-    def test_dagrun_update_state_end_date(self, session):
-        dag = DAG(
-            "test_dagrun_update_state_end_date",
-            schedule=datetime.timedelta(days=1),
-            start_date=DEFAULT_DATE,
-            default_args={"owner": "owner1"},
-        )
-
+    def test_dagrun_update_state_end_date(self, dag_maker, session):
         # A -> B
-        with dag:
+        with dag_maker(schedule=datetime.timedelta(days=1)):
             op1 = EmptyOperator(task_id="A")
             op2 = EmptyOperator(task_id="B")
             op1.set_upstream(op2)
 
-        dag.clear()
-
-        now = pendulum.now("UTC")
-        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
-        dr = dag.create_dagrun(
-            run_id="test_dagrun_update_state_end_date",
-            state=DagRunState.RUNNING,
-            logical_date=now,
-            data_interval=dag.timetable.infer_manual_data_interval(now),
-            start_date=now,
-            **triggered_by_kwargs,
-        )
+        dr = dag_maker.create_dagrun()
 
         # Initial end_date should be NULL
         # DagRunState.SUCCESS and DagRunState.FAILED are all ending state and should set end_date
@@ -689,7 +600,7 @@ class TestDagRun:
 
         dr.update_state()
 
-        dr_database = session.query(DagRun).filter(DagRun.run_id == "test_dagrun_update_state_end_date").one()
+        dr_database = session.query(DagRun).filter(DagRun.run_id == dr.run_id).one()
         assert dr_database.end_date is not None
         assert dr.end_date == dr_database.end_date
 
@@ -697,7 +608,7 @@ class TestDagRun:
         ti_op2.set_state(state=TaskInstanceState.RUNNING, session=session)
         dr.update_state()
 
-        dr_database = session.query(DagRun).filter(DagRun.run_id == "test_dagrun_update_state_end_date").one()
+        dr_database = session.query(DagRun).filter(DagRun.run_id == dr.run_id).one()
 
         assert dr._state == DagRunState.RUNNING
         assert dr.end_date is None
@@ -707,7 +618,7 @@ class TestDagRun:
         ti_op2.set_state(state=TaskInstanceState.FAILED, session=session)
         dr.update_state()
 
-        dr_database = session.query(DagRun).filter(DagRun.run_id == "test_dagrun_update_state_end_date").one()
+        dr_database = session.query(DagRun).filter(DagRun.run_id == dr.run_id).one()
 
         assert dr_database.end_date is not None
         assert dr.end_date == dr_database.end_date
@@ -927,6 +838,11 @@ class TestDagRun:
         session.flush()
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
         dr = dag.create_dagrun(
+            run_id=dag.timetable.generate_run_id(
+                run_type=DagRunType.SCHEDULED,
+                logical_date=DEFAULT_DATE,
+                data_interval=dag.infer_automated_data_interval(DEFAULT_DATE),
+            ),
             run_type=DagRunType.SCHEDULED,
             state=state,
             logical_date=DEFAULT_DATE,
@@ -1000,6 +916,11 @@ class TestDagRun:
             session.flush()
             triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
             dag_run = dag.create_dagrun(
+                run_id=dag.timetable.generate_run_id(
+                    run_type=DagRunType.SCHEDULED,
+                    logical_date=dag.start_date,
+                    data_interval=dag.infer_automated_data_interval(dag.start_date),
+                ),
                 run_type=DagRunType.SCHEDULED,
                 state=DagRunState.SUCCESS,
                 logical_date=dag.start_date,
@@ -1067,12 +988,7 @@ class TestDagRun:
         with dag_maker(session=session) as dag:
             PythonOperator(task_id="t1", python_callable=lambda: print)
             PythonOperator(task_id="t2", python_callable=lambda: print)
-        dr = dag.create_dagrun(
-            state=DagRunState.FAILED,
-            triggered_by=DagRunTriggeredByType.TEST,
-            run_id="abc123",
-            session=session,
-        )
+        dr = dag_maker.create_dagrun(state=DagRunState.FAILED)
         for ti in dr.get_task_instances(session=session):
             ti.state = TaskInstanceState.FAILED
         session.commit()
@@ -2823,9 +2739,10 @@ def test_tis_considered_for_state(dag_maker, session, input, expected):
 def test_dag_run_id_config(session, dag_maker, pattern, run_id, result):
     with conf_vars({("scheduler", "allowed_run_id_pattern"): pattern}):
         with dag_maker():
-            ...
+            pass
+        run_type = DagRunType.from_run_id(run_id)
         if result:
-            dag_maker.create_dagrun(run_id=run_id)
+            dag_maker.create_dagrun(run_id=run_id, run_type=run_type)
         else:
-            with pytest.raises(AirflowException):
-                dag_maker.create_dagrun(run_id=run_id)
+            with pytest.raises(ValueError):
+                dag_maker.create_dagrun(run_id=run_id, run_type=run_type)

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -123,6 +123,8 @@ class TestDagRun:
         if task_states is not None:
             for task_id, task_state in task_states.items():
                 ti = dag_run.get_task_instance(task_id)
+                if TYPE_CHECKING:
+                    assert ti
                 ti.set_state(task_state, session)
             session.flush()
 

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1748,6 +1748,8 @@ class TestTaskInstance:
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
         dr = ti.task.dag.create_dagrun(
             run_id="test2",
+            run_type=DagRunType.MANUAL,
+            logical_date=exec_date,
             data_interval=(exec_date, exec_date),
             state=None,
             **triggered_by_kwargs,
@@ -2022,6 +2024,7 @@ class TestTaskInstance:
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
         dr = ti1.task.dag.create_dagrun(
             logical_date=logical_date,
+            run_type=DagRunType.MANUAL,
             state=None,
             run_id="2",
             session=session,

--- a/tests/utils/test_log_handlers.py
+++ b/tests/utils/test_log_handlers.py
@@ -36,7 +36,6 @@ from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONF
 from airflow.executors import executor_loader
 from airflow.jobs.job import Job
 from airflow.jobs.triggerer_job_runner import TriggererJobRunner
-from airflow.models.dag import DAG
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance
 from airflow.models.trigger import Trigger
@@ -56,10 +55,6 @@ from airflow.utils.timezone import datetime
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.config import conf_vars
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.utils.types import DagRunTriggeredByType
 
 pytestmark = pytest.mark.db_test
 
@@ -91,24 +86,17 @@ class TestFileTaskLogHandler:
         handler = handlers[0]
         assert handler.name == FILE_TASK_HANDLER
 
-    def test_file_task_handler_when_ti_value_is_invalid(self):
+    def test_file_task_handler_when_ti_value_is_invalid(self, dag_maker):
         def task_callable(ti):
             ti.log.info("test")
 
-        dag = DAG("dag_for_testing_file_task_handler", schedule=None, start_date=DEFAULT_DATE)
-        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
-        dagrun = dag.create_dagrun(
-            run_type=DagRunType.MANUAL,
-            state=State.RUNNING,
-            logical_date=DEFAULT_DATE,
-            data_interval=dag.timetable.infer_manual_data_interval(run_after=DEFAULT_DATE),
-            **triggered_by_kwargs,
-        )
-        task = PythonOperator(
-            task_id="task_for_testing_file_log_handler",
-            dag=dag,
-            python_callable=task_callable,
-        )
+        with dag_maker("dag_for_testing_file_task_handler", schedule=None):
+            task = PythonOperator(
+                task_id="task_for_testing_file_log_handler",
+                python_callable=task_callable,
+            )
+
+        dagrun = dag_maker.create_dagrun()
         ti = TaskInstance(task=task, run_id=dagrun.run_id)
 
         logger = ti.log
@@ -146,26 +134,22 @@ class TestFileTaskLogHandler:
         # Remove the generated tmp log file.
         os.remove(log_filename)
 
-    def test_file_task_handler(self):
+    def test_file_task_handler(self, dag_maker, session):
         def task_callable(ti):
             ti.log.info("test")
 
-        dag = DAG("dag_for_testing_file_task_handler", schedule=None, start_date=DEFAULT_DATE)
-        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
-        dagrun = dag.create_dagrun(
-            run_type=DagRunType.MANUAL,
-            state=State.RUNNING,
-            logical_date=DEFAULT_DATE,
-            data_interval=dag.timetable.infer_manual_data_interval(run_after=DEFAULT_DATE),
-            **triggered_by_kwargs,
-        )
-        task = PythonOperator(
-            task_id="task_for_testing_file_log_handler",
-            dag=dag,
-            python_callable=task_callable,
-        )
-        ti = TaskInstance(task=task, run_id=dagrun.run_id)
+        with dag_maker("dag_for_testing_file_task_handler", schedule=None, session=session):
+            PythonOperator(
+                task_id="task_for_testing_file_log_handler",
+                python_callable=task_callable,
+            )
+
+        dagrun = dag_maker.create_dagrun()
+
+        (ti,) = dagrun.get_task_instances()
         ti.try_number += 1
+        session.merge(ti)
+        session.flush()
         logger = ti.log
         ti.log.disabled = False
 
@@ -203,24 +187,16 @@ class TestFileTaskLogHandler:
         # Remove the generated tmp log file.
         os.remove(log_filename)
 
-    def test_file_task_handler_running(self):
+    def test_file_task_handler_running(self, dag_maker):
         def task_callable(ti):
             ti.log.info("test")
 
-        dag = DAG("dag_for_testing_file_task_handler", schedule=None, start_date=DEFAULT_DATE)
-        task = PythonOperator(
-            task_id="task_for_testing_file_log_handler",
-            python_callable=task_callable,
-            dag=dag,
-        )
-        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
-        dagrun = dag.create_dagrun(
-            run_type=DagRunType.MANUAL,
-            state=State.RUNNING,
-            logical_date=DEFAULT_DATE,
-            data_interval=dag.timetable.infer_manual_data_interval(run_after=DEFAULT_DATE),
-            **triggered_by_kwargs,
-        )
+        with dag_maker("dag_for_testing_file_task_handler", schedule=None):
+            task = PythonOperator(
+                task_id="task_for_testing_file_log_handler",
+                python_callable=task_callable,
+            )
+        dagrun = dag_maker.create_dagrun()
         ti = TaskInstance(task=task, run_id=dagrun.run_id)
 
         ti.try_number = 2
@@ -256,7 +232,7 @@ class TestFileTaskLogHandler:
         # Remove the generated tmp log file.
         os.remove(log_filename)
 
-    def test_file_task_handler_rotate_size_limit(self):
+    def test_file_task_handler_rotate_size_limit(self, dag_maker):
         def reset_log_config(update_conf):
             import logging.config
 
@@ -270,20 +246,12 @@ class TestFileTaskLogHandler:
         max_bytes_size = 60000
         update_conf = {"handlers": {"task": {"max_bytes": max_bytes_size, "backup_count": 1}}}
         reset_log_config(update_conf)
-        dag = DAG("dag_for_testing_file_task_handler_rotate_size_limit", start_date=DEFAULT_DATE)
-        task = PythonOperator(
-            task_id="task_for_testing_file_log_handler_rotate_size_limit",
-            python_callable=task_callable,
-            dag=dag,
-        )
-        triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
-        dagrun = dag.create_dagrun(
-            run_type=DagRunType.MANUAL,
-            state=State.RUNNING,
-            logical_date=DEFAULT_DATE,
-            data_interval=dag.timetable.infer_manual_data_interval(run_after=DEFAULT_DATE),
-            **triggered_by_kwargs,
-        )
+        with dag_maker("dag_for_testing_file_task_handler_rotate_size_limit"):
+            task = PythonOperator(
+                task_id="task_for_testing_file_log_handler_rotate_size_limit",
+                python_callable=task_callable,
+            )
+        dagrun = dag_maker.create_dagrun()
         ti = TaskInstance(task=task, run_id=dagrun.run_id)
 
         ti.try_number = 1

--- a/tests/utils/test_sqlalchemy.py
+++ b/tests/utils/test_sqlalchemy.py
@@ -42,6 +42,7 @@ from airflow.utils.sqlalchemy import (
 )
 from airflow.utils.state import State
 from airflow.utils.timezone import utcnow
+from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
@@ -81,6 +82,7 @@ class TestSqlAlchemyUtils:
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
         run = dag.create_dagrun(
             run_id=iso_date,
+            run_type=DagRunType.MANUAL,
             state=State.NONE,
             logical_date=logical_date,
             start_date=start_date,
@@ -115,6 +117,7 @@ class TestSqlAlchemyUtils:
         with pytest.raises((ValueError, StatementError)):
             dag.create_dagrun(
                 run_id=start_date.isoformat,
+                run_type=DagRunType.MANUAL,
                 state=State.NONE,
                 logical_date=start_date,
                 start_date=start_date,

--- a/tests/utils/test_state.py
+++ b/tests/utils/test_state.py
@@ -44,6 +44,11 @@ def test_dagrun_state_enum_escape():
         dag = DAG(dag_id="test_dagrun_state_enum_escape", schedule=timedelta(days=1), start_date=DEFAULT_DATE)
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
         dag.create_dagrun(
+            run_id=dag.timetable.generate_run_id(
+                run_type=DagRunType.SCHEDULED,
+                logical_date=DEFAULT_DATE,
+                data_interval=dag.timetable.infer_manual_data_interval(run_after=DEFAULT_DATE),
+            ),
             run_type=DagRunType.SCHEDULED,
             state=DagRunState.QUEUED,
             logical_date=DEFAULT_DATE,

--- a/tests/www/test_utils.py
+++ b/tests/www/test_utils.py
@@ -616,16 +616,10 @@ def test_dag_run_custom_sqla_interface_delete_no_collateral_damage(dag_maker, se
     interface = DagRunCustomSQLAInterface(obj=DagRun, session=session)
     dag_ids = (f"test_dag_{x}" for x in range(1, 4))
     dates = (pendulum.datetime(2023, 1, x) for x in range(1, 4))
-    triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
     for dag_id, date in itertools.product(dag_ids, dates):
-        with dag_maker(dag_id=dag_id) as dag:
-            dag.create_dagrun(
-                logical_date=date,
-                state="running",
-                run_type="scheduled",
-                data_interval=(date, date),
-                **triggered_by_kwargs,
-            )
+        with dag_maker(dag_id=dag_id):
+            pass
+        dag_maker.create_dagrun(logical_date=date, state="running", run_type="scheduled")
     dag_runs = session.query(DagRun).all()
     assert len(dag_runs) == 9
     assert len(set(x.run_id for x in dag_runs)) == 3

--- a/tests/www/views/test_views_acl.py
+++ b/tests/www/views/test_views_acl.py
@@ -159,6 +159,7 @@ def _init_dagruns(acl_app, _reset_dagruns):
         **triggered_by_kwargs,
     )
     acl_app.dag_bag.get_dag("example_python_operator").create_dagrun(
+        run_id=DEFAULT_RUN_ID,
         run_type=DagRunType.SCHEDULED,
         logical_date=DEFAULT_DATE,
         start_date=timezone.utcnow(),

--- a/tests/www/views/test_views_dagrun.py
+++ b/tests/www/views/test_views_dagrun.py
@@ -23,6 +23,7 @@ from airflow.models import DagBag, DagRun, TaskInstance
 from airflow.security import permissions
 from airflow.utils import timezone
 from airflow.utils.session import create_session
+from airflow.utils.types import DagRunType
 from airflow.www.views import DagRunModelView
 
 from providers.tests.fab.auth_manager.api_endpoints.api_connexion_utils import (
@@ -146,6 +147,7 @@ def running_dag_run(session):
         logical_date=logical_date,
         data_interval=(logical_date, logical_date),
         run_id="test_dag_runs_action",
+        run_type=DagRunType.MANUAL,
         session=session,
         **triggered_by_kwargs,
     )
@@ -169,6 +171,7 @@ def completed_dag_run_with_missing_task(session):
         logical_date=logical_date,
         data_interval=(logical_date, logical_date),
         run_id="test_dag_runs_action",
+        run_type=DagRunType.MANUAL,
         session=session,
         **triggered_by_kwargs,
     )
@@ -324,6 +327,7 @@ def dag_run_with_all_done_task(session):
         logical_date=logical_date,
         data_interval=(logical_date, logical_date),
         run_id="test_dagrun_failed",
+        run_type=DagRunType.MANUAL,
         session=session,
         **triggered_by_kwargs,
     )

--- a/tests/www/views/test_views_decorators.py
+++ b/tests/www/views/test_views_decorators.py
@@ -62,6 +62,7 @@ def xcom_dag(dagbag):
 def dagruns(bash_dag, xcom_dag):
     triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
     bash_dagrun = bash_dag.create_dagrun(
+        run_id="test_bash",
         run_type=DagRunType.SCHEDULED,
         logical_date=EXAMPLE_DAG_DEFAULT_DATE,
         data_interval=(EXAMPLE_DAG_DEFAULT_DATE, EXAMPLE_DAG_DEFAULT_DATE),
@@ -71,6 +72,7 @@ def dagruns(bash_dag, xcom_dag):
     )
 
     xcom_dagrun = xcom_dag.create_dagrun(
+        run_id="test_xcom",
         run_type=DagRunType.SCHEDULED,
         logical_date=EXAMPLE_DAG_DEFAULT_DATE,
         data_interval=(EXAMPLE_DAG_DEFAULT_DATE, EXAMPLE_DAG_DEFAULT_DATE),

--- a/tests/www/views/test_views_extra_links.py
+++ b/tests/www/views/test_views_extra_links.py
@@ -90,6 +90,7 @@ def create_dag_run(dag):
     def _create_dag_run(*, logical_date, session):
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
         return dag.create_dagrun(
+            run_id=f"manual__{logical_date.isoformat()}",
             state=DagRunState.RUNNING,
             logical_date=logical_date,
             data_interval=(logical_date, logical_date),

--- a/tests/www/views/test_views_log.py
+++ b/tests/www/views/test_views_log.py
@@ -160,6 +160,7 @@ def tis(dags, session):
     dag, dag_removed = dags
     triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
     dagrun = dag.create_dagrun(
+        run_id=f"scheduled__{DEFAULT_DATE.isoformat()}",
         run_type=DagRunType.SCHEDULED,
         logical_date=DEFAULT_DATE,
         data_interval=(DEFAULT_DATE, DEFAULT_DATE),
@@ -172,6 +173,7 @@ def tis(dags, session):
     ti.try_number = 1
     ti.hostname = "localhost"
     dagrun_removed = dag_removed.create_dagrun(
+        run_id=f"scheduled__{DEFAULT_DATE.isoformat()}",
         run_type=DagRunType.SCHEDULED,
         logical_date=DEFAULT_DATE,
         data_interval=(DEFAULT_DATE, DEFAULT_DATE),

--- a/tests/www/views/test_views_rendered.py
+++ b/tests/www/views/test_views_rendered.py
@@ -147,6 +147,7 @@ def create_dag_run(dag, task1, task2, task3, task4, task_secret):
     def _create_dag_run(*, logical_date, session):
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
         dag_run = dag.create_dagrun(
+            run_id="test",
             state=DagRunState.RUNNING,
             logical_date=logical_date,
             data_interval=(logical_date, logical_date),
@@ -343,6 +344,7 @@ def test_rendered_task_detail_env_secret(patch_app, admin_client, request, env, 
     with create_session() as session:
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
         dag.create_dagrun(
+            run_id="test",
             state=DagRunState.RUNNING,
             logical_date=DEFAULT_DATE,
             data_interval=(DEFAULT_DATE, DEFAULT_DATE),

--- a/tests/www/views/test_views_tasks.py
+++ b/tests/www/views/test_views_tasks.py
@@ -397,6 +397,7 @@ def test_rendered_k8s_without_k8s(admin_client):
 def test_tree_trigger_origin_tree_view(app, admin_client):
     triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
     app.dag_bag.get_dag("example_bash_operator").create_dagrun(
+        run_id="test",
         run_type=DagRunType.SCHEDULED,
         logical_date=DEFAULT_DATE,
         data_interval=(DEFAULT_DATE, DEFAULT_DATE),
@@ -415,6 +416,7 @@ def test_tree_trigger_origin_tree_view(app, admin_client):
 def test_graph_trigger_origin_grid_view(app, admin_client):
     triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
     app.dag_bag.get_dag("example_bash_operator").create_dagrun(
+        run_id="test",
         run_type=DagRunType.SCHEDULED,
         logical_date=DEFAULT_DATE,
         data_interval=(DEFAULT_DATE, DEFAULT_DATE),
@@ -433,6 +435,7 @@ def test_graph_trigger_origin_grid_view(app, admin_client):
 def test_gantt_trigger_origin_grid_view(app, admin_client):
     triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
     app.dag_bag.get_dag("example_bash_operator").create_dagrun(
+        run_id="test",
         run_type=DagRunType.SCHEDULED,
         logical_date=DEFAULT_DATE,
         data_interval=(DEFAULT_DATE, DEFAULT_DATE),

--- a/tests_common/pytest_plugin.py
+++ b/tests_common/pytest_plugin.py
@@ -884,7 +884,7 @@ def dag_maker(request) -> Generator[DagMaker, None, None]:
 
             dag = self.dag
             kwargs = {
-                "run_type": (run_type := DagRunType.MANUAL),
+                "run_type": DagRunType.MANUAL,
                 "state": DagRunState.RUNNING,
                 "start_date": self.start_date,
                 "session": self.session,
@@ -892,7 +892,7 @@ def dag_maker(request) -> Generator[DagMaker, None, None]:
             }
 
             if logical_date is None:
-                if run_type == DagRunType.MANUAL:
+                if kwargs["run_type"] == DagRunType.MANUAL:
                     logical_date = self.start_date
                 else:
                     logical_date = dag.next_dagrun_info(None).logical_date
@@ -901,7 +901,7 @@ def dag_maker(request) -> Generator[DagMaker, None, None]:
             try:
                 data_interval = kwargs["data_interval"]
             except KeyError:
-                if run_type == DagRunType.MANUAL:
+                if kwargs["run_type"] == DagRunType.MANUAL:
                     data_interval = dag.timetable.infer_manual_data_interval(run_after=logical_date)
                 else:
                     data_interval = dag.infer_automated_data_interval(logical_date)
@@ -909,7 +909,7 @@ def dag_maker(request) -> Generator[DagMaker, None, None]:
 
             if "run_id" not in kwargs:
                 kwargs["run_id"] = dag.timetable.generate_run_id(
-                    run_type=run_type,
+                    run_type=kwargs["run_type"],
                     logical_date=logical_date,
                     data_interval=data_interval,
                 )

--- a/tests_common/pytest_plugin.py
+++ b/tests_common/pytest_plugin.py
@@ -884,32 +884,36 @@ def dag_maker(request) -> Generator[DagMaker, None, None]:
 
             dag = self.dag
             kwargs = {
+                "dag_version": None,
+                "run_type": (run_type := DagRunType.MANUAL),
                 "state": DagRunState.RUNNING,
                 "start_date": self.start_date,
                 "session": self.session,
                 **kwargs,
             }
-            # Need to provide run_id if the user does not either provide one
-            # explicitly, or pass run_type for inference in dag.create_dagrun().
-            if "run_id" not in kwargs and "run_type" not in kwargs:
-                kwargs["run_id"] = "test"
-
-            if "run_type" not in kwargs:
-                kwargs["run_type"] = DagRunType.from_run_id(kwargs["run_id"])
 
             if logical_date is None:
-                if kwargs["run_type"] == DagRunType.MANUAL:
+                if run_type == DagRunType.MANUAL:
                     logical_date = self.start_date
                 else:
                     logical_date = dag.next_dagrun_info(None).logical_date
             logical_date = timezone.coerce_datetime(logical_date)
 
-            if "data_interval" not in kwargs:
-                if kwargs["run_type"] == DagRunType.MANUAL:
+            try:
+                data_interval = kwargs["data_interval"]
+            except KeyError:
+                if run_type == DagRunType.MANUAL:
                     data_interval = dag.timetable.infer_manual_data_interval(run_after=logical_date)
                 else:
                     data_interval = dag.infer_automated_data_interval(logical_date)
                 kwargs["data_interval"] = data_interval
+
+            if "run_id" not in kwargs:
+                kwargs["run_id"] = dag.timetable.generate_run_id(
+                    run_type=run_type,
+                    logical_date=logical_date,
+                    data_interval=data_interval,
+                )
 
             if AIRFLOW_V_3_0_PLUS:
                 kwargs.setdefault("triggered_by", DagRunTriggeredByType.TEST)

--- a/tests_common/pytest_plugin.py
+++ b/tests_common/pytest_plugin.py
@@ -889,7 +889,10 @@ def dag_maker(request) -> Generator[DagMaker, None, None]:
                 "session": self.session,
                 **kwargs,
             }
+
             run_type = kwargs.get("run_type", DagRunType.MANUAL)
+            if not isinstance(run_type, DagRunType):
+                run_type = DagRunType(run_type)
 
             if logical_date is None:
                 if run_type == DagRunType.MANUAL:
@@ -912,7 +915,7 @@ def dag_maker(request) -> Generator[DagMaker, None, None]:
                     kwargs["run_id"] = "test"
                 else:
                     kwargs["run_id"] = dag.timetable.generate_run_id(
-                        run_type=kwargs["run_type"],
+                        run_type=run_type,
                         logical_date=logical_date,
                         data_interval=data_interval,
                     )

--- a/tests_common/pytest_plugin.py
+++ b/tests_common/pytest_plugin.py
@@ -884,7 +884,6 @@ def dag_maker(request) -> Generator[DagMaker, None, None]:
 
             dag = self.dag
             kwargs = {
-                "dag_version": None,
                 "run_type": (run_type := DagRunType.MANUAL),
                 "state": DagRunState.RUNNING,
                 "start_date": self.start_date,
@@ -918,6 +917,7 @@ def dag_maker(request) -> Generator[DagMaker, None, None]:
             if AIRFLOW_V_3_0_PLUS:
                 kwargs.setdefault("triggered_by", DagRunTriggeredByType.TEST)
                 kwargs["logical_date"] = logical_date
+                kwargs["dag_version"] = None
             else:
                 kwargs.pop("triggered_by", None)
                 kwargs["execution_date"] = logical_date


### PR DESCRIPTION
This aims to make the interface more straightforward, removing auto inference logic from the function. Most importantly, it is now entirely the caller site's responsibility to provide valid run_id and run_type values, instead of the function automatically inferring one from the other under certain conditions.

The main goal is to make changes simpler when we make logical date an optional (nullable) value. run_id generation is currently very heavily based on the logical date, and will need to be changed a bit when logical date is None. Removing logic should help us change the run_id generation logic easier.

~~p.s. not yet ready, many tests should fail.~~ Finally ready; this took way much more than I thought.