### PR TITLE
AIP-72: Add support for `get_current_context` in Task SDK

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -108,6 +108,7 @@ from airflow.models.xcom import LazyXComSelectSequence, XCom
 from airflow.plugins_manager import integrate_macros_plugins
 from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetNameRef, AssetUniqueKey, AssetUriRef
 from airflow.sdk.definitions.templater import SandboxedEnvironment
+from airflow.sdk.execution_time.context import _CURRENT_CONTEXT
 from airflow.sentry import Sentry
 from airflow.settings import task_instance_mutation_hook
 from airflow.stats import Stats
@@ -142,7 +143,6 @@ from airflow.utils.xcom import XCOM_RETURN_KEY
 
 TR = TaskReschedule
 
-_CURRENT_CONTEXT: list[Context] = []
 log = logging.getLogger(__name__)
 
 

--- a/providers/src/airflow/providers/standard/operators/python.py
+++ b/providers/src/airflow/providers/standard/operators/python.py
@@ -43,14 +43,10 @@ from airflow.exceptions import (
 )
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.skipmixin import SkipMixin
-from airflow.models.taskinstance import _CURRENT_CONTEXT
 from airflow.models.variable import Variable
 from airflow.operators.branch import BranchMixIn
 from airflow.providers.standard.utils.python_virtualenv import prepare_virtualenv, write_python_script
-from airflow.providers.standard.version_compat import (
-    AIRFLOW_V_2_10_PLUS,
-    AIRFLOW_V_3_0_PLUS,
-)
+from airflow.providers.standard.version_compat import AIRFLOW_V_2_10_PLUS, AIRFLOW_V_3_0_PLUS
 from airflow.utils import hashlib_wrapper
 from airflow.utils.context import context_copy_partial, context_merge
 from airflow.utils.file import get_unique_dag_module_name
@@ -1122,7 +1118,7 @@ class BranchExternalPythonOperator(ExternalPythonOperator, BranchMixIn):
         return self.do_branch(context, super().execute(context))
 
 
-def get_current_context() -> Context:
+def get_current_context() -> Mapping[str, Any]:
     """
     Retrieve the execution context dictionary without altering user method's signature.
 
@@ -1149,9 +1145,22 @@ def get_current_context() -> Context:
     Current context will only have value if this method was called after an operator
     was starting to execute.
     """
+    if AIRFLOW_V_3_0_PLUS:
+        from airflow.sdk import get_current_context
+
+        return get_current_context()
+    else:
+        return _get_current_context()
+
+
+def _get_current_context() -> Mapping[str, Any]:
+    # Airflow 2.x
+    # TODO: To be removed when Airflow 2 support is dropped
+    from airflow.models.taskinstance import _CURRENT_CONTEXT
+
     if not _CURRENT_CONTEXT:
