### PR TITLE
Improve cross-provider dependency detection

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -535,9 +535,7 @@
         "plugin-class": "airflow.providers.edge.plugins.edge_executor_plugin.EdgeExecutorPlugin"
       }
     ],
-    "cross-providers-deps": [
-      "common.compat"
-    ],
+    "cross-providers-deps": [],
     "excluded-python-versions": [],
     "state": "not-ready"
   },

--- a/scripts/ci/pre_commit/update_providers_dependencies.py
+++ b/scripts/ci/pre_commit/update_providers_dependencies.py
@@ -206,11 +206,15 @@ def check_if_different_provider_used(file_path: Path) -> None:
             warnings.append(f"The provider {imported_provider} from {file_path} cannot be found.")
             continue
 
-        if imported_provider == "standard":
-            # Standard -- i.e. BashOperator is used in a lot of example dags, but we don't want to mark this
+        if "/example_dags/" in file_path.as_posix():
+            # If provider is used in a example dags, we don't want to mark this
             # as a provider cross dependency
-            if file_path.name == "celery_executor_utils.py" or "/example_dags/" in file_path.as_posix():
-                continue
+            continue
+        if imported_provider == "standard" and file_path.name == "celery_executor_utils.py":
+            # some common standard operators are pre-imported in celery when it starts in order to speed
+            # up the task startup time - but it does not mean that standard provider is a cross-provider
+            # dependency of the celery executor
+            continue
         if imported_provider:
             if file_provider != imported_provider:
                 ALL_DEPENDENCIES[file_provider]["cross-providers-deps"].append(imported_provider)


### PR DESCRIPTION
When another provider is only used in example dags, we should not make it "cross-provider" dependency - this happened to "edge" provider having "common.compat" as cross-provider dependency.

It has been previously only implemented for "standard" provider but this is a universal rule that could be applied to any other provider.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
