### PR TITLE
Fix rowcount logging in exasol provider (#44022)

### DIFF
--- a/providers/src/airflow/providers/exasol/hooks/exasol.py
+++ b/providers/src/airflow/providers/exasol/hooks/exasol.py
@@ -246,7 +246,7 @@ class ExasolHook(DbApiHook):
                         else:
                             results.append(result)
                             self.descriptions.append(self.get_description(exa_statement))
-                    self.log.info("Rows affected: %s", exa_statement.rowcount)
+                    self.log.info("Rows affected: %s", exa_statement.rowcount())
 
             # If autocommit was set to False or db does not support autocommit, we do a manual commit.
             if not self.get_autocommit(conn):

--- a/providers/tests/exasol/hooks/test_exasol.py
+++ b/providers/tests/exasol/hooks/test_exasol.py
@@ -65,7 +65,7 @@ class TestExasolHookConn:
 
 class TestExasolHook:
     def setup_method(self):
-        self.cur = mock.MagicMock(rowcount=0)
+        self.cur = mock.MagicMock(rowcount=lambda: 0)
         self.conn = mock.MagicMock()
         self.conn.execute.return_value = self.cur
         conn = self.conn

--- a/providers/tests/exasol/hooks/test_sql.py
+++ b/providers/tests/exasol/hooks/test_sql.py
@@ -260,7 +260,7 @@ def test_query(
         cursors = []
         for index in range(len(cursor_descriptions)):
             cur = mock.MagicMock(
-                rowcount=len(cursor_results[index]),
+                rowcount=lambda: len(cursor_results[index]),
             )
             cur.columns.return_value = get_columns(cursor_descriptions[index])
             cur.fetchall.return_value = cursor_results[index]
@@ -287,7 +287,7 @@ def test_query(
 )
 def test_no_query(empty_statement):
     dbapi_hook = ExasolHookForTests()
-    dbapi_hook.get_conn.return_value.cursor.rowcount = 0
+    dbapi_hook.get_conn.return_value.cursor.rowcount = lambda: 0
     with pytest.raises(ValueError) as err:
         dbapi_hook.run(sql=empty_statement)
     assert err.value.args[0] == "List of SQL statements is empty"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #44022 
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

Fix logging the rowcount in the exasol provider by actually calling the method
closes: #44022 

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
