### PR TITLE
feature: Add environment variable controlling the log grooming frequency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1271,10 +1271,11 @@ set -euo pipefail
 
 readonly DIRECTORY="${AIRFLOW_HOME:-/usr/local/airflow}"
 readonly RETENTION="${AIRFLOW__LOG_RETENTION_DAYS:-15}"
+readonly FREQUENCY="${AIRFLOW__LOG_CLEANUP_FREQUENCY_MINUTES:-15}"
 
 trap "exit" INT TERM
 
-readonly EVERY=$((15*60))
+readonly EVERY=$((FREQUENCY*60))
 
 echo "Cleaning logs every $EVERY seconds"
 

--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -215,6 +215,10 @@ spec:
             - name: AIRFLOW__LOG_RETENTION_DAYS
               value: "{{ .Values.dagProcessor.logGroomerSidecar.retentionDays }}"
           {{- end }}
+          {{- if .Values.workers.logGroomerSidecar.frequencyMinutes }}
+            - name: AIRFLOW__LOG_CLEANUP_FREQUENCY_MINUTES
+              value: "{{ .Values.workers.logGroomerSidecar.frequencyMinutes }}"
+          {{- end }}
             - name: AIRFLOW_HOME
               value: "{{ .Values.airflowHome }}"
           {{- if .Values.dagProcessor.logGroomerSidecar.env }}

--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -215,9 +215,9 @@ spec:
             - name: AIRFLOW__LOG_RETENTION_DAYS
               value: "{{ .Values.dagProcessor.logGroomerSidecar.retentionDays }}"
           {{- end }}
-          {{- if .Values.workers.logGroomerSidecar.frequencyMinutes }}
+          {{- if .Values.dagProcessor.logGroomerSidecar.frequencyMinutes }}
             - name: AIRFLOW__LOG_CLEANUP_FREQUENCY_MINUTES
-              value: "{{ .Values.workers.logGroomerSidecar.frequencyMinutes }}"
+              value: "{{ .Values.dagProcessor.logGroomerSidecar.frequencyMinutes }}"
           {{- end }}
             - name: AIRFLOW_HOME
               value: "{{ .Values.airflowHome }}"

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -273,6 +273,10 @@ spec:
             - name: AIRFLOW__LOG_RETENTION_DAYS
               value: "{{ .Values.scheduler.logGroomerSidecar.retentionDays }}"
           {{- end }}
+          {{- if .Values.workers.logGroomerSidecar.frequencyMinutes }}
+            - name: AIRFLOW__LOG_CLEANUP_FREQUENCY_MINUTES
+              value: "{{ .Values.workers.logGroomerSidecar.frequencyMinutes }}"
+          {{- end }}
             - name: AIRFLOW_HOME
               value: "{{ .Values.airflowHome }}"
           {{- if .Values.scheduler.logGroomerSidecar.env }}

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -273,9 +273,9 @@ spec:
             - name: AIRFLOW__LOG_RETENTION_DAYS
               value: "{{ .Values.scheduler.logGroomerSidecar.retentionDays }}"
           {{- end }}
-          {{- if .Values.workers.logGroomerSidecar.frequencyMinutes }}
+          {{- if .Values.scheduler.logGroomerSidecar.frequencyMinutes }}
             - name: AIRFLOW__LOG_CLEANUP_FREQUENCY_MINUTES
-              value: "{{ .Values.workers.logGroomerSidecar.frequencyMinutes }}"
+              value: "{{ .Values.scheduler.logGroomerSidecar.frequencyMinutes }}"
           {{- end }}
             - name: AIRFLOW_HOME
               value: "{{ .Values.airflowHome }}"

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -245,6 +245,10 @@ spec:
             - name: AIRFLOW__LOG_RETENTION_DAYS
               value: "{{ .Values.triggerer.logGroomerSidecar.retentionDays }}"
           {{- end }}
+          {{- if .Values.workers.logGroomerSidecar.frequencyMinutes }}
+            - name: AIRFLOW__LOG_CLEANUP_FREQUENCY_MINUTES
+              value: "{{ .Values.workers.logGroomerSidecar.frequencyMinutes }}"
+          {{- end }}
             - name: AIRFLOW_HOME
               value: "{{ .Values.airflowHome }}"
           {{- if .Values.triggerer.logGroomerSidecar.env }}

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -245,9 +245,9 @@ spec:
             - name: AIRFLOW__LOG_RETENTION_DAYS
               value: "{{ .Values.triggerer.logGroomerSidecar.retentionDays }}"
           {{- end }}
-          {{- if .Values.workers.logGroomerSidecar.frequencyMinutes }}
+          {{- if .Values.triggerer.logGroomerSidecar.frequencyMinutes }}
             - name: AIRFLOW__LOG_CLEANUP_FREQUENCY_MINUTES
-              value: "{{ .Values.workers.logGroomerSidecar.frequencyMinutes }}"
+              value: "{{ .Values.triggerer.logGroomerSidecar.frequencyMinutes }}"
           {{- end }}
             - name: AIRFLOW_HOME
               value: "{{ .Values.airflowHome }}"

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -330,6 +330,10 @@ spec:
             - name: AIRFLOW__LOG_RETENTION_DAYS
               value: "{{ .Values.workers.logGroomerSidecar.retentionDays }}"
           {{- end }}
