### PR TITLE
Cease using ``InventoryFileReader``

### DIFF
--- a/docs/exts/docs_build/fetch_inventories.py
+++ b/docs/exts/docs_build/fetch_inventories.py
@@ -30,7 +30,6 @@ from tempfile import NamedTemporaryFile
 import requests
 import urllib3.exceptions
 from requests.adapters import DEFAULT_POOLSIZE
-from sphinx.util.inventory import InventoryFileReader
 
 from airflow.utils.helpers import partition
 from docs.exts.docs_build.docs_builder import get_available_providers_packages
@@ -73,7 +72,7 @@ def _fetch_file(session: requests.Session, package_name: str, url: str, path: st
         tf.flush()
         tf.seek(0, 0)
 
-        line = InventoryFileReader(tf).readline()
+        line = tf.readline().decode()
         if not line.startswith("# Sphinx inventory version"):
             print(f"{package_name}: Response contain unexpected Sphinx Inventory header: {line!r}.")
             return package_name, False


### PR DESCRIPTION
Hello,

In Sphinx we are looking to refactor handling of inventory reading, which might involve deprecating or removing `InventoryFileReader`. Airflow is one of four projects I have found in the wild that uses it, but your usage can be replaced with a single call to `.readline().decode()`, as you are only sanity-checking the first line of content.

A