### PR TITLE
docs: clarify which fields are masked in the UI

### DIFF
--- a/docs/apache-airflow/security/secrets/mask-sensitive-values.rst
+++ b/docs/apache-airflow/security/secrets/mask-sensitive-values.rst
@@ -39,9 +39,9 @@ When masking is enabled, Airflow will always mask the password field of every Co
 task.
 
 It will also mask the value of a Variable, rendered template dictionaries, XCom dictionaries or the
-field of a Connection's extra JSON blob if the name contains
-any words in ('access_token', 'api_key', 'apikey', 'authorization', 'passphrase', 'passwd',
-'password', 'private_key', 'secret', 'token'). This list can also be extended:
+field of a Connection's extra JSON blob if the name is in the list of known-sensitive fields (i.e. 'access_token',
+'api_key', 'apikey', 'authorization', 'passphrase', 'passwd', 'password', 'private_key', 'secret' or 'token').
+This list can also be extended:
 
 .. code-block:: ini
 


### PR DESCRIPTION
The word 'contains' was used slightly confusingly here: it was meant to mean 'the name field contains any of these strings', but you could also read it as 'the name itself contains any of these strings'. This removes any ambiguity.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
