### PR TITLE
Add `endpoint_prefix` to `LivyHook`

### DIFF
--- a/providers/apache/livy/src/airflow/providers/apache/livy/hooks/livy.py
+++ b/providers/apache/livy/src/airflow/providers/apache/livy/hooks/livy.py
@@ -53,7 +53,7 @@ class BatchState(Enum):
 
 
 def sanitize_endpoint_prefix(endpoint_prefix: str | None) -> str:
-    """ Ensure that the endpoint prefix is prefixed with a slash. """
+    """Ensure that the endpoint prefix is prefixed with a slash."""
     return f"/{endpoint_prefix.strip('/')}" if endpoint_prefix else ""
 
 
@@ -170,7 +170,10 @@ class LivyHook(HttpHook):
         self.log.info("Submitting job %s to %s", batch_submit_body, self.base_url)
 
         response = self.run_method(
-            method="POST", endpoint=f"{self.endpoint_prefix}/batches", data=batch_submit_body, headers=self.extra_headers
+            method="POST",
+            endpoint=f"{self.endpoint_prefix}/batches",
+            data=batch_submit_body,
+            headers=self.extra_headers,
         )
         self.log.debug("Got response: %s", response.text)
 
@@ -199,7 +202,9 @@ class LivyHook(HttpHook):
         self._validate_session_id(session_id)
 
         self.log.debug("Fetching info for batch session %s", session_id)
-        response = self.run_method(endpoint=f"{self.endpoint_prefix}/batches/{session_id}", headers=self.extra_headers)
+        response = self.run_method(
+            endpoint=f"{self.endpoint_prefix}/batches/{session_id}", headers=self.extra_headers
+        )
 
         try:
             response.raise_for_status()
@@ -224,7 +229,9 @@ class LivyHook(HttpHook):
 
         self.log.debug("Fetching info for batch session %s", session_id)
         response = self.run_method(
-            endpoint=f"{self.endpoint_prefix}/batches/{session_id}/state", retry_args=retry_args, headers=self.extra_headers
+            endpoint=f"{self.endpoint_prefix}/batches/{session_id}/state",
+            retry_args=retry_args,
+            headers=self.extra_headers,
         )
 
         try:
@@ -251,7 +258,9 @@ class LivyHook(HttpHook):
 
         self.log.info("Deleting batch session %s", session_id)
         response = self.run_method(
-            method="DELETE", endpoint=f"{self.endpoint_prefix}/batches/{session_id}", headers=self.extra_headers
+            method="DELETE",
+            endpoint=f"{self.endpoint_prefix}/batches/{session_id}",
+            headers=self.extra_headers,
         )
 
         try:
@@ -277,7 +286,9 @@ class LivyHook(HttpHook):
         self._validate_session_id(session_id)
         log_params = {"from": log_start_position, "size": log_batch_size}
         response = self.run_method(
-            endpoint=f"{self.endpoint_prefix}/batches/{session_id}/log", data=log_params, headers=self.extra_headers
+            endpoint=f"{self.endpoint_prefix}/batches/{session_id}/log",
+            data=log_params,
+            headers=self.extra_headers,
         )
         try:
             response.raise_for_status()
@@ -668,7 +679,9 @@ class LivyAsyncHook(HttpAsyncHook):
         """
         self._validate_session_id(session_id)
         log_params = {"from": log_start_position, "size": log_batch_size}
-        result = await self.run_method(endpoint=f"{self.endpoint_prefix}/batches/{session_id}/log", data=log_params)
+        result = await self.run_method(
+            endpoint=f"{self.endpoint_prefix}/batches/{session_id}/log", data=log_params
+        )
         if result["status"] == "error":
             self.log.info(result)
             return {"response": result["response"], "status": "error"}

--- a/providers/apache/livy/src/airflow/providers/apache/livy/hooks/livy.py
+++ b/providers/apache/livy/src/airflow/providers/apache/livy/hooks/livy.py
@@ -52,6 +52,13 @@ class BatchState(Enum):
     SUCCESS = "success"
 
 
+def sanitize_endpoint_prefix(endpoint_prefix) -> str:
+    """
+    Ensure that the endpoint prefix is prefixed with a slash.
+    """
+    return f"/{endpoint_prefix.strip('/')}" if endpoint_prefix else ""
+
+
 class LivyHook(HttpHook):
     """
     Hook for Apache Livy through the REST API.
