### PR TITLE
Use Task SDK's Context dict in `models/taskinstance.py`

### DIFF
--- a/airflow/cli/commands/remote_commands/task_command.py
+++ b/airflow/cli/commands/remote_commands/task_command.py
@@ -173,9 +173,11 @@ def _get_dag_run(
         dag_run = DagRun(
             dag_id=dag.dag_id,
             run_id=logical_date_or_run_id,
+            run_type=DagRunType.MANUAL,
             logical_date=dag_run_logical_date,
             data_interval=dag.timetable.infer_manual_data_interval(run_after=dag_run_logical_date),
             triggered_by=DagRunTriggeredByType.CLI,
+            state=DagRunState.RUNNING,
         )
         return dag_run, True
     elif create_if_necessary == "db":
@@ -186,7 +188,7 @@ def _get_dag_run(
             run_type=DagRunType.MANUAL,
             triggered_by=DagRunTriggeredByType.CLI,
             dag_version=None,
-            state=DagRunState.QUEUED,
+            state=DagRunState.RUNNING,
             session=session,
         )
         return dag_run, True

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -85,6 +85,7 @@ from airflow.utils.edgemodifier import EdgeModifier
 from airflow.utils.operator_helpers import ExecutionCallableRunner
 from airflow.utils.operator_resources import Resources
 from airflow.utils.session import NEW_SESSION, provide_session
+from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunTriggeredByType
 from airflow.utils.xcom import XCOM_RETURN_KEY
 
@@ -632,6 +633,7 @@ class BaseOperator(TaskSDKBaseOperator, AbstractOperator, metaclass=BaseOperator
                     logical_date=info.logical_date,
                     data_interval=info.data_interval,
                     triggered_by=DagRunTriggeredByType.TEST,
+                    state=DagRunState.RUNNING,
                 )
                 ti = TaskInstance(self, run_id=dr.run_id)
                 ti.dag_run = dr

--- a/airflow/utils/context.py
+++ b/airflow/utils/context.py
@@ -52,7 +52,11 @@ from airflow.sdk.definitions.asset import (
     AssetUriRef,
 )
 from airflow.sdk.definitions.context import Context
-from airflow.sdk.execution_time.context import OutletEventAccessors as OutletEventAccessorsSDK
+from airflow.sdk.execution_time.context import (
+    ConnectionAccessor as ConnectionAccessorSDK,
+    OutletEventAccessors as OutletEventAccessorsSDK,
+    VariableAccessor as VariableAccessorSDK,
+)
 from airflow.utils.db import LazySelectSequence
 from airflow.utils.session import create_session
 from airflow.utils.types import NOTSET
@@ -107,21 +111,13 @@ KNOWN_CONTEXT_KEYS: set[str] = {
 }
 
 
-class VariableAccessor:
+class VariableAccessor(VariableAccessorSDK):
     """Wrapper to access Variable values in template."""
-
-    def __init__(self, *, deserialize_json: bool) -> None:
-        self._deserialize_json = deserialize_json
-        self.var: Any = None
 
     def __getattr__(self, key: str) -> Any:
         from airflow.models.variable import Variable
 
-        self.var = Variable.get(key, deserialize_json=self._deserialize_json)
-        return self.var
-
-    def __repr__(self) -> str:
-        return str(self.var)
+        return Variable.get(key, deserialize_json=self._deserialize_json)
 
     def get(self, key, default: Any = NOTSET) -> Any:
         from airflow.models.variable import Variable
@@ -131,27 +127,20 @@ class VariableAccessor:
         return Variable.get(key, default, deserialize_json=self._deserialize_json)
 
 
-class ConnectionAccessor:
+class ConnectionAccessor(ConnectionAccessorSDK):
     """Wrapper to access Connection entries in template."""
 
-    def __init__(self) -> None:
-        self.var: Any = None
-
-    def __getattr__(self, key: str) -> Any:
+    def __getattr__(self, conn_id: str) -> Any:
         from airflow.models.connection import Connection
 
-        self.var = Connection.get_connection_from_secrets(key)
-        return self.var
+        return Connection.get_connection_from_secrets(conn_id)
 
-    def __repr__(self) -> str:
-        return str(self.var)
-
-    def get(self, key: str, default_conn: Any = None) -> Any:
+    def get(self, conn_id: str, default_conn: Any = None) -> Any:
         from airflow.exceptions import AirflowNotFoundException
         from airflow.models.connection import Connection
 
         try:
-            return Connection.get_connection_from_secrets(key)
+            return Connection.get_connection_from_secrets(conn_id)
         except AirflowNotFoundException:
             return default_conn
 

--- a/scripts/ci/pre_commit/template_context_key_sync.py
+++ b/scripts/ci/pre_commit/template_context_key_sync.py
@@ -27,32 +27,65 @@ import typing
 
 ROOT_DIR = pathlib.Path(__file__).resolve().parents[3]
 
-TASKINSTANCE_PY = ROOT_DIR.joinpath("airflow", "models", "taskinstance.py")
+TASKRUNNER_PY = ROOT_DIR.joinpath("task_sdk", "src", "airflow", "sdk", "execution_time", "task_runner.py")
 CONTEXT_PY = ROOT_DIR.joinpath("airflow", "utils", "context.py")
 CONTEXT_HINT = ROOT_DIR.joinpath("task_sdk", "src", "airflow", "sdk", "definitions", "context.py")
 TEMPLATES_REF_RST = ROOT_DIR.joinpath("docs", "apache-airflow", "templates-ref.rst")
 
 
 def _iter_template_context_keys_from_original_return() -> typing.Iterator[str]:
-    ti_mod = ast.parse(TASKINSTANCE_PY.read_text("utf-8"), str(TASKINSTANCE_PY))
-    fn_get_template_context = next(
+    ti_mod = ast.parse(TASKRUNNER_PY.read_text("utf-8"), str(TASKRUNNER_PY))
+
+    # Locate the RuntimeTaskInstance class definition
+    runtime_task_instance_class = next(
         node
         for node in ast.iter_child_nodes(ti_mod)
-        if isinstance(node, ast.FunctionDef) and node.name == "_get_template_context"
+        if isinstance(node, ast.ClassDef) and node.name == "RuntimeTaskInstance"
     )
-    st_context_value = next(
-        stmt.value
+
+    # Locate the get_template_context method in RuntimeTaskInstance
+    fn_get_template_context = next(
+        node
+        for node in ast.iter_child_nodes(runtime_task_instance_class)
+        if isinstance(node, ast.FunctionDef) and node.name == "get_template_context"
+    )
+
+    # Helper function to extract keys from a dictionary node
+    def extract_keys_from_dict(node: ast.Dict) -> typing.Iterator[str]:
+        for key in node.keys:
+            if not isinstance(key, ast.Constant) or not isinstance(key.value, str):
+                raise ValueError("Key in dictionary is not a string literal")
+            yield key.value
+
+    # Extract keys from the main `context` dictionary assignment
+    context_assignment = next(
+        stmt
         for stmt in fn_get_template_context.body
         if isinstance(stmt, ast.AnnAssign)
         and isinstance(stmt.target, ast.Name)
         and stmt.target.id == "context"
     )
-    if not isinstance(st_context_value, ast.Dict):
-        raise ValueError("'context' is not assigned a dict literal")
-    for expr in st_context_value.keys:
-        if not isinstance(expr, ast.Constant) or not isinstance(expr.value, str):
-            raise ValueError("key in 'context' dict is not a str literal")
-        yield expr.value
+
+    if not isinstance(context_assignment.value, ast.Dict):
+        raise ValueError("'context' is not assigned a dictionary literal")
+    yield from extract_keys_from_dict(context_assignment.value)
+
+    # Handle keys added conditionally in `if self._ti_context_from_server`
+    for stmt in fn_get_template_context.body:
+        if (
+            isinstance(stmt, ast.If)
+            and isinstance(stmt.test, ast.Attribute)
+            and stmt.test.attr == "_ti_context_from_server"
+        ):
+            for sub_stmt in stmt.body:
+                # Get keys from `context_from_server` assignment
+                if (
+                    isinstance(sub_stmt, ast.AnnAssign)
+                    and isinstance(sub_stmt.target, ast.Name)
+                    and isinstance(sub_stmt.value, ast.Dict)
+                    and sub_stmt.target.id == "context_from_server"
+                ):
+                    yield from extract_keys_from_dict(sub_stmt.value)
 
 
 def _iter_template_context_keys_from_declaration() -> typing.Iterator[str]:
@@ -104,6 +137,12 @@ def _compare_keys(retn_keys: set[str], decl_keys: set[str], hint_keys: set[str],
 
     # Compat shim for task-sdk, not actually designed for user use
     retn_keys.add("expanded_ti_count")
+
+    # TODO: These are the keys that are yet to be ported over to the Task SDK.
+    retn_keys.add("inlet_events")
+    retn_keys.add("params")
+    retn_keys.add("test_mode")
+    retn_keys.add("triggering_asset_events")
 
     # Only present in callbacks. Not listed in templates-ref (that doc is for task execution).
     retn_keys.update(("exception", "reason", "try_number"))

--- a/task_sdk/src/airflow/sdk/types.py
+++ b/task_sdk/src/airflow/sdk/types.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
 
     from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetAliasEvent, BaseAssetUniqueKey
     from airflow.sdk.definitions.baseoperator import BaseOperator
+    from airflow.sdk.definitions.context import Context
     from airflow.sdk.definitions.mappedoperator import MappedOperator
 
     Operator = Union[BaseOperator, MappedOperator]
@@ -70,6 +71,8 @@ class RuntimeTaskInstanceProtocol(Protocol):
     ) -> Any: ...
 
     def xcom_push(self, key: str, value: Any) -> None: ...
+
+    def get_template_context(self) -> Context: ...
 
 
 class OutletEventAccessorProtocol(Protocol):

--- a/tests/cli/commands/remote_commands/test_task_command.py
+++ b/tests/cli/commands/remote_commands/test_task_command.py
@@ -113,7 +113,7 @@ class TestCliTasks:
             else {}
         )
         cls.dag_run = cls.dag.create_dagrun(
-            state=State.NONE,
+            state=State.RUNNING,
             run_id=cls.run_id,
             run_type=DagRunType.MANUAL,
             logical_date=DEFAULT_DATE,
@@ -184,7 +184,7 @@ class TestCliTasks:
             else {}
         )
         dag.create_dagrun(
-            state=State.NONE,
+            state=State.RUNNING,
             run_id="abc123",
             run_type=DagRunType.MANUAL,
             logical_date=logical_date,

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -134,10 +134,10 @@ class TestDagRun:
 
         return dag_run
 
-    @pytest.mark.parametrize("state", [DagRunState.QUEUED, DagRunState.RUNNING])
-    def test_clear_task_instances_for_backfill_unfinished_dagrun(self, state, session):
+    def test_clear_task_instances_for_backfill_running_dagrun(self, session):
         now = timezone.utcnow()
-        dag_id = "test_clear_task_instances_for_backfill_dagrun"
+        state = DagRunState.RUNNING
+        dag_id = "test_clear_task_instances_for_backfill_running_dagrun"
         dag = DAG(dag_id=dag_id, schedule=datetime.timedelta(days=1), start_date=now)
         dag_run = self.create_dag_run(dag, logical_date=now, is_backfill=True, state=state, session=session)
 
@@ -156,7 +156,7 @@ class TestDagRun:
     @pytest.mark.parametrize("state", [DagRunState.SUCCESS, DagRunState.FAILED])
     def test_clear_task_instances_for_backfill_finished_dagrun(self, state, session):
         now = timezone.utcnow()
-        dag_id = "test_clear_task_instances_for_backfill_dagrun"
+        dag_id = "test_clear_task_instances_for_backfill_finished_dagrun"
         dag = DAG(dag_id=dag_id, schedule=datetime.timedelta(days=1), start_date=now)
         dag_run = self.create_dag_run(dag, logical_date=now, is_backfill=True, state=state, session=session)
 

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2301,7 +2301,7 @@ class TestTaskInstance:
         session.flush()
 
         run_id = str(uuid4())
-        dr = DagRun(dag1.dag_id, run_id=run_id, run_type="anything")
+        dr = DagRun(dag1.dag_id, run_id=run_id, run_type="manual", state=DagRunState.RUNNING)
         session.merge(dr)
         task = dag1.get_task("producing_task_1")
         task.bash_command = "echo 1"  # make it go faster
@@ -2360,7 +2360,7 @@ class TestTaskInstance:
         dagbag.collect_dags(only_if_updated=False, safe_mode=False)
         dagbag.sync_to_db("testing", None, session=session)
         run_id = str(uuid4())
-        dr = DagRun(dag_with_fail_task.dag_id, run_id=run_id, run_type="anything")
+        dr = DagRun(dag_with_fail_task.dag_id, run_id=run_id, run_type="manual", state=DagRunState.RUNNING)
         session.merge(dr)
         task = dag_with_fail_task.get_task("fail_task")
         ti = TaskInstance(task, run_id=run_id)
@@ -2419,7 +2419,7 @@ class TestTaskInstance:
         session.flush()
 
         run_id = str(uuid4())
-        dr = DagRun(dag_with_skip_task.dag_id, run_id=run_id, run_type="anything")
+        dr = DagRun(dag_with_skip_task.dag_id, run_id=run_id, run_type="manual", state=DagRunState.RUNNING)
         session.merge(dr)
         task = dag_with_skip_task.get_task("skip_task")
         ti = TaskInstance(task, run_id=run_id)
@@ -3262,7 +3262,7 @@ class TestTaskInstance:
             run_id="test2",
             run_type=DagRunType.ASSET_TRIGGERED,
             logical_date=logical_date,
-            state=None,
+            state=DagRunState.RUNNING,
             session=session,
             data_interval=(logical_date, logical_date),
             **triggered_by_kwargs,
@@ -3522,11 +3522,13 @@ class TestTaskInstance:
             run_id="test2",
             run_type=DagRunType.MANUAL,
             logical_date=logical_date,
-            state=None,
+            state=DagRunState.RUNNING,
+            start_date=logical_date - datetime.timedelta(hours=1),
             session=session,
             data_interval=(logical_date, logical_date),
             **triggered_by_kwargs,
         )
+        dr.set_state(DagRunState.FAILED)
         ti1 = dr.get_task_instance(task1.task_id, session=session)
         ti1.task = task1
 
@@ -3669,11 +3671,12 @@ class TestTaskInstance:
             run_id="test_ff",
             run_type=DagRunType.MANUAL,
             logical_date=logical_date,
-            state=None,
+            state=DagRunState.RUNNING,
             session=session,
             data_interval=(logical_date, logical_date),
             **triggered_by_kwargs,
         )
+        dr.set_state(DagRunState.SUCCESS)
 
         ti1 = dr.get_task_instance(task1.task_id, session=session)
         ti1.task = task1

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -1595,6 +1595,7 @@ def test_clear_overlapping_external_task_marker(dag_bag_head_tail, session):
         logical_date = DEFAULT_DATE + timedelta(days=delta)
         dagrun = DagRun(
             dag_id=dag.dag_id,
+            start_date=logical_date,
             state=DagRunState.SUCCESS,
             logical_date=logical_date,
             run_type=DagRunType.MANUAL,
@@ -1607,10 +1608,31 @@ def test_clear_overlapping_external_task_marker(dag_bag_head_tail, session):
             ti.state = TaskInstanceState.SUCCESS
     session.flush()
 
-    # The next two lines are doing the same thing. Clearing the first "head" with "Future"
-    # selected is the same as not selecting "Future". They should take similar amount of
-    # time too because dag.clear() uses visited_external_tis to keep track of visited ExternalTaskMarker.
     assert dag.clear(start_date=DEFAULT_DATE, dag_bag=dag_bag_head_tail, session=session) == 30
+
+
+@provide_session
+def test_clear_overlapping_external_task_marker_with_end_date(dag_bag_head_tail, session):
+    dag: DAG = dag_bag_head_tail.get_dag("head_tail")
+
+    # "Run" 10 times.
+    for delta in range(10):
+        logical_date = DEFAULT_DATE + timedelta(days=delta)
+        dagrun = DagRun(
+            dag_id=dag.dag_id,
+            start_date=logical_date,
+            state=DagRunState.SUCCESS,
+            logical_date=logical_date,
+            run_type=DagRunType.MANUAL,
+            run_id=f"test_{delta}",
+        )
+        session.add(dagrun)
+        for task in dag.tasks:
+            ti = TaskInstance(task=task)
+            dagrun.task_instances.append(ti)
+            ti.state = TaskInstanceState.SUCCESS
+    session.flush()
+
     assert (
         dag.clear(
             start_date=DEFAULT_DATE,
@@ -1678,6 +1700,7 @@ def test_clear_overlapping_external_task_marker_mapped_tasks(dag_bag_head_tail_m
         logical_date = DEFAULT_DATE + timedelta(days=delta)
         dagrun = DagRun(
             dag_id=dag.dag_id,
+            start_date=logical_date,
             state=DagRunState.SUCCESS,
             logical_date=logical_date,
             run_type=DagRunType.MANUAL,


### PR DESCRIPTION
This PR re-uses the Context dict from the Task SDK in `models/taskinstance.py`.

Once, CeleryExecutor & KubernetesExecutor are ported over to Task SDK, we can remove all of this code. This PR unifies some of that code.

This also uncovered flawed logic where a Task/TI is in running state but DagRun is in Queued or None state!!!

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
