### PR TITLE
Satisfy Mypy for Livy Hook

### DIFF
--- a/providers/src/airflow/providers/apache/livy/hooks/livy.py
+++ b/providers/src/airflow/providers/apache/livy/hooks/livy.py
@@ -32,7 +32,6 @@ from asgiref.sync import sync_to_async
 
 from airflow.exceptions import AirflowException
 from airflow.providers.http.hooks.http import HttpAsyncHook, HttpHook
-from airflow.utils.log.logging_mixin import LoggingMixin
 
 if TYPE_CHECKING:
     from airflow.models import Connection
@@ -53,7 +52,7 @@ class BatchState(Enum):
     SUCCESS = "success"
 
 
-class LivyHook(HttpHook, LoggingMixin):
+class LivyHook(HttpHook):
     """
     Hook for Apache Livy through the REST API.
 
@@ -88,7 +87,9 @@ class LivyHook(HttpHook, LoggingMixin):
         extra_headers: dict[str, Any] | None = None,
         auth_type: Any | None = None,
     ) -> None:
-        super().__init__(http_conn_id=livy_conn_id)
+        super().__init__()
+        self.method = "POST"
+        self.http_conn_id = livy_conn_id
         self.extra_headers = extra_headers or {}
         self.extra_options = extra_options or {}
         if auth_type:
@@ -457,7 +458,7 @@ class LivyHook(HttpHook, LoggingMixin):
         return True
 
 
-class LivyAsyncHook(HttpAsyncHook, LoggingMixin):
+class LivyAsyncHook(HttpAsyncHook):
     """
     Hook for Apache Livy through the REST API asynchronously.
 
@@ -490,7 +491,9 @@ class LivyAsyncHook(HttpAsyncHook, LoggingMixin):
         extra_options: dict[str, Any] | None = None,
         extra_headers: dict[str, Any] | None = None,
     ) -> None:
-        super().__init__(http_conn_id=livy_conn_id)
+        super().__init__()
+        self.method = "POST"
+        self.http_conn_id = livy_conn_id
         self.extra_headers = extra_headers or {}
         self.extra_options = extra_options or {}
 


### PR DESCRIPTION
The Livy Hook shows ... strange MyPy errors and hard to say why.

First of all it incorrectly used multiple inheritance (BaseHook already inherist from LoggingMixin) but then it seems that mypy has been lost when it comes to fields available in the hook. Setting them directly (like it happens in other hooks deriving from HttpHook solves the MyPy issues.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
