### PR TITLE
Handle exceptions in GitDagBundle Auth

### DIFF
--- a/airflow/dag_processing/bundles/git.py
+++ b/airflow/dag_processing/bundles/git.py
@@ -115,8 +115,12 @@ class GitDagBundle(BaseDagBundle, LoggingMixin):
             self._dag_bundle_root_storage_path / "git" / (self.name + f"+{self.version or self.tracking_ref}")
         )
         self.git_conn_id = git_conn_id
-        self.hook = GitHook(git_conn_id=self.git_conn_id)
-        self.repo_url = self.hook.repo_url
+        self.repo_url: str | None = None
+        try:
+            self.hook = GitHook(git_conn_id=self.git_conn_id)
+            self.repo_url = self.hook.repo_url
+        except AirflowException as e:
+            self.log.error("Error creating GitHook: %s", e)
 
     def _initialize(self):
         self._clone_bare_repo_if_required()
@@ -155,6 +159,8 @@ class GitDagBundle(BaseDagBundle, LoggingMixin):
         self.repo = Repo(self.repo_path)
 
     def _clone_bare_repo_if_required(self) -> None:
+        if not self.repo_url:
+            raise AirflowException(f"Connection {self.git_conn_id} doesn't have a host url")
         if not os.path.exists(self.bare_repo_path):
             self.log.info("Cloning bare repository to %s", self.bare_repo_path)
             Repo.clone_from(
@@ -213,10 +219,10 @@ class GitDagBundle(BaseDagBundle, LoggingMixin):
         self._fetch_bare_repo()
         self.repo.remotes.origin.pull()
 
-    def _convert_git_ssh_url_to_https(self) -> str:
-        if not self.repo_url.startswith("git@"):
-            raise ValueError(f"Invalid git SSH URL: {self.repo_url}")
-        parts = self.repo_url.split(":")
+    def _convert_git_ssh_url_to_https(self, url) -> str:
+        if not url.startswith("git@"):
+            raise ValueError(f"Invalid git SSH URL: {url}")
+        parts = url.split(":")
         domain = parts[0].replace("git@", "https://")
         repo_path = parts[1].replace(".git", "")
         return f"{domain}/{repo_path}"
@@ -225,8 +231,10 @@ class GitDagBundle(BaseDagBundle, LoggingMixin):
         if not version:
             return None
         url = self.repo_url
+        if not url:
+            return None
         if url.startswith("git@"):
-            url = self._convert_git_ssh_url_to_https()
+            url = self._convert_git_ssh_url_to_https(url)
         parsed_url = urlparse(url)
         host = parsed_url.hostname
         if not host:

--- a/airflow/dag_processing/bundles/git.py
+++ b/airflow/dag_processing/bundles/git.py
@@ -115,8 +115,8 @@ class GitDagBundle(BaseDagBundle, LoggingMixin):
             self._dag_bundle_root_storage_path / "git" / (self.name + f"+{self.version or self.tracking_ref}")
         )
         self.git_conn_id = git_conn_id
-        self.hook: GitHook | None = None
-        self.repo_url: str | None = None
+        self.hook = GitHook(git_conn_id=self.git_conn_id)
+        self.repo_url = self.hook.repo_url
 
     def _initialize(self):
         self._clone_bare_repo_if_required()
@@ -132,8 +132,6 @@ class GitDagBundle(BaseDagBundle, LoggingMixin):
             self.refresh()
 
     def initialize(self) -> None:
-        self.hook = GitHook(git_conn_id=self.git_conn_id)
-        self.repo_url = self.hook.repo_url
         if not self.repo_url:
             raise AirflowException(f"Connection {self.git_conn_id} doesn't have a host url")
         if isinstance(self.repo_url, os.PathLike):
@@ -157,9 +155,6 @@ class GitDagBundle(BaseDagBundle, LoggingMixin):
         self.repo = Repo(self.repo_path)
 
     def _clone_bare_repo_if_required(self) -> None:
-        if TYPE_CHECKING:
-            assert self.hook
-            assert self.repo_url
         if not os.path.exists(self.bare_repo_path):
             self.log.info("Cloning bare repository to %s", self.bare_repo_path)
             Repo.clone_from(
@@ -219,8 +214,6 @@ class GitDagBundle(BaseDagBundle, LoggingMixin):
         self.repo.remotes.origin.pull()
 
     def _convert_git_ssh_url_to_https(self) -> str:
-        if TYPE_CHECKING:
-            assert self.repo_url
         if not self.repo_url.startswith("git@"):
             raise ValueError(f"Invalid git SSH URL: {self.repo_url}")
         parts = self.repo_url.split(":")
@@ -231,8 +224,6 @@ class GitDagBundle(BaseDagBundle, LoggingMixin):
     def view_url(self, version: str | None = None) -> str | None:
         if not version:
             return None
-        if TYPE_CHECKING:
-            assert self.repo_url
         url = self.repo_url
         if url.startswith("git@"):
             url = self._convert_git_ssh_url_to_https()

--- a/airflow/dag_processing/bundles/git.py
+++ b/airflow/dag_processing/bundles/git.py
@@ -219,7 +219,8 @@ class GitDagBundle(BaseDagBundle, LoggingMixin):
         self._fetch_bare_repo()
         self.repo.remotes.origin.pull()
 
-    def _convert_git_ssh_url_to_https(self, url) -> str:
+    @staticmethod
+    def _convert_git_ssh_url_to_https(url: str) -> str:
         if not url.startswith("git@"):
             raise ValueError(f"Invalid git SSH URL: {url}")
         parts = url.split(":")

--- a/tests/dag_processing/test_dag_bundles.py
+++ b/tests/dag_processing/test_dag_bundles.py
@@ -355,9 +355,7 @@ class TestGitDagBundle:
             git_conn_id=CONN_NO_REPO_URL,
             tracking_ref=GIT_DEFAULT_BRANCH,
         )
-        with pytest.raises(
-            AirflowException, match=f"Connection {CONN_NO_REPO_URL} doesn't have a git_repo_url"
-        ):
+        with pytest.raises(AirflowException, match=f"Connection {CONN_NO_REPO_URL} doesn't have a host url"):
             bundle.initialize()
 
     @mock.patch("airflow.dag_processing.bundles.git.GitHook")
@@ -431,6 +429,7 @@ class TestGitDagBundle:
             name="test",
             tracking_ref="main",
         )
+        bundle.initialize()
         view_url = bundle.view_url("0f0f0f")
         assert view_url == expected_url
 
@@ -440,5 +439,6 @@ class TestGitDagBundle:
             name="test",
             tracking_ref="main",
         )
+        bundle.initialize()
         view_url = bundle.view_url(None)
         assert view_url is None

--- a/tests/dag_processing/test_dag_bundles.py
+++ b/tests/dag_processing/test_dag_bundles.py
@@ -429,7 +429,6 @@ class TestGitDagBundle:
             name="test",
             tracking_ref="main",
         )
-        bundle.initialize()
         view_url = bundle.view_url("0f0f0f")
         assert view_url == expected_url
 
@@ -439,6 +438,5 @@ class TestGitDagBundle:
             name="test",
             tracking_ref="main",
         )
-        bundle.initialize()
         view_url = bundle.view_url(None)
         assert view_url is None


### PR DESCRIPTION
The exceptions that are raised during bundle initialization should not break the dag processor.

