### PR TITLE
Kubernetes Callbacks - Include pod instance as paramter for `progress_callback`

### DIFF
--- a/providers/src/airflow/providers/cncf/kubernetes/callbacks.py
+++ b/providers/src/airflow/providers/cncf/kubernetes/callbacks.py
@@ -189,7 +189,7 @@ class KubernetesPodOperatorCallback:
         pass
 
     @staticmethod
-    def progress_callback(*, line: str, client: client_type, mode: str, **kwargs) -> None:
+    def progress_callback(*, pod: k8s.V1Pod, line: str, client: client_type, mode: str, **kwargs) -> None:
         """
         Invoke this callback to process pod container logs.
 

--- a/providers/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/providers/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -468,7 +468,7 @@ class PodManager(LoggingMixin):
                                 for line in progress_callback_lines:
                                     for callback in self._callbacks:
                                         callback.progress_callback(
-                                            line=line, client=self._client, mode=ExecutionMode.SYNC
+                                            pod=pod, line=line, client=self._client, mode=ExecutionMode.SYNC
                                         )
                                 if message_to_log is not None:
                                     if is_log_group_marker(message_to_log):
@@ -487,7 +487,7 @@ class PodManager(LoggingMixin):
                     for line in progress_callback_lines:
                         for callback in self._callbacks:
                             callback.progress_callback(
-                                line=line, client=self._client, mode=ExecutionMode.SYNC
+                                pod=pod, line=line, client=self._client, mode=ExecutionMode.SYNC
                             )
                     if message_to_log is not None:
                         if is_log_group_marker(message_to_log):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->


This PR modifies the Kubernetes callback class in order to include the pod instance in the `progress_callback` method. `PodManager` has been modified to always include the observed pod for this method call.

This enables getting access to the pod's details (name, annotations, labels, …) during runtime, helping with use cases such as enriching/modifying received log lines and conditional script/application execution.