### PR TITLE
Add Grid View to new UI

### DIFF
--- a/airflow/ui/src/components/TaskName.tsx
+++ b/airflow/ui/src/components/TaskName.tsx
@@ -16,22 +16,20 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { type LinkProps, Link, Text } from "@chakra-ui/react";
+import { Text, type TextProps } from "@chakra-ui/react";
 import type { CSSProperties } from "react";
 import { FiArrowUpRight, FiArrowDownRight } from "react-icons/fi";
-import { useParams, useSearchParams, Link as RouterLink } from "react-router-dom";
 
 import type { NodeResponse } from "openapi/requests/types.gen";
 
-type Props = {
-  readonly id: string;
+export type TaskNameProps = {
   readonly isGroup?: boolean;
   readonly isMapped?: boolean;
   readonly isOpen?: boolean;
   readonly isZoomedOut?: boolean;
   readonly label: string;
   readonly setupTeardownType?: NodeResponse["setup_teardown_type"];
-} & LinkProps;
+} & TextProps;
 
 const iconStyle: CSSProperties = {
   display: "inline",
@@ -40,7 +38,6 @@ const iconStyle: CSSProperties = {
 };
 
 export const TaskName = ({
-  id,
   isGroup = false,
   isMapped = false,
   isOpen = false,
@@ -48,35 +45,24 @@ export const TaskName = ({
   label,
   setupTeardownType,
   ...rest
-}: Props) => {
-  const { dagId = "", runId, taskId } = useParams();
-  const [searchParams] = useSearchParams();
-
+}: TaskNameProps) => {
   // We don't have a task group details page to link to
   if (isGroup) {
     return (
-      <Text fontSize="md" fontWeight="bold">
+      <Text fontSize="md" fontWeight="bold" {...rest}>
         {label}
       </Text>
     );
   }
 
   return (
-    <Link asChild data-testid={id} fontSize={isZoomedOut ? "lg" : "md"} fontWeight="bold" {...rest}>
-      <RouterLink
-        to={{
-          // Do not include runId if there is no selected run, clicking a second time will deselect a task id
-          pathname: `/dags/${dagId}/${runId === undefined ? "" : `runs/${runId}/`}${taskId === id ? "" : `tasks/${id}`}`,
-          search: searchParams.toString(),
-        }}
-      >
-        {label}
-        {isMapped ? " [ ]" : undefined}
-        {setupTeardownType === "setup" && <FiArrowUpRight size={isZoomedOut ? 24 : 15} style={iconStyle} />}
-        {setupTeardownType === "teardown" && (
-          <FiArrowDownRight size={isZoomedOut ? 24 : 15} style={iconStyle} />
-        )}
-      </RouterLink>
-    </Link>
+    <Text fontSize={isZoomedOut ? "lg" : "md"} fontWeight="bold" {...rest}>
+      {label}
+      {isMapped ? " [ ]" : undefined}
+      {setupTeardownType === "setup" && <FiArrowUpRight size={isZoomedOut ? 24 : 15} style={iconStyle} />}
+      {setupTeardownType === "teardown" && (
+        <FiArrowDownRight size={isZoomedOut ? 24 : 15} style={iconStyle} />
+      )}
+    </Text>
   );
 };

--- a/airflow/ui/src/layouts/Details/DagRunSelect.tsx
+++ b/airflow/ui/src/layouts/Details/DagRunSelect.tsx
@@ -34,11 +34,13 @@ export const DagRunSelect = forwardRef<HTMLDivElement>((_, ref) => {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
 
+  const offset = parseInt(searchParams.get("offset") ?? "0", 10);
+
   const { data, isLoading } = useGridServiceGridData(
     {
       dagId,
-      limit: 14,
-      offset: 0,
+      limit: 25,
+      offset,
       orderBy: "-start_date",
     },
     undefined,

--- a/airflow/ui/src/layouts/Details/DagVizModal.tsx
+++ b/airflow/ui/src/layouts/Details/DagVizModal.tsx
@@ -31,6 +31,7 @@ import { DagRunSelect } from "./DagRunSelect";
 import { Gantt } from "./Gantt";
 import { Graph } from "./Graph";
 import { Grid } from "./Grid";
+import { ToggleGroups } from "./ToggleGroups";
 
 type DAGVizModalProps = {
   dagDisplayName?: DAGResponse["dag_display_name"];
@@ -89,6 +90,7 @@ export const DagVizModal: React.FC<DAGVizModalProps> = ({ dagDisplayName, dagId,
               </RouterLink>
             ))}
             <DagRunSelect ref={contentRef} />
+            <ToggleGroups />
           </HStack>
           <Dialog.CloseTrigger closeButtonProps={{ size: "xl" }} />
         </Dialog.Header>

--- a/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -64,7 +64,7 @@ export const DetailsLayout = ({ children, dag, error, isLoading, tabs }: Props) 
           <SearchDagsButton />
         </HStack>
         <Toaster />
-        {children}
+        {isModalOpen ? undefined : children}
         <ErrorAlert error={error} />
         <ProgressBar size="xs" visibility={isLoading ? "visible" : "hidden"} />
         <NavTabs tabs={tabs} />
@@ -75,9 +75,7 @@ export const DetailsLayout = ({ children, dag, error, isLoading, tabs }: Props) 
           open={isModalOpen}
         />
       </Box>
-      <Box overflow="auto">
-        <Outlet />
-      </Box>
+      <Box overflow="auto">{isModalOpen ? undefined : <Outlet />}</Box>
     </OpenGroupsProvider>
   );
 };

--- a/airflow/ui/src/layouts/Details/Graph/Graph.tsx
+++ b/airflow/ui/src/layouts/Details/Graph/Graph.tsx
@@ -90,7 +90,7 @@ export const Graph = () => {
   const { data: gridData } = useGridServiceGridData(
     {
       dagId,
-      limit: 14,
+      limit: 25,
       offset: 0,
       orderBy: "-start_date",
     },

--- a/airflow/ui/src/layouts/Details/Graph/TaskLink.tsx
+++ b/airflow/ui/src/layouts/Details/Graph/TaskLink.tsx
@@ -1,0 +1,50 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Link } from "@chakra-ui/react";
+import { useParams, useSearchParams, Link as RouterLink } from "react-router-dom";
+
+import { TaskName, type TaskNameProps } from "src/components/TaskName";
+
+type Props = {
+  readonly id: string;
+} & TaskNameProps;
+
+export const TaskLink = ({ id, isGroup, ...rest }: Props) => {
+  const { dagId = "", runId, taskId } = useParams();
+  const [searchParams] = useSearchParams();
+
+  // We don't have a task group details page to link to
+  if (isGroup) {
+    return <TaskName isGroup={true} {...rest} />;
+  }
+
+  return (
+    <Link asChild data-testid={id}>
+      <RouterLink
+        to={{
+          // Do not include runId if there is no selected run, clicking a second time will deselect a task id
+          pathname: `/dags/${dagId}/${runId === undefined ? "" : `runs/${runId}/`}${taskId === id ? "" : `tasks/${id}`}`,
+          search: searchParams.toString(),
+        }}
+      >
+        <TaskName {...rest} />
+      </RouterLink>
+    </Link>
+  );
+};

--- a/airflow/ui/src/layouts/Details/Graph/TaskNode.tsx
+++ b/airflow/ui/src/layouts/Details/Graph/TaskNode.tsx
@@ -26,7 +26,7 @@ import { useOpenGroups } from "src/context/openGroups";
 import { pluralize } from "src/utils";
 
 import { NodeWrapper } from "./NodeWrapper";
-import { TaskName } from "./TaskName";
+import { TaskLink } from "./TaskLink";
 import type { CustomNodeProps } from "./reactflowUtils";
 
 export const TaskNode = ({
@@ -57,7 +57,7 @@ export const TaskNode = ({
     <NodeWrapper>
       <Flex alignItems="center" cursor="default" flexDirection="column">
         <TaskInstanceTooltip
-          openDelay={500}
+          // openDelay={500}
           positioning={{
             placement: "top-start",
           }}
@@ -76,7 +76,7 @@ export const TaskNode = ({
             width={`${width}px`}
           >
             <Box>
-              <TaskName
+              <TaskLink
                 id={id}
                 isGroup={isGroup}
                 isMapped={isMapped}

--- a/airflow/ui/src/layouts/Details/Graph/TaskNode.tsx
+++ b/airflow/ui/src/layouts/Details/Graph/TaskNode.tsx
@@ -57,7 +57,7 @@ export const TaskNode = ({
     <NodeWrapper>
       <Flex alignItems="center" cursor="default" flexDirection="column">
         <TaskInstanceTooltip
-          // openDelay={500}
+          openDelay={500}
           positioning={{
             placement: "top-start",
           }}

--- a/airflow/ui/src/layouts/Details/Grid/Bar.tsx
+++ b/airflow/ui/src/layouts/Details/Grid/Bar.tsx
@@ -1,0 +1,96 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Flex, Box, VStack, Text } from "@chakra-ui/react";
+import { useParams, useSearchParams } from "react-router-dom";
+
+import { RunTypeIcon } from "src/components/RunTypeIcon";
+import Time from "src/components/Time";
+
+import { GridButton } from "./GridButton";
+import { TaskInstances } from "./TaskInstances";
+import type { GridTask, RunWithDuration } from "./utils";
+
+const BAR_HEIGHT = 100;
+
+type Props = {
+  readonly index: number;
+  readonly limit: number;
+  readonly max: number;
+  readonly nodes: Array<GridTask>;
+  readonly run: RunWithDuration;
+};
+
+export const Bar = ({ index, limit, max, nodes, run }: Props) => {
+  const { dagId = "", runId } = useParams();
+  const [searchParams] = useSearchParams();
+
+  const isSelected = runId === run.dag_run_id;
+
+  const search = searchParams.toString();
+
+  const shouldShowTick = index % 8 === 0 || index === limit - 1;
+
+  return (
+    <Box
+      _hover={{ bg: "blue.subtle" }}
+      bg={isSelected ? "blue.muted" : undefined}
+      position="relative"
+      transition="background-color 0.2s"
+    >
+      <Flex
+        alignItems="flex-end"
+        height={BAR_HEIGHT}
+        justifyContent="center"
+        pb="2px"
+        px="5px"
+        width="14px"
+        zIndex={1}
+      >
+        <GridButton
+          dagId={dagId}
+          height={`${(run.duration / max) * BAR_HEIGHT}px`}
+          justifyContent="flex-end"
+          label={run.dag_run_id}
+          minHeight="14px"
+          runId={run.dag_run_id}
+          searchParams={search}
+          state={run.state}
+          zIndex={1}
+        >
+          {run.run_type !== "scheduled" && <RunTypeIcon runType={run.run_type} size="8px" />}
+        </GridButton>
+        {shouldShowTick ? (
+          <VStack gap={0} left="8px" position="absolute" top={0} width={0} zIndex={-1}>
+            <Text
+              color="border.emphasized"
+              fontSize="xs"
+              mt="-35px !important"
+              transform="rotate(-40deg) translateX(28px)"
+              whiteSpace="nowrap"
+            >
+              <Time datetime={run.data_interval_start} format="MMM DD, HH:mm" />
+            </Text>
+            <Box borderLeftWidth={1} height="100px" opacity={0.7} zIndex={0} />
+          </VStack>
+        ) : undefined}
+      </Flex>
+      <TaskInstances nodes={nodes} runId={run.dag_run_id} taskInstances={run.task_instances} />
+    </Box>
+  );
+};

--- a/airflow/ui/src/layouts/Details/Grid/DurationAxis.tsx
+++ b/airflow/ui/src/layouts/Details/Grid/DurationAxis.tsx
@@ -1,0 +1,23 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box, type BoxProps } from "@chakra-ui/react";
+
+export const DurationAxis = (props: BoxProps) => (
+  <Box borderBottomWidth={1} left="30px" position="absolute" right="25px" zIndex={0} {...props} />
+);

--- a/airflow/ui/src/layouts/Details/Grid/DurationTick.tsx
+++ b/airflow/ui/src/layouts/Details/Grid/DurationTick.tsx
@@ -1,0 +1,25 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Text, type TextProps } from "@chakra-ui/react";
+
+export const DurationTick = ({ children, ...rest }: TextProps) => (
+  <Text color="border.emphasized" fontSize="xs" position="absolute" right={1} whiteSpace="nowrap" {...rest}>
+    {children}
+  </Text>
+);

--- a/airflow/ui/src/layouts/Details/Grid/Grid.tsx
+++ b/airflow/ui/src/layouts/Details/Grid/Grid.tsx
@@ -16,6 +16,147 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box } from "@chakra-ui/react";
+import { Box, Flex, IconButton } from "@chakra-ui/react";
+import { keepPreviousData } from "@tanstack/react-query";
+import dayjs from "dayjs";
+import dayjsDuration from "dayjs/plugin/duration";
+import { useMemo } from "react";
+import { FiChevronLeft, FiChevronRight } from "react-icons/fi";
+import { useParams, useSearchParams } from "react-router-dom";
 
-export const Grid = () => <Box>grid</Box>;
+import { useGridServiceGridData, useStructureServiceStructureData } from "openapi/queries";
+import type { GridResponse } from "openapi/requests/types.gen";
+import { useOpenGroups } from "src/context/openGroups";
+
+import { Bar } from "./Bar";
+import { DurationAxis } from "./DurationAxis";
+import { DurationTick } from "./DurationTick";
+import { TaskNames } from "./TaskNames";
+import { flattenNodes, type RunWithDuration } from "./utils";
+
+dayjs.extend(dayjsDuration);
+
+const OFFSET_CHANGE = 10;
+const limit = 25;
+
+export const Grid = () => {
+  const { openGroupIds } = useOpenGroups();
+  const { dagId = "" } = useParams();
+  const { data: structure } = useStructureServiceStructureData({
+    dagId,
+  });
+
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const offset = parseInt(searchParams.get("offset") ?? "0", 10);
+
+  // This is necessary for keepPreviousData
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
+  const { data: gridData } = useGridServiceGridData<GridResponse>(
+    {
+      dagId,
+      limit,
+      offset,
+      orderBy: "-start_date",
+    },
+    undefined,
+    {
+      placeholderData: keepPreviousData,
+    },
+  );
+
+  const runs: Array<RunWithDuration> = useMemo(
+    () =>
+      (gridData?.dag_runs ?? []).map((run) => {
+        const duration = dayjs.duration(dayjs(run.end_date).diff(run.start_date)).asSeconds();
+
+        return {
+          ...run,
+          duration,
+        };
+      }),
+    [gridData?.dag_runs],
+  );
+
+  // calculate dag run bar heights relative to max
+  const max = Math.max.apply(
+    undefined,
+    runs.map((dr) => dr.duration),
+  );
+
+  const onIncrement = () => {
+    if (offset - OFFSET_CHANGE > 0) {
+      const newOffset = offset - OFFSET_CHANGE;
+
+      searchParams.set("offset", newOffset.toString());
+    } else {
+      searchParams.delete("offset");
+    }
+    setSearchParams(searchParams);
+  };
+
+  const onDecrement = () => {
+    const newOffset = offset + OFFSET_CHANGE;
+
+    searchParams.set("offset", newOffset.toString());
+    setSearchParams(searchParams);
+  };
+
+  const { flatNodes } = useMemo(
+    () => flattenNodes(structure?.nodes ?? [], openGroupIds),
+    [structure?.nodes, openGroupIds],
+  );
+
+  return (
+    <Flex justifyContent="flex-end" mr={3} position="relative" pt="75px" width="100%">
+      <Box position="absolute" top="175px" width="100%">
+        <TaskNames nodes={flatNodes} />
+      </Box>
+      <Box>
+        <Flex position="relative">
+          <IconButton
+            aria-label={`-${OFFSET_CHANGE} older dag runs`}
+            disabled={runs.length < limit}
+            height="98px"
+            minW={0}
+            mr={10}
+            onClick={onDecrement}
+            title={`-${OFFSET_CHANGE} older dag runs`}
+            variant="surface"
+            zIndex={1}
+          >
+            <FiChevronLeft />
+          </IconButton>
+          <DurationAxis top="100px" />
+          <DurationAxis top="50px" />
+          <DurationAxis top="4px" />
+          <Flex flexDirection="column-reverse" height="100px" position="relative" width="100%">
+            {Boolean(runs.length) && (
+              <>
+                <DurationTick bottom="92px">{Math.floor(max)}s</DurationTick>
+                <DurationTick bottom="46px">{Math.floor(max / 2)}s</DurationTick>
+                <DurationTick bottom="-4px">0s</DurationTick>
+              </>
+            )}
+          </Flex>
+          {runs.reverse().map((dr, index) => (
+            <Bar index={index} key={dr.dag_run_id} limit={limit} max={max} nodes={flatNodes} run={dr} />
+          ))}
+          <IconButton
+            aria-label={`+${OFFSET_CHANGE} newer dag runs`}
+            disabled={offset === 0}
+            height="98px"
+            minW={0}
+            ml={1}
+            onClick={onIncrement}
+            title={`+${OFFSET_CHANGE} newer dag runs`}
+            variant="surface"
+            zIndex={1}
+          >
+            <FiChevronRight />
+          </IconButton>
+        </Flex>
+      </Box>
+    </Flex>
+  );
+};

--- a/airflow/ui/src/layouts/Details/Grid/GridButton.tsx
+++ b/airflow/ui/src/layouts/Details/Grid/GridButton.tsx
@@ -1,0 +1,80 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Flex, type FlexProps } from "@chakra-ui/react";
+import { Link } from "react-router-dom";
+
+import type { DagRunState, TaskInstanceState } from "openapi/requests/types.gen";
+import { stateColor } from "src/utils/stateColor";
+
+type Props = {
+  readonly dagId: string;
+  readonly isGroup?: boolean;
+  readonly label: string;
+  readonly runId: string;
+  readonly searchParams: string;
+  readonly state: DagRunState | TaskInstanceState | null | undefined;
+  readonly taskId?: string;
+} & FlexProps;
+
+export const GridButton = ({
+  children,
+  dagId,
+  isGroup,
+  label,
+  runId,
+  searchParams,
+  state,
+  taskId,
+  ...rest
+}: Props) =>
+  isGroup ? (
+    <Flex
+      background={stateColor[state ?? "null"]}
+      borderRadius={2}
+      height="10px"
+      minW="10px"
+      pb="2px"
+      px="2px"
+      title={`${label}\n${state}`}
+      {...rest}
+    >
+      {children}
+    </Flex>
+  ) : (
+    <Link
+      replace
+      to={{
+        pathname: `/dags/${dagId}/runs/${runId}/${taskId === undefined ? "" : `tasks/${taskId}`}`,
+        search: searchParams,
+      }}
+    >
+      <Flex
+        background={stateColor[state ?? "null"]}
+        borderRadius={2}
+        height="10px"
+        pb="2px"
+        px="2px"
+        title={`${label}\n${state}`}
+        width="10px"
+        {...rest}
+      >
+        {children}
+      </Flex>
+    </Link>
+  );

--- a/airflow/ui/src/layouts/Details/Grid/GridButton.tsx
+++ b/airflow/ui/src/layouts/Details/Grid/GridButton.tsx
@@ -20,7 +20,6 @@ import { Flex, type FlexProps } from "@chakra-ui/react";
 import { Link } from "react-router-dom";
 
 import type { DagRunState, TaskInstanceState } from "openapi/requests/types.gen";
-import { stateColor } from "src/utils/stateColor";
 
 type Props = {
   readonly dagId: string;
@@ -45,7 +44,7 @@ export const GridButton = ({
 }: Props) =>
   isGroup ? (
     <Flex
-      background={stateColor[state ?? "null"]}
+      background={`${state}.solid`}
       borderRadius={2}
       height="10px"
       minW="10px"
@@ -65,7 +64,7 @@ export const GridButton = ({
       }}
     >
       <Flex
-        background={stateColor[state ?? "null"]}
+        background={`${state}.solid`}
         borderRadius={2}
         height="10px"
         pb="2px"

--- a/airflow/ui/src/layouts/Details/Grid/GridTI.tsx
+++ b/airflow/ui/src/layouts/Details/Grid/GridTI.tsx
@@ -1,0 +1,80 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Flex } from "@chakra-ui/react";
+import type { MouseEvent } from "react";
+import React from "react";
+
+import type { TaskInstanceState } from "openapi/requests/types.gen";
+
+import { GridButton } from "./GridButton";
+
+type Props = {
+  readonly dagId: string;
+  readonly isGroup?: boolean;
+  readonly label: string;
+  readonly runId: string;
+  readonly search: string;
+  readonly state?: TaskInstanceState | null;
+  readonly taskId: string;
+};
+
+const onMouseEnter = (event: MouseEvent<HTMLDivElement>) => {
+  const tasks = document.querySelectorAll<HTMLDivElement>(`#name-${event.currentTarget.id}`);
+
+  tasks.forEach((task) => {
+    task.style.backgroundColor = "var(--chakra-colors-blue-subtle)";
+  });
+};
+
+const onMouseLeave = (event: MouseEvent<HTMLDivElement>) => {
+  const tasks = document.querySelectorAll<HTMLDivElement>(`#name-${event.currentTarget.id}`);
+
+  tasks.forEach((task) => {
+    task.style.backgroundColor = "";
+  });
+};
+
+const Instance = ({ dagId, isGroup, label, runId, search, state, taskId }: Props) => (
+  <Flex
+    alignItems="flex-end"
+    id={taskId.replaceAll(".", "-")}
+    justifyContent="center"
+    key={taskId}
+    onMouseEnter={onMouseEnter}
+    onMouseLeave={onMouseLeave}
+    px="5px"
+    py="5px"
+    transition="background-color 0.2s"
+    width="14px"
+    zIndex={1}
+  >
+    <GridButton
+      dagId={dagId}
+      isGroup={isGroup}
+      label={label}
+      p="2px"
+      runId={runId}
+      searchParams={search}
+      state={state}
+      taskId={taskId}
+    />
+  </Flex>
+);
+
+export const GridTI = React.memo(Instance);

--- a/airflow/ui/src/layouts/Details/Grid/TaskInstances.tsx
+++ b/airflow/ui/src/layouts/Details/Grid/TaskInstances.tsx
@@ -1,0 +1,59 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useParams, useSearchParams } from "react-router-dom";
+
+import type { GridTaskInstanceSummary } from "openapi/requests/types.gen";
+
+import { GridTI } from "./GridTI";
+import type { GridTask } from "./utils";
+
+type Props = {
+  depth?: number;
+  nodes: Array<GridTask>;
+  runId: string;
+  taskInstances: Array<GridTaskInstanceSummary>;
+};
+
+export const TaskInstances = ({ nodes, runId, taskInstances }: Props) => {
+  const { dagId = "" } = useParams();
+  const [searchParams] = useSearchParams();
+
+  return nodes.map((node) => {
+    const taskInstance = taskInstances.find((ti) => ti.task_id === node.id);
+
+    if (!taskInstance) {
+      return undefined;
+    }
+
+    const search = searchParams.toString();
+
+    return (
+      <GridTI
+        dagId={dagId}
+        isGroup={node.isGroup}
+        key={node.id}
+        label={node.label}
+        runId={runId}
+        search={search}
+        state={taskInstance.state}
+        taskId={node.id}
+      />
+    );
+  });
+};

--- a/airflow/ui/src/layouts/Details/Grid/TaskNames.tsx
+++ b/airflow/ui/src/layouts/Details/Grid/TaskNames.tsx
@@ -1,0 +1,101 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box, chakra, Flex, Link } from "@chakra-ui/react";
+import { FiChevronUp } from "react-icons/fi";
+import { Link as RouterLink, useParams, useSearchParams } from "react-router-dom";
+
+import { TaskName } from "src/components/TaskName";
+import { useOpenGroups } from "src/context/openGroups";
+
+import type { GridTask } from "./utils";
+
+type Props = {
+  depth?: number;
+  nodes: Array<GridTask>;
+};
+
+export const TaskNames = ({ nodes }: Props) => {
+  const { toggleGroupId } = useOpenGroups();
+  const { dagId = "", taskId } = useParams();
+  const [searchParams] = useSearchParams();
+
+  return nodes.map((node) => (
+    <Box
+      _hover={{ bg: "blue.subtle" }}
+      bg={node.id === taskId ? "blue.muted" : undefined}
+      borderBottomWidth={1}
+      borderColor={node.isGroup ? "border.emphasized" : "border.muted"}
+      id={`name-${node.id.replaceAll(".", "-")}`}
+      key={node.id}
+      maxHeight="20px"
+      transition="background-color 0.2s"
+    >
+      {node.isGroup ? (
+        <Flex>
+          <TaskName
+            display="inline"
+            fontSize="sm"
+            fontWeight="normal"
+            isGroup={true}
+            isMapped={Boolean(node.is_mapped)}
+            label={node.label}
+            paddingLeft={node.depth * 3 + 2}
+            setupTeardownType={node.setup_teardown_type}
+          />
+          <chakra.button
+            aria-label="Toggle group"
+            display="inline"
+            height="20px"
+            ml={1}
+            onClick={() => toggleGroupId(node.id)}
+            outlineColor="bg.inverted"
+            px={1}
+          >
+            <FiChevronUp
+              size="1rem"
+              style={{
+                transform: `rotate(${node.isOpen ? 0 : 180}deg)`,
+                transition: "transform 0.5s",
+              }}
+            />
+          </chakra.button>
+        </Flex>
+      ) : (
+        <Link asChild data-testid={node.id}>
+          <RouterLink
+            replace
+            to={{
+              pathname: `/dags/${dagId}/tasks/${node.id}`,
+              search: searchParams.toString(),
+            }}
+          >
+            <TaskName
+              fontSize="sm"
+              fontWeight="normal"
+              isMapped={Boolean(node.is_mapped)}
+              label={node.label}
+              paddingLeft={node.depth * 3 + 2}
+              setupTeardownType={node.setup_teardown_type}
+            />
+          </RouterLink>
+        </Link>
+      )}
+    </Box>
+  ));
+};

--- a/airflow/ui/src/layouts/Details/Grid/utils.ts
+++ b/airflow/ui/src/layouts/Details/Grid/utils.ts
@@ -1,0 +1,58 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import type { GridDAGRunwithTIs, NodeResponse } from "openapi/requests/types.gen";
+
+export type RunWithDuration = {
+  duration: number;
+} & GridDAGRunwithTIs;
+
+export type GridTask = {
+  depth: number;
+  isGroup?: boolean;
+  isOpen?: boolean;
+} & NodeResponse;
+
+export const flattenNodes = (nodes: Array<NodeResponse>, openGroupIds: Array<string>, depth: number = 0) => {
+  let flatNodes: Array<GridTask> = [];
+  let allGroupIds: Array<string> = [];
+
+  nodes.forEach((node) => {
+    if (node.type === "task") {
+      if (node.children) {
+        const { children, ...rest } = node;
+
+        flatNodes.push({ ...rest, depth, isGroup: true, isOpen: openGroupIds.includes(node.id) });
+        allGroupIds.push(node.id);
+
+        const { allGroupIds: childGroupIds, flatNodes: childNodes } = flattenNodes(
+          children,
+          openGroupIds,
+          depth + 1,
+        );
+
+        flatNodes = [...flatNodes, ...(openGroupIds.includes(node.id) ? childNodes : [])];
+        allGroupIds = [...allGroupIds, ...childGroupIds];
+      } else {
+        flatNodes.push({ ...node, depth });
+      }
+    }
+  });
+
+  return { allGroupIds, flatNodes };
+};

--- a/airflow/ui/src/layouts/Details/ToggleGroups.tsx
+++ b/airflow/ui/src/layouts/Details/ToggleGroups.tsx
@@ -1,0 +1,81 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { HStack, type StackProps, IconButton } from "@chakra-ui/react";
+import { useMemo } from "react";
+import { MdExpand, MdCompress } from "react-icons/md";
+import { useParams } from "react-router-dom";
+
+import { useStructureServiceStructureData } from "openapi/queries";
+import { useOpenGroups } from "src/context/openGroups";
+
+import { flattenNodes } from "./Grid/utils";
+
+export const ToggleGroups = (props: StackProps) => {
+  const { dagId = "" } = useParams();
+  const { data: structure } = useStructureServiceStructureData({
+    dagId,
+  });
+  const { openGroupIds, setOpenGroupIds } = useOpenGroups();
+
+  const { allGroupIds } = useMemo(
+    () => flattenNodes(structure?.nodes ?? [], openGroupIds),
+    [structure?.nodes, openGroupIds],
+  );
+
+  // Don't show button if the DAG has no task groups
+  if (!allGroupIds.length) {
+    return undefined;
+  }
+
+  const isExpandDisabled = allGroupIds.length === openGroupIds.length;
+  const isCollapseDisabled = !openGroupIds.length;
+
+  const onExpand = () => {
+    setOpenGroupIds(allGroupIds);
+  };
+
+  const onCollapse = () => {
+    setOpenGroupIds([]);
+  };
+
+  return (
+    <HStack gap={2} {...props}>
+      <IconButton
+        aria-label="Expand all task groups"
+        disabled={isExpandDisabled}
+        onClick={onExpand}
+        size="sm"
+        title="Expand all task groups"
+        variant="surface"
+      >
+        <MdExpand />
+      </IconButton>
+      <IconButton
+        aria-label="Collapse all task groups"
+        disabled={isCollapseDisabled}
+        onClick={onCollapse}
+        size="sm"
+        title="Collapse all task groups"
+        variant="surface"
+      >
+        <MdCompress />
+      </IconButton>
+    </HStack>
+  );
+};


### PR DESCRIPTION
Add an initial Grid View to the new UI.

Features:
- expand and collapse task groups
- expand and collapse all task groups (including in graph view)
- basic title to show run_id/task_name and state
- Click on a dag run, task name, or task instance to select
- hover on a dag run, task name or task instance to see your position
- All clickable areas are keyboard accessible
- duration and date axes for the dag run bar graph
- paginate dag runs by increments of 10 even though the limit is 25. I'm open to change this.

Not included:
- Full tooltips. There is an issue with Chakra v3 that tooltips in particular are much slower and so a large grid view would grind to a halt: https://github.com/chakra-ui/chakra-ui/discussions/9488
- Accessible state colors. Will be another PR
- AutoRefresh and detecting new dag runs
- Detecting selected dag run from the url and shifting the grid base date to match
- Filtering by run state or type
- Hovering to highlight different task states
- Task name search

<img width="1100" alt="Screenshot 2025-01-23 at 1 58 13 PM" src="https://github.com/user-attachments/assets/dcb22939-970a-4135-8ab2-fb32e2c2f634" />
<img width="1101" alt="Screenshot 2025-01-23 at 1 58 23 PM" src="https://github.com/user-attachments/assets/7314dbc1-3f87-4979-a079-4a5ebeb7c568" />


I think there's still too many magic numbers to make the layout work. Which I'm happy to work on as well as performance once we confirm that we want to use the grid view in this full page modal.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
