### PR TITLE
Add missing methods in fab provider's AirflowAppBuilder class

### DIFF
--- a/providers/src/airflow/providers/fab/www/extensions/init_appbuilder.py
+++ b/providers/src/airflow/providers/fab/www/extensions/init_appbuilder.py
@@ -521,6 +521,12 @@ class AirflowAppBuilder:
                 log.exception(e)
                 log.error(LOGMSG_ERR_FAB_ADD_PERMISSION_VIEW, e)
 
+    def add_permissions(self, update_perms=False):
+        if self.update_perms or update_perms:
+            for baseview in self.baseviews:
+                self._add_permission(baseview, update_perms=update_perms)
+            self._add_menu_permissions(update_perms=update_perms)
+
     def _add_permissions_menu(self, name, update_perms=False):
         if self.update_perms or update_perms:
             try:


### PR DESCRIPTION
Adding missing method `add_permissions` in FAB's AirflowAppBuilder class which we started using in this [PR](https://github.com/apache/airflow/pull/45441/files).

more info - https://github.com/apache/airflow/pull/45441/files#r1910360144