### PR TITLE
Support `timeout` in BatchOperator

### DIFF
--- a/providers/src/airflow/providers/amazon/aws/operators/batch.py
+++ b/providers/src/airflow/providers/amazon/aws/operators/batch.py
@@ -95,6 +95,7 @@ class BatchOperator(BaseOperator):
         If it is an array job, only the logs of the first task will be printed.
     :param awslogs_fetch_interval: The interval with which cloudwatch logs are to be fetched, 30 sec.
     :param poll_interval: (Deferrable mode only) Time in seconds to wait between polling.
+    :param timeout: timeout configuration for SubmitJob.
 
     .. note::
         Any custom waiters must return a waiter for these calls:
@@ -184,6 +185,7 @@ class BatchOperator(BaseOperator):
         poll_interval: int = 30,
         awslogs_enabled: bool = False,
         awslogs_fetch_interval: timedelta = timedelta(seconds=30),
+        timeout: dict | None = None,
         **kwargs,
     ) -> None:
         BaseOperator.__init__(self, **kwargs)
@@ -208,6 +210,7 @@ class BatchOperator(BaseOperator):
         self.poll_interval = poll_interval
         self.awslogs_enabled = awslogs_enabled
         self.awslogs_fetch_interval = awslogs_fetch_interval
+        self.timeout = timeout
 
         # params for hook
         self.max_retries = max_retries
@@ -313,6 +316,7 @@ class BatchOperator(BaseOperator):
             "retryStrategy": self.retry_strategy,
             "shareIdentifier": self.share_identifier,
             "schedulingPriorityOverride": self.scheduling_priority_override,
+            "timeout": self.timeout,
         }
 
         try:

--- a/providers/src/airflow/providers/amazon/aws/operators/batch.py
+++ b/providers/src/airflow/providers/amazon/aws/operators/batch.py
@@ -95,7 +95,7 @@ class BatchOperator(BaseOperator):
         If it is an array job, only the logs of the first task will be printed.
     :param awslogs_fetch_interval: The interval with which cloudwatch logs are to be fetched, 30 sec.
     :param poll_interval: (Deferrable mode only) Time in seconds to wait between polling.
-    :param boto3_timeout: timeout configuration for SubmitJob.
+    :param boto3_timeout: Timeout configuration for SubmitJob.
 
     .. note::
         Any custom waiters must return a waiter for these calls:

--- a/providers/src/airflow/providers/amazon/aws/operators/batch.py
+++ b/providers/src/airflow/providers/amazon/aws/operators/batch.py
@@ -95,7 +95,7 @@ class BatchOperator(BaseOperator):
         If it is an array job, only the logs of the first task will be printed.
     :param awslogs_fetch_interval: The interval with which cloudwatch logs are to be fetched, 30 sec.
     :param poll_interval: (Deferrable mode only) Time in seconds to wait between polling.
-    :param timeout: timeout configuration for SubmitJob.
+    :param boto3_timeout: timeout configuration for SubmitJob.
 
     .. note::
         Any custom waiters must return a waiter for these calls:
@@ -185,7 +185,7 @@ class BatchOperator(BaseOperator):
         poll_interval: int = 30,
         awslogs_enabled: bool = False,
         awslogs_fetch_interval: timedelta = timedelta(seconds=30),
-        timeout: dict | None = None,
+        boto3_timeout: dict | None = None,
         **kwargs,
     ) -> None:
         BaseOperator.__init__(self, **kwargs)
@@ -210,7 +210,7 @@ class BatchOperator(BaseOperator):
         self.poll_interval = poll_interval
         self.awslogs_enabled = awslogs_enabled
         self.awslogs_fetch_interval = awslogs_fetch_interval
-        self.timeout = timeout
+        self.boto3_timeout = boto3_timeout
 
         # params for hook
         self.max_retries = max_retries
@@ -316,7 +316,7 @@ class BatchOperator(BaseOperator):
             "retryStrategy": self.retry_strategy,
             "shareIdentifier": self.share_identifier,
             "schedulingPriorityOverride": self.scheduling_priority_override,
-            "timeout": self.timeout,
+            "timeout": self.boto3_timeout,
         }
 
         try:

--- a/providers/tests/amazon/aws/operators/test_batch.py
+++ b/providers/tests/amazon/aws/operators/test_batch.py
@@ -70,7 +70,7 @@ class TestBatchOperator:
             aws_conn_id="airflow_test",
             region_name="eu-west-1",
             tags={},
