### PR TITLE
Set up dag file parsing logs with structlog

### DIFF
--- a/tests/dag_processing/test_manager.py
+++ b/tests/dag_processing/test_manager.py
@@ -172,7 +172,8 @@ class TestDagFileProcessorManager:
         # Mock that only one processor exists. This processor runs with 'file_1'
         manager._processors[file_1] = MagicMock()
         # Start New Processes
-        manager._start_new_processes()
+        with mock.patch.object(DagFileProcessorManager, "_create_process"):
+            manager._start_new_processes()
 
         # Because of the config: '[scheduler] parsing_processes = 2'
         # verify that only one extra process is created


### PR DESCRIPTION
This gets the dag file parsing logs working with structlog. This will be further refactored, particularly to make it configurable for end users. But in the meantime, this gets the logs being written again.
