### PR TITLE
Rename Try Number to Attempt

### DIFF
--- a/airflow/ui/src/components/TaskInstanceTooltip.tsx
+++ b/airflow/ui/src/components/TaskInstanceTooltip.tsx
@@ -45,7 +45,7 @@ const TaskInstanceTooltip = ({ children, positioning, taskInstance, ...rest }: P
           <Text>
             End Date: <Time datetime={taskInstance.end_date} />
           </Text>
-          {taskInstance.try_number > 1 && <Text>Try Number: {taskInstance.try_number}</Text>}
+          {taskInstance.try_number > 1 && <Text>Attempt: {taskInstance.try_number}</Text>}
           {"duration" in taskInstance ? (
             <Text>Duration: {taskInstance.duration?.toFixed(2) ?? 0}s</Text>
           ) : undefined}

--- a/airflow/ui/src/components/TaskTrySelect.tsx
+++ b/airflow/ui/src/components/TaskTrySelect.tsx
@@ -68,7 +68,7 @@ export const TaskTrySelect = ({ onSelectTryNumber, selectedTryNumber, taskInstan
 
   return (
     <VStack alignItems="flex-start" gap={1} my={3}>
-      <Heading size="md">Task Tries</Heading>
+      <Heading size="md">Attempts</Heading>
       {showDropdown ? (
         <Select.Root
           collection={tryOptions}
@@ -84,7 +84,7 @@ export const TaskTrySelect = ({ onSelectTryNumber, selectedTryNumber, taskInstan
           width="200px"
         >
           <Select.Trigger>
-            <Select.ValueText placeholder="Task Try">
+            <Select.ValueText placeholder="Attempt">
               {(
                 items: Array<{
                   task_instance: TaskInstanceHistoryResponse;

--- a/airflow/ui/src/pages/Events/Events.tsx
+++ b/airflow/ui/src/pages/Events/Events.tsx
@@ -88,7 +88,7 @@ const eventsColumn = (
   {
     accessorKey: "try_number",
     enableSorting: false,
-    header: "Try Number",
+    header: "Attempt",
     meta: {
       skeletonWidth: 10,
     },

--- a/airflow/ui/src/pages/Run/TaskInstances.tsx
+++ b/airflow/ui/src/pages/Run/TaskInstances.tsx
@@ -68,7 +68,7 @@ const columns: Array<ColumnDef<TaskInstanceResponse>> = [
   {
     accessorKey: "try_number",
     enableSorting: false,
-    header: "Try Number",
+    header: "Attempt",
   },
   {
     accessorKey: "operator",

--- a/airflow/ui/src/pages/Task/Instances.tsx
+++ b/airflow/ui/src/pages/Task/Instances.tsx
@@ -71,7 +71,7 @@ const columns = (isMapped?: boolean): Array<ColumnDef<TaskInstanceResponse>> => 
   {
     accessorKey: "try_number",
     enableSorting: false,
-    header: "Try Number",
+    header: "Attempt",
   },
   {
     cell: ({ row: { original } }) => `${getDuration(original.start_date, original.end_date)}s`,

--- a/airflow/ui/src/pages/TaskInstance/Header.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Header.tsx
@@ -53,7 +53,7 @@ export const Header = ({ taskInstance }: { readonly taskInstance: TaskInstanceRe
       {taskInstance.map_index > -1 ? (
         <Stat label="Map Index">{taskInstance.rendered_map_index ?? taskInstance.map_index}</Stat>
       ) : undefined}
-      {taskInstance.try_number > 1 ? <Stat label="Try Number">{taskInstance.try_number}</Stat> : undefined}
+      {taskInstance.try_number > 1 ? <Stat label="Attempt">{taskInstance.try_number}</Stat> : undefined}
       <Stat label="Start">
         <Time datetime={taskInstance.start_date} />
       </Stat>


### PR DESCRIPTION
Try Number is fine as the column entry. But I think "Attempt" is a more intuitive name for users.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
