### PR TITLE
dag run state change endpoints notify listeners about state change

### DIFF
--- a/tests/listeners/class_listener.py
+++ b/tests/listeners/class_listener.py
@@ -20,11 +20,54 @@ from __future__ import annotations
 from airflow.listeners import hookimpl
 from airflow.utils.state import DagRunState, TaskInstanceState
 
-from tests_common.test_utils.version_compat import AIRFLOW_V_2_10_PLUS
+from tests_common.test_utils.version_compat import AIRFLOW_V_2_10_PLUS, AIRFLOW_V_3_0_PLUS
 
-if AIRFLOW_V_2_10_PLUS:
+if AIRFLOW_V_3_0_PLUS:
 
     class ClassBasedListener:
+        def __init__(self):
+            self.started_component = None
+            self.stopped_component = None
+            self.state = []
+
+        @hookimpl
+        def on_starting(self, component):
+            self.started_component = component
+            self.state.append(DagRunState.RUNNING)
+
+        @hookimpl
+        def before_stopping(self, component):
+            global stopped_component
+            stopped_component = component
+            self.state.append(DagRunState.SUCCESS)
+
+        @hookimpl
+        def on_task_instance_running(self, previous_state, task_instance):
+            self.state.append(TaskInstanceState.RUNNING)
+
+        @hookimpl
+        def on_task_instance_success(self, previous_state, task_instance):
+            self.state.append(TaskInstanceState.SUCCESS)
+
+        @hookimpl
+        def on_task_instance_failed(self, previous_state, task_instance, error: None | str | BaseException):
+            self.state.append(TaskInstanceState.FAILED)
+
+        @hookimpl
+        def on_dag_run_running(self, dag_run, msg: str):
+            self.state.append(DagRunState.RUNNING)
+
+        @hookimpl
+        def on_dag_run_success(self, dag_run, msg: str):
+            self.state.append(DagRunState.SUCCESS)
+
+        @hookimpl
+        def on_dag_run_failed(self, dag_run, msg: str):
+            self.state.append(DagRunState.FAILED)
+
+elif AIRFLOW_V_2_10_PLUS:
+
+    class ClassBasedListener:  # type: ignore[no-redef]
         def __init__(self):
             self.started_component = None
             self.stopped_component = None


### PR DESCRIPTION
When DagRun state changes due to manual or API based actions, listeners are not notified about those. This PR fixes this.

Solves https://github.com/apache/airflow/issues/40735