### PR TITLE
Add Webserver parameters: max_form_parts, max_form_memory_size

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2052,6 +2052,22 @@ webserver:
       type: boolean
       example: ~
       default: "False"
+    max_form_memory_size:
+      description: |
+        The maximum size in bytes any non-file form field may be in a multipart/form-data body.
+        If this limit is exceeded, a 413 RequestEntityTooLarge error is raised by webserver.
+      version_added: 2.10.5
+      type: integer
+      example: ~
+      default: "500000"
+    max_form_parts:
+      description: |
+        The maximum number of fields that may be present in a multipart/form-data body.
+        If this limit is exceeded, a 413 RequestEntityTooLarge error is raised by webserver.
+      version_added: 2.10.5
+      type: integer
+      example: ~
+      default: "1000"
 email:
   description: |
     Configuration email backend and whether to

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -72,6 +72,8 @@ def create_app(config=None, testing=False):
     flask_app.config["PERMANENT_SESSION_LIFETIME"] = timedelta(minutes=settings.get_session_lifetime_config())
 
     flask_app.config["MAX_CONTENT_LENGTH"] = conf.getfloat("webserver", "allowed_payload_size") * 1024 * 1024
+    flask_app.config["MAX_FORM_PARTS"] = conf.getint("webserver", "max_form_parts")
+    flask_app.config["MAX_FORM_MEMORY_SIZE"] = conf.getint("webserver", "max_form_memory_size")
 
     webserver_config = conf.get_mandatory_value("webserver", "config_file")
     # Enable customizations in webserver_config.py to be applied via Flask.current_app.


### PR DESCRIPTION
The problem resolved in this PR:
- `max_form_parts` (https://flask.palletsprojects.com/en/stable/api/#flask.Request.max_form_parts) is not configurable in Airflow web server (1000 is the default value).
- `max_form_parts` is relevant for a "role edit" form in Airflow UI.
- Size of the role (number of permissions) contributes to the number of form parts in POST request generated by Airflow UI.
- There are real-life cases (roles with hundreds of permissions) where max_form_parts is exceeded (error 413) and blocks updating roles through the Airflow UI.

In order to overcome this limitation, two more webserver config options were introduced:
- `[webserver]max_form_parts = 1000`
- `[webserver]max_form_memory_size = 500000`