### PR TITLE
AIP-72: Remove redundant handling of `AirflowException`

### DIFF
--- a/task_sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task_sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -490,13 +490,6 @@ def run(ti: RuntimeTaskInstance, log: Logger):
             end_date=datetime.now(tz=timezone.utc),
         )
         # TODO: Run task failure callbacks here
-    except AirflowException:
-        # TODO: handle the case of up_for_retry here
-        log.exception("Task failed with exception")
-        msg = TaskState(
-            state=TerminalTIState.FAILED,
-            end_date=datetime.now(tz=timezone.utc),
-        )
     except AirflowTaskTerminated:
         # External state updates are already handled with `ti_heartbeat` and will be
         # updated already be another UI API. So, these exceptions should ideally never be thrown.


### PR DESCRIPTION
This is already handled in the code below:
https://github.com/apache/airflow/blob/9de80ab8f76798e0d3daedf6565832bc36650961/task_sdk/src/airflow/sdk/execution_time/task_runner.py#L485-L492

So it will never reach

https://github.com/apache/airflow/blob/9de80ab8f76798e0d3daedf6565832bc36650961/task_sdk/src/airflow/sdk/execution_time/task_runner.py#L493-L499

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
