### PR TITLE
Fixing OPENLINEAGE system tests import failure after new structure changes

### DIFF
--- a/providers/openlineage/tests/system/openlineage/example_openlineage.py
+++ b/providers/openlineage/tests/system/openlineage/example_openlineage.py
@@ -20,9 +20,8 @@ import os
 from datetime import datetime
 
 from airflow import DAG
+from airflow.providers.openlineage.tests.system.openlineage.operator import OpenLineageTestOperator
 from airflow.providers.standard.operators.python import PythonOperator
-
-from providers.tests.system.openlineage.operator import OpenLineageTestOperator
 
 
 def do_nothing():

--- a/providers/openlineage/tests/system/openlineage/example_openlineage_mapped_sensor.py
+++ b/providers/openlineage/tests/system/openlineage/example_openlineage_mapped_sensor.py
@@ -21,10 +21,9 @@ from datetime import datetime, timedelta
 
 from airflow import DAG
 from airflow.models import Variable
+from airflow.providers.openlineage.tests.system.openlineage.operator import OpenLineageTestOperator
 from airflow.providers.standard.operators.python import PythonOperator
 from airflow.providers.standard.sensors.time_delta import TimeDeltaSensor
-
-from providers.tests.system.openlineage.operator import OpenLineageTestOperator
 
 
 def my_task(task_number):

--- a/providers/tests/system/google/cloud/gcs/example_gcs_upload_download.py
+++ b/providers/tests/system/google/cloud/gcs/example_gcs_upload_download.py
@@ -29,10 +29,10 @@ from airflow.models.dag import DAG
 from airflow.providers.google.cloud.operators.gcs import GCSCreateBucketOperator, GCSDeleteBucketOperator
 from airflow.providers.google.cloud.transfers.gcs_to_local import GCSToLocalFilesystemOperator
 from airflow.providers.google.cloud.transfers.local_to_gcs import LocalFilesystemToGCSOperator
+from airflow.providers.openlineage.tests.system.openlineage.operator import OpenLineageTestOperator
 from airflow.utils.trigger_rule import TriggerRule
 
 from providers.tests.system.google import DEFAULT_GCP_SYSTEM_TEST_PROJECT_ID
-from providers.tests.system.openlineage.operator import OpenLineageTestOperator
 
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID", "default")
 PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT") or DEFAULT_GCP_SYSTEM_TEST_PROJECT_ID


### PR DESCRIPTION
Fixing OPENLINEAGE system tests after new structure changes.

Failure details: https://github.com/apache/airflow/actions/runs/13015608406/job/36304419072?pr=46186
<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
