### PR TITLE
Fix scheduler/dag-processor docs typo

### DIFF
--- a/docs/apache-airflow/administration-and-deployment/dagfile-processing.rst
+++ b/docs/apache-airflow/administration-and-deployment/dagfile-processing.rst
@@ -149,7 +149,7 @@ There are several areas of resource usage that you should pay attention to:
   but in case new classes are imported after forking this can lead to extra memory pressure.
   You need to observe if your system is using more memory than it has - which results with using swap disk,
   which dramatically decreases performance. Make sure when you look at memory usage, pay attention to the
-  kind of memory you are observing. Usually you should look at ``working memory``(names might vary depending
+  kind of memory you are observing. Usually you should look at ``working memory`` (names might vary depending
   on your deployment) rather than ``total memory used``.
 
 What can you do, to improve DAG processor's performance

--- a/docs/apache-airflow/administration-and-deployment/scheduler.rst
+++ b/docs/apache-airflow/administration-and-deployment/scheduler.rst
@@ -209,7 +209,7 @@ There are several areas of resource usage that you should pay attention to:
 * The Airflow Scheduler scales almost linearly with several instances, so you can also add more Schedulers
   if your Scheduler's performance is CPU-bound.
 * Make sure when you look at memory usage, pay attention to the kind of memory you are observing.
-  Usually you should look at ``working memory``(names might vary depending on your deployment) rather
+  Usually you should look at ``working memory`` (names might vary depending on your deployment) rather
   than ``total memory used``.
 
 What can you do, to improve Scheduler's performance


### PR DESCRIPTION
This lead to a block of inline code due to the missing space.

Before:
<img width="1039" alt="Screenshot 2025-01-27 at 9 34 00 PM" src="https://github.com/user-attachments/assets/84d4b334-ba91-4db8-a981-755a7bebca2e" />

After:
<img width="1013" alt="Screenshot 2025-01-27 at 9 53 02 PM" src="https://github.com/user-attachments/assets/42fc0c8a-2f53-490c-a710-4eeea322bce1" />
