### PR TITLE
Adjust JSX element depth from 5 to 7

### DIFF
--- a/airflow/ui/rules/react.js
+++ b/airflow/ui/rules/react.js
@@ -458,11 +458,11 @@ export const reactRules = /** @type {const} @satisfies {FlatConfig.Config} */ ({
     [`${reactNamespace}/jsx-key`]: ERROR,
 
     /**
-     * Enforce JSX maximum depth to 5.
+     * Enforce JSX maximum depth to 7.
      *
      * @see [react/jsx-max-depth](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/jsx-max-depth.md)
      */
-    [`${reactNamespace}/jsx-max-depth`]: [ERROR, { max: 5 }],
+    [`${reactNamespace}/jsx-max-depth`]: [ERROR, { max: 7 }],
 
     /**
      * Disallow comments from being inserted as text nodes.


### PR DESCRIPTION
After merge of PR #45273 the canary failed in UI static checks.

Error run is: https://github.com/apache/airflow/actions/runs/12598486200/job/35113887885

Reason is JSX validation which checks element depth <5 - which in my view does not make sense if we render tables with a few elements that unfortunately easily reach a level of 7 - cutting sub-components does not smell resonable.

Therefore with this PR I propose to change the accepted JSX element depth to 7.

Alternatively we would need to revert and rework the PR #45273 and cut more components to the UI.