+          {{- if .Values.workers.logGroomerSidecar.frequencyMinutes }}
+            - name: AIRFLOW__LOG_CLEANUP_FREQUENCY_MINUTES
+              value: "{{ .Values.workers.logGroomerSidecar.frequencyMinutes }}"
+          {{- end }}
             - name: AIRFLOW_HOME
               value: "{{ .Values.airflowHome }}"
           {{- if .Values.workers.logGroomerSidecar.env }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -12205,6 +12205,11 @@
                     "type": "integer",
                     "default": 15
                 },
+                "frequencyMinutes": {
+                    "description": "Number of minutes between attempts to groom the Airflow logs in log groomer sidecar.",
+                    "type": "integer",
+                    "default": 15
+                },
                 "env": {
                     "description": "Add additional env vars to log groomer sidecar container (templated).",
                     "items": {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -824,6 +824,8 @@ workers:
     args: ["bash", "/clean-logs"]
     # Number of days to retain logs
     retentionDays: 15
+    # frequency to attempt to groom logs, in minutes
+    frequencyMinutes: 15
     resources: {}
     #  limits:
     #   cpu: 100m
@@ -1026,6 +1028,8 @@ scheduler:
     args: ["bash", "/clean-logs"]
     # Number of days to retain logs
     retentionDays: 15
+    # frequency to attempt to groom logs, in minutes
+    frequencyMinutes: 15
     resources: {}
     #  limits:
     #   cpu: 100m
@@ -1739,6 +1743,8 @@ triggerer:
     args: ["bash", "/clean-logs"]
     # Number of days to retain logs
     retentionDays: 15
+    # frequency to attempt to groom logs, in minutes
+    frequencyMinutes: 15
     resources: {}
     #  limits:
     #   cpu: 100m
@@ -1925,6 +1931,8 @@ dagProcessor:
     args: ["bash", "/clean-logs"]
     # Number of days to retain logs
     retentionDays: 15
+    # frequency to attempt to groom logs, in minutes
+    frequencyMinutes: 15
     resources: {}
     #  limits:
     #   cpu: 100m

--- a/scripts/docker/clean-logs.sh
+++ b/scripts/docker/clean-logs.sh
@@ -21,10 +21,11 @@ set -euo pipefail
 
 readonly DIRECTORY="${AIRFLOW_HOME:-/usr/local/airflow}"
 readonly RETENTION="${AIRFLOW__LOG_RETENTION_DAYS:-15}"
+readonly FREQUENCY="${AIRFLOW__LOG_CLEANUP_FREQUENCY_MINUTES:-15}"
 
 trap "exit" INT TERM
 
-readonly EVERY=$((15*60))
+readonly EVERY=$((FREQUENCY*60))
 
 echo "Cleaning logs every $EVERY seconds"
 

--- a/tests/charts/log_groomer.py
+++ b/tests/charts/log_groomer.py
@@ -181,9 +181,13 @@ class LogGroomerTestBase:
         )
 
         if retention_result:
-            assert jmespath.search(
-                "spec.template.spec.containers[1].env[?name=='AIRFLOW__LOG_RETENTION_DAYS'].value | [0]", docs[0]
-            ) == retention_result
+            assert (
+                jmespath.search(
+                    "spec.template.spec.containers[1].env[?name=='AIRFLOW__LOG_RETENTION_DAYS'].value | [0]",
+                    docs[0],
+                )
+                == retention_result
+            )
         else:
             assert len(jmespath.search("spec.template.spec.containers[1].env", docs[0])) == 2
 
@@ -205,9 +209,13 @@ class LogGroomerTestBase:
         )
 
         if frequency_result:
-            assert jmespath.search(
-                "spec.template.spec.containers[1].env[?name=='AIRFLOW__LOG_CLEANUP_FREQUENCY_MINUTES'].value | [0]", docs[0]
-            ) == frequency_result
+            assert (
+                jmespath.search(
+                    "spec.template.spec.containers[1].env[?name=='AIRFLOW__LOG_CLEANUP_FREQUENCY_MINUTES'].value | [0]",
+                    docs[0],
+                )
+                == frequency_result
+            )
         else:
             assert len(jmespath.search("spec.template.spec.containers[1].env", docs[0])) == 2
 
@@ -262,6 +270,7 @@ class LogGroomerTestBase:
             values=values, show_only=[f"templates/{self.folder}/{self.obj_name}-deployment.yaml"]
         )
 
-        assert jmespath.search(
-            "spec.template.spec.containers[1].env[?name=='AIRFLOW_HOME'].name | [0]", docs[0]
-        ) == "AIRFLOW_HOME"
+        assert (
+            jmespath.search("spec.template.spec.containers[1].env[?name=='AIRFLOW_HOME'].name | [0]", docs[0])
+            == "AIRFLOW_HOME"
+        )

