### PR TITLE
Deprecating email, email_on_retry, email_on_failure in `BaseOperator`

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2141,12 +2141,13 @@ email:
       description: |
         Whether email alerts should be sent when a task is retried
       version_added: 2.0.0
-      deprecation_reason: |
-        This email integration is no longer coupled with Airflow core.
-        SmtpNotifier provide easy interface to send email notifications.
       type: boolean
       example: ~
       default: "True"
+      version_deprecated: 2.10.5
+      deprecation_reason: |
+        This email integration is no longer coupled with Airflow core.
+        SmtpNotifier provide easy interface to send email notifications.
     default_email_on_failure:
       description: |
         Whether email alerts should be sent when a task failed

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2141,6 +2141,10 @@ email:
       description: |
         Whether email alerts should be sent when a task is retried
       version_added: 2.0.0
+
+      deprecation_reason: |
+        This email integration is no longer coupled with Airflow core.
+        SmtpNotifier provide easy interface to send email notifications.
       type: boolean
       example: ~
       default: "True"
@@ -2151,6 +2155,10 @@ email:
       type: boolean
       example: ~
       default: "True"
+      version_deprecated: 2.10.5
+      deprecation_reason: |
+        This email integration is no longer coupled with Airflow core.
+        SmtpNotifier provide easy interface to send email notifications.
     subject_template:
       description: |
         File that will be used as the template for Email subject (which will be rendered using Jinja2).

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2144,10 +2144,6 @@ email:
       type: boolean
       example: ~
       default: "True"
-      version_deprecated: 2.10.5
-      deprecation_reason: |
-        This email integration is no longer coupled with Airflow core.
-        SmtpNotifier provide easy interface to send email notifications.
     default_email_on_failure:
       description: |
         Whether email alerts should be sent when a task failed
@@ -2155,10 +2151,6 @@ email:
       type: boolean
       example: ~
       default: "True"
-      version_deprecated: 2.10.5
-      deprecation_reason: |
-        This email integration is no longer coupled with Airflow core.
-        SmtpNotifier provide easy interface to send email notifications.
     subject_template:
       description: |
         File that will be used as the template for Email subject (which will be rendered using Jinja2).

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2141,7 +2141,6 @@ email:
       description: |
         Whether email alerts should be sent when a task is retried
       version_added: 2.0.0
-
       deprecation_reason: |
         This email integration is no longer coupled with Airflow core.
         SmtpNotifier provide easy interface to send email notifications.

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -981,7 +981,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         self.email_on_retry = email_on_retry
         self.email_on_failure = email_on_failure
 
-        if emailis not None:
+        if email is not None:
             warnings.warn(
                 "email is deprecated please migrate to SmtpNotifier`.",
                 RemovedInAirflow3Warning,

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -981,19 +981,19 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         self.email_on_retry = email_on_retry
         self.email_on_failure = email_on_failure
 
-        if self.email:
+        if emailis not None:
             warnings.warn(
                 "email is deprecated please migrate to SmtpNotifier`.",
                 RemovedInAirflow3Warning,
                 stacklevel=2,
             )
-        if self.email_on_retry:
+        if email_on_retry is not None:
             warnings.warn(
                 "email_on_retry is deprecated please migrate to SmtpNotifier`.",
                 RemovedInAirflow3Warning,
                 stacklevel=2,
             )
-        if self.email_on_failure:
+        if email_on_failure is not None:
             warnings.warn(
                 "email_on_retry is deprecated please migrate to SmtpNotifier`.",
                 RemovedInAirflow3Warning,

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -610,11 +610,11 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         (e.g. user/person/team/role name) to clarify ownership is recommended.
     :param email: the 'to' email address(es) used in email alerts. This can be a
         single email or multiple ones. Multiple addresses can be specified as a
-        comma or semicolon separated string or by passing a list of strings.
+        comma or semicolon separated string or by passing a list of strings. (deprecated)
     :param email_on_retry: Indicates whether email alerts should be sent when a
-        task is retried
+        task is retried (deprecated)
     :param email_on_failure: Indicates whether email alerts should be sent when
-        a task failed
+        a task failed (deprecated)
     :param retries: the number of retries that should be performed before
         failing the task
     :param retry_delay: delay between retries, can be set as ``timedelta`` or
@@ -981,6 +981,24 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         self.email_on_retry = email_on_retry
         self.email_on_failure = email_on_failure
 
+        if self.email:
+            warnings.warn(
+                "email is deprecated please migrate to SmtpNotifier`.",
+                RemovedInAirflow3Warning,
+                stacklevel=2,
+            )
+        if self.email_on_retry:
+            warnings.warn(
+                "email_on_retry is deprecated please migrate to SmtpNotifier`.",
+                RemovedInAirflow3Warning,
+                stacklevel=2,
+            )
+        if self.email_on_failure:
+            warnings.warn(
+                "email_on_retry is deprecated please migrate to SmtpNotifier`.",
+                RemovedInAirflow3Warning,
+                stacklevel=2,
+            )
         if execution_timeout is not None and not isinstance(execution_timeout, timedelta):
             raise ValueError(
                 f"execution_timeout must be timedelta object but passed as type: {type(execution_timeout)}"


### PR DESCRIPTION
This PR is against **v2-10-test**

I'd like to make sure we deliver deprecation notice as early as possible.
Users should migrate to SmtpNotifier. Email is just another notification integration it should not be favoured by Airflow core.
We have a very nice template introduced in https://github.com/apache/airflow/pull/36226 so migration should be simple enough.

Removal of email integration from main branch will be handled as part of https://github.com/apache/airflow/pull/30531