### PR TITLE
Fix `FileTaskHandler` only read from default executor

### DIFF
--- a/airflow/executors/executor_loader.py
+++ b/airflow/executors/executor_loader.py
@@ -231,6 +231,10 @@ class ExecutorLoader:
     @classmethod
     def lookup_executor_name_by_str(cls, executor_name_str: str) -> ExecutorName:
         # lookup the executor by alias first, if not check if we're given a module path
+        if not _classname_to_executors or not _module_to_executors or not _alias_to_executors:
+            # if we haven't loaded the executors yet, such as directly calling load_executor
+            cls._get_executor_names()
+
         if executor_name := _alias_to_executors.get(executor_name_str):
             return executor_name
         elif executor_name := _module_to_executors.get(executor_name_str):

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -24,7 +24,6 @@ import os
 from collections.abc import Iterable
 from contextlib import suppress
 from enum import Enum
-from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 from urllib.parse import urljoin
@@ -44,6 +43,7 @@ from airflow.utils.state import State, TaskInstanceState
 if TYPE_CHECKING:
     from pendulum import DateTime
 
+    from airflow.executors.base_executor import BaseExecutor
     from airflow.models.taskinstance import TaskInstance
     from airflow.models.taskinstancekey import TaskInstanceKey
 
@@ -314,10 +314,18 @@ class FileTaskHandler(logging.Handler):
     def _read_grouped_logs(self):
         return False
 
-    @cached_property
-    def _executor_get_task_log(self) -> Callable[[TaskInstance, int], tuple[list[str], list[str]]]:
-        """This cached property avoids loading executor repeatedly."""
-        executor = ExecutorLoader.get_default_executor()
+    def _get_executor_get_task_log(
+        self, ti: TaskInstance
+    ) -> Callable[[TaskInstance, int], tuple[list[str], list[str]]]:
+        """
+        Get the get_task_log method from executor of current task instance.
+
+        Since there might be multiple executors, so we need to get the executor of current task instance instead of getting from default executor.
+
+        :param ti: task instance object
+        :return: get_task_log method of the executor
+        """
+        executor: BaseExecutor = ExecutorLoader.load_executor(ti.executor)
         return executor.get_task_log
 
     def _read(
@@ -360,7 +368,8 @@ class FileTaskHandler(logging.Handler):
             messages_list.extend(remote_messages)
         has_k8s_exec_pod = False
         if ti.state == TaskInstanceState.RUNNING:
-            response = self._executor_get_task_log(ti, try_number)
+            executor_get_task_log = self._get_executor_get_task_log(ti)
+            response = executor_get_task_log(ti, try_number)
             if response:
                 executor_messages, executor_logs = response
             if executor_messages:

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -180,7 +180,7 @@ class FileTaskHandler(logging.Handler):
         "Operator inherits from empty operator and thus does not have logs"
     )
     executor_instances: dict[str, BaseExecutor] = {}
