### PR TITLE
AIP-66: Add support for parsing DAG bundles 

### DIFF
--- a/airflow/cli/commands/local_commands/dag_processor_command.py
+++ b/airflow/cli/commands/local_commands/dag_processor_command.py
@@ -39,7 +39,6 @@ def _create_dag_processor_job_runner(args: Any) -> DagProcessorJobRunner:
         job=Job(),
         processor=DagFileProcessorManager(
             processor_timeout=processor_timeout_seconds,
-            dag_directory=args.subdir,
             max_runs=args.num_runs,
         ),
     )

--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -407,7 +407,7 @@ class DagFileProcessorManager:
         DagBundlesManager().sync_bundles_to_db()
 
         self.log.info("Getting all DAG bundles")
-        self._dag_bundles = DagBundlesManager().get_all_dag_bundles()
+        self._dag_bundles = list(DagBundlesManager().get_all_dag_bundles())
 
         return self._run_parsing_loop()
 

--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -661,8 +661,10 @@ class DagFileProcessorManager:
                 ).total_seconds()
                 current_version = bundle.get_current_version()
                 if (
-                    not elapsed_time_since_refresh > bundle.refresh_interval
-                ) and bundle_model.latest_version == current_version:
+                    elapsed_time_since_refresh < bundle.refresh_interval
+                    and bundle_model.latest_version == current_version
+                    and bundle.name in self._bundle_versions
+                ):
                     self.log.info("Not time to refresh %s", bundle.name)
                     continue
 

--- a/airflow/dag_processing/processor.py
+++ b/airflow/dag_processing/processor.py
@@ -50,7 +50,12 @@ def _parse_file_entrypoint():
     import structlog
 
     from airflow.sdk.execution_time import task_runner
+    from airflow.settings import configure_orm
     # Parse DAG file, send JSON back up!
