### PR TITLE
Add shortcut key support for search dags.

### DIFF
--- a/airflow/ui/package.json
+++ b/airflow/ui/package.json
@@ -39,6 +39,7 @@
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.20.0",
+    "react-hotkeys-hook": "^4.6.1",
     "react-icons": "^5.4.0",
     "react-json-view": "^1.21.3",
     "react-markdown": "^9.0.1",

--- a/airflow/ui/pnpm-lock.yaml
+++ b/airflow/ui/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       react-hook-form:
         specifier: ^7.20.0
         version: 7.53.1(react@18.3.1)
+      react-hotkeys-hook:
+        specifier: ^4.6.1
+        version: 4.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-icons:
         specifier: ^5.4.0
         version: 5.4.0(react@18.3.1)
@@ -3440,6 +3443,12 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
+
+  react-hotkeys-hook@4.6.1:
+    resolution: {integrity: sha512-XlZpbKUj9tkfgPgT9gA+1p7Ey6vFIZHttUjPqpTdyT5nqQ8mHL7elxvSbaC+dpSiHUSmr21Ya1mDxBZG3aje4Q==}
+    peerDependencies:
+      react: '>=16.8.1'
+      react-dom: '>=16.8.1'
 
   react-icons@5.4.0:
     resolution: {integrity: sha512-7eltJxgVt7X64oHh6wSWNwwbKTCtMfK35hcjvJS0yxEAhPM8oUKdS3+kqaW1vicIltw+kR2unHaa12S9pPALoQ==}
@@ -8474,6 +8483,11 @@ snapshots:
   react-hook-form@7.53.1(react@18.3.1):
     dependencies:
       react: 18.3.1
+
+  react-hotkeys-hook@4.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react-icons@5.4.0(react@18.3.1):
     dependencies:

--- a/airflow/ui/src/components/SearchDags/SearchDagsButton.tsx
+++ b/airflow/ui/src/components/SearchDags/SearchDagsButton.tsx
@@ -16,8 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Button, Box } from "@chakra-ui/react";
+import { Button, Box, Kbd } from "@chakra-ui/react";
 import { useState } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
 import { MdSearch } from "react-icons/md";
 
 import { Dialog } from "src/components/ui";
@@ -31,10 +32,19 @@ export const SearchDagsButton = () => {
     setIsOpen(false);
   };
 
+  useHotkeys(
+    "mod+k",
+    () => {
+      setIsOpen(true);
+    },
+    [isOpen],
+    { preventDefault: true },
+  );
+
   return (
     <Box>
       <Button justifyContent="flex-start" onClick={() => setIsOpen(true)} variant="subtle" w={200}>
-        <MdSearch /> Search Dags
+        <MdSearch /> Search Dags <Kbd size="lg">⌘K</Kbd>
       </Button>
       <Dialog.Root onOpenChange={onOpenChange} open={isOpen} size="sm">
         <Dialog.Content>

--- a/airflow/ui/src/components/SearchDags/SearchDagsButton.tsx
+++ b/airflow/ui/src/components/SearchDags/SearchDagsButton.tsx
@@ -22,11 +22,13 @@ import { useHotkeys } from "react-hotkeys-hook";
 import { MdSearch } from "react-icons/md";
 
 import { Dialog } from "src/components/ui";
+import { getMetaKey } from "src/utils";
 
 import { SearchDags } from "./SearchDags";
 
 export const SearchDagsButton = () => {
   const [isOpen, setIsOpen] = useState(false);
+  const metaKey = getMetaKey();
 
   const onOpenChange = () => {
     setIsOpen(false);
@@ -44,7 +46,7 @@ export const SearchDagsButton = () => {
   return (
     <Box>
       <Button justifyContent="flex-start" onClick={() => setIsOpen(true)} variant="subtle" w={200}>
-        <MdSearch /> Search Dags <Kbd size="lg">⌘K</Kbd>
+        <MdSearch /> Search Dags <Kbd size="sm">{metaKey}+K</Kbd>
       </Button>
       <Dialog.Root onOpenChange={onOpenChange} open={isOpen} size="sm">
         <Dialog.Content>

--- a/airflow/ui/src/utils/getMetaKey.ts
+++ b/airflow/ui/src/utils/getMetaKey.ts
@@ -17,7 +17,4 @@
  * under the License.
  */
 
-export { capitalize } from "./capitalize";
-export { pluralize } from "./pluralize";
-export { getDuration } from "./datetime_utils";
-export { getMetaKey } from "./getMetaKey";
+export const getMetaKey = () => (navigator.appVersion.includes("Mac") ? "⌘" : "Ctrl");


### PR DESCRIPTION
The PR adds "ctrl+k" as shortcut to open search dags modal in dag details page. The shortcut is similar to Chakra docs and other websites. The shortcut key is added to the button for reference.

![image](https://github.com/user-attachments/assets/b5ede534-ca16-42f6-a63d-ae861eaa7d09)
