### PR TITLE
Ensure that WatchedSubprocess inheritors have consistent method signatures

### DIFF
--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -48,7 +48,11 @@ import airflow.models
 from airflow.callbacks.callback_requests import CallbackRequest, DagCallbackRequest, TaskCallbackRequest
 from airflow.configuration import conf
 from airflow.dag_processing.collection import update_dag_parsing_results_in_db
-from airflow.dag_processing.processor import DagFileParsingResult, DagFileProcessorProcess
+from airflow.dag_processing.processor import (
+    DagFileParsingResult,
+    DagFileProcessorProcess,
+    _parse_file_entrypoint,
+)
 from airflow.models.dag import DagModel
 from airflow.models.dagbag import DagPriorityParsingRequest
 from airflow.models.dagwarning import DagWarning
@@ -864,9 +868,15 @@ class DagFileProcessorManager:
 
         return DagFileProcessorProcess.start(
             id=id,
-            path=file_path,
-            callbacks=callback_to_execute_for_file,
-            selector=self.selector,
+            client=None,
+            constructor_kwargs=dict(
+                selector=self.selector,
+            ),
+            target=_parse_file_entrypoint,
+            on_child_started_kwargs=dict(
+                path=file_path,
+                callbacks=callback_to_execute_for_file,
+            ),
         )
 
     def _start_new_processes(self):

--- a/task_sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task_sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -347,9 +347,7 @@ class WatchedSubprocess:
             # around in the forked processes, especially things that might involve open files or sockets!
             del client
             del logger
-            for k in list(on_child_started_kwargs.keys()):
-                v = on_child_started_kwargs.pop(k)
-                del v
+            del on_child_started_kwargs
 
             # Run the child entrypoint
             _fork_main(child_stdin, child_stdout, child_stderr, child_logs.fileno(), target)

--- a/task_sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task_sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -286,7 +286,7 @@ def _fork_main(
 
 @attrs.define()
 class WatchedSubprocess:
-    id: UUID | None
+    id: UUID
     pid: int
 
     stdin: BinaryIO
@@ -319,7 +319,7 @@ class WatchedSubprocess:
     @classmethod
     def start(
         cls,
-        id: UUID | None,
+        id: UUID,
         client: Client | None,
         target: Callable[[], None] = _subprocess_main,
         logger: FilteringBoundLogger | None = None,


### PR DESCRIPTION
The `start` and `_on_child_started` methods have inconsistent signatures for the dag processor subclass.

This PR resolves that.

Why bother?  Well, I need to change the path handling a little bit to pass rel path and bundle info separately.  And we should get rid of the dags folder concept.  And when I tried to make these changes in the execution context, it broke dag parsing, because of this signature issue.
