### PR TITLE
Allow passing empty labels in the spark kubernetes driver config

### DIFF
--- a/providers/src/airflow/providers/cncf/kubernetes/operators/custom_object_launcher.py
+++ b/providers/src/airflow/providers/cncf/kubernetes/operators/custom_object_launcher.py
@@ -291,7 +291,7 @@ class CustomObjectLauncher(LoggingMixin):
             # Wait for the driver pod to come alive
             self.pod_spec = k8s.V1Pod(
                 metadata=k8s.V1ObjectMeta(
-                    labels=self.spark_obj_spec["spec"]["driver"]["labels"],
+                    labels=self.spark_obj_spec["spec"]["driver"].get("labels"),
                     name=self.spark_obj_spec["metadata"]["name"] + "-driver",
                     namespace=self.namespace,
                 )

--- a/providers/tests/cncf/kubernetes/operators/test_custom_object_launcher.py
+++ b/providers/tests/cncf/kubernetes/operators/test_custom_object_launcher.py
@@ -20,6 +20,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from kubernetes.client import (
+    CustomObjectsApi,
     V1ContainerState,
     V1ContainerStateWaiting,
     V1ContainerStatus,
@@ -37,24 +38,36 @@ from airflow.providers.cncf.kubernetes.operators.custom_object_launcher import (
 
 @pytest.fixture
 def mock_launcher():
+    name = "test-spark-job"
+    spec = {
+        "image": "gcr.io/spark-operator/spark-py:v3.0.0",
+        "driver": {},
+        "executor": {},
+    }
+
+    custom_object_api = CustomObjectsApi()
+    custom_object_api.create_namespaced_custom_object = MagicMock(return_value={
+        "spec": spec,
+        "metadata": {
+            "name": name
+        }
+    })
+
     launcher = CustomObjectLauncher(
-        name="test-spark-job",
+        name=name,
         namespace="default",
         kube_client=MagicMock(),
-        custom_obj_api=MagicMock(),
+        custom_obj_api=custom_object_api,
         template_body={
             "spark": {
-                "spec": {
-                    "image": "gcr.io/spark-operator/spark-py:v3.0.0",
-                    "driver": {},
-                    "executor": {},
-                },
+                "spec": spec,
                 "apiVersion": "sparkoperator.k8s.io/v1beta2",
                 "kind": "SparkApplication",
             },
         },
     )
     launcher.pod_spec = V1Pod()
+    launcher.spark_job_not_running = MagicMock(return_value=False)
     return launcher
 
 
@@ -202,6 +215,10 @@ class TestCustomObjectLauncher:
                 ),
             ]
         )
+
+    @patch("airflow.providers.cncf.kubernetes.operators.custom_object_launcher.PodManager")
+    def test_start_spark_job_no_error(self, mock_pod_manager, mock_launcher):
+        mock_launcher.start_spark_job()
 
     @patch("airflow.providers.cncf.kubernetes.operators.custom_object_launcher.PodManager")
     def test_check_pod_start_failure_no_error(self, mock_pod_manager, mock_launcher):

--- a/providers/tests/cncf/kubernetes/operators/test_custom_object_launcher.py
+++ b/providers/tests/cncf/kubernetes/operators/test_custom_object_launcher.py
@@ -47,7 +47,7 @@ def mock_launcher():
 
     custom_object_api = CustomObjectsApi()
     custom_object_api.create_namespaced_custom_object = MagicMock(
-        return_value = {"spec": spec, "metadata": {"name": name}}
+        return_value={"spec": spec, "metadata": {"name": name}}
     )
 
     launcher = CustomObjectLauncher(

--- a/providers/tests/cncf/kubernetes/operators/test_custom_object_launcher.py
+++ b/providers/tests/cncf/kubernetes/operators/test_custom_object_launcher.py
@@ -46,12 +46,9 @@ def mock_launcher():
     }
 
     custom_object_api = CustomObjectsApi()
-    custom_object_api.create_namespaced_custom_object = MagicMock(return_value={
-        "spec": spec,
-        "metadata": {
-            "name": name
-        }
-    })
+    custom_object_api.create_namespaced_custom_object = MagicMock(
+        return_value = {"spec": spec, "metadata": {"name": name}}
+    )
 
     launcher = CustomObjectLauncher(
         name=name,


### PR DESCRIPTION
"labels" section of the k8s yaml configuration is optional for both [kubernetes client](https://github.com/kubernetes-client/python/blob/e93f240759935f37465ee5bd61e279bae143ea4a/kubernetes/client/models/v1_object_meta.py#L108C9-L108C31) and [spark-operator](https://github.com/kubeflow/spark-operator/blob/master/docs/api-docs.md). However, if labels are not passed as part of the configuration then the job fails with the following exception:

```python
[2025-01-21, 18:10:50 UTC] {custom_object_launcher.py:312} ERROR - Exception when attempting to create spark job
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/providers/cncf/kubernetes/operators/custom_object_launcher.py", line 294, in start_spark_job
    labels=self.spark_obj_spec["spec"]["driver"]["labels"],
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
KeyError: 'labels'
[2025-01-21, 18:10:50 UTC] {taskinstance.py:3311} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/models/taskinstance.py", line 767, in _execute_task
    result = _execute_callable(context=context, **execute_callable_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/models/taskinstance.py", line 733, in _execute_callable
    return ExecutionCallableRunner(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/utils/operator_helpers.py", line 252, in run
    return self.func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/models/baseoperator.py", line 422, in wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py", line 302, in execute
    self.pod = self.get_or_create_spark_crd(self.launcher, context)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py", line 258, in get_or_create_spark_crd
    driver_pod, spark_obj_spec = launcher.start_spark_job(
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/tenacity/__init__.py", line 336, in wrapped_f
    return copy(f, *args, **kw)
           ^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/tenacity/__init__.py", line 475, in __call__
    do = self.iter(retry_state=retry_state)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/tenacity/__init__.py", line 376, in iter
    result = action(retry_state)
             ^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/tenacity/__init__.py", line 398, in <lambda>
    self._add_action_func(lambda rs: rs.outcome.result())
                                     ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/home/airflow/.local/lib/python3.12/site-packages/tenacity/__init__.py", line 478, in __call__
    result = fn(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/providers/cncf/kubernetes/operators/custom_object_launcher.py", line 313, in start_spark_job
    raise e
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/providers/cncf/kubernetes/operators/custom_object_launcher.py", line 294, in start_spark_job
    labels=self.spark_obj_spec["spec"]["driver"]["labels"],
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
KeyError: 'labels'
```

Proposed fix is just to use `get` method, which instead of KeyError would return `None`, which should be perfectly fine for the `V1ObjectMeta` object.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
