### PR TITLE
Wait before exiting in `FileTrigger`

### DIFF
--- a/providers/src/airflow/providers/standard/triggers/file.py
+++ b/providers/src/airflow/providers/standard/triggers/file.py
@@ -69,9 +69,11 @@ class FileTrigger(BaseTrigger):
                     mod_time = datetime.datetime.fromtimestamp(mod_time_f).strftime("%Y%m%d%H%M%S")
                     self.log.info("Found File %s last modified: %s", path, mod_time)
                     yield TriggerEvent(True)
+                    await asyncio.sleep(self.poke_interval)
                     return
                 for _, _, files in os.walk(self.filepath):
                     if files:
                         yield TriggerEvent(True)
+                        await asyncio.sleep(self.poke_interval)
                         return
             await asyncio.sleep(self.poke_interval)


### PR DESCRIPTION
In the current implementation of FileTrigger, the trigger fires and exits immediately upon detecting the file. This behavior works well in Airflow 2 because triggers are exclusively used for deferrable operators, which are designed to fire only once (as the trigger is deleted after firing).

In Airflow 3, however, triggers are also used to schedule DAGs based on events, and in this context, triggers are long-running, remaining active even after firing. For `FileTrigger`, this creates a scenario where multiple events can be sent simultaneously because the trigger exits immediately after detecting the file. Pausing before exiting gives some breathing room between checks (and potentially give some time for other system to delete the file to avoid other DAG executions).

This has no consequence for deferrable operators. The trigger will just leave `self.poke_interval` seconds more in the triggerer. Since it is an async operation, there is no harm.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