-    default_executor_key = "_default_executor"
+    DEFAULT_EXECUTOR_KEY = "_default_executor"
 
     def __init__(
         self,
@@ -327,12 +327,12 @@ class FileTaskHandler(logging.Handler):
         :param ti: task instance object
         :return: get_task_log method of the executor
         """
-        executor_name = ti.executor or self.default_executor_key
+        executor_name = ti.executor or self.DEFAULT_EXECUTOR_KEY
         executor = self.executor_instances.get(executor_name)
         if executor is not None:
             return executor.get_task_log
 
-        if executor_name == self.default_executor_key:
+        if executor_name == self.DEFAULT_EXECUTOR_KEY:
             self.executor_instances[executor_name] = ExecutorLoader.get_default_executor()
         else:
             self.executor_instances[executor_name] = ExecutorLoader.load_executor(executor_name)

--- a/providers/tests/cncf/kubernetes/log_handlers/test_log_handlers.py
+++ b/providers/tests/cncf/kubernetes/log_handlers/test_log_handlers.py
@@ -43,7 +43,6 @@ from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.compat import PythonOperator
 from tests_common.test_utils.config import conf_vars
-from tests_common.test_utils.executor_loader import clean_executor_loader
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 if AIRFLOW_V_3_0_PLUS:
@@ -75,9 +74,10 @@ class TestFileTaskLogHandler:
         "airflow.providers.cncf.kubernetes.executors.kubernetes_executor.KubernetesExecutor.get_task_log"
     )
     @pytest.mark.parametrize("state", [TaskInstanceState.RUNNING, TaskInstanceState.SUCCESS])
-    def test__read_for_k8s_executor(self, mock_k8s_get_task_log, create_task_instance, state):
+    def test__read_for_k8s_executor(
+        self, mock_k8s_get_task_log, create_task_instance, state, clean_executor_loader
+    ):
         """Test for k8s executor, the log is read from get_task_log method"""
-        clean_executor_loader()
         mock_k8s_get_task_log.return_value = ([], [])
         executor_name = "KubernetesExecutor"
         ti = create_task_instance(

--- a/providers/tests/cncf/kubernetes/log_handlers/test_log_handlers.py
+++ b/providers/tests/cncf/kubernetes/log_handlers/test_log_handlers.py
@@ -74,9 +74,8 @@ class TestFileTaskLogHandler:
         "airflow.providers.cncf.kubernetes.executors.kubernetes_executor.KubernetesExecutor.get_task_log"
     )
     @pytest.mark.parametrize("state", [TaskInstanceState.RUNNING, TaskInstanceState.SUCCESS])
-    def test__read_for_k8s_executor(
-        self, mock_k8s_get_task_log, create_task_instance, state, clean_executor_loader
-    ):
+    @pytest.mark.usefixtures("clean_executor_loader")
+    def test__read_for_k8s_executor(self, mock_k8s_get_task_log, create_task_instance, state):
         """Test for k8s executor, the log is read from get_task_log method"""
         mock_k8s_get_task_log.return_value = ([], [])
         executor_name = "KubernetesExecutor"

--- a/tests/executors/test_executor_loader.py
+++ b/tests/executors/test_executor_loader.py
@@ -343,6 +343,15 @@ class TestExecutorLoader:
             )
             assert isinstance(ExecutorLoader.load_executor(executor_loader._executor_names[0]), LocalExecutor)
 
+    @mock.patch(
+        "airflow.executors.executor_loader.ExecutorLoader._get_executor_names",
+        wraps=ExecutorLoader._get_executor_names,
+    )
+    def test_call_load_executor_method_without_init_executors(self, mock_get_executor_names):
+        with conf_vars({("core", "executor"): "LocalExecutor"}):
+            ExecutorLoader.load_executor("LocalExecutor")
+            mock_get_executor_names.assert_called_once()
+
     @mock.patch("airflow.providers.amazon.aws.executors.ecs.ecs_executor.AwsEcsExecutor", autospec=True)
     def test_load_custom_executor_with_classname(self, mock_executor):
         with conf_vars(

--- a/tests/ti_deps/deps/test_ready_to_reschedule_dep.py
+++ b/tests/ti_deps/deps/test_ready_to_reschedule_dep.py
@@ -49,9 +49,10 @@ def not_expected_tr_db_call():
         yield m
 
 
+@pytest.mark.usefixtures("clean_executor_loader")
 class TestNotInReschedulePeriodDep:
     @pytest.fixture(autouse=True)
-    def setup_test_cases(self, request, create_task_instance, clean_executor_loader):
+    def setup_test_cases(self, request, create_task_instance):
         db.clear_db_runs()
         db.clear_rendered_ti_fields()
 

--- a/tests/ti_deps/deps/test_ready_to_reschedule_dep.py
+++ b/tests/ti_deps/deps/test_ready_to_reschedule_dep.py
@@ -32,6 +32,7 @@ from airflow.utils.session import create_session
 from airflow.utils.state import State
 
 from tests_common.test_utils import db
+from tests_common.test_utils.executor_loader import clean_executor_loader
 
 pytestmark = pytest.mark.db_test
 
@@ -54,6 +55,7 @@ class TestNotInReschedulePeriodDep:
     def setup_test_cases(self, request, create_task_instance):
         db.clear_db_runs()
         db.clear_rendered_ti_fields()
+        clean_executor_loader()
 
         self.dag_id = f"dag_{slugify(request.cls.__name__)}"
         self.task_id = f"task_{slugify(request.node.name, max_length=40)}"
@@ -64,6 +66,7 @@ class TestNotInReschedulePeriodDep:
             yield
         db.clear_rendered_ti_fields()
         db.clear_db_runs()
+        clean_executor_loader()
 
     def _get_task_instance(self, state, *, map_index=-1):
         """Helper which create fake task_instance"""

--- a/tests/ti_deps/deps/test_ready_to_reschedule_dep.py
+++ b/tests/ti_deps/deps/test_ready_to_reschedule_dep.py
@@ -32,7 +32,6 @@ from airflow.utils.session import create_session
 from airflow.utils.state import State
 
 from tests_common.test_utils import db
-from tests_common.test_utils.executor_loader import clean_executor_loader
 
 pytestmark = pytest.mark.db_test
 
@@ -52,10 +51,9 @@ def not_expected_tr_db_call():
 
 class TestNotInReschedulePeriodDep:
     @pytest.fixture(autouse=True)
-    def setup_test_cases(self, request, create_task_instance):
+    def setup_test_cases(self, request, create_task_instance, clean_executor_loader):
         db.clear_db_runs()
         db.clear_rendered_ti_fields()
-        clean_executor_loader()
 
         self.dag_id = f"dag_{slugify(request.cls.__name__)}"
         self.task_id = f"task_{slugify(request.node.name, max_length=40)}"
@@ -66,7 +64,6 @@ class TestNotInReschedulePeriodDep:
             yield
         db.clear_rendered_ti_fields()
         db.clear_db_runs()
-        clean_executor_loader()
 
     def _get_task_instance(self, state, *, map_index=-1):
         """Helper which create fake task_instance"""

--- a/tests/utils/test_log_handlers.py
+++ b/tests/utils/test_log_handlers.py
@@ -55,7 +55,6 @@ from airflow.utils.timezone import datetime
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.config import conf_vars
-from tests_common.test_utils.executor_loader import clean_executor_loader
 
 pytestmark = pytest.mark.db_test
 
@@ -217,9 +216,13 @@ class TestFileTaskLogHandler:
         wraps=executor_loader.ExecutorLoader.get_default_executor,
     )
     def test_file_task_handler_with_multiple_executors(
-        self, mock_get_default_executor, mock_load_executor, executor_name, create_task_instance
+        self,
+        mock_get_default_executor,
+        mock_load_executor,
+        executor_name,
+        create_task_instance,
+        clean_executor_loader,
     ):
-        clean_executor_loader()
         executors_mapping = executor_loader.ExecutorLoader.executors
         default_executor_name = executor_loader.ExecutorLoader.get_default_executor_name()
         path_to_executor_class: str

--- a/tests/utils/test_log_handlers.py
+++ b/tests/utils/test_log_handlers.py
@@ -33,7 +33,7 @@ from pydantic.v1.utils import deep_update
 from requests.adapters import Response
 
 from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
-from airflow.executors import executor_loader
+from airflow.executors import executor_constants, executor_loader
 from airflow.jobs.job import Job
 from airflow.jobs.triggerer_job_runner import TriggererJobRunner
 from airflow.models.dagrun import DagRun
@@ -186,6 +186,66 @@ class TestFileTaskLogHandler:
 
         # Remove the generated tmp log file.
         os.remove(log_filename)
+
+    @pytest.mark.parametrize(
+        "executor_name",
+        [
+            (executor_constants.LOCAL_KUBERNETES_EXECUTOR),
+            (executor_constants.CELERY_KUBERNETES_EXECUTOR),
+            (executor_constants.KUBERNETES_EXECUTOR),
+        ],
+    )
+    @conf_vars(
+        {
+            ("core", "EXECUTOR"): ",".join(
+                [
+                    executor_constants.LOCAL_KUBERNETES_EXECUTOR,
+                    executor_constants.CELERY_KUBERNETES_EXECUTOR,
+                    executor_constants.KUBERNETES_EXECUTOR,
+                ]
+            ),
+        }
+    )
+    def test_file_task_handler_with_multiple_executors(self, executor_name, create_task_instance):
+        reload(executor_loader)
+        executors_mapping = executor_loader.ExecutorLoader.executors
+        path_to_executor_class = executors_mapping[executor_name]
+
+        with patch(f"{path_to_executor_class}.get_task_log") as mock_get_task_log:
+            mock_get_task_log.return_value = ([], [])
+            ti = create_task_instance(
+                dag_id="dag_for_testing_multiple_executors",
+                task_id="task_for_testing_multiple_executors",
+                run_type=DagRunType.SCHEDULED,
+                logical_date=DEFAULT_DATE,
+            )
+            ti.executor = executor_name
+            ti.state = TaskInstanceState.RUNNING
+            ti.try_number = 1
+            logger = ti.log
+            ti.log.disabled = False
+
+            file_handler = next(
+                (handler for handler in logger.handlers if handler.name == FILE_TASK_HANDLER), None
+            )
+            assert file_handler is not None
+
+            set_context(logger, ti)
+            assert file_handler.handler is not None
+            # We expect set_context generates a file locally.
+            log_filename = file_handler.handler.baseFilename
+            assert os.path.isfile(log_filename)
+            assert log_filename.endswith("1.log"), log_filename
+
+            ti.run(ignore_ti_state=True)
+
+            file_handler.flush()
+            file_handler.close()
+
+            assert hasattr(file_handler, "read")
+            file_handler.read(ti)
+            os.remove(log_filename)
+            mock_get_task_log.assert_called_once()
 
     def test_file_task_handler_running(self, dag_maker):
         def task_callable(ti):

--- a/tests/utils/test_log_handlers.py
+++ b/tests/utils/test_log_handlers.py
@@ -238,8 +238,8 @@ class TestFileTaskLogHandler:
             )
             if executor_name is not None:
                 ti.executor = executor_name
-            ti.state = TaskInstanceState.RUNNING
             ti.try_number = 1
+            ti.state = TaskInstanceState.RUNNING
             logger = ti.log
             ti.log.disabled = False
 
@@ -249,13 +249,13 @@ class TestFileTaskLogHandler:
             assert file_handler is not None
 
             set_context(logger, ti)
+            # clear executor_instances cache
+            file_handler.executor_instances = {}
             assert file_handler.handler is not None
             # We expect set_context generates a file locally.
             log_filename = file_handler.handler.baseFilename
             assert os.path.isfile(log_filename)
             assert log_filename.endswith("1.log"), log_filename
-
-            ti.run(ignore_ti_state=True)
 
             file_handler.flush()
             file_handler.close()

--- a/tests/utils/test_log_handlers.py
+++ b/tests/utils/test_log_handlers.py
@@ -55,6 +55,7 @@ from airflow.utils.timezone import datetime
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.executor_loader import clean_executor_loader
 
 pytestmark = pytest.mark.db_test
 
@@ -218,6 +219,7 @@ class TestFileTaskLogHandler:
     def test_file_task_handler_with_multiple_executors(
         self, mock_get_default_executor, mock_load_executor, executor_name, create_task_instance
     ):
+        clean_executor_loader()
         executors_mapping = executor_loader.ExecutorLoader.executors
         default_executor_name = executor_loader.ExecutorLoader.get_default_executor_name()
         path_to_executor_class: str

--- a/tests_common/pytest_plugin.py
+++ b/tests_common/pytest_plugin.py
@@ -1569,12 +1569,15 @@ def clean_dags_and_dagruns():
 
 @pytest.fixture
 def clean_executor_loader():
+    """Clean the executor_loader state, as it stores global variables in the module, causing side effects for some tests."""
+    from airflow.executors.executor_loader import ExecutorLoader
+
     from tests_common.test_utils.executor_loader import clean_executor_loader_module
 
-    """Clean the executor_loader state, as it stores global variables in the module, causing side effects for some tests."""
     clean_executor_loader_module()
     yield  # Test runs here
     clean_executor_loader_module()
+    ExecutorLoader.init_executors()
 
 
 @pytest.fixture(scope="session")

--- a/tests_common/pytest_plugin.py
+++ b/tests_common/pytest_plugin.py
@@ -1567,6 +1567,16 @@ def clean_dags_and_dagruns():
     clear_db_runs()
 
 
+@pytest.fixture
+def clean_executor_loader():
+    from tests_common.test_utils.executor_loader import clean_executor_loader_module
+
+    """Clean the executor_loader state, as it stores global variables in the module, causing side effects for some tests."""
+    clean_executor_loader_module()
+    yield  # Test runs here
+    clean_executor_loader_module()
+
+
 @pytest.fixture(scope="session")
 def app():
     from tests_common.test_utils.config import conf_vars

--- a/tests_common/test_utils/executor_loader.py
+++ b/tests_common/test_utils/executor_loader.py
@@ -1,0 +1,34 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import airflow.executors.executor_loader as executor_loader
+
+if TYPE_CHECKING:
+    from airflow.executors.executor_utils import ExecutorName
+
+
+def clean_executor_loader():
+    """Clean the executor loader state, as it stores global variables in the module, causing side effects for some tests."""
+    executor_loader._alias_to_executors: dict[str, ExecutorName] = {}
+    executor_loader._module_to_executors: dict[str, ExecutorName] = {}
+    executor_loader._team_id_to_executors: dict[str | None, ExecutorName] = {}
+    executor_loader._classname_to_executors: dict[str, ExecutorName] = {}
+    executor_loader._executor_names: list[ExecutorName] = []

--- a/tests_common/test_utils/executor_loader.py
+++ b/tests_common/test_utils/executor_loader.py
@@ -25,8 +25,8 @@ if TYPE_CHECKING:
     from airflow.executors.executor_utils import ExecutorName
 
 
-def clean_executor_loader():
-    """Clean the executor loader state, as it stores global variables in the module, causing side effects for some tests."""
+def clean_executor_loader_module():
+    """Clean the executor_loader state, as it stores global variables in the module, causing side effects for some tests."""
     executor_loader._alias_to_executors: dict[str, ExecutorName] = {}
     executor_loader._module_to_executors: dict[str, ExecutorName] = {}
     executor_loader._team_id_to_executors: dict[str | None, ExecutorName] = {}


### PR DESCRIPTION
closes: #45529

Also added `test_file_task_handler_with_multiple_executors` to verify that the correct `get_task_log` method of different executors is called.  

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
