### PR TITLE
Add `consumer_secret` to Salesforce Connection

### DIFF
--- a/providers/src/airflow/providers/salesforce/hooks/salesforce.py
+++ b/providers/src/airflow/providers/salesforce/hooks/salesforce.py
@@ -105,6 +105,7 @@ class SalesforceHook(BaseHook):
             "security_token": PasswordField(lazy_gettext("Security Token"), widget=BS3PasswordFieldWidget()),
             "domain": StringField(lazy_gettext("Domain"), widget=BS3TextFieldWidget()),
             "consumer_key": StringField(lazy_gettext("Consumer Key"), widget=BS3TextFieldWidget()),
+            "consumer_secret": PasswordField(lazy_gettext("Consumer Secret"), widget=BS3PasswordFieldWidget()),
             "private_key_file_path": PasswordField(
                 lazy_gettext("Private Key File Path"), widget=BS3PasswordFieldWidget()
             ),
@@ -151,6 +152,7 @@ class SalesforceHook(BaseHook):
             session=self.session,
             client_id=self._get_field(extras, "client_id") or None,
             consumer_key=self._get_field(extras, "consumer_key") or None,
+            consumer_secret=self._get_field(extras, "consumer_secret") or None,
             privatekey_file=self._get_field(extras, "private_key_file_path") or None,
             privatekey=self._get_field(extras, "private_key") or None,
         )


### PR DESCRIPTION
Adds `consumer_secret` to `SalesforceHook` / Connection to allow OAuth2 login.
See https://github.com/simple-salesforce/simple-salesforce/pull/764

Does this need tests? It's passing a field directly through to the underlying library 🤔 not sure how to test, other than testing the libraries actual ability to login via this mechanism