### PR TITLE
Fix selection of providers for tests in new provider's structure

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/run_tests.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_tests.py
@@ -188,14 +188,20 @@ TEST_TYPE_CORE_MAP_TO_PYTEST_ARGS: dict[str, list[str]] = {
 }
 
 ALL_NEW_PROVIDER_TEST_FOLDERS: list[str] = sorted(
-    [path.as_posix() for path in AIRFLOW_SOURCES_ROOT.glob("providers/*/test/")]
-    + [path.as_posix() for path in AIRFLOW_SOURCES_ROOT.glob("providers/*/*/test/")]
+    [
+        path.relative_to(AIRFLOW_SOURCES_ROOT).as_posix()
+        for path in AIRFLOW_SOURCES_ROOT.glob("providers/*/tests/")
+    ]
+    + [
+        path.relative_to(AIRFLOW_SOURCES_ROOT).as_posix()
+        for path in AIRFLOW_SOURCES_ROOT.glob("providers/*/*/tests/")
+    ]
 )
 
 TEST_GROUP_TO_TEST_FOLDERS: dict[GroupOfTests, list[str]] = {
     GroupOfTests.CORE: ["tests"],
     # TODO(potiuk): remove me when we migrate all providers to new structure
-    GroupOfTests.PROVIDERS: ["providers/tests", *ALL_NEW_PROVIDER_TEST_FOLDERS],
+    GroupOfTests.PROVIDERS: [*ALL_NEW_PROVIDER_TEST_FOLDERS, "providers/tests"],
     GroupOfTests.TASK_SDK: ["task_sdk/tests"],
     GroupOfTests.HELM: ["helm_tests"],
     GroupOfTests.INTEGRATION_CORE: ["tests/integration"],

--- a/dev/breeze/tests/test_pytest_args_for_test_types.py
+++ b/dev/breeze/tests/test_pytest_args_for_test_types.py
@@ -66,7 +66,7 @@ from airflow_breeze.utils.run_tests import convert_parallel_types_to_folders, co
         (
             GroupOfTests.PROVIDERS,
             "Providers",
-            ["providers/tests"],
+            ["providers/airbyte/tests", "providers/tests"],
         ),
         (
             GroupOfTests.PROVIDERS,
@@ -87,6 +87,7 @@ from airflow_breeze.utils.run_tests import convert_parallel_types_to_folders, co
             GroupOfTests.PROVIDERS,
             "Providers[-amazon,google,microsoft.azure]",
             [
+                "providers/airbyte/tests",
                 "providers/tests",
                 "--ignore=providers/tests/amazon",
                 "--ignore=providers/amazon",
@@ -104,7 +105,7 @@ from airflow_breeze.utils.run_tests import convert_parallel_types_to_folders, co
         (
             GroupOfTests.PROVIDERS,
             "All-Quarantined",
-            ["providers/tests", "-m", "quarantined", "--include-quarantined"],
+            ["providers/airbyte/tests", "providers/tests", "-m", "quarantined", "--include-quarantined"],
         ),
         (
             GroupOfTests.CORE,
@@ -202,6 +203,7 @@ def test_pytest_args_for_missing_provider():
             GroupOfTests.PROVIDERS,
             "Providers",
             [
+                "providers/airbyte/tests",
                 "providers/tests",
             ],
         ),
@@ -224,6 +226,7 @@ def test_pytest_args_for_missing_provider():
             GroupOfTests.PROVIDERS,
             "Providers[-amazon,google]",
             [
+                "providers/airbyte/tests",
                 "providers/tests",
             ],
         ),
@@ -231,6 +234,7 @@ def test_pytest_args_for_missing_provider():
             GroupOfTests.PROVIDERS,
             "Providers[-amazon,google] Providers[amazon] Providers[google]",
             [
+                "providers/airbyte/tests",
                 "providers/tests",
             ],
         ),

--- a/dev/breeze/tests/test_run_test_args.py
+++ b/dev/breeze/tests/test_run_test_args.py
@@ -94,10 +94,12 @@ def test_irregular_provider_with_extra_ignore_should_be_valid_cmd(mock_run_comma
     # (the container id is simply to anchor the pattern so we know where we are starting; _run_tests should
     # be refactored to make arg testing easier but until then we have to regex-test the entire command string
     match_pattern = re.compile(
-        f" airflow providers/tests .+ --ignore=providers/tests/{fake_provider_name} --ignore=providers/tests/system/{fake_provider_name} --ignore=providers/tests/integration/{fake_provider_name}"
+        f".* airflow providers/.*/tests.*providers/tests .* --ignore=providers/tests/{fake_provider_name} "
+        f"--ignore=providers/tests/system/{fake_provider_name} "
+        f"--ignore=providers/tests/integration/{fake_provider_name}"
     )
 
-    assert match_pattern.search(arg_str)
+    assert match_pattern.search(arg_str), arg_str
 
 
 def test_primary_test_arg_is_excluded_by_extra_pytest_arg(mock_run_command):


### PR DESCRIPTION
There was a  teething problem after #45259 - when running tests for all providers rather than selectively the "new structure" providers (currently airbyte) tests were not running when "all" provider tests were run. There were two problems:

* typo in "tests" (was "test") folder name for providers
* full local paths were passed from Host (rather than relative paths from airlfow root) for found providers

Also the "new" providers are moved to be first in the list of pytest folders to see that it is actually working.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