@@ -93,7 +100,7 @@ class LivyHook(HttpHook):
         self.http_conn_id = livy_conn_id
         self.extra_headers = extra_headers or {}
         self.extra_options = extra_options or {}
-        self.endpoint_prefix = endpoint_prefix or ""
+        self.endpoint_prefix = sanitize_endpoint_prefix(endpoint_prefix)
         if auth_type:
             self.auth_type = auth_type
 

--- a/providers/apache/livy/src/airflow/providers/apache/livy/hooks/livy.py
+++ b/providers/apache/livy/src/airflow/providers/apache/livy/hooks/livy.py
@@ -506,7 +506,7 @@ class LivyAsyncHook(HttpAsyncHook):
         self.http_conn_id = livy_conn_id
         self.extra_headers = extra_headers or {}
         self.extra_options = extra_options or {}
-        self.endpoint_prefix = endpoint_prefix
+        self.endpoint_prefix = sanitize_endpoint_prefix(endpoint_prefix)
 
     async def _do_api_call_async(
         self,

--- a/providers/apache/livy/src/airflow/providers/apache/livy/hooks/livy.py
+++ b/providers/apache/livy/src/airflow/providers/apache/livy/hooks/livy.py
@@ -52,10 +52,8 @@ class BatchState(Enum):
     SUCCESS = "success"
 
 
-def sanitize_endpoint_prefix(endpoint_prefix) -> str:
-    """
-    Ensure that the endpoint prefix is prefixed with a slash.
-    """
+def sanitize_endpoint_prefix(endpoint_prefix: str | None) -> str:
+    """ Ensure that the endpoint prefix is prefixed with a slash. """
     return f"/{endpoint_prefix.strip('/')}" if endpoint_prefix else ""
 
 
@@ -499,7 +497,7 @@ class LivyAsyncHook(HttpAsyncHook):
         livy_conn_id: str = default_conn_name,
         extra_options: dict[str, Any] | None = None,
         extra_headers: dict[str, Any] | None = None,
-        endpoint_prefix: str = "",
+        endpoint_prefix: str | None = None,
     ) -> None:
         super().__init__()
         self.method = "POST"

--- a/providers/apache/livy/src/airflow/providers/apache/livy/operators/livy.py
+++ b/providers/apache/livy/src/airflow/providers/apache/livy/operators/livy.py
@@ -88,6 +88,7 @@ class LivyOperator(BaseOperator):
         proxy_user: str | None = None,
         livy_conn_id: str = "livy_default",
         livy_conn_auth_type: Any | None = None,
+        livy_endpoint_prefix: str | None = None,
         polling_interval: int = 0,
         extra_options: dict[str, Any] | None = None,
         extra_headers: dict[str, Any] | None = None,
@@ -119,6 +120,7 @@ class LivyOperator(BaseOperator):
         self.spark_params = spark_params
         self._livy_conn_id = livy_conn_id
         self._livy_conn_auth_type = livy_conn_auth_type
+        self._livy_endpoint_prefix = livy_endpoint_prefix
         self._polling_interval = polling_interval
         self._extra_options = extra_options or {}
         self._extra_headers = extra_headers or {}
@@ -139,6 +141,7 @@ class LivyOperator(BaseOperator):
             extra_headers=self._extra_headers,
             extra_options=self._extra_options,
             auth_type=self._livy_conn_auth_type,
+            endpoint_prefix=self._livy_endpoint_prefix,
         )
 
     def execute(self, context: Context) -> Any:

--- a/providers/apache/livy/src/airflow/providers/apache/livy/sensors/livy.py
+++ b/providers/apache/livy/src/airflow/providers/apache/livy/sensors/livy.py
@@ -46,6 +46,7 @@ class LivySensor(BaseSensorOperator):
         livy_conn_id: str = "livy_default",
         livy_conn_auth_type: Any | None = None,
         extra_options: dict[str, Any] | None = None,
+        endpoint_prefix: str | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -54,6 +55,7 @@ class LivySensor(BaseSensorOperator):
         self._livy_conn_auth_type = livy_conn_auth_type
         self._livy_hook: LivyHook | None = None
         self._extra_options = extra_options or {}
