### PR TITLE
Add missing newline on dbt Cloud conn string example

### DIFF
--- a/docs/apache-airflow-providers-dbt-cloud/connections.rst
+++ b/docs/apache-airflow-providers-dbt-cloud/connections.rst
@@ -116,6 +116,7 @@ For example, to add a connection with the connection ID of "dbt_cloud_default":
         export AIRFLOW_CONN_DBT_CLOUD_DEFAULT='dbt-cloud://:api_token@my-access-url'
 
     As an example, if my account is hosted in the Cell-based North America region and my access URL is ab123.us1.dbt.com, my conn string should be:
+
     .. code-block:: bash
 
         export AIRFLOW_CONN_DBT_CLOUD_DEFAULT='dbt-cloud://:api_token@ab123.us1.dbt.com'


### PR DESCRIPTION
The [Connecting to dbt Cloud](https://airflow.apache.org/docs/apache-airflow-providers-dbt-cloud/stable/connections.html) page has a code block which is not rendering correctly: 

<img width="878" alt="Screenshot 2025-01-13 at 12 03 44 PM" src="https://github.com/user-attachments/assets/0a0f9917-6abe-4b59-97bf-2eafcb8f7edb" />

This PR adds the missing newline so that it will be properly treated as a code block. 


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
