### PR TITLE
AIP-84 Fix dag reports tests outside of breeze

### DIFF
--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -2590,9 +2590,9 @@ paths:
     get:
       tags:
       - DagReport
-      summary: Get Dag Report
+      summary: Get Dag Reports
       description: Get DAG report.
-      operationId: get_dag_report
+      operationId: get_dag_reports
       parameters:
       - name: subdir
         in: query

--- a/airflow/api_fastapi/core_api/routes/public/dag_report.py
+++ b/airflow/api_fastapi/core_api/routes/public/dag_report.py
@@ -42,7 +42,7 @@ dag_report_router = AirflowRouter(tags=["DagReport"], prefix="/dagReports")
         ]
     ),
 )
-def get_dag_report(
+def get_dag_reports(
     subdir: str,
 ):
     """Get DAG report."""

--- a/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow/ui/openapi-gen/queries/common.ts
@@ -651,22 +651,22 @@ export const UseDagStatsServiceGetDagStatsKeyFn = (
   } = {},
   queryKey?: Array<unknown>,
 ) => [useDagStatsServiceGetDagStatsKey, ...(queryKey ?? [{ dagIds }])];
-export type DagReportServiceGetDagReportDefaultResponse = Awaited<
-  ReturnType<typeof DagReportService.getDagReport>
+export type DagReportServiceGetDagReportsDefaultResponse = Awaited<
+  ReturnType<typeof DagReportService.getDagReports>
 >;
-export type DagReportServiceGetDagReportQueryResult<
-  TData = DagReportServiceGetDagReportDefaultResponse,
+export type DagReportServiceGetDagReportsQueryResult<
+  TData = DagReportServiceGetDagReportsDefaultResponse,
   TError = unknown,
 > = UseQueryResult<TData, TError>;
-export const useDagReportServiceGetDagReportKey = "DagReportServiceGetDagReport";
-export const UseDagReportServiceGetDagReportKeyFn = (
+export const useDagReportServiceGetDagReportsKey = "DagReportServiceGetDagReports";
+export const UseDagReportServiceGetDagReportsKeyFn = (
   {
     subdir,
   }: {
     subdir: string;
   },
   queryKey?: Array<unknown>,
-) => [useDagReportServiceGetDagReportKey, ...(queryKey ?? [{ subdir }])];
+) => [useDagReportServiceGetDagReportsKey, ...(queryKey ?? [{ subdir }])];
 export type DagWarningServiceListDagWarningsDefaultResponse = Awaited<
   ReturnType<typeof DagWarningService.listDagWarnings>
 >;

--- a/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -889,14 +889,14 @@ export const prefetchUseDagStatsServiceGetDagStats = (
     queryFn: () => DagStatsService.getDagStats({ dagIds }),
   });
 /**
- * Get Dag Report
+ * Get Dag Reports
  * Get DAG report.
  * @param data The data for the request.
  * @param data.subdir
  * @returns unknown Successful Response
  * @throws ApiError
  */
