### PR TITLE
AIP-38 Fix clear mapped task with a note

### DIFF
--- a/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
+++ b/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
@@ -136,6 +136,7 @@ const ClearTaskInstanceDialog = ({
                 mutatePatchTaskInstance({
                   dagId,
                   dagRunId,
+                  mapIndex,
                   requestBody: { note },
                   taskId,
                 });


### PR DESCRIPTION
Clearing a mapped task instance while updating the `note` would fail. We were not providing the mapIndex in the request.

## Before
![Screenshot 2025-01-21 at 00 20 16](https://github.com/user-attachments/assets/c2edd22f-6299-4242-8044-72e522a6cc8d)

## After
![Screenshot 2025-01-21 at 00 18 34](https://github.com/user-attachments/assets/348896e5-7bdc-4541-8d32-c21d7fc19dd7)
