### PR TITLE
fix: log action get the correct request body

### DIFF
--- a/airflow/www/decorators.py
+++ b/airflow/www/decorators.py
@@ -95,7 +95,7 @@ def action_logging(func: T | None = None, event: str | None = None) -> T | Calla
                     user_display = get_auth_manager().get_user_display_name()
 
                 isAPIRequest = request.blueprint == "/api/v1"
-                hasJsonBody = request.headers.get("content-type") == "application/json" and request.json
+                hasJsonBody = "application/json" in request.headers.get("content-type") and request.json
 
                 fields_skip_logging = {
                     "csrf_token",


### PR DESCRIPTION
### Apache Airflow version
main (development)

### How to reproduce
POST request with `content-type` as `application/json; charset=utf-8`
```
curl -X 'PATCH' \
  'https://you_host_com/api/v1/dags/dag_id/dagRuns/run_id' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json; charset=utf-8' \
  -d '{
  "state": "success"
}'
```

### Problem Description
When an API call is made, if the API has the `@action_logging` annotation, the event will be recorded in the db `log` table as follows
![image](https://github.com/user-attachments/assets/4f82db26-96e4-4085-a4e7-3b0f75f880c1)

### Related Code
Currently, whether the current request contains json_body is determined by judging whether `request.headers.get("content-type")` is equal to `application/json`. The relevant code is as follows
![image](https://github.com/user-attachments/assets/f67c9a58-44b7-4582-be66-f4b7ace23fbc)


But in many cases, the `content-type` contains other information besides `application/json`, such as `application/json; charset=utf-8`. In this case, the database will not record valid information.
![image](https://github.com/user-attachments/assets/a3637f3d-5536-415b-933b-d3b31752ab46)

### Solution
So the judgment condition should be changed to include