### PR TITLE
Extend and fix "airflow config lint" rules

### DIFF
--- a/airflow/cli/cli_config.py
+++ b/airflow/cli/cli_config.py
@@ -858,6 +858,7 @@ ARG_OPTION = Arg(
     help="The option name",
 )
 
+# lint
 ARG_LINT_CONFIG_SECTION = Arg(
     ("--section",),
     help="The section name(s) to lint in the airflow config.",

--- a/airflow/cli/commands/remote_commands/config_command.py
+++ b/airflow/cli/commands/remote_commands/config_command.py
@@ -122,12 +122,11 @@ CONFIGS_CHANGES = [
     # core
     ConfigChange(
         config=ConfigParameter("core", "check_slas"),
-        suggestion="The SLA feature is removed in Airflow 3.0, to be replaced with Airflow Alerts in "
-        "future",
+        suggestion="The SLA feature is removed in Airflow 3.0, to be replaced with Airflow Alerts in future",
     ),
     ConfigChange(
-        config=ConfigParameter("core", "strict_asset_uri_validation"),
-        suggestion="Asset URI with a defined scheme will now always be validated strictly, "
+        config=ConfigParameter("core", "strict_dataset_uri_validation"),
+        suggestion="Dataset URI with a defined scheme will now always be validated strictly, "
         "raising a hard error on validation failure.",
     ),
     ConfigChange(

--- a/airflow/cli/commands/remote_commands/config_command.py
+++ b/airflow/cli/commands/remote_commands/config_command.py
@@ -130,6 +130,14 @@ CONFIGS_CHANGES = [
         "raising a hard error on validation failure.",
     ),
     ConfigChange(
+        config=ConfigParameter("core", "dataset_manager_class"),
+        renamed_to=ConfigParameter("core", "asset_manager_class"),
+    ),
+    ConfigChange(
+        config=ConfigParameter("core", "dataset_manager_kwargs"),
+        renamed_to=ConfigParameter("core", "asset_manager_kwargs"),
+    ),
+    ConfigChange(
         config=ConfigParameter("core", "worker_precheck"),
         renamed_to=ConfigParameter("celery", "worker_precheck"),
     ),

--- a/airflow/cli/commands/remote_commands/config_command.py
+++ b/airflow/cli/commands/remote_commands/config_command.py
@@ -245,6 +245,9 @@ CONFIGS_CHANGES = [
         config=ConfigParameter("webserver", "allow_raw_html_descriptions"),
     ),
     ConfigChange(
+        config=ConfigParameter("webserver", "cookie_samesite"),
+    ),
+    ConfigChange(
         config=ConfigParameter("webserver", "update_fab_perms"),
         renamed_to=ConfigParameter("fab", "update_fab_perms"),
     ),

--- a/tests/cli/commands/remote_commands/test_config_command.py
+++ b/tests/cli/commands/remote_commands/test_config_command.py
@@ -264,8 +264,8 @@ class TestConfigLint:
             ),
             (
                 "core",
-                "strict_asset_uri_validation",
-                "Asset URI with a defined scheme will now always be validated strictly, raising a hard error on validation failure.",
+                "strict_dataset_uri_validation",
+                "Dataset URI with a defined scheme will now always be validated strictly, raising a hard error on validation failure.",
             ),
             (
                 "logging",
@@ -324,7 +324,7 @@ class TestConfigLint:
     def test_lint_detects_multiple_issues(self):
         with mock.patch(
             "airflow.configuration.conf.has_option",
-            side_effect=lambda s, o: o in ["check_slas", "strict_asset_uri_validation"],
+            side_effect=lambda s, o: o in ["check_slas", "strict_dataset_uri_validation"],
         ):
             with contextlib.redirect_stdout(StringIO()) as temp_stdout:
                 config_command.lint_config(cli_parser.get_parser().parse_args(["config", "lint"]))
@@ -338,7 +338,7 @@ class TestConfigLint:
             in normalized_output
         )
         assert (
-            "Removed deprecated `strict_asset_uri_validation` configuration parameter from `core` section."
+            "Removed deprecated `strict_dataset_uri_validation` configuration parameter from `core` section."
             in normalized_output
         )
 
@@ -353,8 +353,8 @@ class TestConfigLint:
                 ),
                 (
                     "core",
-                    "strict_asset_uri_validation",
-                    "Asset URI with a defined scheme will now always be validated strictly, raising a hard error on validation failure.",
+                    "strict_dataset_uri_validation",
+                    "Dataset URI with a defined scheme will now always be validated strictly, raising a hard error on validation failure.",
                 ),
                 (
                     "logging",
@@ -425,12 +425,12 @@ class TestConfigLint:
                 "Removed deprecated `check_slas` configuration parameter from `core` section.",
             ),
             (
-                "AIRFLOW__CORE__STRICT_ASSET_URI_VALIDATION",
+                "AIRFLOW__CORE__strict_dataset_uri_validation",
                 ConfigChange(
-                    config=ConfigParameter("core", "strict_asset_uri_validation"),
-                    suggestion="Asset URI with a defined scheme will now always be validated strictly, raising a hard error on validation failure.",
+                    config=ConfigParameter("core", "strict_dataset_uri_validation"),
+                    suggestion="Dataset URI with a defined scheme will now always be validated strictly, raising a hard error on validation failure.",
                 ),
-                "Removed deprecated `strict_asset_uri_validation` configuration parameter from `core` section.",
+                "Removed deprecated `strict_dataset_uri_validation` configuration parameter from `core` section.",
             ),
         ],
     )


### PR DESCRIPTION
* feat
    * warn `webserver.cookie_samesite` usage
        * config removed 
    * warn `core.dataset_manager_class` and `core.dataset_manager_kwargs` usage
        * replace them with `core.asset_manager_class` and `core.asset_manager_kwargs` 
* fix
    * warn `strict_dataset_uri_validation` instead of `strict_asset_uri_validation`

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