-        raise AirflowException(
+        raise RuntimeError(
             "Current context was requested but no context was found! "
-            "Are you running within an airflow task?"
+            "Are you running within an Airflow task?"
         )
     return _CURRENT_CONTEXT[-1]

--- a/providers/tests/standard/operators/test_python.py
+++ b/providers/tests/standard/operators/test_python.py
@@ -1069,7 +1069,7 @@ class BaseTestPythonVirtualenvOperator(BasePythonTest):
         with pytest.raises(
             AirflowException,
             match="Current context was requested but no context was found! "
-            "Are you running within an airflow task?",
+            "Are you running within an Airflow task?",
         ):
             self.run_as_task(f, return_ti=True, use_airflow_context=False)
 
@@ -1890,7 +1890,7 @@ class TestBranchExternalPythonOperator(BaseTestBranchPythonVirtualenvOperator):
 
 class TestCurrentContext:
     def test_current_context_no_context_raise(self):
-        with pytest.raises(AirflowException):
+        with pytest.raises(RuntimeError):
             get_current_context()
 
     def test_current_context_roundtrip(self):
@@ -1904,7 +1904,7 @@ class TestCurrentContext:
 
         with set_current_context(example_context):
             pass
-        with pytest.raises(AirflowException):
+        with pytest.raises(RuntimeError):
             get_current_context()
 
     def test_nested_context(self):

--- a/task_sdk/src/airflow/sdk/__init__.py
+++ b/task_sdk/src/airflow/sdk/__init__.py
@@ -26,6 +26,7 @@ __all__ = [
     "TaskGroup",
     "dag",
     "Connection",
+    "get_current_context",
     "__version__",
 ]
 
@@ -34,6 +35,7 @@ __version__ = "1.0.0.dev1"
 if TYPE_CHECKING:
     from airflow.sdk.definitions.baseoperator import BaseOperator
     from airflow.sdk.definitions.connection import Connection
+    from airflow.sdk.definitions.contextmanager import get_current_context
     from airflow.sdk.definitions.dag import DAG, dag
     from airflow.sdk.definitions.edges import EdgeModifier, Label
     from airflow.sdk.definitions.taskgroup import TaskGroup
@@ -47,6 +49,7 @@ __lazy_imports: dict[str, str] = {
     "Label": ".definitions.edges",
     "Connection": ".definitions.connection",
     "Variable": ".definitions.variable",
+    "get_current_context": ".definitions.contextmanager",
 }
 
 

--- a/task_sdk/src/airflow/sdk/definitions/contextmanager.py
+++ b/task_sdk/src/airflow/sdk/definitions/contextmanager.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import sys
 from collections import deque
+from collections.abc import Mapping
 from types import ModuleType
 from typing import Any, Generic, TypeVar
 
@@ -27,10 +28,47 @@ from airflow.sdk.definitions.taskgroup import TaskGroup
 
 T = TypeVar("T")
 
-__all__ = [
-    "DagContext",
-    "TaskGroupContext",
-]
+__all__ = ["DagContext", "TaskGroupContext", "get_current_context"]
+
+# This is a global variable that stores the current Task context.
+# It is used to push the Context dictionary when Task starts execution
+# and it is used to retrieve the current context in PythonOperator or Taskflow API via
+# the `get_current_context` function.
+_CURRENT_CONTEXT: list[Mapping[str, Any]] = []
+
+
+def get_current_context() -> Mapping[str, Any]:
+    """
+    Retrieve the execution context dictionary without altering user method's signature.
+
+    This is the simplest method of retrieving the execution context dictionary.
+
+    **Old style:**
+
+    .. code:: python
+
+        def my_task(**context):
+            ti = context["ti"]
+
+    **New style:**
+
+    .. code:: python
+
+        from airflow.providers.standard.operators.python import get_current_context
+
+
+        def my_task():
+            context = get_current_context()
+            ti = context["ti"]
+
+    Current context will only have value if this method was called after an operator
+    was starting to execute.
+    """
+    if not _CURRENT_CONTEXT:
+        raise RuntimeError(
+            "Current context was requested but no context was found! Are you running within an Airflow task?"
+        )
+    return _CURRENT_CONTEXT[-1]
 
 
 # In order to add a `@classproperty`-like thing we need to define a property on a metaclass.

--- a/task_sdk/tests/defintions/test_contextmanager.py
+++ b/task_sdk/tests/defintions/test_contextmanager.py
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from airflow.sdk import get_current_context
+
+
+class TestCurrentContext:
+    def test_current_context_no_context_raise(self):
+        with pytest.raises(RuntimeError):
+            get_current_context()
+
+    def test_get_current_context_with_context(self, monkeypatch):
+        mock_context = {"ti": "task_instance", "key": "value"}
+        monkeypatch.setattr("airflow.sdk.definitions.contextmanager._CURRENT_CONTEXT", [mock_context])
+        result = get_current_context()
+        assert result == mock_context
+
+    def test_get_current_context_without_context(self, monkeypatch):
+        monkeypatch.setattr("airflow.sdk.definitions.contextmanager._CURRENT_CONTEXT", [])
+        with pytest.raises(RuntimeError, match="Current context was requested but no context was found!"):
+            get_current_context()

--- a/task_sdk/tests/execution_time/conftest.py
+++ b/task_sdk/tests/execution_time/conftest.py
@@ -18,7 +18,16 @@
 from __future__ import annotations
 
 import sys
+from typing import TYPE_CHECKING
 from unittest import mock
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from airflow.sdk.api.datamodels._generated import TIRunContext
+    from airflow.sdk.definitions.baseoperator import BaseOperator
+    from airflow.sdk.execution_time.comms import StartupDetails
+    from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
 
 import pytest
 
@@ -40,3 +49,95 @@ def mock_supervisor_comms():
         "airflow.sdk.execution_time.task_runner.SUPERVISOR_COMMS", create=True
     ) as supervisor_comms:
         yield supervisor_comms
