### PR TITLE
AIP-38 Improve clear dagrun table display for long task display names

### DIFF
--- a/airflow/ui/src/components/ClearRun/ClearRunTaskAccordion.tsx
+++ b/airflow/ui/src/components/ClearRun/ClearRunTaskAccordion.tsx
@@ -23,8 +23,9 @@ import { Link as RouterLink } from "react-router-dom";
 
 import type { TaskInstanceCollectionResponse, TaskInstanceResponse } from "openapi/requests/types.gen";
 import { DataTable } from "src/components/DataTable";
-import { Status } from "src/components/ui";
+import { Status, Tooltip } from "src/components/ui";
 import { getTaskInstanceLink } from "src/utils/links";
+import { trimText } from "src/utils/trimTextFn";
 
 import { Accordion } from "../ui";
 
@@ -32,9 +33,13 @@ const columns: Array<ColumnDef<TaskInstanceResponse>> = [
   {
     accessorKey: "task_display_name",
     cell: ({ row: { original } }) => (
-      <Link asChild color="fg.info" fontWeight="bold">
-        <RouterLink to={getTaskInstanceLink(original)}>{original.task_display_name}</RouterLink>
-      </Link>
+      <Tooltip content={original.task_display_name}>
+        <Link asChild color="fg.info" fontWeight="bold" maxWidth="200px" overflow="hidden">
+          <RouterLink to={getTaskInstanceLink(original)}>
+            {trimText(original.task_display_name, 25).trimmedText}
+          </RouterLink>
+        </Link>
+      </Tooltip>
     ),
     enableSorting: false,
     header: "Task ID",

--- a/airflow/ui/src/utils/TrimText.tsx
+++ b/airflow/ui/src/utils/TrimText.tsx
@@ -21,6 +21,7 @@ import { Text, Box, useDisclosure, Heading, Stack } from "@chakra-ui/react";
 import { Dialog, Tooltip } from "src/components/ui";
 
 import { capitalize } from "./capitalize";
+import { trimText } from "./trimTextFn";
 
 const formatKey = (key: string): string => {
   const formatted = capitalize(key).replaceAll("_", " ");
@@ -44,8 +45,7 @@ export const TrimText = ({
   text,
 }: TrimTextProps) => {
   const safeText = text ?? "";
-  const isTrimmed = safeText.length > charLimit;
-  const trimmedText = isTrimmed ? `${safeText.slice(0, charLimit)}...` : safeText;
+  const { isTrimmed, trimmedText } = trimText(safeText, charLimit);
 
   const { onClose, onOpen, open } = useDisclosure();
 

--- a/airflow/ui/src/utils/trimTextFn.ts
+++ b/airflow/ui/src/utils/trimTextFn.ts
@@ -1,0 +1,24 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export const trimText = (text: string, charLimit: number): { isTrimmed: boolean; trimmedText: string } => {
+  const isTrimmed = text.length > charLimit;
+
+  return { isTrimmed, trimmedText: isTrimmed ? `${text.slice(0, charLimit)}...` : text };
+};


### PR DESCRIPTION
Long task display name are an issue because they overflow-x the table and make other columns wrap, which isn't great for the display. Also it doesn't bring much because that column is already a 'link' so we can just click on it to land on the full task instance detail page.

Before:
![Screenshot 2025-01-06 at 14 33 41](https://github.com/user-attachments/assets/d8f7f5ae-0269-4f62-9e4e-53034e7a24c9)

After:
![Screenshot 2025-01-06 at 16 29 38](https://github.com/user-attachments/assets/bfd9f665-0003-41ef-b463-45e885c537e2)