--- a/tests/charts/log_groomer.py
+++ b/tests/charts/log_groomer.py
@@ -195,7 +195,10 @@ class LogGroomerTestBase:
     def test_log_groomer_frequency_minutes_overrides(self, frequency_minutes, frequency_result):
         if self.obj_name == "dag-processor":
             values = {
-                "dagProcessor": {"enabled": True, "logGroomerSidecar": {"frequencyMinutes": frequency_minutes}}
+                "dagProcessor": {
+                    "enabled": True,
+                    "logGroomerSidecar": {"frequencyMinutes": frequency_minutes},
+                }
             }
         else:
             values = {f"{self.folder}": {"logGroomerSidecar": {"frequencyMinutes": frequency_minutes}}}

--- a/tests/charts/log_groomer.py
+++ b/tests/charts/log_groomer.py
@@ -191,6 +191,31 @@ class LogGroomerTestBase:
         else:
             assert len(jmespath.search("spec.template.spec.containers[1].env", docs[0])) == 1
 
+    @pytest.mark.parametrize("frequency_minutes, frequency_result", [(None, None), (20, "20")])
+    def test_log_groomer_frequency_minutes_overrides(self, frequency_minutes, frequency_result):
+        if self.obj_name == "dag-processor":
+            values = {
+                "dagProcessor": {"enabled": True, "logGroomerSidecar": {"frequencyMinutes": frequency_minutes}}
+            }
+        else:
+            values = {f"{self.folder}": {"logGroomerSidecar": {"frequencyMinutes": frequency_minutes}}}
+
+        docs = render_chart(
+            values=values,
+            show_only=[f"templates/{self.folder}/{self.obj_name}-deployment.yaml"],
+        )
+
+        if frequency_result:
+            assert (
+                jmespath.search("spec.template.spec.containers[1].env[0].name", docs[0])
+                == "AIRFLOW__LOG_CLEANUP_FREQUENCY_MINUTES"
+            )
+            assert frequency_result == jmespath.search(
+                "spec.template.spec.containers[1].env[0].value", docs[0]
+            )
+        else:
+            assert len(jmespath.search("spec.template.spec.containers[1].env", docs[0])) == 1
+
     def test_log_groomer_resources(self):
         if self.obj_name == "dag-processor":
             values = {

--- a/tests/charts/log_groomer.py
+++ b/tests/charts/log_groomer.py
@@ -181,15 +181,11 @@ class LogGroomerTestBase:
         )
 
         if retention_result:
-            assert (
-                jmespath.search("spec.template.spec.containers[1].env[0].name", docs[0])
-                == "AIRFLOW__LOG_RETENTION_DAYS"
-            )
-            assert retention_result == jmespath.search(
-                "spec.template.spec.containers[1].env[0].value", docs[0]
-            )
+            assert jmespath.search(
+                "spec.template.spec.containers[1].env[?name=='AIRFLOW__LOG_RETENTION_DAYS'].value | [0]", docs[0]
+            ) == retention_result
         else:
-            assert len(jmespath.search("spec.template.spec.containers[1].env", docs[0])) == 1
+            assert len(jmespath.search("spec.template.spec.containers[1].env", docs[0])) == 2
 
     @pytest.mark.parametrize("frequency_minutes, frequency_result", [(None, None), (20, "20")])
     def test_log_groomer_frequency_minutes_overrides(self, frequency_minutes, frequency_result):
@@ -209,15 +205,11 @@ class LogGroomerTestBase:
         )
 
         if frequency_result:
-            assert (
-                jmespath.search("spec.template.spec.containers[1].env[0].name", docs[0])
-                == "AIRFLOW__LOG_CLEANUP_FREQUENCY_MINUTES"
-            )
-            assert frequency_result == jmespath.search(
-                "spec.template.spec.containers[1].env[0].value", docs[0]
-            )
+            assert jmespath.search(
+                "spec.template.spec.containers[1].env[?name=='AIRFLOW__LOG_CLEANUP_FREQUENCY_MINUTES'].value | [0]", docs[0]
+            ) == frequency_result
         else:
-            assert len(jmespath.search("spec.template.spec.containers[1].env", docs[0])) == 1
+            assert len(jmespath.search("spec.template.spec.containers[1].env", docs[0])) == 2
 
     def test_log_groomer_resources(self):
         if self.obj_name == "dag-processor":
@@ -270,4 +262,6 @@ class LogGroomerTestBase:
             values=values, show_only=[f"templates/{self.folder}/{self.obj_name}-deployment.yaml"]
         )
 
-        assert jmespath.search("spec.template.spec.containers[1].env[1].name", docs[0]) == "AIRFLOW_HOME"
+        assert jmespath.search(
+            "spec.template.spec.containers[1].env[?name=='AIRFLOW_HOME'].name | [0]", docs[0]
+        ) == "AIRFLOW_HOME"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

We've recently run into an issue where log grooming sidecar containers in our Airflow Kubernetes pods are incurring an absurd amount of transaction costs. That is because the log grooming process runs on a fixed, and for some use cases way too frequent schedule. We've hacked around it for now by overwriting the cleanup shell script in our custom Docker image, but I figured I would add a feature upstream that makes this configurable.

Let me know if there's anything I missed!

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
