### PR TITLE
Fix transient issue in main

### DIFF
--- a/airflow/auth/managers/simple/views/auth.py
+++ b/airflow/auth/managers/simple/views/auth.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
-import pytest
 from flask import redirect, request, session, url_for
 from flask_appbuilder import expose
 
@@ -64,9 +63,6 @@ class SimpleAuthManagerAuthenticationViews(AirflowBaseView):
         session.clear()
         return redirect(url_for("SimpleAuthManagerAuthenticationViews.login"))
 
-    @pytest.mark.skip(
-        "This test will be deleted soon, meanwhile disabling it because it is flaky. See: https://github.com/apache/airflow/issues/45818"
-    )
     @csrf.exempt
     @expose("/login_submit", methods=("GET", "POST"))
     def login_submit(self):

--- a/tests/auth/managers/simple/views/test_auth.py
+++ b/tests/auth/managers/simple/views/test_auth.py
@@ -55,6 +55,9 @@ class TestSimpleAuthManagerAuthenticationViews:
             assert response.location == "/login"
             assert session.get("user") is None
 
+    @pytest.mark.skip(
+        "This test will be deleted soon, meanwhile disabling it because it is flaky. See: https://github.com/apache/airflow/issues/45818"
+    )
     @pytest.mark.parametrize(
         "username, password, is_successful, query_params, expected_redirect",
         [


### PR DESCRIPTION
#45820 was created to disable one flaky test that causes some failures in the CI for times to times. Shamefully .... I added the `@pytest.mark.skip(` to the implementation and not the test ... 😭 . This PR actually skips the test.

Example of error: https://apache-airflow.slack.com/archives/C015SLQF059/p1737578261968529

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
