### PR TITLE
feat(smtp): support html_content and subject templates from SMTP connection

### DIFF
--- a/docs/apache-airflow-providers-smtp/connections/smtp.rst
+++ b/docs/apache-airflow-providers-smtp/connections/smtp.rst
@@ -62,6 +62,8 @@ Extra (optional)
     * ``ssl_context``: Can be "default" or "none". Only valid when SSL is used. The "default" context provides a balance between security and compatibility, "none" is not recommended
       as it disables validation of certificates and allow MITM attacks, and is only needed in case your certificates are wrongly configured in your system. If not specified, defaults are taken from the
       "smtp_provider", "ssl_context" configuration with the fallback to "email". "ssl_context" configuration. If none of it is specified, "default" is used.
+    * ``subject_template``: A path to a file containing the email subject template.
+    * ``html_content_template``: A path to a file containing the email html content template.
 
 When specifying the connection in environment variable you should specify
 it using URI syntax.

--- a/providers/tests/smtp/notifications/test_smtp.py
+++ b/providers/tests/smtp/notifications/test_smtp.py
@@ -128,6 +128,8 @@ class TestSmtpNotifier:
             from_email=conf.get("smtp", "smtp_mail_from"),
             to="test_reciver@test.com",
         )
+        mock_smtphook_hook.return_value.subject_template = None
+        mock_smtphook_hook.return_value.html_content_template = None
         notifier(context)
         mock_smtphook_hook.return_value.__enter__().send_email_smtp.assert_called_once_with(
             from_email=conf.get("smtp", "smtp_mail_from"),
@@ -149,6 +151,10 @@ class TestSmtpNotifier:
     def test_notifier_with_nondefault_conf_vars(self, mock_smtphook_hook, create_task_instance):
         ti = create_task_instance(dag_id="dag", task_id="op", logical_date=timezone.datetime(2018, 1, 1))
         context = {"dag": ti.dag_run.dag, "ti": ti}
+
+        mock_smtphook_hook.return_value.from_email = None
+        mock_smtphook_hook.return_value.subject_template = None
+        mock_smtphook_hook.return_value.html_content_template = None
 
         with (
             tempfile.NamedTemporaryFile(mode="wt", suffix=".txt") as f_subject,
@@ -184,3 +190,39 @@ class TestSmtpNotifier:
                     mime_charset="utf-8",
                     custom_headers=None,
                 )
+
+    @mock.patch("airflow.providers.smtp.notifications.smtp.SmtpHook")
+    def test_notifier_with_nondefault_connection_extra(self, mock_smtphook_hook, create_task_instance):
+        ti = create_task_instance(dag_id="dag", task_id="op", logical_date=timezone.datetime(2018, 1, 1))
+        context = {"dag": ti.dag_run.dag, "ti": ti}
+
+        with (
+            tempfile.NamedTemporaryFile(mode="wt", suffix=".txt") as f_subject,
+            tempfile.NamedTemporaryFile(mode="wt", suffix=".txt") as f_content,
+        ):
+            f_subject.write("Task {{ ti.task_id }} failed")
+            f_subject.flush()
+
+            f_content.write("Mock content goes here")
+            f_content.flush()
+
+            mock_smtphook_hook.return_value.subject_template = f_subject.name
+            mock_smtphook_hook.return_value.html_content_template = f_content.name
+            notifier = SmtpNotifier(
+                from_email=conf.get("smtp", "smtp_mail_from"),
+                to="test_reciver@test.com",
+            )
+            notifier(context)
+            mock_smtphook_hook.return_value.__enter__().send_email_smtp.assert_called_once_with(
+                from_email=conf.get("smtp", "smtp_mail_from"),
+                to="test_reciver@test.com",
+                subject="Task op failed",
+                html_content="Mock content goes here",
+                smtp_conn_id="smtp_default",
+                files=None,
+                cc=None,
+                bcc=None,
+                mime_subtype="mixed",
+                mime_charset="utf-8",
+                custom_headers=None,
+            )


### PR DESCRIPTION
This PR adds support for configuring `subject` and `html_content` template files in the SMTP connection to use them in `SmtpNotifier` and `EmailOperator`

part_of: #46041