### PR TITLE
Add StrictHostKeyChecking option to GitDagBundle

### DIFF
--- a/airflow/dag_processing/bundles/git.py
+++ b/airflow/dag_processing/bundles/git.py
@@ -71,9 +71,12 @@ class GitHook(BaseHook):
         self.repo_url = connection.host
         self.auth_token = connection.password
         self.key_file = connection.extra_dejson.get("key_file")
+        strict_host_key_checking = connection.extra_dejson.get("strict_host_key_checking", "no")
         self.env: dict[str, str] = {}
         if self.key_file:
-            self.env["GIT_SSH_COMMAND"] = f"ssh -i {self.key_file} -o IdentitiesOnly=yes"
+            self.env["GIT_SSH_COMMAND"] = (
+                f"ssh -i {self.key_file} -o IdentitiesOnly=yes -o StrictHostKeyChecking={strict_host_key_checking}"
+            )
         self._process_git_auth_url()
 
     def _process_git_auth_url(self):

--- a/tests/dag_processing/test_dag_bundles.py
+++ b/tests/dag_processing/test_dag_bundles.py
@@ -121,6 +121,7 @@ class TestGitHook:
                 conn_id=CONN_DEFAULT,
                 host=AIRFLOW_GIT,
                 conn_type="git",
+                extra='{"key_file": "/files/pkey.pem"}',
             )
         )
         db.merge_conn(
@@ -133,10 +134,7 @@ class TestGitHook:
         )
         db.merge_conn(
             Connection(
-                conn_id=CONN_HTTPS_PASSWORD,
-                host=AIRFLOW_HTTPS_URL,
-                conn_type="git",
-                password=ACCESS_TOKEN,
+                conn_id=CONN_HTTPS_PASSWORD, host=AIRFLOW_HTTPS_URL, conn_type="git", password=ACCESS_TOKEN
             )
         )
         db.merge_conn(
@@ -159,6 +157,22 @@ class TestGitHook:
     def test_correct_repo_urls(self, conn_id, expected_repo_url):
         hook = GitHook(git_conn_id=conn_id)
         assert hook.repo_url == expected_repo_url
+
+    def test_env_var(self, session):
+        hook = GitHook(git_conn_id=CONN_DEFAULT)
+        assert hook.env == {
+            "GIT_SSH_COMMAND": "ssh -i /files/pkey.pem -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
+        }
+
+        conn = session.query(Connection).filter(Connection.conn_id == CONN_DEFAULT).one()
+        conn.extra = '{"key_file":"/files/pkey.pem", "strict_host_key_checking": "yes"}'
+        session.merge(conn)
+        session.commit()
+
+        hook = GitHook(git_conn_id=CONN_DEFAULT)
+        assert hook.env == {
+            "GIT_SSH_COMMAND": "ssh -i /files/pkey.pem -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes"
+        }
 
 
 class TestGitDagBundle:

--- a/tests/dag_processing/test_dag_bundles.py
+++ b/tests/dag_processing/test_dag_bundles.py
@@ -163,13 +163,16 @@ class TestGitHook:
         assert hook.env == {
             "GIT_SSH_COMMAND": "ssh -i /files/pkey.pem -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
         }
+        db.merge_conn(
+            Connection(
+                conn_id="my_git_conn_strict",
+                host=AIRFLOW_GIT,
+                conn_type="git",
+                extra='{"key_file": "/files/pkey.pem", "strict_host_key_checking": "yes"}',
+            )
+        )
 
-        conn = session.query(Connection).filter(Connection.conn_id == CONN_DEFAULT).one()
-        conn.extra = '{"key_file":"/files/pkey.pem", "strict_host_key_checking": "yes"}'
-        session.merge(conn)
-        session.commit()
-
-        hook = GitHook(git_conn_id=CONN_DEFAULT)
+        hook = GitHook(git_conn_id="my_git_conn_strict")
         assert hook.env == {
             "GIT_SSH_COMMAND": "ssh -i /files/pkey.pem -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes"
         }


### PR DESCRIPTION
This adds an option to enable or disable StrictHostKeyChecking in GitDagBundle. Host key is not checked by default. You have to enable host key checking in the connection extra.

