### PR TITLE
Speed up fixing-ownership when leaving breeze on Linux

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -579,6 +579,8 @@ def fix_ownership_using_docker(quiet: bool = False):
         "-e",
         f"HOST_GROUP_ID={get_host_group_id()}",
         "-e",
+        f"VERBOSE={str(get_verbose()).lower()}",
+        "-e",
         f"DOCKER_IS_ROOTLESS={is_docker_rootless()}",
         "--rm",
         "-t",

--- a/scripts/in_container/run_fix_ownership.py
+++ b/scripts/in_container/run_fix_ownership.py
@@ -44,27 +44,41 @@ def change_ownership_of_files(path: Path) -> None:
         sys.exit(1)
     count_files = 0
     root_uid = pwd.getpwnam("root").pw_uid
-    for file in path.rglob("*"):
-        try:
-            if file.is_symlink() and file.lstat().st_uid == root_uid:
-                # Change ownership of symlink itself (by default stat/chown follow the symlinks)
-                os.chown(file, int(host_user_id), int(host_group_id), follow_symlinks=False)
-                count_files += 1
+    skip_folders = {".venv", "node_modules", ".mypy_cache", ".pytest_cache", ".ruff_cache"}
+    for root, dirs, files in os.walk(path):
+        original_length = len(dirs)
+        original_dirs = dirs.copy()
+        # skip known big folders if they are not owned by root
+        dirs[:] = [d for d in dirs if d not in skip_folders or (Path(root) / d).stat().st_uid == root_uid]
+        new_length = len(dirs)
+        if new_length != original_length:
+            if os.environ.get("VERBOSE", "false") == "true":
+                print(
+                    f"{root}: Skipped {original_length - new_length} "
+                    f"folders: {set(original_dirs) - set(dirs)}"
+                )
+        for name in files:
+            file = Path(root) / name
+            try:
+                if file.is_symlink() and file.lstat().st_uid == root_uid:
+                    # Change ownership of symlink itself (by default stat/chown follow the symlinks)
+                    os.chown(file, int(host_user_id), int(host_group_id), follow_symlinks=False)
+                    count_files += 1
+                    if os.environ.get("VERBOSE_COMMANDS", "false") == "true":
+                        print(f"Changed ownership of symlink {file}")
+                if file.stat().st_uid == root_uid:
+                    # And here change ownership of the file (or if it is a symlink - the file it points to)
+                    os.chown(file, int(host_user_id), int(host_group_id))
+                    count_files += 1
+                    if os.environ.get("VERBOSE_COMMANDS", "false") == "true":
+                        print(f"Changed ownership of {file.resolve()}")
+            except FileNotFoundError:
+                # This is OK - file might have been deleted in the meantime or linked in Host from
+                # another place
                 if os.environ.get("VERBOSE_COMMANDS", "false") == "true":
-                    print(f"Changed ownership of symlink {file}")
-            if file.stat().st_uid == root_uid:
-                # And here change ownership of the file (or if it is a symlink - the file it points to)
-                os.chown(file, int(host_user_id), int(host_group_id))
-                count_files += 1
-                if os.environ.get("VERBOSE_COMMANDS", "false") == "true":
-                    print(f"Changed ownership of {file.resolve()}")
-        except FileNotFoundError:
-            # This is OK - file might have been deleted in the meantime or linked in Host from
-            # another place
-            if os.environ.get("VERBOSE_COMMANDS", "false") == "true":
-                print(f"Could not change ownership of {file}")
-    if count_files:
-        print(f"Changed ownership of {count_files} files back to {host_user_id}:{host_group_id}.")
+                    print(f"Could not change ownership of {file}")
+        if count_files:
+            print(f"Changed ownership of {count_files} files back to {host_user_id}:{host_group_id}.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When leaving breeze on Linux we are fixing ownership of potential new generated files to be the same as the HOST user - because files created in container will be owned by root.

This takes quite some time however, especially when you have .venv or node_modules or other folders with large amount of files.

This change skips such files from being considered in fixing ownership if the folders are already properly owned.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