-export const prefetchUseDagReportServiceGetDagReport = (
+export const prefetchUseDagReportServiceGetDagReports = (
   queryClient: QueryClient,
   {
     subdir,
@@ -905,8 +905,8 @@ export const prefetchUseDagReportServiceGetDagReport = (
   },
 ) =>
   queryClient.prefetchQuery({
-    queryKey: Common.UseDagReportServiceGetDagReportKeyFn({ subdir }),
-    queryFn: () => DagReportService.getDagReport({ subdir }),
+    queryKey: Common.UseDagReportServiceGetDagReportsKeyFn({ subdir }),
+    queryFn: () => DagReportService.getDagReports({ subdir }),
   });
 /**
  * List Dag Warnings

--- a/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow/ui/openapi-gen/queries/queries.ts
@@ -1077,15 +1077,15 @@ export const useDagStatsServiceGetDagStats = <
     ...options,
   });
 /**
- * Get Dag Report
+ * Get Dag Reports
  * Get DAG report.
  * @param data The data for the request.
  * @param data.subdir
  * @returns unknown Successful Response
  * @throws ApiError
  */
-export const useDagReportServiceGetDagReport = <
-  TData = Common.DagReportServiceGetDagReportDefaultResponse,
+export const useDagReportServiceGetDagReports = <
+  TData = Common.DagReportServiceGetDagReportsDefaultResponse,
   TError = unknown,
   TQueryKey extends Array<unknown> = unknown[],
 >(
@@ -1098,8 +1098,8 @@ export const useDagReportServiceGetDagReport = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useQuery<TData, TError>({
-    queryKey: Common.UseDagReportServiceGetDagReportKeyFn({ subdir }, queryKey),
-    queryFn: () => DagReportService.getDagReport({ subdir }) as TData,
+    queryKey: Common.UseDagReportServiceGetDagReportsKeyFn({ subdir }, queryKey),
+    queryFn: () => DagReportService.getDagReports({ subdir }) as TData,
     ...options,
   });
 /**

--- a/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow/ui/openapi-gen/queries/suspense.ts
@@ -1056,15 +1056,15 @@ export const useDagStatsServiceGetDagStatsSuspense = <
     ...options,
   });
 /**
- * Get Dag Report
+ * Get Dag Reports
  * Get DAG report.
  * @param data The data for the request.
  * @param data.subdir
  * @returns unknown Successful Response
  * @throws ApiError
  */
-export const useDagReportServiceGetDagReportSuspense = <
-  TData = Common.DagReportServiceGetDagReportDefaultResponse,
+export const useDagReportServiceGetDagReportsSuspense = <
+  TData = Common.DagReportServiceGetDagReportsDefaultResponse,
   TError = unknown,
   TQueryKey extends Array<unknown> = unknown[],
 >(
@@ -1077,8 +1077,8 @@ export const useDagReportServiceGetDagReportSuspense = <
   options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">,
 ) =>
   useSuspenseQuery<TData, TError>({
-    queryKey: Common.UseDagReportServiceGetDagReportKeyFn({ subdir }, queryKey),
-    queryFn: () => DagReportService.getDagReport({ subdir }) as TData,
+    queryKey: Common.UseDagReportServiceGetDagReportsKeyFn({ subdir }, queryKey),
+    queryFn: () => DagReportService.getDagReports({ subdir }) as TData,
     ...options,
   });
 /**

--- a/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -93,8 +93,8 @@ import type {
   GetDagSourceResponse,
   GetDagStatsData,
   GetDagStatsResponse,
-  GetDagReportData,
-  GetDagReportResponse,
+  GetDagReportsData,
+  GetDagReportsResponse,
   ListDagWarningsData,
   ListDagWarningsResponse,
   GetDagsData,
@@ -1524,14 +1524,14 @@ export class DagStatsService {
 
 export class DagReportService {
   /**
-   * Get Dag Report
+   * Get Dag Reports
    * Get DAG report.
    * @param data The data for the request.
    * @param data.subdir
    * @returns unknown Successful Response
    * @throws ApiError
    */
-  public static getDagReport(data: GetDagReportData): CancelablePromise<GetDagReportResponse> {
+  public static getDagReports(data: GetDagReportsData): CancelablePromise<GetDagReportsResponse> {
     return __request(OpenAPI, {
       method: "GET",
       url: "/public/dagReports",

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1877,11 +1877,11 @@ export type GetDagStatsData = {
 
 export type GetDagStatsResponse = DagStatsCollectionResponse;
 
-export type GetDagReportData = {
+export type GetDagReportsData = {
   subdir: string;
 };
 
-export type GetDagReportResponse = unknown;
+export type GetDagReportsResponse = unknown;
 
 export type ListDagWarningsData = {
   dagId?: string | null;
@@ -3551,7 +3551,7 @@ export type $OpenApiTs = {
   };
   "/public/dagReports": {
     get: {
-      req: GetDagReportData;
+      req: GetDagReportsData;
       res: {
         /**
          * Successful Response

--- a/tests/api_fastapi/core_api/routes/public/test_dag_report.py
+++ b/tests/api_fastapi/core_api/routes/public/test_dag_report.py
@@ -35,8 +35,10 @@ TEST_DAG_FOLDER_INVALID_2 = "/root/airflow/tests/dags/"
 
 
 def get_corresponding_dag_file_count(dir: str, include_examples: bool = True) -> int:
+    from airflow import example_dags
+
     return len(list_py_file_paths(directory=dir)) + (
-        len(list_py_file_paths("/opt/airflow/airflow/example_dags")) if include_examples else 0
+        len(list_py_file_paths(next(iter(example_dags.__path__)))) if include_examples else 0
     )
 
 


### PR DESCRIPTION
There was a breeze specific path assertion in the tests. Fixing that so they can also run successfully outside of breeze.

> Also a small naming update.