+
+    # We need to reconfigure the orm here, as DagFileProcessorManager does db queries for bundles, and
+    # the session across forks blows things up.
+    configure_orm()
 
     comms_decoder = task_runner.CommsDecoder[DagFileParseRequest, DagFileParsingResult](
         input=sys.stdin,

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -30,7 +30,6 @@ from contextlib import ExitStack, suppress
 from datetime import timedelta
 from functools import lru_cache, partial
 from itertools import groupby
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
 from deprecated import deprecated
@@ -922,7 +921,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         processor_timeout = timedelta(seconds=processor_timeout_seconds)
         if not self._standalone_dag_processor and not self.processor_agent:
             self.processor_agent = DagFileProcessorAgent(
-                dag_directory=Path(self.subdir),
                 max_runs=self.num_times_parse_dags,
                 processor_timeout=processor_timeout,
             )

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -770,6 +770,16 @@ class DAG(TaskSDKDag, LoggingMixin):
         """Return a boolean indicating whether this DAG is paused."""
         return session.scalar(select(DagModel.is_paused).where(DagModel.dag_id == self.dag_id))
 
+    @provide_session
+    def get_bundle_name(self, session=NEW_SESSION) -> None:
+        """Return the bundle name this DAG is in."""
+        return session.scalar(select(DagModel.bundle_name).where(DagModel.dag_id == self.dag_id))
+
+    @provide_session
+    def get_latest_bundle_version(self, session=NEW_SESSION) -> None:
+        """Return the bundle name this DAG is in."""
+        return session.scalar(select(DagModel.latest_bundle_version).where(DagModel.dag_id == self.dag_id))
+
     @methodtools.lru_cache(maxsize=None)
     @classmethod
     def get_serialized_fields(cls):
@@ -1832,6 +1842,8 @@ class DAG(TaskSDKDag, LoggingMixin):
     @provide_session
     def bulk_write_to_db(
         cls,
+        bundle_name: str,
+        bundle_version: str | None,
         dags: Collection[MaybeSerializedDAG],
         session: Session = NEW_SESSION,
     ):
@@ -1847,7 +1859,9 @@ class DAG(TaskSDKDag, LoggingMixin):
         from airflow.dag_processing.collection import AssetModelOperation, DagModelOperation
 
         log.info("Sync %s DAGs", len(dags))
-        dag_op = DagModelOperation({dag.dag_id: dag for dag in dags})  # type: ignore[misc]
+        dag_op = DagModelOperation(
+            bundle_name=bundle_name, bundle_version=bundle_version, dags={dag.dag_id: dag for dag in dags}
+        )  # type: ignore[misc]
 
         orm_dags = dag_op.add_dags(session=session)
         dag_op.update_dags(orm_dags, session=session)
@@ -1873,7 +1887,10 @@ class DAG(TaskSDKDag, LoggingMixin):
 
         :return: None
         """
-        self.bulk_write_to_db([self], session=session)
+        # TODO: AIP-66 should this be in the model?
+        bundle_name = self.get_bundle_name(session=session)
+        bundle_version = self.get_latest_bundle_version(session=session)
+        self.bulk_write_to_db(bundle_name, bundle_version, [self], session=session)
 
     def get_default_view(self):
         """Allow backward compatible jinja2 templates."""

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1860,7 +1860,7 @@ class DAG(TaskSDKDag, LoggingMixin):
 
         log.info("Sync %s DAGs", len(dags))
         dag_op = DagModelOperation(
-            bundle_name=bundle_name, bundle_version=bundle_version, dags={dag.dag_id: dag for dag in dags}
+            bundle_name=bundle_name, bundle_version=bundle_version, dags={d.dag_id: d for d in dags}
         )  # type: ignore[misc]
 
         orm_dags = dag_op.add_dags(session=session)

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -626,11 +626,13 @@ class DagBag(LoggingMixin):
         return report
 
     @provide_session
-    def sync_to_db(self, session: Session = NEW_SESSION):
+    def sync_to_db(self, bundle_name: str, bundle_version: str | None, session: Session = NEW_SESSION):
         """Save attributes about list of DAG to the DB."""
         from airflow.dag_processing.collection import update_dag_parsing_results_in_db
 
         update_dag_parsing_results_in_db(
+            bundle_name,
+            bundle_version,
             self.dags.values(),  # type: ignore[arg-type]  # We should create a proto for DAG|LazySerializedDAG
             self.import_errors,
             self.dag_warnings,

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -568,11 +568,17 @@ class DagBag(LoggingMixin):
 
         # Ensure dag_folder is a str -- it may have been a pathlib.Path
         dag_folder = correct_maybe_zipped(str(dag_folder))
-        for filepath in list_py_file_paths(
-            dag_folder,
-            safe_mode=safe_mode,
-            include_examples=include_examples,
-        ):
+
+        files_to_parse = list_py_file_paths(dag_folder, safe_mode=safe_mode)
+
+        if include_examples:
+            from airflow import example_dags
+
+            example_dag_folder = next(iter(example_dags.__path__))
+
+            files_to_parse.extend(list_py_file_paths(example_dag_folder, safe_mode=safe_mode))
+
+        for filepath in files_to_parse:
             try:
                 file_parse_start_dttm = timezone.utcnow()
                 found_dags = self.process_file(filepath, only_if_updated=only_if_updated, safe_mode=safe_mode)

--- a/airflow/models/dagbundle.py
+++ b/airflow/models/dagbundle.py
@@ -16,10 +16,16 @@
 # under the License.
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from sqlalchemy import Boolean, Column, String
 
 from airflow.models.base import Base, StringID
+from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.sqlalchemy import UtcDateTime
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
 
 
 class DagBundleModel(Base):
@@ -41,3 +47,8 @@ class DagBundleModel(Base):
 
     def __init__(self, *, name: str):
         self.name = name
+
+    @staticmethod
+    @provide_session
+    def get(name: str, session: Session = NEW_SESSION) -> DagBundleModel:
+        return session.query(DagBundleModel).get(name)

--- a/airflow/models/dagbundle.py
+++ b/airflow/models/dagbundle.py
@@ -16,16 +16,10 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from sqlalchemy import Boolean, Column, String
 
 from airflow.models.base import Base, StringID
-from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.sqlalchemy import UtcDateTime
-
-if TYPE_CHECKING:
-    from sqlalchemy.orm import Session
 
 
 class DagBundleModel(Base):
@@ -47,8 +41,3 @@ class DagBundleModel(Base):
 
     def __init__(self, *, name: str):
         self.name = name
-
-    @staticmethod
-    @provide_session
-    def get(name: str, session: Session = NEW_SESSION) -> DagBundleModel:
-        return session.query(DagBundleModel).get(name)

--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -245,7 +245,6 @@ def find_path_from_directory(
 def list_py_file_paths(
     directory: str | os.PathLike[str] | None,
     safe_mode: bool = conf.getboolean("core", "DAG_DISCOVERY_SAFE_MODE", fallback=True),
-    include_examples: bool | None = None,
 ) -> list[str]:
     """
     Traverse a directory and look for Python files.
@@ -255,11 +254,8 @@ def list_py_file_paths(
         contains Airflow DAG definitions. If not provided, use the
         core.DAG_DISCOVERY_SAFE_MODE configuration setting. If not set, default
         to safe.
-    :param include_examples: include example DAGs
     :return: a list of paths to Python files in the specified directory
     """
-    if include_examples is None:
-        include_examples = conf.getboolean("core", "LOAD_EXAMPLES")
     file_paths: list[str] = []
     if directory is None:
         file_paths = []
@@ -267,11 +263,6 @@ def list_py_file_paths(
         file_paths = [str(directory)]
     elif os.path.isdir(directory):
         file_paths.extend(find_dag_file_paths(directory, safe_mode))
-    if include_examples:
-        from airflow import example_dags
-
-        example_dag_folder = next(iter(example_dags.__path__))
-        file_paths.extend(list_py_file_paths(example_dag_folder, safe_mode, include_examples=False))
     return file_paths
 
 

--- a/providers/tests/fab/auth_manager/conftest.py
+++ b/providers/tests/fab/auth_manager/conftest.py
@@ -16,11 +16,14 @@
 # under the License.
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from airflow.www import app
 
 from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.db import parse_and_sync_to_db
 from tests_common.test_utils.decorators import dont_initialize_flask_app_submodules
 
 
@@ -72,5 +75,5 @@ def set_auth_role_public(request):
 def dagbag():
     from airflow.models import DagBag
 
-    DagBag(include_examples=True, read_dags_from_db=False).sync_to_db()
-    return DagBag(include_examples=True, read_dags_from_db=True)
+    parse_and_sync_to_db(os.devnull, include_examples=True)
+    return DagBag(read_dags_from_db=True)

--- a/task_sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task_sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -254,10 +254,6 @@ def _fork_main(
                 atexit._run_exitfuncs()
                 base_exit(n)
 
-    from airflow import settings
-
-    settings.configure_orm()
-
     try:
         target()
         exit(0)

--- a/task_sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task_sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -254,6 +254,10 @@ def _fork_main(
                 atexit._run_exitfuncs()
                 base_exit(n)
 
+    from airflow import settings
+
+    settings.configure_orm()
+
     try:
         target()
         exit(0)

--- a/tests/api_connexion/conftest.py
+++ b/tests/api_connexion/conftest.py
@@ -16,11 +16,14 @@
 # under the License.
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from airflow.www import app
 
 from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.db import parse_and_sync_to_db
 from tests_common.test_utils.decorators import dont_initialize_flask_app_submodules
 
 
@@ -64,5 +67,5 @@ def session():
 def dagbag():
     from airflow.models import DagBag
 
-    DagBag(include_examples=True, read_dags_from_db=False).sync_to_db()
-    return DagBag(include_examples=True, read_dags_from_db=True)
+    parse_and_sync_to_db(os.devnull, include_examples=True)
+    return DagBag(read_dags_from_db=True)

--- a/tests/api_connexion/endpoints/test_dag_parsing.py
+++ b/tests/api_connexion/endpoints/test_dag_parsing.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING
 
 import pytest
 from sqlalchemy import select
@@ -26,17 +25,14 @@ from airflow.models import DagBag
 from airflow.models.dagbag import DagPriorityParsingRequest
 
 from tests_common.test_utils.api_connexion_utils import create_user, delete_user
-from tests_common.test_utils.db import clear_db_dag_parsing_requests
+from tests_common.test_utils.db import clear_db_dag_parsing_requests, parse_and_sync_to_db
 
 pytestmark = pytest.mark.db_test
 
-if TYPE_CHECKING:
-    from airflow.models.dag import DAG
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
 EXAMPLE_DAG_FILE = os.path.join("airflow", "example_dags", "example_bash_operator.py")
-EXAMPLE_DAG_ID = "example_bash_operator"
-TEST_DAG_ID = "latest_only"
+TEST_DAG_ID = "example_bash_operator"
 NOT_READABLE_DAG_ID = "latest_only_with_trigger"
 TEST_MULTIPLE_DAGS_ID = "asset_produces_1"
 
@@ -72,9 +68,9 @@ class TestDagParsingRequest:
         clear_db_dag_parsing_requests()
 
     def test_201_and_400_requests(self, url_safe_serializer, session):
-        dagbag = DagBag(dag_folder=EXAMPLE_DAG_FILE)
-        dagbag.sync_to_db()
-        test_dag: DAG = dagbag.dags[TEST_DAG_ID]
+        parse_and_sync_to_db(EXAMPLE_DAG_FILE)
+        dagbag = DagBag(read_dags_from_db=True)
+        test_dag = dagbag.get_dag(TEST_DAG_ID)
 
         url = f"/api/v1/parseDagFile/{url_safe_serializer.dumps(test_dag.fileloc)}"
         response = self.client.put(

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -93,7 +93,7 @@ class TestDagRunEndpoint:
         dag = DAG(dag_id=dag_id, schedule=None, params={"validated_number": Param(1, minimum=1, maximum=10)})
         DagBundlesManager().sync_bundles_to_db()
         self.app.dag_bag.bag_dag(dag)
-        self.app.dag_bag.sync_to_db("dags_folder", None)
+        self.app.dag_bag.sync_to_db("dags-folder", None)
         return dag_instance
 
     def _create_test_dag_run(self, state=DagRunState.RUNNING, extra_dag=False, commit=True, idx_start=1):

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -25,6 +25,7 @@ import pytest
 import time_machine
 
 from airflow.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
+from airflow.dag_processing.bundles.manager import DagBundlesManager
 from airflow.models import Log
 from airflow.models.asset import AssetEvent, AssetModel
 from airflow.models.dag import DAG, DagModel
@@ -90,8 +91,9 @@ class TestDagRunEndpoint:
         with create_session() as session:
             session.add(dag_instance)
         dag = DAG(dag_id=dag_id, schedule=None, params={"validated_number": Param(1, minimum=1, maximum=10)})
+        DagBundlesManager().sync_bundles_to_db()
         self.app.dag_bag.bag_dag(dag)
-        self.app.dag_bag.sync_to_db()
+        self.app.dag_bag.sync_to_db("dags_folder", None)
         return dag_instance
 
     def _create_test_dag_run(self, state=DagRunState.RUNNING, extra_dag=False, commit=True, idx_start=1):

--- a/tests/api_connexion/endpoints/test_dag_source_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_source_endpoint.py
@@ -16,6 +16,8 @@
 # under the License.
 from __future__ import annotations
 
+import os
+
 import pytest
 from sqlalchemy import select
 
@@ -24,13 +26,12 @@ from airflow.models.dagcode import DagCode
 from airflow.models.serialized_dag import SerializedDagModel
 
 from tests_common.test_utils.api_connexion_utils import assert_401, create_user, delete_user
-from tests_common.test_utils.db import clear_db_dags
+from tests_common.test_utils.db import clear_db_dags, parse_and_sync_to_db
 
 pytestmark = pytest.mark.db_test
 
 
-EXAMPLE_DAG_ID = "example_bash_operator"
-TEST_DAG_ID = "latest_only"
+TEST_DAG_ID = "example_bash_operator"
 
 
 @pytest.fixture(scope="module")
@@ -51,9 +52,9 @@ def configured_app(minimal_app_for_api):
 
 @pytest.fixture
 def test_dag():
-    dagbag = DagBag(include_examples=True)
-    dagbag.sync_to_db()
-    return dagbag.dags[TEST_DAG_ID]
+    parse_and_sync_to_db(os.devnull, include_examples=True)
+    dagbag = DagBag(read_dags_from_db=True)
+    return dagbag.get_dag(TEST_DAG_ID)
 
 
 class TestGetSource:

--- a/tests/api_connexion/endpoints/test_extra_link_endpoint.py
+++ b/tests/api_connexion/endpoints/test_extra_link_endpoint.py
@@ -22,6 +22,7 @@ from urllib.parse import quote_plus
 import pytest
 
 from airflow.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
+from airflow.dag_processing.bundles.manager import DagBundlesManager
 from airflow.models.dag import DAG
 from airflow.models.dagbag import DagBag
 from airflow.models.xcom import XCom
@@ -73,9 +74,10 @@ class TestGetExtraLinks:
 
         self.dag = self._create_dag()
 
+        DagBundlesManager().sync_bundles_to_db()
         self.app.dag_bag = DagBag(os.devnull, include_examples=False)
         self.app.dag_bag.dags = {self.dag.dag_id: self.dag}
-        self.app.dag_bag.sync_to_db()
+        self.app.dag_bag.sync_to_db("dags_folder", None)
 
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
         self.dag.create_dagrun(

--- a/tests/api_connexion/endpoints/test_extra_link_endpoint.py
+++ b/tests/api_connexion/endpoints/test_extra_link_endpoint.py
@@ -77,7 +77,7 @@ class TestGetExtraLinks:
         DagBundlesManager().sync_bundles_to_db()
         self.app.dag_bag = DagBag(os.devnull, include_examples=False)
         self.app.dag_bag.dags = {self.dag.dag_id: self.dag}
-        self.app.dag_bag.sync_to_db("dags_folder", None)
+        self.app.dag_bag.sync_to_db("dags-folder", None)
 
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST} if AIRFLOW_V_3_0_PLUS else {}
         self.dag.create_dagrun(

--- a/tests/api_connexion/endpoints/test_mapped_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_mapped_task_instance_endpoint.py
@@ -24,6 +24,7 @@ import urllib
 import pytest
 
 from airflow.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
+from airflow.dag_processing.bundles.manager import DagBundlesManager
 from airflow.models import TaskInstance
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.dagbag import DagBag
@@ -122,9 +123,10 @@ class TestMappedTaskInstanceEndpoint:
                 setattr(ti, "start_date", DEFAULT_DATETIME_1)
                 session.add(ti)
 
+            DagBundlesManager().sync_bundles_to_db()
             self.app.dag_bag = DagBag(os.devnull, include_examples=False)
             self.app.dag_bag.dags = {dag_id: dag_maker.dag}
-            self.app.dag_bag.sync_to_db()
+            self.app.dag_bag.sync_to_db("dags_folder", None)
             session.flush()
 
             mapped.expand_mapped_task(dr.run_id, session=session)

--- a/tests/api_connexion/endpoints/test_mapped_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_mapped_task_instance_endpoint.py
@@ -126,7 +126,7 @@ class TestMappedTaskInstanceEndpoint:
             DagBundlesManager().sync_bundles_to_db()
             self.app.dag_bag = DagBag(os.devnull, include_examples=False)
             self.app.dag_bag.dags = {dag_id: dag_maker.dag}
-            self.app.dag_bag.sync_to_db("dags_folder", None)
+            self.app.dag_bag.sync_to_db("dags-folder", None)
             session.flush()
 
             mapped.expand_mapped_task(dr.run_id, session=session)

--- a/tests/api_connexion/endpoints/test_task_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_endpoint.py
@@ -22,6 +22,7 @@ from datetime import datetime
 
 import pytest
 
+from airflow.dag_processing.bundles.manager import DagBundlesManager
 from airflow.models import DagBag
 from airflow.models.dag import DAG
 from airflow.models.expandinput import EXPAND_INPUT_EMPTY
@@ -80,13 +81,15 @@ class TestTaskEndpoint:
             task5 = EmptyOperator(task_id=self.unscheduled_task_id2, params={"is_unscheduled": True})
         task1 >> task2
         task4 >> task5
+
+        DagBundlesManager().sync_bundles_to_db()
         dag_bag = DagBag(os.devnull, include_examples=False)
         dag_bag.dags = {
             dag.dag_id: dag,
             mapped_dag.dag_id: mapped_dag,
             unscheduled_dag.dag_id: unscheduled_dag,
         }
-        dag_bag.sync_to_db()
+        dag_bag.sync_to_db("dags_folder", None)
         configured_app.dag_bag = dag_bag  # type:ignore
 
     @staticmethod

--- a/tests/api_connexion/endpoints/test_task_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_endpoint.py
@@ -89,7 +89,7 @@ class TestTaskEndpoint:
             mapped_dag.dag_id: mapped_dag,
             unscheduled_dag.dag_id: unscheduled_dag,
         }
-        dag_bag.sync_to_db("dags_folder", None)
+        dag_bag.sync_to_db("dags-folder", None)
         configured_app.dag_bag = dag_bag  # type:ignore
 
     @staticmethod

--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -1224,7 +1224,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             task_instances=task_instances,
             update_extras=False,
         )
-        self.app.dag_bag.sync_to_db()
+        self.app.dag_bag.sync_to_db("dags_folder", None)
         response = self.client.post(
             f"/api/v1/dags/{request_dag}/clearTaskInstances",
             environ_overrides={"REMOTE_USER": "test"},
@@ -1246,7 +1246,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         self.create_task_instances(session)
         dag_id = "example_python_operator"
         payload = {"reset_dag_runs": True, "dry_run": False}
-        self.app.dag_bag.sync_to_db()
+        self.app.dag_bag.sync_to_db("dags_folder", None)
         response = self.client.post(
             f"/api/v1/dags/{dag_id}/clearTaskInstances",
             environ_overrides={"REMOTE_USER": "test"},
@@ -1266,7 +1266,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         assert dagrun.state == "running"
 
         payload = {"dry_run": False, "reset_dag_runs": True, "task_ids": [""]}
-        self.app.dag_bag.sync_to_db()
+        self.app.dag_bag.sync_to_db("dags_folder", None)
         response = self.client.post(
             f"/api/v1/dags/{dag_id}/clearTaskInstances",
             environ_overrides={"REMOTE_USER": "test"},
@@ -1693,7 +1693,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             task_instances=task_instances,
             update_extras=False,
         )
-        self.app.dag_bag.sync_to_db()
+        self.app.dag_bag.sync_to_db("dags_folder", None)
         response = self.client.post(
             "/api/v1/dags/example_python_operator/clearTaskInstances",
             environ_overrides={"REMOTE_USER": "test"},

--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -1224,7 +1224,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             task_instances=task_instances,
             update_extras=False,
         )
-        self.app.dag_bag.sync_to_db("dags_folder", None)
+        self.app.dag_bag.sync_to_db("dags-folder", None)
         response = self.client.post(
             f"/api/v1/dags/{request_dag}/clearTaskInstances",
             environ_overrides={"REMOTE_USER": "test"},
@@ -1246,7 +1246,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         self.create_task_instances(session)
         dag_id = "example_python_operator"
         payload = {"reset_dag_runs": True, "dry_run": False}
-        self.app.dag_bag.sync_to_db("dags_folder", None)
+        self.app.dag_bag.sync_to_db("dags-folder", None)
         response = self.client.post(
             f"/api/v1/dags/{dag_id}/clearTaskInstances",
             environ_overrides={"REMOTE_USER": "test"},
@@ -1266,7 +1266,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         assert dagrun.state == "running"
 
         payload = {"dry_run": False, "reset_dag_runs": True, "task_ids": [""]}
-        self.app.dag_bag.sync_to_db("dags_folder", None)
+        self.app.dag_bag.sync_to_db("dags-folder", None)
         response = self.client.post(
             f"/api/v1/dags/{dag_id}/clearTaskInstances",
             environ_overrides={"REMOTE_USER": "test"},
@@ -1693,7 +1693,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             task_instances=task_instances,
             update_extras=False,
         )
-        self.app.dag_bag.sync_to_db("dags_folder", None)
+        self.app.dag_bag.sync_to_db("dags-folder", None)
         response = self.client.post(
             "/api/v1/dags/example_python_operator/clearTaskInstances",
             environ_overrides={"REMOTE_USER": "test"},

--- a/tests/api_fastapi/conftest.py
+++ b/tests/api_fastapi/conftest.py
@@ -16,10 +16,14 @@
 # under the License.
 from __future__ import annotations
 
+import os
+
 import pytest
 from fastapi.testclient import TestClient
 
 from airflow.api_fastapi.app import create_app
+
+from tests_common.test_utils.db import parse_and_sync_to_db
 
 
 @pytest.fixture
@@ -42,6 +46,5 @@ def client():
 def dagbag():
     from airflow.models import DagBag
 
-    dagbag_instance = DagBag(include_examples=True, read_dags_from_db=False)
-    dagbag_instance.sync_to_db()
-    return dagbag_instance
+    parse_and_sync_to_db(os.devnull, include_examples=True)
+    return DagBag(read_dags_from_db=True)

--- a/tests/api_fastapi/core_api/routes/public/test_dag_parsing.py
+++ b/tests/api_fastapi/core_api/routes/public/test_dag_parsing.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING
 
 import pytest
 from sqlalchemy import select
@@ -26,19 +25,15 @@ from airflow.models import DagBag
 from airflow.models.dagbag import DagPriorityParsingRequest
 from airflow.utils.session import provide_session
 
-from tests_common.test_utils.db import clear_db_dag_parsing_requests
+from tests_common.test_utils.db import clear_db_dag_parsing_requests, parse_and_sync_to_db
 
 pytestmark = pytest.mark.db_test
-
-if TYPE_CHECKING:
-    from airflow.models.dag import DAG
 
 
 class TestDagParsingEndpoint:
     ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
     EXAMPLE_DAG_FILE = os.path.join("airflow", "example_dags", "example_bash_operator.py")
-    EXAMPLE_DAG_ID = "example_bash_operator"
-    TEST_DAG_ID = "latest_only"
+    TEST_DAG_ID = "example_bash_operator"
     NOT_READABLE_DAG_ID = "latest_only_with_trigger"
     TEST_MULTIPLE_DAGS_ID = "asset_produces_1"
 
@@ -55,9 +50,9 @@ class TestDagParsingEndpoint:
         self.clear_db()
 
     def test_201_and_400_requests(self, url_safe_serializer, session, test_client):
-        dagbag = DagBag(dag_folder=self.EXAMPLE_DAG_FILE)
-        dagbag.sync_to_db()
-        test_dag: DAG = dagbag.dags[self.TEST_DAG_ID]
+        parse_and_sync_to_db(self.EXAMPLE_DAG_FILE)
+        dagbag = DagBag(read_dags_from_db=True)
+        test_dag = dagbag.get_dag(self.TEST_DAG_ID)
 
         url = f"/public/parseDagFile/{url_safe_serializer.dumps(test_dag.fileloc)}"
         response = test_client.put(url, headers={"Accept": "application/json"})

--- a/tests/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/tests/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -141,7 +141,7 @@ def setup(request, dag_maker, session=None):
         logical_date=LOGICAL_DATE4,
     )
 
-    dag_maker.dagbag.sync_to_db()
+    dag_maker.sync_dagbag_to_db()
     dag_maker.dag_model
     dag_maker.dag_model.has_task_concurrency_limits = True
     session.merge(ti1)

--- a/tests/api_fastapi/core_api/routes/public/test_dag_sources.py
+++ b/tests/api_fastapi/core_api/routes/public/test_dag_sources.py
@@ -28,7 +28,7 @@ from airflow.models.dagbag import DagBag
 from airflow.models.dagcode import DagCode
 from airflow.models.serialized_dag import SerializedDagModel
 
-from tests_common.test_utils.db import clear_db_dags
+from tests_common.test_utils.db import clear_db_dags, parse_and_sync_to_db
 
 pytestmark = pytest.mark.db_test
 
@@ -36,14 +36,13 @@ API_PREFIX = "/public/dagSources"
 
 # Example bash operator located here: airflow/example_dags/example_bash_operator.py
 EXAMPLE_DAG_FILE = os.path.join("airflow", "example_dags", "example_bash_operator.py")
-TEST_DAG_ID = "latest_only"
+TEST_DAG_ID = "example_bash_operator"
 
 
 @pytest.fixture
 def test_dag():
-    dagbag = DagBag(include_examples=True)
-    dagbag.sync_to_db()
-    return dagbag.dags[TEST_DAG_ID]
+    parse_and_sync_to_db(EXAMPLE_DAG_FILE, include_examples=False)
+    return DagBag(read_dags_from_db=True).get_dag(TEST_DAG_ID)
 
 
 class TestGetDAGSource:
@@ -131,9 +130,7 @@ class TestGetDAGSource:
                 "version_number": 2,
             }
 
-    def test_should_respond_406_unsupport_mime_type(self, test_client):
-        dagbag = DagBag(include_examples=True)
-        dagbag.sync_to_db()
+    def test_should_respond_406_unsupport_mime_type(self, test_client, test_dag):
         response = test_client.get(
             f"{API_PREFIX}/{TEST_DAG_ID}",
             headers={"Accept": "text/html"},

--- a/tests/api_fastapi/core_api/routes/public/test_dag_tags.py
+++ b/tests/api_fastapi/core_api/routes/public/test_dag_tags.py
@@ -111,6 +111,7 @@ class TestDagEndpoint:
         ):
             EmptyOperator(task_id=TASK_ID)
 
+        dag_maker.sync_dagbag_to_db()
         dag_maker.create_dagrun(state=DagRunState.FAILED)
 
         with dag_maker(
@@ -127,7 +128,7 @@ class TestDagEndpoint:
         self._create_deactivated_paused_dag(session)
         self._create_dag_tags(session)
 
-        dag_maker.dagbag.sync_to_db()
+        dag_maker.sync_dagbag_to_db()
         dag_maker.dag_model.has_task_concurrency_limits = True
         session.merge(dag_maker.dag_model)
         session.commit()

--- a/tests/api_fastapi/core_api/routes/public/test_dags.py
+++ b/tests/api_fastapi/core_api/routes/public/test_dags.py
@@ -127,7 +127,7 @@ class TestDagEndpoint:
         self._create_deactivated_paused_dag(session)
         self._create_dag_tags(session)
 
-        dag_maker.dagbag.sync_to_db()
+        dag_maker.sync_dagbag_to_db()
         dag_maker.dag_model.has_task_concurrency_limits = True
         session.merge(dag_maker.dag_model)
         session.commit()
@@ -409,7 +409,7 @@ class TestDeleteDAG(TestDagEndpoint):
             ti = dr.get_task_instances()[0]
             ti.set_state(TaskInstanceState.RUNNING)
 
-        dag_maker.dagbag.sync_to_db()
+        dag_maker.sync_dagbag_to_db()
 
     @pytest.mark.parametrize(
         "dag_id, dag_display_name, status_code_delete, status_code_details, has_running_dagruns, is_create_dag",

--- a/tests/api_fastapi/core_api/routes/public/test_extra_links.py
+++ b/tests/api_fastapi/core_api/routes/public/test_extra_links.py
@@ -21,6 +21,7 @@ from urllib.parse import quote_plus
 
 import pytest
 
+from airflow.dag_processing.bundles.manager import DagBundlesManager
 from airflow.models.dag import DAG
 from airflow.models.dagbag import DagBag
 from airflow.models.xcom import XCom
@@ -67,10 +68,11 @@ class TestExtraLinks:
 
         self.dag = self._create_dag()
 
+        DagBundlesManager().sync_bundles_to_db()
         dag_bag = DagBag(os.devnull, include_examples=False)
         dag_bag.dags = {self.dag.dag_id: self.dag}
         test_client.app.state.dag_bag = dag_bag
-        dag_bag.sync_to_db()
+        dag_bag.sync_to_db("dags_folder", None)
 
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST}
 

--- a/tests/api_fastapi/core_api/routes/public/test_extra_links.py
+++ b/tests/api_fastapi/core_api/routes/public/test_extra_links.py
@@ -72,7 +72,7 @@ class TestExtraLinks:
         dag_bag = DagBag(os.devnull, include_examples=False)
         dag_bag.dags = {self.dag.dag_id: self.dag}
         test_client.app.state.dag_bag = dag_bag
-        dag_bag.sync_to_db("dags_folder", None)
+        dag_bag.sync_to_db("dags-folder", None)
 
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.TEST}
 

--- a/tests/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/tests/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -526,7 +526,7 @@ class TestGetMappedTaskInstances:
             DagBundlesManager().sync_bundles_to_db()
             dagbag = DagBag(os.devnull, include_examples=False)
             dagbag.dags = {dag_id: dag_maker.dag}
-            dagbag.sync_to_db("dags_folder", None)
+            dagbag.sync_to_db("dags-folder", None)
             session.flush()
 
             mapped.expand_mapped_task(dr.run_id, session=session)
@@ -1859,7 +1859,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             task_instances=task_instances,
             update_extras=False,
         )
-        self.dagbag.sync_to_db("dags_folder", None)
+        self.dagbag.sync_to_db("dags-folder", None)
         response = test_client.post(
             f"/public/dags/{request_dag}/clearTaskInstances",
             json=payload,
@@ -1873,7 +1873,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         self.create_task_instances(session)
         dag_id = "example_python_operator"
         payload = {"reset_dag_runs": True, "dry_run": False}
-        self.dagbag.sync_to_db("dags_folder", None)
+        self.dagbag.sync_to_db("dags-folder", None)
         response = test_client.post(
             f"/public/dags/{dag_id}/clearTaskInstances",
             json=payload,
@@ -1893,7 +1893,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         assert dagrun.state == "running"
 
         payload = {"dry_run": False, "reset_dag_runs": True, "task_ids": [""]}
-        self.dagbag.sync_to_db("dags_folder", None)
+        self.dagbag.sync_to_db("dags-folder", None)
         response = test_client.post(
             f"/public/dags/{dag_id}/clearTaskInstances",
             json=payload,
@@ -1943,7 +1943,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             update_extras=False,
             dag_run_state=DagRunState.FAILED,
         )
-        self.dagbag.sync_to_db("dags_folder", None)
+        self.dagbag.sync_to_db("dags-folder", None)
         response = test_client.post(
             f"/public/dags/{dag_id}/clearTaskInstances",
             json=payload,
@@ -2030,7 +2030,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             update_extras=False,
             dag_run_state=State.FAILED,
         )
-        self.dagbag.sync_to_db("dags_folder", None)
+        self.dagbag.sync_to_db("dags-folder", None)
         response = test_client.post(
             f"/public/dags/{dag_id}/clearTaskInstances",
             json=payload,
@@ -2112,7 +2112,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             update_extras=False,
             dag_run_state=State.FAILED,
         )
-        self.dagbag.sync_to_db("dags_folder", None)
+        self.dagbag.sync_to_db("dags-folder", None)
         response = test_client.post(
             f"/public/dags/{dag_id}/clearTaskInstances",
             json=payload,
@@ -2196,7 +2196,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             update_extras=False,
             dag_run_state=State.FAILED,
         )
-        self.dagbag.sync_to_db("dags_folder", None)
+        self.dagbag.sync_to_db("dags-folder", None)
         response = test_client.post(
             f"/public/dags/{dag_id}/clearTaskInstances",
             json=payload,
@@ -2346,7 +2346,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             task_instances=task_instances,
             update_extras=False,
         )
-        self.dagbag.sync_to_db("dags_folder", None)
+        self.dagbag.sync_to_db("dags-folder", None)
         response = test_client.post(
             "/public/dags/example_python_operator/clearTaskInstances",
             json=payload,

--- a/tests/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/tests/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -26,6 +26,7 @@ import pendulum
 import pytest
 from sqlalchemy import select
 
+from airflow.dag_processing.bundles.manager import DagBundlesManager
 from airflow.jobs.job import Job
 from airflow.jobs.triggerer_job_runner import TriggererJobRunner
 from airflow.models import DagRun, TaskInstance
@@ -522,9 +523,10 @@ class TestGetMappedTaskInstances:
                 setattr(ti, "start_date", DEFAULT_DATETIME_1)
                 session.add(ti)
 
+            DagBundlesManager().sync_bundles_to_db()
             dagbag = DagBag(os.devnull, include_examples=False)
             dagbag.dags = {dag_id: dag_maker.dag}
-            dagbag.sync_to_db()
+            dagbag.sync_to_db("dags_folder", None)
             session.flush()
 
             mapped.expand_mapped_task(dr.run_id, session=session)
@@ -1857,7 +1859,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             task_instances=task_instances,
             update_extras=False,
         )
-        self.dagbag.sync_to_db()
+        self.dagbag.sync_to_db("dags_folder", None)
         response = test_client.post(
             f"/public/dags/{request_dag}/clearTaskInstances",
             json=payload,
@@ -1871,7 +1873,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         self.create_task_instances(session)
         dag_id = "example_python_operator"
         payload = {"reset_dag_runs": True, "dry_run": False}
-        self.dagbag.sync_to_db()
+        self.dagbag.sync_to_db("dags_folder", None)
         response = test_client.post(
             f"/public/dags/{dag_id}/clearTaskInstances",
             json=payload,
@@ -1891,7 +1893,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         assert dagrun.state == "running"
 
         payload = {"dry_run": False, "reset_dag_runs": True, "task_ids": [""]}
-        self.dagbag.sync_to_db()
+        self.dagbag.sync_to_db("dags_folder", None)
         response = test_client.post(
             f"/public/dags/{dag_id}/clearTaskInstances",
             json=payload,
@@ -1941,7 +1943,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             update_extras=False,
             dag_run_state=DagRunState.FAILED,
         )
-        self.dagbag.sync_to_db()
+        self.dagbag.sync_to_db("dags_folder", None)
         response = test_client.post(
             f"/public/dags/{dag_id}/clearTaskInstances",
             json=payload,
@@ -2028,7 +2030,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             update_extras=False,
             dag_run_state=State.FAILED,
         )
-        self.dagbag.sync_to_db()
+        self.dagbag.sync_to_db("dags_folder", None)
         response = test_client.post(
             f"/public/dags/{dag_id}/clearTaskInstances",
             json=payload,
@@ -2110,7 +2112,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             update_extras=False,
             dag_run_state=State.FAILED,
         )
-        self.dagbag.sync_to_db()
+        self.dagbag.sync_to_db("dags_folder", None)
         response = test_client.post(
             f"/public/dags/{dag_id}/clearTaskInstances",
             json=payload,
@@ -2194,7 +2196,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             update_extras=False,
             dag_run_state=State.FAILED,
         )
-        self.dagbag.sync_to_db()
+        self.dagbag.sync_to_db("dags_folder", None)
         response = test_client.post(
             f"/public/dags/{dag_id}/clearTaskInstances",
             json=payload,
@@ -2344,7 +2346,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             task_instances=task_instances,
             update_extras=False,
         )
-        self.dagbag.sync_to_db()
+        self.dagbag.sync_to_db("dags_folder", None)
         response = test_client.post(
             "/public/dags/example_python_operator/clearTaskInstances",
             json=payload,

--- a/tests/api_fastapi/core_api/routes/ui/test_assets.py
+++ b/tests/api_fastapi/core_api/routes/ui/test_assets.py
@@ -46,7 +46,7 @@ def test_next_run_assets(test_client, dag_maker):
         EmptyOperator(task_id="task1")
 
     dag_maker.create_dagrun()
-    dag_maker.dagbag.sync_to_db()
+    dag_maker.sync_dagbag_to_db()
 
     response = test_client.get("/ui/next_run_assets/upstream")
 

--- a/tests/api_fastapi/core_api/routes/ui/test_dashboard.py
+++ b/tests/api_fastapi/core_api/routes/ui/test_dashboard.py
@@ -95,7 +95,7 @@ def make_dag_runs(dag_maker, session, time_machine):
     for ti in run2.task_instances:
         ti.state = TaskInstanceState.FAILED
 
-    dag_maker.dagbag.sync_to_db()
+    dag_maker.sync_dagbag_to_db()
     time_machine.move_to("2023-07-02T00:00:00+00:00", tick=False)
 
 

--- a/tests/api_fastapi/core_api/routes/ui/test_structure.py
+++ b/tests/api_fastapi/core_api/routes/ui/test_structure.py
@@ -59,7 +59,7 @@ def make_dag(dag_maker, session, time_machine):
     ):
         TriggerDagRunOperator(task_id="trigger_dag_run_operator", trigger_dag_id=DAG_ID)
 
-    dag_maker.dagbag.sync_to_db()
+    dag_maker.sync_dagbag_to_db()
 
     with dag_maker(
         dag_id=DAG_ID,
@@ -78,7 +78,7 @@ def make_dag(dag_maker, session, time_machine):
             >> EmptyOperator(task_id="task_2")
         )
 
-    dag_maker.dagbag.sync_to_db()
+    dag_maker.sync_dagbag_to_db()
 
 
 class TestStructureDataEndpoint:

--- a/tests/cli/commands/remote_commands/test_asset_command.py
+++ b/tests/cli/commands/remote_commands/test_asset_command.py
@@ -21,15 +21,15 @@ from __future__ import annotations
 import contextlib
 import io
 import json
+import os
 import typing
 
 import pytest
 
 from airflow.cli import cli_parser
 from airflow.cli.commands.remote_commands import asset_command
-from airflow.models.dagbag import DagBag
 
-from tests_common.test_utils.db import clear_db_dags, clear_db_runs
+from tests_common.test_utils.db import clear_db_dags, clear_db_runs, parse_and_sync_to_db
 
 if typing.TYPE_CHECKING:
     from argparse import ArgumentParser
@@ -39,7 +39,7 @@ pytestmark = [pytest.mark.db_test]
 
 @pytest.fixture(scope="module", autouse=True)
 def prepare_examples():
-    DagBag(include_examples=True).sync_to_db()
+    parse_and_sync_to_db(os.devnull, include_examples=True)
     yield
     clear_db_runs()
     clear_db_dags()

--- a/tests/cli/commands/remote_commands/test_backfill_command.py
+++ b/tests/cli/commands/remote_commands/test_backfill_command.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 from datetime import datetime
 from unittest import mock
 
@@ -26,11 +27,10 @@ import pytest
 
 import airflow.cli.commands.remote_commands.backfill_command
 from airflow.cli import cli_parser
-from airflow.models import DagBag
 from airflow.models.backfill import ReprocessBehavior
 from airflow.utils import timezone
 
-from tests_common.test_utils.db import clear_db_backfills, clear_db_dags, clear_db_runs
+from tests_common.test_utils.db import clear_db_backfills, clear_db_dags, clear_db_runs, parse_and_sync_to_db
 
 DEFAULT_DATE = timezone.make_aware(datetime(2015, 1, 1), timezone=timezone.utc)
 if pendulum.__version__.startswith("3"):
@@ -48,8 +48,7 @@ class TestCliBackfill:
 
     @classmethod
     def setup_class(cls):
-        cls.dagbag = DagBag(include_examples=True)
-        cls.dagbag.sync_to_db()
+        parse_and_sync_to_db(os.devnull, include_examples=True)
         cls.parser = cli_parser.get_parser()
 
     @classmethod

--- a/tests/cli/commands/remote_commands/test_dag_command.py
+++ b/tests/cli/commands/remote_commands/test_dag_command.py
@@ -50,7 +50,7 @@ from airflow.utils.types import DagRunType
 
 from tests.models import TEST_DAGS_FOLDER
 from tests_common.test_utils.config import conf_vars
-from tests_common.test_utils.db import clear_db_dags, clear_db_runs
+from tests_common.test_utils.db import clear_db_dags, clear_db_runs, parse_and_sync_to_db
 
 DEFAULT_DATE = timezone.make_aware(datetime(2015, 1, 1), timezone=timezone.utc)
 if pendulum.__version__.startswith("3"):
@@ -68,8 +68,7 @@ class TestCliDags:
 
     @classmethod
     def setup_class(cls):
-        cls.dagbag = DagBag(include_examples=True)
-        cls.dagbag.sync_to_db()
+        parse_and_sync_to_db(os.devnull, include_examples=True)
         cls.parser = cli_parser.get_parser()
 
     @classmethod
@@ -207,8 +206,7 @@ class TestCliDags:
 
         with time_machine.travel(DEFAULT_DATE):
             clear_db_dags()
-            self.dagbag = DagBag(dag_folder=tmp_path, include_examples=False)
-            self.dagbag.sync_to_db()
+            parse_and_sync_to_db(tmp_path, include_examples=False)
 
         default_run = DEFAULT_DATE
         future_run = default_run + timedelta(days=5)
@@ -255,8 +253,7 @@ class TestCliDags:
 
         # Rebuild Test DB for other tests
         clear_db_dags()
-        TestCliDags.dagbag = DagBag(include_examples=True)
-        TestCliDags.dagbag.sync_to_db()
+        parse_and_sync_to_db(os.devnull, include_examples=True)
 
     @conf_vars({("core", "load_examples"): "true"})
     def test_cli_report(self):
@@ -405,24 +402,24 @@ class TestCliDags:
     def test_pause(self):
         args = self.parser.parse_args(["dags", "pause", "example_bash_operator"])
         dag_command.dag_pause(args)
-        assert self.dagbag.dags["example_bash_operator"].get_is_paused()
+        assert DagModel.get_dagmodel("example_bash_operator").is_paused
         dag_command.dag_unpause(args)
-        assert not self.dagbag.dags["example_bash_operator"].get_is_paused()
+        assert not DagModel.get_dagmodel("example_bash_operator").is_paused
 
     @mock.patch("airflow.cli.commands.remote_commands.dag_command.ask_yesno")
     def test_pause_regex(self, mock_yesno):
         args = self.parser.parse_args(["dags", "pause", "^example_.*$", "--treat-dag-id-as-regex"])
         dag_command.dag_pause(args)
         mock_yesno.assert_called_once()
-        assert self.dagbag.dags["example_bash_decorator"].get_is_paused()
-        assert self.dagbag.dags["example_kubernetes_executor"].get_is_paused()
-        assert self.dagbag.dags["example_xcom_args"].get_is_paused()
+        assert DagModel.get_dagmodel("example_bash_decorator").is_paused
+        assert DagModel.get_dagmodel("example_kubernetes_executor").is_paused
+        assert DagModel.get_dagmodel("example_xcom_args").is_paused
 
         args = self.parser.parse_args(["dags", "unpause", "^example_.*$", "--treat-dag-id-as-regex"])
         dag_command.dag_unpause(args)
-        assert not self.dagbag.dags["example_bash_decorator"].get_is_paused()
-        assert not self.dagbag.dags["example_kubernetes_executor"].get_is_paused()
-        assert not self.dagbag.dags["example_xcom_args"].get_is_paused()
+        assert not DagModel.get_dagmodel("example_bash_decorator").is_paused
+        assert not DagModel.get_dagmodel("example_kubernetes_executor").is_paused
+        assert not DagModel.get_dagmodel("example_xcom_args").is_paused
 
     @mock.patch("airflow.cli.commands.remote_commands.dag_command.ask_yesno")
     def test_pause_regex_operation_cancelled(self, ask_yesno, capsys):

--- a/tests/cli/commands/remote_commands/test_task_command.py
+++ b/tests/cli/commands/remote_commands/test_task_command.py
@@ -53,7 +53,7 @@ from airflow.utils.state import State, TaskInstanceState
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.config import conf_vars
-from tests_common.test_utils.db import clear_db_pools, clear_db_runs
+from tests_common.test_utils.db import clear_db_pools, clear_db_runs, parse_and_sync_to_db
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 if AIRFLOW_V_3_0_PLUS:
@@ -97,12 +97,12 @@ class TestCliTasks:
     @pytest.fixture(autouse=True)
     def setup_class(cls):
         logging.config.dictConfig(DEFAULT_LOGGING_CONFIG)
-        cls.dagbag = DagBag(include_examples=True)
+        parse_and_sync_to_db(os.devnull, include_examples=True)
         cls.parser = cli_parser.get_parser()
         clear_db_runs()
 
+        cls.dagbag = DagBag(read_dags_from_db=True)
         cls.dag = cls.dagbag.get_dag(cls.dag_id)
-        cls.dagbag.sync_to_db()
         data_interval = cls.dag.timetable.infer_manual_data_interval(run_after=DEFAULT_DATE)
         triggered_by_kwargs = {"triggered_by": DagRunTriggeredByType.CLI} if AIRFLOW_V_3_0_PLUS else {}
         cls.dag_run = cls.dag.create_dagrun(
@@ -164,7 +164,7 @@ class TestCliTasks:
         with conf_vars({("core", "dags_folder"): orig_dags_folder.as_posix()}):
             dagbag = DagBag(include_examples=False)
             dag = dagbag.get_dag("test_dags_folder")
-            dagbag.sync_to_db(session=session)
+            dagbag.sync_to_db("dags_folder", None, session=session)
 
         logical_date = pendulum.now("UTC")
         data_interval = dag.timetable.infer_manual_data_interval(run_after=logical_date)

--- a/tests/cli/commands/remote_commands/test_task_command.py
+++ b/tests/cli/commands/remote_commands/test_task_command.py
@@ -164,7 +164,7 @@ class TestCliTasks:
         with conf_vars({("core", "dags_folder"): orig_dags_folder.as_posix()}):
             dagbag = DagBag(include_examples=False)
             dag = dagbag.get_dag("test_dags_folder")
-            dagbag.sync_to_db("dags_folder", None, session=session)
+            dagbag.sync_to_db("dags-folder", None, session=session)
 
         logical_date = pendulum.now("UTC")
         data_interval = dag.timetable.infer_manual_data_interval(run_after=logical_date)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,14 +16,19 @@
 # under the License.
 from __future__ import annotations
 
+import json
 import logging
 import os
 import sys
+from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 import pytest
 
 from tests_common.test_utils.log_handlers import non_pytest_handlers
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # We should set these before loading _any_ of the rest of airflow so that the
 # unit test mode config is set as early as possible.
@@ -79,6 +84,36 @@ def clear_all_logger_handlers():
     remove_all_non_pytest_log_handlers()
     yield
     remove_all_non_pytest_log_handlers()
+
+
+@pytest.fixture
+def testing_dag_bundle():
+    from airflow.models.dagbundle import DagBundleModel
+    from airflow.utils.session import create_session
+
+    with create_session() as session:
+        if session.query(DagBundleModel).filter(DagBundleModel.name == "testing").count() == 0:
+            testing = DagBundleModel(name="testing")
+            session.add(testing)
+
+
+@pytest.fixture
+def configure_testing_dag_bundle():
+    """Configure the testing DAG bundle with the provided path, and disable the DAGs folder bundle."""
+    from tests_common.test_utils.config import conf_vars
+
+    @contextmanager
+    def _config_bundle(path_to_parse: Path | str):
+        bundle_config = {
+            "classpath": "airflow.dag_processing.bundles.local.LocalDagBundle",
+            "kwargs": {"local_folder": str(path_to_parse), "refresh_interval": 30},
+        }
+        with conf_vars(
+            {("dag_bundles", "testing"): json.dumps(bundle_config), ("dag_bundles", "dags_folder"): ""}
+        ):
+            yield
+
+    return _config_bundle
 
 
 if TYPE_CHECKING:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,7 +108,7 @@ def configure_testing_dag_bundle():
             {
                 "name": "testing",
                 "classpath": "airflow.dag_processing.bundles.local.LocalDagBundle",
-                "kwargs": {"local_folder": str(path_to_parse), "refresh_interval": 30},
+                "kwargs": {"local_folder": str(path_to_parse), "refresh_interval": 0},
             }
         ]
         with conf_vars({("dag_bundles", "backends"): json.dumps(bundle_config)}):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,13 +104,14 @@ def configure_testing_dag_bundle():
 
     @contextmanager
     def _config_bundle(path_to_parse: Path | str):
-        bundle_config = {
-            "classpath": "airflow.dag_processing.bundles.local.LocalDagBundle",
-            "kwargs": {"local_folder": str(path_to_parse), "refresh_interval": 30},
-        }
-        with conf_vars(
-            {("dag_bundles", "testing"): json.dumps(bundle_config), ("dag_bundles", "dags_folder"): ""}
-        ):
+        bundle_config = [
+            {
+                "name": "testing",
+                "classpath": "airflow.dag_processing.bundles.local.LocalDagBundle",
+                "kwargs": {"local_folder": str(path_to_parse), "refresh_interval": 30},
+            }
+        ]
+        with conf_vars({("dag_bundles", "backends"): json.dumps(bundle_config)}):
             yield
 
     return _config_bundle

--- a/tests/dag_processing/test_collection.py
+++ b/tests/dag_processing/test_collection.py
@@ -185,7 +185,7 @@ class TestUpdateDagParsingResults:
 
     @pytest.mark.usefixtures("clean_db")  # sync_perms in fab has bad session commit hygiene
     def test_sync_perms_syncs_dag_specific_perms_on_update(
-        self, monkeypatch, spy_agency: SpyAgency, session, time_machine
+        self, monkeypatch, spy_agency: SpyAgency, session, time_machine, testing_dag_bundle
     ):
         """
         Test that dagbag.sync_to_db will sync DAG specific permissions when a DAG is
@@ -210,7 +210,7 @@ class TestUpdateDagParsingResults:
             sync_perms_spy.reset_calls()
             time_machine.shift(20)
 
-            update_dag_parsing_results_in_db([dag], dict(), set(), session)
+            update_dag_parsing_results_in_db("testing", None, [dag], dict(), set(), session)
 
         _sync_to_db()
         spy_agency.assert_spy_called_with(sync_perms_spy, dag, session=session)
@@ -228,7 +228,9 @@ class TestUpdateDagParsingResults:
 
     @patch.object(SerializedDagModel, "write_dag")
     @patch("airflow.models.dag.DAG.bulk_write_to_db")
-    def test_sync_to_db_is_retried(self, mock_bulk_write_to_db, mock_s10n_write_dag, session):
+    def test_sync_to_db_is_retried(
+        self, mock_bulk_write_to_db, mock_s10n_write_dag, testing_dag_bundle, session
+    ):
         """Test that important DB operations in db sync are retried on OperationalError"""
 
         serialized_dags_count = session.query(func.count(SerializedDagModel.dag_id)).scalar()
@@ -244,14 +246,16 @@ class TestUpdateDagParsingResults:
         mock_bulk_write_to_db.side_effect = side_effect
 
         mock_session = mock.MagicMock()
-        update_dag_parsing_results_in_db(dags=dags, import_errors={}, warnings=set(), session=mock_session)
+        update_dag_parsing_results_in_db(
+            "testing", None, dags=dags, import_errors={}, warnings=set(), session=mock_session
+        )
 
         # Test that 3 attempts were made to run 'DAG.bulk_write_to_db' successfully
         mock_bulk_write_to_db.assert_has_calls(
             [
-                mock.call(mock.ANY, session=mock.ANY),
-                mock.call(mock.ANY, session=mock.ANY),
-                mock.call(mock.ANY, session=mock.ANY),
+                mock.call("testing", None, mock.ANY, session=mock.ANY),
+                mock.call("testing", None, mock.ANY, session=mock.ANY),
+                mock.call("testing", None, mock.ANY, session=mock.ANY),
             ]
         )
         # Assert that rollback is called twice (i.e. whenever OperationalError occurs)
@@ -268,7 +272,7 @@ class TestUpdateDagParsingResults:
         serialized_dags_count = session.query(func.count(SerializedDagModel.dag_id)).scalar()
         assert serialized_dags_count == 0
 
-    def test_serialized_dags_are_written_to_db_on_sync(self, session):
+    def test_serialized_dags_are_written_to_db_on_sync(self, testing_dag_bundle, session):
         """
         Test that when dagbag.sync_to_db is called the DAGs are Serialized and written to DB
         even when dagbag.read_dags_from_db is False
@@ -278,14 +282,14 @@ class TestUpdateDagParsingResults:
 
         dag = DAG(dag_id="test")
 
-        update_dag_parsing_results_in_db([dag], dict(), set(), session)
+        update_dag_parsing_results_in_db("testing", None, [dag], dict(), set(), session)
 
         new_serialized_dags_count = session.query(func.count(SerializedDagModel.dag_id)).scalar()
         assert new_serialized_dags_count == 1
 
     @patch.object(SerializedDagModel, "write_dag")
     def test_serialized_dag_errors_are_import_errors(
-        self, mock_serialize, caplog, session, dag_import_error_listener
+        self, mock_serialize, caplog, session, dag_import_error_listener, testing_dag_bundle
     ):
         """
         Test that errors serializing a DAG are recorded as import_errors in the DB
@@ -298,7 +302,7 @@ class TestUpdateDagParsingResults:
         dag.fileloc = "abc.py"
 
         import_errors = {}
-        update_dag_parsing_results_in_db([dag], import_errors, set(), session)
+        update_dag_parsing_results_in_db("testing", None, [dag], import_errors, set(), session)
         assert "SerializationError" in caplog.text
 
         # Should have been edited in place
@@ -320,7 +324,7 @@ class TestUpdateDagParsingResults:
         assert len(dag_import_error_listener.existing) == 0
         assert dag_import_error_listener.new["abc.py"] == import_error.stacktrace
 
-    def test_new_import_error_replaces_old(self, session, dag_import_error_listener):
+    def test_new_import_error_replaces_old(self, session, dag_import_error_listener, testing_dag_bundle):
         """
         Test that existing import error is updated and new record not created
         for a dag with the same filename
@@ -336,6 +340,8 @@ class TestUpdateDagParsingResults:
         prev_error_id = prev_error.id
 
         update_dag_parsing_results_in_db(
+            bundle_name="testing",
+            bundle_version=None,
             dags=[],
             import_errors={"abc.py": "New error"},
             warnings=set(),
@@ -353,7 +359,7 @@ class TestUpdateDagParsingResults:
         assert len(dag_import_error_listener.existing) == 1
         assert dag_import_error_listener.existing["abc.py"] == prev_error.stacktrace
 
-    def test_remove_error_clears_import_error(self, session):
+    def test_remove_error_clears_import_error(self, testing_dag_bundle, session):
         # Pre-condition: there is an import error for the dag file
         filename = "abc.py"
         prev_error = ParseImportError(
@@ -381,7 +387,7 @@ class TestUpdateDagParsingResults:
         dag.fileloc = filename
 
         import_errors = {}
-        update_dag_parsing_results_in_db([dag], import_errors, set(), session)
+        update_dag_parsing_results_in_db("testing", None, [dag], import_errors, set(), session)
 
         dag_model: DagModel = session.get(DagModel, (dag.dag_id,))
         assert dag_model.has_import_errors is False
@@ -473,7 +479,7 @@ class TestUpdateDagParsingResults:
         ],
     )
     @pytest.mark.usefixtures("clean_db")
-    def test_dagmodel_properties(self, attrs, expected, session, time_machine):
+    def test_dagmodel_properties(self, attrs, expected, session, time_machine, testing_dag_bundle):
         """Test that properties on the dag model are correctly set when dealing with a LazySerializedDag"""
         dt = tz.datetime(2020, 1, 5, 0, 0, 0)
         time_machine.move_to(dt, tick=False)
@@ -493,7 +499,7 @@ class TestUpdateDagParsingResults:
             session.add(dr1)
             session.commit()
 
-        update_dag_parsing_results_in_db([self.dag_to_lazy_serdag(dag)], {}, set(), session)
+        update_dag_parsing_results_in_db("testing", None, [self.dag_to_lazy_serdag(dag)], {}, set(), session)
 
         orm_dag = session.get(DagModel, ("dag",))
 
@@ -505,14 +511,14 @@ class TestUpdateDagParsingResults:
 
         assert orm_dag.last_parsed_time == dt
 
-    def test_existing_dag_is_paused_upon_creation(self, session):
+    def test_existing_dag_is_paused_upon_creation(self, testing_dag_bundle, session):
         dag = DAG("dag_paused", schedule=None)
-        update_dag_parsing_results_in_db([self.dag_to_lazy_serdag(dag)], {}, set(), session)
+        update_dag_parsing_results_in_db("testing", None, [self.dag_to_lazy_serdag(dag)], {}, set(), session)
         orm_dag = session.get(DagModel, ("dag_paused",))
         assert orm_dag.is_paused is False
 
         dag = DAG("dag_paused", schedule=None, is_paused_upon_creation=True)
-        update_dag_parsing_results_in_db([self.dag_to_lazy_serdag(dag)], {}, set(), session)
+        update_dag_parsing_results_in_db("testing", None, [self.dag_to_lazy_serdag(dag)], {}, set(), session)
         # Since the dag existed before, it should not follow the pause flag upon creation
         orm_dag = session.get(DagModel, ("dag_paused",))
         assert orm_dag.is_paused is False

--- a/tests/dag_processing/test_collection.py
+++ b/tests/dag_processing/test_collection.py
@@ -522,3 +522,10 @@ class TestUpdateDagParsingResults:
         # Since the dag existed before, it should not follow the pause flag upon creation
         orm_dag = session.get(DagModel, ("dag_paused",))
         assert orm_dag.is_paused is False
+
+    def test_bundle_name_and_version_are_stored(self, testing_dag_bundle, session):
+        dag = DAG("mydag", schedule=None)
+        update_dag_parsing_results_in_db("testing", "1.0", [self.dag_to_lazy_serdag(dag)], {}, set(), session)
+        orm_dag = session.get(DagModel, "mydag")
+        assert orm_dag.bundle_name == "testing"
+        assert orm_dag.latest_bundle_version == "1.0"

--- a/tests/dag_processing/test_manager.py
+++ b/tests/dag_processing/test_manager.py
@@ -44,12 +44,13 @@ from uuid6 import uuid7
 from airflow.callbacks.callback_requests import DagCallbackRequest
 from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
 from airflow.dag_processing.manager import (
+    DagFilePath,
     DagFileProcessorAgent,
     DagFileProcessorManager,
     DagFileStat,
 )
 from airflow.dag_processing.processor import DagFileProcessorProcess
-from airflow.models import DagBag, DagModel, DbCallbackRequest
+from airflow.models import DAG, DagBag, DagModel, DbCallbackRequest
 from airflow.models.asset import TaskOutletAssetReference
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagcode import DagCode
@@ -78,6 +79,10 @@ TEST_DAG_FOLDER = pathlib.Path(__file__).parents[1].resolve() / "dags"
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 
 
+def _get_dag_file_paths(files: list[str]) -> list[DagFilePath]:
+    return [DagFilePath(bundle_name="testing", path=f) for f in files]
+
+
 class TestDagFileProcessorManager:
     @pytest.fixture(autouse=True)
     def _disable_examples(self):
@@ -102,7 +107,7 @@ class TestDagFileProcessorManager:
         clear_db_import_errors()
 
     def run_processor_manager_one_loop(self, manager: DagFileProcessorManager) -> None:
-        manager._run_parsing_loop()
+        manager.run()
 
     def mock_processor(self) -> DagFileProcessorProcess:
         proc = MagicMock()
@@ -124,49 +129,51 @@ class TestDagFileProcessorManager:
 
     @pytest.mark.usefixtures("clear_parse_import_errors")
     @conf_vars({("core", "load_examples"): "False"})
-    def test_remove_file_clears_import_error(self, tmp_path):
+    def test_remove_file_clears_import_error(self, tmp_path, configure_testing_dag_bundle):
         path_to_parse = tmp_path / "temp_dag.py"
 
         # Generate original import error
         path_to_parse.write_text("an invalid airflow DAG")
 
-        manager = DagFileProcessorManager(
-            dag_directory=path_to_parse.parent,
-            max_runs=1,
-            processor_timeout=365 * 86_400,
-        )
+        with configure_testing_dag_bundle(path_to_parse):
+            manager = DagFileProcessorManager(
+                max_runs=1,
+                processor_timeout=365 * 86_400,
+            )
 
-        with create_session() as session:
-            self.run_processor_manager_one_loop(manager)
+            with create_session() as session:
+                self.run_processor_manager_one_loop(manager)
 
-            import_errors = session.query(ParseImportError).all()
-            assert len(import_errors) == 1
+                import_errors = session.query(ParseImportError).all()
+                assert len(import_errors) == 1
 
-            path_to_parse.unlink()
+                path_to_parse.unlink()
 
-            # Rerun the parser once the dag file has been removed
-            self.run_processor_manager_one_loop(manager)
-            import_errors = session.query(ParseImportError).all()
+                # Rerun the parser once the dag file has been removed
+                self.run_processor_manager_one_loop(manager)
+                import_errors = session.query(ParseImportError).all()
 
-            assert len(import_errors) == 0
-            session.rollback()
+                assert len(import_errors) == 0
+                session.rollback()
 
     @conf_vars({("core", "load_examples"): "False"})
     def test_max_runs_when_no_files(self, tmp_path):
-        manager = DagFileProcessorManager(dag_directory=tmp_path, max_runs=1)
+        with conf_vars({("core", "dags_folder"): str(tmp_path)}):
+            manager = DagFileProcessorManager(max_runs=1)
+            self.run_processor_manager_one_loop(manager)
 
-        self.run_processor_manager_one_loop(manager)
+        # TODO: AIP-66 no asserts?
 
     def test_start_new_processes_with_same_filepath(self):
         """
         Test that when a processor already exist with a filepath, a new processor won't be created
         with that filepath. The filepath will just be removed from the list.
         """
-        manager = DagFileProcessorManager(dag_directory="directory", max_runs=1)
+        manager = DagFileProcessorManager(max_runs=1)
 
-        file_1 = "file_1.py"
-        file_2 = "file_2.py"
-        file_3 = "file_3.py"
+        file_1 = DagFilePath(bundle_name="testing", path="file_1.py")
+        file_2 = DagFilePath(bundle_name="testing", path="file_2.py")
+        file_3 = DagFilePath(bundle_name="testing", path="file_3.py")
         manager._file_path_queue = deque([file_1, file_2, file_3])
 
         # Mock that only one processor exists. This processor runs with 'file_1'
@@ -185,49 +192,47 @@ class TestDagFileProcessorManager:
         assert deque([file_3]) == manager._file_path_queue
 
     def test_set_file_paths_when_processor_file_path_not_in_new_file_paths(self):
-        manager = DagFileProcessorManager(dag_directory="directory", max_runs=1)
+        """Ensure processors and file stats are removed when the file path is not in the new file paths"""
+        manager = DagFileProcessorManager(max_runs=1)
+        file = DagFilePath(bundle_name="testing", path="missing_file.txt")
 
-        mock_processor = MagicMock()
-        mock_processor.stop.side_effect = AttributeError("DagFileProcessor object has no attribute stop")
-        mock_processor.terminate.side_effect = None
-
-        manager._processors["missing_file.txt"] = mock_processor
-        manager._file_stats["missing_file.txt"] = DagFileStat()
+        manager._processors[file] = MagicMock()
+        manager._file_stats[file] = DagFileStat()
 
         manager.set_file_paths(["abc.txt"])
         assert manager._processors == {}
-        assert "missing_file.txt" not in manager._file_stats
+        assert file not in manager._file_stats
 
     def test_set_file_paths_when_processor_file_path_is_in_new_file_paths(self):
-        manager = DagFileProcessorManager(dag_directory="directory", max_runs=1)
-
+        manager = DagFileProcessorManager(max_runs=1)
+        file = DagFilePath(bundle_name="testing", path="abc.txt")
         mock_processor = MagicMock()
-        mock_processor.stop.side_effect = AttributeError("DagFileProcessor object has no attribute stop")
-        mock_processor.terminate.side_effect = None
 
-        manager._processors["abc.txt"] = mock_processor
+        manager._processors[file] = mock_processor
 
-        manager.set_file_paths(["abc.txt"])
-        assert manager._processors == {"abc.txt": mock_processor}
+        manager.set_file_paths([file])
+        assert manager._processors == {file: mock_processor}
 
     @conf_vars({("scheduler", "file_parsing_sort_mode"): "alphabetical"})
     def test_file_paths_in_queue_sorted_alphabetically(self):
         """Test dag files are sorted alphabetically"""
-        dag_files = ["file_3.py", "file_2.py", "file_4.py", "file_1.py"]
+        file_names = ["file_3.py", "file_2.py", "file_4.py", "file_1.py"]
+        dag_files = _get_dag_file_paths(file_names)
+        ordered_dag_files = _get_dag_file_paths(sorted(file_names))
 
-        manager = DagFileProcessorManager(dag_directory="directory", max_runs=1)
+        manager = DagFileProcessorManager(max_runs=1)
 
         manager.set_file_paths(dag_files)
         assert manager._file_path_queue == deque()
         manager.prepare_file_path_queue()
-        assert manager._file_path_queue == deque(["file_1.py", "file_2.py", "file_3.py", "file_4.py"])
+        assert manager._file_path_queue == deque(ordered_dag_files)
 
     @conf_vars({("scheduler", "file_parsing_sort_mode"): "random_seeded_by_host"})
     def test_file_paths_in_queue_sorted_random_seeded_by_host(self):
         """Test files are randomly sorted and seeded by host name"""
-        dag_files = ["file_3.py", "file_2.py", "file_4.py", "file_1.py"]
+        dag_files = _get_dag_file_paths(["file_3.py", "file_2.py", "file_4.py", "file_1.py"])
 
-        manager = DagFileProcessorManager(dag_directory="directory", max_runs=1)
+        manager = DagFileProcessorManager(max_runs=1)
 
         manager.set_file_paths(dag_files)
         assert manager._file_path_queue == deque()
@@ -247,45 +252,50 @@ class TestDagFileProcessorManager:
     def test_file_paths_in_queue_sorted_by_modified_time(self, mock_getmtime):
         """Test files are sorted by modified time"""
         paths_with_mtime = {"file_3.py": 3.0, "file_2.py": 2.0, "file_4.py": 5.0, "file_1.py": 4.0}
-        dag_files = list(paths_with_mtime.keys())
+        dag_files = _get_dag_file_paths(paths_with_mtime.keys())
         mock_getmtime.side_effect = list(paths_with_mtime.values())
 
-        manager = DagFileProcessorManager(dag_directory="directory", max_runs=1)
+        manager = DagFileProcessorManager(max_runs=1)
 
         manager.set_file_paths(dag_files)
         assert manager._file_path_queue == deque()
         manager.prepare_file_path_queue()
-        assert manager._file_path_queue == deque(["file_4.py", "file_1.py", "file_3.py", "file_2.py"])
+        ordered_files = _get_dag_file_paths(["file_4.py", "file_1.py", "file_3.py", "file_2.py"])
+        assert manager._file_path_queue == deque(ordered_files)
 
     @conf_vars({("scheduler", "file_parsing_sort_mode"): "modified_time"})
     @mock.patch("airflow.utils.file.os.path.getmtime")
     def test_file_paths_in_queue_excludes_missing_file(self, mock_getmtime):
         """Check that a file is not enqueued for processing if it has been deleted"""
-        dag_files = ["file_3.py", "file_2.py", "file_4.py"]
+        dag_files = _get_dag_file_paths(["file_3.py", "file_2.py", "file_4.py"])
         mock_getmtime.side_effect = [1.0, 2.0, FileNotFoundError()]
 
-        manager = DagFileProcessorManager(dag_directory="directory", max_runs=1)
+        manager = DagFileProcessorManager(max_runs=1)
 
         manager.set_file_paths(dag_files)
         manager.prepare_file_path_queue()
-        assert manager._file_path_queue == deque(["file_2.py", "file_3.py"])
+
+        ordered_files = _get_dag_file_paths(["file_2.py", "file_3.py"])
+        assert manager._file_path_queue == deque(ordered_files)
 
     @conf_vars({("scheduler", "file_parsing_sort_mode"): "modified_time"})
     @mock.patch("airflow.utils.file.os.path.getmtime")
     def test_add_new_file_to_parsing_queue(self, mock_getmtime):
         """Check that new file is added to parsing queue"""
-        dag_files = ["file_1.py", "file_2.py", "file_3.py"]
+        dag_files = _get_dag_file_paths(["file_1.py", "file_2.py", "file_3.py"])
         mock_getmtime.side_effect = [1.0, 2.0, 3.0]
 
-        manager = DagFileProcessorManager(dag_directory="directory", max_runs=1)
+        manager = DagFileProcessorManager(max_runs=1)
 
         manager.set_file_paths(dag_files)
         manager.prepare_file_path_queue()
-        assert manager._file_path_queue == deque(["file_3.py", "file_2.py", "file_1.py"])
+        ordered_files = _get_dag_file_paths(["file_3.py", "file_2.py", "file_1.py"])
+        assert manager._file_path_queue == deque(ordered_files)
 
-        manager.set_file_paths([*dag_files, "file_4.py"])
+        manager.set_file_paths([*dag_files, DagFilePath(bundle_name="testing", path="file_4.py")])
         manager.add_new_file_path_to_queue()
-        assert manager._file_path_queue == deque(["file_4.py", "file_3.py", "file_2.py", "file_1.py"])
+        ordered_files = _get_dag_file_paths(["file_4.py", "file_3.py", "file_2.py", "file_1.py"])
+        assert manager._file_path_queue == deque(ordered_files)
 
     @conf_vars({("scheduler", "file_parsing_sort_mode"): "modified_time"})
     @mock.patch("airflow.utils.file.os.path.getmtime")
@@ -295,15 +305,16 @@ class TestDagFileProcessorManager:
         """
         freezed_base_time = timezone.datetime(2020, 1, 5, 0, 0, 0)
         initial_file_1_mtime = (freezed_base_time - timedelta(minutes=5)).timestamp()
-        dag_files = ["file_1.py"]
+        dag_file = DagFilePath(bundle_name="testing", path="file_1.py")
+        dag_files = [dag_file]
         mock_getmtime.side_effect = [initial_file_1_mtime]
 
-        manager = DagFileProcessorManager(dag_directory="directory", max_runs=3)
+        manager = DagFileProcessorManager(max_runs=3)
 
         # let's say the DAG was just parsed 10 seconds before the Freezed time
         last_finish_time = freezed_base_time - timedelta(seconds=10)
         manager._file_stats = {
-            "file_1.py": DagFileStat(1, 0, last_finish_time, 1.0, 1, 1),
+            dag_file: DagFileStat(1, 0, last_finish_time, 1.0, 1, 1),
         }
         with time_machine.travel(freezed_base_time):
             manager.set_file_paths(dag_files)
@@ -323,13 +334,14 @@ class TestDagFileProcessorManager:
             mock_getmtime.side_effect = [file_1_new_mtime_ts]
             manager.prepare_file_path_queue()
             # Check that file is added to the queue even though file was just recently passed
-            assert manager._file_path_queue == deque(["file_1.py"])
+            assert manager._file_path_queue == deque(dag_files)
             assert last_finish_time < file_1_new_mtime
             assert (
                 manager._file_process_interval
-                > (freezed_base_time - manager._file_stats["file_1.py"].last_finish_time).total_seconds()
+                > (freezed_base_time - manager._file_stats[dag_file].last_finish_time).total_seconds()
             )
 
+    @pytest.mark.skip("AIP-66: parsing requests are not bundle aware yet")
     def test_file_paths_in_queue_sorted_by_priority(self):
         from airflow.models.dagbag import DagPriorityParsingRequest
 
@@ -351,25 +363,27 @@ class TestDagFileProcessorManager:
             parsing_request_after = session2.query(DagPriorityParsingRequest).get(parsing_request.id)
         assert parsing_request_after is None
 
-    def test_scan_stale_dags(self):
+    def test_scan_stale_dags(self, testing_dag_bundle):
         """
         Ensure that DAGs are marked inactive when the file is parsed but the
         DagModel.last_parsed_time is not updated.
         """
         manager = DagFileProcessorManager(
-            dag_directory="directory",
             max_runs=1,
             processor_timeout=10 * 60,
         )
 
-        test_dag_path = str(TEST_DAG_FOLDER / "test_example_bash_operator.py")
-        dagbag = DagBag(test_dag_path, read_dags_from_db=False, include_examples=False)
+        test_dag_path = DagFilePath(
+            bundle_name="testing",
+            path=str(TEST_DAG_FOLDER / "test_example_bash_operator.py"),
+        )
+        dagbag = DagBag(test_dag_path.path, read_dags_from_db=False, include_examples=False)
 
         with create_session() as session:
             # Add stale DAG to the DB
             dag = dagbag.get_dag("test_example_bash_operator")
             dag.last_parsed_time = timezone.utcnow()
-            dag.sync_to_db()
+            DAG.bulk_write_to_db("testing", None, [dag])
             SerializedDagModel.write_dag(dag)
 
             # Add DAG to the file_parsing_stats
@@ -386,7 +400,7 @@ class TestDagFileProcessorManager:
 
             active_dag_count = (
                 session.query(func.count(DagModel.dag_id))
-                .filter(DagModel.is_active, DagModel.fileloc == test_dag_path)
+                .filter(DagModel.is_active, DagModel.fileloc == test_dag_path.path)
                 .scalar()
             )
             assert active_dag_count == 1
@@ -395,7 +409,7 @@ class TestDagFileProcessorManager:
 
             active_dag_count = (
                 session.query(func.count(DagModel.dag_id))
-                .filter(DagModel.is_active, DagModel.fileloc == test_dag_path)
+                .filter(DagModel.is_active, DagModel.fileloc == test_dag_path.path)
                 .scalar()
             )
             assert active_dag_count == 0
@@ -410,11 +424,11 @@ class TestDagFileProcessorManager:
             assert serialized_dag_count == 1
 
     def test_kill_timed_out_processors_kill(self):
-        manager = DagFileProcessorManager(dag_directory="directory", max_runs=1, processor_timeout=5)
+        manager = DagFileProcessorManager(max_runs=1, processor_timeout=5)
 
         processor = self.mock_processor()
         processor._process.create_time.return_value = timezone.make_aware(datetime.min).timestamp()
-        manager._processors = {"abc.txt": processor}
+        manager._processors = {DagFilePath(bundle_name="testing", path="abc.txt"): processor}
         with mock.patch.object(type(processor), "kill") as mock_kill:
             manager._kill_timed_out_processors()
         mock_kill.assert_called_once_with(signal.SIGKILL)
@@ -422,14 +436,13 @@ class TestDagFileProcessorManager:
 
     def test_kill_timed_out_processors_no_kill(self):
         manager = DagFileProcessorManager(
-            dag_directory=TEST_DAG_FOLDER,
             max_runs=1,
             processor_timeout=5,
         )
 
         processor = self.mock_processor()
         processor._process.create_time.return_value = timezone.make_aware(datetime.max).timestamp()
-        manager._processors = {"abc.txt": processor}
+        manager._processors = {DagFilePath(bundle_name="testing", path="abc.txt"): processor}
         with mock.patch.object(type(processor), "kill") as mock_kill:
             manager._kill_timed_out_processors()
         mock_kill.assert_not_called()
@@ -472,7 +485,7 @@ class TestDagFileProcessorManager:
 
     @conf_vars({("core", "load_examples"): "False"})
     @pytest.mark.execution_timeout(10)
-    def test_dag_with_system_exit(self):
+    def test_dag_with_system_exit(self, configure_testing_dag_bundle):
         """
         Test to check that a DAG with a system.exit() doesn't break the scheduler.
         """
@@ -484,9 +497,9 @@ class TestDagFileProcessorManager:
         clear_db_dags()
         clear_db_serialized_dags()
 
-        manager = DagFileProcessorManager(dag_directory=dag_directory, max_runs=1)
-
-        manager._run_parsing_loop()
+        with configure_testing_dag_bundle(dag_directory):
+            manager = DagFileProcessorManager(max_runs=1)
+            manager.run()
 
         # Three files in folder should be processed
         assert sum(stat.run_count for stat in manager._file_stats.values()) == 3
@@ -496,7 +509,7 @@ class TestDagFileProcessorManager:
 
     @conf_vars({("core", "load_examples"): "False"})
     @pytest.mark.execution_timeout(30)
-    def test_pipe_full_deadlock(self):
+    def test_pipe_full_deadlock(self, configure_testing_dag_bundle):
         dag_filepath = TEST_DAG_FOLDER / "test_scheduler_dags.py"
 
         child_pipe, parent_pipe = multiprocessing.Pipe()
@@ -533,38 +546,43 @@ class TestDagFileProcessorManager:
 
         thread = threading.Thread(target=keep_pipe_full, args=(parent_pipe, exit_event))
 
-        manager = DagFileProcessorManager(
-            dag_directory=dag_filepath,
-            # A reasonable large number to ensure that we trigger the deadlock
-            max_runs=100,
-            processor_timeout=5,
-            signal_conn=child_pipe,
-            # Make it loop sub-processes quickly. Need to be non-zero to exercise the bug, else it finishes
-            # too quickly
-            file_process_interval=0.01,
-        )
+        with configure_testing_dag_bundle(dag_filepath):
+            manager = DagFileProcessorManager(
+                # A reasonable large number to ensure that we trigger the deadlock
+                max_runs=100,
+                processor_timeout=5,
+                signal_conn=child_pipe,
+                # Make it loop sub-processes quickly. Need to be non-zero to exercise the bug, else it finishes
+                # too quickly
+                file_process_interval=0.01,
+            )
 
-        try:
-            thread.start()
+            try:
+                thread.start()
 
-            # If this completes without hanging, then the test is good!
-            with mock.patch.object(
-                DagFileProcessorProcess, "start", side_effect=lambda *args, **kwargs: self.mock_processor()
-            ):
-                manager.run()
-            exit_event.set()
-        finally:
-            logger.info("Closing pipes")
-            parent_pipe.close()
-            child_pipe.close()
-            logger.info("Closed pipes")
-            logger.info("Joining thread")
-            thread.join(timeout=1.0)
-            logger.info("Joined thread")
+                # If this completes without hanging, then the test is good!
+                with mock.patch.object(
+                    DagFileProcessorProcess,
+                    "start",
+                    side_effect=lambda *args, **kwargs: self.mock_processor(),
+                ):
+                    manager.run()
+                exit_event.set()
+            finally:
+                logger.info("Closing pipes")
+                parent_pipe.close()
+                child_pipe.close()
+                logger.info("Closed pipes")
+                logger.info("Joining thread")
+                thread.join(timeout=1.0)
+                logger.info("Joined thread")
 
     @conf_vars({("core", "load_examples"): "False"})
     @mock.patch("airflow.dag_processing.manager.Stats.timing")
-    def test_send_file_processing_statsd_timing(self, statsd_timing_mock, tmp_path):
+    @pytest.mark.skip("AIP-66: stats are not implemented yet")
+    def test_send_file_processing_statsd_timing(
+        self, statsd_timing_mock, tmp_path, configure_testing_dag_bundle
+    ):
         path_to_parse = tmp_path / "temp_dag.py"
         dag_code = textwrap.dedent(
             """
@@ -574,11 +592,11 @@ class TestDagFileProcessorManager:
         )
         path_to_parse.write_text(dag_code)
 
-        manager = DagFileProcessorManager(dag_directory=path_to_parse.parent, max_runs=1)
+        with configure_testing_dag_bundle(tmp_path):
+            manager = DagFileProcessorManager(max_runs=1)
+            self.run_processor_manager_one_loop(manager)
 
-        self.run_processor_manager_one_loop(manager)
         last_runtime = manager._file_stats[os.fspath(path_to_parse)].last_duration
-
         statsd_timing_mock.assert_has_calls(
             [
                 mock.call("dag_processing.last_duration.temp_dag", last_runtime),
@@ -587,17 +605,19 @@ class TestDagFileProcessorManager:
             any_order=True,
         )
 
-    def test_refresh_dags_dir_doesnt_delete_zipped_dags(self, tmp_path):
+    def test_refresh_dags_dir_doesnt_delete_zipped_dags(self, tmp_path, configure_testing_dag_bundle):
         """Test DagFileProcessorManager._refresh_dag_dir method"""
-        manager = DagFileProcessorManager(dag_directory=TEST_DAG_FOLDER, max_runs=1)
         dagbag = DagBag(dag_folder=tmp_path, include_examples=False)
         zipped_dag_path = os.path.join(TEST_DAGS_FOLDER, "test_zip.zip")
         dagbag.process_file(zipped_dag_path)
         dag = dagbag.get_dag("test_zip_dag")
-        dag.sync_to_db()
+        DAG.bulk_write_to_db("testing", None, [dag])
         SerializedDagModel.write_dag(dag)
-        manager.last_dag_dir_refresh_time = time.monotonic() - 10 * 60
-        manager._refresh_dag_dir()
+
+        with configure_testing_dag_bundle(zipped_dag_path):
+            manager = DagFileProcessorManager(max_runs=1)
+            manager.run()
+
         # Assert dag not deleted in SDM
         assert SerializedDagModel.has_dag("test_zip_dag")
         # assert code not deleted
@@ -605,20 +625,23 @@ class TestDagFileProcessorManager:
         # assert dag still active
         assert dag.get_is_active()
 
-    def test_refresh_dags_dir_deactivates_deleted_zipped_dags(self, tmp_path):
+    def test_refresh_dags_dir_deactivates_deleted_zipped_dags(self, tmp_path, configure_testing_dag_bundle):
         """Test DagFileProcessorManager._refresh_dag_dir method"""
-        manager = DagFileProcessorManager(dag_directory=TEST_DAG_FOLDER, max_runs=1)
         dagbag = DagBag(dag_folder=tmp_path, include_examples=False)
         zipped_dag_path = os.path.join(TEST_DAGS_FOLDER, "test_zip.zip")
         dagbag.process_file(zipped_dag_path)
         dag = dagbag.get_dag("test_zip_dag")
         dag.sync_to_db()
         SerializedDagModel.write_dag(dag)
-        manager.last_dag_dir_refresh_time = time.monotonic() - 10 * 60
+
+        # TODO: this test feels a bit fragile - pointing at the zip directly causes the test to fail
+        # TODO: jed look at this more closely - bagbad then process_file?!
 
         # Mock might_contain_dag to mimic deleting the python file from the zip
         with mock.patch("airflow.dag_processing.manager.might_contain_dag", return_value=False):
-            manager._refresh_dag_dir()
+            with configure_testing_dag_bundle(TEST_DAGS_FOLDER):
+                manager = DagFileProcessorManager(max_runs=1)
+                manager.run()
 
         # Deleting the python file should not delete SDM for versioning sake
         assert SerializedDagModel.has_dag("test_zip_dag")
@@ -635,7 +658,7 @@ class TestDagFileProcessorManager:
             ("scheduler", "standalone_dag_processor"): "True",
         }
     )
-    def test_fetch_callbacks_from_database(self, tmp_path):
+    def test_fetch_callbacks_from_database(self, tmp_path, configure_testing_dag_bundle):
         dag_filepath = TEST_DAG_FOLDER / "test_on_failure_callback_dag.py"
 
         callback1 = DagCallbackRequest(
@@ -655,13 +678,12 @@ class TestDagFileProcessorManager:
             session.add(DbCallbackRequest(callback=callback1, priority_weight=11))
             session.add(DbCallbackRequest(callback=callback2, priority_weight=10))
 
-        manager = DagFileProcessorManager(
-            dag_directory=os.fspath(tmp_path), max_runs=1, standalone_dag_processor=True
-        )
+        with configure_testing_dag_bundle(tmp_path):
+            manager = DagFileProcessorManager(max_runs=1, standalone_dag_processor=True)
 
-        with create_session() as session:
-            self.run_processor_manager_one_loop(manager)
-            assert session.query(DbCallbackRequest).count() == 0
+            with create_session() as session:
+                self.run_processor_manager_one_loop(manager)
+                assert session.query(DbCallbackRequest).count() == 0
 
     @conf_vars(
         {
@@ -670,7 +692,7 @@ class TestDagFileProcessorManager:
             ("core", "load_examples"): "False",
         }
     )
-    def test_fetch_callbacks_from_database_max_per_loop(self, tmp_path):
+    def test_fetch_callbacks_from_database_max_per_loop(self, tmp_path, configure_testing_dag_bundle):
         """Test DagFileProcessorManager._fetch_callbacks method"""
         dag_filepath = TEST_DAG_FOLDER / "test_on_failure_callback_dag.py"
 
@@ -684,15 +706,16 @@ class TestDagFileProcessorManager:
                 )
                 session.add(DbCallbackRequest(callback=callback, priority_weight=i))
 
-        manager = DagFileProcessorManager(dag_directory=tmp_path, max_runs=1)
+        with configure_testing_dag_bundle(tmp_path):
+            manager = DagFileProcessorManager(max_runs=1)
 
-        with create_session() as session:
-            self.run_processor_manager_one_loop(manager)
-            assert session.query(DbCallbackRequest).count() == 3
+            with create_session() as session:
+                self.run_processor_manager_one_loop(manager)
+                assert session.query(DbCallbackRequest).count() == 3
 
-        with create_session() as session:
-            self.run_processor_manager_one_loop(manager)
-            assert session.query(DbCallbackRequest).count() == 1
+            with create_session() as session:
+                self.run_processor_manager_one_loop(manager)
+                assert session.query(DbCallbackRequest).count() == 1
 
     @conf_vars(
         {
@@ -700,7 +723,7 @@ class TestDagFileProcessorManager:
             ("core", "load_examples"): "False",
         }
     )
-    def test_fetch_callbacks_from_database_not_standalone(self, tmp_path):
+    def test_fetch_callbacks_from_database_not_standalone(self, tmp_path, configure_testing_dag_bundle):
         dag_filepath = TEST_DAG_FOLDER / "test_on_failure_callback_dag.py"
 
         with create_session() as session:
@@ -712,22 +735,23 @@ class TestDagFileProcessorManager:
             )
             session.add(DbCallbackRequest(callback=callback, priority_weight=10))
 
-        manager = DagFileProcessorManager(dag_directory=tmp_path, max_runs=1)
-
-        self.run_processor_manager_one_loop(manager)
+        with configure_testing_dag_bundle(tmp_path):
+            manager = DagFileProcessorManager(max_runs=1)
+            self.run_processor_manager_one_loop(manager)
 
         # Verify no callbacks removed from database.
         with create_session() as session:
             assert session.query(DbCallbackRequest).count() == 1
 
+    @pytest.mark.skip("AIP-66: callbacks are not implemented yet")
     def test_callback_queue(self, tmp_path):
         # given
         manager = DagFileProcessorManager(
-            dag_directory=TEST_DAG_FOLDER,
             max_runs=1,
             processor_timeout=365 * 86_400,
         )
 
+        dag1_path = DagFilePath(bundle_name="testing", path="/green_eggs/ham/file1.py")
         dag1_req1 = DagCallbackRequest(
             full_filepath="/green_eggs/ham/file1.py",
             dag_id="dag1",
@@ -743,6 +767,7 @@ class TestDagFileProcessorManager:
             msg=None,
         )
 
+        dag2_path = DagFilePath(bundle_name="testing", path="/green_eggs/ham/file2.py")
         dag2_req1 = DagCallbackRequest(
             full_filepath="/green_eggs/ham/file2.py",
             dag_id="dag2",
@@ -756,7 +781,7 @@ class TestDagFileProcessorManager:
         manager._add_callback_to_queue(dag2_req1)
 
         # then - requests should be in manager's queue, with dag2 ahead of dag1 (because it was added last)
-        assert manager._file_path_queue == deque([dag2_req1.full_filepath, dag1_req1.full_filepath])
+        assert manager._file_path_queue == deque([dag2_path, dag1_path])
         assert set(manager._callback_to_execute.keys()) == {
             dag1_req1.full_filepath,
             dag2_req1.full_filepath,
@@ -787,18 +812,17 @@ class TestDagFileProcessorManager:
         # And removed from the queue
         assert dag1_req1.full_filepath not in manager._callback_to_execute
 
-    def test_dag_with_assets(self, session):
+    def test_dag_with_assets(self, session, configure_testing_dag_bundle):
         """'Integration' test to ensure that the assets get parsed and stored correctly for parsed dags."""
 
         test_dag_path = str(TEST_DAG_FOLDER / "test_assets.py")
 
-        manager = DagFileProcessorManager(
-            dag_directory=test_dag_path,
-            max_runs=1,
-            processor_timeout=365 * 86_400,
-        )
-
-        self.run_processor_manager_one_loop(manager)
+        with configure_testing_dag_bundle(test_dag_path):
+            manager = DagFileProcessorManager(
+                max_runs=1,
+                processor_timeout=365 * 86_400,
+            )
+            self.run_processor_manager_one_loop(manager)
 
         dag_model = session.get(DagModel, ("dag_with_skip_task"))
         assert dag_model.task_outlet_asset_references == [
@@ -815,14 +839,12 @@ class TestDagFileProcessorAgent:
     def test_launch_process(self):
         from airflow.configuration import conf
 
-        test_dag_path = TEST_DAG_FOLDER / "test_scheduler_dags.py"
-
         log_file_loc = conf.get("logging", "DAG_PROCESSOR_MANAGER_LOG_LOCATION")
         with suppress(OSError):
             os.remove(log_file_loc)
 
         # Starting dag processing with 0 max_runs to avoid redundant operations.
-        processor_agent = DagFileProcessorAgent(test_dag_path, 0, timedelta(days=365))
+        processor_agent = DagFileProcessorAgent(0, timedelta(days=365))
         processor_agent.start()
 
         processor_agent._process.join()
@@ -830,25 +852,25 @@ class TestDagFileProcessorAgent:
         assert os.path.isfile(log_file_loc)
 
     def test_get_callbacks_pipe(self):
-        processor_agent = DagFileProcessorAgent("", 1, timedelta(days=365))
+        processor_agent = DagFileProcessorAgent(1, timedelta(days=365))
         processor_agent._parent_signal_conn = Mock()
         retval = processor_agent.get_callbacks_pipe()
         assert retval == processor_agent._parent_signal_conn
 
     def test_get_callbacks_pipe_no_parent_signal_conn(self):
-        processor_agent = DagFileProcessorAgent("", 1, timedelta(days=365))
+        processor_agent = DagFileProcessorAgent(1, timedelta(days=365))
         processor_agent._parent_signal_conn = None
         with pytest.raises(ValueError, match="Process not started"):
             processor_agent.get_callbacks_pipe()
 
     def test_heartbeat_no_parent_signal_conn(self):
-        processor_agent = DagFileProcessorAgent("", 1, timedelta(days=365))
+        processor_agent = DagFileProcessorAgent(1, timedelta(days=365))
         processor_agent._parent_signal_conn = None
         with pytest.raises(ValueError, match="Process not started"):
             processor_agent.heartbeat()
 
     def test_heartbeat_poll_eof_error(self):
-        processor_agent = DagFileProcessorAgent("", 1, timedelta(days=365))
+        processor_agent = DagFileProcessorAgent(1, timedelta(days=365))
         processor_agent._parent_signal_conn = Mock()
         processor_agent._parent_signal_conn.poll.return_value = True
         processor_agent._parent_signal_conn.recv = Mock()
@@ -857,7 +879,7 @@ class TestDagFileProcessorAgent:
         assert ret_val is None
 
     def test_heartbeat_poll_connection_error(self):
-        processor_agent = DagFileProcessorAgent("", 1, timedelta(days=365))
+        processor_agent = DagFileProcessorAgent(1, timedelta(days=365))
         processor_agent._parent_signal_conn = Mock()
         processor_agent._parent_signal_conn.poll.return_value = True
         processor_agent._parent_signal_conn.recv = Mock()
@@ -866,7 +888,7 @@ class TestDagFileProcessorAgent:
         assert ret_val is None
 
     def test_heartbeat_poll_process_message(self):
-        processor_agent = DagFileProcessorAgent("", 1, timedelta(days=365))
+        processor_agent = DagFileProcessorAgent(1, timedelta(days=365))
         processor_agent._parent_signal_conn = Mock()
         processor_agent._parent_signal_conn.poll.side_effect = [True, False]
         processor_agent._parent_signal_conn.recv = Mock()
@@ -877,13 +899,13 @@ class TestDagFileProcessorAgent:
 
     def test_process_message_invalid_type(self):
         message = "xyz"
-        processor_agent = DagFileProcessorAgent("", 1, timedelta(days=365))
+        processor_agent = DagFileProcessorAgent(1, timedelta(days=365))
         with pytest.raises(RuntimeError, match="Unexpected message received of type str"):
             processor_agent._process_message(message)
 
     @mock.patch("airflow.utils.process_utils.reap_process_group")
     def test_heartbeat_manager_process_restart(self, mock_pg, monkeypatch):
-        processor_agent = DagFileProcessorAgent("", 1, timedelta(days=365))
+        processor_agent = DagFileProcessorAgent(1, timedelta(days=365))
         processor_agent._parent_signal_conn = Mock()
         processor_agent._process = MagicMock()
         monkeypatch.setattr(processor_agent._process, "pid", 1234)
@@ -899,7 +921,7 @@ class TestDagFileProcessorAgent:
     @mock.patch("time.monotonic")
     @mock.patch("airflow.dag_processing.manager.reap_process_group")
     def test_heartbeat_manager_process_reap(self, mock_pg, mock_time_monotonic, mock_stats):
-        processor_agent = DagFileProcessorAgent("", 1, timedelta(days=365))
+        processor_agent = DagFileProcessorAgent(1, timedelta(days=365))
         processor_agent._parent_signal_conn = Mock()
         processor_agent._process = Mock()
         processor_agent._process.pid = 12345
@@ -920,7 +942,7 @@ class TestDagFileProcessorAgent:
         processor_agent.start.assert_called()
 
     def test_heartbeat_manager_end_no_process(self):
-        processor_agent = DagFileProcessorAgent("", 1, timedelta(days=365))
+        processor_agent = DagFileProcessorAgent(1, timedelta(days=365))
         processor_agent._process = Mock()
         processor_agent._process.__bool__ = Mock(return_value=False)
         processor_agent._process.side_effect = [None]
@@ -931,26 +953,25 @@ class TestDagFileProcessorAgent:
         processor_agent._process.join.assert_not_called()
 
     @pytest.mark.execution_timeout(5)
-    def test_terminate(self, tmp_path):
-        processor_agent = DagFileProcessorAgent(tmp_path, -1, timedelta(days=365))
+    def test_terminate(self, tmp_path, configure_testing_dag_bundle):
+        with configure_testing_dag_bundle(tmp_path):
+            processor_agent = DagFileProcessorAgent(-1, timedelta(days=365))
 
-        processor_agent.start()
-        try:
-            processor_agent.terminate()
+            processor_agent.start()
+            try:
+                processor_agent.terminate()
 
-            processor_agent._process.join(timeout=1)
-            assert processor_agent._process.is_alive() is False
-            assert processor_agent._process.exitcode == 0
-        except Exception:
-            reap_process_group(processor_agent._process.pid, logger=logger)
-            raise
+                processor_agent._process.join(timeout=1)
+                assert processor_agent._process.is_alive() is False
+                assert processor_agent._process.exitcode == 0
+            except Exception:
+                reap_process_group(processor_agent._process.pid, logger=logger)
+                raise
 
     @conf_vars({("logging", "dag_processor_manager_log_stdout"): "True"})
     def test_log_to_stdout(self, capfd):
-        test_dag_path = TEST_DAG_FOLDER / "test_scheduler_dags.py"
-
         # Starting dag processing with 0 max_runs to avoid redundant operations.
-        processor_agent = DagFileProcessorAgent(test_dag_path, 0, timedelta(days=365))
+        processor_agent = DagFileProcessorAgent(0, timedelta(days=365))
         processor_agent.start()
 
         processor_agent._process.join()
@@ -961,10 +982,8 @@ class TestDagFileProcessorAgent:
 
     @conf_vars({("logging", "dag_processor_manager_log_stdout"): "False"})
     def test_not_log_to_stdout(self, capfd):
-        test_dag_path = TEST_DAG_FOLDER / "test_scheduler_dags.py"
-
         # Starting dag processing with 0 max_runs to avoid redundant operations.
-        processor_agent = DagFileProcessorAgent(test_dag_path, 0, timedelta(days=365))
+        processor_agent = DagFileProcessorAgent(0, timedelta(days=365))
         processor_agent.start()
 
         processor_agent._process.join()

--- a/tests/dag_processing/test_manager.py
+++ b/tests/dag_processing/test_manager.py
@@ -830,16 +830,22 @@ class TestDagFileProcessorManager:
         ]
 
     def test_bundles_are_refreshed(self):
+        """
+        Ensure bundles are refreshed by the manager, when necessary.
+
+        - refresh if the bundle hasn't been refreshed in the refresh_interval
+        - when the latest_version in the db doesn't match the version this parser knows about
+        """
         config = [
             {
                 "name": "bundleone",
                 "classpath": "airflow.dag_processing.bundles.local.LocalDagBundle",
-                "kwargs": {"local_folder": "/dev/null", "refresh_interval": 1},
+                "kwargs": {"local_folder": "/dev/null", "refresh_interval": 0},
             },
             {
                 "name": "bundletwo",
                 "classpath": "airflow.dag_processing.bundles.local.LocalDagBundle",
-                "kwargs": {"local_folder": "/dev/null", "refresh_interval": 1},
+                "kwargs": {"local_folder": "/dev/null", "refresh_interval": 300},
             },
         ]
 
@@ -882,7 +888,7 @@ class TestDagFileProcessorManager:
             {
                 "name": "mybundle",
                 "classpath": "airflow.dag_processing.bundles.local.LocalDagBundle",
-                "kwargs": {"local_folder": "/dev/null", "refresh_interval": 1},
+                "kwargs": {"local_folder": "/dev/null", "refresh_interval": 0},
             },
         ]
 

--- a/tests/models/test_dagcode.py
+++ b/tests/models/test_dagcode.py
@@ -41,8 +41,17 @@ pytestmark = pytest.mark.db_test
 
 def make_example_dags(module):
     """Loads DAGs from a module for test."""
+    # TODO: AIP-66 dedup with tests/models/test_serdag
+    from airflow.models.dagbundle import DagBundleModel
+    from airflow.utils.session import create_session
+
+    with create_session() as session:
+        if session.query(DagBundleModel).filter(DagBundleModel.name == "testing").count() == 0:
+            testing = DagBundleModel(name="testing")
+            session.add(testing)
+
     dagbag = DagBag(module.__path__[0])
-    DAG.bulk_write_to_db(dagbag.dags.values())
+    DAG.bulk_write_to_db("testing", None, dagbag.dags.values())
     return dagbag.dags
 
 

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -518,7 +518,7 @@ class TestDagRun:
         assert dag_run.state == DagRunState.SUCCESS
         mock_on_success.assert_called_once()
 
-    def test_dagrun_update_state_with_handle_callback_success(self, session):
+    def test_dagrun_update_state_with_handle_callback_success(self, testing_dag_bundle, session):
         def on_success_callable(context):
             assert context["dag_run"].dag_id == "test_dagrun_update_state_with_handle_callback_success"
 
@@ -528,7 +528,7 @@ class TestDagRun:
             start_date=datetime.datetime(2017, 1, 1),
             on_success_callback=on_success_callable,
         )
-        DAG.bulk_write_to_db(dags=[dag], session=session)
+        DAG.bulk_write_to_db("testing", None, dags=[dag], session=session)
 
         dag_task1 = EmptyOperator(task_id="test_state_succeeded1", dag=dag)
         dag_task2 = EmptyOperator(task_id="test_state_succeeded2", dag=dag)
@@ -556,7 +556,7 @@ class TestDagRun:
             msg="success",
         )
 
-    def test_dagrun_update_state_with_handle_callback_failure(self, session):
+    def test_dagrun_update_state_with_handle_callback_failure(self, testing_dag_bundle, session):
         def on_failure_callable(context):
             assert context["dag_run"].dag_id == "test_dagrun_update_state_with_handle_callback_failure"
 
@@ -566,7 +566,7 @@ class TestDagRun:
             start_date=datetime.datetime(2017, 1, 1),
             on_failure_callback=on_failure_callable,
         )
-        DAG.bulk_write_to_db(dags=[dag], session=session)
+        DAG.bulk_write_to_db("testing", None, dags=[dag], session=session)
 
         dag_task1 = EmptyOperator(task_id="test_state_succeeded1", dag=dag)
         dag_task2 = EmptyOperator(task_id="test_state_failed2", dag=dag)

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -80,7 +80,7 @@ def clean_db():
 
 
 @pytest.fixture
-def dag_zip_maker():
+def dag_zip_maker(testing_dag_bundle):
     class DagZipMaker:
         def __call__(self, *dag_files):
             self.__dag_files = [os.sep.join([TEST_DAGS_FOLDER.__str__(), dag_file]) for dag_file in dag_files]
@@ -98,7 +98,7 @@ def dag_zip_maker():
                 for dag_file in self.__dag_files:
                     zf.write(dag_file, os.path.basename(dag_file))
             dagbag = DagBag(dag_folder=self.__tmp_dir, include_examples=False)
-            dagbag.sync_to_db()
+            dagbag.sync_to_db("testing", None)
             return dagbag
 
         def __exit__(self, exc_type, exc_val, exc_tb):

--- a/tests/www/views/conftest.py
+++ b/tests/www/views/conftest.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import os
 from collections.abc import Generator
 from contextlib import contextmanager
 from typing import Any, NamedTuple
@@ -31,6 +32,7 @@ from airflow.www.app import create_app
 
 from tests_common.test_utils.api_connexion_utils import delete_user
 from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.db import parse_and_sync_to_db
 from tests_common.test_utils.decorators import dont_initialize_flask_app_submodules
 from tests_common.test_utils.www import (
     client_with_login,
@@ -47,8 +49,8 @@ def session():
 
 @pytest.fixture(autouse=True, scope="module")
 def examples_dag_bag(session):
-    DagBag(include_examples=True).sync_to_db()
-    dag_bag = DagBag(include_examples=True, read_dags_from_db=True)
+    parse_and_sync_to_db(os.devnull, include_examples=True)
+    dag_bag = DagBag(read_dags_from_db=True)
     session.commit()
     return dag_bag
 

--- a/tests/www/views/test_views_acl.py
+++ b/tests/www/views/test_views_acl.py
@@ -293,9 +293,9 @@ def test_dag_autocomplete_success(client_all_dags):
             "dag_display_name": None,
         },
         {"name": "example_setup_teardown_taskflow", "type": "dag", "dag_display_name": None},
-        {"name": "test_mapped_taskflow", "type": "dag", "dag_display_name": None},
         {"name": "tutorial_taskflow_api", "type": "dag", "dag_display_name": None},
         {"name": "tutorial_taskflow_api_virtualenv", "type": "dag", "dag_display_name": None},
+        {"name": "tutorial_taskflow_templates", "type": "dag", "dag_display_name": None},
     ]
 
     assert resp.json == expected

--- a/tests/www/views/test_views_decorators.py
+++ b/tests/www/views/test_views_decorators.py
@@ -17,6 +17,8 @@
 # under the License.
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from airflow.models import DagBag, Variable
@@ -24,7 +26,7 @@ from airflow.utils import timezone
 from airflow.utils.state import State
 from airflow.utils.types import DagRunType
 
-from tests_common.test_utils.db import clear_db_runs, clear_db_variables
+from tests_common.test_utils.db import clear_db_runs, clear_db_variables, parse_and_sync_to_db
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 from tests_common.test_utils.www import (
     _check_last_log,
@@ -42,8 +44,8 @@ EXAMPLE_DAG_DEFAULT_DATE = timezone.utcnow().replace(hour=0, minute=0, second=0,
 
 @pytest.fixture(scope="module")
 def dagbag():
-    DagBag(include_examples=True, read_dags_from_db=False).sync_to_db()
-    return DagBag(include_examples=True, read_dags_from_db=True)
+    parse_and_sync_to_db(os.devnull, include_examples=True)
+    return DagBag(read_dags_from_db=True)
 
 
 @pytest.fixture(scope="module")

--- a/tests/www/views/test_views_log.py
+++ b/tests/www/views/test_views_log.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import copy
 import logging
 import logging.config
+import os
 import pathlib
 import shutil
 import sys
@@ -127,7 +128,7 @@ def _reset_modules_after_every_test(backup_modules):
 
 
 @pytest.fixture(autouse=True)
-def dags(log_app, create_dummy_dag, session):
+def dags(log_app, create_dummy_dag, testing_dag_bundle, session):
     dag, _ = create_dummy_dag(
         dag_id=DAG_ID,
         task_id=TASK_ID,
@@ -143,10 +144,10 @@ def dags(log_app, create_dummy_dag, session):
         session=session,
     )
 
-    bag = DagBag(include_examples=False)
+    bag = DagBag(os.devnull, include_examples=False)
     bag.bag_dag(dag=dag)
     bag.bag_dag(dag=dag_removed)
-    bag.sync_to_db(session=session)
+    bag.sync_to_db("testing", None, session=session)
     log_app.dag_bag = bag
 
     yield dag, dag_removed

--- a/tests/www/views/test_views_tasks.py
+++ b/tests/www/views/test_views_tasks.py
@@ -597,7 +597,7 @@ class _ForceHeartbeatCeleryExecutor(CeleryExecutor):
 def test_delete_dag_button_for_dag_on_scheduler_only(admin_client, dag_maker):
     with dag_maker() as dag:
         EmptyOperator(task_id="task")
-    dag.sync_to_db()
+    dag_maker.sync_dagbag_to_db()
     # The delete-dag URL should be generated correctly
     test_dag_id = dag.dag_id
     resp = admin_client.get("/", follow_redirects=True)
@@ -606,12 +606,12 @@ def test_delete_dag_button_for_dag_on_scheduler_only(admin_client, dag_maker):
 
 
 @pytest.fixture
-def new_dag_to_delete():
+def new_dag_to_delete(testing_dag_bundle):
     dag = DAG(
         "new_dag_to_delete", is_paused_upon_creation=True, schedule="0 * * * *", start_date=DEFAULT_DATE
     )
     session = settings.Session()
-    dag.sync_to_db(session=session)
+    DAG.bulk_write_to_db("testing", None, [dag], session=session)
     return dag
 
 

--- a/tests_common/pytest_plugin.py
+++ b/tests_common/pytest_plugin.py
@@ -935,6 +935,15 @@ def dag_maker(request) -> Generator[DagMaker, None, None]:
                 **kwargs,
             )
 
+        def sync_dagbag_to_db(self):
+            from airflow.models.dagbundle import DagBundleModel
+
+            if self.session.query(DagBundleModel).filter(DagBundleModel.name == "dag_maker").count() == 0:
+                self.session.add(DagBundleModel(name="dag_maker"))
+                self.session.commit()
+
+            self.dagbag.sync_to_db("dag_maker", None)
+
         def __call__(
             self,
             dag_id="test_dag",

--- a/tests_common/pytest_plugin.py
+++ b/tests_common/pytest_plugin.py
@@ -936,6 +936,10 @@ def dag_maker(request) -> Generator[DagMaker, None, None]:
             )
 
         def sync_dagbag_to_db(self):
+            if not AIRFLOW_V_3_0_PLUS:
+                self.dagbag.sync_to_db()
+                return
+
             from airflow.models.dagbundle import DagBundleModel
 
             if self.session.query(DagBundleModel).filter(DagBundleModel.name == "dag_maker").count() == 0:

--- a/tests_common/test_utils/db.py
+++ b/tests_common/test_utils/db.py
@@ -72,7 +72,7 @@ def _bootstrap_dagbag():
         dagbag = DagBag()
         # Save DAGs in the ORM
         if AIRFLOW_V_3_0_PLUS:
-            dagbag.sync_to_db(bundle_name="dags_folder", bundle_version=None, session=session)
+            dagbag.sync_to_db(bundle_name="dags-folder", bundle_version=None, session=session)
         else:
             dagbag.sync_to_db(session=session)
 
@@ -120,7 +120,7 @@ def parse_and_sync_to_db(folder: Path | str, include_examples: bool = False):
 
         dagbag = DagBag(dag_folder=folder, include_examples=include_examples)
         if AIRFLOW_V_3_0_PLUS:
-            dagbag.sync_to_db("dags_folder", None, session)
+            dagbag.sync_to_db("dags-folder", None, session)
         else:
             dagbag.sync_to_db(session=session)  # type: ignore[call-arg]
         session.commit()

--- a/tests_common/test_utils/db.py
+++ b/tests_common/test_utils/db.py
@@ -17,6 +17,8 @@
 # under the License.
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from airflow.jobs.job import Job
 from airflow.models import (
     Connection,
@@ -51,15 +53,22 @@ from tests_common.test_utils.compat import (
 )
 from tests_common.test_utils.version_compat import AIRFLOW_V_2_10_PLUS, AIRFLOW_V_3_0_PLUS
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
 
 def _bootstrap_dagbag():
+    from airflow.dag_processing.bundles.manager import DagBundlesManager
     from airflow.models.dag import DAG
     from airflow.models.dagbag import DagBag
 
     with create_session() as session:
+        DagBundlesManager().sync_bundles_to_db(session=session)
+        session.commit()
+
         dagbag = DagBag()
         # Save DAGs in the ORM
-        dagbag.sync_to_db(session=session)
+        dagbag.sync_to_db(bundle_name="dags_folder", bundle_version=None, session=session)
 
         # Deactivate the unknown ones
         DAG.deactivate_unknown_dags(dagbag.dags.keys(), session=session)
@@ -90,6 +99,19 @@ def initial_db_init():
         from airflow.www.extensions.init_auth_manager import get_auth_manager
 
     get_auth_manager().init()
+
+
+def parse_and_sync_to_db(folder: Path | str, include_examples: bool = False):
+    from airflow.dag_processing.bundles.manager import DagBundlesManager
+    from airflow.models.dagbag import DagBag
+
+    with create_session() as session:
+        DagBundlesManager().sync_bundles_to_db(session=session)
+        session.commit()
+
+        dagbag = DagBag(dag_folder=folder, include_examples=include_examples)
+        dagbag.sync_to_db("dags_folder", None, session)
+        session.commit()
 
 
 def clear_db_runs():


### PR DESCRIPTION
This is #45371, which had to be reverted.

Let's start parsing DAG bundles! This moves us away from parsing a
single local directory to being able to parse many different bundles,
including optional support for versioning.

This is just the basics - it keeps the parsing loop largely untouched.
We still have a single list of "dag files" to parse, and queue of them.
However, instead of just a path, this list and queue now contain
`DagFilePath`s, which hold both a local path and the bundle its from.

There are a number of things that are not fully functional at this
stage, like versioned callbacks. These will be refactored later. There
is enough churn with the basics (particularly with the number of test
changes).