### PR TITLE
New Optional dbt Cloud Job Operator Params

### DIFF
--- a/providers/dbt/cloud/docs/operators.rst
+++ b/providers/dbt/cloud/docs/operators.rst
@@ -82,6 +82,17 @@ via the ``additional_run_config`` dictionary.
     :start-after: [START howto_operator_dbt_cloud_run_job_async]
     :end-before: [END howto_operator_dbt_cloud_run_job_async]
 
+You can also trigger a dbt Cloud job without providing the ``job_id``. Instead, you can identify the job
+by providing the ``project_name``, ``environment_name``, and ``job_name``.
+Please note that it will only work if the above three parameters uniquely identify a job in your account
+(i.e. you cannot have two jobs with the same name in the same project and environment).
+
+.. exampleinclude:: /../../providers/tests/system/dbt/cloud/example_dbt_cloud.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_dbt_cloud_run_job_without_job_id]
+    :end-before: [END howto_operator_dbt_cloud_run_job_without_job_id]
+
 .. _howto/operator:DbtCloudJobRunSensor:
 
 Poll for status of a dbt Cloud Job run

--- a/providers/dbt/cloud/docs/operators.rst
+++ b/providers/dbt/cloud/docs/operators.rst
@@ -87,7 +87,7 @@ by providing the ``project_name``, ``environment_name``, and ``job_name``.
 Please note that it will only work if the above three parameters uniquely identify a job in your account
 (i.e. you cannot have two jobs with the same name in the same project and environment).
 
-.. exampleinclude:: /../../providers/tests/system/dbt/cloud/example_dbt_cloud.py
+.. exampleinclude:: /../../providers/dbt/cloud/tests/system/dbt/cloud/example_dbt_cloud.py
     :language: python
     :dedent: 4
     :start-after: [START howto_operator_dbt_cloud_run_job_without_job_id]

--- a/providers/dbt/cloud/src/airflow/providers/dbt/cloud/hooks/dbt.py
+++ b/providers/dbt/cloud/src/airflow/providers/dbt/cloud/hooks/dbt.py
@@ -482,11 +482,11 @@ class DbtCloudHook(HttpHook):
         :return: The details of a job.
         """
         # get project_id using project_name
-        projects = self.list_projects(name_contains=project_name, account_id=account_id)
-        # flatten & filter the list of responses
+        list_projects_responses = self.list_projects(name_contains=project_name, account_id=account_id)
+        # flatten & filter the list of responses to find the exact match
         projects = [
             project
-            for response in projects
+            for response in list_projects_responses
             for project in response.json()["data"]
             if project["name"] == project_name
         ]
@@ -495,13 +495,13 @@ class DbtCloudHook(HttpHook):
         project_id = projects[0]["id"]
 
         # get environment_id using project_id and environment_name
-        environments = self.list_environments(
+        list_environments_responses = self.list_environments(
             project_id=project_id, name_contains=environment_name, account_id=account_id
         )
-        # flatten & filter the list of responses
+        # flatten & filter the list of responses to find the exact match
         environments = [
             env
-            for response in environments
+            for response in list_environments_responses
             for env in response.json()["data"]
             if env["name"] == environment_name
         ]
@@ -518,7 +518,7 @@ class DbtCloudHook(HttpHook):
             name_contains=job_name,
             account_id=account_id,
         )
-        # flatten & filter the list of responses
+        # flatten & filter the list of responses to find the exact match
         jobs = [
             job
             for response in list_jobs_responses
@@ -527,7 +527,7 @@ class DbtCloudHook(HttpHook):
         ]
         if len(jobs) != 1:
             raise AirflowException(
-                f"Found {len(jobs)} jobs with name `{job_name}` in project `{project_name}` and environment `{environment_name}`."
+                f"Found {len(jobs)} jobs with name `{job_name}` in environment `{environment_name}` in project `{project_name}`."
             )
 
         return jobs[0]

--- a/providers/dbt/cloud/src/airflow/providers/dbt/cloud/hooks/dbt.py
+++ b/providers/dbt/cloud/src/airflow/providers/dbt/cloud/hooks/dbt.py
@@ -460,7 +460,7 @@ class DbtCloudHook(HttpHook):
     @fallback_to_default_account
     def get_job_by_name(
         self, project_name: str, environment_name: str, job_name: str, account_id: int | None = None
-    ) -> Response:
+    ) -> dict:
         """
         Retrieve metadata for a specific job by combination of project, environment, and job name.
 
