### PR TITLE
Export selected variables on variables list page

### DIFF
--- a/airflow/ui/src/pages/Variables/Variables.tsx
+++ b/airflow/ui/src/pages/Variables/Variables.tsx
@@ -34,6 +34,7 @@ import { ActionBar } from "src/components/ui/ActionBar";
 import { Checkbox } from "src/components/ui/Checkbox";
 import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
 import { TrimText } from "src/utils/TrimText";
+import { downloadJson } from "src/utils/downloadJson";
 
 import DeleteVariablesButton from "./DeleteVariablesButton";
 import ImportVariablesButton from "./ImportVariablesButton";
@@ -178,20 +179,6 @@ export const Variables = () => {
     }
   }, [selectedRows, data, selectedVariables]);
 
-  const handleExport = () => {
-    const jsonData = JSON.stringify(selectedVariables, undefined, 2);
-    const blob = new Blob([jsonData], { type: "application/json" });
-    const url = URL.createObjectURL(blob);
-
-    const link = document.createElement("a");
-
-    link.href = url;
-    link.download = "variables.json";
-    link.click();
-
-    URL.revokeObjectURL(url);
-  };
-
   return (
     <>
       <VStack alignItems="none">
@@ -228,8 +215,8 @@ export const Variables = () => {
           <Tooltip content="Delete selected variables">
             <DeleteVariablesButton clearSelections={clearSelections} deleteKeys={[...selectedRows.keys()]} />
           </Tooltip>
-          <Tooltip content="Export selected variable coming soon..">
-            <Button onClick={handleExport} size="sm" variant="outline">
+          <Tooltip content="Export selected variables">
+            <Button onClick={() => downloadJson(selectedVariables, "variables")} size="sm" variant="outline">
               <FiShare />
               Export
             </Button>

--- a/airflow/ui/src/utils/downloadJson.ts
+++ b/airflow/ui/src/utils/downloadJson.ts
@@ -1,0 +1,32 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export const downloadJson = (data: Record<string, string | undefined>, name: string) => {
+  const jsonData = JSON.stringify(data, undefined, 2);
+  const blob = new Blob([jsonData], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+
+  const link = document.createElement("a");
+
+  link.href = url;
+  link.download = `${name}.json`;
+  link.click();
+
+  URL.revokeObjectURL(url);
+};


### PR DESCRIPTION
Relates: [#43709](https://github.com/apache/airflow/issues/43709)

Export selected variables on variables list page as variables.json

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/a894c834-e065-4622-96ef-c8045f2f429a" />


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
