### PR TITLE
Add a retry on first PowerBI refresh status check

### DIFF
--- a/providers/src/airflow/providers/microsoft/azure/hooks/powerbi.py
+++ b/providers/src/airflow/providers/microsoft/azure/hooks/powerbi.py
@@ -20,8 +20,9 @@ from __future__ import annotations
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from airflow.exceptions import AirflowException
 from airflow.providers.microsoft.azure.hooks.msgraph import KiotaRequestAdapterHook
+
+from airflow.exceptions import AirflowException
 
 if TYPE_CHECKING:
     from msgraph_core import APIVersion
@@ -48,6 +49,10 @@ class PowerBIDatasetRefreshStatus:
 
 
 class PowerBIDatasetRefreshException(AirflowException):
+    """An exception that indicates a dataset refresh failed to complete."""
+
+
+class PowerBIDatasetRefreshStatusException(AirflowException):
     """An exception that indicates a dataset refresh failed to complete."""
 
 
@@ -157,7 +162,7 @@ class PowerBIHook(KiotaRequestAdapterHook):
         refresh_histories = await self.get_refresh_history(dataset_id=dataset_id, group_id=group_id)
 
         if len(refresh_histories) == 0:
-            raise PowerBIDatasetRefreshException(
+            raise PowerBIDatasetRefreshStatusException(
                 f"Unable to fetch the details of dataset refresh with Request Id: {refresh_id}"
             )
 
@@ -167,7 +172,7 @@ class PowerBIHook(KiotaRequestAdapterHook):
         ]
 
         if refresh_id not in refresh_ids:
-            raise PowerBIDatasetRefreshException(
+            raise PowerBIDatasetRefreshStatusException(
                 f"Unable to fetch the details of dataset refresh with Request Id: {refresh_id}"
             )
 

--- a/providers/src/airflow/providers/microsoft/azure/hooks/powerbi.py
+++ b/providers/src/airflow/providers/microsoft/azure/hooks/powerbi.py
@@ -20,9 +20,8 @@ from __future__ import annotations
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from airflow.providers.microsoft.azure.hooks.msgraph import KiotaRequestAdapterHook
-
 from airflow.exceptions import AirflowException
+from airflow.providers.microsoft.azure.hooks.msgraph import KiotaRequestAdapterHook
 
 if TYPE_CHECKING:
     from msgraph_core import APIVersion

--- a/providers/src/airflow/providers/microsoft/azure/triggers/powerbi.py
+++ b/providers/src/airflow/providers/microsoft/azure/triggers/powerbi.py
@@ -27,7 +27,6 @@ from airflow.providers.microsoft.azure.hooks.powerbi import (
     PowerBIDatasetRefreshStatusException,
     PowerBIHook,
 )
-
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 
 if TYPE_CHECKING:

--- a/providers/tests/microsoft/azure/hooks/test_powerbi.py
+++ b/providers/tests/microsoft/azure/hooks/test_powerbi.py
@@ -26,6 +26,7 @@ from airflow.providers.microsoft.azure.hooks.powerbi import (
     PowerBIDatasetRefreshException,
     PowerBIDatasetRefreshFields,
     PowerBIDatasetRefreshStatus,
+    PowerBIDatasetRefreshStatusException,
     PowerBIHook,
 )
 
@@ -140,7 +141,7 @@ class TestPowerBIHook:
 
         # Call the function with an invalid request ID
         invalid_request_id = "invalid_request_id"
-        with pytest.raises(PowerBIDatasetRefreshException):
+        with pytest.raises(PowerBIDatasetRefreshStatusException):
             await powerbi_hook.get_refresh_details_by_refresh_id(
                 dataset_id=DATASET_ID, group_id=GROUP_ID, refresh_id=invalid_request_id
             )
@@ -154,7 +155,7 @@ class TestPowerBIHook:
         # Call the function with a request ID
         refresh_id = "any_request_id"
         with pytest.raises(
-            PowerBIDatasetRefreshException,
+            PowerBIDatasetRefreshStatusException,
             match=f"Unable to fetch the details of dataset refresh with Request Id: {refresh_id}",
         ):
             await powerbi_hook.get_refresh_details_by_refresh_id(
@@ -170,7 +171,7 @@ class TestPowerBIHook:
         # Call the function with an invalid request ID
         invalid_request_id = "invalid_request_id"
         with pytest.raises(
-            PowerBIDatasetRefreshException,
+            PowerBIDatasetRefreshStatusException,
             match=f"Unable to fetch the details of dataset refresh with Request Id: {invalid_request_id}",
         ):
             await powerbi_hook.get_refresh_details_by_refresh_id(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Fix for the issue: https://github.com/apache/airflow/issues/44618

This MR aims to add a retry to the first request that checks the PowerBI refresh status, which sometimes fail due to lack of sync API side.

## Tests

- [x] This was tested locally:

![image](https://github.com/user-attachments/assets/5b018255-2616-40b6-acd4-d470c70ceca6)

- [ ] A unit test was added to check the retry behavior.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
