### PR TITLE
Rename the `dag_bundles` config section to `dag_processor`

### DIFF
--- a/airflow/cli/commands/remote_commands/config_command.py
+++ b/airflow/cli/commands/remote_commands/config_command.py
@@ -329,7 +329,7 @@ CONFIGS_CHANGES = [
     ),
     ConfigChange(
         config=ConfigParameter("scheduler", "dag_dir_list_interval"),
-        renamed_to=ConfigParameter("dag_bundles", "refresh_interval"),
+        renamed_to=ConfigParameter("dag_processor", "refresh_interval"),
     ),
     # celery
     ConfigChange(

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2625,10 +2625,13 @@ sensors:
       type: float
       example: ~
       default: "604800"
-dag_bundles:
+dag_processor:
   description: |
-    Configuration for the DAG bundles. This allows Airflow to load DAGs from different sources.
-
+    Configuration for the Airflow DAG processor. This includes, for example:
+      - DAG bundles, which allows Airflow to load DAGs from different sources
+      - Parsing configuration, like:
+         - how often to refresh DAGs from those sources
+         - how many files to parse concurrently
   options:
     dag_bundle_storage_path:
       description: |
@@ -2640,11 +2643,11 @@ dag_bundles:
       example: "/tmp/some-place"
       default: ~
 
-    config_list:
+    dag_bundle_config_list:
       description: |
         List of backend configs.  Must supply name, classpath, and kwargs for each backend.
 
-        By default, ``refresh_interval`` is set to ``[dag_bundles] refresh_interval``, but that can
+        By default, ``refresh_interval`` is set to ``[dag_processor] refresh_interval``, but that can
         also be overridden in kwargs if desired.
 
         The default is the dags folder dag bundle.

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -325,7 +325,7 @@ class AirflowConfigParser(ConfigParser):
     # When reading new option, the old option will be checked to see if it exists. If it does a
     # DeprecationWarning will be issued and the old option will be used instead
     deprecated_options: dict[tuple[str, str], tuple[str, str, str]] = {
-        ("dag_bundles", "refresh_interval"): ("scheduler", "dag_dir_list_interval", "3.0"),
+        ("dag_processor", "refresh_interval"): ("scheduler", "dag_dir_list_interval", "3.0"),
     }
 
     # A mapping of new section -> (old section, since_version).

--- a/airflow/dag_processing/bundles/base.py
+++ b/airflow/dag_processing/bundles/base.py
@@ -50,7 +50,7 @@ class BaseDagBundle(ABC):
         self,
         *,
         name: str,
-        refresh_interval: int = conf.getint("dag_bundles", "refresh_interval"),
+        refresh_interval: int = conf.getint("dag_processor", "refresh_interval"),
         version: str | None = None,
     ) -> None:
         self.name = name
