### PR TITLE
BigQueryCreateExternalTableOperator pass schema_fields through if only it set explicitly

### DIFF
--- a/providers/src/airflow/providers/google/cloud/operators/bigquery.py
+++ b/providers/src/airflow/providers/google/cloud/operators/bigquery.py
@@ -1722,7 +1722,7 @@ class BigQueryCreateExternalTableOperator(GoogleCloudBaseOperator):
             "encryptionConfiguration": self.encryption_configuration,
         }
 
-        if self.schema_fields:
+        if schema_fields:
             table_resource["schema"] = {"fields": schema_fields}
 
         # Save table as attribute for further use by OpenLineage

--- a/providers/src/airflow/providers/google/cloud/operators/bigquery.py
+++ b/providers/src/airflow/providers/google/cloud/operators/bigquery.py
@@ -1717,11 +1717,13 @@ class BigQueryCreateExternalTableOperator(GoogleCloudBaseOperator):
                 "tableId": table_id,
             },
             "labels": self.labels,
-            "schema": {"fields": schema_fields},
             "externalDataConfiguration": external_data_configuration,
             "location": self.location,
             "encryptionConfiguration": self.encryption_configuration,
         }
+
+        if self.schema_fields:
+            table_resource["schema"] = {"fields": schema_fields}
 
         # Save table as attribute for further use by OpenLineage
         self._table = bq_hook.create_empty_table(table_resource=table_resource)

--- a/providers/tests/google/cloud/operators/test_bigquery.py
+++ b/providers/tests/google/cloud/operators/test_bigquery.py
@@ -469,6 +469,25 @@ class TestBigQueryCreateExternalTableOperator:
             ),
         }
 
+    @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
+    def test_execute_with_schema_fields_not_set(self, mock_hook: MagicMock):
+        operator = BigQueryCreateExternalTableOperator(
+            task_id=TASK_ID,
+            bucket=TEST_GCS_BUCKET,
+            source_objects=TEST_GCS_CSV_DATA,
+            autodetect=True,
+            destination_project_dataset_table=f"{TEST_GCP_PROJECT_ID}.{TEST_DATASET}.{TEST_TABLE_ID}",
+        )
+
+        mock_hook.return_value.split_tablename.return_value = (
+            TEST_GCP_PROJECT_ID,
+            TEST_DATASET,
+            TEST_TABLE_ID,
+        )
+
+        operator.execute(context=MagicMock())
+        assert "schema" not in mock_hook.return_value.create_empty_table.call_args.kwargs["table_resource"]
+
 
 class TestBigQueryDeleteDatasetOperator:
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")

--- a/providers/tests/google/cloud/operators/test_bigquery.py
+++ b/providers/tests/google/cloud/operators/test_bigquery.py
@@ -469,25 +469,6 @@ class TestBigQueryCreateExternalTableOperator:
             ),
         }
 
-    @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
-    def test_execute_with_schema_fields_not_set(self, mock_hook: MagicMock):
-        operator = BigQueryCreateExternalTableOperator(
-            task_id=TASK_ID,
-            bucket=TEST_GCS_BUCKET,
-            source_objects=TEST_GCS_CSV_DATA,
-            autodetect=True,
-            destination_project_dataset_table=f"{TEST_GCP_PROJECT_ID}.{TEST_DATASET}.{TEST_TABLE_ID}",
-        )
-
-        mock_hook.return_value.split_tablename.return_value = (
-            TEST_GCP_PROJECT_ID,
-            TEST_DATASET,
-            TEST_TABLE_ID,
-        )
-
-        operator.execute(context=MagicMock())
-        assert "schema" not in mock_hook.return_value.create_empty_table.call_args.kwargs["table_resource"]
-
 
 class TestBigQueryDeleteDatasetOperator:
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")


### PR DESCRIPTION
Closes https://github.com/apache/airflow/issues/45512

This PR fixes the case when schema `autodetect` is used in `BigQueryCreateExternalTableOperator`. Currently, the table created in BigQuery can't be queried when empty `schema.fields` are passed to GCP. Simply omitting empty `schema.fields` to be passed in request body to GCP allows schema auto-detection flow to prosper.

This part of API is marked as deprecated, hence [unit tests](https://github.com/apache/airflow/commit/ffe09d62ed15bbc09aeba19ebd5d1b2a2cc8e0ed) I was able to come up with fail:
```
E   airflow.exceptions.AirflowProviderDeprecationWarning: Passing table parameters via keywords arguments will be deprecated. Please provide table definition using `table_resource` parameter.
```

I was able to run that test with `--disable-forbidden-warnings ` flag:
```
pytest --disable-forbidden-warnings providers/tests/google/cloud/operators/test_bigquery.py::TestBigQueryCreateExternalTableOperator
...

providers/tests/google/cloud/operators/test_bigquery.py::TestBigQueryCreateExternalTableOperator::test_execute_with_csv_format PASSED                                                                          [ 25%]
providers/tests/google/cloud/operators/test_bigquery.py::TestBigQueryCreateExternalTableOperator::test_execute_with_parquet_format PASSED                                                                      [ 50%]
providers/tests/google/cloud/operators/test_bigquery.py::TestBigQueryCreateExternalTableOperator::test_get_openlineage_facets_on_complete PASSED                                                               [ 75%]
providers/tests/google/cloud/operators/test_bigquery.py::TestBigQueryCreateExternalTableOperator::test_execute_with_schema_fields_not_set PASSED                                                               [100%]
...
============================================================================================ 4 passed, 1 warning in 1.83s ============================================================================================
```