### PR TITLE
(feat) HttpToS3Operator: do not load file in-memory

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/http_to_s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/http_to_s3.py
@@ -38,6 +38,9 @@ class HttpToS3Operator(BaseOperator):
     """
     Calls an endpoint on an HTTP system to execute an action and store the result in S3.
 
+    By default, it loads file in memory before S3 upload.
+    Use requests streaming mode for lazy load (`extra_options={"stream": True}`).
+
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
         :ref:`howto/operator:HttpToS3Operator`

--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/http_to_s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/http_to_s3.py
@@ -164,12 +164,21 @@ class HttpToS3Operator(BaseOperator):
     def execute(self, context: Context):
         self.log.info("Calling HTTP method")
         response = self.http_hook.run(self.endpoint, self.data, self.headers, self.extra_options)
-
-        self.s3_hook.load_bytes(
-            response.content,
-            self.s3_key,
-            self.s3_bucket,
-            self.replace,
-            self.encrypt,
-            self.acl_policy,
-        )
+        if self.extra_options.get("stream", False):
+            self.s3_hook.load_file_obj(
+                response.raw,
+                self.s3_key,
+                self.s3_bucket,
+                self.replace,
+                self.encrypt,
+                self.acl_policy,
+            )
+        else:
+            self.s3_hook.load_bytes(
+                response.content,
+                self.s3_key,
+                self.s3_bucket,
+                self.replace,
+                self.encrypt,
+                self.acl_policy,
+            )

--- a/providers/amazon/tests/unit/amazon/aws/transfers/test_http_to_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/transfers/test_http_to_s3.py
@@ -24,6 +24,7 @@ import boto3
 from moto import mock_aws
 
 from airflow.models.dag import DAG
+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.amazon.aws.transfers.http_to_s3 import HttpToS3Operator
 
 EXAMPLE_URL = "http://www.example.com"
@@ -67,7 +68,14 @@ class TestHttpToS3Operator:
             s3_bucket=self.s3_bucket,
             dag=self.dag,
         )
-        operator.execute(None)
+        with mock.patch(
+            "airflow.providers.amazon.aws.hooks.s3.S3Hook.load_bytes",
+            autospec=True,
+            side_effect=S3Hook.load_bytes,
+        ) as m:
+            operator.execute(None)
+            # file was loaded using standard API
+            m.assert_called_once()
 
         objects_in_bucket = conn.list_objects(Bucket=self.s3_bucket, Prefix=self.s3_key)
         # there should be object found, and there should only be one object found
@@ -89,7 +97,14 @@ class TestHttpToS3Operator:
             dag=self.dag,
             extra_options={"stream": True},
         )
-        operator.execute(None)
+        with mock.patch(
+            "airflow.providers.amazon.aws.hooks.s3.S3Hook.load_file_obj",
+            autospec=True,
+            side_effect=S3Hook.load_file_obj,
+        ) as m:
+            operator.execute(None)
+            # file was loaded using lazy API
+            m.assert_called_once()
 
         objects_in_bucket = conn.list_objects(Bucket=self.s3_bucket, Prefix=self.s3_key)
         # there should be object found, and there should only be one object found

--- a/providers/amazon/tests/unit/amazon/aws/transfers/test_http_to_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/transfers/test_http_to_s3.py
@@ -60,7 +60,7 @@ class TestHttpToS3Operator:
         conn = boto3.client("s3")
         conn.create_bucket(Bucket=self.s3_bucket)
         operator = HttpToS3Operator(
-            task_id="s3_to_file_sensor",
+            task_id="http_to_s3_operator",
             http_conn_id=self.http_conn_id,
             endpoint=self.endpoint,
             s3_key=self.s3_key,
@@ -81,7 +81,7 @@ class TestHttpToS3Operator:
         conn = boto3.client("s3")
         conn.create_bucket(Bucket=self.s3_bucket)
         operator = HttpToS3Operator(
-            task_id="s3_to_file_sensor",
+            task_id="http_to_s3_operator",
             http_conn_id=self.http_conn_id,
             endpoint=self.endpoint,
             s3_key=self.s3_key,

--- a/providers/amazon/tests/unit/amazon/aws/transfers/test_http_to_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/transfers/test_http_to_s3.py
@@ -74,3 +74,25 @@ class TestHttpToS3Operator:
         assert len(objects_in_bucket["Contents"]) == 1
         # the object found should be consistent with dest_key specified earlier
         assert objects_in_bucket["Contents"][0]["Key"] == self.s3_key
+
+    @mock_aws
+    def test_execute_stream(self, requests_mock):
+        requests_mock.register_uri("GET", EXAMPLE_URL, content=self.response)
+        conn = boto3.client("s3")
+        conn.create_bucket(Bucket=self.s3_bucket)
+        operator = HttpToS3Operator(
+            task_id="s3_to_file_sensor",
+            http_conn_id=self.http_conn_id,
+            endpoint=self.endpoint,
+            s3_key=self.s3_key,
+            s3_bucket=self.s3_bucket,
+            dag=self.dag,
+            extra_options={"stream": True},
+        )
+        operator.execute(None)
+
+        objects_in_bucket = conn.list_objects(Bucket=self.s3_bucket, Prefix=self.s3_key)
+        # there should be object found, and there should only be one object found
+        assert len(objects_in_bucket["Contents"]) == 1
+        # the object found should be consistent with dest_key specified earlier
+        assert objects_in_bucket["Contents"][0]["Key"] == self.s3_key


### PR DESCRIPTION
If stream=True is set in extra_options, use stream API instead of loading file in-memory.

Closes: #46066
