### PR TITLE
AIP-38 Mark DagRun as failed/success

### DIFF
--- a/airflow/ui/src/components/MarkAs/MarkAsAccordion.tsx
+++ b/airflow/ui/src/components/MarkAs/MarkAsAccordion.tsx
@@ -1,0 +1,72 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Editable, Text, VStack } from "@chakra-ui/react";
+import type { ChangeEvent } from "react";
+
+import type { DAGRunResponse } from "openapi/requests/types.gen";
+import ReactMarkdown from "src/components/ReactMarkdown";
+import { Accordion } from "src/components/ui";
+
+type Props = {
+  readonly note: DAGRunResponse["note"];
+  readonly setNote: (value: string) => void;
+};
+
+const MarkAsAccordion = ({ note, setNote }: Props) => (
+  <Accordion.Root collapsible defaultValue={["note"]} multiple={false} variant="enclosed">
+    <Accordion.Item key="note" value="note">
+      <Accordion.ItemTrigger>
+        <Text fontWeight="bold">Note</Text>
+      </Accordion.ItemTrigger>
+      <Accordion.ItemContent>
+        <Editable.Root
+          onChange={(event: ChangeEvent<HTMLInputElement>) => setNote(event.target.value)}
+          value={note ?? ""}
+        >
+          <Editable.Preview
+            _hover={{ backgroundColor: "transparent" }}
+            alignItems="flex-start"
+            as={VStack}
+            gap="0"
+            height="200px"
+            overflowY="auto"
+            width="100%"
+          >
+            {Boolean(note) ? (
+              <ReactMarkdown>{note}</ReactMarkdown>
+            ) : (
+              <Text color="gray" opacity={0.6}>
+                Add a note...
+              </Text>
+            )}
+          </Editable.Preview>
+          <Editable.Textarea
+            data-testid="notes-input"
+            height="200px"
+            overflowY="auto"
+            placeholder="Add a note..."
+            resize="none"
+          />
+        </Editable.Root>
+      </Accordion.ItemContent>
+    </Accordion.Item>
+  </Accordion.Root>
+);
+
+export default MarkAsAccordion;

--- a/airflow/ui/src/components/MarkAs/Run/MarkRunAsButton.tsx
+++ b/airflow/ui/src/components/MarkAs/Run/MarkRunAsButton.tsx
@@ -1,0 +1,77 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box, useDisclosure } from "@chakra-ui/react";
+import { useState } from "react";
+import { MdArrowDropDown } from "react-icons/md";
+
+import type { DAGRunPatchStates, DAGRunResponse } from "openapi/requests/types.gen";
+import { Menu, Status } from "src/components/ui";
+import ActionButton from "src/components/ui/ActionButton";
+
+import MarkRunAsDialog from "./MarkRunAsDialog";
+
+type Props = {
+  readonly dagRun: DAGRunResponse;
+  readonly withText?: boolean;
+};
+
+const allowedStates: Array<DAGRunPatchStates> = ["success", "failed"];
+
+const MarkRunAsButton = ({ dagRun, withText = true }: Props) => {
+  const { onClose, onOpen, open } = useDisclosure();
+  const [state, setState] = useState<DAGRunPatchStates>("success");
+
+  return (
+    <Box>
+      <Menu.Root positioning={{ gutter: 0, placement: "bottom" }}>
+        <Menu.Trigger asChild>
+          <ActionButton
+            actionName="Mark Dag Run as..."
+            flexDirection="row-reverse"
+            icon={<MdArrowDropDown />}
+            text="Mark Run as..."
+            withText={withText}
+          />
+        </Menu.Trigger>
+        <Menu.Content>
+          {allowedStates.map((menuState: DAGRunPatchStates) => (
+            <Menu.Item
+              asChild
+              disabled={dagRun.state === menuState}
+              key={menuState}
+              onClick={() => {
+                if (dagRun.state !== menuState) {
+                  setState(menuState);
+                  onOpen();
+                }
+              }}
+              value={menuState}
+            >
+              <Status state={menuState}>{menuState}</Status>
+            </Menu.Item>
+          ))}
+        </Menu.Content>
+      </Menu.Root>
+
+      <MarkRunAsDialog dagRun={dagRun} onClose={onClose} open={open} state={state} />
+    </Box>
+  );
+};
+
+export default MarkRunAsButton;

