### PR TITLE
Minor query fix changing session.execute to session.scalars

### DIFF
--- a/airflow/models/serialized_dag.py
+++ b/airflow/models/serialized_dag.py
@@ -194,11 +194,11 @@ class SerializedDagModel(Base):
 
         log.debug("Checking if DAG (%s) changed", dag.dag_id)
         new_serialized_dag = cls(dag)
-        serialized_dag_db = session.execute(
+        serialized_dag_hash = session.scalars(
             select(cls.dag_hash).where(cls.dag_id == dag.dag_id).order_by(cls.created_at.desc())
         ).first()
 
-        if serialized_dag_db is not None and serialized_dag_db.dag_hash == new_serialized_dag.dag_hash:
+        if serialized_dag_hash is not None and serialized_dag_hash == new_serialized_dag.dag_hash:
             log.debug("Serialized DAG (%s) is unchanged. Skipping writing to DB", dag.dag_id)
             return False
         dagv = DagVersion.write_dag(


### PR DESCRIPTION
Since this query no longer looks at two columns, we should use scalars. Using execute returns a tuple ('4q4qw4',), for example, and IDE complains because we used serialized_dag.dag_hash to access the tuple. With scalars, it's now just the dag_hash that is returned

