### PR TITLE
Mark image as refreshed after it's build

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
@@ -97,7 +97,7 @@ from airflow_breeze.utils.docker_command_utils import (
 )
 from airflow_breeze.utils.github import download_artifact_from_pr, download_artifact_from_run_id
 from airflow_breeze.utils.image import run_pull_image, run_pull_in_parallel
-from airflow_breeze.utils.mark_image_as_refreshed import mark_image_as_refreshed
+from airflow_breeze.utils.mark_image_as_refreshed import mark_image_as_rebuilt
 from airflow_breeze.utils.md5_build_check import md5sum_check_if_build_is_needed
 from airflow_breeze.utils.parallel import (
     DockerBuildxProgressMatcher,
@@ -692,7 +692,7 @@ def load(
         image_file.unlink()
     if get_verbose():
         run_command(["docker", "images", "-a"])
-    mark_image_as_refreshed(ci_image_params=build_ci_params)
+    mark_image_as_rebuilt(ci_image_params=build_ci_params)
 
 
 @ci_image.command(
@@ -938,6 +938,8 @@ def run_build_ci_image(
                 get_console().print(
                     "[info]Run `breeze ci-image build --upgrade-to-newer-dependencies` to upgrade them.\n"
                 )
+        if build_command_result.returncode == 0:
+            mark_image_as_rebuilt(ci_image_params=ci_image_params)
     return build_command_result.returncode, f"Image build: {param_description}"
 
 

--- a/dev/breeze/src/airflow_breeze/utils/image.py
+++ b/dev/breeze/src/airflow_breeze/utils/image.py
@@ -29,7 +29,7 @@ from airflow_breeze.params.build_ci_params import BuildCiParams
 from airflow_breeze.params.shell_params import ShellParams
 from airflow_breeze.utils.ci_group import ci_group
 from airflow_breeze.utils.console import Output, get_console
-from airflow_breeze.utils.mark_image_as_refreshed import mark_image_as_refreshed
+from airflow_breeze.utils.mark_image_as_refreshed import mark_image_as_rebuilt
 from airflow_breeze.utils.parallel import (
     DOCKER_PULL_PROGRESS_REGEXP,
     GenericRegexpProgressMatcher,
@@ -149,7 +149,7 @@ def run_pull_image(
                         f"Image Python {image_params.python}",
                     )
                 if isinstance(image_params, BuildCiParams):
-                    mark_image_as_refreshed(image_params)
+                    mark_image_as_rebuilt(image_params)
             return command_result.returncode, f"Image Python {image_params.python}"
         if wait_for_image:
             if get_verbose() or get_dry_run():

--- a/dev/breeze/src/airflow_breeze/utils/mark_image_as_refreshed.py
+++ b/dev/breeze/src/airflow_breeze/utils/mark_image_as_refreshed.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from airflow_breeze.params.build_ci_params import BuildCiParams
 
 
-def mark_image_as_refreshed(ci_image_params: BuildCiParams):
+def mark_image_as_rebuilt(ci_image_params: BuildCiParams):
     ci_image_cache_dir = BUILD_CACHE_DIR / ci_image_params.airflow_branch
     ci_image_cache_dir.mkdir(parents=True, exist_ok=True)
     touch_cache_file(f"built_{ci_image_params.python}", root_dir=ci_image_cache_dir)


### PR DESCRIPTION
Somewhere in the last refactorings and ci cache we lost marking the image as "refreshed" after it's build. Currently it does not matter if you press "y" or "n" when you are asked for image rebuilding next time you are asked again, but it should not happen if your image is rebuilt successfully.

This PR restores "mark image as refreshed" after it's rebuild and renames it to "mark_image_as_rebuilt"

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
