### PR TITLE
Evaluate canary-run condition in run-tests SelectiveChecks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
       run-kubernetes-tests: ${{ steps.selective-checks.outputs.run-kubernetes-tests }}
       run-task-sdk-tests: ${{ steps.selective-checks.outputs.run-task-sdk-tests }}
       run-system-tests: ${{ steps.selective-checks.outputs.run-system-tests }}
-      run-tests: ${{ steps.selective-checks.outputs.run-tests }}
+      run-tests: ${{ steps.source-run-info.outputs.canary-run == 'true' && 'true' || steps.selective-checks.outputs.run-tests }}
       run-ui-tests: ${{ steps.selective-checks.outputs.run-ui-tests }}
       run-www-tests: ${{ steps.selective-checks.outputs.run-www-tests }}
       runs-on-as-json-default: ${{ steps.selective-checks.outputs.runs-on-as-json-default }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
       run-kubernetes-tests: ${{ steps.selective-checks.outputs.run-kubernetes-tests }}
       run-task-sdk-tests: ${{ steps.selective-checks.outputs.run-task-sdk-tests }}
       run-system-tests: ${{ steps.selective-checks.outputs.run-system-tests }}
-      run-tests: ${{ steps.source-run-info.outputs.canary-run == 'true' && 'true' || steps.selective-checks.outputs.run-tests }}
+      run-tests: ${{ steps.selective-checks.outputs.run-tests }}
       run-ui-tests: ${{ steps.selective-checks.outputs.run-ui-tests }}
       run-www-tests: ${{ steps.selective-checks.outputs.run-www-tests }}
       runs-on-as-json-default: ${{ steps.selective-checks.outputs.runs-on-as-json-default }}

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -746,6 +746,8 @@ class SelectiveChecks:
 
     @cached_property
     def run_tests(self) -> bool:
+        if self._is_canary_run():
+            return True
         if self.only_new_ui_files:
             return False
         # we should run all test


### PR DESCRIPTION
This will help cases like when `run-tests` becomes false if it is canary-run . 
Some times tests are getting skipped in canary run.

We have condition in jobs to trigger for `run-tests`, even thought this works but often some times `run-tests` becomes false when the last merge commit main has only some UI changes. then this causing skipping of canary run tests jobs. see below it has skipped most of the jobs. because the selective check here https://github.com/apache/airflow/actions/runs/12602875121/job/35126775759#step:8:217 triggered only the ui file changes

https://github.com/apache/airflow/actions/runs/12602875121/job/35126775759
https://github.com/apache/airflow/actions/runs/12602875121/job/35126775759#step:8:310
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
