### PR TITLE
Add autorefresh to Task Instance and Dag Run pages

### DIFF
--- a/airflow/ui/src/components/TaskTrySelect.tsx
+++ b/airflow/ui/src/components/TaskTrySelect.tsx
@@ -56,7 +56,7 @@ export const TaskTrySelect = ({ onSelectTryNumber, selectedTryNumber, taskInstan
     {
       enabled: Boolean(finalTryNumber && finalTryNumber > 1), // Only try to look up task tries if try number > 1
       refetchInterval: (query) =>
-        // We actually wan tot use || here
+        // We actually want to use || here
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         query.state.data?.task_instances.some((ti) => isStatePending(ti.state)) || isStatePending(state)
           ? autoRefreshInterval * 1000

--- a/airflow/ui/src/components/TaskTrySelect.tsx
+++ b/airflow/ui/src/components/TaskTrySelect.tsx
@@ -21,6 +21,8 @@ import { Button, createListCollection, HStack, VStack, Heading } from "@chakra-u
 import { useTaskInstanceServiceGetMappedTaskInstanceTries } from "openapi/queries";
 import type { TaskInstanceHistoryResponse, TaskInstanceResponse } from "openapi/requests/types.gen";
 import { StateBadge } from "src/components/StateBadge";
+import { useConfig } from "src/queries/useConfig";
+import { isStatePending } from "src/utils/refresh";
 
 import TaskInstanceTooltip from "./TaskInstanceTooltip";
 import { Select } from "./ui";
@@ -36,9 +38,12 @@ export const TaskTrySelect = ({ onSelectTryNumber, selectedTryNumber, taskInstan
     dag_id: dagId,
     dag_run_id: dagRunId,
     map_index: mapIndex,
+    state,
     task_id: taskId,
     try_number: finalTryNumber,
   } = taskInstance;
+
+  const autoRefreshInterval = useConfig("auto_refresh_interval") as number;
 
   const { data: tiHistory } = useTaskInstanceServiceGetMappedTaskInstanceTries(
     {
@@ -50,6 +55,12 @@ export const TaskTrySelect = ({ onSelectTryNumber, selectedTryNumber, taskInstan
     undefined,
     {
       enabled: Boolean(finalTryNumber && finalTryNumber > 1), // Only try to look up task tries if try number > 1
+      refetchInterval: (query) =>
+        // We actually wan tot use || here
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        query.state.data?.task_instances.some((ti) => isStatePending(ti.state)) || isStatePending(state)
+          ? autoRefreshInterval * 1000
+          : false,
     },
   );
 

--- a/airflow/ui/src/components/ui/ProgressBar.tsx
+++ b/airflow/ui/src/components/ui/ProgressBar.tsx
@@ -20,7 +20,9 @@ import { Progress as ChakraProgress } from "@chakra-ui/react";
 import { forwardRef } from "react";
 
 export const ProgressBar = forwardRef<HTMLDivElement, ChakraProgress.RootProps>((props, ref) => (
-  <ChakraProgress.Root {...props} ref={ref}>
+  // default to indeterminate
+  // eslint-disable-next-line unicorn/no-null
+  <ChakraProgress.Root value={null} {...props} ref={ref}>
     <ChakraProgress.Track>
       <ChakraProgress.Range />
     </ChakraProgress.Track>

--- a/airflow/ui/src/pages/Run/Header.tsx
+++ b/airflow/ui/src/pages/Run/Header.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Flex, Heading, HStack, SimpleGrid, Text } from "@chakra-ui/react";
+import { Box, Flex, Heading, HStack, SimpleGrid, Spinner, Text } from "@chakra-ui/react";
 import { FiBarChart, FiMessageSquare } from "react-icons/fi";
 
 import type { DAGRunResponse } from "openapi/requests/types.gen";
@@ -29,7 +29,13 @@ import { StateBadge } from "src/components/StateBadge";
 import Time from "src/components/Time";
 import { getDuration } from "src/utils";
 
-export const Header = ({ dagRun }: { readonly dagRun: DAGRunResponse }) => (
+export const Header = ({
+  dagRun,
+  isRefreshing,
+}: {
+  readonly dagRun: DAGRunResponse;
+  readonly isRefreshing?: boolean;
+}) => (
   <Box borderColor="border" borderRadius={8} borderWidth={1} p={2}>
     <Flex alignItems="center" justifyContent="space-between" mb={2}>
       <HStack alignItems="center" gap={2}>
@@ -39,9 +45,7 @@ export const Header = ({ dagRun }: { readonly dagRun: DAGRunResponse }) => (
           {dagRun.dag_run_id}
         </Heading>
         <StateBadge state={dagRun.state}>{dagRun.state}</StateBadge>
-        <Flex>
-          <div />
-        </Flex>
+        {isRefreshing ? <Spinner /> : <div />}
       </HStack>
       <HStack>
         {dagRun.note === null || dagRun.note.length === 0 ? undefined : (

--- a/airflow/ui/src/pages/Run/TaskInstances.tsx
+++ b/airflow/ui/src/pages/Run/TaskInstances.tsx
@@ -39,8 +39,10 @@ import { StateBadge } from "src/components/StateBadge";
 import Time from "src/components/Time";
 import { Select } from "src/components/ui";
 import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
+import { useConfig } from "src/queries/useConfig";
 import { capitalize, getDuration } from "src/utils";
 import { getTaskInstanceLink } from "src/utils/links";
+import { isStatePending } from "src/utils/refresh";
 
 const columns: Array<ColumnDef<TaskInstanceResponse>> = [
   {
@@ -176,6 +178,8 @@ export const TaskInstances = () => {
     setSearchParams(searchParams);
   };
 
+  const autoRefreshInterval = useConfig("auto_refresh_interval") as number;
+
   const { data, error, isFetching, isLoading } = useTaskInstanceServiceGetTaskInstances(
     {
       dagId,
@@ -187,7 +191,13 @@ export const TaskInstances = () => {
       taskDisplayNamePattern: Boolean(taskDisplayNamePattern) ? taskDisplayNamePattern : undefined,
     },
     undefined,
-    { enabled: !isNaN(pagination.pageSize) },
+    {
+      enabled: !isNaN(pagination.pageSize),
+      refetchInterval: (query) =>
+        query.state.data?.task_instances.some((ti) => isStatePending(ti.state))
+          ? autoRefreshInterval * 1000
+          : false,
+    },
   );
 
   return (

--- a/airflow/ui/src/pages/TaskInstance/Header.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Header.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Flex, Heading, HStack, SimpleGrid } from "@chakra-ui/react";
+import { Box, Flex, Heading, HStack, SimpleGrid, Spinner } from "@chakra-ui/react";
 import { FiMessageSquare } from "react-icons/fi";
 import { MdOutlineTask } from "react-icons/md";
 
@@ -28,7 +28,13 @@ import { StateBadge } from "src/components/StateBadge";
 import Time from "src/components/Time";
 import { getDuration } from "src/utils";
 
-export const Header = ({ taskInstance }: { readonly taskInstance: TaskInstanceResponse }) => (
+export const Header = ({
+  isRefreshing,
+  taskInstance,
+}: {
+  readonly isRefreshing?: boolean;
+  readonly taskInstance: TaskInstanceResponse;
+}) => (
   <Box borderColor="border" borderRadius={8} borderWidth={1} p={2}>
     <Flex alignItems="center" justifyContent="space-between" mb={2}>
       <HStack alignItems="center" gap={2}>
@@ -38,9 +44,7 @@ export const Header = ({ taskInstance }: { readonly taskInstance: TaskInstanceRe
           {taskInstance.task_display_name} <Time datetime={taskInstance.start_date} />
         </Heading>
         <StateBadge state={taskInstance.state}>{taskInstance.state}</StateBadge>
-        <Flex>
-          <div />
-        </Flex>
+        {isRefreshing ? <Spinner /> : <div />}
       </HStack>
       <HStack>
         {taskInstance.note === null || taskInstance.note.length === 0 ? undefined : (

--- a/airflow/ui/src/pages/TaskInstance/Logs/Logs.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Logs/Logs.tsx
@@ -76,10 +76,8 @@ export const Logs = () => {
     isLoading: isLoadingLogs,
   } = useLogs({
     dagId,
-    mapIndex,
-    runId,
-    taskId,
-    tryNumber: tryNumber ?? 1,
+    taskInstance,
+    tryNumber: tryNumber === 0 ? 1 : tryNumber,
   });
 
   return (

--- a/airflow/ui/src/pages/TaskInstance/TaskInstance.tsx
+++ b/airflow/ui/src/pages/TaskInstance/TaskInstance.tsx
@@ -22,6 +22,8 @@ import { useParams, Link as RouterLink, useSearchParams } from "react-router-dom
 import { useDagServiceGetDagDetails, useTaskInstanceServiceGetMappedTaskInstance } from "openapi/queries";
 import { Breadcrumb } from "src/components/ui";
 import { DetailsLayout } from "src/layouts/Details/DetailsLayout";
+import { useConfig } from "src/queries/useConfig";
+import { isStatePending } from "src/utils/refresh";
 
 import { Header } from "./Header";
 
@@ -40,16 +42,25 @@ export const TaskInstance = () => {
   const mapIndexParam = searchParams.get("map_index");
   const mapIndex = parseInt(mapIndexParam ?? "-1", 10);
 
+  const autoRefreshInterval = useConfig("auto_refresh_interval") as number;
+
   const {
     data: taskInstance,
     error,
     isLoading,
-  } = useTaskInstanceServiceGetMappedTaskInstance({
-    dagId,
-    dagRunId: runId,
-    mapIndex,
-    taskId,
-  });
+  } = useTaskInstanceServiceGetMappedTaskInstance(
+    {
+      dagId,
+      dagRunId: runId,
+      mapIndex,
+      taskId,
+    },
+    undefined,
+    {
+      refetchInterval: (query) =>
+        isStatePending(query.state.data?.state) ? autoRefreshInterval * 1000 : false,
+    },
+  );
 
   const {
     data: dag,

--- a/airflow/ui/src/pages/TaskInstance/TaskInstance.tsx
+++ b/airflow/ui/src/pages/TaskInstance/TaskInstance.tsx
@@ -100,7 +100,12 @@ export const TaskInstance = () => {
           );
         })}
       </Breadcrumb.Root>
-      {taskInstance === undefined ? undefined : <Header taskInstance={taskInstance} />}
+      {taskInstance === undefined ? undefined : (
+        <Header
+          isRefreshing={Boolean(isStatePending(taskInstance.state) && autoRefreshInterval)}
+          taskInstance={taskInstance}
+        />
+      )}
     </DetailsLayout>
   );
 };

--- a/airflow/ui/src/queries/useClearTaskInstances.ts
+++ b/airflow/ui/src/queries/useClearTaskInstances.ts
@@ -21,8 +21,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import {
   UseDagRunServiceGetDagRunKeyFn,
   useDagRunServiceGetDagRunsKey,
-  UseTaskInstanceServiceGetTaskInstanceKeyFn,
-  useTaskInstanceServiceGetTaskInstancesKey,
+  UseTaskInstanceServiceGetMappedTaskInstanceKeyFn,
   useTaskInstanceServicePostClearTaskInstances,
 } from "openapi/queries";
 import type { ClearTaskInstancesBody, TaskInstanceCollectionResponse } from "openapi/requests/types.gen";
@@ -64,16 +63,16 @@ export const useClearTaskInstances = ({
               return undefined;
             }
 
-            const params = { dagId, dagRunId: runId, taskId: actualTaskId };
+            // TODO: update mapIndex when the endpoint supports clearing mapped tasks
+            const params = { dagId, dagRunId: runId, mapIndex: -1, taskId: actualTaskId };
 
-            return UseTaskInstanceServiceGetTaskInstanceKeyFn(params);
+            return UseTaskInstanceServiceGetMappedTaskInstanceKeyFn(params);
           })
           .filter((key) => key !== undefined),
       ),
     ];
 
     const queryKeys = [
-      [useTaskInstanceServiceGetTaskInstancesKey],
       ...taskInstanceKeys,
       UseDagRunServiceGetDagRunKeyFn({ dagId, dagRunId }),
       [useDagRunServiceGetDagRunsKey],

--- a/airflow/ui/src/utils/refresh.ts
+++ b/airflow/ui/src/utils/refresh.ts
@@ -16,29 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Badge, type BadgeProps } from "@chakra-ui/react";
-import * as React from "react";
-
 import type { TaskInstanceState } from "openapi/requests/types.gen";
 
-import { StateIcon } from "./StateIcon";
-
-export type Props = {
-  state?: TaskInstanceState | null;
-} & BadgeProps;
-
-export const StateBadge = React.forwardRef<HTMLDivElement, Props>(({ children, state, ...rest }, ref) => (
-  <Badge
-    borderRadius="full"
-    colorPalette={state === null ? "none" : state}
-    fontSize="sm"
-    px={children === undefined ? 1 : 2}
-    py={1}
-    ref={ref}
-    variant="solid"
-    {...rest}
-  >
-    {state === undefined ? undefined : <StateIcon state={state} />}
-    {children}
-  </Badge>
-));
+export const isStatePending = (state?: TaskInstanceState | null) =>
+  state === "deferred" ||
+  state === "scheduled" ||
+  state === "running" ||
+  state === "up_for_reschedule" ||
+  state === "up_for_retry" ||
+  state === "queued" ||
+  state === "restarting" ||
+  !Boolean(state);


### PR DESCRIPTION
Add auto refresh to the new UI, starting with the task instance and dag run pages

What should refresh:
- Task Instance: Header, details, tries and logs
 - Dag Run: Header, details and the list of task instances

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
