### PR TITLE
Expose security views in Flask application in FAB provider

### DIFF
--- a/providers/src/airflow/providers/fab/www/extensions/init_appbuilder.py
+++ b/providers/src/airflow/providers/fab/www/extensions/init_appbuilder.py
@@ -36,7 +36,7 @@ from flask_appbuilder.const import (
 )
 from flask_appbuilder.filters import TemplateFilters
 from flask_appbuilder.menu import Menu
-from flask_appbuilder.views import IndexView
+from flask_appbuilder.views import IndexView, UtilView
 
 from airflow import settings
 from airflow.api_fastapi.app import create_auth_manager, get_auth_manager
@@ -296,6 +296,7 @@ class AirflowAppBuilder:
         """Register indexview, utilview (back function), babel views and Security views."""
         self.indexview = self._check_and_init(self.indexview)
         self.add_view_no_menu(self.indexview)
+        self.add_view_no_menu(UtilView())
         get_auth_manager().register_views()
 
     def _add_addon_views(self):

--- a/providers/src/airflow/providers/fab/www/views.py
+++ b/providers/src/airflow/providers/fab/www/views.py
@@ -51,7 +51,7 @@ class FabIndexView(IndexView):
             token = get_auth_manager().get_jwt_token(g.user)
             return redirect(f"/webapp?token={token}", code=302)
         else:
-            super().index(self)
+            return super().index()
 
 
 def show_traceback(error):


### PR DESCRIPTION
All the views under the `security` tab in Airflow 2 are provided by FAB auth manager. These views are: list roles, list users, ... We do not want to re-build these pages in the new UI since, in the future, we want to get rid of FAB auth. The idea is to use these Flask generated views and embed them in the Flask application created in FAB provider. It will probably be confusing for the user because these views use the legacy UI but given we do not want to re-build these pages, this is the only solution we have. 

Technically, these pages are already part of the Flask application, this PR just solves some bugs I found out when trying to access them.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
