### PR TITLE
Do not print content of loaded toml file from new providers in CI

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/packages.py
+++ b/dev/breeze/src/airflow_breeze/utils/packages.py
@@ -55,7 +55,6 @@ from airflow_breeze.utils.publish_docs_helpers import (
     OLD_PROVIDER_DATA_SCHEMA_PATH,
 )
 from airflow_breeze.utils.run_utils import run_command
-from airflow_breeze.utils.shared_options import get_verbose
 from airflow_breeze.utils.version_utils import remove_local_version_suffix
 from airflow_breeze.utils.versions import get_version_tag, strip_leading_zeros_from_version
 
@@ -636,14 +635,11 @@ def load_pyproject_toml(pyproject_toml_file_path: Path) -> dict[str, Any]:
     except ImportError:
         import tomli as tomllib
     toml_content = pyproject_toml_file_path.read_text()
-    syntax = Syntax(toml_content, "toml", theme="monokai", line_numbers=True)
-    if get_verbose():
-        get_console().print(syntax)
+    syntax = Syntax(toml_content, "toml", theme="ansi_dark", line_numbers=True)
     try:
         return tomllib.loads(toml_content)
     except tomllib.TOMLDecodeError as e:
-        if not get_verbose():
-            get_console().print(syntax)
+        get_console().print(syntax)
         get_console().print(f"[red]Error when loading {pyproject_toml_file_path}: {e}:")
         sys.exit(1)
 


### PR DESCRIPTION
When running breeze in CI we run it with VERBOSE="true". We print the content of the loaded pyproject.toml provider when read via verbose command and that pollutes the CI logs.

This PR will only print content of such pyproject.toml when there is a decode error (which was the main reason for this printing).

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
