### PR TITLE
Invalidate task instance query on marking dagrun state to refetch task instance states.

### DIFF
--- a/airflow/ui/src/queries/usePatchDagRun.ts
+++ b/airflow/ui/src/queries/usePatchDagRun.ts
@@ -26,6 +26,8 @@ import {
 } from "openapi/queries";
 import { toaster } from "src/components/ui";
 
+import { useClearDagRunDryRunKey } from "./useClearDagRunDryRun";
+
 const onError = () => {
   toaster.create({
     description: "Patch Dag Run request failed",
@@ -50,7 +52,7 @@ export const usePatchDagRun = ({
       UseDagRunServiceGetDagRunKeyFn({ dagId, dagRunId }),
       [useDagRunServiceGetDagRunsKey],
       [useTaskInstanceServiceGetTaskInstancesKey, { dagId, dagRunId }],
-      ["clearDagRun", dagId],
+      [useClearDagRunDryRunKey, dagId],
     ];
 
     await Promise.all(queryKeys.map((key) => queryClient.invalidateQueries({ queryKey: key })));

--- a/airflow/ui/src/queries/usePatchDagRun.ts
+++ b/airflow/ui/src/queries/usePatchDagRun.ts
@@ -49,7 +49,8 @@ export const usePatchDagRun = ({
     const queryKeys = [
       UseDagRunServiceGetDagRunKeyFn({ dagId, dagRunId }),
       [useDagRunServiceGetDagRunsKey],
-      [useTaskInstanceServiceGetTaskInstancesKey],
+      [useTaskInstanceServiceGetTaskInstancesKey, { dagId, dagRunId }],
+      ["clearDagRun", dagId],
     ];
 
     await Promise.all(queryKeys.map((key) => queryClient.invalidateQueries({ queryKey: key })));

--- a/airflow/ui/src/queries/usePatchDagRun.ts
+++ b/airflow/ui/src/queries/usePatchDagRun.ts
@@ -22,6 +22,7 @@ import {
   UseDagRunServiceGetDagRunKeyFn,
   useDagRunServiceGetDagRunsKey,
   useDagRunServicePatchDagRun,
+  useTaskInstanceServiceGetTaskInstancesKey,
 } from "openapi/queries";
 import { toaster } from "src/components/ui";
 
@@ -45,7 +46,11 @@ export const usePatchDagRun = ({
   const queryClient = useQueryClient();
 
   const onSuccessFn = async () => {
-    const queryKeys = [UseDagRunServiceGetDagRunKeyFn({ dagId, dagRunId }), [useDagRunServiceGetDagRunsKey]];
+    const queryKeys = [
+      UseDagRunServiceGetDagRunKeyFn({ dagId, dagRunId }),
+      [useDagRunServiceGetDagRunsKey],
+      [useTaskInstanceServiceGetTaskInstancesKey],
+    ];
 
     await Promise.all(queryKeys.map((key) => queryClient.invalidateQueries({ queryKey: key })));
 


### PR DESCRIPTION
Whenever the dagrun is marked as success or failed the corresponding tasks in running or no state will be marked as success or skipped. During clear run the key is invalidated to fetch the updated task state. Similarly on marking the dagrun the key can be used to invalidate the query to fetch updated task states.

https://github.com/apache/airflow/blob/7a28f29842e4fa103466e8b49b2986389862f486/airflow/ui/src/queries/useClearRun.ts#L63-L68