@@ -470,7 +470,7 @@ class DbtCloudHook(HttpHook):
         :param environment_name: The name of a dbt Cloud environment.
         :param job_name: The name of a dbt Cloud job.
         :param account_id: Optional. The ID of a dbt Cloud account.
-        :return: The request response.
+        :return: The details of a job.
         """
         # get project_id using project_name
         projects = self.list_projects(name_contains=project_name, account_id=account_id)[0].json()["data"]
@@ -499,7 +499,7 @@ class DbtCloudHook(HttpHook):
                 f"Found {len(jobs)} jobs with name `{job_name}` in project `{project_name}` and environment `{environment_name}`."
             )
 
-        return list_jobs_responses[0]
+        return jobs[0]
 
     @fallback_to_default_account
     def trigger_job_run(

--- a/providers/dbt/cloud/src/airflow/providers/dbt/cloud/hooks/dbt.py
+++ b/providers/dbt/cloud/src/airflow/providers/dbt/cloud/hooks/dbt.py
@@ -477,7 +477,7 @@ class DbtCloudHook(HttpHook):
         """
         Retrieve metadata for a specific job by combination of project, environment, and job name.
 
-        Raises AirflowException if the job is not found or cannot be uniquely identified by provided parameters.
+        Raises DbtCloudResourceLookupError if the job is not found or cannot be uniquely identified by provided parameters.
 
         :param project_name: The name of a dbt Cloud project.
         :param environment_name: The name of a dbt Cloud environment.

--- a/providers/dbt/cloud/src/airflow/providers/dbt/cloud/operators/dbt.py
+++ b/providers/dbt/cloud/src/airflow/providers/dbt/cloud/operators/dbt.py
@@ -158,7 +158,7 @@ class DbtCloudRunJobOperator(BaseOperator):
                 project_name=self.project_name,
                 environment_name=self.environment_name,
                 job_name=self.job_name,
-            ).json()["data"]["id"]
+            )["id"]
 
         non_terminal_runs = None
         if self.reuse_existing_run:

--- a/providers/dbt/cloud/src/airflow/providers/dbt/cloud/operators/dbt.py
+++ b/providers/dbt/cloud/src/airflow/providers/dbt/cloud/operators/dbt.py
@@ -24,7 +24,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from airflow.configuration import conf
-from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator, BaseOperatorLink, XCom
 from airflow.providers.dbt.cloud.hooks.dbt import (
     DbtCloudHook,
@@ -150,7 +149,7 @@ class DbtCloudRunJobOperator(BaseOperator):
 
         if self.job_id is None:
             if not all([self.project_name, self.environment_name, self.job_name]):
-                raise AirflowException(
+                raise ValueError(
                     "Either job_id or project_name, environment_name, and job_name must be provided."
                 )
             self.job_id = self.hook.get_job_by_name(

--- a/providers/dbt/cloud/tests/provider_tests/dbt/cloud/hooks/test_dbt.py
+++ b/providers/dbt/cloud/tests/provider_tests/dbt/cloud/hooks/test_dbt.py
@@ -32,6 +32,7 @@ from airflow.providers.dbt.cloud.hooks.dbt import (
     DbtCloudHook,
     DbtCloudJobRunException,
     DbtCloudJobRunStatus,
+    DbtCloudResourceLookupError,
     TokenAuth,
     fallback_to_default_account,
 )
@@ -520,7 +521,7 @@ class TestDbtCloudHook:
         job_name,
     ):
         hook = DbtCloudHook(ACCOUNT_ID_CONN)
-        with pytest.raises(AirflowException, match="Found 0"):
+        with pytest.raises(DbtCloudResourceLookupError, match="Found 0"):
             hook.get_job_by_name(
                 project_name=project_name,
                 environment_name=environment_name,
@@ -572,7 +573,7 @@ class TestDbtCloudHook:
                 return_value=[mock_response_json(mock_list_projects_response)],
             ),
         ):
-            with pytest.raises(AirflowException, match=f"Found 2 {duplicated}"):
+            with pytest.raises(DbtCloudResourceLookupError, match=f"Found 2 {duplicated}"):
                 hook.get_job_by_name(
                     project_name=PROJECT_NAME,
                     environment_name=ENVIRONMENT_NAME,

--- a/providers/dbt/cloud/tests/provider_tests/dbt/cloud/hooks/test_dbt.py
+++ b/providers/dbt/cloud/tests/provider_tests/dbt/cloud/hooks/test_dbt.py
@@ -422,14 +422,14 @@ class TestDbtCloudHook:
         self, mock_list_projects, mock_list_environments, mock_list_jobs
     ):
         hook = DbtCloudHook(ACCOUNT_ID_CONN)
-        response = hook.get_job_by_name(
+        job_details = hook.get_job_by_name(
             project_name=PROJECT_NAME,
             environment_name=ENVIRONMENT_NAME,
             job_name=JOB_NAME,
             account_id=None,
         )
 
-        assert isinstance(response, Response)
+        assert job_details == DEFAULT_LIST_JOBS_RESPONSE["data"][0]
 
     @pytest.mark.parametrize(
         argnames="project_name, environment_name, job_name",

--- a/providers/dbt/cloud/tests/provider_tests/dbt/cloud/operators/test_dbt.py
+++ b/providers/dbt/cloud/tests/provider_tests/dbt/cloud/operators/test_dbt.py
@@ -22,7 +22,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from airflow.exceptions import TaskDeferred
+from airflow.exceptions import AirflowException, TaskDeferred
 from airflow.models import DAG, Connection
 from airflow.providers.dbt.cloud.hooks.dbt import DbtCloudHook, DbtCloudJobRunException, DbtCloudJobRunStatus
 from airflow.providers.dbt.cloud.operators.dbt import (
@@ -43,7 +43,11 @@ DEFAULT_ACCOUNT_ID = 11111
 ACCOUNT_ID = 22222
 TOKEN = "token"
 PROJECT_ID = 33333
+PROJECT_NAME = "project_name"
+ENVIRONMENT_ID = 44444
+ENVIRONMENT_NAME = "environment_name"
 JOB_ID = 4444
+JOB_NAME = "job_name"
 RUN_ID = 5555
 EXPECTED_JOB_RUN_OP_EXTRA_LINK = (
     "https://cloud.getdbt.com/#/accounts/{account_id}/projects/{project_id}/runs/{run_id}/"
@@ -74,6 +78,12 @@ JOB_RUN_ERROR_RESPONSE = {
             "status": DbtCloudJobRunStatus.ERROR.value,
         }
     ]
+}
+DEFAULT_ACCOUNT_JOB_RESPONSE = {
+    "data": {
+        "id": JOB_ID,
+        "account_id": DEFAULT_ACCOUNT_ID,
+    }
 }
 
 
@@ -199,6 +209,95 @@ class TestDbtCloudRunJobOperator:
         with pytest.raises(TaskDeferred) as exc:
             dbt_op.execute(MagicMock())
         assert isinstance(exc.value.trigger, DbtCloudRunJobTrigger), "Trigger is not a DbtCloudRunJobTrigger"
+
+    @patch(
+        "airflow.providers.dbt.cloud.hooks.dbt.DbtCloudHook.get_job_by_name",
+        return_value=mock_response_json(DEFAULT_ACCOUNT_JOB_RESPONSE),
+    )
+    @patch(
+        "airflow.providers.dbt.cloud.hooks.dbt.DbtCloudHook.get_job_run_status",
+        return_value=DbtCloudJobRunStatus.SUCCESS.value,
+    )
+    @patch("airflow.providers.dbt.cloud.hooks.dbt.DbtCloudHook.get_connection")
+    @patch(
+        "airflow.providers.dbt.cloud.hooks.dbt.DbtCloudHook.trigger_job_run",
+        return_value=mock_response_json(DEFAULT_ACCOUNT_JOB_RUN_RESPONSE),
+    )
+    def test_dbt_run_job_by_name(
+        self, mock_trigger_job_run, mock_dbt_hook, mock_job_run_status, mock_job_by_name
+    ):
+        """
+        Test alternative way to run a job by project,
+        environment and job name instead of job id.
+        """
+        dbt_op = DbtCloudRunJobOperator(
+            dbt_cloud_conn_id=ACCOUNT_ID_CONN,
+            task_id=TASK_ID,
+            project_name=PROJECT_NAME,
+            environment_name=ENVIRONMENT_NAME,
+            job_name=JOB_NAME,
+            check_interval=1,
+            timeout=3,
+            dag=self.dag,
+        )
+        dbt_op.execute(MagicMock())
+        mock_trigger_job_run.assert_called_once()
+
+    @pytest.mark.parametrize(
+        argnames="project_name, environment_name, job_name",
+        argvalues=[
+            (None, ENVIRONMENT_NAME, JOB_NAME),
+            (PROJECT_NAME, "", JOB_NAME),
+            (PROJECT_NAME, ENVIRONMENT_NAME, None),
+            ("", "", ""),
+        ],
+    )
+    @patch(
+        "airflow.providers.dbt.cloud.hooks.dbt.DbtCloudHook.get_job_by_name",
+        return_value=mock_response_json(DEFAULT_ACCOUNT_JOB_RESPONSE),
+    )
+    @patch(
+        "airflow.providers.dbt.cloud.hooks.dbt.DbtCloudHook.get_job_run_status",
+        return_value=DbtCloudJobRunStatus.SUCCESS.value,
+    )
+    @patch("airflow.providers.dbt.cloud.hooks.dbt.DbtCloudHook.get_connection")
+    @patch(
+        "airflow.providers.dbt.cloud.hooks.dbt.DbtCloudHook.trigger_job_run",
+        return_value=mock_response_json(DEFAULT_ACCOUNT_JOB_RUN_RESPONSE),
+    )
+    def test_dbt_run_job_by_incorrect_name_raises_exception(
+        self,
+        mock_trigger_job_run,
+        mock_dbt_hook,
+        mock_job_run_status,
+        mock_job_by_name,
+        project_name,
+        environment_name,
+        job_name,
+    ):
+        """
+        Test alternative way to run a job by project,
+        environment and job name instead of job id.
+
+        This test is to check if the operator raises an exception
+        when the project, environment or job name is missing.
+        """
+        dbt_op = DbtCloudRunJobOperator(
+            dbt_cloud_conn_id=ACCOUNT_ID_CONN,
+            task_id=TASK_ID,
+            project_name=project_name,
+            environment_name=environment_name,
+            job_name=job_name,
+            check_interval=1,
+            timeout=3,
+            dag=self.dag,
+        )
+        with pytest.raises(
+            AirflowException,
+            match="Either job_id or project_name, environment_name, and job_name must be provided.",
+        ):
+            dbt_op.execute(MagicMock())
+        mock_trigger_job_run.assert_not_called()
 
     @patch.object(
         DbtCloudHook, "trigger_job_run", return_value=mock_response_json(DEFAULT_ACCOUNT_JOB_RUN_RESPONSE)

--- a/providers/dbt/cloud/tests/provider_tests/dbt/cloud/operators/test_dbt.py
+++ b/providers/dbt/cloud/tests/provider_tests/dbt/cloud/operators/test_dbt.py
@@ -22,7 +22,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from airflow.exceptions import AirflowException, TaskDeferred
+from airflow.exceptions import TaskDeferred
 from airflow.models import DAG, Connection
 from airflow.providers.dbt.cloud.hooks.dbt import DbtCloudHook, DbtCloudJobRunException, DbtCloudJobRunStatus
 from airflow.providers.dbt.cloud.operators.dbt import (
@@ -293,7 +293,7 @@ class TestDbtCloudRunJobOperator:
             dag=self.dag,
         )
         with pytest.raises(
-            AirflowException,
+            ValueError,
             match="Either job_id or project_name, environment_name, and job_name must be provided.",
         ):
             dbt_op.execute(MagicMock())

--- a/providers/dbt/cloud/tests/system/dbt/cloud/example_dbt_cloud.py
+++ b/providers/dbt/cloud/tests/system/dbt/cloud/example_dbt_cloud.py
@@ -67,6 +67,17 @@ with DAG(
     )
     # [END howto_operator_dbt_cloud_run_job_async]
 
+    # [START howto_operator_dbt_cloud_run_job_without_job_id]
+    trigger_job_run3 = DbtCloudRunJobOperator(
+        task_id="trigger_job_run3",
+        project_name="my_dbt_project",
+        environment_name="prod",
+        job_name="my_dbt_job",
+        check_interval=10,
+        timeout=300,
+    )
+    # [END howto_operator_dbt_cloud_run_job_without_job_id]
+
     # [START howto_operator_dbt_cloud_run_job_sensor]
     job_run_sensor = DbtCloudJobRunSensor(
         task_id="job_run_sensor", run_id=trigger_job_run2.output, timeout=20


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
### Summary
Allow triggering dbt Cloud jobs using ``project_name``, ``environment_name``, and ``job_name`` instead of ``job_id``.

It is not a breaking change, but optional, alternative way of triggering a job - both options will work:

```py
# regular job run by id
trigger_job_run1 = DbtCloudRunJobOperator(
    task_id="trigger_job_run1",
    job_id=48617,
    check_interval=10,
    timeout=300,
)

# equivalent job run by name
trigger_job_run3 = DbtCloudRunJobOperator(
    task_id="trigger_job_run3",
    project_name="my_dbt_project",
    environment_name="prod",
    job_name="my_dbt_job",
    check_interval=10,
    timeout=300,
)
```

This is beneficial in dynamically configured environments (e.g. managed by Infrastructure as Code) when ``job_id`` is not known upfront (or may change over time) and therefore hardcoding it is not convenient.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
