### PR TITLE
When Task SDK sources change, we also run provider tests

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -886,7 +886,7 @@ class SelectiveChecks:
     def _get_providers_test_types_to_run(self, split_to_individual_providers: bool = False) -> list[str]:
         if self._default_branch != "main":
             return []
-        if self.full_tests_needed:
+        if self.full_tests_needed or self.run_task_sdk_tests:
             if split_to_individual_providers:
                 return list(providers_test_type())
             else:

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -516,16 +516,16 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                         ",mypy-airflow,mypy-dev,mypy-docs,mypy-providers,mypy-task-sdk"
                         ",ts-compile-format-lint-ui,ts-compile-format-lint-www"
                     ),
-                    "skip-providers-tests": "true",
+                    "skip-providers-tests": "false",
                     "upgrade-to-newer-dependencies": "false",
                     "core-test-types-list-as-string": (
                         "API Always CLI Core Operators Other Serialization WWW"
                     ),
-                    "providers-test-types-list-as-string": "",
+                    "providers-test-types-list-as-string": "Providers[-amazon,google,standard] Providers[amazon] Providers[google] Providers[standard]",
                     "needs-mypy": "true",
-                    "mypy-checks": "['mypy-task-sdk']",
+                    "mypy-checks": "['mypy-providers', 'mypy-task-sdk']",
                 },
-                id="Task SDK source file changed - Task SDK & Core tests should run",
+                id="Task SDK source file changed - Task SDK, Core and provider tests should run",
             )
         ),
         (
@@ -2474,11 +2474,11 @@ def test_provider_compatibility_checks(labels: tuple[str, ...], expected_outputs
             ("task_sdk/src/airflow/sdk/a_file.py",),
             {
                 "needs-mypy": "true",
-                "mypy-checks": "['mypy-task-sdk']",
+                "mypy-checks": "['mypy-providers', 'mypy-task-sdk']",
             },
             "main",
             (),
-            id="Airflow mypy checks on Task SDK files",
+            id="Airflow mypy checks on Task SDK files (implies providers)",
         ),
         pytest.param(
             ("docs/a_file.py",),


### PR DESCRIPTION
When Task SDK sources change, provider code is impacted as they are using Task SDK - some tests might fail because of changes there.

Example case: #45917

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