+        self._endpoint_prefix = endpoint_prefix
 
     def get_hook(self) -> LivyHook:
         """
@@ -66,6 +68,7 @@ class LivySensor(BaseSensorOperator):
                 livy_conn_id=self._livy_conn_id,
                 extra_options=self._extra_options,
                 auth_type=self._livy_conn_auth_type,
+                endpoint_prefix=self._endpoint_prefix,
             )
         return self._livy_hook
 

--- a/providers/apache/livy/src/airflow/providers/apache/livy/triggers/livy.py
+++ b/providers/apache/livy/src/airflow/providers/apache/livy/triggers/livy.py
@@ -57,6 +57,7 @@ class LivyTrigger(BaseTrigger):
         extra_headers: dict[str, Any] | None = None,
         livy_hook_async: LivyAsyncHook | None = None,
         execution_timeout: timedelta | None = None,
+        endpoint_prefix: str | None = None,
     ):
         super().__init__()
         self._batch_id = batch_id
@@ -67,6 +68,7 @@ class LivyTrigger(BaseTrigger):
         self._extra_headers = extra_headers
         self._livy_hook_async = livy_hook_async
         self._execution_timeout = execution_timeout
+        self._endpoint_prefix = endpoint_prefix
 
     def serialize(self) -> tuple[str, dict[str, Any]]:
         """Serialize LivyTrigger arguments and classpath."""
@@ -170,5 +172,6 @@ class LivyTrigger(BaseTrigger):
                 livy_conn_id=self._livy_conn_id,
                 extra_headers=self._extra_headers,
                 extra_options=self._extra_options,
+                endpoint_prefix=self._endpoint_prefix,
             )
         return self._livy_hook_async

--- a/providers/apache/livy/tests/provider_tests/apache/livy/hooks/test_livy.py
+++ b/providers/apache/livy/tests/provider_tests/apache/livy/hooks/test_livy.py
@@ -428,6 +428,7 @@ class TestLivyDbHook:
 
         auth_type.assert_called_once_with("login", "secret")
 
+    @patch("airflow.providers.apache.livy.hooks.livy.LivyHook.run_method")
     def test_post_batch_with_endpoint_prefix(self, mock_request):
         mock_request.return_value.status_code = 201
         mock_request.return_value.json.return_value = {

--- a/providers/apache/livy/tests/provider_tests/apache/livy/hooks/test_livy.py
+++ b/providers/apache/livy/tests/provider_tests/apache/livy/hooks/test_livy.py
@@ -898,11 +898,7 @@ class TestLivyAsyncHook:
             "status": "success",
         }
         mock_run_method.assert_called_once_with(
-            method="GET",
             endpoint=f"/livy/batches/{BATCH_ID}/state",
-            data=None,
-            headers=None,
-            extra_options=None,
         )
 
     @pytest.mark.asyncio
@@ -914,9 +910,6 @@ class TestLivyAsyncHook:
         assert state["status"] == "success"
 
         mock_run_method.assert_called_once_with(
-            method="GET",
             endpoint=f"/livy/batches/{BATCH_ID}/log",
             data={"from": 0, "size": 100},
-            headers=None,
-            extra_options=None,
         )

--- a/providers/apache/livy/tests/provider_tests/apache/livy/hooks/test_livy.py
+++ b/providers/apache/livy/tests/provider_tests/apache/livy/hooks/test_livy.py
@@ -479,13 +479,8 @@ class TestLivyDbHook:
 
     @pytest.mark.parametrize(
         "prefix",
-        [
-            "/livy/",
-            "livy",
-            "/livy",
-            "livy/"
-        ],
-        ids=["leading_and_trailing_slashes", "no_slashes", "leading_slash", "trailing_slash"]
+        ["/livy/", "livy", "/livy", "livy/"],
+        ids=["leading_and_trailing_slashes", "no_slashes", "leading_slash", "trailing_slash"],
     )
     def test_endpoint_prefix_is_sanitized_simple(self, requests_mock, prefix):
         requests_mock.register_uri(
@@ -502,6 +497,7 @@ class TestLivyDbHook:
         resp = LivyHook(endpoint_prefix="/livy/foo/bar/").get_batch(BATCH_ID)
         assert isinstance(resp, dict)
         assert "id" in resp
+
 
 class TestLivyAsyncHook:
     @pytest.mark.asyncio


### PR DESCRIPTION
adding endpoint_prefix to allow for accessing livy that is behind a reverse proxy and not available on the root path of the server

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
