### PR TITLE
Default tooltips to showArrow

### DIFF
--- a/airflow/ui/src/components/DagRunInfo.tsx
+++ b/airflow/ui/src/components/DagRunInfo.tsx
@@ -71,7 +71,6 @@ const DagRunInfo = ({
           </Text>
         </VStack>
       }
-      showArrow
     >
       <HStack fontSize="sm">
         <Time datetime={dataIntervalStart} showTooltip={false} />

--- a/airflow/ui/src/components/TaskInstanceTooltip.tsx
+++ b/airflow/ui/src/components/TaskInstanceTooltip.tsx
@@ -50,7 +50,6 @@ const TaskInstanceTooltip = ({ children, taskInstance }: Props) => (
       },
       placement: "bottom-start",
     }}
-    showArrow
   >
     {children}
   </Tooltip>

--- a/airflow/ui/src/components/ui/Tooltip.tsx
+++ b/airflow/ui/src/components/ui/Tooltip.tsx
@@ -29,7 +29,16 @@ export type TooltipProps = {
 } & ChakraTooltip.RootProps;
 
 export const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>((props, ref) => {
-  const { children, content, contentProps, disabled, portalled, portalRef, showArrow, ...rest } = props;
+  const {
+    children,
+    content,
+    contentProps,
+    disabled,
+    portalled,
+    portalRef,
+    showArrow = true,
+    ...rest
+  } = props;
 
   if (disabled) {
     return children;

--- a/airflow/ui/src/pages/Dag/Header.tsx
+++ b/airflow/ui/src/pages/Dag/Header.tsx
@@ -63,7 +63,7 @@ export const Header = ({
       <SimpleGrid columns={4} gap={4} my={2}>
         <Stat label="Schedule">
           {Boolean(dag?.timetable_summary) ? (
-            <Tooltip content={dag?.timetable_description} showArrow>
+            <Tooltip content={dag?.timetable_description}>
               <Text fontSize="sm">
                 <FiCalendar style={{ display: "inline" }} /> {dag?.timetable_summary}
               </Text>

--- a/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -41,7 +41,7 @@ export const DagCard = ({ dag }: Props) => {
     <Box borderColor="border.emphasized" borderRadius={8} borderWidth={1} overflow="hidden">
       <Flex alignItems="center" bg="bg.muted" justifyContent="space-between" px={3} py={2}>
         <HStack>
-          <Tooltip content={dag.description} disabled={!Boolean(dag.description)} showArrow>
+          <Tooltip content={dag.description} disabled={!Boolean(dag.description)}>
             <Link asChild color="fg.info" fontWeight="bold">
               <RouterLink to={`/dags/${dag.dag_id}`}>{dag.dag_display_name}</RouterLink>
             </Link>

--- a/airflow/ui/src/pages/DagsList/DagTags.tsx
+++ b/airflow/ui/src/pages/DagsList/DagTags.tsx
@@ -48,7 +48,6 @@ export const DagTags = ({ hideIcon = false, tags }: Props) =>
               ))}
             </VStack>
           }
-          showArrow
         >
           <Text>, +{tags.length - MAX_TAGS} more</Text>
         </Tooltip>

--- a/airflow/ui/src/pages/DagsList/RecentRuns.tsx
+++ b/airflow/ui/src/pages/DagsList/RecentRuns.tsx
@@ -70,7 +70,6 @@ export const RecentRuns = ({
             },
             placement: "bottom-start",
           }}
-          showArrow
         >
           <Link to={`/dags/${run.dag_id}/runs/${run.dag_run_id}/`}>
             <Box p={1}>

--- a/airflow/ui/src/pages/DagsList/Schedule.tsx
+++ b/airflow/ui/src/pages/DagsList/Schedule.tsx
@@ -28,7 +28,7 @@ type Props = {
 
 export const Schedule = ({ dag }: Props) =>
   Boolean(dag.timetable_summary) && dag.timetable_description !== "Never, external triggers only" ? (
-    <Tooltip content={dag.timetable_description} showArrow>
+    <Tooltip content={dag.timetable_description}>
       <Text fontSize="sm">
         <FiCalendar style={{ display: "inline" }} /> {dag.timetable_summary}
       </Text>

--- a/airflow/ui/src/pages/Dashboard/Health/HealthSection.tsx
+++ b/airflow/ui/src/pages/Dashboard/Health/HealthSection.tsx
@@ -44,7 +44,6 @@ export const HealthSection = ({
         </div>
       }
       disabled={!Boolean(latestHeartbeat)}
-      showArrow
     >
       <Tag
         borderColor={status === "healthy" ? "success.100" : "error.100"}

--- a/airflow/ui/src/pages/Dashboard/Health/HealthTag.tsx
+++ b/airflow/ui/src/pages/Dashboard/Health/HealthTag.tsx
@@ -48,7 +48,6 @@ export const HealthTag = ({
         </div>
       }
       disabled={!Boolean(latestHeartbeat)}
-      showArrow
     >
       <Tag borderRadius="full" colorPalette={status === "healthy" ? "green" : "red"} size="lg">
         <TagLabel>{title}</TagLabel>


### PR DESCRIPTION
Tooltips in the new UI to show an arrow by default

Based on conversation [here](https://github.com/apache/airflow/pull/44854#discussion_r1905481009)

<img width="338" alt="Screenshot 2025-01-07 at 11 35 36 AM" src="https://github.com/user-attachments/assets/badf010a-3ea7-4d53-b987-e259cc1f3c07" />

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