+
+
+@pytest.fixture
+def mocked_parse(spy_agency):
+    """
+    Fixture to set up an inline DAG and use it in a stubbed `parse` function. Use this fixture if you
+    want to isolate and test `parse` or `run` logic without having to define a DAG file.
+
+    This fixture returns a helper function `set_dag` that:
+    1. Creates an in line DAG with the given `dag_id` and `task` (limited to one task)
+    2. Constructs a `RuntimeTaskInstance` based on the provided `StartupDetails` and task.
+    3. Stubs the `parse` function using `spy_agency`, to return the mocked `RuntimeTaskInstance`.
+
+    After adding the fixture in your test function signature, you can use it like this ::
+
+            mocked_parse(
+                StartupDetails(
+                    ti=TaskInstance(id=uuid7(), task_id="hello", dag_id="super_basic_run", run_id="c", try_number=1),
+                    file="",
+                    requests_fd=0,
+                ),
+                "example_dag_id",
+                CustomOperator(task_id="hello"),
+            )
+    """
+
+    def set_dag(what: StartupDetails, dag_id: str, task: BaseOperator) -> RuntimeTaskInstance:
+        from airflow.sdk.definitions.dag import DAG
+        from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance, parse
+        from airflow.utils import timezone
+
+        dag = DAG(dag_id=dag_id, start_date=timezone.datetime(2024, 12, 3))
+        task.dag = dag
+        t = dag.task_dict[task.task_id]
+        ti = RuntimeTaskInstance.model_construct(**what.ti.model_dump(exclude_unset=True), task=t)
+        spy_agency.spy_on(parse, call_fake=lambda _: ti)
+        return ti
+
+    return set_dag
+
+
+@pytest.fixture
+def create_runtime_ti(
+    mocked_parse: Callable[[StartupDetails, str, BaseOperator], RuntimeTaskInstance],
+    make_ti_context: Callable[..., TIRunContext],
+) -> Callable[[BaseOperator, TIRunContext | None, StartupDetails | None], RuntimeTaskInstance]:
+    """
+    Fixture to create a Runtime TaskInstance for testing purposes without defining a dag file.
+
+    This fixture sets up a `RuntimeTaskInstance` with default or custom `TIRunContext` and `StartupDetails`,
+    making it easy to simulate task execution scenarios in tests.
+
+    Example usage: ::
+
+        def test_custom_task_instance(create_runtime_ti):
+            class MyTaskOperator(BaseOperator):
+                def execute(self, context):
+                    assert context["dag_run"].run_id == "test_run"
+
+            task = MyTaskOperator(task_id="test_task")
+            ti = create_runtime_ti(task, context_from_server=make_ti_context(run_id="test_run"))
+            # Further test logic...
+    """
+    from uuid6 import uuid7
+
+    from airflow.sdk.api.datamodels._generated import TaskInstance
+    from airflow.sdk.execution_time.comms import StartupDetails
+
+    def _create_task_instance(
+        task, context_from_server: TIRunContext | None = None, startup_details: StartupDetails | None = None
+    ) -> RuntimeTaskInstance:
+        if context_from_server is None:
+            context_from_server = make_ti_context()
+
+        if not startup_details:
+            startup_details = StartupDetails(
+                ti=TaskInstance(
+                    id=uuid7(),
+                    task_id=task.task_id,
+                    dag_id=context_from_server.dag_run.dag_id,
+                    run_id=context_from_server.dag_run.run_id,
+                    try_number=1,
+                ),
+                file="",
+                requests_fd=0,
+                ti_context=context_from_server,
+            )
+
+        ti = mocked_parse(startup_details, context_from_server.dag_run.dag_id, task)
+        return ti
+
+    return _create_task_instance


### PR DESCRIPTION
closes https://github.com/apache/airflow/issues/45234

I am putting the logic for `set_current_context` in `execution_time/context.py`. I didn't want to put `_CURRENT_CONTEXT` in `task_sdk/src/airflow/sdk/definitions/contextmanager.py` to avoid execution logic in a user-facing module but I couldn't think of another way to store it from execution & allow retrieving (via `get_current_context` in the Standard Provider) in their Task.

Upcoming PRs:
- Move most of the internal stuff in Task SDK to a separate module.
- Use `create_runtime_ti` fixture more widely in tests

---

Tested with the following DAG:

```py
import pendulum

from airflow.decorators import dag, task
from airflow.providers.standard.operators.python import get_current_context

@dag(
    schedule=None,
    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
    catchup=False,
)
def x_get_context():
    @task
    def template_test(data_interval_end):
        context = get_current_context()

        # Will print `2024-10-10 00:00:00+00:00`.
        # Note how we didn't pass this value when calling the task. Instead
        # it was passed by the decorator from the context
        print(f"data_interval_end: {data_interval_end}")

        # Will print the full context dict
        print(f"context: {context}")

    template_test()

x_get_context()

```
<img width="1703" alt="image" src="https://github.com/user-attachments/assets/2763963a-d299-412f-bee3-3b20904ca7c8" />





<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
