### PR TITLE
Remove classes from `typing_compat` that can be imported directly

### DIFF
--- a/airflow/api_connexion/schemas/provider_schema.py
+++ b/airflow/api_connexion/schemas/provider_schema.py
@@ -16,11 +16,9 @@
 # under the License.
 from __future__ import annotations
 
-from typing import NamedTuple
+from typing import NamedTuple, TypedDict
 
 from marshmallow import Schema, fields
-
-from airflow.typing_compat import TypedDict
 
 
 class ProviderSchema(Schema):

--- a/airflow/cli/commands/local_commands/info_command.py
+++ b/airflow/cli/commands/local_commands/info_command.py
@@ -25,6 +25,7 @@ import platform
 import subprocess
 import sys
 from enum import Enum
+from typing import Protocol
 from urllib.parse import urlsplit, urlunsplit
 
 import httpx
@@ -33,7 +34,6 @@ import tenacity
 from airflow import configuration
 from airflow.cli.simple_table import AirflowConsole
 from airflow.providers_manager import ProvidersManager
-from airflow.typing_compat import Protocol
 from airflow.utils.cli import suppress_logs_and_warning
 from airflow.utils.platform import getuser
 from airflow.utils.providers_configuration_loader import providers_configuration_loaded

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -22,16 +22,7 @@ import textwrap
 import warnings
 from collections.abc import Collection, Iterator, Mapping, Sequence
 from functools import cached_property, update_wrapper
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    ClassVar,
-    Generic,
-    TypeVar,
-    cast,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Generic, Protocol, TypeVar, cast, overload
 
 import attr
 import re2
@@ -55,7 +46,7 @@ from airflow.models.xcom_arg import XComArg
 from airflow.sdk.definitions._internal.contextmanager import DagContext, TaskGroupContext
 from airflow.sdk.definitions.asset import Asset
 from airflow.sdk.definitions.baseoperator import BaseOperator as TaskSDKBaseOperator
-from airflow.typing_compat import ParamSpec, Protocol
+from airflow.typing_compat import ParamSpec
 from airflow.utils import timezone
 from airflow.utils.context import KNOWN_CONTEXT_KEYS
 from airflow.utils.decorators import remove_task_decorator

--- a/airflow/hooks/base.py
+++ b/airflow/hooks/base.py
@@ -20,9 +20,8 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
-from airflow.typing_compat import Protocol
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 if TYPE_CHECKING:

--- a/airflow/jobs/triggerer_job_runner.py
+++ b/airflow/jobs/triggerer_job_runner.py
@@ -28,7 +28,7 @@ from collections import deque
 from contextlib import suppress
 from copy import copy
 from queue import SimpleQueue
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict
 
 from sqlalchemy import func, select
 
@@ -39,7 +39,6 @@ from airflow.models.trigger import Trigger
 from airflow.stats import Stats
 from airflow.traces.tracer import Trace, add_span
 from airflow.triggers.base import TriggerEvent
-from airflow.typing_compat import TypedDict
 from airflow.utils import timezone
 from airflow.utils.log.file_task_handler import FileTaskHandler
 from airflow.utils.log.logging_mixin import LoggingMixin

--- a/airflow/metrics/base_stats_logger.py
+++ b/airflow/metrics/base_stats_logger.py
@@ -17,10 +17,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 from airflow.metrics.protocols import Timer
-from airflow.typing_compat import Protocol
 
 if TYPE_CHECKING:
     from airflow.metrics.protocols import DeltaType, TimerProtocol

--- a/airflow/metrics/protocols.py
+++ b/airflow/metrics/protocols.py
@@ -19,9 +19,7 @@ from __future__ import annotations
 
 import datetime
 import time
-from typing import Union
-
-from airflow.typing_compat import Protocol
+from typing import Protocol, Union
 
 DeltaType = Union[int, float, datetime.timedelta]
 

--- a/airflow/models/crypto.py
+++ b/airflow/models/crypto.py
@@ -18,10 +18,10 @@
 from __future__ import annotations
 
 import logging
+from typing import Protocol
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
-from airflow.typing_compat import Protocol
 
 log = logging.getLogger(__name__)
 

--- a/airflow/models/pool.py
+++ b/airflow/models/pool.py
@@ -17,14 +17,13 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict
 
 from sqlalchemy import Boolean, Column, Integer, String, Text, func, select
 
 from airflow.exceptions import AirflowException, PoolNotFound
 from airflow.models.base import Base
 from airflow.ti_deps.dependencies_states import EXECUTION_STATES
-from airflow.typing_compat import TypedDict
 from airflow.utils.db import exists_query
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.sqlalchemy import with_row_locks

--- a/airflow/serialization/json_schema.py
+++ b/airflow/serialization/json_schema.py
@@ -21,11 +21,10 @@ from __future__ import annotations
 
 import pkgutil
 from collections.abc import Iterable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 from airflow.exceptions import AirflowException
 from airflow.settings import json
-from airflow.typing_compat import Protocol
 
 if TYPE_CHECKING:
     import jsonschema

--- a/airflow/timetables/base.py
+++ b/airflow/timetables/base.py
@@ -17,10 +17,9 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple, Protocol, runtime_checkable
 
 from airflow.sdk.definitions.asset import AssetUniqueKey, BaseAsset
