### PR TITLE
AIP-38 Better markdown rendering

### DIFF
--- a/airflow/ui/rules/react.js
+++ b/airflow/ui/rules/react.js
@@ -546,7 +546,7 @@ export const reactRules = /** @type {const} @satisfies {FlatConfig.Config} */ ({
      *
      * @see [react/no-multi-comp](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/no-multi-comp.md)
      */
-    [`${reactNamespace}/no-multi-comp`]: WARN,
+    [`${reactNamespace}/no-multi-comp`]: [WARN, { ignoreStateless: true }],
 
     /**
      * Enforce that namespaces are not used in React elements.

--- a/airflow/ui/src/components/ClearRun/ClearRunTaskAccordion.tsx
+++ b/airflow/ui/src/components/ClearRun/ClearRunTaskAccordion.tsx
@@ -20,7 +20,6 @@ import { Box, Editable, Text, VStack } from "@chakra-ui/react";
 import { Link } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
 import type { ChangeEvent } from "react";
-import Markdown from "react-markdown";
 import { Link as RouterLink } from "react-router-dom";
 
 import type {
@@ -29,11 +28,11 @@ import type {
   TaskInstanceResponse,
 } from "openapi/requests/types.gen";
 import { DataTable } from "src/components/DataTable";
+import ReactMarkdown from "src/components/ReactMarkdown";
 import { Status, Tooltip } from "src/components/ui";
+import { Accordion } from "src/components/ui";
 import { getTaskInstanceLink } from "src/utils/links";
 import { trimText } from "src/utils/trimTextFn";
-
-import { Accordion } from "../ui";
 
 const columns: Array<ColumnDef<TaskInstanceResponse>> = [
   {
@@ -116,6 +115,7 @@ const ClearRunTasksAccordion = ({ affectedTasks, note, setNote }: Props) => (
           value={note ?? ""}
         >
           <Editable.Preview
+            _hover={{ backgroundColor: "transparent" }}
             alignItems="flex-start"
             as={VStack}
             gap="0"
@@ -124,7 +124,7 @@ const ClearRunTasksAccordion = ({ affectedTasks, note, setNote }: Props) => (
             width="100%"
           >
             {Boolean(note) ? (
-              <Markdown>{note}</Markdown>
+              <ReactMarkdown>{note}</ReactMarkdown>
             ) : (
               <Text color="gray" opacity={0.6}>
                 Add a note...

--- a/airflow/ui/src/components/DocumentationModal.tsx
+++ b/airflow/ui/src/components/DocumentationModal.tsx
@@ -19,10 +19,10 @@
 import { Box, Heading } from "@chakra-ui/react";
 import { useState } from "react";
 import { FiBookOpen } from "react-icons/fi";
-import Markdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 
 import { Button, Dialog } from "src/components/ui";
+
+import ReactMarkdown from "./ReactMarkdown";
 
 const DocumentationModal = ({ docMd, docType }: { readonly docMd: string; readonly docType: string }) => {
   const [isDocsOpen, setIsDocsOpen] = useState(false);
@@ -40,7 +40,7 @@ const DocumentationModal = ({ docMd, docType }: { readonly docMd: string; readon
             <Dialog.CloseTrigger closeButtonProps={{ size: "xl" }} />
           </Dialog.Header>
           <Dialog.Body display="flex">
-            <Markdown remarkPlugins={[remarkGfm]}>{docMd}</Markdown>
+            <ReactMarkdown>{docMd}</ReactMarkdown>
           </Dialog.Body>
         </Dialog.Content>
       </Dialog.Root>

--- a/airflow/ui/src/components/ReactMarkdown.tsx
+++ b/airflow/ui/src/components/ReactMarkdown.tsx
@@ -1,0 +1,117 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {
+  Box,
+  Code,
+  Separator,
+  Heading,
+  Image,
+  type ImageProps,
+  Link,
+  List,
+  Table,
+  Text,
+} from "@chakra-ui/react";
+import type { PropsWithChildren, ReactNode } from "react";
+import type { Components, Options } from "react-markdown";
+import ReactMD from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+const fontSizeMapping = {
+  h1: "1.5em",
+  h2: "1.25em",
+  h3: "1.125em",
+  h4: "1em",
+  h5: "0.875em",
+  h6: "0.75em",
+};
+
+const makeHeading =
+  (header: keyof typeof fontSizeMapping) =>
+  ({ children, ...props }: PropsWithChildren) => (
+    <Heading as={header} fontSize={fontSizeMapping[header]} {...props} my={3}>
+      {children}
+    </Heading>
+  );
+
+const components = {
+  // eslint-disable-next-line id-length
+  a: ({ children, href, title }: { children: ReactNode; href: string; title?: string }) => (
+    <Link color="blue.600" fontWeight="bold" href={href} title={title}>
+      {children}
+    </Link>
+  ),
+  blockquote: ({ children }: PropsWithChildren) => (
+    <Box as="blockquote" borderColor="gray.400" borderLeft="solid 2px" fontStyle="italic" my={3} pl={2}>
+      {children}
+    </Box>
+  ),
+  code: ({ children, className, inline }: { children: ReactNode; className?: string; inline?: boolean }) => {
+    if (inline) {
+      return (
+        <Code display="inline" p={2}>
+          {children}
+        </Code>
+      );
+    }
+
+    return (
+      <Code className={className} display="block" p={2} w="full" whiteSpace="break-spaces">
+        {children}
+      </Code>
+    );
+  },
+  del: ({ children }: PropsWithChildren) => <Text as="del">{children}</Text>,
+  em: ({ children }: PropsWithChildren) => <Text as="em">{children}</Text>,
+  h1: makeHeading("h1"),
+  h2: makeHeading("h2"),
+  h3: makeHeading("h3"),
+  h4: makeHeading("h4"),
+  h5: makeHeading("h5"),
+  h6: makeHeading("h6"),
+  hr: () => <Separator my={3} />,
+  img: (props: ImageProps) => <Image my={3} {...props} maxWidth="300px" />,
+  li: ({ children }: PropsWithChildren) => <List.Item>{children}</List.Item>,
+  ol: ({ children }: PropsWithChildren) => (
+    <List.Root as="ol" mb={3} pl={4}>
+      {children}
+    </List.Root>
+  ),
+  // eslint-disable-next-line id-length
+  p: ({ children }: PropsWithChildren) => <Text>{children}</Text>,
+  pre: ({ children }: PropsWithChildren) => <Code my={3}>{children}</Code>,
+  table: ({ children }: PropsWithChildren) => <Table.Root mb={3}>{children}</Table.Root>,
+  tbody: Table.Body,
+  td: Table.Cell,
+  text: ({ children }: PropsWithChildren) => <Text as="span">{children}</Text>,
+  th: Table.ColumnHeader,
+  thead: Table.Header,
+  tr: Table.Row,
+  ul: ({ children }: PropsWithChildren) => (
+    <List.Root mb={3} pl={4}>
+      {children}
+    </List.Root>
+  ),
+};
+
+const ReactMarkdown = (props: Options) => (
+  <ReactMD components={components as Components} {...props} remarkPlugins={[remarkGfm]} skipHtml />
+);
+
+export default ReactMarkdown;


### PR DESCRIPTION
Only the last commit is relevant. Depends on https://github.com/apache/airflow/pull/45434

This fixes the markdown rendering. Due to the ChakraUI CSS reset (good practice), native elements have no styling. We need to remap html tags to Chakra components in the markdown renderer. Example of the css reset, those are correctly h1, ul, li tags, but no style are applied (CSS reset):
![Screenshot 2025-01-07 at 11 18 25](https://github.com/user-attachments/assets/0af6477c-4fa0-4394-a67e-55d1a9cb6b56)
 


## Before:
![Screenshot 2025-01-07 at 11 17 04](https://github.com/user-attachments/assets/eb005aa0-a54f-4a48-9c34-fd36b14bf64b)
![Screenshot 2025-01-07 at 11 17 23](https://github.com/user-attachments/assets/e1acf82d-445c-4181-bd2f-35bd58a5ac18)
![Screenshot 2025-01-07 at 11 17 34](https://github.com/user-attachments/assets/3f8e1475-7fab-476c-a048-7ac302c5f940)

## After:
![Screenshot 2025-01-07 at 11 15 44](https://github.com/user-attachments/assets/aff61e55-ba61-4d91-9f46-ebad9003938a)
![Screenshot 2025-01-07 at 11 16 03](https://github.com/user-attachments/assets/3cc03115-c3e8-4b38-920e-70f57823114f)
![Screenshot 2025-01-07 at 11 16 29](https://github.com/user-attachments/assets/603faef7-9a99-4781-a93a-f0f90b505ae4)
