### PR TITLE
Fix pymongo generated dependencies not updated in pymongo fix

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -888,7 +888,7 @@
     "deps": [
       "apache-airflow>=2.9.0",
       "dnspython>=1.13.0",
-      "pymongo>=4.0.0"
+      "pymongo>=4.0.0,!=4.11"
     ],
     "devel-deps": [
       "mongomock>=4.0.0"

--- a/providers/mongo/README.rst
+++ b/providers/mongo/README.rst
@@ -56,7 +56,7 @@ PIP package         Version required
 ==================  ==================
 ``apache-airflow``  ``>=2.9.0``
 ``dnspython``       ``>=1.13.0``
-``pymongo``         ``>=4.0.0``
+``pymongo``         ``>=4.0.0,!=4.11``
 ==================  ==================
 
 The changelog for the provider package can be found in the

--- a/providers/mongo/src/airflow/providers/mongo/get_provider_info.py
+++ b/providers/mongo/src/airflow/providers/mongo/get_provider_info.py
@@ -72,6 +72,6 @@ def get_provider_info():
         "connection-types": [
             {"hook-class-name": "airflow.providers.mongo.hooks.mongo.MongoHook", "connection-type": "mongo"}
         ],
-        "dependencies": ["apache-airflow>=2.9.0", "dnspython>=1.13.0", "pymongo>=4.0.0"],
+        "dependencies": ["apache-airflow>=2.9.0", "dnspython>=1.13.0", "pymongo>=4.0.0,!=4.11"],
         "devel-dependencies": ["mongomock>=4.0.0"],
     }


### PR DESCRIPTION
Related: #46216

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
