### PR TITLE
Allow empty value while variable creation

### DIFF
--- a/airflow/api_fastapi/core_api/datamodels/variables.py
+++ b/airflow/api_fastapi/core_api/datamodels/variables.py
@@ -33,7 +33,7 @@ class VariableResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True, from_attributes=True)
 
     key: str
-    val: str | None = Field(alias="value")
+    val: str = Field(alias="value")
     description: str | None
     is_encrypted: bool
 
@@ -56,7 +56,7 @@ class VariableBody(BaseModel):
     """Variable serializer for bodies."""
 
     key: str = Field(max_length=ID_LEN)
-    value: str | None = Field(serialization_alias="val")
+    value: str = Field(serialization_alias="val")
     description: str | None = Field(default=None)
 
 

--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -9736,9 +9736,7 @@ components:
           maxLength: 250
           title: Key
         value:
-          anyOf:
-          - type: string
-          - type: 'null'
+          type: string
           title: Value
         description:
           anyOf:
@@ -9773,9 +9771,7 @@ components:
           type: string
           title: Key
         value:
-          anyOf:
-          - type: string
-          - type: 'null'
+          type: string
           title: Value
         description:
           anyOf:

--- a/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -5485,14 +5485,7 @@ export const $VariableBody = {
       title: "Key",
     },
     value: {
-      anyOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
+      type: "string",
       title: "Value",
     },
     description: {
@@ -5540,14 +5533,7 @@ export const $VariableResponse = {
       title: "Key",
     },
     value: {
-      anyOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
+      type: "string",
       title: "Value",
     },
     description: {

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1276,7 +1276,7 @@ export type ValidationError = {
  */
 export type VariableBody = {
   key: string;
-  value: string | null;
+  value: string;
   description?: string | null;
 };
 
@@ -1293,7 +1293,7 @@ export type VariableCollectionResponse = {
  */
 export type VariableResponse = {
   key: string;
-  value: string | null;
+  value: string;
   description: string | null;
   is_encrypted: boolean;
 };

--- a/airflow/ui/src/pages/Variables/ManageVariable/EditVariableButton.tsx
+++ b/airflow/ui/src/pages/Variables/ManageVariable/EditVariableButton.tsx
@@ -36,7 +36,7 @@ const EditVariableButton = ({ variable }: Props) => {
   const initialVariableValue: VariableBody = {
     description: variable.description ?? "",
     key: variable.key,
-    value: variable.value ?? "",
+    value: variable.value,
   };
   const { editVariable, error, isPending, setError } = useEditVariable(initialVariableValue, {
     onSuccessConfirm: onClose,

--- a/airflow/ui/src/pages/Variables/ManageVariable/VariableForm.tsx
+++ b/airflow/ui/src/pages/Variables/ManageVariable/VariableForm.tsx
@@ -80,18 +80,14 @@ const VariableForm = ({ error, initialVariable, isPending, manageMutate, setErro
       <Controller
         control={control}
         name="value"
-        render={({ field, fieldState }) => (
-          <Field.Root invalid={Boolean(fieldState.error)} mt={4} required>
+        render={({ field }) => (
+          <Field.Root mt={4}>
             <Field.Label fontSize="md">
               Value <Field.RequiredIndicator />
             </Field.Label>
-            <Textarea {...field} required size="sm" />
-            {fieldState.error ? <Field.ErrorText>{fieldState.error.message}</Field.ErrorText> : undefined}
+            <Textarea {...field} size="sm" />
           </Field.Root>
         )}
-        rules={{
-          required: "Value is required",
-        }}
       />
 
       <Controller

--- a/tests/api_fastapi/core_api/routes/public/test_variables.py
+++ b/tests/api_fastapi/core_api/routes/public/test_variables.py
@@ -356,6 +356,19 @@ class TestPostVariable(TestVariableEndpoint):
                     "is_encrypted": True,
                 },
             ),
+            (
+                {
+                    "key": "empty value variable",
+                    "value": "",
+                    "description": "some description",
+                },
+                {
+                    "key": "empty value variable",
+                    "value": "",
+                    "description": "some description",
+                    "is_encrypted": True,
+                },
+            ),
         ],
     )
     def test_post_should_respond_201(self, test_client, session, body, expected_response):
@@ -396,6 +409,25 @@ class TestPostVariable(TestVariableEndpoint):
                     "msg": "String should have at most 250 characters",
                     "input": large_key,
                     "ctx": {"max_length": 250},
+                }
+            ]
+        }
+
+    def test_post_should_respond_422_when_value_is_null(self, test_client):
+        body = {
+            "key": "null value key",
+            "value": None,
+            "description": "key too large",
+        }
+        response = test_client.post("/public/variables", json=body)
+        assert response.status_code == 422
+        assert response.json() == {
+            "detail": [
+                {
+                    "type": "string_type",
+                    "loc": ["body", "value"],
+                    "msg": "Input should be a valid string",
+                    "input": None,
                 }
             ]
         }


### PR DESCRIPTION
As discussed in https://apache-airflow.slack.com/archives/C0809U4S1Q9/p1736000063416279 , Variables with empty value  is allowed.

<img width="984" alt="image" src="https://github.com/user-attachments/assets/bbba686f-a916-4f77-86f5-1a3624be09e7" />

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/583970ea-ea6c-4638-9793-61c8f1c2a2a9" />


Incase of null :
<img width="1406" alt="image" src="https://github.com/user-attachments/assets/ac93f58d-f370-428b-8434-ac4de178b3e8" />



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