-from airflow.typing_compat import Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from pendulum import DateTime

--- a/airflow/traces/tracer.py
+++ b/airflow/traces/tracer.py
@@ -20,10 +20,9 @@ from __future__ import annotations
 import logging
 import socket
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, Protocol
 
 from airflow.configuration import conf
-from airflow.typing_compat import Protocol
 
 log = logging.getLogger(__name__)
 

--- a/airflow/typing_compat.py
+++ b/airflow/typing_compat.py
@@ -22,16 +22,12 @@ from __future__ import annotations
 __all__ = [
     "Literal",
     "ParamSpec",
-    "Protocol",
     "Self",
     "TypeAlias",
-    "TypedDict",
     "TypeGuard",
-    "runtime_checkable",
 ]
 
 import sys
-from typing import Protocol, TypedDict, runtime_checkable
 
 # Literal from typing module has various issues in different Python versions, see:
 # - https://typing-extensions.readthedocs.io/en/latest/#Literal

--- a/airflow/utils/context.pyi
+++ b/airflow/utils/context.pyi
@@ -27,7 +27,7 @@
 from __future__ import annotations
 
 from collections.abc import Collection, Container, Iterable, Iterator, Mapping, Sequence
-from typing import Any, overload
+from typing import Any, TypedDict, overload
 
 from pendulum import DateTime
 from sqlalchemy.orm import Session
@@ -39,7 +39,6 @@ from airflow.models.dagrun import DagRun
 from airflow.models.param import ParamsDict
 from airflow.models.taskinstance import TaskInstance
 from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetRef, AssetUniqueKey, BaseAssetUniqueKey
-from airflow.typing_compat import TypedDict
 
 KNOWN_CONTEXT_KEYS: set[str]
 

--- a/airflow/utils/types.py
+++ b/airflow/utils/types.py
@@ -17,13 +17,14 @@
 from __future__ import annotations
 
 import enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict
 
 import airflow.sdk.definitions._internal.types
-from airflow.typing_compat import TypeAlias, TypedDict
 
 if TYPE_CHECKING:
     from datetime import datetime
+
+    from airflow.typing_compat import TypeAlias
 
 ArgNotSet: TypeAlias = airflow.sdk.definitions._internal.types.ArgNotSet
 

--- a/providers/src/airflow/providers/amazon/aws/hooks/batch_client.py
+++ b/providers/src/airflow/providers/amazon/aws/hooks/batch_client.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import itertools
 import random
 import time
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Callable, Protocol, runtime_checkable
 
 import botocore.client
 import botocore.exceptions
@@ -38,7 +38,6 @@ import botocore.waiter
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
-from airflow.typing_compat import Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from airflow.providers.amazon.aws.utils.task_log_fetcher import AwsTaskLogFetcher

--- a/providers/src/airflow/providers/amazon/aws/hooks/ecs.py
+++ b/providers/src/airflow/providers/amazon/aws/hooks/ecs.py
@@ -17,12 +17,11 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from airflow.providers.amazon.aws.exceptions import EcsOperatorError, EcsTaskFailToStart
 from airflow.providers.amazon.aws.hooks.base_aws import AwsGenericHook
 from airflow.providers.amazon.aws.utils import _StringCompareEnum
-from airflow.typing_compat import Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from botocore.waiter import Waiter

--- a/providers/src/airflow/providers/dbt/cloud/hooks/dbt.py
+++ b/providers/src/airflow/providers/dbt/cloud/hooks/dbt.py
@@ -24,7 +24,7 @@ from collections.abc import Sequence
 from enum import Enum
 from functools import cached_property, wraps
 from inspect import signature
-from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Callable, TypedDict, TypeVar, cast
 
 import aiohttp
 from asgiref.sync import sync_to_async
@@ -33,7 +33,6 @@ from requests.sessions import Session
 
 from airflow.exceptions import AirflowException
 from airflow.providers.http.hooks.http import HttpHook
-from airflow.typing_compat import TypedDict
 
 if TYPE_CHECKING:
     from requests.models import PreparedRequest, Response

--- a/providers/src/airflow/providers/openlineage/sqlparser.py
+++ b/providers/src/airflow/providers/openlineage/sqlparser.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Callable, TypedDict
 
 import sqlparse
 from attrs import define
@@ -32,7 +32,6 @@ from airflow.providers.openlineage.utils.sql import (
     get_table_schemas,
 )
 from airflow.providers.openlineage.utils.utils import should_use_external_connection
-from airflow.typing_compat import TypedDict
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 if TYPE_CHECKING:

--- a/providers/tests/amazon/aws/operators/test_eks.py
+++ b/providers/tests/amazon/aws/operators/test_eks.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, TypedDict
 from unittest import mock
 
 import pytest
@@ -40,7 +40,6 @@ from airflow.providers.amazon.aws.triggers.eks import (
     EksDeleteFargateProfileTrigger,
 )
 from airflow.providers.cncf.kubernetes.utils.pod_manager import OnFinishAction
-from airflow.typing_compat import TypedDict
 
 from providers.tests.amazon.aws.utils.eks_test_constants import (
     NODEROLE_ARN,


### PR DESCRIPTION
`Protocol`, `TypedDict` and `runtime_checkable` are directly importable from `typing` module for the Python versions supported by Airflow main and Providers.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