-            timeout={"attemptDurationSeconds": 3600},
+            boto3_timeout={"attemptDurationSeconds": 3600},
         )
         self.client_mock = self.get_client_type_mock.return_value
         # We're mocking all actual AWS calls and don't need a connection. This
@@ -110,7 +110,7 @@ class TestBatchOperator:
         assert self.batch.hook.client == self.client_mock
         assert self.batch.tags == {}
         assert self.batch.wait_for_completion is True
-        assert self.batch.timeout == {"attemptDurationSeconds": 3600}
+        assert self.batch.boto3_timeout == {"attemptDurationSeconds": 3600}
 
         self.get_client_type_mock.assert_called_once_with(region_name="eu-west-1")
 
@@ -143,7 +143,7 @@ class TestBatchOperator:
         assert issubclass(type(batch_job.hook.client), botocore.client.BaseClient)
         assert batch_job.tags == {}
         assert batch_job.wait_for_completion is True
-        assert batch_job.timeout is None
+        assert batch_job.boto3_timeout is None
 
     def test_template_fields_overrides(self):
         assert self.batch.template_fields == (
@@ -184,7 +184,7 @@ class TestBatchOperator:
             parameters={},
             retryStrategy={"attempts": 1},
             tags={},
-            timeout={"attemptDurationSeconds": 3600},
+            boto3_timeout={"attemptDurationSeconds": 3600},
         )
 
         assert self.batch.job_id == JOB_ID
@@ -209,7 +209,7 @@ class TestBatchOperator:
             parameters={},
             retryStrategy={"attempts": 1},
             tags={},
-            timeout={"attemptDurationSeconds": 3600},
+            boto3_timeout={"attemptDurationSeconds": 3600},
         )
 
     @mock.patch.object(BatchClientHook, "get_job_description")
@@ -266,7 +266,7 @@ class TestBatchOperator:
             parameters={},
             retryStrategy={"attempts": 1},
             tags={},
-            timeout={"attemptDurationSeconds": 3600},
+            boto3_timeout={"attemptDurationSeconds": 3600},
         )
 
     @mock.patch.object(BatchClientHook, "get_job_description")
@@ -365,7 +365,7 @@ class TestBatchOperator:
             parameters={},
             retryStrategy={"attempts": 1},
             tags={},
-            timeout={"attemptDurationSeconds": 3600},
+            boto3_timeout={"attemptDurationSeconds": 3600},
         )
 
     @mock.patch.object(BatchClientHook, "check_job_success")

--- a/providers/tests/amazon/aws/operators/test_batch.py
+++ b/providers/tests/amazon/aws/operators/test_batch.py
@@ -70,6 +70,7 @@ class TestBatchOperator:
             aws_conn_id="airflow_test",
             region_name="eu-west-1",
             tags={},
+            timeout={"attemptDurationSeconds": 3600},
         )
         self.client_mock = self.get_client_type_mock.return_value
         # We're mocking all actual AWS calls and don't need a connection. This
@@ -109,6 +110,7 @@ class TestBatchOperator:
         assert self.batch.hook.client == self.client_mock
         assert self.batch.tags == {}
         assert self.batch.wait_for_completion is True
+        assert self.batch.timeout == {"attemptDurationSeconds": 3600}
 
         self.get_client_type_mock.assert_called_once_with(region_name="eu-west-1")
 
@@ -141,6 +143,7 @@ class TestBatchOperator:
         assert issubclass(type(batch_job.hook.client), botocore.client.BaseClient)
         assert batch_job.tags == {}
         assert batch_job.wait_for_completion is True
+        assert batch_job.timeout is None
 
     def test_template_fields_overrides(self):
         assert self.batch.template_fields == (

--- a/providers/tests/amazon/aws/operators/test_batch.py
+++ b/providers/tests/amazon/aws/operators/test_batch.py
@@ -184,6 +184,7 @@ class TestBatchOperator:
             parameters={},
             retryStrategy={"attempts": 1},
             tags={},
+            timeout={"attemptDurationSeconds": 3600},
         )
 
         assert self.batch.job_id == JOB_ID
@@ -208,6 +209,7 @@ class TestBatchOperator:
             parameters={},
             retryStrategy={"attempts": 1},
             tags={},
+            timeout={"attemptDurationSeconds": 3600},
         )
 
     @mock.patch.object(BatchClientHook, "get_job_description")
