### PR TITLE
Change Paralell constraints generation to sequential

### DIFF
--- a/.github/workflows/generate-constraints.yml
+++ b/.github/workflows/generate-constraints.yml
@@ -112,9 +112,11 @@ jobs:
         env:
           CHICKEN_EGG_PROVIDERS: ${{ inputs.chicken-egg-providers }}
         run: >
-          breeze release-management generate-constraints --run-in-parallel
-          --airflow-constraints-mode constraints --answer yes
-          --chicken-egg-providers "${CHICKEN_EGG_PROVIDERS}" --parallelism 3
+          for PYTHON in $PYTHON_VERSIONS; do
+            breeze release-management generate-constraints
+            --airflow-constraints-mode constraints --answer yes
+            --chicken-egg-providers "${CHICKEN_EGG_PROVIDERS}"
+          done
       - name: "Dependency upgrade summary"
         shell: bash
         env:
@@ -123,6 +125,7 @@ jobs:
           for PYTHON_VERSION in $PYTHON_VERSIONS; do
             echo "Summarizing Python $PYTHON_VERSION"
             cat "files/constraints-${PYTHON_VERSION}"/*.md >> $GITHUB_STEP_SUMMARY || true
+            df -H
           done
       - name: "Upload constraint artifacts"
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Parallel constraint generation runs several docker containers and it produces some build artifacts in paralllel (when compiling spar) that are huge - when run in parallell we are runnig out of disk space for them. Changing to sequential execution hopefully shoudl fix it.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
