### PR TITLE
Don't display table/card header and pagination when no rows are present.

### DIFF
--- a/airflow/ui/src/components/DataTable/DataTable.tsx
+++ b/airflow/ui/src/components/DataTable/DataTable.tsx
@@ -115,33 +115,34 @@ export const DataTable = <TData,>({
   const { rows } = table.getRowModel();
 
   const display = displayMode === "card" && Boolean(cardDef) ? "card" : "table";
+  const hasRows = rows.length > 0;
 
   return (
     <>
       <ProgressBar size="xs" visibility={Boolean(isFetching) && !Boolean(isLoading) ? "visible" : "hidden"} />
       <Toaster />
       {errorMessage}
-      {display === "table" && <TableList table={table} />}
-      {display === "card" && cardDef !== undefined && (
+      {display === "table" && hasRows ? <TableList table={table} /> : undefined}
+      {display === "card" && cardDef !== undefined && hasRows ? (
         <CardList cardDef={cardDef} isLoading={isLoading} table={table} />
-      )}
-      {!Boolean(isLoading) && !rows.length && (
-        <Text pt={1}>{noRowsMessage ?? `No ${modelName}s found.`}</Text>
-      )}
-      <Pagination.Root
-        count={table.getRowCount()}
-        my={2}
-        onPageChange={(page) => table.setPageIndex(page.page - 1)}
-        page={table.getState().pagination.pageIndex + 1}
-        pageSize={table.getState().pagination.pageSize}
-        siblingCount={1}
-      >
-        <HStack>
-          <Pagination.PrevTrigger data-testid="prev" />
-          <Pagination.Items />
-          <Pagination.NextTrigger data-testid="next" />
-        </HStack>
-      </Pagination.Root>
+      ) : undefined}
+      {!Boolean(isLoading) && !hasRows && <Text pt={1}>{noRowsMessage ?? `No ${modelName}s found.`}</Text>}
+      {hasRows ? (
+        <Pagination.Root
+          count={table.getRowCount()}
+          my={2}
+          onPageChange={(page) => table.setPageIndex(page.page - 1)}
+          page={table.getState().pagination.pageIndex + 1}
+          pageSize={table.getState().pagination.pageSize}
+          siblingCount={1}
+        >
+          <HStack>
+            <Pagination.PrevTrigger data-testid="prev" />
+            <Pagination.Items />
+            <Pagination.NextTrigger data-testid="next" />
+          </HStack>
+        </Pagination.Root>
+      ) : undefined}
     </>
   );
 };

--- a/airflow/ui/src/components/DataTable/DataTable.tsx
+++ b/airflow/ui/src/components/DataTable/DataTable.tsx
@@ -122,11 +122,11 @@ export const DataTable = <TData,>({
       <ProgressBar size="xs" visibility={Boolean(isFetching) && !Boolean(isLoading) ? "visible" : "hidden"} />
       <Toaster />
       {errorMessage}
-      {display === "table" && hasRows ? <TableList table={table} /> : undefined}
-      {display === "card" && cardDef !== undefined && hasRows ? (
+      {hasRows && display === "table" ? <TableList table={table} /> : undefined}
+      {hasRows && display === "card" && cardDef !== undefined ? (
         <CardList cardDef={cardDef} isLoading={isLoading} table={table} />
       ) : undefined}
-      {!Boolean(isLoading) && !hasRows && <Text pt={1}>{noRowsMessage ?? `No ${modelName}s found.`}</Text>}
+      {!hasRows && !Boolean(isLoading) && <Text pt={1}>{noRowsMessage ?? `No ${modelName}s found.`}</Text>}
       {hasRows ? (
         <Pagination.Root
           count={table.getRowCount()}


### PR DESCRIPTION
If there are no rows to display the current table component displays the header and pagination with no rows message in between. The header and pagination can be hidden when there are no rows.

main

![image](https://github.com/user-attachments/assets/4e23c0bd-eecd-4885-a9c0-3dd75e7614e9)

After PR

![image](https://github.com/user-attachments/assets/b26ee134-3907-4f4d-b82d-057c127d0307)

