### PR TITLE
AIP-72: Supporting Pulling multiple XCOM values

### DIFF
--- a/task_sdk/tests/execution_time/test_task_runner.py
+++ b/task_sdk/tests/execution_time/test_task_runner.py
@@ -472,6 +472,40 @@ def test_get_context_in_task(create_runtime_ti, time_machine, mock_supervisor_co
 
 
 @pytest.mark.parametrize(
+    "task_ids",
+    [
+        "push_task",
+        ["push_task1", "push_task2"],
+        {"push_task1", "push_task2"},
+    ],
+)
+def test_xcom_pull_behavior(create_runtime_ti, mock_supervisor_comms, spy_agency, task_ids):
+    """Test that a task pulls the expected XCom value if it exists."""
+
+    class CustomOperator(BaseOperator):
+        def execute(self, context):
+            value = context["ti"].xcom_pull(task_ids=task_ids, key="key")
+            print(f"Pulled XCom Value: {value}")
+
+    task = CustomOperator(task_id="pull_task")
+    ti = TaskInstance(
+        id=uuid7(), task_id=task.task_id, dag_id="xcom_pull_dag", run_id="test_run", try_number=1
+    )
+
+    what = StartupDetails(ti=ti, file="", requests_fd=0, ti_context=make_ti_context())
+    runtime_ti = create_runtime_ti(task=task)
+
+    mock_supervisor_comms.xcom_pull.return_value = "xcom_value"
+
+    spy_agency.spy_on(runtime_ti.xcom_pull, call_original=False)
+
+    run(runtime_ti, log=mock.MagicMock())
+
+    spy_agency.assert_spy_called(runtime_ti.xcom_pull)
+    spy_agency.assert_spy_called_with(runtime_ti.xcom_pull, task_ids=task_ids, key="key")
+
+
+@pytest.mark.parametrize(
     ["dag_id", "task_id", "fail_with_exception"],
     [
         pytest.param(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/45243

We can just handle xcoms for multiple task ids in the client directly by reusing the same task runner machinery.

DAG:
```
from airflow import DAG
from airflow.providers.standard.operators.python import PythonOperator

def push_to_xcom(**kwargs):
    value = "Hello, XCom!"
    return value

def push_to_xcom2(**kwargs):
    value = "Hello, XCom2!"
    return value

def pull_from_xcom(**kwargs):
    ti = kwargs['ti']
    xcom_value = ti.xcom_pull(task_ids=["push_xcom_task", "push_xcom_task2"])
    print(f"Retrieved XCom Value: {xcom_value}")


with DAG(
    'xcom_example',
    schedule=None,
    catchup=False,
) as dag:

    push_xcom_task = PythonOperator(
        task_id='push_xcom_task',
        python_callable=push_to_xcom,
    )

    push_xcom_task2 = PythonOperator(
        task_id='push_xcom_task2',
        python_callable=push_to_xcom2,
    )

    pull_xcom_task = PythonOperator(
        task_id='pull_xcom_task',
        python_callable=pull_from_xcom,
    )

    push_xcom_task >> push_xcom_task2 >> pull_xcom_task

```

Task1:
![image](https://github.com/user-attachments/assets/04b38cdd-fe9f-4995-9aac-6eb472a94ec1)

Task2:
![image](https://github.com/user-attachments/assets/c2809825-fba7-4169-9438-27b2bc4a68e3)

Task3: (gets xcoms pushed by 1 and 2)
![image](https://github.com/user-attachments/assets/a5166296-0fba-41ac-8205-5e7891949195)



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