@@ -264,6 +266,7 @@ class TestBatchOperator:
             parameters={},
             retryStrategy={"attempts": 1},
             tags={},
+            timeout={"attemptDurationSeconds": 3600},
         )
 
     @mock.patch.object(BatchClientHook, "get_job_description")
@@ -362,6 +365,7 @@ class TestBatchOperator:
             parameters={},
             retryStrategy={"attempts": 1},
             tags={},
+            timeout={"attemptDurationSeconds": 3600},
         )
 
     @mock.patch.object(BatchClientHook, "check_job_success")

--- a/providers/tests/amazon/aws/operators/test_batch.py
+++ b/providers/tests/amazon/aws/operators/test_batch.py
@@ -70,7 +70,7 @@ class TestBatchOperator:
             aws_conn_id="airflow_test",
             region_name="eu-west-1",
             tags={},
-            timeout={"attemptDurationSeconds": 3600},
+            boto3_timeout={"attemptDurationSeconds": 3600},
         )
         self.client_mock = self.get_client_type_mock.return_value
         # We're mocking all actual AWS calls and don't need a connection. This
@@ -184,7 +184,7 @@ class TestBatchOperator:
             parameters={},
             retryStrategy={"attempts": 1},
             tags={},
-            boto3_timeout={"attemptDurationSeconds": 3600},
+            timeout={"attemptDurationSeconds": 3600},
         )
 
         assert self.batch.job_id == JOB_ID
@@ -209,7 +209,7 @@ class TestBatchOperator:
             parameters={},
             retryStrategy={"attempts": 1},
             tags={},
-            boto3_timeout={"attemptDurationSeconds": 3600},
+            timeout={"attemptDurationSeconds": 3600},
         )
 
     @mock.patch.object(BatchClientHook, "get_job_description")
@@ -266,7 +266,7 @@ class TestBatchOperator:
             parameters={},
             retryStrategy={"attempts": 1},
             tags={},
-            boto3_timeout={"attemptDurationSeconds": 3600},
+            timeout={"attemptDurationSeconds": 3600},
         )
 
     @mock.patch.object(BatchClientHook, "get_job_description")
@@ -365,7 +365,7 @@ class TestBatchOperator:
             parameters={},
             retryStrategy={"attempts": 1},
             tags={},
-            boto3_timeout={"attemptDurationSeconds": 3600},
+            timeout={"attemptDurationSeconds": 3600},
         )
 
     @mock.patch.object(BatchClientHook, "check_job_success")

--- a/providers/tests/amazon/aws/operators/test_batch.py
+++ b/providers/tests/amazon/aws/operators/test_batch.py
@@ -70,7 +70,7 @@ class TestBatchOperator:
             aws_conn_id="airflow_test",
             region_name="eu-west-1",
             tags={},
-            boto3_timeout={"attemptDurationSeconds": 3600},
+            timeout={"attemptDurationSeconds": 3600},
         )
         self.client_mock = self.get_client_type_mock.return_value
         # We're mocking all actual AWS calls and don't need a connection. This


### PR DESCRIPTION
When using a deferrable BatchOperator, it is possible to specify the `max_retries` and `poll_interval`, but this does not appear to terminate the job once the task times out.

Having the ability to specify the timeout and letting the job be terminated will allow us to enforce strict timeouts on critical pipelines running on Fargate via AWS Batch.

This PR adds support to allow specifying `timeout` in the BatchOperator constructor:\
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/batch/client/submit_job.html

> timeout (dict) –
>
> The timeout configuration for this SubmitJob operation. You can specify a timeout duration after which Batch terminates your jobs if they haven’t finished. If a job is terminated due to a timeout, it isn’t retried. The minimum value for the timeout is 60 seconds. This configuration overrides any timeout configuration specified in the job definition. For array jobs, child jobs have the same timeout configuration as the parent job. For more information, see [Job Timeouts](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/job_timeouts.html) in the Amazon Elastic Container Service Developer Guide.
>
> - attemptDurationSeconds (integer) –
>
>    The job timeout time (in seconds) that’s measured from the job attempt’s startedAt timestamp. After this time passes, Batch terminates your jobs if they aren’t finished. The minimum value for the timeout is 60 seconds.
>
>    For array jobs, the timeout applies to the child jobs, not to the parent array job.
>
>    For multi-node parallel (MNP) jobs, the timeout applies to the whole job, not to the individual nodes.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
