### PR TITLE
Fix TestTriggerDagRun logging db assertion

### DIFF
--- a/tests/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/tests/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -1189,7 +1189,7 @@ class TestTriggerDagRun:
         }
 
         assert response.json() == expected_response_json
-        _check_last_log(session, dag_id=DAG1_ID, event=f"public.dags.{DAG1_ID}.dagRuns", logical_date=None)
+        _check_last_log(session, dag_id=DAG1_ID, event=f"/public/dags/{DAG1_ID}/dagRuns", logical_date=None)
 
     @pytest.mark.parametrize(
         "post_body, expected_detail",


### PR DESCRIPTION
We are currently adding the `path.url `as it is in log table instead of replacing `\` with `.`  
<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
