### PR TITLE
Remove 42439 from newsfragments

### DIFF
--- a/newsfragments/42439.bugfix.rst
+++ b/newsfragments/42439.bugfix.rst
@@ -1,1 +1,0 @@
-Refactor ``bucket.get_blob`` calls in ``GCSHook`` to handle validation for non-existent objects.


### PR DESCRIPTION
The change in https://github.com/apache/airflow/pull/42474 is not core change. No need for newsfragment on it.