### PR TITLE
Add asset event source from trigger to extra.

### DIFF
--- a/airflow/models/trigger.py
+++ b/airflow/models/trigger.py
@@ -244,8 +244,7 @@ class Trigger(Base):
         trigger = session.scalars(select(cls).where(cls.id == trigger_id)).one()
         for asset in trigger.assets:
             AssetManager.register_asset_change(
-                asset=asset.to_public(),
-                session=session,
+                asset=asset.to_public(), session=session, extra={"from_trigger": True}
             )
 
     @classmethod

--- a/tests/models/test_trigger.py
+++ b/tests/models/test_trigger.py
@@ -185,6 +185,9 @@ def test_submit_event(session, create_task_instance):
     # Check that the asset has received an event
     assert session.query(AssetEvent).filter_by(asset_id=asset.id).count() == 1
 
+    event = session.query(AssetEvent).filter_by(asset_id=asset.id).first()
+    assert event.extra == {"from_trigger": True}
+
 
 def test_submit_failure(session, create_task_instance):
     """


### PR DESCRIPTION
closes #44944

This is similar to events created through API adding the source info to extra. Recording this information for triggers will also help with UI in https://github.com/apache/airflow/pull/44961

https://github.com/apache/airflow/blob/c77c7f003a2458698a1d5a440670b9728783ff78/airflow/api_connexion/endpoints/asset_endpoint.py#L350