### PR TITLE
Fixed assignment of proxies in KiotaRequestAdapter for HTTPX 0.28.x compliancy

### DIFF
--- a/providers/src/airflow/providers/microsoft/azure/hooks/msgraph.py
+++ b/providers/src/airflow/providers/microsoft/azure/hooks/msgraph.py
@@ -288,7 +288,7 @@ class KiotaRequestAdapterHook(BaseHook):
             http_client = GraphClientFactory.create_with_default_middleware(
                 api_version=api_version,  # type: ignore
                 client=httpx.AsyncClient(
-                    mounts=httpx_proxies,
+                    proxy=httpx_proxies,  # type: ignore
                     timeout=Timeout(timeout=self.timeout),
                     verify=verify,
                     trust_env=trust_env,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: [#45464](https://github.com/apache/airflow/pull/45464)

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

The previous PR [#45464](https://github.com/apache/airflow/pull/45464) did some changes to be HTTPX 0.28.x, unfortunately it broke the parametrization of the proxies parameter, this is fixed in this PR.

As the proxies parameter is deprecated in HTTPX 0.27.x and is removed in 0.28.x, it was wrongly assigned to the mounts parameter, it should in fact be assigned to the proxy parameter, this PR fixes it.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
