### PR TITLE
[draft] AIP-85 PoC

### DIFF
--- a/airflow/api_connexion/endpoints/dag_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_endpoint.py
@@ -78,9 +78,10 @@ def get_dag_details(
     *, dag_id: str, fields: Collection[str] | None = None, session: Session = NEW_SESSION
 ) -> APIResponse:
     """Get details of DAG."""
-    dag: DAG = get_airflow_app().dag_bag.get_dag(dag_id)
-    if not dag:
+    ingested_dag: DAG = get_airflow_app().dag_source.load_dag(dag_id)
+    if not ingested_dag:
         raise NotFound("DAG not found", detail=f"The DAG with dag_id: {dag_id} was not found")
+    dag = ingested_dag.dag
     dag_model: DagModel = session.get(DagModel, dag_id)
     for key, value in dag.__dict__.items():
         if not key.startswith("_") and not hasattr(dag_model, key):

--- a/airflow/api_connexion/endpoints/log_endpoint.py
+++ b/airflow/api_connexion/endpoints/log_endpoint.py
@@ -103,10 +103,10 @@ def get_log(
         metadata["end_of_log"] = True
         raise NotFound(title="TaskInstance not found")
 
-    dag = get_airflow_app().dag_bag.get_dag(dag_id)
-    if dag:
+    ingested_dag = get_airflow_app().dag_source.load_dag(dag_id)
+    if ingested_dag:
         try:
-            ti.task = dag.get_task(ti.task_id)
+            ti.task = ingested_dag.dag.get_task(ti.task_id)
         except TaskNotFound:
             pass
 

--- a/airflow/api_fastapi/core_api/app.py
+++ b/airflow/api_fastapi/core_api/app.py
@@ -27,19 +27,20 @@ from starlette.responses import HTMLResponse
 from starlette.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
 
+from airflow.dag_processing.dag_store import DagSource, DagStore
 from airflow.settings import AIRFLOW_PATH
-from airflow.www.extensions.init_dagbag import get_dag_bag
+
 
 log = logging.getLogger(__name__)
 
 
 def init_dag_bag(app: FastAPI) -> None:
     """
-    Create global DagBag for the FastAPI application.
+    Create global DagSource for the FastAPI application.
 
-    To access it use ``request.app.state.dag_bag``.
+    To access it use ``request.app.state.dag_source``.
     """
-    app.state.dag_bag = get_dag_bag()
+    app.state.dag_source: DagSource = DagStore()
 
 
 def init_views(app: FastAPI) -> None:

--- a/airflow/api_fastapi/core_api/routes/public/dags.py
+++ b/airflow/api_fastapi/core_api/routes/public/dags.py
@@ -51,6 +51,7 @@ from airflow.api_fastapi.core_api.serializers.dags import (
     DAGResponse,
     DAGTagCollectionResponse,
 )
+from airflow.dag_processing.dag_store import DagStore, IngestedDag
 from airflow.exceptions import AirflowException, DagNotFound
 from airflow.models import DAG, DagModel, DagTag
 
@@ -135,9 +136,10 @@ async def get_dag(
     dag_id: str, session: Annotated[Session, Depends(get_session)], request: Request
 ) -> DAGResponse:
     """Get basic information about a DAG."""
-    dag: DAG = request.app.state.dag_bag.get_dag(dag_id)
-    if not dag:
+    ingested_dag: IngestedDag = request.app.state.dag_source.load_dag(dag_id)
+    if not ingested_dag:
         raise HTTPException(404, f"Dag with id {dag_id} was not found")
+    dag: DAG = ingested_dag.dag
 
     dag_model: DagModel = session.get(DagModel, dag_id)
     if not dag_model:
@@ -155,9 +157,10 @@ async def get_dag_details(
     dag_id: str, session: Annotated[Session, Depends(get_session)], request: Request
 ) -> DAGDetailsResponse:
     """Get details of DAG."""
-    dag: DAG = request.app.state.dag_bag.get_dag(dag_id)
-    if not dag:
+    ingested_dag: IngestedDag = request.app.state.dag_source.load_dag(dag_id)
+    if not ingested_dag:
         raise HTTPException(404, f"Dag with id {dag_id} was not found")
+    dag: DAG = ingested_dag.dag
 
     dag_model: DagModel = session.get(DagModel, dag_id)
     if not dag_model:

--- a/airflow/api_fastapi/core_api/routes/ui/assets.py
+++ b/airflow/api_fastapi/core_api/routes/ui/assets.py
@@ -24,6 +24,7 @@ from typing_extensions import Annotated
 
 from airflow.api_fastapi.common.db.common import get_session
 from airflow.api_fastapi.common.router import AirflowRouter
+from airflow.dag_processing.dag_store import IngestedDag
 from airflow.models import DagModel
 from airflow.models.asset import AssetDagRunQueue, AssetEvent, AssetModel, DagScheduleAssetReference
 
@@ -36,9 +37,8 @@ async def next_run_assets(
     request: Request,
     session: Annotated[Session, Depends(get_session)],
 ) -> dict:
-    dag = request.app.state.dag_bag.get_dag(dag_id)
-
-    if not dag:
+    ingested_dag: IngestedDag = request.app.state.dag_source.load_dag(dag_id)
+    if not ingested_dag:
         raise HTTPException(404, f"can't find dag {dag_id}")
 
     dag_model = DagModel.get_dagmodel(dag_id, session=session)

--- a/airflow/cli/commands/dag_processor_command.py
+++ b/airflow/cli/commands/dag_processor_command.py
@@ -42,14 +42,7 @@ def _create_dag_processor_job_runner(args: Any) -> DagProcessorJobRunner:
         from airflow.models.renderedtifields import RenderedTaskInstanceFields  # noqa: F401
         from airflow.models.trigger import Trigger  # noqa: F401
     return DagProcessorJobRunner(
-        job=Job(),
-        processor=DagFileProcessorManager(
-            processor_timeout=processor_timeout,
-            dag_directory=args.subdir,
-            max_runs=args.num_runs,
-            dag_ids=[],
-            pickle_dags=args.do_pickle,
-        ),
+        job=Job()
     )
 
 

--- a/airflow/cli/commands/internal_api_command.py
+++ b/airflow/cli/commands/internal_api_command.py
@@ -48,7 +48,7 @@ from airflow.models import import_all_models
 from airflow.utils import cli as cli_utils
 from airflow.utils.cli import setup_locations
 from airflow.utils.providers_configuration_loader import providers_configuration_loaded
-from airflow.www.extensions.init_dagbag import init_dagbag
+from airflow.www.extensions.init_dag_source import init_dag_source
 from airflow.www.extensions.init_jinja_globals import init_jinja_globals
 from airflow.www.extensions.init_manifest_files import configure_manifest_files
 from airflow.www.extensions.init_security import init_xframe_protection
@@ -236,7 +236,7 @@ def create_app(config=None, testing=False):
     db.session = settings.Session
     db.init_app(flask_app)
 
-    init_dagbag(flask_app)
+    init_dag_source(flask_app)
 
     cache_config = {"CACHE_TYPE": "flask_caching.backends.filesystem", "CACHE_DIR": gettempdir()}
     Cache(app=flask_app, config=cache_config)

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2477,6 +2477,13 @@ scheduler:
       type: boolean
       example: ~
       default: "False"
+    ingester_mode:
+      description: |
+        Ingester mode - "once" or "continuous".
+      version_added: 2.11.0
+      type: string
+      example: ~
+      default: "continuous"
     max_callbacks_per_loop:
       description: |
         Only applicable if ``[scheduler] standalone_dag_processor`` is true and  callbacks are stored

--- a/airflow/dag_processing/README.tmp.md
+++ b/airflow/dag_processing/README.tmp.md
@@ -1,0 +1,127 @@
+# DagBag refactoring
+
+DAG metadata -> load from DB             -> DAG store
+DAG discover & load -> parse from files  -> DAG importer
+DAG sync to DB -> save to DB             -> DAG store
+DAG apply policies                       -> DAG importer
+
+
+Airflow 2-sh: FS -> DAG importer (how to generate DAG from source) -> DAG ingester (how/when store the DAG) -> DAG parser - top-level control
+Airflow 3-sh: DAG bundle -> DAG importer (how to generate DAG from source) -> DAG ingester (how/when store the DAG) -> DAG parser - top-level control
+
+
+Sample manifest.yaml:
+
+
+```yaml
+config:
+   ingester: CompositeIngester
+    composites:
+      - ingester: OnceIngester
+        paths:
+          - path: /files/dags/static_1
+          - path: /files/dags/static_2
+            bundle:
+              type: GitDagBundle
+              repo_url: git://...
+              tracking_ref: live
+              refresh_interval: 10m
+      - ingestion_options:
+          ingestion_interval: 5m
+        paths:
+          - path: /files/dags/dynamic_1
+      - ingestion_options:
+          on_change_only: true
+        paths:
+          - path: /files/dags/dynamic_2
+      - paths:
+          - path: /files/dags/notebooks
+            importer: NotebooksImporter
+```
+
+Which will expand to:
+
+```yaml
+config:
+    ingester: CompositeIngester
+    composites:
+        - ingester: OnceIngester
+        ingestion_options: {}
+        paths:
+          - path: /files/dags/static_1
+            importer: FSDagImporter
+            bundle:
+                type: LocalDagBundle
+          - path: /files/dags/static_2
+            importer: FSDagImporter
+            bundle:
+                type: GitDagBundle
+                repo_url: git://...
+                tracking_ref: live
+                refresh_interval: 10m
+      - ingester: ContinousIngester
+        ingestion_options:
+            ingestion_interval: 5m
+        paths:
+          - path: /files/dags/dynamic_1
+            importer: FSDagImporter
+            bundle:
+                type: LocalDagBundle
+      - ingester: ContinousIngester
+        ingestion_options:
+            on_change_only: true
+        paths:
+          - path: /files/dags/dynamic_2
+            importer: FSDagImporter
+            bundle:
+                type: LocalDagBundle
+      - ingester: ContinousIngester
+        ingestion_options: {}
+        paths:
+          - path: /files/dags/notebooks
+            importer: NotebooksImporter
+            bundle:
+                type: LocalDagBundle
+```
+
+Default manifest is effectively:
+
+```yaml
+config:
+    ingester: ContinousIngester
+    ingestion_options: {}
+    paths:
+      - path: <DAG Folder>
+        importer: FSDagImporter
+        bundle:
+            type: LocalDagBundle
+```
+
+Manifest spec (pseudocode):
+```yaml
+schema:
+    config:
+        type: object[ParsingSpec]
+        properties:
+            ingester:
+                type: string # Ingester class name
+              ingestion_options:
+                type: object[IngesterParameters]
+                properties:
+                  ... # Ingester-dependent properties
+            composites:
+                type: array[ParsingSpec] # Nested parsing specs
+            paths:
+                type: array[PathSpec]
+                properties:
+                    path: # Path to import DAGs from, can be path in FS, can be virtual, if importer understands it
+                      type: string
+                    importer: # Importer class to use
+                      type: string
+                    bundle: # Bundle config, responsible for supplying requested data to importer
+                      type: object[BundleSpec]
+                      properties:
+                        type: # Bundle class
+                          type: string
+                        ... # Type-dependent properties   
+```

--- a/airflow/dag_processing/continuous_ingester.py
+++ b/airflow/dag_processing/continuous_ingester.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING, Callable, Mapping
+
+from airflow.configuration import conf
+from airflow.dag_processing.dag_ingester import DagIngester
+from airflow.dag_processing.manager import DagFileProcessorManager
+
+if TYPE_CHECKING:
+    from airflow.dag_processing.dag_store import DagStore
+    from airflow.dag_processing.dag_importer import DagImporter
+
+
+class ContinuousIngester(DagIngester):
+    def run_ingestion(self, dag_store: DagStore, importers: Mapping[str, DagImporter], heartbeat_callback: Callable[[], None] | None = None) -> None:
+        self.log.info("Starting Continuous Ingester: %s", importers)
+        processor_timeout_seconds: int = conf.getint("core", "dag_file_processor_timeout")
+        processor_timeout = timedelta(seconds=processor_timeout_seconds)
+        processor_manager = DagFileProcessorManager(processor_timeout=processor_timeout, 
+            importers = importers,
+            dag_store=dag_store,
+            max_runs=-1,
+            dag_ids=[],
+            pickle_dags=False,
+        )
+        processor_manager.heartbeat = heartbeat_callback or (lambda: None)
+        processor_manager.start()
+
+    def supports_priority_parsing(self, subpath: str):
+        return True

--- a/airflow/dag_processing/dag_importer.py
+++ b/airflow/dag_processing/dag_importer.py
@@ -1,0 +1,98 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Collection, Generator, Iterable, Mapping
+
+from airflow.utils.log.logging_mixin import LoggingMixin
+
+if TYPE_CHECKING:
+    from airflow.models.dag import DAG
+
+
+@dataclass(frozen=True)
+class DagsImportResult:
+    # DAG ID -> imported DAG
+    dags: Mapping[str, DAG]
+    # Import path -> error message
+    import_errors: Mapping[str, str]
+    # Import path -> Warning
+    import_warnings: Mapping[str, Collection[str]]
+    # Skipped unchanged paths
+    skipped_paths: Collection[str] = ()
+
+
+@dataclass(frozen=True)
+class ImportOptions:
+    skip_unchanged: bool = False
+
+
+@dataclass(frozen=True)
+class PathData:
+    path: str
+    metadata: Mapping[str, str] | None = None
+
+
+class DagImporter(LoggingMixin):
+    """
+    Abstract importer - piece of logic responsible of translation of abstract DAG paths into DAGs.
+
+    In addition to being in charge of "how to create DAG from filepath", also provides metadata
+    about the paths and if they contain any new changes.
+    """
+    @abstractmethod
+    def import_path(self, dagpath: str, options: ImportOptions | None = None) -> Generator[DagsImportResult, None, None]:
+        """
+        Import all DAGs from a given path.
+
+        Args:
+            dagpath (str): Path to import DAGs from.
+            options (ImportOptions | None): Options for DAG importing.
+
+        Yields:
+            DagsImportResult: Result of importing DAGs. Completes when all DAGs were parsed.
+        """
+        ...
+
+    @abstractmethod
+    def list_paths(self, subpath: str) -> Iterable[PathData]: 
+        """
+        List all potential DAG paths or its parents.
+
+        Returned paths can be both individual files or directories. 
+        There is no gurantee that there are any DAGs or that DAGs fileloc is exact returned path.
+
+        The following invariants should hold true:
+        - If returned 'path' contains DAGs, their fileloc should be a supath of the returned 'path'.
+          Examples: path = /a/b/c.py -> DAG fileloc = /a/b/c.py
+                    path = /a/x.zip -> DAG_1 fileloc = /a/x.zip/a.py; DAG_2 fileloc = /a/x.zip/b.py
+        - Returned paths should be non-overlapping.
+        - For every DAG exactly one path should be returned. Path can cover any number of DAGs.
+
+        Naive universal implementation - return a single path equal to the requested subpath.
+
+        The goal of these paths - provide the ingester paths that can be used to import DAGs in the efficient way.
+
+        Args:
+            subpath (str): Subpath to list DAG paths for.
+
+        Returns:
+            Iterable[PathData]: Iterable of PathData.
+        """
+        ...

--- a/airflow/dag_processing/dag_ingester.py
+++ b/airflow/dag_processing/dag_ingester.py
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import TYPE_CHECKING, Callable, Iterable, Mapping
+
+from airflow.utils.log.logging_mixin import LoggingMixin
+
+if TYPE_CHECKING:
+    from airflow.dag_processing.dag_store import DagStore
+    from airflow.dag_processing.dag_importer import DagImporter
+
+
+class DagIngester(LoggingMixin):
+
+    @abstractmethod
+    def run_ingestion(self, 
+        dag_store: DagStore, 
+        importers: Mapping[str, DagImporter], 
+        heartbeat_callback: Callable[[], None] | None = None
+    ) -> None:
+        """
+        Run ingestion policy.
+        """
+        ...
+
+    @abstractmethod
+    def supports_priority_parsing(self, subpath: str) -> bool:
+        """
+        Whether DAG ingester supports priority parsing for a given subpath.
+
+        If not, re-parsing request in Airflow UI is disabled for DAGs using this ingester.
+        """
+        ...

--- a/airflow/dag_processing/dag_parser.py
+++ b/airflow/dag_processing/dag_parser.py
@@ -1,0 +1,86 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import itertools
+import pathlib
+from typing import TYPE_CHECKING, Callable, Generator
+
+from airflow.configuration import conf
+from airflow.dag_processing.dag_store import DagStore
+from airflow.exceptions import AirflowException
+
+if TYPE_CHECKING:
+    from airflow.dag_processing.dag_importer import DagImporter, DagsImportResult, ImportOptions
+    from airflow.dag_processing.dag_ingester import DagIngester
+
+
+class DagParser:
+    def __init__(self):
+        # path -> importer
+        self.importers: dict[str, DagImporter] = {}
+        self.ingester: DagIngester = None
+        self._load_parsers_configuration()
+
+    def run_ingestion(self, heartbeat_callback: Callable[[], None] | None = None) -> None:
+        """
+        Run ingestion as configured in the ingester.
+
+        Used by dag-processor.
+        """
+        dag_store = DagStore()
+        self.ingester.run_ingestion(dag_store, self.importers, heartbeat_callback)
+
+    def parse_paths(self, subdir: str | None = None, options: ImportOptions | None = None) -> Generator[DagsImportResult, None, None]:
+        """
+        Parse paths with importer covering this path. Used by airflow workers to get an executable task instance of a DAG.
+        """
+        if not subdir:
+            return itertools.chain(*[importer.import_path(path, options) for path, importer in self.importers.items()])
+        subpath = pathlib.Path(subdir)
+        for covered_path in self.importers:
+            # TODO: This assumes that all paths are non-overlapping by design.
+            if subpath.is_relative_to(covered_path):
+                return self.importers[covered_path].import_path(subdir, options)
+
+        raise AirflowException(f"Unknown subdir: {subdir}")
+
+    def _load_parsers_configuration(self) -> None:
+        from airflow import settings
+        
+        from airflow.dag_processing.fs_dag_importer import FSDagImporter
+        from airflow.providers.google.common.importers.notebooks_importer import NotebooksImporter
+        from airflow.dag_processing.example_dag_importer import ExampleDagImporter
+
+        # TODO: depend on configuration, so "deployment manager" user can customize it,
+        # here it is static for demonstration purpose only. (Can be similar to "bundle" configuration).
+        self.importers = {
+            settings.DAGS_FOLDER: FSDagImporter(),
+            '/files/notebooks': NotebooksImporter(),
+        }
+        if conf.getboolean("core", "LOAD_EXAMPLES"):
+            from airflow.dag_processing.example_dag_importer import example_dags_path
+            self.importers[example_dags_path()] = ExampleDagImporter()
+        ingester_mode = conf.get("scheduler", "ingester_mode")
+        if ingester_mode == "continuous":
+            from airflow.dag_processing.continuous_ingester import ContinuousIngester
+            self.ingester = ContinuousIngester()
+        elif ingester_mode == "once":
+            from airflow.dag_processing.once_ingester import OnceIngester
+            self.ingester = OnceIngester()
+        else:
+            raise ValueError(f"Unknown ingester mode: {ingester_mode}")

--- a/airflow/dag_processing/dag_store.py
+++ b/airflow/dag_processing/dag_store.py
@@ -1,0 +1,344 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import traceback
+
+from abc import ABCMeta, abstractmethod
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+import functools
+from typing import Iterable, Collection, List, Mapping, Tuple, TYPE_CHECKING
+
+from airflow import settings
+from airflow.listeners.listener import get_listener_manager
+from airflow.models.dag import DAG
+from airflow.serialization.serialized_objects import SerializedDAG
+from airflow.utils import timezone
+from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.retries import MAX_DB_RETRIES, run_with_db_retries
+from airflow.utils.session import NEW_SESSION, provide_session
+from sqlalchemy import delete, select
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import load_only, Session
+
+
+@dataclass(frozen=True)
+class IngestedDag:
+    dag: SerializedDAG
+    fetch_time: datetime
+    dag_hash: str
+
+
+@dataclass(frozen=True)
+class DagMetadata:
+    dag_id: str
+    fileloc: str
+    ingestion_time: datetime
+
+
+class DagSource(metaclass=ABCMeta):
+    @abstractmethod
+    def load_dag(self, dag_id: str, session: Session = NEW_SESSION) -> IngestedDag | None:
+        raise NotImplementedError()
+
+
+class DagStore(DagSource, LoggingMixin):
+    """
+        Data source of ingested DAG.
+
+        :param load_op_links: Load extra op links, which might contain user-defined code.
+    """
+    def __init__(self, load_op_links: bool = False):
+        self.load_op_links = load_op_links
+
+    @classmethod
+    @provide_session
+    def _sync_perm_for_dag(cls, dag: DAG, session: Session = NEW_SESSION):
+        """Sync DAG specific permissions."""
+        dag_id = dag.dag_id
+
+        cls.logger().debug("Syncing DAG permissions: %s to the DB", dag_id)
+        from airflow.www.security_appless import ApplessAirflowSecurityManager
+
+        security_manager = ApplessAirflowSecurityManager(session=session)
+        security_manager.sync_perm_for_dag(dag_id, dag.access_control)
+
+    @provide_session
+    def list_dags_metadata(self, *, processor_subdir: str | None = None, parsed_before: datetime | None = None,  session: Session = NEW_SESSION) -> Collection[DagMetadata]:
+        """List all DAGs with optional filters."""
+        from airflow.models.dag import DagModel
+
+        query = select(DagModel).where(DagModel.is_active).options(load_only(DagModel.dag_id, DagModel.last_parsed_time, DagModel.fileloc))
+        if processor_subdir:
+            query = query.where(DagModel.processor_subdir == processor_subdir)
+        if parsed_before:
+            query = query.where(DagModel.last_parsed_time < parsed_before)
+        dags = session.scalars(query)
+        return [DagMetadata(dag.dag_id, dag.fileloc, dag.last_parsed_time) for dag in dags]
+
+
+    @provide_session
+    def load_dag(self, dag_id: str, session: Session = NEW_SESSION) -> IngestedDag | None:
+        """
+        Load the DAG from metadata DB, it it exists.
+
+        :param dag_id: DAG ID
+        """
+        from airflow.models.serialized_dag import SerializedDagModel
+
+        dag_model: SerializedDagModel | None = SerializedDagModel.get(dag_id, session)
+        if not dag_model:
+            return None
+        fetch_time = timezone.utcnow()
+        dag_model.load_op_links = self.load_op_links
+
+        return IngestedDag(dag_model.dag, fetch_time, dag_model.dag_hash)
+
+    @provide_session
+    def store_dags(
+        self,
+        # TODO: Also accept DAG code provider
+        dags: Collection[DAG],
+        processor_subdir: str | None = None,
+        session: Session = NEW_SESSION,
+    ) -> dict[str, str]:
+        """Save attributes about DAGs to the DB."""
+        from airflow.configuration import conf
+        from airflow.models.serialized_dag import SerializedDagModel
+
+        def _serialize_dag_capturing_errors(dag: DAG, session: Session, processor_subdir: str | None) -> List[Tuple[str, str]]:
+            """
+            Try to serialize the dag to the DB, but make a note of any errors.
+
+            We can't place them directly in import_errors, as this may be retried, and work the next time
+            """
+            try:
+                # We can't use bulk_write_to_db as we want to capture each error individually
+                dag_was_updated = SerializedDagModel.write_dag(
+                    dag,
+                    min_update_interval=settings.MIN_SERIALIZED_DAG_UPDATE_INTERVAL,
+                    session=session,
+                    processor_subdir=processor_subdir,
+                )
+                if dag_was_updated:
+                    DagStore._sync_perm_for_dag(dag, session=session)
+                return []
+            except OperationalError:
+                raise
+            except Exception:
+                self.log.exception("Failed to write serialized DAG: %s", dag.fileloc)
+                dagbag_import_error_traceback_depth = conf.getint(
+                    "core", "dagbag_import_error_traceback_depth"
+                )
+                return [(dag.dag_id, traceback.format_exc(limit=-dagbag_import_error_traceback_depth))]
+
+        # Retry 'DAG.bulk_write_to_db' & 'SerializedDagModel.bulk_sync_to_db' in case
+        # of any Operational Errors
+        # In case of failures, provide_session handles rollback
+        import_errors = {}
+        for attempt in run_with_db_retries(logger=self.log):
+            with attempt:
+                serialize_errors = []
+                self.log.debug(
+                    "Running dagbag.sync_to_db with retries. Try %d of %d",
+                    attempt.retry_state.attempt_number,
+                    MAX_DB_RETRIES,
+                )
+                self.log.debug("Calling the DAG.bulk_sync_to_db method")
+                try:
+                    # Write Serialized DAGs to DB, capturing errors
+                    for dag in dags:
+                        serialize_errors.extend(
+                            _serialize_dag_capturing_errors(dag, session, processor_subdir)
+                        )
+
+                    DAG.bulk_write_to_db(dags, processor_subdir=processor_subdir, session=session)
+                except OperationalError:
+                    session.rollback()
+                    raise
+                # Only now we are "complete" do we update import_errors - don't want to record errors from
+                # previous failed attempts
+                import_errors.update(dict(serialize_errors))
+
+        return import_errors
+
+    @provide_session
+    def delete_dags(self, dag_ids: Iterable[str], session: Session = NEW_SESSION):
+        from airflow.models.dag import DagModel
+        from airflow.models.dagcode import DagCode
+        from airflow.models.serialized_dag import SerializedDagModel
+
+        ids_set = set(dag_ids)
+        SerializedDagModel.remove_dags(
+            dag_ids=ids_set,
+            session=session,
+        )
+
+        DagModel.deactivate_dags(dag_ids=ids_set, session=session)
+
+        def _collect_dags(subdir2fileloc: dict[str, list[str]], dag: DagModel):
+            subdir2fileloc[dag.processor_subdir].append(dag.fileloc)
+            return subdir2fileloc
+        subdir2fileloc = functools.reduce(
+            _collect_dags, 
+            filter(
+                lambda dag: dag.dag_id not in ids_set,
+                DagModel.active_dag_filelocs(session=session)
+            ),
+            defaultdict(list)
+        )
+        for subdir in subdir2fileloc:
+            DagCode.remove_deleted_code(
+                alive_dag_filelocs=subdir2fileloc[subdir],
+                processor_subdir=subdir,
+                session=session,
+            )
+    
+    @provide_session
+    def delete_removed_entries_dags(self, alive_entry_filelocs: Collection[str], processor_subdir: str, filepath_prefix: str = "", session: Session = NEW_SESSION):
+        from airflow.models.dag import DagModel
+        from airflow.models.dagcode import DagCode
+        from airflow.models.serialized_dag import SerializedDagModel
+
+        SerializedDagModel.remove_deleted_dags(
+            alive_dag_filelocs=alive_entry_filelocs,
+            processor_subdir=processor_subdir,
+            filepath_prefix=filepath_prefix,
+            session=session,
+        )
+        DagModel.deactivate_deleted_dags(
+            alive_dag_filelocs=alive_entry_filelocs,
+            processor_subdir=processor_subdir,
+            filepath_prefix=filepath_prefix,
+            session=session,
+        )
+        DagCode.remove_deleted_code(
+            alive_dag_filelocs=alive_entry_filelocs,
+            processor_subdir=processor_subdir,
+            filepath_prefix=filepath_prefix,
+            session=session,
+        )
+
+    @provide_session
+    def delete_removed_processor_subdir_dags(self, alive_processor_subdirs: Collection[str], session: Session = NEW_SESSION):
+        from airflow.models.dag import DagModel
+
+        removed_dags = session.scalars(select(DagModel).where(DagModel.is_active, DagModel.processor_subdir.notin_(alive_processor_subdirs)).options(load_only(DagModel.dag_id)))
+        self.delete_dags(map(lambda dag: dag.dag_id, removed_dags))
+
+    @provide_session
+    def update_import_errors(self, import_errors: Mapping[str, str], processor_subdir: str, session: Session = NEW_SESSION):
+        from airflow.models.errors import ParseImportError
+
+        existing_import_error_files = [x.filename for x in session.query(ParseImportError.filename).all()]
+
+        # Add the errors of the processed files
+        for filename, stacktrace in import_errors.items():
+            if filename in existing_import_error_files:
+                session.query(ParseImportError).filter(ParseImportError.filename == filename).update(
+                    {"filename": filename, "timestamp": timezone.utcnow(), "stacktrace": stacktrace},
+                    synchronize_session="fetch",
+                )
+                # sending notification when an existing dag import error occurs
+                get_listener_manager().hook.on_existing_dag_import_error(
+                    filename=filename, stacktrace=stacktrace
+                )
+            else:
+                session.add(
+                    ParseImportError(
+                        filename=filename,
+                        timestamp=timezone.utcnow(),
+                        stacktrace=stacktrace,
+                        processor_subdir=processor_subdir,
+                    )
+                )
+                # sending notification when a new dag import error occurs
+                get_listener_manager().hook.on_new_dag_import_error(filename=filename, stacktrace=stacktrace)
+
+    @provide_session
+    def delete_excluded_import_errors(self, filenames_to_keep: Collection[str], processor_subdir: str, filepath_prefix: str = "", session: Session = NEW_SESSION):
+        from airflow.models.errors import ParseImportError
+
+        session.execute(
+                delete(ParseImportError)
+                .where(
+                    ParseImportError.processor_subdir == processor_subdir,
+                    ParseImportError.filename.notin_(filenames_to_keep),
+                    ParseImportError.filename.startswith(filepath_prefix),
+                )
+                .execution_options(synchronize_session="fetch")
+        )
+    
+    @provide_session
+    def delete_excluded_subdir_import_errors(self, processor_subdirs_to_keep: Collection[str], session: Session = NEW_SESSION):
+        from airflow.models.errors import ParseImportError
+
+        session.execute(
+                delete(ParseImportError)
+                .where(ParseImportError.processor_subdir.notin_(processor_subdirs_to_keep))
+                .execution_options(synchronize_session="fetch")
+        )
+
+
+class CachedDagStore(DagSource, LoggingMixin):
+    def __init__(self, store: DagStore):
+        super().__init__()
+
+        self.store = store
+        self.cached_dags: dict[str, IngestedDag] = {}
+
+    @provide_session
+    def load_dag(self, dag_id: str, session: Session = NEW_SESSION) -> IngestedDag | None:
+        from airflow.models.serialized_dag import SerializedDagModel
+
+        if dag_id not in self.cached_dags:
+            return self._refresh_from_store(dag_id, session)
+
+        # If DAG is in the cache, check the following
+        # 1. if time has come to check if DAG is updated (controlled by min_serialized_dag_fetch_secs)
+        # 2. check the last_updated and hash columns in SerializedDag table to see if
+        # Serialized DAG is updated
+        # 3. if (2) is yes, fetch the Serialized DAG.
+        # 4. if (2) returns None (i.e. Serialized DAG is deleted), revoke from cache
+        # if it exists and return None.
+        ingested_dag = self.cached_dags[dag_id]
+        min_serialized_dag_fetch_secs = timedelta(seconds=settings.MIN_SERIALIZED_DAG_FETCH_INTERVAL)
+        if timezone.utcnow() > ingested_dag.fetch_time + min_serialized_dag_fetch_secs:
+            sd_latest_version_and_updated_datetime = (
+                    SerializedDagModel.get_latest_version_hash_and_updated_datetime(
+                        dag_id=dag_id, session=session
+                    )
+                )
+            if not sd_latest_version_and_updated_datetime:
+                self.log.warning("Serialized DAG %s no longer exists", dag_id)
+                del self.cached_dags[dag_id]
+                return None
+
+            sd_latest_version, sd_last_updated_datetime = sd_latest_version_and_updated_datetime
+            if (
+                sd_last_updated_datetime > ingested_dag.fetch_time
+                        or sd_latest_version != ingested_dag.dag_hash
+            ):
+                return self._refresh_from_store(dag_id, session)
+        return self.cached_dags[dag_id]
+
+    def _refresh_from_store(self, dag_id: str, session: Session) -> IngestedDag | None:
+        dag = self.store.load_dag(dag_id, session)
+        if not dag:
+            return None
+        self.cached_dags[dag_id] = dag
+        return dag

--- a/airflow/dag_processing/example_dag_importer.py
+++ b/airflow/dag_processing/example_dag_importer.py
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import pathlib
+from typing import Generator, Iterable
+
+from airflow.dag_processing.fs_dag_importer import FSDagImporter
+from airflow.dag_processing.dag_importer import DagsImportResult, DagImporter, ImportOptions, PathData
+from airflow.exceptions import AirflowException
+
+
+def example_dags_path():
+    from airflow import example_dags
+
+    return example_dags.__path__[0]
+
+
+class ExampleDagImporter(DagImporter):
+    def __init__(self):
+        super().__init__()
+        self.fs_importer = FSDagImporter()
+
+    def import_path(self, dagpath: str, options: ImportOptions | None = None) -> Generator[DagsImportResult, None, None]:
+        if not pathlib.Path(dagpath).is_relative_to(example_dags_path()):
+            raise AirflowException(
+                f"Unexpected dagpath {dagpath} for example DAG, should be a subpath of {example_dags_path()}"
+            )
+        return self.fs_importer.import_path(dagpath, options)
+
+    def list_paths(self, subpath: str) -> Iterable[PathData]:
+        return self.fs_importer.list_paths(subpath)

--- a/airflow/dag_processing/fs_dag_importer.py
+++ b/airflow/dag_processing/fs_dag_importer.py
@@ -1,0 +1,366 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass
+import functools
+import importlib
+import os
+import pathlib
+import sys
+import traceback
+from typing import TYPE_CHECKING, Collection, Generator, Mapping, Tuple
+import zipfile
+
+from airflow import settings
+from airflow.configuration import conf
+from airflow.dag_processing.dag_importer import DagsImportResult, DagImporter, ImportOptions, PathData
+from airflow.exceptions import (
+    AirflowClusterPolicyError,
+    AirflowClusterPolicySkipDag,
+    AirflowClusterPolicyViolation,
+    AirflowDagCycleException,
+    AirflowDagDuplicatedIdException,
+    AirflowException,
+    AirflowTaskTimeout,
+)
+from airflow.listeners.listener import get_listener_manager
+from airflow.utils import timezone
+from airflow.utils.dag_cycle_tester import check_cycle
+from airflow.utils.docs import get_docs_url
+from airflow.utils.file import (
+    correct_maybe_zipped,
+    get_unique_dag_module_name,
+    list_py_file_paths,
+    might_contain_dag,
+)
+from airflow.utils.timeout import timeout
+from airflow.utils.warnings import capture_with_reraise
+
+if TYPE_CHECKING:
+    from types import ModuleType
+    from airflow.models.dag import DAG
+
+
+@dataclass(frozen=True)
+class FileLoadStat:
+    """
+    Information about single file.
+
+    :param file: Loaded file.
+    :param duration: Time spent on process file.
+    :param dag_num: Total number of DAGs loaded in this file.
+    :param task_num: Total number of Tasks loaded in this file.
+    :param dags: DAGs names loaded in this file.
+    :param warning_num: Total number of warnings captured from processing this file.
+    """
+
+    file: str
+    duration: datetime.timedelta
+    dag_num: int
+    task_num: int
+    dags: str
+    warning_num: int
+
+
+class FSDagImporter(DagImporter):
+    def __init__(self):
+        # TODO: add mtime-based cache. Keep expiration from get_dag in mind.
+        super().__init__()
+        # For backwards compatibility.
+        self.safe_mode = conf.getboolean("core", "DAG_DISCOVERY_SAFE_MODE")
+        self.dagbag_import_error_tracebacks = conf.getboolean("core", "dagbag_import_error_tracebacks")
+        self.dagbag_import_error_traceback_depth = conf.getint("core", "dagbag_import_error_traceback_depth")
+
+    def import_path(self, dagpath: str, options: ImportOptions | None = None) -> Generator[DagsImportResult, None, None]:
+        # TODO: Support import options, for ex. skip_unchanged.
+        if not options:
+            options = ImportOptions()
+        yield self._collect_dags(dagpath)
+    
+    def list_paths(self, subpath: str) -> Iterable[PathData]:
+        return map(lambda path: PathData(path), self._list_py_file_paths(subpath))
+
+    def _collect_dags(
+        self,
+        dag_folder: str,
+    ):
+        """
+        Look for python modules in a given path, import them, and add them to the dagbag collection.
+
+        Note that if a ``.airflowignore`` file is found while processing
+        the directory, it will behave much like a ``.gitignore``,
+        ignoring files that match any of the patterns specified
+        in the file.
+
+        **Note**: The patterns in ``.airflowignore`` are interpreted as either
+        un-anchored regexes or gitignore-like glob expressions, depending on
+        the ``DAG_IGNORE_FILE_SYNTAX`` configuration parameter.
+        """
+
+        self.log.info("Importing DAGs from %s", dag_folder)
+        # Used to store stats around DagBag processing
+        stats = []
+
+        import_results = []
+        for filepath in self._list_py_file_paths(str(dag_folder)):
+            try:
+                file_parse_start_dttm = timezone.utcnow()
+                result = self._process_file(filepath)
+                if not result:
+                    continue
+                import_results.append(result)
+
+                file_parse_end_dttm = timezone.utcnow()
+                stats.append(
+                    FileLoadStat(
+                        file=filepath.replace(settings.DAGS_FOLDER, ""),
+                        duration=file_parse_end_dttm - file_parse_start_dttm,
+                        dag_num=len(result.dags),
+                        task_num=sum(len(dag.tasks) for dag in result.dags.values()),
+                        dags=str([dag.dag_id for dag in result.dags.values()]),
+                        warning_num=len(result.import_warnings),
+                    )
+                )
+
+            except Exception as e:
+                self.log.exception(e)
+        return DagsImportResult(
+            # TODO: check collisions
+            dags=functools.reduce(lambda agg, result: {**agg, **result.dags}, import_results, {}),
+            import_errors=functools.reduce(lambda agg, result: {**agg, **result.import_errors}, import_results, {}),
+            import_warnings=functools.reduce(lambda agg, result: {**agg, **result.import_errors}, import_results, {}),
+        )
+
+    def _process_file(self, filepath) -> DagsImportResult|None:
+        """Given a path to a python module or zip file, import the module and look for dag objects within."""
+        from airflow.models.dag import DagContext
+
+        if filepath is None or not os.path.isfile(filepath):
+            return None
+
+        try:
+            # TODO: put check here
+            self.log.debug("Importing %s", filepath)
+        except Exception as e:
+            self.log.exception(e)
+            return None
+
+        # Ensure we don't pick up anything else we didn't mean to
+        DagContext.autoregistered_dags.clear()
+
+        with capture_with_reraise() as captured_warnings:
+            if filepath.endswith(".py") or not zipfile.is_zipfile(filepath):
+                mods, import_errors = self._load_modules_from_file(filepath)
+            else:
+                mods, import_errors = self._load_modules_from_zip(filepath)
+
+        warnings = {}
+        if captured_warnings:
+            formatted_warnings = []
+            for msg in captured_warnings:
+                category = msg.category.__name__
+                if (module := msg.category.__module__) != "builtins":
+                    category = f"{module}.{category}"
+                formatted_warnings.append(f"{msg.filename}:{msg.lineno}: {category}: {msg.message}")
+            warnings = {filepath: tuple(formatted_warnings)}
+
+        found_dags, module_import_errors = self._process_modules(filepath, mods)
+        import_errors.update(module_import_errors)
+
+        return DagsImportResult(
+            dags={dag.dag_id: dag for dag in found_dags},
+            import_warnings=warnings,
+            import_errors=import_errors,
+        )
+
+    def _load_modules_from_file(self, filepath) -> Tuple[Collection[ModuleType], Mapping[str, str]]:
+        from airflow.models.dag import DagContext
+
+        if not might_contain_dag(filepath, self.safe_mode):
+            # Don't want to spam user with skip messages
+            
+            self.log.info("File %s assumed to contain no DAGs. Skipping.", filepath)
+            return [], None
+
+        self.log.debug("Importing %s", filepath)
+        mod_name = get_unique_dag_module_name(filepath)
+
+        if mod_name in sys.modules:
+            del sys.modules[mod_name]
+
+        DagContext.current_autoregister_module_name = mod_name
+
+        def parse(mod_name, filepath):
+            try:
+                loader = importlib.machinery.SourceFileLoader(mod_name, filepath)
+                spec = importlib.util.spec_from_loader(mod_name, loader)
+                new_module = importlib.util.module_from_spec(spec)
+                sys.modules[spec.name] = new_module
+                loader.exec_module(new_module)
+                return [new_module], {}
+            except (Exception, AirflowTaskTimeout) as e:
+                DagContext.autoregistered_dags.clear()
+                self.log.exception("Failed to import: %s", filepath)
+                if self.dagbag_import_error_tracebacks:
+                    return [], {
+                        filepath: traceback.format_exc(
+                            limit=-self.dagbag_import_error_traceback_depth)
+                    }
+                else:
+                    return [], {filepath: str(e)}
+
+        dagbag_import_timeout = settings.get_dagbag_import_timeout(filepath)
+
+        if not isinstance(dagbag_import_timeout, (int, float)):
+            raise TypeError(
+                f"Value ({dagbag_import_timeout}) from get_dagbag_import_timeout must be int or float"
+            )
+
+        if dagbag_import_timeout <= 0:  # no parsing timeout
+            return parse(mod_name, filepath)
+
+        timeout_msg = (
+            f"DagBag import timeout for {filepath} after {dagbag_import_timeout}s.\n"
+            "Please take a look at these docs to improve your DAG import time:\n"
+            f"* {get_docs_url('best-practices.html#top-level-python-code')}\n"
+            f"* {get_docs_url('best-practices.html#reducing-dag-complexity')}"
+        )
+        with timeout(dagbag_import_timeout, error_message=timeout_msg):
+            return parse(mod_name, filepath)
+
+    def _load_modules_from_zip(self, filepath) -> Tuple[Collection[ModuleType], Mapping[str, str]]:
+        from airflow.models.dag import DagContext
+
+        mods = []
+        import_errors = {}
+        with zipfile.ZipFile(filepath) as current_zip_file:
+            for zip_info in current_zip_file.infolist():
+                zip_path = pathlib.Path(zip_info.filename)
+                if zip_path.suffix not in [".py", ".pyc"] or len(zip_path.parts) > 1:
+                    continue
+
+                if zip_path.stem == "__init__":
+                    self.log.warning("Found %s at root of %s", zip_path.name, filepath)
+
+                self.log.debug("Reading %s from %s", zip_info.filename, filepath)
+
+                if not might_contain_dag(zip_info.filename, self.safe_mode, current_zip_file):
+                    # todo: create ignore list
+                    # Don't want to spam user with skip messages
+                    self.log.info(
+                        "File %s:%s assumed to contain no DAGs. Skipping.", filepath, zip_info.filename
+                    )
+                    continue
+
+                mod_name = zip_path.stem
+                if mod_name in sys.modules:
+                    del sys.modules[mod_name]
+
+                DagContext.current_autoregister_module_name = mod_name
+                try:
+                    sys.path.insert(0, filepath)
+                    current_module = importlib.import_module(mod_name)
+                    mods.append(current_module)
+                except Exception as e:
+                    DagContext.autoregistered_dags.clear()
+                    fileloc = os.path.join(filepath, zip_info.filename)
+                    self.log.exception("Failed to import: %s", fileloc)
+                    if self.dagbag_import_error_tracebacks:
+                        import_errors[fileloc] = traceback.format_exc(
+                            limit=-self.dagbag_import_error_traceback_depth
+                        )
+                    else:
+                        import_errors[fileloc] = str(e)
+                finally:
+                    if sys.path[0] == filepath:
+                        del sys.path[0]
+        return mods, import_errors
+
+    def _process_modules(self, filepath, mods) -> Tuple[Collection[DAG], Mapping[str, str]]:
+        from airflow.models.dag import DAG, DagContext  # Avoid circular import
+
+        top_level_dags = {(o, m) for m in mods for o in m.__dict__.values() if isinstance(o, DAG)}
+
+        top_level_dags.update(DagContext.autoregistered_dags)
+
+        DagContext.current_autoregister_module_name = None
+        DagContext.autoregistered_dags.clear()
+
+        found_dags = []
+        import_errors = {}
+
+        for dag, mod in top_level_dags:
+            dag.fileloc = mod.__file__
+            try:
+                self._validate_dag(dag=dag)
+            except AirflowClusterPolicySkipDag:
+                pass
+            except Exception as e:
+                self.log.exception("Failed to bag_dag: %s", dag.fileloc)
+                import_errors[dag.fileloc] = f"{type(e).__name__}: {e}"
+            else:
+                found_dags.append(dag)
+        return found_dags, import_errors
+
+    def _validate_dag(self, dag: DAG):
+        """
+        Add the DAG into the bag.
+
+        :raises: AirflowDagCycleException if a cycle is detected in this dag or its subdags.
+        :raises: AirflowDagDuplicatedIdException if this dag or its subdags already exists in the bag.
+        """
+
+        dag.validate()
+        check_cycle(dag)  # throws if a task cycle is found
+
+        dag.resolve_template_files()
+        dag.last_loaded = timezone.utcnow()
+
+        try:
+            # Check policies
+            settings.dag_policy(dag)
+
+            for task in dag.tasks:
+                # The listeners are not supported when ending a task via a trigger on asynchronous operators.
+                if getattr(task, "end_from_trigger", False) and get_listener_manager().has_listeners:
+                    raise AirflowException(
+                        "Listeners are not supported with end_from_trigger=True for deferrable operators. "
+                        "Task %s in DAG %s has end_from_trigger=True with listeners from plugins. "
+                        "Set end_from_trigger=False to use listeners.",
+                        task.task_id,
+                        dag.dag_id,
+                    )
+
+                settings.task_policy(task)
+        except (AirflowClusterPolicyViolation, AirflowClusterPolicySkipDag):
+            raise
+        except Exception as e:
+            self.log.exception(e)
+            raise AirflowClusterPolicyError(e)
+
+        self.log.debug("Validated DAG %s", dag)
+
+    def _list_py_file_paths(self, subdir: str) -> list[str]:
+        # Ensure dag_folder is a str -- it may have been a pathlib.Path
+        corrected_subdir = correct_maybe_zipped(subdir)
+        return list_py_file_paths(
+            corrected_subdir,
+            safe_mode=self.safe_mode,
+            include_examples=False,
+        )

--- a/airflow/dag_processing/once_ingester.py
+++ b/airflow/dag_processing/once_ingester.py
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable, Mapping
+
+from airflow.dag_processing.dag_ingester import DagIngester
+
+if TYPE_CHECKING:
+    from airflow.dag_processing.dag_store import DagStore
+    from airflow.dag_processing.dag_importer import DagImporter
+
+
+class OnceIngester(DagIngester):
+    def run_ingestion(self, 
+        dag_store: DagStore,
+        importers: Mapping[str, DagImporter],
+        heartbeat_callback: Callable[[], None] | None = None
+    ) -> None:
+
+        for path in importers:
+            # TODO: Make use of multi-processing.
+            self.log.info(f'Importing DAGs from {path}...')
+
+            path_import_errors = set()
+            imported_paths = {}
+            for results in importers[path].import_path(path):
+                import_errors = {**results.import_errors}
+                if results.dags:
+                    imported_paths.update({dag.dag_id: dag.fileloc for dag in results.dags.values()})
+                    store_errors = dag_store.store_dags(results.dags.values(), processor_subdir=path)
+                    import_errors.update({imported_paths[dag_id]: store_errors[dag_id] for dag_id in store_errors})
+
+                    for failed_dag_id in store_errors:
+                        imported_paths.pop(failed_dag_id)
+
+                path_import_errors.update(import_errors)
+                dag_store.update_import_errors(import_errors, processor_subdir=path)
+                # TODO: handle warnings
+            dag_store.delete_excluded_import_errors(path_import_errors, processor_subdir=path)
+            dag_store.delete_removed_entries_dags(imported_paths.values(), processor_subdir=path)
+        dag_store.delete_removed_processor_subdir_dags(alive_processor_subdirs=importers)
+        dag_store.delete_excluded_subdir_import_errors(set(importers.keys()))
+
+    def supports_priority_parsing(self, subpath: str):
+        return True

--- a/airflow/models/dagcode.py
+++ b/airflow/models/dagcode.py
@@ -136,6 +136,7 @@ class DagCode(Base):
         cls,
         alive_dag_filelocs: Collection[str],
         processor_subdir: str,
+        filepath_prefix: str = "",
         session: Session = NEW_SESSION,
     ) -> None:
         """
@@ -154,6 +155,7 @@ class DagCode(Base):
             .where(
                 cls.fileloc_hash.notin_(alive_fileloc_hashes),
                 cls.fileloc.notin_(alive_dag_filelocs),
+                cls.fileloc.startswith(filepath_prefix),
                 cls.fileloc.contains(processor_subdir),
             )
             .execution_options(synchronize_session="fetch")

--- a/airflow/utils/sensor_helper.py
+++ b/airflow/utils/sensor_helper.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, cast
 
 from sqlalchemy import func, select
 
+from airflow.dag_processing.dag_store import DagStore
 from airflow.models import DagBag, DagRun, TaskInstance
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.sqlalchemy import tuple_in_condition
@@ -104,8 +105,9 @@ def _get_external_task_group_task_ids(dttm_filter, external_task_group_id, exter
     :param external_dag_id: The ID of the external DAG.
     :param session: airflow session object
     """
