### PR TITLE
AIP-72: Handle clearing of XComs when task starts execution

### DIFF
--- a/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -39,11 +39,11 @@ from airflow.api_fastapi.execution_api.datamodels.taskinstance import (
     TIStateUpdate,
     TITerminalStatePayload,
 )
-from airflow.models import XCom
 from airflow.models.dagrun import DagRun as DR
 from airflow.models.taskinstance import TaskInstance as TI, _update_rtif
 from airflow.models.taskreschedule import TaskReschedule
 from airflow.models.trigger import Trigger
+from airflow.models.xcom import XCom
 from airflow.utils import timezone
 from airflow.utils.state import State, TerminalTIState
 
@@ -74,9 +74,13 @@ def ti_run(
     # We only use UUID above for validation purposes
     ti_id_str = str(task_instance_id)
 
-    old = select(TI.state, TI.dag_id, TI.run_id).where(TI.id == ti_id_str).with_for_update()
+    old = (
+        select(TI.state, TI.dag_id, TI.run_id, TI.task_id, TI.map_index, TI.next_method)
+        .where(TI.id == ti_id_str)
+        .with_for_update()
+    )
     try:
-        (previous_state, dag_id, run_id) = session.execute(old).one()
+        (previous_state, dag_id, run_id, task_id, map_index, next_method) = session.execute(old).one()
     except NoResultFound:
         log.error("Task Instance %s not found", ti_id_str)
         raise HTTPException(
@@ -147,11 +151,6 @@ def ti_run(
 
         # Clear XCom data for the task instance since we are certain it is executing
         # However, do not clear it for deferral
-        task_instance = select(TI.dag_id, TI.task_id, TI.run_id, TI.map_index, TI.next_method).where(
-            TI.id == ti_id_str
-        )
-        (dag_id, task_id, run_id, map_index, next_method) = session.execute(task_instance).one()
-
         if not next_method:
             if map_index < 0:
                 map_index = None


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


closes: https://github.com/apache/airflow/issues/45419

XComs have to be cleared when a task starts execution. We are handling this in the `run` endpoint as this endpoint marks "execution" for a task instance.

Few points:
- Do not clear XComs for cases when "next_method" is set - for deferrable and reschedule tasks
- Clear Xcoms for other regular tasks
- Ported unit tests from `test_taskinstance.py` - only `test_xcom_pull_different_logical_date` is pending.


### Testing

#### Normal DAG
Steps:
1. Create a normal DAG like this that doesn't push an xcom
```
from airflow import DAG
from airflow.providers.standard.operators.bash import BashOperator
from datetime import datetime, timedelta

dag = DAG(
    'hello_world_dag',
    schedule=None,
    catchup=False,
)

hello_task = BashOperator(
    task_id='say_hello',
    bash_command='echo "Hello World from Airflow!"',
    dag=dag,
    do_xcom_push=False
)

hello_task
```

2. Directly hit the API in fast api to set an xcom for the task instance to stage an older Xcom being present
![image](https://github.com/user-attachments/assets/dc4499d0-d105-43fc-8047-23180cdafc28)

<img width="1233" alt="image" src="https://github.com/user-attachments/assets/09cd72a5-f77e-40de-b8de-4d102d11f344" />


3. Run the dag again, the xcom will get cleared
<img width="1233" alt="image" src="https://github.com/user-attachments/assets/fa2d3690-b1e4-43f9-ab2e-65e3abf00068" />



#### DAG with a deferred Task

DAG:
```
from datetime import datetime, timedelta
from airflow import DAG
from airflow.models import BaseOperator
from airflow.providers.standard.triggers.temporal import TimeDeltaTrigger


class XComPushDeferOperator(BaseOperator):
    def execute(self, context):
        context["ti"].xcom_push("test", "test_value")

        self.defer(
            trigger=TimeDeltaTrigger(delta=timedelta(seconds=10)),
            method_name="next",
        )

    def next(self, context, event=None):
        pass


with DAG(
    "xcom_clear", schedule=None, start_date=datetime(2025, 1, 8),
) as dag:
    XComPushDeferOperator(task_id="xcom_push")

``` (ref from https://github.com/apache/airflow/issues/22931)

Steps:
1. Run the dag:
<img width="1725" alt="image" src="https://github.com/user-attachments/assets/4f6932c0-2df5-412a-a091-9594094684ae" />

2. XComs aren't cleared, still present
<img width="1725" alt="image" src="https://github.com/user-attachments/assets/c4b741a2-6356-4fae-888b-eb65d6dc0a80" />

3. Triggers running
![image](https://github.com/user-attachments/assets/50f3fd7e-2a31-43f0-9571-c6bca5b497d7)




<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