@@ -74,7 +74,7 @@ class BaseDagBundle(ABC):
 
         This is the root path, shared by various bundles. Each bundle should have its own subdirectory.
         """
-        if configured_location := conf.get("dag_bundles", "dag_bundle_storage_path", fallback=None):
+        if configured_location := conf.get("dag_processor", "dag_bundle_storage_path", fallback=None):
             return Path(configured_location)
         return Path(tempfile.gettempdir(), "airflow", "dag_bundles")
 

--- a/airflow/dag_processing/bundles/manager.py
+++ b/airflow/dag_processing/bundles/manager.py
@@ -54,7 +54,7 @@ class DagBundlesManager(LoggingMixin):
         if self._bundle_config:
             return
 
-        backends = conf.getjson("dag_bundles", "config_list")
+        backends = conf.getjson("dag_processor", "dag_bundle_config_list")
 
         if not backends:
             return
@@ -62,7 +62,7 @@ class DagBundlesManager(LoggingMixin):
         if not isinstance(backends, list):
             raise AirflowConfigException(
                 "Bundle config is not a list. Check config value"
-                " for section `dag_bundles` and key `backends`."
+                " for section `dag_processor` and key `dag_bundle_config_list`."
             )
 
         if any(b["name"] == "example_dags" for b in backends):

--- a/docs/apache-airflow/best-practices.rst
+++ b/docs/apache-airflow/best-practices.rst
@@ -443,7 +443,7 @@ each parameter by following the links):
 
 * :ref:`config:scheduler__scheduler_idle_sleep_time`
 * :ref:`config:scheduler__min_file_process_interval`
-* :ref:`config:dag_bundles__refresh_interval`
+* :ref:`config:dag_processor__refresh_interval`
 * :ref:`config:scheduler__parsing_processes`
 * :ref:`config:scheduler__file_parsing_sort_mode`
 

--- a/newsfragments/45722.significant.rst
+++ b/newsfragments/45722.significant.rst
@@ -1,4 +1,4 @@
-Move airflow config ``scheduler.dag_dir_list_interval`` to ``dag_bundles.refresh_interval``
+Move airflow config ``scheduler.dag_dir_list_interval`` to ``dag_processor.refresh_interval``
 
 * Types of change
 
@@ -15,4 +15,4 @@ Move airflow config ``scheduler.dag_dir_list_interval`` to ``dag_bundles.refresh
 
   * ``airflow config lint``
 
-    * [x] ``scheduler.dag_dir_list_interval`` → ``dag_bundles.refresh_interval``
+    * [x] ``scheduler.dag_dir_list_interval`` → ``dag_processor.refresh_interval``

--- a/providers/tests/fab/auth_manager/conftest.py
+++ b/providers/tests/fab/auth_manager/conftest.py
@@ -95,7 +95,7 @@ def configure_testing_dag_bundle():
                 "kwargs": {"path": str(path_to_parse), "refresh_interval": 0},
             }
         ]
-        with conf_vars({("dag_bundles", "config_list"): json.dumps(bundle_config)}):
+        with conf_vars({("dag_processor", "dag_bundle_config_list"): json.dumps(bundle_config)}):
             yield
 
     return _config_bundle

--- a/task_sdk/tests/execution_time/test_supervisor.py
+++ b/task_sdk/tests/execution_time/test_supervisor.py
@@ -80,7 +80,7 @@ def lineno():
 
 def local_dag_bundle_cfg(path, name="my-bundle"):
     return {
-        "AIRFLOW__DAG_BUNDLES__CONFIG_LIST": json.dumps(
+        "AIRFLOW__DAG_PROCESSOR__DAG_BUNDLE_CONFIG_LIST": json.dumps(
             [
                 {
                     "name": name,

--- a/task_sdk/tests/execution_time/test_task_runner.py
+++ b/task_sdk/tests/execution_time/test_task_runner.py
@@ -138,7 +138,7 @@ def test_parse(test_dags_dir: Path, make_ti_context):
     with patch.dict(
         os.environ,
         {
-            "AIRFLOW__DAG_BUNDLES__CONFIG_LIST": json.dumps(
+            "AIRFLOW__DAG_PROCESSOR__DAG_BUNDLE_CONFIG_LIST": json.dumps(
                 [
                     {
                         "name": "my-bundle",
@@ -589,7 +589,7 @@ def test_dag_parsing_context(make_ti_context, mock_supervisor_comms, monkeypatch
         ]
     )
 
-    monkeypatch.setenv("AIRFLOW__DAG_BUNDLES__CONFIG_LIST", dag_bundle_val)
+    monkeypatch.setenv("AIRFLOW__DAG_PROCESSOR__DAG_BUNDLE_CONFIG_LIST", dag_bundle_val)
     ti, _ = startup()
 
     # Presence of `conditional_task` below means DAG ID is properly set in the parsing context!

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,7 +111,7 @@ def configure_testing_dag_bundle():
                 "kwargs": {"path": str(path_to_parse), "refresh_interval": 0},
             }
         ]
-        with conf_vars({("dag_bundles", "config_list"): json.dumps(bundle_config)}):
+        with conf_vars({("dag_processor", "dag_bundle_config_list"): json.dumps(bundle_config)}):
             yield
 
     return _config_bundle

--- a/tests/dag_processing/test_dag_bundles.py
+++ b/tests/dag_processing/test_dag_bundles.py
@@ -39,12 +39,12 @@ pytestmark = pytest.mark.db_test
 
 @pytest.fixture(autouse=True)
 def bundle_temp_dir(tmp_path):
-    with conf_vars({("dag_bundles", "dag_bundle_storage_path"): str(tmp_path)}):
+    with conf_vars({("dag_processor", "dag_bundle_storage_path"): str(tmp_path)}):
         yield tmp_path
 
 
 def test_default_dag_storage_path():
-    with conf_vars({("dag_bundles", "dag_bundle_storage_path"): ""}):
+    with conf_vars({("dag_processor", "dag_bundle_storage_path"): ""}):
         bundle = LocalDagBundle(name="test", path="/hello")
         assert bundle._dag_bundle_root_storage_path == Path(tempfile.gettempdir(), "airflow", "dag_bundles")
 
@@ -60,7 +60,7 @@ def test_dag_bundle_root_storage_path():
         def path(self):
             pass
 
-    with conf_vars({("dag_bundles", "dag_bundle_storage_path"): None}):
+    with conf_vars({("dag_processor", "dag_bundle_storage_path"): None}):
         bundle = BasicBundle(name="test")
         assert bundle._dag_bundle_root_storage_path == Path(tempfile.gettempdir(), "airflow", "dag_bundles")
 

--- a/tests/dag_processing/test_manager.py
+++ b/tests/dag_processing/test_manager.py
@@ -749,7 +749,7 @@ class TestDagFileProcessorManager:
         bundletwo.refresh_interval = 300
         bundletwo.get_current_version.return_value = None
 
-        with conf_vars({("dag_bundles", "config_list"): json.dumps(config)}):
+        with conf_vars({("dag_processor", "dag_bundle_config_list"): json.dumps(config)}):
             DagBundlesManager().sync_bundles_to_db()
             with mock.patch(
                 "airflow.dag_processing.bundles.manager.DagBundlesManager"
@@ -802,7 +802,7 @@ class TestDagFileProcessorManager:
         mybundle.supports_versioning = True
         mybundle.get_current_version.return_value = "123"
 
-        with conf_vars({("dag_bundles", "config_list"): json.dumps(config)}):
+        with conf_vars({("dag_processor", "dag_bundle_config_list"): json.dumps(config)}):
             DagBundlesManager().sync_bundles_to_db()
             with mock.patch(
                 "airflow.dag_processing.bundles.manager.DagBundlesManager"


### PR DESCRIPTION
There are some non-bundle specific configs we will want to keep grouped together, and most importantly, not shoved into the scheduler section even though they are not really scheduler related (e.g.  `parsing_processes`). Those moves will come later, but for easier review this just renames the section for the options we have already in preparation.