### PR TITLE
Fix Failing scheduler test

### DIFF
--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -4520,6 +4520,7 @@ class TestSchedulerJob:
         ]
         assert dagrun_logical_dates == expected_logical_dates
 
+    @pytest.mark.usefixtures("testing_dag_bundle")
     def test_do_schedule_max_active_runs_and_manual_trigger(self, dag_maker, mock_executors):
         """
         Make sure that when a DAG is already at max_active_runs, that manually triggered

--- a/tests_common/pytest_plugin.py
+++ b/tests_common/pytest_plugin.py
@@ -927,8 +927,8 @@ def dag_maker(request) -> Generator[DagMaker, None, None]:
             if AIRFLOW_V_3_0_PLUS:
                 kwargs.setdefault("triggered_by", DagRunTriggeredByType.TEST)
                 kwargs["logical_date"] = logical_date
-                kwargs["dag_version"] = None
             else:
+                kwargs.pop("dag_version", None)
                 kwargs.pop("triggered_by", None)
                 kwargs["execution_date"] = logical_date
 


### PR DESCRIPTION
This test fails consistently in local dev.
The bundle referenced in the test is not in the DB and also dag_version
is being removed in dag_maker.create_dagrun kwargs. This PR fixes the issues