### PR TITLE
Add backward compatibility for old Airflow versions for CloudComposerDAGRunSensor

### DIFF
--- a/providers/tests/google/cloud/sensors/test_cloud_composer.py
+++ b/providers/tests/google/cloud/sensors/test_cloud_composer.py
@@ -21,36 +21,41 @@ import json
 from datetime import datetime
 from unittest import mock
 
+import pytest
+
 from airflow.providers.google.cloud.sensors.cloud_composer import CloudComposerDAGRunSensor
 
 TEST_PROJECT_ID = "test_project_id"
 TEST_OPERATION_NAME = "test_operation_name"
 TEST_REGION = "region"
 TEST_ENVIRONMENT_ID = "test_env_id"
-TEST_JSON_RESULT = lambda state: json.dumps(
+TEST_JSON_RESULT = lambda state, date_key: json.dumps(
     [
         {
             "dag_id": "test_dag_id",
             "run_id": "scheduled__2024-05-22T11:10:00+00:00",
             "state": state,
-            "logical_date": "2024-05-22T11:10:00+00:00",
+            date_key: "2024-05-22T11:10:00+00:00",
             "start_date": "2024-05-22T11:20:01.531988+00:00",
             "end_date": "2024-05-22T11:20:11.997479+00:00",
         }
     ]
 )
-TEST_EXEC_RESULT = lambda state: {
-    "output": [{"line_number": 1, "content": TEST_JSON_RESULT(state)}],
+TEST_EXEC_RESULT = lambda state, date_key: {
+    "output": [{"line_number": 1, "content": TEST_JSON_RESULT(state, date_key)}],
     "output_end": True,
     "exit_info": {"exit_code": 0, "error": ""},
 }
 
 
 class TestCloudComposerDAGRunSensor:
+    @pytest.mark.parametrize("composer_airflow_version", [2, 3])
     @mock.patch("airflow.providers.google.cloud.sensors.cloud_composer.ExecuteAirflowCommandResponse.to_dict")
     @mock.patch("airflow.providers.google.cloud.sensors.cloud_composer.CloudComposerHook")
-    def test_wait_ready(self, mock_hook, to_dict_mode):
-        mock_hook.return_value.wait_command_execution_result.return_value = TEST_EXEC_RESULT("success")
+    def test_wait_ready(self, mock_hook, to_dict_mode, composer_airflow_version):
+        mock_hook.return_value.wait_command_execution_result.return_value = TEST_EXEC_RESULT(
+            "success", "execution_date" if composer_airflow_version < 3 else "logical_date"
+        )
 
         task = CloudComposerDAGRunSensor(
             task_id="task-id",
@@ -60,13 +65,17 @@ class TestCloudComposerDAGRunSensor:
             composer_dag_id="test_dag_id",
             allowed_states=["success"],
         )
+        task._composer_airflow_version = composer_airflow_version
 
         assert task.poke(context={"logical_date": datetime(2024, 5, 23, 0, 0, 0)})
 
+    @pytest.mark.parametrize("composer_airflow_version", [2, 3])
     @mock.patch("airflow.providers.google.cloud.sensors.cloud_composer.ExecuteAirflowCommandResponse.to_dict")
     @mock.patch("airflow.providers.google.cloud.sensors.cloud_composer.CloudComposerHook")
-    def test_wait_not_ready(self, mock_hook, to_dict_mode):
-        mock_hook.return_value.wait_command_execution_result.return_value = TEST_EXEC_RESULT("running")
+    def test_wait_not_ready(self, mock_hook, to_dict_mode, composer_airflow_version):
+        mock_hook.return_value.wait_command_execution_result.return_value = TEST_EXEC_RESULT(
+            "running", "execution_date" if composer_airflow_version < 3 else "logical_date"
+        )
 
         task = CloudComposerDAGRunSensor(
             task_id="task-id",
@@ -76,5 +85,6 @@ class TestCloudComposerDAGRunSensor:
             composer_dag_id="test_dag_id",
             allowed_states=["success"],
         )
+        task._composer_airflow_version = composer_airflow_version
 
         assert not task.poke(context={"logical_date": datetime(2024, 5, 23, 0, 0, 0)})

--- a/providers/tests/google/cloud/triggers/test_cloud_composer.py
+++ b/providers/tests/google/cloud/triggers/test_cloud_composer.py
@@ -44,6 +44,7 @@ TEST_END_DATE = datetime(2024, 3, 22, 12, 0, 0)
 TEST_STATES = ["success"]
 TEST_GCP_CONN_ID = "test_gcp_conn_id"
 TEST_POLL_INTERVAL = 10
+TEST_COMPOSER_AIRFLOW_VERSION = 3
 TEST_IMPERSONATION_CHAIN = "test_impersonation_chain"
 TEST_EXEC_RESULT = {
     "output": [{"line_number": 1, "content": "test_content"}],
@@ -86,6 +87,7 @@ def dag_run_trigger(mock_conn):
         gcp_conn_id=TEST_GCP_CONN_ID,
         impersonation_chain=TEST_IMPERSONATION_CHAIN,
         poll_interval=TEST_POLL_INTERVAL,
+        composer_airflow_version=TEST_COMPOSER_AIRFLOW_VERSION,
     )
 
 
@@ -140,6 +142,7 @@ class TestCloudComposerDAGRunTrigger:
                 "gcp_conn_id": TEST_GCP_CONN_ID,
                 "impersonation_chain": TEST_IMPERSONATION_CHAIN,
                 "poll_interval": TEST_POLL_INTERVAL,
+                "composer_airflow_version": TEST_COMPOSER_AIRFLOW_VERSION,
             },
         )
         assert actual_data == expected_data


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

In this PR I have added backward compatibility for old Airflow versions for CloudComposerDAGRunSensor.

By this PR https://github.com/apache/airflow/pull/43902 inside the Airflow core for the DAG model `execution_date` was changed to the `logical_date`. This change was made for Airflow 3, but because it was renamed for the whole codebase it affected Google provider. The problem was faced , because the new google provider was released before Airflow 3.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
