### PR TITLE
Revert "Fix GitDagBundle to support https (#46073)"

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2667,15 +2667,6 @@ dag_processor:
                     "repo_url": "git@github.com:example.com/my-dags.git",
                     "tracking_ref": "main",
                     "refresh_interval": 0
-            },
-            {
-                "name": "my-git-repo",
-                "classpath": "airflow.dag_processing.bundles.git.GitDagBundle",
-                "kwargs": {
-                    "subdir": "dags",
-                    "repo_url": "https://github.com/example/my-dags.git",
-                    "tracking_ref": "main",
-                    "refresh_interval": 0
             }
             ]
       default: >

--- a/airflow/dag_processing/bundles/git.py
+++ b/airflow/dag_processing/bundles/git.py
@@ -140,11 +140,9 @@ class GitDagBundle(BaseDagBundle, LoggingMixin):
             raise AirflowException(f"Connection {self.git_conn_id} doesn't have a host url")
         if isinstance(self.repo_url, os.PathLike):
             self._initialize()
-        elif not (
-            self.repo_url.startswith("git@") or self.repo_url.startswith("https")
-        ) or not self.repo_url.endswith(".git"):
+        elif not self.repo_url.startswith("git@") or not self.repo_url.endswith(".git"):
             raise AirflowException(
-                f"Invalid git URL: {self.repo_url}. URL must start with git@ or https and end with .git"
+                f"Invalid git URL: {self.repo_url}. URL must start with git@ and end with .git"
             )
         else:
             self._initialize()
@@ -238,8 +236,6 @@ class GitDagBundle(BaseDagBundle, LoggingMixin):
             return None
         if url.startswith("git@"):
             url = self._convert_git_ssh_url_to_https(url)
-        if url.startswith("https"):
-            url = url.replace(".git", "")
         parsed_url = urlparse(url)
         host = parsed_url.hostname
         if not host:

--- a/tests/dag_processing/test_dag_bundles.py
+++ b/tests/dag_processing/test_dag_bundles.py
@@ -399,8 +399,7 @@ class TestGitDagBundle:
             tracking_ref=GIT_DEFAULT_BRANCH,
         )
         with pytest.raises(
-            AirflowException,
-            match=f"Invalid git URL: {repo_url}. URL must start with git@ or https and end with .git",
+            AirflowException, match=f"Invalid git URL: {repo_url}. URL must start with git@ and end with .git"
         ):
             bundle.initialize()
 
@@ -414,7 +413,6 @@ class TestGitDagBundle:
                 "git@myorg.github.com:apache/airflow.git",
                 "https://myorg.github.com/apache/airflow/tree/0f0f0f",
             ),
-            ("https://github.com/apache/airflow.git", "https://github.com/apache/airflow/tree/0f0f0f"),
         ],
     )
     @mock.patch("airflow.dag_processing.bundles.git.Repo")


### PR DESCRIPTION
This reverts commit a605f0412347743dc289c23e2616053f7360e728.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
