### PR TITLE
Fix grid sort bug

### DIFF
--- a/airflow/ui/src/components/TaskTrySelect.tsx
+++ b/airflow/ui/src/components/TaskTrySelect.tsx
@@ -100,8 +100,8 @@ export const TaskTrySelect = ({ onSelectTryNumber, selectedTryNumber, taskInstan
               )}
             </Select.ValueText>
           </Select.Trigger>
-          <Select.Content>
-            {tryOptions.items.reverse().map((option) => (
+          <Select.Content flexDirection="column-reverse">
+            {tryOptions.items.map((option) => (
               <Select.Item item={option} key={option.value}>
                 <span>
                   {option.value}:

--- a/airflow/ui/src/layouts/Details/Grid/Grid.tsx
+++ b/airflow/ui/src/layouts/Details/Grid/Grid.tsx
@@ -139,9 +139,11 @@ export const Grid = () => {
               </>
             )}
           </Flex>
-          {runs.reverse().map((dr, index) => (
-            <Bar index={index} key={dr.dag_run_id} limit={limit} max={max} nodes={flatNodes} run={dr} />
-          ))}
+          <Flex flexDirection="row-reverse">
+            {runs.map((dr, index) => (
+              <Bar index={index} key={dr.dag_run_id} limit={limit} max={max} nodes={flatNodes} run={dr} />
+            ))}
+          </Flex>
           <IconButton
             aria-label={`+${OFFSET_CHANGE} newer dag runs`}
             disabled={offset === 0}


### PR DESCRIPTION
Fix an [issue](https://github.com/apache/airflow/pull/45497#issuecomment-2614095717) where the grid view was resorting itself. This was due to the inline use of `.reverse()` which edited the runs in place. Now we reverse the list using a much safer css approach.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