--- a/airflow/ui/src/components/MarkAs/Run/MarkRunAsDialog.tsx
+++ b/airflow/ui/src/components/MarkAs/Run/MarkRunAsDialog.tsx
@@ -1,0 +1,79 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Flex, Heading, VStack } from "@chakra-ui/react";
+import { useState } from "react";
+import { FiRefreshCw } from "react-icons/fi";
+
+import type { DAGRunPatchStates, DAGRunResponse } from "openapi/requests/types.gen";
+import { Button, Dialog, Status } from "src/components/ui";
+import { usePatchDagRun } from "src/queries/usePatchDagRun";
+
+import MarkAsAccordion from "../MarkAsAccordion";
+
+type Props = {
+  readonly dagRun: DAGRunResponse;
+  readonly onClose: () => void;
+  readonly open: boolean;
+  readonly state: DAGRunPatchStates;
+};
+
+const MarkRunAsDialog = ({ dagRun, onClose, open, state }: Props) => {
+  const dagId = dagRun.dag_id;
+  const dagRunId = dagRun.dag_run_id;
+
+  const [note, setNote] = useState<string | null>(dagRun.note);
+  const { isPending, mutate } = usePatchDagRun({ dagId, dagRunId, onSuccess: onClose });
+
+  return (
+    <Dialog.Root onOpenChange={onClose} open={open} size="xl">
+      <Dialog.Content backdrop>
+        <Dialog.Header>
+          <VStack align="start" gap={4}>
+            <Heading size="xl">
+              <strong>Mark DagRun as {state}:</strong> {dagRunId} <Status state={state} />
+            </Heading>
+          </VStack>
+        </Dialog.Header>
+
+        <Dialog.CloseTrigger />
+
+        <Dialog.Body width="full">
+          <MarkAsAccordion note={note} setNote={setNote} />
+          <Flex justifyContent="end" mt={3}>
+            <Button
+              colorPalette="blue"
+              loading={isPending}
+              onClick={() => {
+                mutate({
+                  dagId,
+                  dagRunId,
+                  requestBody: { note, state },
+                });
+              }}
+            >
+              <FiRefreshCw /> Confirm
+            </Button>
+          </Flex>
+        </Dialog.Body>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+};
+
+export default MarkRunAsDialog;

--- a/airflow/ui/src/components/MarkAs/Run/index.tsx
+++ b/airflow/ui/src/components/MarkAs/Run/index.tsx
@@ -1,0 +1,20 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export { default } from "./MarkRunAsButton";

--- a/airflow/ui/src/components/MarkAs/index.tsx
+++ b/airflow/ui/src/components/MarkAs/index.tsx
@@ -1,0 +1,20 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export { default as MarkRunAsButton } from "./Run";

--- a/airflow/ui/src/components/ui/ActionButton.tsx
+++ b/airflow/ui/src/components/ui/ActionButton.tsx
@@ -25,7 +25,7 @@ type Props = {
   readonly actionName: string;
   readonly colorPalette?: string;
   readonly icon: ReactElement;
-  readonly onClick: () => void;
+  readonly onClick?: () => void;
   readonly text: string;
   readonly variant?: string;
   readonly withText?: boolean;
@@ -40,22 +40,27 @@ const ActionButton = ({
   text,
   variant = "outline",
   withText = true,
+  ...rest
 }: Props) => {
   const ButtonComponent: FC<ButtonProps> = withText ? Button : IconButton;
 
   return (
     <Tooltip content={actionName} disabled={Boolean(withText)}>
-      <ButtonComponent
-        aria-label={actionName}
-        colorPalette={withText ? colorPalette : "blue"}
-        disabled={disabled}
-        onClick={onClick}
-        size={withText ? "md" : "sm"}
-        variant={withText ? variant : "ghost"}
-      >
-        {icon}
-        {withText ? text : ""}
-      </ButtonComponent>
+      {/* Extra div required for the Tooltip to be properly positioned if the ActionButton is used inside a Menu component*/}
+      <div>
+        <ButtonComponent
+          aria-label={actionName}
+          colorPalette={withText ? colorPalette : "blue"}
+          disabled={disabled}
+          onClick={onClick}
+          size={withText ? "md" : "sm"}
+          variant={withText ? variant : "ghost"}
+          {...rest}
+        >
+          {icon}
+          {withText ? text : ""}
+        </ButtonComponent>
+      </div>
     </Tooltip>
   );
 };

--- a/airflow/ui/src/pages/Dag/Runs/Runs.tsx
+++ b/airflow/ui/src/pages/Dag/Runs/Runs.tsx
@@ -35,6 +35,7 @@ import { ClearRunButton } from "src/components/Clear";
 import { DataTable } from "src/components/DataTable";
 import { useTableURLState } from "src/components/DataTable/useTableUrlState";
 import { ErrorAlert } from "src/components/ErrorAlert";
+import { MarkRunAsButton } from "src/components/MarkAs";
 import { RunTypeIcon } from "src/components/RunTypeIcon";
 import Time from "src/components/Time";
 import { Select, Status } from "src/components/ui";
@@ -92,6 +93,7 @@ const columns: Array<ColumnDef<DAGRunResponse>> = [
     cell: ({ row }) => (
       <Flex justifyContent="end">
         <ClearRunButton dagRun={row.original} withText={false} />
+        <MarkRunAsButton dagRun={row.original} withText={false} />
       </Flex>
     ),
     enableSorting: false,

--- a/airflow/ui/src/pages/Run/Header.tsx
+++ b/airflow/ui/src/pages/Run/Header.tsx
@@ -22,6 +22,7 @@ import { FiBarChart, FiMessageSquare } from "react-icons/fi";
 import type { DAGRunResponse } from "openapi/requests/types.gen";
 import { ClearRunButton } from "src/components/Clear";
 import DisplayMarkdownButton from "src/components/DisplayMarkdownButton";
+import { MarkRunAsButton } from "src/components/MarkAs";
 import { RunTypeIcon } from "src/components/RunTypeIcon";
 import { Stat } from "src/components/Stat";
 import Time from "src/components/Time";
@@ -52,6 +53,7 @@ export const Header = ({ dagRun }: { readonly dagRun: DAGRunResponse }) => (
           />
         )}
         <ClearRunButton dagRun={dagRun} />
+        <MarkRunAsButton dagRun={dagRun} />
       </HStack>
     </Flex>
     <SimpleGrid columns={4} gap={4}>

--- a/airflow/ui/src/queries/usePatchDagRun.ts
+++ b/airflow/ui/src/queries/usePatchDagRun.ts
@@ -33,17 +33,29 @@ const onError = () => {
   });
 };
 
