### PR TITLE
Dagrun details page

### DIFF
--- a/airflow/ui/package.json
+++ b/airflow/ui/package.json
@@ -40,6 +40,7 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.20.0",
     "react-icons": "^5.4.0",
+    "react-json-view": "^1.21.3",
     "react-markdown": "^9.0.1",
     "react-router-dom": "^6.26.2",
     "react-syntax-highlighter": "^15.5.6",

--- a/airflow/ui/pnpm-lock.yaml
+++ b/airflow/ui/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       react-icons:
         specifier: ^5.4.0
         version: 5.4.0(react@18.3.1)
+      react-json-view:
+        specifier: ^1.21.3
+        version: 1.21.3(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-markdown:
         specifier: ^9.0.1
         version: 9.0.1(@types/react@18.3.5)(react@18.3.1)
@@ -1637,6 +1640,9 @@ packages:
     resolution: {integrity: sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==}
     engines: {node: '>= 0.4'}
 
+  asap@2.0.6:
+    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -1671,6 +1677,9 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  base16@1.0.0:
+    resolution: {integrity: sha512-pNdYkNPiJUnEhnfXV56+sQy8+AaPcG3POZAUnwr4EeqCUZFz4u2PePbo3e5Gj4ziYPCWGUZT9RHisvJKnwFuBQ==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -1858,6 +1867,9 @@ packages:
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+
+  cross-fetch@3.2.0:
+    resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
 
   cross-spawn@7.0.5:
     resolution: {integrity: sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==}
@@ -2269,6 +2281,15 @@ packages:
   fault@1.0.4:
     resolution: {integrity: sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==}
 
+  fbemitter@3.0.0:
+    resolution: {integrity: sha512-KWKaceCwKQU0+HPoop6gn4eOHk50bBv/VxjJtGMfwmJt3D29JpN4H4eisCtIPA+a8GVBam+ldMMpMjJUvpDyHw==}
+
+  fbjs-css-vars@1.0.2:
+    resolution: {integrity: sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==}
+
+  fbjs@3.0.5:
+    resolution: {integrity: sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -2294,6 +2315,11 @@ packages:
 
   flatted@3.3.1:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
+
+  flux@4.0.4:
+    resolution: {integrity: sha512-NCj3XlayA2UsapRpM7va6wU1+9rE5FIL7qoMcmxWHRzbp0yujihMBm9BBHZ1MDIk5h5o2Bl6eGiCe8rYELAmYw==}
+    peerDependencies:
+      react: ^15.0.2 || ^16.0.0 || ^17.0.0
 
   focus-trap@7.6.0:
     resolution: {integrity: sha512-1td0l3pMkWJLFipobUcGaf+5DTY4PLDDrcqoSaKP8ediO/CoWCCYk/fT/Y2A4e6TNB+Sh6clRJCjOPPnKoNHnQ==}
@@ -2760,8 +2786,14 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.curry@4.1.1:
+    resolution: {integrity: sha512-/u14pXGviLaweY5JI0IUzgzF2J6Ne8INyzAZjImcryjgkZ+ebruBxy2/JaOOkTqScddcYtakjhSaeemV8lR0tA==}
+
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
+
+  lodash.flow@3.5.0:
+    resolution: {integrity: sha512-ff3BX/tSioo+XojX4MOsOMhJw0nZoUEF011LX8g8d3gvjVbxd89cCio4BCXronjxcTUIJUoqKEUA+n4CqvvRPw==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -3037,6 +3069,15 @@ packages:
   node-fetch-native@1.6.4:
     resolution: {integrity: sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==}
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-releases@2.0.18:
     resolution: {integrity: sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==}
 
@@ -3233,6 +3274,9 @@ packages:
     resolution: {integrity: sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==}
     engines: {node: '>=6'}
 
+  promise@7.3.1:
+    resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -3255,11 +3299,17 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  pure-color@1.3.0:
+    resolution: {integrity: sha512-QFADYnsVoBMw1srW7OVKEYjG+MbIa49s54w1MA1EDY6r2r/sTcKKYqRX1f4GYvnXP7eN/Pe9HFcX+hwzmrXRHA==}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   rc9@2.1.2:
     resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
+
+  react-base16-styling@0.6.0:
+    resolution: {integrity: sha512-yvh/7CArceR/jNATXOKDlvTnPKPmGZz7zsenQ3jUwLzHkNUR0CvY3yGYJbWJ/nnxsL8Sgmt5cO3/SILVuPO6TQ==}
 
   react-chartjs-2@5.2.0:
     resolution: {integrity: sha512-98iN5aguJyVSxp5U3CblRLH67J8gkfyGNbiK3c+l1QI/G4irHMPQw44aEPmjVag+YKTyQ260NcF82GTQ3bdscA==}
@@ -3288,6 +3338,15 @@ packages:
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-json-view@1.21.3:
+    resolution: {integrity: sha512-13p8IREj9/x/Ye4WI/JpjhoIwuzEgUAtgJZNBJckfzJt1qyh24BdTm6UQNGnyTq9dapQdrqvquZTo3dz1X6Cjw==}
+    peerDependencies:
+      react: ^17.0.0 || ^16.3.0 || ^15.5.4
+      react-dom: ^17.0.0 || ^16.3.0 || ^15.5.4
+
+  react-lifecycles-compat@3.0.4:
+    resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
 
   react-markdown@9.0.1:
     resolution: {integrity: sha512-186Gw/vF1uRkydbsOIkcGXw7aHq0sZOCRFFjGrr7b9+nVZg4UfA4enXCaxm4fUzecU38sWfrNDitGhshuU7rdg==}
@@ -3318,6 +3377,12 @@ packages:
     resolution: {integrity: sha512-OqJ2/vL7lEeV5zTJyG7kmARppUjiB9h9udl4qHQjjgEos66z00Ia0OckwYfRxCSFrW8RJIBnsBwQsHZbVPspqg==}
     peerDependencies:
       react: '>= 0.14.0'
+
+  react-textarea-autosize@8.5.7:
+    resolution: {integrity: sha512-2MqJ3p0Jh69yt9ktFIaZmORHXw4c4bxSIhCeWiFwmJ9EYKgLmuNII3e9c9b2UO+ijl4StnpZdqpxNIhTdHvqtQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
@@ -3437,6 +3502,9 @@ packages:
   set-function-name@2.0.2:
     resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
     engines: {node: '>= 0.4'}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -3618,6 +3686,9 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
@@ -3678,6 +3749,10 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  ua-parser-js@1.0.40:
+    resolution: {integrity: sha512-z6PJ8Lml+v3ichVojCiB8toQJBuwR42ySM4ezjXIqXK3M0HczmKQ3LF4rhU55PfD99KEEXQG6yb7iOMyvYuHew==}
+    hasBin: true
+
   ufo@1.5.4:
     resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
 
@@ -3722,6 +3797,15 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  use-composed-ref@1.4.0:
+    resolution: {integrity: sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   use-debounce@10.0.3:
     resolution: {integrity: sha512-DxQSI9ZKso689WM1mjgGU3ozcxU1TJElBJ3X6S4SMzMNcm2lVH0AHmyXB+K7ewjz2BSUKJTDqTcwtSMRfB89dg==}
     engines: {node: '>= 16.0.0'}
@@ -3733,6 +3817,15 @@ packages:
     peerDependencies:
       '@types/react': '*'
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-latest@1.3.0:
+    resolution: {integrity: sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -3829,6 +3922,9 @@ packages:
   web-worker@1.3.0:
     resolution: {integrity: sha512-BSR9wyRsy/KOValMgd5kMyr3JzpdeoR9KVId8u5GVlTTAtNChlsE4yTxeY7zMdNSyOmoKBv8NH2qeRY9Tg+IaA==}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -3836,6 +3932,9 @@ packages:
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
@@ -6019,6 +6118,8 @@ snapshots:
       is-array-buffer: 3.0.4
       is-shared-array-buffer: 1.0.3
 
+  asap@2.0.6: {}
+
   assertion-error@2.0.1: {}
 
   ast-types-flow@0.0.8: {}
@@ -6050,6 +6151,8 @@ snapshots:
   bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
+
+  base16@1.0.0: {}
 
   binary-extensions@2.3.0: {}
 
@@ -6250,6 +6353,12 @@ snapshots:
       yaml: 1.10.2
 
   crelt@1.0.6: {}
+
+  cross-fetch@3.2.0:
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   cross-spawn@7.0.5:
     dependencies:
@@ -6809,6 +6918,26 @@ snapshots:
     dependencies:
       format: 0.2.2
 
+  fbemitter@3.0.0:
+    dependencies:
+      fbjs: 3.0.5
+    transitivePeerDependencies:
+      - encoding
+
+  fbjs-css-vars@1.0.2: {}
+
+  fbjs@3.0.5:
+    dependencies:
+      cross-fetch: 3.2.0
+      fbjs-css-vars: 1.0.2
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      promise: 7.3.1
+      setimmediate: 1.0.5
+      ua-parser-js: 1.0.40
+    transitivePeerDependencies:
+      - encoding
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -6835,6 +6964,14 @@ snapshots:
       keyv: 4.5.4
 
   flatted@3.3.1: {}
+
+  flux@4.0.4(react@18.3.1):
+    dependencies:
+      fbemitter: 3.0.0
+      fbjs: 3.0.5
+      react: 18.3.1
+    transitivePeerDependencies:
+      - encoding
 
   focus-trap@7.6.0:
     dependencies:
@@ -7302,7 +7439,11 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.curry@4.1.1: {}
+
   lodash.debounce@4.0.8: {}
+
+  lodash.flow@3.5.0: {}
 
   lodash.merge@4.6.2: {}
 
@@ -7767,6 +7908,10 @@ snapshots:
 
   node-fetch-native@1.6.4: {}
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   node-releases@2.0.18: {}
 
   normalize-package-data@2.5.0:
@@ -7966,6 +8111,10 @@ snapshots:
 
   prismjs@1.29.0: {}
 
+  promise@7.3.1:
+    dependencies:
+      asap: 2.0.6
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -7988,12 +8137,21 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  pure-color@1.3.0: {}
+
   queue-microtask@1.2.3: {}
 
   rc9@2.1.2:
     dependencies:
       defu: 6.1.4
       destr: 2.0.3
+
+  react-base16-styling@0.6.0:
+    dependencies:
+      base16: 1.0.0
+      lodash.curry: 4.1.1
+      lodash.flow: 3.5.0
+      pure-color: 1.3.0
 
   react-chartjs-2@5.2.0(chart.js@4.4.6)(react@18.3.1):
     dependencies:
@@ -8017,6 +8175,20 @@ snapshots:
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
+
+  react-json-view@1.21.3(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      flux: 4.0.4(react@18.3.1)
+      react: 18.3.1
+      react-base16-styling: 0.6.0
+      react-dom: 18.3.1(react@18.3.1)
+      react-lifecycles-compat: 3.0.4
+      react-textarea-autosize: 8.5.7(@types/react@18.3.5)(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - encoding
+
+  react-lifecycles-compat@3.0.4: {}
 
   react-markdown@9.0.1(@types/react@18.3.5)(react@18.3.1):
     dependencies:
@@ -8073,6 +8245,15 @@ snapshots:
       prismjs: 1.29.0
       react: 18.3.1
       refractor: 3.6.0
+
+  react-textarea-autosize@8.5.7(@types/react@18.3.5)(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.25.6
+      react: 18.3.1
+      use-composed-ref: 1.4.0(@types/react@18.3.5)(react@18.3.1)
+      use-latest: 1.3.0(@types/react@18.3.5)(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
 
   react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -8260,6 +8441,8 @@ snapshots:
       functions-have-names: 1.2.3
       has-property-descriptors: 1.0.2
 
+  setimmediate@1.0.5: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -8446,6 +8629,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  tr46@0.0.3: {}
+
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
@@ -8514,6 +8699,8 @@ snapshots:
 
   typescript@5.5.4: {}
 
+  ua-parser-js@1.0.40: {}
+
   ufo@1.5.4: {}
 
   uglify-js@3.19.2:
@@ -8573,6 +8760,12 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  use-composed-ref@1.4.0(@types/react@18.3.5)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.5
+
   use-debounce@10.0.3(react@18.3.1):
     dependencies:
       react: 18.3.1
@@ -8580,6 +8773,13 @@ snapshots:
   use-isomorphic-layout-effect@1.1.2(@types/react@18.3.5)(react@18.3.1):
     dependencies:
       react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.5
+
+  use-latest@1.3.0(@types/react@18.3.5)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      use-isomorphic-layout-effect: 1.1.2(@types/react@18.3.5)(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.5
 
@@ -8676,9 +8876,16 @@ snapshots:
 
   web-worker@1.3.0: {}
 
+  webidl-conversions@3.0.1: {}
+
   webidl-conversions@7.0.0: {}
 
   whatwg-mimetype@3.0.0: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.0.2:
     dependencies:

--- a/airflow/ui/src/components/RenderedJsonField.tsx
+++ b/airflow/ui/src/components/RenderedJsonField.tsx
@@ -1,0 +1,57 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Flex, Spacer, type FlexProps } from "@chakra-ui/react";
+import { useTheme } from "next-themes";
+import ReactJson, { type ReactJsonViewProps } from "react-json-view";
+
+import { ClipboardRoot, ClipboardButton } from "src/components/ui";
+
+type Props = {
+  readonly content: object;
+  readonly jsonProps?: Omit<ReactJsonViewProps, "src">;
+} & FlexProps;
+
+const RenderedJsonField = ({ content, jsonProps, ...rest }: Props) => {
+  const contentFormatted = JSON.stringify(content, null, 4);
+  const { theme } = useTheme();
+
+  return (
+    <Flex {...rest} p={2}>
+      <ReactJson
+        displayDataTypes={false}
+        enableClipboard={false}
+        iconStyle="triangle"
+        indentWidth={2}
+        name={false}
+        src={content}
+        style={{
+          backgroundColor: "inherit",
+        }}
+        theme={theme === "dark" ? "monokai" : "rjv-default"}
+        {...jsonProps}
+      />
+      <Spacer />
+      <ClipboardRoot value={contentFormatted}>
+        <ClipboardButton />
+      </ClipboardRoot>
+    </Flex>
+  );
+};
+
+export default RenderedJsonField;

--- a/airflow/ui/src/pages/Run/Details.tsx
+++ b/airflow/ui/src/pages/Run/Details.tsx
@@ -16,178 +16,113 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Flex, HStack, Table } from "@chakra-ui/react";
-import { useParams, useSearchParams } from "react-router-dom";
+import { Box, Flex, HStack, Table, Text } from "@chakra-ui/react";
+import { useParams } from "react-router-dom";
 
-import {
-  useTaskInstanceServiceGetMappedTaskInstance,
-  useTaskInstanceServiceGetTaskInstanceTryDetails,
-} from "openapi/queries";
-import { TaskTrySelect } from "src/components/TaskTrySelect";
+import { useDagRunServiceGetDagRun } from "openapi/queries";
+import { RunTypeIcon } from "src/components/RunTypeIcon";
 import Time from "src/components/Time";
 import { ClipboardRoot, ClipboardIconButton, Status } from "src/components/ui";
 import { getDuration } from "src/utils";
 
 export const Details = () => {
-  const { dagId = "", runId = "", taskId = "" } = useParams();
-  const [searchParams, setSearchParams] = useSearchParams();
+  const { dagId = "", runId = "" } = useParams();
 
-  const mapIndexParam = searchParams.get("map_index");
-  const tryNumberParam = searchParams.get("try_number");
-  const mapIndex = parseInt(mapIndexParam ?? "-1", 10);
-
-  const { data: taskInstance } = useTaskInstanceServiceGetMappedTaskInstance({
+  const { data: dagRun } = useDagRunServiceGetDagRun({
     dagId,
     dagRunId: runId,
-    mapIndex,
-    taskId,
   });
 
-  const onSelectTryNumber = (newTryNumber: number) => {
-    if (newTryNumber === taskInstance?.try_number) {
-      searchParams.delete("try_number");
-    } else {
-      searchParams.set("try_number", newTryNumber.toString());
-    }
-    setSearchParams(searchParams);
-  };
-
-  const tryNumber = tryNumberParam === null ? taskInstance?.try_number : parseInt(tryNumberParam, 10);
-
-  const { data: tryInstance } = useTaskInstanceServiceGetTaskInstanceTryDetails({
-    dagId,
-    dagRunId: runId,
-    mapIndex,
-    taskId,
-    taskTryNumber: tryNumber ?? 1,
-  });
-
+  // TODO : Render DagRun configuration object
   return (
     <Box p={2}>
-      {taskInstance === undefined || tryNumber === undefined || taskInstance.try_number <= 1 ? (
+      {dagRun === undefined ? (
         <div />
       ) : (
-        <TaskTrySelect
-          onSelectTryNumber={onSelectTryNumber}
-          selectedTryNumber={tryNumber}
-          taskInstance={taskInstance}
-        />
+        <Table.Root striped>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>Status</Table.Cell>
+              <Table.Cell>
+                <Flex gap={1}>
+                  <Status state={dagRun.state} />
+                  {dagRun.state}
+                </Flex>
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Run ID</Table.Cell>
+              <Table.Cell>
+                <HStack>
+                  {dagRun.dag_run_id}
+                  <ClipboardRoot value={dagRun.dag_run_id}>
+                    <ClipboardIconButton />
+                  </ClipboardRoot>
+                </HStack>
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Run Type</Table.Cell>
+              <Table.Cell>
+                <HStack>
+                  <RunTypeIcon runType={dagRun.run_type} />
+                  <Text>{dagRun.run_type}</Text>
+                </HStack>
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Run Duration</Table.Cell>
+              <Table.Cell>{getDuration(dagRun.start_date, dagRun.end_date)}s</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Last Scheduling Decision</Table.Cell>
+              <Table.Cell>
+                <Time datetime={dagRun.last_scheduling_decision} />
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Queued at</Table.Cell>
+              <Table.Cell>
+                <Time datetime={dagRun.queued_at} />
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Start Date</Table.Cell>
+              <Table.Cell>
+                <Time datetime={dagRun.start_date} />
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>End Date</Table.Cell>
+              <Table.Cell>
+                <Time datetime={dagRun.end_date} />
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Data Interval Start</Table.Cell>
+              <Table.Cell>
+                <Time datetime={dagRun.data_interval_start} />
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Data Interval End</Table.Cell>
+              <Table.Cell>
+                <Time datetime={dagRun.data_interval_end} />
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Externally Triggered</Table.Cell>
+              <Table.Cell>{dagRun.external_trigger ? "True" : "False"}</Table.Cell>
+            </Table.Row>
+            {dagRun.external_trigger ? (
+              <Table.Row>
+                <Table.Cell>Externally Trigger Source</Table.Cell>
+                <Table.Cell>{dagRun.triggered_by}</Table.Cell>
+              </Table.Row>
+            ) : undefined}
+          </Table.Body>
+        </Table.Root>
       )}
-      <Table.Root striped>
-        <Table.Body>
-          <Table.Row>
-            <Table.Cell>Status</Table.Cell>
-            <Table.Cell>
-              <Flex gap={1}>
-                <Status state={tryInstance?.state ?? null} />
-                {tryInstance?.state ?? "no status"}
-              </Flex>
-            </Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>Task ID</Table.Cell>
-            <Table.Cell>
-              <HStack>
-                {tryInstance?.task_id}
-                <ClipboardRoot value={tryInstance?.task_id}>
-                  <ClipboardIconButton />
-                </ClipboardRoot>
-              </HStack>
-            </Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>Run ID</Table.Cell>
-            <Table.Cell>
-              <HStack>
-                {tryInstance?.dag_run_id}
-                <ClipboardRoot value={tryInstance?.dag_run_id}>
-                  <ClipboardIconButton />
-                </ClipboardRoot>
-              </HStack>
-            </Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>Map Index</Table.Cell>
-            <Table.Cell>{tryInstance?.map_index}</Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>Operator</Table.Cell>
-            <Table.Cell>{tryInstance?.operator}</Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>Duration</Table.Cell>
-            <Table.Cell>
-              {getDuration(tryInstance?.start_date ?? null, tryInstance?.end_date ?? null)}s
-            </Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>Started</Table.Cell>
-            <Table.Cell>
-              <Time datetime={tryInstance?.start_date} />
-            </Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>Ended</Table.Cell>
-            <Table.Cell>
-              <Time datetime={tryInstance?.end_date} />
-            </Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>Process ID (PID)</Table.Cell>
-            <Table.Cell>
-              <HStack>
-                {tryInstance?.pid}
-                <ClipboardRoot value={String(tryInstance?.pid ?? "")}>
-                  <ClipboardIconButton />
-                </ClipboardRoot>
-              </HStack>
-            </Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>Hostname</Table.Cell>
-            <Table.Cell>
-              <HStack>
-                {tryInstance?.hostname}
-                <ClipboardRoot value={tryInstance?.hostname ?? ""}>
-                  <ClipboardIconButton />
-                </ClipboardRoot>
-              </HStack>
-            </Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>Pool</Table.Cell>
-            <Table.Cell>{tryInstance?.pool}</Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>Pool Slots</Table.Cell>
-            <Table.Cell>{tryInstance?.pool_slots}</Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>Executor</Table.Cell>
-            <Table.Cell>{tryInstance?.executor}</Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>Executor Config</Table.Cell>
-            <Table.Cell>{tryInstance?.executor_config}</Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>Unix Name</Table.Cell>
-            <Table.Cell>{tryInstance?.unixname}</Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>Max Tries</Table.Cell>
-            <Table.Cell>{tryInstance?.max_tries}</Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>Queue</Table.Cell>
-            <Table.Cell>{tryInstance?.queue}</Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>Priority Weight</Table.Cell>
-            <Table.Cell>{tryInstance?.priority_weight}</Table.Cell>
-          </Table.Row>
-        </Table.Body>
-      </Table.Root>
     </Box>
   );
 };

--- a/airflow/ui/src/pages/Run/Details.tsx
+++ b/airflow/ui/src/pages/Run/Details.tsx
@@ -20,6 +20,7 @@ import { Box, Flex, HStack, Table, Text } from "@chakra-ui/react";
 import { useParams } from "react-router-dom";
 
 import { useDagRunServiceGetDagRun } from "openapi/queries";
+import RenderedJsonField from "src/components/RenderedJsonField";
 import { RunTypeIcon } from "src/components/RunTypeIcon";
 import Time from "src/components/Time";
 import { ClipboardRoot, ClipboardIconButton, Status } from "src/components/ui";
@@ -120,6 +121,12 @@ export const Details = () => {
                 <Table.Cell>{dagRun.triggered_by}</Table.Cell>
               </Table.Row>
             ) : undefined}
+            <Table.Row>
+              <Table.Cell>Run Config</Table.Cell>
+              <Table.Cell>
+                <RenderedJsonField content={dagRun.conf} />
+              </Table.Cell>
+            </Table.Row>
           </Table.Body>
         </Table.Root>
       )}

--- a/airflow/ui/src/pages/Run/Run.tsx
+++ b/airflow/ui/src/pages/Run/Run.tsx
@@ -29,6 +29,7 @@ const tabs = [
   { label: "Task Instances", value: "" },
   { label: "Events", value: "events" },
   { label: "Code", value: "code" },
+  { label: "Details", value: "details" },
 ];
 
 export const Run = () => {

--- a/airflow/ui/src/pages/TaskInstance/Details.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Details.tsx
@@ -1,0 +1,193 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box, Flex, HStack, Table } from "@chakra-ui/react";
+import { useParams, useSearchParams } from "react-router-dom";
+
+import {
+  useTaskInstanceServiceGetMappedTaskInstance,
+  useTaskInstanceServiceGetTaskInstanceTryDetails,
+} from "openapi/queries";
+import { TaskTrySelect } from "src/components/TaskTrySelect";
+import Time from "src/components/Time";
+import { ClipboardRoot, ClipboardIconButton, Status } from "src/components/ui";
+import { getDuration } from "src/utils";
+
+export const Details = () => {
+  const { dagId = "", runId = "", taskId = "" } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const mapIndexParam = searchParams.get("map_index");
+  const tryNumberParam = searchParams.get("try_number");
+  const mapIndex = parseInt(mapIndexParam ?? "-1", 10);
+
+  const { data: taskInstance } = useTaskInstanceServiceGetMappedTaskInstance({
+    dagId,
+    dagRunId: runId,
+    mapIndex,
+    taskId,
+  });
+
+  const onSelectTryNumber = (newTryNumber: number) => {
+    if (newTryNumber === taskInstance?.try_number) {
+      searchParams.delete("try_number");
+    } else {
+      searchParams.set("try_number", newTryNumber.toString());
+    }
+    setSearchParams(searchParams);
+  };
+
+  const tryNumber = tryNumberParam === null ? taskInstance?.try_number : parseInt(tryNumberParam, 10);
+
+  const { data: tryInstance } = useTaskInstanceServiceGetTaskInstanceTryDetails({
+    dagId,
+    dagRunId: runId,
+    mapIndex,
+    taskId,
+    taskTryNumber: tryNumber ?? 1,
+  });
+
+  return (
+    <Box p={2}>
+      {taskInstance === undefined || tryNumber === undefined || taskInstance.try_number <= 1 ? (
+        <div />
+      ) : (
+        <TaskTrySelect
+          onSelectTryNumber={onSelectTryNumber}
+          selectedTryNumber={tryNumber}
+          taskInstance={taskInstance}
+        />
+      )}
+      <Table.Root striped>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>Status</Table.Cell>
+            <Table.Cell>
+              <Flex gap={1}>
+                <Status state={tryInstance?.state ?? null} />
+                {tryInstance?.state ?? "no status"}
+              </Flex>
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>Task ID</Table.Cell>
+            <Table.Cell>
+              <HStack>
+                {tryInstance?.task_id}
+                <ClipboardRoot value={tryInstance?.task_id}>
+                  <ClipboardIconButton />
+                </ClipboardRoot>
+              </HStack>
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>Run ID</Table.Cell>
+            <Table.Cell>
+              <HStack>
+                {tryInstance?.dag_run_id}
+                <ClipboardRoot value={tryInstance?.dag_run_id}>
+                  <ClipboardIconButton />
+                </ClipboardRoot>
+              </HStack>
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>Map Index</Table.Cell>
+            <Table.Cell>{tryInstance?.map_index}</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>Operator</Table.Cell>
+            <Table.Cell>{tryInstance?.operator}</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>Duration</Table.Cell>
+            <Table.Cell>
+              {getDuration(tryInstance?.start_date ?? null, tryInstance?.end_date ?? null)}s
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>Started</Table.Cell>
+            <Table.Cell>
+              <Time datetime={tryInstance?.start_date} />
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>Ended</Table.Cell>
+            <Table.Cell>
+              <Time datetime={tryInstance?.end_date} />
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>Process ID (PID)</Table.Cell>
+            <Table.Cell>
+              <HStack>
+                {tryInstance?.pid}
+                <ClipboardRoot value={String(tryInstance?.pid ?? "")}>
+                  <ClipboardIconButton />
+                </ClipboardRoot>
+              </HStack>
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>Hostname</Table.Cell>
+            <Table.Cell>
+              <HStack>
+                {tryInstance?.hostname}
+                <ClipboardRoot value={tryInstance?.hostname ?? ""}>
+                  <ClipboardIconButton />
+                </ClipboardRoot>
+              </HStack>
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>Pool</Table.Cell>
+            <Table.Cell>{tryInstance?.pool}</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>Pool Slots</Table.Cell>
+            <Table.Cell>{tryInstance?.pool_slots}</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>Executor</Table.Cell>
+            <Table.Cell>{tryInstance?.executor}</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>Executor Config</Table.Cell>
+            <Table.Cell>{tryInstance?.executor_config}</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>Unix Name</Table.Cell>
+            <Table.Cell>{tryInstance?.unixname}</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>Max Tries</Table.Cell>
+            <Table.Cell>{tryInstance?.max_tries}</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>Queue</Table.Cell>
+            <Table.Cell>{tryInstance?.queue}</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>Priority Weight</Table.Cell>
+            <Table.Cell>{tryInstance?.priority_weight}</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table.Root>
+    </Box>
+  );
+};

--- a/airflow/ui/src/router.tsx
+++ b/airflow/ui/src/router.tsx
@@ -32,10 +32,11 @@ import { Dashboard } from "src/pages/Dashboard";
 import { ErrorPage } from "src/pages/Error";
 import { Events } from "src/pages/Events";
 import { Run } from "src/pages/Run";
-import { Details } from "src/pages/Run/Details";
+import { Details as DagRunDetails } from "src/pages/Run/Details";
 import { TaskInstances } from "src/pages/Run/TaskInstances";
 import { Task, Instances } from "src/pages/Task";
 import { TaskInstance, Logs } from "src/pages/TaskInstance";
+import { Details } from "src/pages/TaskInstance/Details";
 import { XCom } from "src/pages/XCom";
 
 import { Pools } from "./pages/Pools";
@@ -86,6 +87,7 @@ export const router = createBrowserRouter(
             { element: <TaskInstances />, index: true },
             { element: <Events />, path: "events" },
             { element: <Code />, path: "code" },
+            { element: <DagRunDetails />, path: "details" },
           ],
           element: <Run />,
           path: "dags/:dagId/runs/:runId",


### PR DESCRIPTION
Add a details tab similar to task instance details page since the header is missing information like data interval start, data interval end, conf etc. I have ported the `RenderedJsonField` to accept only object with usage limited to `dagrun.conf` which is an object type as per the API. The diff is larger because taskinstance details was using `Run/Details` where run folder is for dagrun related pages. I have moved the taskinstance details code to `TaskInstance/Details` for clarity.

Please let me know if there is a different design for this page.

![image](https://github.com/user-attachments/assets/03f3acdd-bffd-4f81-9c9c-410b5abafc51)
