### PR TITLE
Reserve the 'example_dags' bundle name

### DIFF
--- a/airflow/dag_processing/bundles/manager.py
+++ b/airflow/dag_processing/bundles/manager.py
@@ -65,6 +65,12 @@ class DagBundlesManager(LoggingMixin):
                 " for section `dag_bundles` and key `backends`."
             )
 
+        if any(b["name"] == "example_dags" for b in backends):
+            raise AirflowConfigException(
+                "Bundle name 'example_dags' is a reserved name. Please choose another name for your bundle."
+                " Example DAGs can be enabled with the '[core] load_examples' config."
+            )
+
         # example dags!
         if conf.getboolean("core", "LOAD_EXAMPLES"):
             from airflow import example_dags

--- a/tests/dag_processing/bundles/test_dag_bundle_manager.py
+++ b/tests/dag_processing/bundles/test_dag_bundle_manager.py
@@ -181,3 +181,10 @@ def test_example_dags_bundle_added():
         manager = DagBundlesManager()
         manager.parse_config()
         assert "example_dags" not in manager._bundle_config
+
+
+def test_example_dags_name_is_reserved():
+    reserved_name_config = [{"name": "example_dags"}]
+    with conf_vars({("dag_bundles", "backends"): json.dumps(reserved_name_config)}):
+        with pytest.raises(AirflowConfigException, match="Bundle name 'example_dags' is a reserved name."):
+            DagBundlesManager().parse_config()


### PR DESCRIPTION
Users can enable example dags with config, so we will reserve the bundle name, as it's added automatically based on that config.