### PR TITLE
Added ability to pass namespace to hashicorp vault

### DIFF
--- a/providers/src/airflow/providers/hashicorp/_internal_client/vault_client.py
+++ b/providers/src/airflow/providers/hashicorp/_internal_client/vault_client.py
@@ -216,7 +216,11 @@ class _VaultClient(LoggingMixin):
                 session.verify = self.kwargs["verify"]
             self.kwargs["session"] = session
 
-        _client = hvac.Client(url=self.url, **self.kwargs)
+        if "namespace" in self.kwargs:
+            namespace = self.kwargs["namespace"]
+            _client = hvac.Client(url=self.url, namespace=namespace, **self.kwargs)
+        else:
+            _client = hvac.Client(url=self.url, **self.kwargs)
         if self.auth_type == "approle":
             self._auth_approle(_client)
         elif self.auth_type == "aws_iam":

--- a/providers/tests/hashicorp/_internal_client/test_vault_client.py
+++ b/providers/tests/hashicorp/_internal_client/test_vault_client.py
@@ -43,14 +43,14 @@ class TestVaultClient:
         vault_client = _VaultClient(auth_type="userpass", mount_point="custom")
         assert vault_client.mount_point == "custom"
 
-    # @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
-    # def test_namespace(self, mock_hvac):
-    #     mock_client = mock.MagicMock()
-    #     mock_hvac.Client.return_value = mock_client
-    #     vault_client = _VaultClient(namespace="mach")
-    #     assert vault_client.namespace == "mach"
-    #     vault_client = _VaultClient()
-    #     assert vault_client.namespace == None
+    @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
+    def test_namespace(self, mock_hvac):
+        mock_client = mock.MagicMock()
+        mock_hvac.Client.return_value = mock_client
+        vault_client = _VaultClient(namespace="mach")
+        assert vault_client.namespace == "mach"
+        vault_client = _VaultClient()
+        assert vault_client.namespace == None
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
     def test_version_one_init(self, mock_hvac):

--- a/providers/tests/hashicorp/_internal_client/test_vault_client.py
+++ b/providers/tests/hashicorp/_internal_client/test_vault_client.py
@@ -43,15 +43,6 @@ class TestVaultClient:
         vault_client = _VaultClient(auth_type="userpass", mount_point="custom")
         assert vault_client.mount_point == "custom"
 
-    # @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
-    # def test_namespace(self, mock_hvac):
-    #     mock_client = mock.MagicMock()
-    #     mock_hvac.Client.return_value = mock_client
-    #     vault_client = _VaultClient(namespace="mach")
-    #     assert vault_client.namespace == "mach"
-    #     vault_client = _VaultClient()
-    #     assert vault_client.namespace == None
-
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
     def test_namespace(self, mock_hvac):
         mock_client = mock.MagicMock()

--- a/providers/tests/hashicorp/_internal_client/test_vault_client.py
+++ b/providers/tests/hashicorp/_internal_client/test_vault_client.py
@@ -43,6 +43,15 @@ class TestVaultClient:
         vault_client = _VaultClient(auth_type="userpass", mount_point="custom")
         assert vault_client.mount_point == "custom"
 
+    # @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
+    # def test_namespace(self, mock_hvac):
+    #     mock_client = mock.MagicMock()
+    #     mock_hvac.Client.return_value = mock_client
+    #     vault_client = _VaultClient(namespace="mach")
+    #     assert vault_client.namespace == "mach"
+    #     vault_client = _VaultClient()
+    #     assert vault_client.namespace == None
+
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
     def test_version_one_init(self, mock_hvac):
         mock_client = mock.MagicMock()


### PR DESCRIPTION
Adding the ability to pass a namespace from backend kwargs to the vault client.

Closes : #45413 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
