### PR TITLE
Fix view_url replace properly url in GitHook

### DIFF
--- a/airflow/dag_processing/bundles/git.py
+++ b/airflow/dag_processing/bundles/git.py
@@ -238,8 +238,8 @@ class GitDagBundle(BaseDagBundle, LoggingMixin):
             return None
         if url.startswith("git@"):
             url = self._convert_git_ssh_url_to_https(url)
-        if url.startswith("https"):
-            url = url.replace(".git", "")
+        if url.endswith(".git"):
+            url = url[:-4]
         parsed_url = urlparse(url)
         host = parsed_url.hostname
         if not host:

--- a/tests/dag_processing/test_dag_bundles.py
+++ b/tests/dag_processing/test_dag_bundles.py
@@ -415,6 +415,10 @@ class TestGitDagBundle:
                 "https://myorg.github.com/apache/airflow/tree/0f0f0f",
             ),
             ("https://github.com/apache/airflow.git", "https://github.com/apache/airflow/tree/0f0f0f"),
+            (
+                "https://myorg.github.com/apache/airflow.git",
+                "https://myorg.github.com/apache/airflow/tree/0f0f0f",
+            ),
         ],
     )
     @mock.patch("airflow.dag_processing.bundles.git.Repo")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

related: #45998

I found [my PR](https://github.com/apache/airflow/pull/46073) is wrong to replace `.git` to blank. If url include `.git` the middle(git@myorg.github.com:apache/airflow.git), return `https://myorghub.com:apache/airflow`. Missed it..

All tests in `test_dag_bundles.py` passed
@jedcunningham 

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
