### PR TITLE
Simplify TaskSDK's CommsDecoder interface

### DIFF
--- a/task_sdk/src/airflow/sdk/execution_time/comms.py
+++ b/task_sdk/src/airflow/sdk/execution_time/comms.py
@@ -182,7 +182,11 @@ ToTask = Annotated[
 ]
 
 
-class TaskState(BaseModel):
+class NoResponseMessage:
+    """A "marker" class/mixin that indicates this message type does not receive a response from the Supervisor."""
+
+
+class TaskState(BaseModel, NoResponseMessage):
     """
     Update a task's state.
 
@@ -196,13 +200,13 @@ class TaskState(BaseModel):
     type: Literal["TaskState"] = "TaskState"
 
 
-class DeferTask(TIDeferredStatePayload):
+class DeferTask(TIDeferredStatePayload, NoResponseMessage):
     """Update a task instance state to deferred."""
 
     type: Literal["DeferTask"] = "DeferTask"
 
 
-class RescheduleTask(TIRescheduleStatePayload):
+class RescheduleTask(TIRescheduleStatePayload, NoResponseMessage):
     """Update a task instance state to reschedule/up_for_reschedule."""
 
     type: Literal["RescheduleTask"] = "RescheduleTask"
@@ -217,7 +221,7 @@ class GetXCom(BaseModel):
     type: Literal["GetXCom"] = "GetXCom"
 
 
-class SetXCom(BaseModel):
+class SetXCom(BaseModel, NoResponseMessage):
     key: str
     value: Annotated[
         # JsonValue can handle non JSON stringified dicts, lists and strings, which is better
@@ -265,7 +269,7 @@ class PutVariable(BaseModel):
     type: Literal["PutVariable"] = "PutVariable"
 
 
-class SetRenderedFields(BaseModel):
+class SetRenderedFields(BaseModel, NoResponseMessage):
     """Payload for setting RTIF for a task instance."""
 
     # We are using a BaseModel here compared to server using RootModel because we

--- a/task_sdk/src/airflow/sdk/execution_time/context.py
+++ b/task_sdk/src/airflow/sdk/execution_time/context.py
@@ -81,8 +81,7 @@ def _get_connection(conn_id: str) -> Connection:
     from airflow.sdk.execution_time.comms import ErrorResponse, GetConnection
     from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
 
-    SUPERVISOR_COMMS.send_request(log=log, msg=GetConnection(conn_id=conn_id))
-    msg = SUPERVISOR_COMMS.get_message()
+    msg = SUPERVISOR_COMMS.send_request(log=log, msg=GetConnection(conn_id=conn_id))
     if isinstance(msg, ErrorResponse):
         raise AirflowRuntimeError(msg)
 
@@ -100,8 +99,7 @@ def _get_variable(key: str, deserialize_json: bool) -> Variable:
     from airflow.sdk.execution_time.comms import ErrorResponse, GetVariable
     from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
 
-    SUPERVISOR_COMMS.send_request(log=log, msg=GetVariable(key=key))
-    msg = SUPERVISOR_COMMS.get_message()
+    msg = SUPERVISOR_COMMS.send_request(log=log, msg=GetVariable(key=key))
     if isinstance(msg, ErrorResponse):
         raise AirflowRuntimeError(msg)
 
@@ -265,13 +263,12 @@ class OutletEventAccessors(Mapping[Union[Asset, AssetAlias], OutletEventAccessor
         from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
 
         if name:
-            SUPERVISOR_COMMS.send_request(log=log, msg=GetAssetByName(name=name))
+            msg = SUPERVISOR_COMMS.send_request(log=log, msg=GetAssetByName(name=name))
         elif uri:
-            SUPERVISOR_COMMS.send_request(log=log, msg=GetAssetByUri(uri=uri))
+            msg = SUPERVISOR_COMMS.send_request(log=log, msg=GetAssetByUri(uri=uri))
         else:
             raise ValueError("Either name or uri must be provided")
 
-        msg = SUPERVISOR_COMMS.get_message()
         if isinstance(msg, ErrorResponse):
             raise AirflowRuntimeError(msg)
 
@@ -289,8 +286,7 @@ def get_previous_dagrun_success(ti_id: UUID) -> PrevSuccessfulDagRunResponse:
     )
     from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
 
-    SUPERVISOR_COMMS.send_request(log=log, msg=GetPrevSuccessfulDagRun(ti_id=ti_id))
-    msg = SUPERVISOR_COMMS.get_message()
+    msg = SUPERVISOR_COMMS.send_request(log=log, msg=GetPrevSuccessfulDagRun(ti_id=ti_id))
 
     if TYPE_CHECKING:
         assert isinstance(msg, PrevSuccessfulDagRunResult)

--- a/task_sdk/tests/execution_time/test_task_runner.py
+++ b/task_sdk/tests/execution_time/test_task_runner.py
@@ -438,16 +438,16 @@ def test_startup_and_run_dag_with_rtif(
     startup()
     run(ti, log=mock.MagicMock())
     expected_calls = [
-        mock.call.send_request(
+        mock.call(
             msg=SetRenderedFields(rendered_fields=expected_rendered_fields),
             log=mock.ANY,
         ),
-        mock.call.send_request(
+        mock.call(
             msg=TaskState(end_date=instant, state=TerminalTIState.SUCCESS),
             log=mock.ANY,
         ),
     ]
-    mock_supervisor_comms.assert_has_calls(expected_calls)
+    mock_supervisor_comms.send_request.assert_has_calls(expected_calls)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Most of the uses cases of `send_request` are also followed by `get_message` --
so lets do that for users -- this makes it closer to an HTTP request too,
where you send a request and get a request.

Some message types don't have a response, so in order to know if we should
call `get_message` or not we define a "marker" class of `NoResponseMessage`,
and if we subclass that then we don't expect, and don't read anything back.

The other option I considered was to have the supervisor always send a message
back (i.e. send an empty line when there is otherwise no response to send) and
have `get_message()` typed to be `ToTask | None`. It felt marginally better to
have `get_message()` typed and behave to always expect a messsage.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
