### PR TITLE
AIP-38 Fix UI following Vite upgrade

### DIFF
--- a/airflow/ui/vite.config.ts
+++ b/airflow/ui/vite.config.ts
@@ -34,6 +34,9 @@ export default defineConfig({
     cssInjectedByJsPlugin(),
   ],
   resolve: { alias: { openapi: "/openapi-gen", src: "/src" } },
+  server: {
+    cors: true, // Only used by the dev server.
+  },
   test: {
     coverage: {
       include: ["src/**/*.ts", "src/**/*.tsx"],


### PR DESCRIPTION
We recently upgraded vite in https://github.com/apache/airflow/pull/45868

Unfortunately [5.4.12](https://github.com/vitejs/vite/blob/v5.4.12/packages/vite/CHANGELOG.md) holds a breaking change that affect us. Straightening the dev server CORS policy making the UI not render.

We allow back any origin to access the vite dev webserver, our code is public so there's not really a point in trying to block that with a more restrictive rule.

## Before
![Screenshot 2025-01-22 at 16 21 36](https://github.com/user-attachments/assets/4e1a314d-dfc2-4630-9b0c-e098d37ae18a)


## After
![Screenshot 2025-01-22 at 16 18 06](https://github.com/user-attachments/assets/cb0886c7-1242-4656-9036-03e945549d40)