-    refreshed_dag_info = DagBag(read_dags_from_db=True).get_dag(external_dag_id, session)
-    task_group = refreshed_dag_info.task_group_dict.get(external_task_group_id)
+    refreshed_dag_info = DagStore().load_dag(external_dag_id, session)
+
+    task_group = refreshed_dag_info.dag.task_group_dict.get(external_task_group_id)
 
     if task_group:
         group_tasks = session.scalars(

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -37,7 +37,7 @@ from airflow.utils.json import AirflowJsonProvider
 from airflow.www.extensions.init_appbuilder import init_appbuilder
 from airflow.www.extensions.init_appbuilder_links import init_appbuilder_links
 from airflow.www.extensions.init_cache import init_cache
-from airflow.www.extensions.init_dagbag import init_dagbag
+from airflow.www.extensions.init_dag_source import init_dag_source
 from airflow.www.extensions.init_jinja_globals import init_jinja_globals
 from airflow.www.extensions.init_manifest_files import configure_manifest_files
 from airflow.www.extensions.init_robots import init_robots
@@ -136,7 +136,7 @@ def create_app(config=None, testing=False):
     db.session = settings.Session
     db.init_app(flask_app)
 
-    init_dagbag(flask_app)
+    init_dag_source(flask_app)
 
     init_api_auth(flask_app)
 

--- a/airflow/www/extensions/init_dag_source.py
+++ b/airflow/www/extensions/init_dag_source.py
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import os
+
+from airflow.dag_processing.dag_store import DagSource, DagStore
+
+
+def init_dag_source(app):
+    """
+    Create global DagSource for webserver and API.
+
+    To access it use ``flask.current_app.dag_source``.
+    """
+    app.dag_source: DagSource = DagStore(load_op_links=True)

--- a/providers/src/airflow/providers/google/common/importers/__init__.py
+++ b/providers/src/airflow/providers/google/common/importers/__init__.py
@@ -14,25 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from __future__ import annotations
-
-import os
-
-from airflow.models import DagBag
-from airflow.settings import DAGS_FOLDER
-
-
-def get_dag_bag() -> DagBag:
-    """Instantiate the appropriate DagBag based on the ``SKIP_DAGS_PARSING`` environment variable."""
-    if os.environ.get("SKIP_DAGS_PARSING") == "True":
-        return DagBag(os.devnull, include_examples=False)
-    return DagBag(DAGS_FOLDER, read_dags_from_db=True)
-
-
-def init_dagbag(app):
-    """
-    Create global DagBag for webserver and API.
-
-    To access it use ``flask.current_app.dag_bag``.
-    """
-    app.dag_bag = get_dag_bag()

--- a/providers/src/airflow/providers/google/common/importers/notebooks_importer.py
+++ b/providers/src/airflow/providers/google/common/importers/notebooks_importer.py
@@ -1,0 +1,182 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import functools
+import pathlib
+import os
+import sys
+import types
+from typing import Iterable, TYPE_CHECKING
+
+import nbformat
+import IPython
+
+from airflow.dag_processing.dag_importer import DagImporter, DagsImportResult, ImportOptions, PathData
+from airflow.exceptions import (
+    AirflowClusterPolicyError,
+    AirflowClusterPolicySkipDag,
+    AirflowClusterPolicyViolation,
+    AirflowDagCycleException,
+    AirflowDagDuplicatedIdException,
+    AirflowException,
+    AirflowTaskTimeout,
+)
+from airflow.listeners.listener import get_listener_manager
+from airflow import settings
+from airflow.configuration import conf
+from airflow.utils import timezone
+from airflow.utils.dag_cycle_tester import check_cycle
+
+
+def _list_ipynb_files(dagpath: str) -> list[str]:
+    ipynb_files = []
+    if pathlib.Path(dagpath).is_dir():
+        for filename in os.listdir(dagpath):
+            if filename.endswith(".ipynb"):
+                ipynb_files.append(os.path.join(dagpath, filename))
+    else:
+        ipynb_files.append(dagpath)
+    return ipynb_files
+
+
+
+class NotebooksImporter(DagImporter):
+    """
+    This is just a simplified demo, it is not going to be included as part of AIP-85.
+    """
+    def import_path(self, dagpath: str, options: ImportOptions | None = None) -> Generator[DagsImportResult, None, None]:
+        from airflow.models.dag import DagContext
+
+        ipynb_files = _list_ipynb_files(dagpath)
+        import_results = []
+        for notebook in ipynb_files:
+            try:
+                module_name = pathlib.Path(notebook).name
+                with open(notebook, "r") as f:
+                    content = nbformat.read(f, 4)
+                
+                mod = types.ModuleType(module_name)
+                mod.__loader__ = self
+                mod.__dict__["get_ipython"] = IPython.get_ipython
+                mod.__file__ = notebook
+                sys.modules[module_name] = mod
+                ipython_instance = IPython.core.interactiveshell.InteractiveShell.instance()
+                instance_ns = ipython_instance.user_ns
+                ipython_instance.user_ns = mod.__dict__
+
+                DagContext.current_autoregister_module_name = module_name
+                try:
+                    for cell in content.cells:
+                        if cell.cell_type != "code":
+                            continue
+                        rendered_cell = ipython_instance.input_transformer_manager.transform_cell(cell.source)
+                        exec(rendered_cell, mod.__dict__)
+                except (Exception, AirflowTaskTimeout) as e:
+                    DagContext.autoregistered_dags.clear()
+                    self.log.exception("Failed to import: %s", notebook)
+                    import_results.append(DagsImportResult(
+                        dags={},
+                        import_warnings={},
+                        import_errors={notebook: str(e)},
+                    ))
+                finally:
+                    ipython_instance.user_ns = instance_ns
+                found_dags, module_import_errors = self._process_modules(notebook, [mod])
+
+                import_results.append(DagsImportResult(
+                    dags={dag.dag_id: dag for dag in found_dags},
+                    import_warnings={},
+                    import_errors=module_import_errors,
+                ))
+
+            except Exception as e:
+                self.log.exception(e)
+        
+        yield DagsImportResult(
+            # TODO: check collisions
+            dags=functools.reduce(lambda agg, result: {**agg, **result.dags}, import_results, {}),
+            import_errors=functools.reduce(lambda agg, result: {**agg, **result.import_errors}, import_results, {}),
+            import_warnings=functools.reduce(lambda agg, result: {**agg, **result.import_errors}, import_results, {}),
+        )
+
+    def list_paths(self, subpath: str) -> Iterable[PathData]:
+        return map(lambda path: PathData(path), _list_ipynb_files(subpath))
+
+    def _process_modules(self, filepath, mods) -> Tuple[Collection[DAG], Mapping[str, str]]:
+        from airflow.models.dag import DAG, DagContext  # Avoid circular import
+
+        top_level_dags = {(o, m) for m in mods for o in m.__dict__.values() if isinstance(o, DAG)}
+
+        top_level_dags.update(DagContext.autoregistered_dags)
+
+        DagContext.current_autoregister_module_name = None
+        DagContext.autoregistered_dags.clear()
+
+        found_dags = []
+        import_errors = {}
+
+        for dag, mod in top_level_dags:
+            dag.fileloc = mod.__file__
+            try:
+                self._validate_dag(dag=dag)
+            except AirflowClusterPolicySkipDag:
+                pass
+            except Exception as e:
+                self.log.exception("Failed to bag_dag: %s", dag.fileloc)
+                import_errors[dag.fileloc] = f"{type(e).__name__}: {e}"
+            else:
+                found_dags.append(dag)
+        return found_dags, import_errors
+    
+    def _validate_dag(self, dag: DAG):
+        """
+        Add the DAG into the bag.
+
+        :raises: AirflowDagCycleException if a cycle is detected in this dag or its subdags.
+        :raises: AirflowDagDuplicatedIdException if this dag or its subdags already exists in the bag.
+        """
+
+        dag.validate()
+        check_cycle(dag)  # throws if a task cycle is found
+
+        dag.resolve_template_files()
+        dag.last_loaded = timezone.utcnow()
+
+        try:
+            # Check policies
+            settings.dag_policy(dag)
+
+            for task in dag.tasks:
+                # The listeners are not supported when ending a task via a trigger on asynchronous operators.
+                if getattr(task, "end_from_trigger", False) and get_listener_manager().has_listeners:
+                    raise AirflowException(
+                        "Listeners are not supported with end_from_trigger=True for deferrable operators. "
+                        "Task %s in DAG %s has end_from_trigger=True with listeners from plugins. "
+                        "Set end_from_trigger=False to use listeners.",
+                        task.task_id,
+                        dag.dag_id,
+                    )
+
+                settings.task_policy(task)
+        except (AirflowClusterPolicyViolation, AirflowClusterPolicySkipDag):
+            raise
+        except Exception as e:
+            self.log.exception(e)
+            raise AirflowClusterPolicyError(e)
+
+        self.log.debug("Validated DAG %s", dag)

--- a/scripts/cov/www_coverage.py
+++ b/scripts/cov/www_coverage.py
@@ -33,7 +33,7 @@ files_not_fully_covered = [
     "airflow/www/decorators.py",
     "airflow/www/extensions/init_appbuilder.py",
     "airflow/www/extensions/init_auth_manager.py",
-    "airflow/www/extensions/init_dagbag.py",
+    "airflow/www/extensions/init_dag_source.py",
     "airflow/www/extensions/init_jinja_globals.py",
     "airflow/www/extensions/init_manifest_files.py",
     "airflow/www/extensions/init_security.py",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
This is a simple draft with PoC of AIP-85 https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-85+Extendable+DAG+parsing+controls.

The key highlights and proposed interfaces/implementations are:
1) `airflow/dag_processing/dag_importer.py`: DagImporter - a mechanism abstracting a way of how a "path" is translated into one or more parsed DAGs. 
   - Default implementation is `FSDagImporter` (`airflow/dag_processing/fs_dag_importer.py`) - read a DAG from definition in a Python file. 
   - Alternative "demo" implementation - `NotebooksImporter` (`providers/src/airflow/providers/google/common/importers/notebooks_importer.py`), which imports Python definitions from Jupyter notebook files (for demonstration purposes only, not part of the actual AIP).

2) `airflow/dag_processing/dag_ingester.py`: DagIngester - a mechanism to abstract away the logic of operations of parsing/adding/updating/removing DAGs and their importing metadata (i.e. importing errors/warnings). Sample implementations:
   - Continuous ingester (`airflow/dag_processing/continuous_ingester.py`) - replication of the current regular dag-processor paring logic (by reusing current DagFileProcessingManagers)
   - Once ingester (`airflow/dag_processing/once_ingester.py`) - ingester that only imports DAGs once

Those 2 interfaces (that are allowed to be extended by providers/core Airflow) build a foundation to address AIP-85 requirements - increase flexibility of how DAGs are being updated and how they can be defined.

Apart from that, DagBag usage is replaced in most places with one of the following components:
  - DagStore (`airflow/dag_processing/dag_store.py`) - access to Airflow DAGs in metadata DBs (no access to DAG sources required). Used by any component that requires access to DAG's metadata (i.e. by scheduler, public API, etc.).
  - DagParser (`airflow/dag_processing/dag_parser.py`) - access to parsed DAGs (used by worker and dag-processor).

A lot of things are "swept under the rug" here as this is just a PoC based on an older Airflow branch before most of Airflow 3 changes landed. Big things that are missing:
  - Callbacks are not yet moved to a separate component (temporarily disabled)
  - Integration with bundles
  - Missing optimizations around module importing
  - DagCode is not propagated for non-FSDagImporter


**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
