### PR TITLE
Fix authentication for cases where webserver.base_url is not defined and worker is not using localhost in 2.10.

### DIFF
--- a/providers/edge/README.rst
+++ b/providers/edge/README.rst
@@ -24,7 +24,7 @@
 
 Package ``apache-airflow-providers-edge``
 
-Release: ``0.10.1pre0``
+Release: ``0.10.2pre0``
 
 
 Handle edge workers on remote sites via HTTP(s) connection and orchestrates work over distributed sites
@@ -37,7 +37,7 @@ This is a provider package for ``edge`` provider. All classes for this provider 
 are in ``airflow.providers.edge`` python package.
 
 You can find package information and changelog for the provider
-in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.10.1pre0/>`_.
+in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.10.2pre0/>`_.
 
 Installation
 ------------
@@ -60,4 +60,4 @@ PIP package         Version required
 ==================  ==================
 
 The changelog for the provider package can be found in the
-`changelog <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.10.1pre0/changelog.html>`_.
+`changelog <https://airflow.apache.org/docs/apache-airflow-providers-edge/0.10.2pre0/changelog.html>`_.

--- a/providers/edge/docs/changelog.rst
+++ b/providers/edge/docs/changelog.rst
@@ -27,6 +27,14 @@
 Changelog
 ---------
 
+0.10.2pre0
+..........
+
+Misc
+~~~~
+
+* ``Fix authentication for cases where webserver.base_url is not defined and worker is not using localhost in 2.10.``
+
 0.10.1pre0
 ..........
 

--- a/providers/edge/provider.yaml
+++ b/providers/edge/provider.yaml
@@ -25,7 +25,7 @@ source-date-epoch: 1737371680
 
 # note that those versions are maintained by release manager - do not update them manually
 versions:
-  - 0.10.1pre0
+  - 0.10.2pre0
 
 plugins:
   - name: edge_executor

--- a/providers/edge/pyproject.toml
+++ b/providers/edge/pyproject.toml
@@ -26,7 +26,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "apache-airflow-providers-edge"
-version = "0.10.1pre0"
+version = "0.10.2pre0"
 description = "Provider package apache-airflow-providers-edge for Apache Airflow"
 readme = "README.rst"
 authors = [
@@ -61,8 +61,8 @@ dependencies = [
 ]
 
 [project.urls]
-"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-edge/0.10.1pre0"
-"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-edge/0.10.1pre0/changelog.html"
+"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-edge/0.10.2pre0"
+"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-edge/0.10.2pre0/changelog.html"
 "Bug Tracker" = "https://github.com/apache/airflow/issues"
 "Source Code" = "https://github.com/apache/airflow"
 "Slack Chat" = "https://s.apache.org/airflow-slack"

--- a/providers/edge/src/airflow/providers/edge/__init__.py
+++ b/providers/edge/src/airflow/providers/edge/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "0.10.1pre0"
+__version__ = "0.10.2pre0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.10.0"

--- a/providers/edge/src/airflow/providers/edge/get_provider_info.py
+++ b/providers/edge/src/airflow/providers/edge/get_provider_info.py
@@ -28,7 +28,7 @@ def get_provider_info():
         "description": "Handle edge workers on remote sites via HTTP(s) connection and orchestrates work over distributed sites\n",
         "state": "not-ready",
         "source-date-epoch": 1737371680,
-        "versions": ["0.10.1pre0"],
+        "versions": ["0.10.2pre0"],
         "plugins": [
             {
                 "name": "edge_executor",

--- a/providers/edge/src/airflow/providers/edge/worker_api/auth.py
+++ b/providers/edge/src/airflow/providers/edge/worker_api/auth.py
@@ -66,18 +66,13 @@ def _forbidden_response(message: str):
 def jwt_token_authorization(method: str, authorization: str):
     """Check if the JWT token is correct."""
     try:
-        # worker sends method without api_url
-        api_url = conf.get("edge", "api_url")
-        base_url = conf.get("webserver", "base_url")
-        url_prefix = api_url.replace(base_url, "").replace("/rpcapi", "/")
-        pure_method = method.replace(url_prefix, "")
         payload = jwt_signer().verify_token(authorization)
         signed_method = payload.get("method")
-        if not signed_method or signed_method != pure_method:
+        if not signed_method or signed_method != method:
             _forbidden_response(
                 "Invalid method in token authorization. "
                 f"signed method='{signed_method}' "
-                f"called method='{pure_method}'",
+                f"called method='{method}'",
             )
     except BadSignature:
         _forbidden_response("Bad Signature. Please use only the tokens provided by the API.")


### PR DESCRIPTION
While testing edge deployment with @cmarteepants we found one problem when running Edge Provider in Airflow 2.10.4 - The authentication required to set webserver.base_url parameter to cut the server name from the called URL. This leads to failures when the base_url is not set and you run edge worker not on localhost.

This PR changes authentication in 2.10 to be the same like in main and not using base_url but take only the authentication URL part after the API prefix.