-export const usePatchDagRun = ({ dagId, dagRunId }: { dagId: string; dagRunId: string }) => {
+export const usePatchDagRun = ({
+  dagId,
+  dagRunId,
+  onSuccess,
+}: {
+  dagId: string;
+  dagRunId: string;
+  onSuccess?: () => void;
+}) => {
   const queryClient = useQueryClient();
 
-  const onSuccess = async () => {
+  const onSuccessFn = async () => {
     const queryKeys = [UseDagRunServiceGetDagRunKeyFn({ dagId, dagRunId }), [useDagRunServiceGetDagRunsKey]];
 
     await Promise.all(queryKeys.map((key) => queryClient.invalidateQueries({ queryKey: key })));
+
+    if (onSuccess) {
+      onSuccess();
+    }
   };
 
   return useDagRunServicePatchDagRun({
     onError,
-    onSuccess,
+    onSuccess: onSuccessFn,
   });
 };


### PR DESCRIPTION
Related to: https://github.com/apache/airflow/issues/43712
Allow to mark runs as failed or success both in the:
- DagRun details view
- DagRuns list view


![Screenshot 2025-01-23 at 13 46 55](https://github.com/user-attachments/assets/027facc7-f62d-4768-9db3-b862a97aa8a7)
![Screenshot 2025-01-23 at 13 47 09](https://github.com/user-attachments/assets/80790ea6-1729-4914-863f-7be3e3fa3c22)
![Screenshot 2025-01-23 at 13 47 44](https://github.com/user-attachments/assets/f33e2b02-a8ac-4a07-a66b-fb526d93f2d5)
![Screenshot 2025-01-23 at 13 47 55](https://github.com/user-attachments/assets/f153f11c-f5b1-4ec4-a9a3-ae85011ceb4d)
![Screenshot 2025-01-23 at 13 48 06](https://github.com/user-attachments/assets/8e24aeae-0750-4db2-b3f0-8d8032ff5906)
![Screenshot 2025-01-23 at 13 48 26](https://github.com/user-attachments/assets/e1c22933-fe30-41e8-acb6-be63776b6c95)

