### PR TITLE
Use setSearchParams after setTableURLState to ensure updates are not overriden by setTableURLState.

### DIFF
--- a/airflow/ui/src/pages/Dag/Runs/Runs.tsx
+++ b/airflow/ui/src/pages/Dag/Runs/Runs.tsx
@@ -144,11 +144,11 @@ export const Runs = () => {
       } else {
         searchParams.set(STATE_PARAM, val);
       }
-      setSearchParams(searchParams);
       setTableURLState({
         pagination: { ...pagination, pageIndex: 0 },
         sorting,
       });
+      setSearchParams(searchParams);
     },
     [pagination, searchParams, setSearchParams, setTableURLState, sorting],
   );

--- a/airflow/ui/src/pages/DagsList/DagsFilters.tsx
+++ b/airflow/ui/src/pages/DagsList/DagsFilters.tsx
@@ -81,11 +81,11 @@ export const DagsFilters = () => {
       } else {
         searchParams.set(PAUSED_PARAM, val);
       }
-      setSearchParams(searchParams);
       setTableURLState({
         pagination: { ...pagination, pageIndex: 0 },
         sorting,
       });
+      setSearchParams(searchParams);
     },
     [pagination, searchParams, setSearchParams, setTableURLState, sorting],
   );
@@ -97,11 +97,11 @@ export const DagsFilters = () => {
       } else {
         searchParams.set(LAST_DAG_RUN_STATE_PARAM, value);
       }
-      setSearchParams(searchParams);
       setTableURLState({
         pagination: { ...pagination, pageIndex: 0 },
         sorting,
       });
+      setSearchParams(searchParams);
     },
     [pagination, searchParams, setSearchParams, setTableURLState, sorting],
   );

--- a/airflow/ui/src/pages/Variables/Variables.tsx
+++ b/airflow/ui/src/pages/Variables/Variables.tsx
@@ -138,11 +138,11 @@ export const Variables = () => {
     } else {
       searchParams.delete(NAME_PATTERN_PARAM);
     }
-    setSearchParams(searchParams);
     setTableURLState({
       pagination: { ...pagination, pageIndex: 0 },
       sorting,
     });
+    setSearchParams(searchParams);
     setVariableKeyPattern(value);
   };
 


### PR DESCRIPTION
Ref : https://github.com/apache/airflow/pull/45095#issuecomment-2561957593

It seems `setTableURLState` also uses `setSearchParams` and the updates to `setSearchParams` before `setTableURLState` get overridden inside the `setTableURLState` call. This looks similar to a reported issue where multiple calls to `setSearchParams` seem to be not safe  https://github.com/remix-run/react-router/issues/9757 .