### PR TITLE
fix(cncf-kubernetes): correctly shutdown xcom after job is complete

### DIFF
--- a/providers/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/providers/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -855,7 +855,7 @@ class PodManager(LoggingMixin):
                 _preload_content=False,
             )
         ) as resp:
-            self._exec_pod_command(resp, "kill -2 $(pgrep -u $(whoami) -f trap)")
+            self._exec_pod_command(resp, "kill -2 $(pgrep -u $(id -u) -f 'sh')")
 
     def _exec_pod_command(self, resp, command: str) -> str | None:
         res = ""


### PR DESCRIPTION
closes: #45452
related: #45053

I fixed a regression we encountered when upgrading to the latest cncf-kubernetes provider `10.1.0`

I got the following logs when using the original statement

```
docker run -u 1000 -it alpine sh # alpine container seems to be run under uid 1000 in kubernetes
sh -c trap "exit 0" INT; while true; do sleep 1; done;
````

```
kill -2 $(pgrep -u $(whoami) -f 'trap')
```

```
whoami
whoami: unknown uid 1000
```

```
pgrep -f 'trap' # returns no processes
```

instead with:

```
kill -2 $(pgrep -u $(id -u) -f 'sh')
```

it stops the processes as it should.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #45452
related: #45053

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
