### PR TITLE
Move Pod*Exceptions to separate module to avoid unnecessary slow imports in CLI

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -461,7 +461,7 @@ class TaskDeferralTimeout(AirflowException):
 # 2) if you have new provider, both provider and pod generator will throw the
 #    "airflow.providers.cncf.kubernetes" as it will be imported here from the provider.
 try:
-    from airflow.providers.cncf.kubernetes.pod_generator import PodMutationHookException
+    from airflow.providers.cncf.kubernetes.exceptions import PodMutationHookException
 except ImportError:
 
     class PodMutationHookException(AirflowException):  # type: ignore[no-redef]
@@ -469,7 +469,7 @@ except ImportError:
 
 
 try:
-    from airflow.providers.cncf.kubernetes.pod_generator import PodReconciliationError
+    from airflow.providers.cncf.kubernetes.exceptions import PodReconciliationError
 except ImportError:
 
     class PodReconciliationError(AirflowException):  # type: ignore[no-redef]

--- a/providers/src/airflow/providers/cncf/kubernetes/exceptions.py
+++ b/providers/src/airflow/providers/cncf/kubernetes/exceptions.py
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from airflow.exceptions import (
+    AirflowException,
+)
+
+
+class PodMutationHookException(AirflowException):
+    """Raised when exception happens during Pod Mutation Hook execution."""
+
+
+class PodReconciliationError(AirflowException):
+    """Raised when an error is encountered while trying to merge pod configs."""

--- a/providers/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -61,13 +61,13 @@ from airflow.configuration import conf
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.executors.base_executor import BaseExecutor
 from airflow.executors.executor_constants import KUBERNETES_EXECUTOR
+from airflow.providers.cncf.kubernetes.exceptions import PodMutationHookException, PodReconciliationError
 from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import (
     ADOPTED,
     POD_EXECUTOR_DONE_KEY,
 )
 from airflow.providers.cncf.kubernetes.kube_config import KubeConfig
 from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import annotations_to_key
-from airflow.providers.cncf.kubernetes.pod_generator import PodMutationHookException, PodReconciliationError
 from airflow.stats import Stats
 from airflow.utils.event_scheduler import EventScheduler
 from airflow.utils.log.logging_mixin import remove_escape_codes

--- a/providers/src/airflow/providers/cncf/kubernetes/pod_generator.py
+++ b/providers/src/airflow/providers/cncf/kubernetes/pod_generator.py
@@ -39,9 +39,9 @@ from kubernetes.client.api_client import ApiClient
 
 from airflow.exceptions import (
     AirflowConfigException,
-    AirflowException,
 )
 from airflow.providers.cncf.kubernetes.backcompat import get_logical_date_key
+from airflow.providers.cncf.kubernetes.exceptions import PodMutationHookException, PodReconciliationError
 from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import (
     POD_NAME_MAX_LENGTH,
     add_unique_suffix,
@@ -56,14 +56,6 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 MAX_LABEL_LEN = 63
-
-
-class PodMutationHookException(AirflowException):
-    """Raised when exception happens during Pod Mutation Hook execution."""
-
-
-class PodReconciliationError(AirflowException):
-    """Raised when an error is encountered while trying to merge pod configs."""
 
 
 def make_safe_label_value(string: str) -> str:

--- a/tests/core/test_exceptions.py
+++ b/tests/core/test_exceptions.py
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import sys
+
+
+class TestExceptions:
+    def setup_method(self):
+        self.old_modules = dict(sys.modules)
+
+    def teardown_method(self):
+        # Remove any new modules imported during the test run. This lets us
+        # import the same source files for more than one test.
+        for mod in [m for m in sys.modules if m not in self.old_modules]:
+            del sys.modules[mod]
+
+    def test_pod_mutation_hook_exceptions_compatibility(
+        self,
+    ):
+        from airflow.exceptions import (
+            PodMutationHookException as CoreMutationHookException,
+        )
+        from airflow.providers.cncf.kubernetes.exceptions import (
+            PodMutationHookException as ProviderMutationHookException,
+        )
+        from airflow.providers.cncf.kubernetes.pod_generator import (
+            PodMutationHookException as ProviderGeneratorMutationHookException,
+        )
+
+        assert ProviderMutationHookException == CoreMutationHookException
+        assert ProviderMutationHookException == ProviderGeneratorMutationHookException
+
+    def test_pod_reconciliation_error_exceptions_compatibility(
+        self,
+    ):
+        from airflow.exceptions import (
+            PodReconciliationError as CoreReconciliationError,
+        )
+        from airflow.providers.cncf.kubernetes.exceptions import (
+            PodReconciliationError as ProviderReconciliationError,
+        )
+        from airflow.providers.cncf.kubernetes.pod_generator import (
+            PodReconciliationError as ProviderGeneratorReconciliationError,
+        )
+
+        assert ProviderReconciliationError == CoreReconciliationError
+        assert ProviderReconciliationError == ProviderGeneratorReconciliationError


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Pod*Exceptions has been moved from core to providers back in https://github.com/apache/airflow/commit/de92a81f002e6c1b3e74ad9d074438b65acb87b6, but kept in `airflow/exceptions.py` under try-case for backwards compatibility and allow for usage of an older k8s provider with a newer core airflow.

This resulted in 2 unintended side-effects:

1. Any CLI command started taking ~ 1s longer to start. That is because importing anything from `airflow` resulted in importing `kubernetes` client. It is effectively the most expensive import out of all CLI does for any command, even though it is used by very few commands. Here are the timings of a trivial `airflow dag-processor --help`
  - Before this PR: 6.0s https://pastebin.com/zb0QHFq9
  - After this PR: 4.97s https://pastebin.com/QC5Rbyt5
 2. Some time ago the compatibility import broke altogether. Because of the amount of imports in `pod_generator.py`, the import from `exceptions.py` failed even if providers were up to date with recursive import. But it was caught by exception handling, resulting in `from airflow.exceptions import PodMutationHookException` and `from airflow.providers.cncf.kubernetes.pod_generator import PodMutationHookException` pointing to different classes defeating the purpose of the fallback.

This PR addresses both by moving PodGenerator exceptions to the separate module that only import its base class. This keeps imports backwards compatible, doesn't attempt to load k8s modules and fixes the divergence of exception classes in `airflow.providers.cncf.kubernetes.pod_generator` and `airflow.exceptions`.

It is worth noting, that all usages of those exceptions in core Airflow also has been cleaned up since then, so if you believe that we need to remove those exceptions from `airflow/exceptions.py`, please let me know.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
