### PR TITLE
AIP-84 - remove dry_run in post backfill tests

### DIFF
--- a/tests/api_fastapi/core_api/routes/public/test_backfills.py
+++ b/tests/api_fastapi/core_api/routes/public/test_backfills.py
@@ -192,7 +192,6 @@ class TestCreateBackfill(TestBackfillEndpoint):
             "max_active_runs": max_active_runs,
             "run_backwards": False,
             "dag_run_conf": {"param1": "val1", "param2": True},
-            "dry_run": False,
         }
         if repro_act is not None:
             data["reprocess_behavior"] = repro_act
@@ -230,7 +229,6 @@ class TestCreateBackfill(TestBackfillEndpoint):
             "max_active_runs": max_active_runs,
             "run_backwards": False,
             "dag_run_conf": {"param1": "val1", "param2": True},
-            "dry_run": False,
             "reprocess_behavior": ReprocessBehavior.NONE,
         }
         response = test_client.post(
@@ -257,7 +255,6 @@ class TestCreateBackfill(TestBackfillEndpoint):
             "max_active_runs": max_active_runs,
             "run_backwards": False,
             "dag_run_conf": {"param1": "val1", "param2": True},
-            "dry_run": False,
             "reprocess_behavior": ReprocessBehavior.NONE,
         }
         response = test_client.post(
@@ -294,7 +291,6 @@ class TestCreateBackfill(TestBackfillEndpoint):
             "max_active_runs": max_active_runs,
             "run_backwards": run_backwards,
             "dag_run_conf": {"param1": "val1", "param2": True},
-            "dry_run": False,
             "reprocess_behavior": repro_act,
         }
         response = test_client.post(


### PR DESCRIPTION
I noticed a dry_run argument being sent in creating backfill tests. It's not part of the request body as per https://github.com/apache/airflow/blob/d4609728ede88a4b8c411f774911efcfdef01ed2/airflow/api_fastapi/core_api/datamodels/backfills.py#L26-L35


We can either add it to the model(but I don't see it being utilized by underlying functionality) or remove it from tests.

Found this issue while working on https://github.com/apache/airflow/pull/44306