### PR TITLE
Add Parameters to SqlToS3Operator template fields. 

### DIFF
--- a/providers/src/airflow/providers/amazon/aws/transfers/sql_to_s3.py
+++ b/providers/src/airflow/providers/amazon/aws/transfers/sql_to_s3.py
@@ -94,6 +94,7 @@ class SqlToS3Operator(BaseOperator):
         "s3_key",
         "query",
         "sql_conn_id",
+        "parameters"
     )
     template_ext: Sequence[str] = (".sql",)
     template_fields_renderers = {


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


Adds parameters to the template_fields for the SqlToS3Operator.

Team was writing some basic automations and we came across some use cases where we want to dynamically run some reports with parameters and the thought of direct replacement inside the SQL instead of using SQL parameters is irking. 

An example of what we currently need todo. 
```
SqlToS3Operator(
        task_id="export_sql_to_s3",
        sql_conn_id="trino_chart_retrieval_ro_id",
        query="""select * from foo where date > {{ params.date}}""",
        s3_bucket="{{params.s3bucket}}",
        s3_key="{{params.filepath }}" + "/" + "{{params.filename}}",
        pd_kwargs={"index": False, "quoting": csv.QUOTE_ALL},
        file_format="csv",
        aws_conn_id="aws_conn_id",
        replace=True,
    )
```

vs with the parameters field being templated.  
```
SqlToS3Operator(
        task_id="export_sql_to_s3",
        sql_conn_id="trino_chart_retrieval_ro_id",
        query="""select * from foo where date > %s""",
        parameters=({{params.date}},),
        s3_bucket="{{params.s3bucket}}",
        s3_key="{{params.filepath }}" + "/" + "{{params.filename}}",
        pd_kwargs={"index": False, "quoting": csv.QUOTE_ALL},
        file_format="csv",
        aws_conn_id="aws_conn_id",
        replace=True,
    )
```


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
