### PR TITLE
Fixed retry of PowerBIDatasetRefreshOperator when dataset refresh wasn't directly available

### DIFF
--- a/providers/src/airflow/providers/microsoft/azure/operators/powerbi.py
+++ b/providers/src/airflow/providers/microsoft/azure/operators/powerbi.py
@@ -59,7 +59,6 @@ class PowerBIDatasetRefreshOperator(BaseOperator):
     :param group_id: The workspace id.
     :param conn_id: Airflow Connection ID that contains the connection information for the Power BI account used for authentication.
     :param timeout: Time in seconds to wait for a dataset to reach a terminal status for asynchronous waits. Used only if ``wait_for_termination`` is True.
-    :param api_timeout: Time in seconds to wait for the API request to get the refresh status.
     :param check_interval: Number of seconds to wait before rechecking the
         refresh status.
     """
@@ -81,7 +80,6 @@ class PowerBIDatasetRefreshOperator(BaseOperator):
         timeout: float = 60 * 60 * 24 * 7,
         proxies: dict | None = None,
         api_version: APIVersion | str | None = None,
-        api_timeout: float = 30,
         check_interval: int = 60,
         **kwargs,
     ) -> None:
@@ -92,7 +90,6 @@ class PowerBIDatasetRefreshOperator(BaseOperator):
         self.wait_for_termination = True
         self.conn_id = conn_id
         self.timeout = timeout
-        self.api_timeout = api_timeout
         self.check_interval = check_interval
 
     @property
@@ -115,7 +112,6 @@ class PowerBIDatasetRefreshOperator(BaseOperator):
                     proxies=self.proxies,
                     api_version=self.api_version,
                     check_interval=self.check_interval,
-                    api_timeout=self.api_timeout,
                     wait_for_termination=self.wait_for_termination,
                 ),
                 method_name=self.execute_complete.__name__,

--- a/providers/src/airflow/providers/microsoft/azure/operators/powerbi.py
+++ b/providers/src/airflow/providers/microsoft/azure/operators/powerbi.py
@@ -59,6 +59,7 @@ class PowerBIDatasetRefreshOperator(BaseOperator):
     :param group_id: The workspace id.
     :param conn_id: Airflow Connection ID that contains the connection information for the Power BI account used for authentication.
     :param timeout: Time in seconds to wait for a dataset to reach a terminal status for asynchronous waits. Used only if ``wait_for_termination`` is True.
+    :param api_timeout: Time in seconds to wait for the API request to get the refresh status.
     :param check_interval: Number of seconds to wait before rechecking the
         refresh status.
     """

--- a/providers/src/airflow/providers/microsoft/azure/operators/powerbi.py
+++ b/providers/src/airflow/providers/microsoft/azure/operators/powerbi.py
@@ -80,6 +80,7 @@ class PowerBIDatasetRefreshOperator(BaseOperator):
         timeout: float = 60 * 60 * 24 * 7,
         proxies: dict | None = None,
         api_version: APIVersion | str | None = None,
+        api_timeout: float = 30,
         check_interval: int = 60,
         **kwargs,
     ) -> None:
@@ -90,6 +91,7 @@ class PowerBIDatasetRefreshOperator(BaseOperator):
         self.wait_for_termination = True
         self.conn_id = conn_id
         self.timeout = timeout
+        self.api_timeout = api_timeout
         self.check_interval = check_interval
 
     @property
@@ -112,6 +114,7 @@ class PowerBIDatasetRefreshOperator(BaseOperator):
                     proxies=self.proxies,
                     api_version=self.api_version,
                     check_interval=self.check_interval,
+                    api_timeout=self.api_timeout,
                     wait_for_termination=self.wait_for_termination,
                 ),
                 method_name=self.execute_complete.__name__,

--- a/providers/src/airflow/providers/microsoft/azure/operators/powerbi.py
+++ b/providers/src/airflow/providers/microsoft/azure/operators/powerbi.py
@@ -158,6 +158,6 @@ class PowerBIDatasetRefreshOperator(BaseOperator):
 
             self.xcom_push(
                 context=context,
-                key=f"{context['ti'].task_id}.powerbi_dataset_refresh_status",
+                key=f"{self.task_id}.powerbi_dataset_refresh_status",
                 value=event["dataset_refresh_status"],
             )

