### PR TITLE
AIP-38 Ability to update note when clearing a DagRun

### DIFF
--- a/airflow/ui/src/components/ClearRun/ClearRunButton.tsx
+++ b/airflow/ui/src/components/ClearRun/ClearRunButton.tsx
@@ -20,19 +20,21 @@ import { Box, useDisclosure } from "@chakra-ui/react";
 import { useState } from "react";
 import { FiRefreshCw } from "react-icons/fi";
 
-import type { TaskInstanceCollectionResponse } from "openapi/requests/types.gen";
+import type {
+  DAGRunResponse,
+  TaskInstanceCollectionResponse,
+} from "openapi/requests/types.gen";
 import { useClearDagRun } from "src/queries/useClearRun";
 
 import ActionButton from "../ui/ActionButton";
 import ClearRunDialog from "./ClearRunDialog";
 
 type Props = {
-  readonly dagId: string;
-  readonly dagRunId: string;
+  readonly dagRun: DAGRunResponse;
   readonly withText?: boolean;
 };
 
-const ClearRunButton = ({ dagId, dagRunId, withText = true }: Props) => {
+const ClearRunButton = ({ dagRun, withText = true }: Props) => {
   const { onClose, onOpen, open } = useDisclosure();
 
   const [onlyFailed, setOnlyFailed] = useState(false);
@@ -41,6 +43,9 @@ const ClearRunButton = ({ dagId, dagRunId, withText = true }: Props) => {
     task_instances: [],
     total_entries: 0,
   });
+
+  const dagId = dagRun.dag_id;
+  const dagRunId = dagRun.dag_run_id;
 
   const { isPending, mutate } = useClearDagRun({
     dagId,
@@ -68,8 +73,7 @@ const ClearRunButton = ({ dagId, dagRunId, withText = true }: Props) => {
 
       <ClearRunDialog
         affectedTasks={affectedTasks}
-        dagId={dagId}
-        dagRunId={dagRunId}
+        dagRun={dagRun}
         isPending={isPending}
         mutate={mutate}
         onClose={onClose}

--- a/airflow/ui/src/components/ClearRun/ClearRunButton.tsx
+++ b/airflow/ui/src/components/ClearRun/ClearRunButton.tsx
@@ -20,10 +20,7 @@ import { Box, useDisclosure } from "@chakra-ui/react";
 import { useState } from "react";
 import { FiRefreshCw } from "react-icons/fi";
 
-import type {
-  DAGRunResponse,
-  TaskInstanceCollectionResponse,
-} from "openapi/requests/types.gen";
+import type { DAGRunResponse, TaskInstanceCollectionResponse } from "openapi/requests/types.gen";
 import { useClearDagRun } from "src/queries/useClearRun";
 
 import ActionButton from "../ui/ActionButton";

--- a/airflow/ui/src/components/ClearRun/ClearRunDialog.tsx
+++ b/airflow/ui/src/components/ClearRun/ClearRunDialog.tsx
@@ -64,8 +64,7 @@ const ClearRunDialog = ({
   const dagRunId = dagRun.dag_run_id;
 
   const [note, setNote] = useState<string | null>(dagRun.note);
-  const { isPending: isPendingPatchDagRun, mutate: mutatePatchDagRun } =
-    usePatchDagRun({ dagId, dagRunId });
+  const { isPending: isPendingPatchDagRun, mutate: mutatePatchDagRun } = usePatchDagRun({ dagId, dagRunId });
 
   const onChange = (value: string) => {
     switch (value) {
@@ -119,11 +118,7 @@ const ClearRunDialog = ({
               value={onlyFailed ? "only_failed" : "existing_tasks"}
             />
           </Flex>
-          <ClearRunTasksAccordion
-            affectedTasks={affectedTasks}
-            note={note}
-            setNote={setNote}
-          />
+          <ClearRunTasksAccordion affectedTasks={affectedTasks} note={note} setNote={setNote} />
           <Flex justifyContent="end" mt={3}>
             <Button
               colorPalette="blue"

--- a/airflow/ui/src/components/ClearRun/ClearRunDialog.tsx
+++ b/airflow/ui/src/components/ClearRun/ClearRunDialog.tsx
@@ -17,18 +17,23 @@
  * under the License.
  */
 import { Flex, Heading, VStack } from "@chakra-ui/react";
+import { useState } from "react";
 import { FiRefreshCw } from "react-icons/fi";
 
-import type { DAGRunClearBody, TaskInstanceCollectionResponse } from "openapi/requests/types.gen";
+import type {
+  DAGRunClearBody,
+  DAGRunResponse,
+  TaskInstanceCollectionResponse,
+} from "openapi/requests/types.gen";
 import { Button, Dialog } from "src/components/ui";
+import { usePatchDagRun } from "src/queries/usePatchDagRun";
 
 import SegmentedControl from "../ui/SegmentedControl";
 import ClearRunTasksAccordion from "./ClearRunTaskAccordion";
 
 type Props = {
   readonly affectedTasks: TaskInstanceCollectionResponse;
-  readonly dagId: string;
-  readonly dagRunId: string;
+  readonly dagRun: DAGRunResponse;
   readonly isPending: boolean;
   readonly mutate: ({
     dagId,
@@ -47,8 +52,7 @@ type Props = {
 
 const ClearRunDialog = ({
   affectedTasks,
-  dagId,
-  dagRunId,
+  dagRun,
   isPending,
   mutate,
   onClose,
@@ -56,6 +60,13 @@ const ClearRunDialog = ({
   open,
   setOnlyFailed,
 }: Props) => {
+  const dagId = dagRun.dag_id;
+  const dagRunId = dagRun.dag_run_id;
+
+  const [note, setNote] = useState<string | null>(dagRun.note);
+  const { isPending: isPendingPatchDagRun, mutate: mutatePatchDagRun } =
+    usePatchDagRun({ dagId, dagRunId });
+
   const onChange = (value: string) => {
     switch (value) {
       case "existing_tasks":
@@ -108,16 +119,25 @@ const ClearRunDialog = ({
               value={onlyFailed ? "only_failed" : "existing_tasks"}
             />
           </Flex>
-          <ClearRunTasksAccordion affectedTasks={affectedTasks} />
+          <ClearRunTasksAccordion
+            affectedTasks={affectedTasks}
+            note={note}
+            setNote={setNote}
+          />
           <Flex justifyContent="end" mt={3}>
             <Button
               colorPalette="blue"
-              loading={isPending}
+              loading={isPending || isPendingPatchDagRun}
               onClick={() => {
                 mutate({
                   dagId,
                   dagRunId,
                   requestBody: { dry_run: false, only_failed: onlyFailed },
+                });
+                mutatePatchDagRun({
+                  dagId,
+                  dagRunId,
+                  requestBody: { note },
                 });
               }}
             >

--- a/airflow/ui/src/components/ClearRun/ClearRunTaskAccordion.tsx
+++ b/airflow/ui/src/components/ClearRun/ClearRunTaskAccordion.tsx
@@ -16,12 +16,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Text } from "@chakra-ui/react";
+import { Box, Editable, Text, VStack } from "@chakra-ui/react";
 import { Link } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
+import type { ChangeEvent } from "react";
+import Markdown from "react-markdown";
 import { Link as RouterLink } from "react-router-dom";
 
-import type { TaskInstanceCollectionResponse, TaskInstanceResponse } from "openapi/requests/types.gen";
+import type {
+  DAGRunResponse,
+  TaskInstanceCollectionResponse,
+  TaskInstanceResponse,
+} from "openapi/requests/types.gen";
 import { DataTable } from "src/components/DataTable";
 import { Status, Tooltip } from "src/components/ui";
 import { getTaskInstanceLink } from "src/utils/links";
@@ -69,12 +75,14 @@ const columns: Array<ColumnDef<TaskInstanceResponse>> = [
 
 type Props = {
   readonly affectedTasks?: TaskInstanceCollectionResponse;
+  readonly note: DAGRunResponse["note"];
+  readonly setNote: (value: string) => void;
 };
 
 // Table is in memory, pagination and sorting are disabled.
 // TODO: Make a front-end only unconnected table component with client side ordering and pagination
-const ClearRunTasksAccordion = ({ affectedTasks }: Props) => (
-  <Accordion.Root collapsible variant="enclosed">
+const ClearRunTasksAccordion = ({ affectedTasks, note, setNote }: Props) => (
+  <Accordion.Root collapsible multiple variant="enclosed">
     <Accordion.Item key="tasks" value="tasks">
       <Accordion.ItemTrigger>
         <Text fontWeight="bold">Affected Tasks: {affectedTasks?.total_entries ?? 0}</Text>
@@ -96,6 +104,34 @@ const ClearRunTasksAccordion = ({ affectedTasks }: Props) => (
             total={affectedTasks?.total_entries}
           />
         </Box>
+      </Accordion.ItemContent>
+    </Accordion.Item>
+    <Accordion.Item key="note" value="note">
+      <Accordion.ItemTrigger>
+        <Text fontWeight="bold">Note</Text>
+      </Accordion.ItemTrigger>
+      <Accordion.ItemContent>
+        <Editable.Root
+          onChange={(event: ChangeEvent<HTMLInputElement>) => setNote(event.target.value)}
+          value={note ?? ""}
+        >
+          <Editable.Preview alignItems="flex-start" as={VStack} gap="0" height="200px" width="100%">
+            {Boolean(note) ? (
+              <Markdown>{note}</Markdown>
+            ) : (
+              <Text color="gray" opacity={0.6}>
+                Add a note...
+              </Text>
+            )}
+          </Editable.Preview>
+          <Editable.Textarea
+            data-testid="notes-input"
+            height="200px"
+            overflow="hidden"
+            placeholder="Add a note..."
+            resize="none"
+          />
+        </Editable.Root>
       </Accordion.ItemContent>
     </Accordion.Item>
   </Accordion.Root>

--- a/airflow/ui/src/components/ClearRun/ClearRunTaskAccordion.tsx
+++ b/airflow/ui/src/components/ClearRun/ClearRunTaskAccordion.tsx
@@ -82,7 +82,7 @@ type Props = {
 // Table is in memory, pagination and sorting are disabled.
 // TODO: Make a front-end only unconnected table component with client side ordering and pagination
 const ClearRunTasksAccordion = ({ affectedTasks, note, setNote }: Props) => (
-  <Accordion.Root collapsible multiple={false} variant="enclosed">
+  <Accordion.Root collapsible defaultValue={["note"]} multiple={false} variant="enclosed">
     <Accordion.Item key="tasks" value="tasks">
       <Accordion.ItemTrigger>
         <Text fontWeight="bold">Affected Tasks: {affectedTasks?.total_entries ?? 0}</Text>

--- a/airflow/ui/src/components/ClearRun/ClearRunTaskAccordion.tsx
+++ b/airflow/ui/src/components/ClearRun/ClearRunTaskAccordion.tsx
@@ -82,7 +82,7 @@ type Props = {
 // Table is in memory, pagination and sorting are disabled.
 // TODO: Make a front-end only unconnected table component with client side ordering and pagination
 const ClearRunTasksAccordion = ({ affectedTasks, note, setNote }: Props) => (
-  <Accordion.Root collapsible multiple variant="enclosed">
+  <Accordion.Root collapsible multiple={false} variant="enclosed">
     <Accordion.Item key="tasks" value="tasks">
       <Accordion.ItemTrigger>
         <Text fontWeight="bold">Affected Tasks: {affectedTasks?.total_entries ?? 0}</Text>
@@ -115,7 +115,14 @@ const ClearRunTasksAccordion = ({ affectedTasks, note, setNote }: Props) => (
           onChange={(event: ChangeEvent<HTMLInputElement>) => setNote(event.target.value)}
           value={note ?? ""}
         >
-          <Editable.Preview alignItems="flex-start" as={VStack} gap="0" height="200px" width="100%">
+          <Editable.Preview
+            alignItems="flex-start"
+            as={VStack}
+            gap="0"
+            height="200px"
+            overflowY="auto"
+            width="100%"
+          >
             {Boolean(note) ? (
               <Markdown>{note}</Markdown>
             ) : (
@@ -127,7 +134,7 @@ const ClearRunTasksAccordion = ({ affectedTasks, note, setNote }: Props) => (
           <Editable.Textarea
             data-testid="notes-input"
             height="200px"
-            overflow="hidden"
+            overflowY="auto"
             placeholder="Add a note..."
             resize="none"
           />

--- a/airflow/ui/src/pages/Dag/Runs/Runs.tsx
+++ b/airflow/ui/src/pages/Dag/Runs/Runs.tsx
@@ -27,11 +27,7 @@ import {
 } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useCallback } from "react";
-import {
-  useParams,
-  Link as RouterLink,
-  useSearchParams,
-} from "react-router-dom";
+import { useParams, Link as RouterLink, useSearchParams } from "react-router-dom";
 
 import { useDagRunServiceGetDagRuns } from "openapi/queries";
 import type { DAGRunResponse, DagRunState } from "openapi/requests/types.gen";
@@ -88,8 +84,7 @@ const columns: Array<ColumnDef<DAGRunResponse>> = [
     header: "End Date",
   },
   {
-    cell: ({ row: { original } }) =>
-      getDuration(original.start_date, original.end_date),
+    cell: ({ row: { original } }) => getDuration(original.start_date, original.end_date),
     header: "Duration",
   },
   {
@@ -173,9 +168,7 @@ export const Runs = () => {
                 filteredState === null ? (
                   "All States"
                 ) : (
-                  <Status state={filteredState as DagRunState}>
-                    {capitalize(filteredState)}
-                  </Status>
+                  <Status state={filteredState as DagRunState}>{capitalize(filteredState)}</Status>
                 )
               }
             </Select.ValueText>
@@ -186,9 +179,7 @@ export const Runs = () => {
                 {option.value === "all" ? (
                   option.label
                 ) : (
-                  <Status state={option.value as DagRunState}>
-                    {option.label}
-                  </Status>
+                  <Status state={option.value as DagRunState}>{option.label}</Status>
                 )}
               </Select.Item>
             ))}

--- a/airflow/ui/src/pages/Dag/Runs/Runs.tsx
+++ b/airflow/ui/src/pages/Dag/Runs/Runs.tsx
@@ -27,7 +27,11 @@ import {
 } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useCallback } from "react";
-import { useParams, Link as RouterLink, useSearchParams } from "react-router-dom";
+import {
+  useParams,
+  Link as RouterLink,
+  useSearchParams,
+} from "react-router-dom";
 
 import { useDagRunServiceGetDagRuns } from "openapi/queries";
 import type { DAGRunResponse, DagRunState } from "openapi/requests/types.gen";
@@ -84,14 +88,15 @@ const columns: Array<ColumnDef<DAGRunResponse>> = [
     header: "End Date",
   },
   {
-    cell: ({ row: { original } }) => getDuration(original.start_date, original.end_date),
+    cell: ({ row: { original } }) =>
+      getDuration(original.start_date, original.end_date),
     header: "Duration",
   },
   {
     accessorKey: "clear_dag_run",
     cell: ({ row }) => (
       <Flex justifyContent="end">
-        <ClearRunButton dagId={row.original.dag_id} dagRunId={row.original.dag_run_id} withText={false} />
+        <ClearRunButton dagRun={row.original} withText={false} />
       </Flex>
     ),
     enableSorting: false,
@@ -168,7 +173,9 @@ export const Runs = () => {
                 filteredState === null ? (
                   "All States"
                 ) : (
-                  <Status state={filteredState as DagRunState}>{capitalize(filteredState)}</Status>
+                  <Status state={filteredState as DagRunState}>
+                    {capitalize(filteredState)}
+                  </Status>
                 )
               }
             </Select.ValueText>
@@ -179,7 +186,9 @@ export const Runs = () => {
                 {option.value === "all" ? (
                   option.label
                 ) : (
-                  <Status state={option.value as DagRunState}>{option.label}</Status>
+                  <Status state={option.value as DagRunState}>
+                    {option.label}
+                  </Status>
                 )}
               </Select.Item>
             ))}

--- a/airflow/ui/src/pages/Run/Header.tsx
+++ b/airflow/ui/src/pages/Run/Header.tsx
@@ -43,7 +43,7 @@ export const Header = ({ dagRun }: { readonly dagRun: DAGRunResponse }) => (
         </Flex>
       </HStack>
       <HStack>
-        <ClearRunButton dagId={dagRun.dag_id} dagRunId={dagRun.dag_run_id} />
+        <ClearRunButton dagRun={dagRun} />
       </HStack>
     </Flex>
     {dagRun.note === null || dagRun.note.length === 0 ? undefined : (

--- a/airflow/ui/src/queries/usePatchDagRun.ts
+++ b/airflow/ui/src/queries/usePatchDagRun.ts
@@ -19,61 +19,41 @@
 import { useQueryClient } from "@tanstack/react-query";
 
 import {
-  useDagRunServiceClearDagRun,
   UseDagRunServiceGetDagRunKeyFn,
   useDagRunServiceGetDagRunsKey,
-  UseDagServiceGetDagDetailsKeyFn,
-  useTaskInstanceServiceGetTaskInstancesKey,
+  useDagRunServicePatchDagRun,
 } from "openapi/queries";
-import type { DAGRunClearBody, TaskInstanceCollectionResponse } from "openapi/requests/types.gen";
 import { toaster } from "src/components/ui";
 
 const onError = () => {
   toaster.create({
-    description: "Clear Dag Run request failed",
-    title: "Failed to clear the Dag Run",
+    description: "Patch Dag Run request failed",
+    title: "Failed to patch the Dag Run",
     type: "error",
   });
 };
 
-export const useClearDagRun = ({
+export const usePatchDagRun = ({
   dagId,
   dagRunId,
-  onSuccessConfirm,
-  onSuccessDryRun,
 }: {
   dagId: string;
   dagRunId: string;
-  onSuccessConfirm: () => void;
-  onSuccessDryRun: (date: TaskInstanceCollectionResponse) => void;
 }) => {
   const queryClient = useQueryClient();
 
-  const onSuccess = async (
-    data: TaskInstanceCollectionResponse,
-    variables: {
-      dagId: string;
-      dagRunId: string;
-      requestBody: DAGRunClearBody;
-    },
-  ) => {
-    if (variables.requestBody.dry_run) {
-      onSuccessDryRun(data);
-    } else {
-      const queryKeys = [
-        [useTaskInstanceServiceGetTaskInstancesKey],
-        UseDagServiceGetDagDetailsKeyFn({ dagId }),
-        UseDagRunServiceGetDagRunKeyFn({ dagId, dagRunId }),
-        [useDagRunServiceGetDagRunsKey],
-      ];
+  const onSuccess = async () => {
+    const queryKeys = [
+      UseDagRunServiceGetDagRunKeyFn({ dagId, dagRunId }),
+      [useDagRunServiceGetDagRunsKey],
+    ];
 
-      await Promise.all(queryKeys.map((key) => queryClient.invalidateQueries({ queryKey: key })));
-
-      onSuccessConfirm();
-    }
+    await Promise.all(
+      queryKeys.map((key) => queryClient.invalidateQueries({ queryKey: key })),
+    );
   };
 
-  return useDagRunServiceClearDagRun({
+  return useDagRunServicePatchDagRun({
     onError,
     onSuccess,
   });

--- a/airflow/ui/src/queries/usePatchDagRun.ts
+++ b/airflow/ui/src/queries/usePatchDagRun.ts
@@ -33,24 +33,13 @@ const onError = () => {
   });
 };
 
-export const usePatchDagRun = ({
-  dagId,
-  dagRunId,
-}: {
-  dagId: string;
-  dagRunId: string;
-}) => {
+export const usePatchDagRun = ({ dagId, dagRunId }: { dagId: string; dagRunId: string }) => {
   const queryClient = useQueryClient();
 
   const onSuccess = async () => {
-    const queryKeys = [
-      UseDagRunServiceGetDagRunKeyFn({ dagId, dagRunId }),
-      [useDagRunServiceGetDagRunsKey],
-    ];
+    const queryKeys = [UseDagRunServiceGetDagRunKeyFn({ dagId, dagRunId }), [useDagRunServiceGetDagRunsKey]];
 
-    await Promise.all(
-      queryKeys.map((key) => queryClient.invalidateQueries({ queryKey: key })),
-    );
+    await Promise.all(queryKeys.map((key) => queryClient.invalidateQueries({ queryKey: key })));
   };
 
   return useDagRunServicePatchDagRun({


### PR DESCRIPTION
related to: https://github.com/apache/airflow/issues/44859

Adds the ability to write/update the note of the DagRun that is being cleared.

![Screenshot 2025-01-06 at 14 21 51](https://github.com/user-attachments/assets/a3c8cf18-a8ef-497e-982f-34910c6801bd)
![Screenshot 2025-01-06 at 14 24 26](https://github.com/user-attachments/assets/ddf64569-4686-42c2-9772-238247d30689)

![Screenshot 2025-01-06 at 14 22 28](https://github.com/user-attachments/assets/6e7343d3-e2c7-4eb7-810b-7ed965138a8c)
![Screenshot 2025-01-06 at 14 22 38](https://github.com/user-attachments/assets/aba6863f-ef99-4e78-8dfe-4494e9fff7f3)
![Screenshot 2025-01-06 at 14 22 57](https://github.com/user-attachments/assets/7567fbb1-d9af-4bb8-a615-71b4fbd6c9ff)