--- a/providers/src/airflow/providers/microsoft/azure/operators/powerbi.py
+++ b/providers/src/airflow/providers/microsoft/azure/operators/powerbi.py
@@ -128,7 +128,7 @@ class PowerBIDatasetRefreshOperator(BaseOperator):
         if dataset_refresh_id:
             self.xcom_push(
                 context=context,
-                key=f"{context['ti'].task_id}.powerbi_dataset_refresh_Id",
+                key=f"{self.task_id}.powerbi_dataset_refresh_Id",
                 value=dataset_refresh_id,
             )
             self.defer(

--- a/providers/src/airflow/providers/microsoft/azure/operators/powerbi.py
+++ b/providers/src/airflow/providers/microsoft/azure/operators/powerbi.py
@@ -153,11 +153,10 @@ class PowerBIDatasetRefreshOperator(BaseOperator):
         Relies on trigger to throw an exception, otherwise it assumes execution was successful.
         """
         if event:
-            if event["status"] == "error":
-                raise AirflowException(event["message"])
-
             self.xcom_push(
                 context=context,
                 key=f"{self.task_id}.powerbi_dataset_refresh_status",
                 value=event["dataset_refresh_status"],
             )
+            if event["status"] == "error":
+                raise AirflowException(event["message"])

--- a/providers/src/airflow/providers/microsoft/azure/operators/powerbi.py
+++ b/providers/src/airflow/providers/microsoft/azure/operators/powerbi.py
@@ -118,21 +118,19 @@ class PowerBIDatasetRefreshOperator(BaseOperator):
             )
 
     def get_refresh_status(self, context: Context, event: dict[str, str] | None = None):
-        """Push the refresh Id to XCom then runs the Triggers to wait for refresh completion."""
+        """Push the refresh Id to XCom then runs the Trigger to wait for refresh completion."""
         if event:
             if event["status"] == "error":
                 raise AirflowException(event["message"])
 
+            dataset_refresh_id = event["dataset_refresh_id"]
+
+        if dataset_refresh_id:
             self.xcom_push(
                 context=context,
                 key=f"{context['ti'].task_id}.powerbi_dataset_refresh_Id",
-                value=event["dataset_refresh_id"],
+                value=dataset_refresh_id,
             )
-
-        dataset_refresh_id = self.xcom_pull(
-            context=context, key=f"{context['ti'].task_id}.powerbi_dataset_refresh_Id"
-        )
-        if dataset_refresh_id:
             self.defer(
                 trigger=PowerBITrigger(
                     conn_id=self.conn_id,

--- a/providers/src/airflow/providers/microsoft/azure/triggers/powerbi.py
+++ b/providers/src/airflow/providers/microsoft/azure/triggers/powerbi.py
@@ -153,8 +153,8 @@ class PowerBITrigger(BaseTrigger):
                     refresh_id=self.dataset_refresh_id,
                 )
                 return refresh_details["status"], refresh_details["error"]
-            else:
-                raise PowerBIDatasetRefreshException("Dataset refresh Id is missing.")
+
+            raise PowerBIDatasetRefreshException("Dataset refresh Id is missing.")
 
         try:
             dataset_refresh_status, dataset_refresh_error = await fetch_refresh_status_and_error()

--- a/providers/src/airflow/providers/microsoft/azure/triggers/powerbi.py
+++ b/providers/src/airflow/providers/microsoft/azure/triggers/powerbi.py
@@ -22,7 +22,11 @@ import time
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING
 
-from airflow.providers.microsoft.azure.hooks.powerbi import PowerBIDatasetRefreshStatus, PowerBIHook
+from airflow.providers.microsoft.azure.hooks.powerbi import (
+    PowerBIDatasetRefreshException,
+    PowerBIDatasetRefreshStatus,
+    PowerBIHook,
+)
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 
 if TYPE_CHECKING:
@@ -58,6 +62,7 @@ class PowerBITrigger(BaseTrigger):
         proxies: dict | None = None,
         api_version: APIVersion | str | None = None,
         check_interval: int = 60,
+        api_timeout: float = 30,
         wait_for_termination: bool = True,
     ):
         super().__init__()
@@ -66,6 +71,7 @@ class PowerBITrigger(BaseTrigger):
         self.timeout = timeout
         self.group_id = group_id
         self.check_interval = check_interval
+        self.api_timeout = api_timeout
         self.wait_for_termination = wait_for_termination
 
     def serialize(self):
@@ -80,6 +86,7 @@ class PowerBITrigger(BaseTrigger):
                 "group_id": self.group_id,
                 "timeout": self.timeout,
                 "check_interval": self.check_interval,
+                "api_timeout": self.api_timeout,
                 "wait_for_termination": self.wait_for_termination,
             },
         )

--- a/providers/src/airflow/providers/microsoft/azure/triggers/powerbi.py
+++ b/providers/src/airflow/providers/microsoft/azure/triggers/powerbi.py
@@ -23,12 +23,12 @@ from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING
 
 import tenacity
-
 from airflow.providers.microsoft.azure.hooks.powerbi import (
     PowerBIDatasetRefreshException,
     PowerBIDatasetRefreshStatus,
     PowerBIHook,
 )
+
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 
 if TYPE_CHECKING:
@@ -115,8 +115,8 @@ class PowerBITrigger(BaseTrigger):
             reraise=True,
             retry=tenacity.retry_if_exception_type(PowerBIDatasetRefreshException),
         )
-        async def fetch_refresh_status() -> str:
-            """Fetch the current status of the dataset refresh."""
+        async def fetch_refresh_status_and_error() -> tuple[str, str]:
+            """Fetch the current status and error of the dataset refresh."""
             refresh_details = await self.hook.get_refresh_details_by_refresh_id(
                 dataset_id=self.dataset_id,
                 group_id=self.group_id,

--- a/providers/src/airflow/providers/microsoft/azure/triggers/powerbi.py
+++ b/providers/src/airflow/providers/microsoft/azure/triggers/powerbi.py
@@ -23,12 +23,12 @@ from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING
 
 import tenacity
+
 from airflow.providers.microsoft.azure.hooks.powerbi import (
     PowerBIDatasetRefreshException,
     PowerBIDatasetRefreshStatus,
     PowerBIHook,
 )
-
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 
 if TYPE_CHECKING:
@@ -49,6 +49,7 @@ class PowerBITrigger(BaseTrigger):
         You can pass an enum named APIVersion which has 2 possible members v1 and beta,
         or you can pass a string as `v1.0` or `beta`.
     :param dataset_id: The dataset Id to refresh.
+    :param dataset_refresh_id: The dataset refresh Id
     :param group_id: The workspace Id where dataset is located.
     :param end_time: Time in seconds when trigger should stop polling.
     :param check_interval: Time in seconds to wait between each poll.
@@ -61,6 +62,7 @@ class PowerBITrigger(BaseTrigger):
         dataset_id: str,
         group_id: str,
         timeout: float = 60 * 60 * 24 * 7,
+        dataset_refresh_id: str | None = None,
         proxies: dict | None = None,
         api_version: APIVersion | str | None = None,
         check_interval: int = 60,
@@ -69,6 +71,7 @@ class PowerBITrigger(BaseTrigger):
         super().__init__()
         self.hook = PowerBIHook(conn_id=conn_id, proxies=proxies, api_version=api_version, timeout=timeout)
         self.dataset_id = dataset_id
+        self.dataset_refresh_id = dataset_refresh_id
         self.timeout = timeout
         self.group_id = group_id
         self.check_interval = check_interval
@@ -83,6 +86,7 @@ class PowerBITrigger(BaseTrigger):
                 "proxies": self.proxies,
                 "api_version": self.api_version,
                 "dataset_id": self.dataset_id,
+                "dataset_refresh_id": self.dataset_refresh_id,
                 "group_id": self.group_id,
                 "timeout": self.timeout,
                 "check_interval": self.check_interval,
@@ -104,25 +108,39 @@ class PowerBITrigger(BaseTrigger):
 
     async def run(self) -> AsyncIterator[TriggerEvent]:
         """Make async connection to the PowerBI and polls for the dataset refresh status."""
-        self.dataset_refresh_id = await self.hook.trigger_dataset_refresh(
-            dataset_id=self.dataset_id,
-            group_id=self.group_id,
-        )
+        if not self.dataset_refresh_id:
+            dataset_refresh_id = await self.hook.trigger_dataset_refresh(
+                dataset_id=self.dataset_id,
+                group_id=self.group_id,
+            )
+            self.log.info("Triggered dataset refresh %s", dataset_refresh_id)
+            yield TriggerEvent(
+                {
+                    "status": "success",
+                    "dataset_refresh_status": None,
+                    "message": f"The dataset refresh {self.dataset_refresh_id} has been triggered.",
+                    "dataset_refresh_id": dataset_refresh_id,
+                }
+            )
+            return
 
         @tenacity.retry(
             stop=tenacity.stop_after_attempt(3),
-            wait=tenacity.wait_exponential(multiplier=1, min=3, max=60),
+            wait=tenacity.wait_exponential(min=5, multiplier=2),
             reraise=True,
             retry=tenacity.retry_if_exception_type(PowerBIDatasetRefreshException),
         )
         async def fetch_refresh_status_and_error() -> tuple[str, str]:
             """Fetch the current status and error of the dataset refresh."""
-            refresh_details = await self.hook.get_refresh_details_by_refresh_id(
-                dataset_id=self.dataset_id,
-                group_id=self.group_id,
-                refresh_id=self.dataset_refresh_id,
-            )
-            return refresh_details["status"], refresh_details["error"]
+            if self.dataset_refresh_id:
+                refresh_details = await self.hook.get_refresh_details_by_refresh_id(
+                    dataset_id=self.dataset_id,
+                    group_id=self.group_id,
+                    refresh_id=self.dataset_refresh_id,
+                )
+                return refresh_details["status"], refresh_details["error"]
+            else:
+                raise Exception("Dataset refresh Id is missing.")
 
         try:
             dataset_refresh_status, dataset_refresh_error = await fetch_refresh_status_and_error()

--- a/providers/src/airflow/providers/microsoft/azure/triggers/powerbi.py
+++ b/providers/src/airflow/providers/microsoft/azure/triggers/powerbi.py
@@ -126,16 +126,16 @@ class PowerBITrigger(BaseTrigger):
                     }
                 )
                 return
-            else:
-                yield TriggerEvent(
-                    {
-                        "status": "error",
-                        "dataset_refresh_status": None,
-                        "message": "Failed to trigger the dataset refresh.",
-                        "dataset_refresh_id": None,
-                    }
-                )
-                return
+
+            yield TriggerEvent(
+                {
+                    "status": "error",
+                    "dataset_refresh_status": None,
+                    "message": "Failed to trigger the dataset refresh.",
+                    "dataset_refresh_id": None,
+                }
+            )
+            return
 
         # The dataset refresh is already triggered. Poll for the dataset refresh status.
         @tenacity.retry(

--- a/providers/tests/microsoft/azure/operators/test_powerbi.py
+++ b/providers/tests/microsoft/azure/operators/test_powerbi.py
@@ -144,7 +144,7 @@ class TestPowerBIDatasetRefreshOperator(Base):
                     "dataset_refresh_id": "1234",
                 },
             )
-        assert context["ti"].xcom_push.call_count == 0
+        assert context["ti"].xcom_push.call_count == 1
         assert str(exc.value) == "error"
 
     def test_powerbi_operator_refresh_fail(self):
@@ -163,7 +163,7 @@ class TestPowerBIDatasetRefreshOperator(Base):
                     "dataset_refresh_id": "1234",
                 },
             )
-        assert context["ti"].xcom_push.call_count == 0
+        assert context["ti"].xcom_push.call_count == 1
         assert str(exc.value) == "error message"
 
     def test_execute_complete_no_event(self):

--- a/providers/tests/microsoft/azure/operators/test_powerbi.py
+++ b/providers/tests/microsoft/azure/operators/test_powerbi.py
@@ -44,6 +44,7 @@ CONFIG = {
     "group_id": GROUP_ID,
     "dataset_id": DATASET_ID,
     "check_interval": 1,
+    "api_timeout": 40,
     "timeout": 3,
 }
 NEW_REFRESH_REQUEST_ID = "5e2d9921-e91b-491f-b7e1-e7d8db49194c"
@@ -162,6 +163,7 @@ class TestPowerBIDatasetRefreshOperator(Base):
             group_id=GROUP_ID,
             dataset_id=DATASET_ID,
             check_interval=1,
+            api_timeout=40,
             timeout=3,
         )
 

--- a/providers/tests/microsoft/azure/operators/test_powerbi.py
+++ b/providers/tests/microsoft/azure/operators/test_powerbi.py
@@ -95,6 +95,7 @@ class TestPowerBIDatasetRefreshOperator(Base):
             operator.execute(context)
 
         assert isinstance(exc.value.trigger, PowerBITrigger)
+        assert exc.value.trigger.dataset_refresh_id is None
 
     @mock.patch("airflow.hooks.base.BaseHook.get_connection", side_effect=get_airflow_connection)
     def test_powerbi_operator_async_get_refresh_status_success(self, connection):
@@ -104,7 +105,6 @@ class TestPowerBIDatasetRefreshOperator(Base):
         )
         context = {"ti": MagicMock()}
         context["ti"].task_id = TASK_ID
-        context["ti"].xcom_pull = MagicMock(return_value=NEW_REFRESH_REQUEST_ID)
 
         with pytest.raises(TaskDeferred) as exc:
             operator.get_refresh_status(
@@ -113,9 +113,8 @@ class TestPowerBIDatasetRefreshOperator(Base):
             )
 
         assert isinstance(exc.value.trigger, PowerBITrigger)
-
+        assert exc.value.trigger.dataset_refresh_id is NEW_REFRESH_REQUEST_ID
         assert context["ti"].xcom_push.call_count == 1
-        assert context["ti"].xcom_pull.call_count == 1
 
     def test_powerbi_operator_async_execute_complete_success(self):
         """Assert that execute_complete log success message"""

--- a/providers/tests/microsoft/azure/operators/test_powerbi.py
+++ b/providers/tests/microsoft/azure/operators/test_powerbi.py
@@ -44,7 +44,6 @@ CONFIG = {
     "group_id": GROUP_ID,
     "dataset_id": DATASET_ID,
     "check_interval": 1,
-    "api_timeout": 40,
     "timeout": 3,
 }
 NEW_REFRESH_REQUEST_ID = "5e2d9921-e91b-491f-b7e1-e7d8db49194c"
@@ -163,7 +162,6 @@ class TestPowerBIDatasetRefreshOperator(Base):
             group_id=GROUP_ID,
             dataset_id=DATASET_ID,
             check_interval=1,
-            api_timeout=40,
             timeout=3,
         )
 

--- a/providers/tests/microsoft/azure/triggers/test_powerbi.py
+++ b/providers/tests/microsoft/azure/triggers/test_powerbi.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 from unittest import mock
 
 import pytest
@@ -39,7 +38,6 @@ DATASET_REFRESH_ID = "dataset_refresh_id"
 TIMEOUT = 5
 MODULE = "airflow.providers.microsoft.azure"
 CHECK_INTERVAL = 1
-API_TIMEOUT = 30
 API_VERSION = "v1.0"
 
 
@@ -53,7 +51,6 @@ def powerbi_trigger(timeout=TIMEOUT, check_interval=CHECK_INTERVAL) -> PowerBITr
         dataset_id=DATASET_ID,
         group_id=GROUP_ID,
         check_interval=check_interval,
-        api_timeout=API_TIMEOUT,
         wait_for_termination=True,
         timeout=timeout,
     )
@@ -70,7 +67,6 @@ class TestPowerBITrigger:
             dataset_id=DATASET_ID,
             group_id=GROUP_ID,
             check_interval=CHECK_INTERVAL,
-            api_timeout=API_TIMEOUT,
             wait_for_termination=True,
             timeout=TIMEOUT,
         )
@@ -85,7 +81,6 @@ class TestPowerBITrigger:
             "proxies": None,
             "api_version": API_VERSION,
             "check_interval": CHECK_INTERVAL,
-            "api_timeout": API_TIMEOUT,
             "wait_for_termination": True,
         }
 
@@ -192,19 +187,18 @@ class TestPowerBITrigger:
     @mock.patch(f"{MODULE}.hooks.powerbi.PowerBIHook.cancel_dataset_refresh")
     @mock.patch(f"{MODULE}.hooks.powerbi.PowerBIHook.get_refresh_details_by_refresh_id")
     @mock.patch(f"{MODULE}.hooks.powerbi.PowerBIHook.trigger_dataset_refresh")
-    async def test_powerbi_trigger_run_PowerBIDatasetRefreshExceptionn_during_refresh_check_loop(
+    async def test_powerbi_trigger_run_PowerBIDatasetRefreshException_during_refresh_check_loop(
         self,
         mock_trigger_dataset_refresh,
         mock_get_refresh_details_by_refresh_id,
         mock_cancel_dataset_refresh,
-        caplog,
         powerbi_trigger,
     ):
         """Assert that run catch PowerBIDatasetRefreshException and triggers retry mechanism"""
         mock_get_refresh_details_by_refresh_id.side_effect = PowerBIDatasetRefreshException("Test exception")
         mock_trigger_dataset_refresh.return_value = DATASET_REFRESH_ID
 
-        with caplog.at_level(logging.INFO):
+        with mock.patch("tenacity.wait.wait_exponential.__call__") as mock_retry:
             task = [i async for i in powerbi_trigger.run()]
             response = TriggerEvent(
                 {
@@ -215,9 +209,8 @@ class TestPowerBITrigger:
             )
             assert len(task) == 1
             assert response in task
-            mock_cancel_dataset_refresh.assert_called_once()
-
-        assert "Retrying in 5 seconds" in caplog.text  # Test the retry mechanism
+            assert mock_cancel_dataset_refresh.call_count == 1
+            assert mock_retry.call_count == 3
 
     @pytest.mark.asyncio
     @mock.patch(f"{MODULE}.hooks.powerbi.PowerBIHook.cancel_dataset_refresh")

--- a/providers/tests/microsoft/azure/triggers/test_powerbi.py
+++ b/providers/tests/microsoft/azure/triggers/test_powerbi.py
@@ -18,11 +18,15 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from unittest import mock
 
 import pytest
 
-from airflow.providers.microsoft.azure.hooks.powerbi import PowerBIDatasetRefreshStatus
+from airflow.providers.microsoft.azure.hooks.powerbi import (
+    PowerBIDatasetRefreshException,
+    PowerBIDatasetRefreshStatus,
+)
 from airflow.providers.microsoft.azure.triggers.powerbi import PowerBITrigger
 from airflow.triggers.base import TriggerEvent
 
@@ -35,6 +39,7 @@ DATASET_REFRESH_ID = "dataset_refresh_id"
 TIMEOUT = 5
 MODULE = "airflow.providers.microsoft.azure"
 CHECK_INTERVAL = 1
+API_TIMEOUT = 30
 API_VERSION = "v1.0"
 
 
@@ -48,6 +53,7 @@ def powerbi_trigger(timeout=TIMEOUT, check_interval=CHECK_INTERVAL) -> PowerBITr
         dataset_id=DATASET_ID,
         group_id=GROUP_ID,
         check_interval=check_interval,
+        api_timeout=API_TIMEOUT,
         wait_for_termination=True,
         timeout=timeout,
     )
@@ -64,6 +70,7 @@ class TestPowerBITrigger:
             dataset_id=DATASET_ID,
             group_id=GROUP_ID,
             check_interval=CHECK_INTERVAL,
+            api_timeout=API_TIMEOUT,
             wait_for_termination=True,
             timeout=TIMEOUT,
         )
@@ -78,6 +85,7 @@ class TestPowerBITrigger:
             "proxies": None,
             "api_version": API_VERSION,
             "check_interval": CHECK_INTERVAL,
+            "api_timeout": API_TIMEOUT,
             "wait_for_termination": True,
         }
 
@@ -179,6 +187,37 @@ class TestPowerBITrigger:
         assert len(task) == 1
         assert response in task
         mock_cancel_dataset_refresh.assert_called_once()
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{MODULE}.hooks.powerbi.PowerBIHook.cancel_dataset_refresh")
+    @mock.patch(f"{MODULE}.hooks.powerbi.PowerBIHook.get_refresh_details_by_refresh_id")
+    @mock.patch(f"{MODULE}.hooks.powerbi.PowerBIHook.trigger_dataset_refresh")
+    async def test_powerbi_trigger_run_PowerBIDatasetRefreshExceptionn_during_refresh_check_loop(
+        self,
+        mock_trigger_dataset_refresh,
+        mock_get_refresh_details_by_refresh_id,
+        mock_cancel_dataset_refresh,
+        caplog,
+        powerbi_trigger,
+    ):
+        """Assert that run catch PowerBIDatasetRefreshException and triggers retry mechanism"""
+        mock_get_refresh_details_by_refresh_id.side_effect = PowerBIDatasetRefreshException("Test exception")
+        mock_trigger_dataset_refresh.return_value = DATASET_REFRESH_ID
+
+        with caplog.at_level(logging.INFO):
+            task = [i async for i in powerbi_trigger.run()]
+            response = TriggerEvent(
+                {
+                    "status": "error",
+                    "message": "An error occurred: Test exception",
+                    "dataset_refresh_id": DATASET_REFRESH_ID,
+                }
+            )
+            assert len(task) == 1
+            assert response in task
+            mock_cancel_dataset_refresh.assert_called_once()
+
+        assert "Retrying in 5 seconds" in caplog.text  # Test the retry mechanism
 
     @pytest.mark.asyncio
     @mock.patch(f"{MODULE}.hooks.powerbi.PowerBIHook.cancel_dataset_refresh")

--- a/providers/tests/microsoft/azure/triggers/test_powerbi.py
+++ b/providers/tests/microsoft/azure/triggers/test_powerbi.py
@@ -220,20 +220,19 @@ class TestPowerBITrigger:
         mock_get_refresh_details_by_refresh_id.side_effect = PowerBIDatasetRefreshException("Test exception")
         mock_trigger_dataset_refresh.return_value = DATASET_REFRESH_ID
 
-        with mock.patch("tenacity.wait.wait_exponential.__call__") as mock_retry:
-            task = [i async for i in powerbi_trigger.run()]
-            response = TriggerEvent(
-                {
-                    "status": "error",
-                    "dataset_refresh_status": None,
-                    "message": "An error occurred: Test exception",
-                    "dataset_refresh_id": DATASET_REFRESH_ID,
-                }
-            )
-            assert len(task) == 1
-            assert response in task
-            assert mock_cancel_dataset_refresh.call_count == 1
-            assert mock_retry.call_count == 3
+        task = [i async for i in powerbi_trigger.run()]
+        response = TriggerEvent(
+            {
+                "status": "error",
+                "dataset_refresh_status": None,
+                "message": "An error occurred: Test exception",
+                "dataset_refresh_id": DATASET_REFRESH_ID,
+            }
+        )
+        assert mock_get_refresh_details_by_refresh_id.call_count == 3
+        assert len(task) == 1
+        assert response in task
+        assert mock_cancel_dataset_refresh.call_count == 1
 
     @pytest.mark.asyncio
     @mock.patch(f"{MODULE}.hooks.powerbi.PowerBIHook.cancel_dataset_refresh")

--- a/providers/tests/system/microsoft/azure/example_powerbi_dataset_refresh.py
+++ b/providers/tests/system/microsoft/azure/example_powerbi_dataset_refresh.py
@@ -65,7 +65,6 @@ with DAG(
         dataset_id=DATASET_ID,
         group_id=GROUP_ID,
         check_interval=30,
-        api_timeout=30,
         timeout=120,
     )
     # [END howto_operator_powerbi_refresh_async]

--- a/providers/tests/system/microsoft/azure/example_powerbi_dataset_refresh.py
+++ b/providers/tests/system/microsoft/azure/example_powerbi_dataset_refresh.py
@@ -65,6 +65,7 @@ with DAG(
         dataset_id=DATASET_ID,
         group_id=GROUP_ID,
         check_interval=30,
+        api_timeout=30,
         timeout=120,
     )
     # [END howto_operator_powerbi_refresh_async]


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

Fixes: https://github.com/apache/airflow/issues/44618

## Changes

This PR adds 2 changes:
- a retry mechanism on the API request to get the refresh status, to fix the bug when the API is not yet up-to-date with the triggered `refreshId`
- a new separation between the refresh trigger and the status polling

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
