### PR TITLE
tests: Add OpenLineage to system tests in Google provider

### DIFF
--- a/providers/tests/system/google/cloud/bigquery/example_bigquery_dts.py
+++ b/providers/tests/system/google/cloud/bigquery/example_bigquery_dts.py
@@ -44,6 +44,7 @@ from airflow.providers.google.cloud.operators.gcs import GCSCreateBucketOperator
 from airflow.providers.google.cloud.sensors.bigquery_dts import BigQueryDataTransferServiceTransferRunSensor
 from airflow.providers.google.cloud.transfers.local_to_gcs import LocalFilesystemToGCSOperator
 from airflow.utils.trigger_rule import TriggerRule
+from providers.openlineage.tests.system.openlineage.operator import OpenLineageTestOperator
 
 from providers.tests.system.google import DEFAULT_GCP_SYSTEM_TEST_PROJECT_ID
 
@@ -158,6 +159,11 @@ with DAG(
         task_id="delete_bucket", bucket_name=BUCKET_NAME, trigger_rule=TriggerRule.ALL_DONE
     )
 
+    check_openlineage_events = OpenLineageTestOperator(
+        task_id="check_openlineage_events",
+        file_path=str(Path(__file__).parent / "resources" / "openlineage" / "bigquery_dts.json"),
+    )
+
     # Task dependencies created via `XComArgs`:
     #   gcp_bigquery_create_transfer >> gcp_bigquery_start_transfer
     #   gcp_bigquery_create_transfer >> gcp_run_sensor
@@ -178,6 +184,7 @@ with DAG(
         # TEST TEARDOWN
         delete_dataset,
         delete_bucket,
+        check_openlineage_events,
     )
 
     from tests_common.test_utils.watcher import watcher

--- a/providers/tests/system/google/cloud/bigquery/example_bigquery_jobs.py
+++ b/providers/tests/system/google/cloud/bigquery/example_bigquery_jobs.py
@@ -1,0 +1,197 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Example Airflow DAG for Google BigQuery service.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from pathlib import Path
+
+from airflow.models.dag import DAG
+from airflow.providers.google.cloud.operators.bigquery import (
+    BigQueryCreateEmptyDatasetOperator,
+    BigQueryCreateEmptyTableOperator,
+    BigQueryDeleteDatasetOperator,
+    BigQueryInsertJobOperator,
+)
+from airflow.providers.google.cloud.operators.gcs import GCSCreateBucketOperator, GCSDeleteBucketOperator
+from airflow.utils.trigger_rule import TriggerRule
+from providers.openlineage.tests.system.openlineage.operator import OpenLineageTestOperator
+
+from providers.tests.system.google import DEFAULT_GCP_SYSTEM_TEST_PROJECT_ID
+
+ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID", "default")
+PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT") or DEFAULT_GCP_SYSTEM_TEST_PROJECT_ID
+LOCATION = "us-east1"
+
+TABLE_1 = "table1"
+TABLE_2 = "table2"
+TABLE_3 = "table3"
+TABLE_4 = "table4"
+
+SCHEMA = [
+    {"name": "value", "type": "INTEGER", "mode": "REQUIRED"},
+    {"name": "name", "type": "STRING", "mode": "NULLABLE"},
+    {"name": "ds", "type": "DATE", "mode": "NULLABLE"},
+]
+
+DAG_ID = "bigquery_jobs"
+DATASET_NAME = f"dataset_{DAG_ID}_{ENV_ID}"
+BUCKET_NAME = f"bucket_{DAG_ID}_{ENV_ID}"
+DATASET = f"{DATASET_NAME}1"
+INSERT_DATE = "2030-01-01"
+INSERT_ROWS_QUERY = (
+    f"INSERT {DATASET}.{TABLE_1} VALUES "
+    f"(42, 'monty python', '{INSERT_DATE}'), "
+    f"(42, 'fishy fish', '{INSERT_DATE}');"
+)
+
+CTAS_QUERY = (
+    f"CREATE OR REPLACE TABLE {DATASET}.{TABLE_3} AS SELECT value, name, ds FROM {DATASET}.{TABLE_1};"
+)
+
+with DAG(
+    DAG_ID,
+    schedule="@once",
+    start_date=datetime(2021, 1, 1),
+    catchup=False,
+    tags=["example", "bigquery"],
+) as dag:
+    create_bucket = GCSCreateBucketOperator(
+        task_id="create_bucket", bucket_name=BUCKET_NAME, project_id=PROJECT_ID, storage_class="STANDARD"
+    )
+
+    create_dataset = BigQueryCreateEmptyDatasetOperator(
+        task_id="create_dataset",
+        dataset_id=DATASET,
+    )
+
+    create_table = BigQueryCreateEmptyTableOperator(
+        task_id="create_table",
+        dataset_id=DATASET,
+        table_id=TABLE_1,
+        schema_fields=SCHEMA,
+    )
+
+    insert_query_job = BigQueryInsertJobOperator(
+        task_id="insert_query_job",
+        configuration={
+            "query": {
+                "query": INSERT_ROWS_QUERY,
+                "useLegacySql": False,
+                "priority": "BATCH",
+            }
+        },
+    )
+
+    execute_copy_job = BigQueryInsertJobOperator(
+        task_id="execute_copy_job",
+        configuration={
+            "copy": {
+                "sourceTables": [{"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE_1}],
+                "destinationTable": {"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE_2},
+                "writeDisposition": "WRITE_TRUNCATE",
+                "operationType": "COPY",
+            }
+        },
+    )
+
+    execute_ctas_query = BigQueryInsertJobOperator(
+        task_id="execute_ctas_query",
+        configuration={
+            "query": {
+                "query": CTAS_QUERY,
+                "useLegacySql": False,
+            }
+        },
+    )
+
+    execute_load_job = BigQueryInsertJobOperator(
+        task_id="execute_load_job",
+        configuration={
+            "load": {
+                "sourceUris": ["gs://cloud-samples-data/bigquery/us-states/us-states.csv"],
+                "destinationTable": {
+                    "projectId": PROJECT_ID,
+                    "datasetId": DATASET,
+                    "tableId": TABLE_4,
+                },
+                "schema": {
+                    "fields": [
+                        {"name": "name", "type": "STRING", "mode": "NULLABLE"},
+                        {"name": "post_abbr", "type": "STRING", "mode": "NULLABLE"},
+                    ]
+                },
+                "write_disposition": "WRITE_TRUNCATE",
+                "sourceFormat": "CSV",
+            }
+        },
+    )
+
+    execute_extract_job = BigQueryInsertJobOperator(
+        task_id="execute_extract_job",
+        configuration={
+            "extract": {
+                "sourceTable": {"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE_4},
+                "destinationUris": [
+                    f"gs://{BUCKET_NAME}/extract.csv",
+                ],
+                "destinationFormat": "CSV",
+            }
+        },
+    )
+
+    delete_dataset = BigQueryDeleteDatasetOperator(
+        task_id="delete_dataset",
+        dataset_id=DATASET,
+        delete_contents=True,
+        trigger_rule=TriggerRule.ALL_DONE,
+    )
+
+    delete_bucket = GCSDeleteBucketOperator(
+        task_id="delete_bucket", bucket_name=BUCKET_NAME, trigger_rule=TriggerRule.ALL_DONE
+    )
+
+    # if not location:
+    check_openlineage_events = OpenLineageTestOperator(
+        task_id="check_openlineage_events",
+        file_path=str(Path(__file__).parent / "resources" / "openlineage" / "bigquery_jobs.json"),
+    )
+    delete_dataset >> check_openlineage_events
+
+    # TEST SETUP
+    create_dataset >> create_table
+    # TEST BODY
+    create_table >> insert_query_job >> execute_copy_job >> execute_ctas_query >> delete_dataset
+    create_dataset >> execute_load_job >> execute_extract_job >> delete_dataset
+    # TEST TEARDOWN
+    delete_dataset >> delete_bucket
+
+    from tests_common.test_utils.watcher import watcher
+
+    # This test needs watcher in order to properly mark success/failure
+    # when "tearDown" task with trigger rule is part of the DAG
+    list(dag.tasks) >> watcher()
+
+from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
+
+# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+test_run = get_test_run(dag)

--- a/providers/tests/system/google/cloud/bigquery/example_bigquery_tables.py
+++ b/providers/tests/system/google/cloud/bigquery/example_bigquery_tables.py
@@ -41,6 +41,7 @@ from airflow.providers.google.cloud.operators.bigquery import (
 from airflow.providers.google.cloud.operators.gcs import GCSCreateBucketOperator, GCSDeleteBucketOperator
 from airflow.providers.google.cloud.transfers.local_to_gcs import LocalFilesystemToGCSOperator
 from airflow.utils.trigger_rule import TriggerRule
+from providers.openlineage.tests.system.openlineage.operator import OpenLineageTestOperator
 
 from providers.tests.system.google import DEFAULT_GCP_SYSTEM_TEST_PROJECT_ID
 
@@ -199,6 +200,11 @@ with DAG(
         task_id="delete_bucket", bucket_name=BUCKET_NAME, trigger_rule=TriggerRule.ALL_DONE
     )
 
+    check_openlineage_events = OpenLineageTestOperator(
+        task_id="check_openlineage_events",
+        file_path=str(Path(__file__).parent / "resources" / "openlineage" / "bigquery_tables.json"),
+    )
+
     (
         # TEST SETUP
         create_bucket
@@ -222,6 +228,7 @@ with DAG(
         # TEST TEARDOWN
         >> delete_bucket
         >> delete_dataset
+        >> check_openlineage_events
     )
 
     from tests_common.test_utils.watcher import watcher

--- a/providers/tests/system/google/cloud/bigquery/example_bigquery_to_gcs_async.py
+++ b/providers/tests/system/google/cloud/bigquery/example_bigquery_to_gcs_async.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import os
 from datetime import datetime
+from pathlib import Path
 
 from airflow.models.dag import DAG
 from airflow.providers.google.cloud.operators.bigquery import (
@@ -33,6 +34,7 @@ from airflow.providers.google.cloud.operators.bigquery import (
 from airflow.providers.google.cloud.operators.gcs import GCSCreateBucketOperator, GCSDeleteBucketOperator
 from airflow.providers.google.cloud.transfers.bigquery_to_gcs import BigQueryToGCSOperator
 from airflow.utils.trigger_rule import TriggerRule
+from providers.openlineage.tests.system.openlineage.operator import OpenLineageTestOperator
 
 from providers.tests.system.google import DEFAULT_GCP_SYSTEM_TEST_PROJECT_ID
 
@@ -87,6 +89,11 @@ with DAG(
         trigger_rule=TriggerRule.ALL_DONE,
     )
 
+    check_openlineage_events = OpenLineageTestOperator(
+        task_id="check_openlineage_events",
+        file_path=str(Path(__file__).parent / "resources" / "openlineage" / "bigquery_to_gcs_async.json"),
+    )
+
     (
         # TEST SETUP
         [create_bucket, create_dataset]
@@ -94,7 +101,7 @@ with DAG(
         # TEST BODY
         >> bigquery_to_gcs_async
         # TEST TEARDOWN
-        >> [delete_bucket, delete_dataset]
+        >> [delete_bucket, delete_dataset, check_openlineage_events]
     )
 
     from tests_common.test_utils.watcher import watcher

--- a/providers/tests/system/google/cloud/bigquery/example_bigquery_transfer.py
+++ b/providers/tests/system/google/cloud/bigquery/example_bigquery_transfer.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import os
 from datetime import datetime
+from pathlib import Path
 
 from airflow.models.dag import DAG
 from airflow.providers.google.cloud.operators.bigquery import (
@@ -34,6 +35,7 @@ from airflow.providers.google.cloud.operators.gcs import GCSCreateBucketOperator
 from airflow.providers.google.cloud.transfers.bigquery_to_bigquery import BigQueryToBigQueryOperator
 from airflow.providers.google.cloud.transfers.bigquery_to_gcs import BigQueryToGCSOperator
 from airflow.utils.trigger_rule import TriggerRule
+from providers.openlineage.tests.system.openlineage.operator import OpenLineageTestOperator
 
 from providers.tests.system.google import DEFAULT_GCP_SYSTEM_TEST_PROJECT_ID
 
@@ -103,6 +105,11 @@ with DAG(
         task_id="delete_bucket", bucket_name=BUCKET_NAME, trigger_rule=TriggerRule.ALL_DONE
     )
 
+    check_openlineage_events = OpenLineageTestOperator(
+        task_id="check_openlineage_events",
+        file_path=str(Path(__file__).parent / "resources" / "openlineage" / "bigquery_transfer.json"),
+    )
+
     (
         # TEST SETUP
         create_bucket
@@ -115,6 +122,7 @@ with DAG(
         # TEST TEARDOWN
         >> delete_dataset
         >> delete_bucket
+        >> check_openlineage_events
     )
 
     from tests_common.test_utils.watcher import watcher

--- a/providers/tests/system/google/cloud/bigquery/resources/openlineage/__init__.py
+++ b/providers/tests/system/google/cloud/bigquery/resources/openlineage/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/tests/system/google/cloud/bigquery/resources/openlineage/bigquery_dts.json
+++ b/providers/tests/system/google/cloud/bigquery/resources/openlineage/bigquery_dts.json
@@ -1,0 +1,63 @@
+[
+    {
+        "eventType": "START",
+        "job": {
+            "name": "gcp_bigquery_dts.create_table"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "gcp_bigquery_dts.create_table"
+        },
+        "inputs": [],
+        "outputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_gcp_bigquery_dts_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.DTS_BQ_TABLE",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "post_abbr",
+                                "type": "STRING"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "gcp_bigquery_dts.gcp_bigquery_start_transfer"
+        }
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "gcp_bigquery_dts.gcp_bigquery_start_transfer"
+        },
+        "inputs": [
+            {
+                "namespace": "gs://bucket-gcp_bigquery_dts-{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "us-states.csv"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_gcp_bigquery_dts_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.DTS_BQ_TABLE"
+            }
+        ]
+    }
+]

--- a/providers/tests/system/google/cloud/bigquery/resources/openlineage/bigquery_jobs.json
+++ b/providers/tests/system/google/cloud/bigquery/resources/openlineage/bigquery_jobs.json
@@ -1,0 +1,535 @@
+[
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_jobs.create_table"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_jobs.create_table"
+        },
+        "inputs": [],
+        "outputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_jobs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}1.table1",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "fields": [],
+                                "name": "name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "ds",
+                                "type": "DATE"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_jobs.insert_query_job"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_jobs.insert_query_job",
+            "facets": {
+                "sql": {
+                    "query": "INSERT dataset_bigquery_jobs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}1.table1 VALUES (42, 'monty python', '2030-01-01'), (42, 'fishy fish', '2030-01-01')"
+                }
+            }
+        },
+        "run": {
+            "facets": {
+                "externalQuery": {
+                    "externalQueryId": "{{ result.startswith('airflow_bigquery_jobs_insert_query_job') }}",
+                    "source": "bigquery"
+                },
+                "bigQueryJob": {
+                    "billedBytes": "{{ result is number }}",
+                    "cached": false,
+                    "properties": "{{ result is string }}"
+                }
+            }
+        },
+        "inputs": [],
+        "outputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_jobs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}1.table1",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "fields": [],
+                                "name": "name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "ds",
+                                "type": "DATE"
+                            }
+                        ]
+                    }
+                },
+                "outputFacets": {
+                    "outputStatistics": {
+                        "rowCount": "{{ result is number }}",
+                        "size": "{{ result is number }}"
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_jobs.execute_copy_job"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_jobs.execute_copy_job"
+        },
+        "run": {
+            "facets": {
+                "externalQuery": {
+                    "externalQueryId": "{{ result.startswith('airflow_bigquery_jobs_execute_copy_job') }}",
+                    "source": "bigquery"
+                },
+                "bigQueryJob": {
+                    "cached": false,
+                    "properties": "{{ result is string }}"
+                }
+            }
+        },
+        "inputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_jobs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}1.table1",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "fields": [],
+                                "name": "name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "ds",
+                                "type": "DATE"
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_jobs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}1.table2",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "fields": [],
+                                "name": "name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "ds",
+                                "type": "DATE"
+                            }
+                        ]
+                    },
+                    "columnLineage": {
+                        "fields": {
+                            "value": {
+                                "inputFields": [
+                                    {
+                                        "field": "value",
+                                        "namespace": "bigquery",
+                                        "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_jobs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}1.table1"
+                                    }
+                                ]
+                            },
+                            "name": {
+                                "inputFields": [
+                                    {
+                                        "field": "name",
+                                        "namespace": "bigquery",
+                                        "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_jobs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}1.table1"
+                                    }
+                                ]
+                            },
+                            "ds": {
+                                "inputFields": [
+                                    {
+                                        "field": "ds",
+                                        "namespace": "bigquery",
+                                        "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_jobs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}1.table1"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "outputFacets": {
+                    "outputStatistics": {
+                        "rowCount": "{{ result is number }}",
+                        "size": "{{ result is number }}"
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_jobs.execute_ctas_query"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_jobs.execute_ctas_query"
+        },
+        "run": {
+            "facets": {
+                "externalQuery": {
+                    "externalQueryId": "{{ result.startswith('airflow_bigquery_jobs_execute_ctas_query') }}",
+                    "source": "bigquery"
+                },
+                "bigQueryJob": {
+                    "billedBytes": "{{ result is number }}",
+                    "cached": false,
+                    "properties": "{{ result is string }}"
+                }
+            }
+        },
+        "inputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_jobs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}1.table1",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "fields": [],
+                                "name": "name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "ds",
+                                "type": "DATE"
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_jobs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}1.table3",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "fields": [],
+                                "name": "name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "ds",
+                                "type": "DATE"
+                            }
+                        ]
+                    },
+                    "columnLineage": {
+                        "fields": {
+                            "value": {
+                                "inputFields": [
+                                    {
+                                        "field": "value",
+                                        "namespace": "bigquery",
+                                        "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_jobs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}1.table1"
+                                    }
+                                ]
+                            },
+                            "name": {
+                                "inputFields": [
+                                    {
+                                        "field": "name",
+                                        "namespace": "bigquery",
+                                        "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_jobs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}1.table1"
+                                    }
+                                ]
+                            },
+                            "ds": {
+                                "inputFields": [
+                                    {
+                                        "field": "ds",
+                                        "namespace": "bigquery",
+                                        "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_jobs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}1.table1"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "outputFacets": {
+                    "outputStatistics": {
+                        "rowCount": "{{ result is number }}",
+                        "size": "{{ result is number }}"
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_jobs.execute_load_job"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_jobs.execute_load_job"
+        },
+        "run": {
+            "facets": {
+                "externalQuery": {
+                    "externalQueryId": "{{ result.startswith('airflow_bigquery_jobs_execute_load_job') }}",
+                    "source": "bigquery"
+                },
+                "bigQueryJob": {
+                    "cached": false,
+                    "properties": "{{ result is string }}"
+                }
+            }
+        },
+        "inputs": [
+            {
+                "namespace": "gs://cloud-samples-data",
+                "name": "bigquery/us-states/us-states.csv",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "post_abbr",
+                                "type": "STRING"
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_jobs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}1.table4",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "post_abbr",
+                                "type": "STRING"
+                            }
+                        ]
+                    },
+                    "columnLineage": {
+                        "fields": {
+                            "name": {
+                                "inputFields": [
+                                    {
+                                        "field": "name",
+                                        "namespace": "gs://cloud-samples-data",
+                                        "name": "bigquery/us-states/us-states.csv"
+                                    }
+                                ]
+                            },
+                            "post_abbr": {
+                                "inputFields": [
+                                    {
+                                        "field": "post_abbr",
+                                        "namespace": "gs://cloud-samples-data",
+                                        "name": "bigquery/us-states/us-states.csv"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "outputFacets": {
+                    "outputStatistics": {
+                        "rowCount": "{{ result is number }}",
+                        "size": "{{ result is number }}"
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_jobs.execute_extract_job"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_jobs.execute_extract_job"
+        },
+        "run": {
+            "facets": {
+                "externalQuery": {
+                    "externalQueryId": "{{ result.startswith('airflow_bigquery_jobs_execute_extract_job') }}",
+                    "source": "bigquery"
+                },
+                "bigQueryJob": {
+                    "cached": false,
+                    "properties": "{{ result is string }}"
+                }
+            }
+        },
+        "inputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_jobs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}1.table4",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "post_abbr",
+                                "type": "STRING"
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket_bigquery_jobs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "extract.csv",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "post_abbr",
+                                "type": "STRING"
+                            }
+                        ]
+                    },
+                    "columnLineage": {
+                        "fields": {
+                            "name": {
+                                "inputFields": [
+                                    {
+                                        "field": "name",
+                                        "namespace": "bigquery",
+                                        "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_jobs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}1.table4"
+                                    }
+                                ]
+                            },
+                            "post_abbr": {
+                                "inputFields": [
+                                    {
+                                        "field": "post_abbr",
+                                        "namespace": "bigquery",
+                                        "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_jobs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}1.table4"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        ]
+    }
+]

--- a/providers/tests/system/google/cloud/bigquery/resources/openlineage/bigquery_operations.json
+++ b/providers/tests/system/google/cloud/bigquery/resources/openlineage/bigquery_operations.json
@@ -1,0 +1,84 @@
+[
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_operations.upload_file_to_bucket"
+        },
+        "inputs": [
+            {
+                "namespace": "file",
+                "name": "{{ result.endswith('airflow/providers/tests/system/google/cloud/bigquery/resources/us-states.csv') }}"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket_bigquery_operations_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "bigquery/us-states/us-states.csv"
+            }
+        ]
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_operations.upload_file_to_bucket"
+        },
+        "inputs": [
+            {
+                "namespace": "file",
+                "name": "{{ result.endswith('airflow/providers/tests/system/google/cloud/bigquery/resources/us-states.csv') }}"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket_bigquery_operations_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "bigquery/us-states/us-states.csv"
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_operations.create_external_table"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_operations.create_external_table"
+        },
+        "inputs": [],
+        "outputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_operations_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.external_table",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "emp_name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "salary",
+                                "type": "INTEGER"
+                            }
+                        ]
+                    },
+                    "symlink": {
+                        "identifiers": [
+                            {
+                                "namespace": "gs://bucket_bigquery_operations_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                                "name": "bigquery/us-states/us-states.csv",
+                                "type": "file"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    }
+]

--- a/providers/tests/system/google/cloud/bigquery/resources/openlineage/bigquery_queries.json
+++ b/providers/tests/system/google/cloud/bigquery/resources/openlineage/bigquery_queries.json
@@ -1,0 +1,428 @@
+[
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_queries.create_table_1"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_queries.create_table_1"
+        },
+        "inputs": [],
+        "outputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_queries_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.table1",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "fields": [],
+                                "name": "name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "ds",
+                                "type": "DATE"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_queries.create_table_2"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_queries.create_table_2"
+        },
+        "inputs": [],
+        "outputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_queries_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.table2",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "fields": [],
+                                "name": "name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "ds",
+                                "type": "DATE"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_queries.insert_query_job"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_queries.insert_query_job",
+            "facets": {
+                "sql": {
+                    "query": "INSERT dataset_bigquery_queries_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.table1 VALUES (42, 'monty python', '2030-01-01'), (42, 'fishy fish', '2030-01-01')"
+                }
+            }
+        },
+        "run": {
+            "facets": {
+                "externalQuery": {
+                    "externalQueryId": "{{ result.startswith('airflow_bigquery_queries_insert_query_job') }}",
+                    "source": "bigquery"
+                },
+                "bigQueryJob": {
+                    "billedBytes": "{{ result is number }}",
+                    "cached": false,
+                    "properties": "{{ result is string }}"
+                }
+            }
+        },
+        "inputs": [],
+        "outputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_queries_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.table1",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "fields": [],
+                                "name": "name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "ds",
+                                "type": "DATE"
+                            }
+                        ]
+                    }
+                },
+                "outputFacets": {
+                    "outputStatistics": {
+                        "rowCount": "{{ result is number }}",
+                        "size": "{{ result is number }}"
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_queries.select_query_job"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_queries.select_query_job",
+            "facets": {
+                "sql": {
+                    "query": "SELECT * FROM dataset_bigquery_queries_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.table1"
+                }
+            }
+        },
+        "run": {
+            "facets": {
+                "externalQuery": {
+                    "externalQueryId": "{{ result.startswith('airflow_bigquery_queries_select_query_job') }}",
+                    "source": "bigquery"
+                },
+                "bigQueryJob": {
+                    "billedBytes": "{{ result is number }}",
+                    "cached": false,
+                    "properties": "{{ result is string }}"
+                }
+            }
+        },
+        "inputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_queries_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.table1",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "fields": [],
+                                "name": "name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "ds",
+                                "type": "DATE"
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ result.split('.')[1].startswith('_') }}",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "fields": [],
+                                "name": "name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "ds",
+                                "type": "DATE"
+                            }
+                        ]
+                    }
+                },
+                "outputFacets": {
+                    "outputStatistics": {
+                        "rowCount": "{{ result is number }}",
+                        "size": "{{ result is number }}"
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_queries.execute_query_save"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_queries.execute_query_save",
+            "facets": {
+                "sql": {
+                    "query": "SELECT * FROM dataset_bigquery_queries_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.table1"
+                }
+            }
+        },
+        "run": {
+            "facets": {
+                "externalQuery": {
+                    "externalQueryId": "{{ result.startswith('airflow_bigquery_queries_execute_query_save') }}",
+                    "source": "bigquery"
+                },
+                "bigQueryJob": {
+                    "billedBytes": "{{ result is number }}",
+                    "cached": false,
+                    "properties": "{{ result is string }}"
+                }
+            }
+        },
+        "inputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_queries_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.table1",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "fields": [],
+                                "name": "name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "ds",
+                                "type": "DATE"
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_queries_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.table2",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "fields": [],
+                                "name": "name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "ds",
+                                "type": "DATE"
+                            }
+                        ]
+                    }
+                },
+                "outputFacets": {
+                    "outputStatistics": {
+                        "rowCount": "{{ result is number }}",
+                        "size": "{{ result is number }}"
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_queries.execute_multi_query"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_queries.execute_multi_query",
+            "facets": {
+                "sql": {
+                    "query": "SELECT * FROM dataset_bigquery_queries_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.table2;\nSELECT COUNT(*) FROM dataset_bigquery_queries_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.table2"
+                }
+            }
+        },
+        "run": {
+            "facets": {
+                "externalQuery": {
+                    "externalQueryId": "{{ result.startswith('airflow_bigquery_queries_execute_multi_query') }}",
+                    "source": "bigquery"
+                },
+                "bigQueryJob": {
+                    "billedBytes": "{{ result is number }}",
+                    "cached": false,
+                    "properties": "{{ result is string }}"
+                }
+            }
+        },
+        "inputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_queries_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.table2",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "fields": [],
+                                "name": "name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "ds",
+                                "type": "DATE"
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ result.split('.')[1].startswith('_') }}",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "fields": [],
+                                "name": "name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "ds",
+                                "type": "DATE"
+                            }
+                        ]
+                    }
+                },
+                "outputFacets": {
+                    "outputStatistics": {
+                        "rowCount": "{{ result is number }}",
+                        "size": "{{ result is number }}"
+                    }
+                }
+            }
+        ]
+    }
+]

--- a/providers/tests/system/google/cloud/bigquery/resources/openlineage/bigquery_queries_async.json
+++ b/providers/tests/system/google/cloud/bigquery/resources/openlineage/bigquery_queries_async.json
@@ -1,0 +1,386 @@
+[
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_queries_async.create_table_1"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_queries_async.create_table_1"
+        },
+        "inputs": [],
+        "outputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_queries_async_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.table_bigquery_queries_async_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}_1",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "fields": [],
+                                "name": "name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "ds",
+                                "type": "STRING"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_queries_async.insert_query_job"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_queries_async.insert_query_job",
+            "facets": {
+                "sql": {
+                    "query": "INSERT dataset_bigquery_queries_async_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.table_bigquery_queries_async_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}_1 VALUES (42, 'monty python', '2030-01-01'), (42, 'fishy fish', '2030-01-01')"
+                }
+            }
+        },
+        "run": {
+            "facets": {
+                "externalQuery": {
+                    "externalQueryId": "{{ result.startswith('airflow_bigquery_queries_async_insert_query_job') }}",
+                    "source": "bigquery"
+                },
+                "bigQueryJob": {
+                    "billedBytes": "{{ result is number }}",
+                    "cached": false,
+                    "properties": "{{ result is string }}"
+                }
+            }
+        },
+        "inputs": [],
+        "outputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_queries_async_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.table_bigquery_queries_async_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}_1",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "fields": [],
+                                "name": "name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "ds",
+                                "type": "STRING"
+                            }
+                        ]
+                    }
+                },
+                "outputFacets": {
+                    "outputStatistics": {
+                        "rowCount": "{{ result is number }}",
+                        "size": "{{ result is number }}"
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_queries_async.select_query_job"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_queries_async.select_query_job",
+            "facets": {
+                "sql": {
+                    "query": "SELECT * FROM dataset_bigquery_queries_async_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.table_bigquery_queries_async_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}_1"
+                }
+            }
+        },
+        "run": {
+            "facets": {
+                "externalQuery": {
+                    "externalQueryId": "{{ result.startswith('airflow_bigquery_queries_async_select_query_job') }}",
+                    "source": "bigquery"
+                },
+                "bigQueryJob": {
+                    "billedBytes": "{{ result is number }}",
+                    "cached": false,
+                    "properties": "{{ result is string }}"
+                }
+            }
+        },
+        "inputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_queries_async_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.table_bigquery_queries_async_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}_1",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "fields": [],
+                                "name": "name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "ds",
+                                "type": "STRING"
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ result.split('.')[1].startswith('_') }}",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "fields": [],
+                                "name": "name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "ds",
+                                "type": "STRING"
+                            }
+                        ]
+                    }
+                },
+                "outputFacets": {
+                    "outputStatistics": {
+                        "rowCount": "{{ result is number }}",
+                        "size": "{{ result is number }}"
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_queries_async.execute_query_save"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_queries_async.execute_query_save",
+            "facets": {
+                "sql": {
+                    "query": "SELECT * FROM dataset_bigquery_queries_async_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.table_bigquery_queries_async_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}_1"
+                }
+            }
+        },
+        "run": {
+            "facets": {
+                "externalQuery": {
+                    "externalQueryId": "{{ result.startswith('airflow_bigquery_queries_async_execute_query_save') }}",
+                    "source": "bigquery"
+                },
+                "bigQueryJob": {
+                    "billedBytes": "{{ result is number }}",
+                    "cached": false,
+                    "properties": "{{ result is string }}"
+                }
+            }
+        },
+        "inputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_queries_async_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.table_bigquery_queries_async_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}_1",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "fields": [],
+                                "name": "name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "ds",
+                                "type": "STRING"
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_queries_async_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.table_bigquery_queries_async_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}_2",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "fields": [],
+                                "name": "name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "ds",
+                                "type": "STRING"
+                            }
+                        ]
+                    }
+                },
+                "outputFacets": {
+                    "outputStatistics": {
+                        "rowCount": "{{ result is number }}",
+                        "size": "{{ result is number }}"
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_queries_async.execute_multi_query"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_queries_async.execute_multi_query",
+            "facets": {
+                "sql": {
+                    "query": "SELECT * FROM dataset_bigquery_queries_async_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.table_bigquery_queries_async_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}_2;\nSELECT COUNT(*) FROM dataset_bigquery_queries_async_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.table_bigquery_queries_async_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}_2"
+                }
+            }
+        },
+        "run": {
+            "facets": {
+                "externalQuery": {
+                    "externalQueryId": "{{ result.startswith('airflow_bigquery_queries_async_execute_multi_query') }}",
+                    "source": "bigquery"
+                },
+                "bigQueryJob": {
+                    "billedBytes": "{{ result is number }}",
+                    "cached": false,
+                    "properties": "{{ result is string }}"
+                }
+            }
+        },
+        "inputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_queries_async_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.table_bigquery_queries_async_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}_2",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "fields": [],
+                                "name": "name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "ds",
+                                "type": "STRING"
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ result.split('.')[1].startswith('_') }}",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "value",
+                                "type": "INTEGER"
+                            },
+                            {
+                                "fields": [],
+                                "name": "name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "ds",
+                                "type": "STRING"
+                            }
+                        ]
+                    }
+                },
+                "outputFacets": {
+                    "outputStatistics": {
+                        "rowCount": "{{ result is number }}",
+                        "size": "{{ result is number }}"
+                    }
+                }
+            }
+        ]
+    }
+]

--- a/providers/tests/system/google/cloud/bigquery/resources/openlineage/bigquery_tables.json
+++ b/providers/tests/system/google/cloud/bigquery/resources/openlineage/bigquery_tables.json
@@ -1,0 +1,257 @@
+[
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_tables.create_table"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_tables.create_table"
+        },
+        "inputs": [],
+        "outputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_tables_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.test_table",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "emp_name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "salary",
+                                "type": "INTEGER"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_tables.create_materialized_view"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_tables.create_materialized_view"
+        },
+        "inputs": [],
+        "outputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_tables_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.test_materialized_view",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "sum_salary",
+                                "type": "INTEGER"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_tables.create_view"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_tables.create_view"
+        },
+        "inputs": [],
+        "outputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_tables_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.test_view",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "emp_name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "salary",
+                                "type": "INTEGER"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_tables.update_table"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_tables.update_table"
+        },
+        "inputs": [],
+        "outputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_tables_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.test_table",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "emp_name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "salary",
+                                "type": "INTEGER"
+                            }
+                        ]
+                    },
+                    "documentation": {
+                        "description": "Updated Table"
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_tables.upsert_table"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_tables.upsert_table"
+        },
+        "inputs": [],
+        "outputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_tables_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.test_table_id"
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_tables.update_table_schema"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_tables.update_table_schema"
+        },
+        "inputs": [],
+        "outputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_tables_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.test_table",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "description": "Name of employee",
+                                "fields": [],
+                                "name": "emp_name",
+                                "type": "STRING"
+                            },
+                            {
+                                "description": "Monthly salary in USD",
+                                "fields": [],
+                                "name": "salary",
+                                "type": "INTEGER"
+                            }
+                        ]
+                    },
+                    "documentation": {
+                        "description": "Updated Table"
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_tables.update_table_schema_json"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_tables.update_table_schema_json"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_tables.delete_table"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_tables.delete_table"
+        },
+        "inputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_tables_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.test_table",
+                "facets": {
+                    "lifecycleStateChange": {
+                        "lifecycleStateChange": "DROP",
+                        "previousIdentifier": {
+                            "namespace": "bigquery",
+                            "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_tables_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.test_table"
+                        }
+                    }
+                }
+            }
+        ],
+        "outputs": []
+    }
+]

--- a/providers/tests/system/google/cloud/bigquery/resources/openlineage/bigquery_to_gcs_async.json
+++ b/providers/tests/system/google/cloud/bigquery/resources/openlineage/bigquery_to_gcs_async.json
@@ -1,0 +1,126 @@
+[
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_to_gcs_async.create_table"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_to_gcs_async.create_table"
+        },
+        "inputs": [],
+        "outputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_to_gcs_async_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.test",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "emp_name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "salary",
+                                "type": "INTEGER"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_to_gcs_async.bigquery_to_gcs"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_to_gcs_async.bigquery_to_gcs"
+        },
+        "inputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_to_gcs_async_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.test",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "emp_name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "salary",
+                                "type": "INTEGER"
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "outputs": [
+            {
+                "facets": {
+                    "columnLineage": {
+                        "dataset": [],
+                        "fields": {
+                            "emp_name": {
+                                "inputFields": [
+                                    {
+                                        "field": "emp_name",
+                                        "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_to_gcs_async_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.test",
+                                        "namespace": "bigquery",
+                                        "transformations": []
+                                    }
+                                ],
+                                "transformationDescription": "identical",
+                                "transformationType": "IDENTITY"
+                            },
+                            "salary": {
+                                "inputFields": [
+                                    {
+                                        "field": "salary",
+                                        "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_to_gcs_async_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.test",
+                                        "namespace": "bigquery",
+                                        "transformations": []
+                                    }
+                                ],
+                                "transformationDescription": "identical",
+                                "transformationType": "IDENTITY"
+                            }
+                        }
+                    },
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "emp_name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "salary",
+                                "type": "INTEGER"
+                            }
+                        ]
+                    }
+                },
+                "name": "test.csv",
+                "namespace": "gs://bucket_bigquery_to_gcs_async_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}"
+            }
+        ]
+    }
+]

--- a/providers/tests/system/google/cloud/bigquery/resources/openlineage/bigquery_transfer.json
+++ b/providers/tests/system/google/cloud/bigquery/resources/openlineage/bigquery_transfer.json
@@ -1,0 +1,147 @@
+[
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_transfer.copy_selected_data"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_transfer.copy_selected_data"
+        },
+        "inputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_transfer_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.origin",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "emp_name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "salary",
+                                "type": "INTEGER"
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_transfer_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.target",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "emp_name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "salary",
+                                "type": "INTEGER"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "bigquery_transfer.bigquery_to_gcs"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "bigquery_transfer.bigquery_to_gcs"
+        },
+        "inputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_transfer_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.origin",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "emp_name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "salary",
+                                "type": "INTEGER"
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "outputs": [
+            {
+                "facets": {
+                    "columnLineage": {
+                        "dataset": [],
+                        "fields": {
+                            "emp_name": {
+                                "inputFields": [
+                                    {
+                                        "field": "emp_name",
+                                        "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_transfer_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.origin",
+                                        "namespace": "bigquery",
+                                        "transformations": []
+                                    }
+                                ],
+                                "transformationDescription": "identical",
+                                "transformationType": "IDENTITY"
+                            },
+                            "salary": {
+                                "inputFields": [
+                                    {
+                                        "field": "salary",
+                                        "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_bigquery_transfer_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.origin",
+                                        "namespace": "bigquery",
+                                        "transformations": []
+                                    }
+                                ],
+                                "transformationDescription": "identical",
+                                "transformationType": "IDENTITY"
+                            }
+                        }
+                    },
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "emp_name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "salary",
+                                "type": "INTEGER"
+                            }
+                        ]
+                    }
+                },
+                "name": "export-bigquery.csv",
+                "namespace": "gs://bucket_bigquery_transfer_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}"
+            }
+        ]
+    }
+]

--- a/providers/tests/system/google/cloud/cloud_sql/example_cloud_sql_query.py
+++ b/providers/tests/system/google/cloud/cloud_sql/example_cloud_sql_query.py
@@ -44,6 +44,7 @@ from airflow.providers.google.cloud.operators.cloud_sql import (
 )
 from airflow.settings import Session
 from airflow.utils.trigger_rule import TriggerRule
+from providers.openlineage.tests.system.openlineage.operator import OpenLineageTestOperator
 
 from providers.tests.system.google import DEFAULT_GCP_SYSTEM_TEST_PROJECT_ID
 
@@ -384,6 +385,11 @@ with DAG(
     catchup=False,
     tags=["example", "cloudsql", "postgres"],
 ) as dag:
+    check_openlineage_events = OpenLineageTestOperator(
+        task_id="check_openlineage_events",
+        file_path=str(Path(__file__).parent / "resources" / "openlineage" / "cloud_sql_query.json"),
+    )
+
     for db_provider in DB_PROVIDERS:
         database_type: str = db_provider["database_type"]
         cloud_sql_instance_name: str = db_provider["cloud_sql_instance_name"]
@@ -537,7 +543,7 @@ with DAG(
             # TEST BODY
             >> execute_queries_task
             # TEST TEARDOWN
-            >> [delete_instance, delete_connections_task]
+            >> [delete_instance, delete_connections_task, check_openlineage_events]
         )
 
     # ### Everything below this line is not part of example ###

--- a/providers/tests/system/google/cloud/cloud_sql/resources/__init__.py
+++ b/providers/tests/system/google/cloud/cloud_sql/resources/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/tests/system/google/cloud/cloud_sql/resources/openlineage/__init__.py
+++ b/providers/tests/system/google/cloud/cloud_sql/resources/openlineage/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/tests/system/google/cloud/cloud_sql/resources/openlineage/cloud_sql_query.json
+++ b/providers/tests/system/google/cloud/cloud_sql/resources/openlineage/cloud_sql_query.json
@@ -1,0 +1,66 @@
+[
+    {
+        "eventType": "START",
+        "job": {
+            "name": "cloudsql_query.execute_queries_mysql.execute_query_cloudsql_query_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}_proxy_socket_mysql"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "cloudsql_query.execute_queries_mysql.execute_query_cloudsql_query_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}_proxy_socket_mysql"
+        },
+        "run": {
+            "facets": {
+                "sql": {
+                    "query": "CREATE TABLE IF NOT EXISTS TABLE_TEST (I INTEGER);\nCREATE TABLE IF NOT EXISTS TABLE_TEST (I INTEGER);\nINSERT INTO TABLE_TEST VALUES (0);\nCREATE TABLE IF NOT EXISTS TABLE_TEST2 (I INTEGER);\nDROP TABLE TABLE_TEST;\nDROP TABLE TABLE_TEST2"
+                }
+            }
+        },
+        "inputs": [],
+        "outputs": [
+            {
+                "namespace": "{{ result.startswith('mysql://') }}",
+                "name": "test_db.TABLE_TEST"
+            },
+            {
+                "namespace": "{{ result.startswith('mysql://') }}",
+                "name": "test_db.TABLE_TEST2"
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "cloudsql_query.execute_queries_postgres.execute_query_cloudsql_query_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}_proxy_socket_postgres"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "cloudsql_query.execute_queries_postgres.execute_query_cloudsql_query_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}_proxy_socket_postgres"
+        },
+        "run": {
+            "facets": {
+                "sql": {
+                    "query": "CREATE TABLE IF NOT EXISTS TABLE_TEST (I INTEGER);\nCREATE TABLE IF NOT EXISTS TABLE_TEST (I INTEGER);\nINSERT INTO TABLE_TEST VALUES (0);\nCREATE TABLE IF NOT EXISTS TABLE_TEST2 (I INTEGER);\nDROP TABLE TABLE_TEST;\nDROP TABLE TABLE_TEST2"
+                }
+            }
+        },
+        "inputs": [],
+        "outputs": [
+            {
+                "namespace": "{{ result.startswith('postgres://') }}",
+                "name": "test_db.public.TABLE_TEST"
+            },
+            {
+                "namespace": "{{ result.startswith('postgres://') }}",
+                "name": "test_db.public.TABLE_TEST2"
+            }
+        ]
+    }
+]

--- a/providers/tests/system/google/cloud/gcs/example_gcs_to_bigquery_async.py
+++ b/providers/tests/system/google/cloud/gcs/example_gcs_to_bigquery_async.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import os
 from datetime import datetime
+from pathlib import Path
 
 from airflow.models.dag import DAG
 from airflow.providers.google.cloud.operators.bigquery import (
@@ -31,6 +32,7 @@ from airflow.providers.google.cloud.operators.bigquery import (
 )
 from airflow.providers.google.cloud.transfers.gcs_to_bigquery import GCSToBigQueryOperator
 from airflow.utils.trigger_rule import TriggerRule
+from providers.openlineage.tests.system.openlineage.operator import OpenLineageTestOperator
 
 from providers.tests.system.google import DEFAULT_GCP_SYSTEM_TEST_PROJECT_ID
 
@@ -156,6 +158,11 @@ with DAG(
         trigger_rule=TriggerRule.ALL_DONE,
     )
 
+    check_openlineage_events = OpenLineageTestOperator(
+        task_id="check_openlineage_events",
+        file_path=str(Path(__file__).parent / "resources" / "openlineage" / "gcs_to_bigquery_async.json"),
+    )
+
     (
         # TEST SETUP
         create_test_dataset_for_string_fields
@@ -172,6 +179,7 @@ with DAG(
         >> delete_test_dataset_date
         >> delete_test_dataset_json
         >> delete_test_dataset_delimiter
+        >> check_openlineage_events
     )
 
     from tests_common.test_utils.watcher import watcher

--- a/providers/tests/system/google/cloud/gcs/example_gcs_transform.py
+++ b/providers/tests/system/google/cloud/gcs/example_gcs_transform.py
@@ -33,6 +33,7 @@ from airflow.providers.google.cloud.operators.gcs import (
 )
 from airflow.providers.google.cloud.transfers.gcs_to_gcs import GCSToGCSOperator
 from airflow.utils.trigger_rule import TriggerRule
+from providers.openlineage.tests.system.openlineage.operator import OpenLineageTestOperator
 
 from providers.tests.system.google import DEFAULT_GCP_SYSTEM_TEST_PROJECT_ID
 
@@ -85,6 +86,11 @@ with DAG(
         task_id="delete_bucket", bucket_name=BUCKET_NAME, trigger_rule=TriggerRule.ALL_DONE
     )
 
+    check_openlineage_events = OpenLineageTestOperator(
+        task_id="check_openlineage_events",
+        file_path=str(Path(__file__).parent / "resources" / "openlineage" / "gcs_transform.json"),
+    )
+
     (
         # TEST SETUP
         create_bucket
@@ -92,7 +98,7 @@ with DAG(
         # TEST BODY
         >> transform_file
         # TEST TEARDOWN
-        >> delete_bucket
+        >> [delete_bucket, check_openlineage_events]
     )
 
     from tests_common.test_utils.watcher import watcher

--- a/providers/tests/system/google/cloud/gcs/example_gcs_transform_timespan.py
+++ b/providers/tests/system/google/cloud/gcs/example_gcs_transform_timespan.py
@@ -34,6 +34,7 @@ from airflow.providers.google.cloud.operators.gcs import (
 )
 from airflow.providers.google.cloud.transfers.gcs_to_gcs import GCSToGCSOperator
 from airflow.utils.trigger_rule import TriggerRule
+from providers.openlineage.tests.system.openlineage.operator import OpenLineageTestOperator
 
 from providers.tests.system.google import DEFAULT_GCP_SYSTEM_TEST_PROJECT_ID
 
@@ -104,6 +105,11 @@ with DAG(
         task_id="delete_bucket_dst", bucket_name=BUCKET_NAME_DST, trigger_rule=TriggerRule.ALL_DONE
     )
 
+    check_openlineage_events = OpenLineageTestOperator(
+        task_id="check_openlineage_events",
+        file_path=str(Path(__file__).parent / "resources" / "openlineage" / "gcs_transform_timespan.json"),
+    )
+
     chain(
         # TEST SETUP
         [create_bucket_src, create_bucket_dst],
@@ -111,7 +117,7 @@ with DAG(
         # TEST BODY
         gcs_timespan_transform_files_task,
         # TEST TEARDOWN
-        [delete_bucket_src, delete_bucket_dst],
+        [delete_bucket_src, delete_bucket_dst, check_openlineage_events],
     )
 
     from tests_common.test_utils.watcher import watcher

--- a/providers/tests/system/google/cloud/gcs/example_gcs_upload_download.py
+++ b/providers/tests/system/google/cloud/gcs/example_gcs_upload_download.py
@@ -83,9 +83,9 @@ with DAG(
     # [END howto_operator_gcs_delete_bucket]
     delete_bucket.trigger_rule = TriggerRule.ALL_DONE
 
-    check_events = OpenLineageTestOperator(
+    check_openlineage_events = OpenLineageTestOperator(
         task_id="check_openlineage_events",
-        file_path=str(Path(__file__).parent / "resources" / "openlineage_gcs_upload_download.json"),
+        file_path=str(Path(__file__).parent / "resources" / "openlineage" / "gcs_upload_download.json"),
     )
 
     (
@@ -95,7 +95,7 @@ with DAG(
         # TEST BODY
         >> download_file
         # TEST TEARDOWN
-        >> [delete_bucket, check_events]
+        >> [delete_bucket, check_openlineage_events]
     )
 
     from tests_common.test_utils.watcher import watcher

--- a/providers/tests/system/google/cloud/gcs/resources/openlineage/__init__.py
+++ b/providers/tests/system/google/cloud/gcs/resources/openlineage/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/tests/system/google/cloud/gcs/resources/openlineage/gcs_copy_delete.json
+++ b/providers/tests/system/google/cloud/gcs/resources/openlineage/gcs_copy_delete.json
@@ -1,0 +1,98 @@
+[
+    {
+        "eventType": "START",
+        "job": {
+            "name": "gcs_copy_delete.upload_file"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "gcs_copy_delete.upload_file"
+        },
+        "inputs": [
+            {
+                "namespace": "gs://airflow-system-tests-resources",
+                "name": "gcs/example_upload.txt"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket_gcs_copy_delete_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "example_upload.txt"
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "gcs_copy_delete.copy_file"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "gcs_copy_delete.copy_file"
+        },
+        "inputs": [
+            {
+                "namespace": "gs://bucket_gcs_copy_delete_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "example_upload.txt"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket_dst_gcs_copy_delete_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "example_upload.txt"
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "gcs_copy_delete.delete_files"
+        },
+        "inputs": [
+            {
+                "namespace": "gs://bucket_gcs_copy_delete_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "example_upload.txt",
+                "facets": {
+                    "lifecycleStateChange": {
+                        "lifecycleStateChange": "DROP",
+                        "previousIdentifier": {
+                            "namespace": "gs://bucket_gcs_copy_delete_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                            "name": "example_upload.txt"
+                        }
+                    }
+                }
+            }
+        ],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "gcs_copy_delete.delete_files"
+        },
+        "inputs": [
+            {
+                "namespace": "gs://bucket_gcs_copy_delete_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "example_upload.txt",
+                "facets": {
+                    "lifecycleStateChange": {
+                        "lifecycleStateChange": "DROP",
+                        "previousIdentifier": {
+                            "namespace": "gs://bucket_gcs_copy_delete_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                            "name": "example_upload.txt"
+                        }
+                    }
+                }
+            }
+        ],
+        "outputs": []
+    }
+]

--- a/providers/tests/system/google/cloud/gcs/resources/openlineage/gcs_to_bigquery.json
+++ b/providers/tests/system/google/cloud/gcs/resources/openlineage/gcs_to_bigquery.json
@@ -1,0 +1,44 @@
+[
+    {
+        "eventType": "START",
+        "job": {
+            "name": "gcs_to_bigquery_operator.gcs_to_bigquery_example"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "gcs_to_bigquery_operator.gcs_to_bigquery_example"
+        },
+        "inputs": [
+            {
+                "namespace": "gs://cloud-samples-data",
+                "name": "bigquery/us-states/us-states.csv"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_gcs_to_bigquery_operator_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}.test",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "name",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "post_abbr",
+                                "type": "STRING"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    }
+]

--- a/providers/tests/system/google/cloud/gcs/resources/openlineage/gcs_to_bigquery_async.json
+++ b/providers/tests/system/google/cloud/gcs/resources/openlineage/gcs_to_bigquery_async.json
@@ -1,0 +1,44 @@
+[
+    {
+        "eventType": "START",
+        "job": {
+            "name": "gcs_to_bigquery_operator_async.gcs_to_bigquery_example_str_csv_async"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "gcs_to_bigquery_operator_async.gcs_to_bigquery_example_str_csv_async"
+        },
+        "inputs": [
+            {
+                "namespace": "gs://cloud-samples-data",
+                "name": "bigquery/us-states/us-states.csv"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "bigquery",
+                "name": "{{ env_var('SYSTEM_TESTS_GCP_PROJECT', 'example-project') }}.dataset_gcs_to_bigquery_operator_async_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}_STR.test_str",
+                "facets": {
+                    "schema": {
+                        "fields": [
+                            {
+                                "fields": [],
+                                "name": "string_field_0",
+                                "type": "STRING"
+                            },
+                            {
+                                "fields": [],
+                                "name": "string_field_1",
+                                "type": "STRING"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    }
+]

--- a/providers/tests/system/google/cloud/gcs/resources/openlineage/gcs_to_gcs.json
+++ b/providers/tests/system/google/cloud/gcs/resources/openlineage/gcs_to_gcs.json
@@ -1,0 +1,158 @@
+[
+    {
+        "eventType": "START",
+        "job": {
+            "name": "gcs_to_gcs.copy_single_gcs_file"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "gcs_to_gcs.copy_single_gcs_file"
+        },
+        "inputs": [
+            {
+                "namespace": "gs://bucket_gcs_to_gcs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "home/airflow/gcs/data/gcs_to_gcs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}/random.bin"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket_dst_gcs_to_gcs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "backup_random.bin"
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "gcs_to_gcs.copy_files"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "gcs_to_gcs.copy_files"
+        },
+        "inputs": [
+            {
+                "namespace": "gs://bucket_gcs_to_gcs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "home/airflow/gcs/data/gcs_to_gcs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}/subdir"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket_dst_gcs_to_gcs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "backup"
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "gcs_to_gcs.copy_files_with_match_glob"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "gcs_to_gcs.copy_files_with_match_glob"
+        },
+        "inputs": [
+            {
+                "namespace": "gs://bucket_gcs_to_gcs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "data"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket_dst_gcs_to_gcs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "backup"
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "gcs_to_gcs.copy_files_with_list"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "gcs_to_gcs.copy_files_with_list"
+        },
+        "inputs": [
+            {
+                "namespace": "gs://bucket_gcs_to_gcs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "home/airflow/gcs/data/gcs_to_gcs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}/random.bin"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket_dst_gcs_to_gcs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "backup"
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "gcs_to_gcs.move_single_file"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "gcs_to_gcs.move_single_file"
+        },
+        "inputs": [
+            {
+                "namespace": "gs://bucket_gcs_to_gcs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "home/airflow/gcs/data/gcs_to_gcs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}/random.bin"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket_dst_gcs_to_gcs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "backup_random.bin"
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "gcs_to_gcs.move_files_with_list"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "gcs_to_gcs.move_files_with_list"
+        },
+        "inputs": [
+            {
+                "namespace": "gs://bucket_gcs_to_gcs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "home/airflow/gcs/data/gcs_to_gcs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}/random.bin"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket_dst_gcs_to_gcs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "backup"
+            }
+        ]
+    }
+]

--- a/providers/tests/system/google/cloud/gcs/resources/openlineage/gcs_to_sftp.json
+++ b/providers/tests/system/google/cloud/gcs/resources/openlineage/gcs_to_sftp.json
@@ -1,0 +1,146 @@
+[
+    {
+        "eventType": "START",
+        "job": {
+            "name": "example_gcs_to_sftp.file-copy-sftp-to-gcs-destination"
+        },
+        "inputs": [
+            {
+                "namespace": "file://localhost:22",
+                "name": "{{ result.endswith('airflow/providers/tests/system/google/cloud/gcs/resources/tmp/tests_sftp_hook_dir/parent-1.bin') }}"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket-example_gcs_to_sftp-{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "destination_dir/destination_filename.bin"
+            }
+        ]
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "example_gcs_to_sftp.file-copy-sftp-to-gcs-destination"
+        },
+        "inputs": [
+            {
+                "namespace": "file://localhost:22",
+                "name": "{{ result.endswith('airflow/providers/tests/system/google/cloud/gcs/resources/tmp/tests_sftp_hook_dir/parent-1.bin') }}"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket-example_gcs_to_sftp-{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "destination_dir/destination_filename.bin"
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "example_gcs_to_sftp.dir-copy-sftp-to-gcs"
+        },
+        "inputs": [
+            {
+                "namespace": "file://localhost:22",
+                "name": "{{ result.endswith('airflow/providers/tests/system/google/cloud/gcs/resources/tmp/tests_sftp_hook_dir/subdir') }}"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket-example_gcs_to_sftp-{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "another_dir"
+            }
+        ]
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "example_gcs_to_sftp.dir-copy-sftp-to-gcs"
+        },
+        "inputs": [
+            {
+                "namespace": "file://localhost:22",
+                "name": "{{ result.endswith('airflow/providers/tests/system/google/cloud/gcs/resources/tmp/tests_sftp_hook_dir/subdir') }}"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket-example_gcs_to_sftp-{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "another_dir"
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "example_gcs_to_sftp.file-copy-from-gcs-to-sftp"
+        },
+        "inputs": [
+            {
+                "namespace": "gs://bucket-example_gcs_to_sftp-{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "destination_dir/destination_filename.bin"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "file://localhost:22",
+                "name": "{{ result.endswith('airflow/providers/tests/system/google/cloud/gcs/resources/tmp/tests_sftp_hook_dir/destination_dir/destination_filename.bin') }}"
+            }
+        ]
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "example_gcs_to_sftp.file-copy-from-gcs-to-sftp"
+        },
+        "inputs": [
+            {
+                "namespace": "gs://bucket-example_gcs_to_sftp-{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "destination_dir/destination_filename.bin"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "file://localhost:22",
+                "name": "{{ result.endswith('airflow/providers/tests/system/google/cloud/gcs/resources/tmp/tests_sftp_hook_dir/destination_dir/destination_filename.bin') }}"
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "example_gcs_to_sftp.dir-copy-gcs-to-sftp"
+        },
+        "inputs": [
+            {
+                "namespace": "gs://bucket-example_gcs_to_sftp-{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "another_dir"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "file://localhost:22",
+                "name": "{{ result.endswith('airflow/providers/tests/system/google/cloud/gcs/resources/tmp/tests_sftp_hook_dir/subdir') }}"
+            }
+        ]
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "example_gcs_to_sftp.dir-copy-gcs-to-sftp"
+        },
+        "inputs": [
+            {
+                "namespace": "gs://bucket-example_gcs_to_sftp-{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "another_dir"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "file://localhost:22",
+                "name": "{{ result.endswith('airflow/providers/tests/system/google/cloud/gcs/resources/tmp/tests_sftp_hook_dir/subdir') }}"
+            }
+        ]
+    }
+]

--- a/providers/tests/system/google/cloud/gcs/resources/openlineage/gcs_transform.json
+++ b/providers/tests/system/google/cloud/gcs/resources/openlineage/gcs_transform.json
@@ -1,0 +1,64 @@
+[
+    {
+        "eventType": "START",
+        "job": {
+            "name": "gcs_transform.upload_file"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "gcs_transform.upload_file"
+        },
+        "inputs": [
+            {
+                "namespace": "gs://airflow-system-tests-resources",
+                "name": "gcs/example_upload.txt"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket_gcs_transform_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "example_upload.txt"
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "gcs_transform.transform_file"
+        },
+        "inputs": [
+            {
+                "namespace": "gs://bucket_gcs_transform_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "example_upload.txt"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket_gcs_transform_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "example_upload.txt"
+            }
+        ]
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "gcs_transform.transform_file"
+        },
+        "inputs": [
+            {
+                "namespace": "gs://bucket_gcs_transform_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "example_upload.txt"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket_gcs_transform_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "example_upload.txt"
+            }
+        ]
+    }
+]

--- a/providers/tests/system/google/cloud/gcs/resources/openlineage/gcs_transform_timespan.json
+++ b/providers/tests/system/google/cloud/gcs/resources/openlineage/gcs_transform_timespan.json
@@ -1,0 +1,54 @@
+[
+    {
+        "eventType": "START",
+        "job": {
+            "name": "gcs_transform_timespan.copy_example_gcs_file"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "gcs_transform_timespan.copy_example_gcs_file"
+        },
+        "inputs": [
+            {
+                "namespace": "gs://airflow-system-tests-resources",
+                "name": "gcs/example_upload.txt"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket_gcs_transform_timespan_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "timespan_source/example_upload.txt"
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "gcs_transform_timespan.gcs_timespan_transform_files"
+        },
+        "inputs": [],
+        "outputs": []
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "gcs_transform_timespan.gcs_timespan_transform_files"
+        },
+        "inputs": [
+            {
+                "namespace": "gs://bucket_gcs_transform_timespan_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "/"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket_dst_gcs_transform_timespan_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "/"
+            }
+        ]
+    }
+]

--- a/providers/tests/system/google/cloud/gcs/resources/openlineage/gcs_upload_download.json
+++ b/providers/tests/system/google/cloud/gcs/resources/openlineage/gcs_upload_download.json
@@ -1,20 +1,8 @@
 [
     {
         "eventType": "START",
-        "eventTime": "{{ is_datetime(result) }}",
-        "run": {
-            "runId": "{{ is_uuid(result) }}"
-        },
         "job": {
-            "namespace": "default",
-            "name": "gcs_upload_download.upload_file",
-            "facets": {
-                "jobType": {
-                    "integration": "AIRFLOW",
-                    "jobType": "TASK",
-                    "processingType": "BATCH"
-                }
-            }
+            "name": "gcs_upload_download.upload_file"
         },
         "inputs": [
             {
@@ -31,20 +19,8 @@
     },
     {
         "eventType": "COMPLETE",
-        "eventTime": "{{ is_datetime(result) }}",
-        "run": {
-            "runId": "{{ is_uuid(result) }}"
-        },
         "job": {
-            "namespace": "default",
-            "name": "gcs_upload_download.upload_file",
-            "facets": {
-                "jobType": {
-                    "integration": "AIRFLOW",
-                    "jobType": "TASK",
-                    "processingType": "BATCH"
-                }
-            }
+            "name": "gcs_upload_download.upload_file"
         },
         "inputs": [
             {
@@ -61,20 +37,9 @@
     },
     {
         "eventType": "START",
-        "eventTime": "{{ is_datetime(result) }}",
-        "run": {
-            "runId": "{{ is_uuid(result) }}"
-        },
         "job": {
             "namespace": "default",
-            "name": "gcs_upload_download.download_file",
-            "facets": {
-                "jobType": {
-                    "integration": "AIRFLOW",
-                    "jobType": "TASK",
-                    "processingType": "BATCH"
-                }
-            }
+            "name": "gcs_upload_download.download_file"
         },
         "inputs": [
             {
@@ -89,23 +54,10 @@
             }
         ]
     },
-
     {
         "eventType": "COMPLETE",
-        "eventTime": "{{ is_datetime(result) }}",
-        "run": {
-            "runId": "{{ is_uuid(result) }}"
-        },
         "job": {
-            "namespace": "default",
-            "name": "gcs_upload_download.download_file",
-            "facets": {
-                "jobType": {
-                    "integration": "AIRFLOW",
-                    "jobType": "TASK",
-                    "processingType": "BATCH"
-                }
-            }
+            "name": "gcs_upload_download.download_file"
         },
         "inputs": [
             {

--- a/providers/tests/system/google/cloud/gcs/resources/openlineage/mssql_to_gcs.json
+++ b/providers/tests/system/google/cloud/gcs/resources/openlineage/mssql_to_gcs.json
@@ -1,0 +1,52 @@
+[
+    {
+        "eventType": "START",
+        "job": {
+            "name": "example_mssql_to_gcs.mssql_to_gcs"
+        },
+        "run": {
+            "facets": {
+                "sql": {
+                    "query": "USE airflow SELECT * FROM Country"
+                }
+            }
+        },
+        "inputs": [
+            {
+                "namespace": "{{ result.startswith('mssql://') }}",
+                "name": "airflow.dbo.Country"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket_example_mssql_to_gcs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "test_file"
+            }
+        ]
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "example_mssql_to_gcs.mssql_to_gcs"
+        },
+        "run": {
+            "facets": {
+                "sql": {
+                    "query": "USE airflow SELECT * FROM Country"
+                }
+            }
+        },
+        "inputs": [
+            {
+                "namespace": "{{ result.startswith('mssql://') }}",
+                "name": "airflow.dbo.Country"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket_example_mssql_to_gcs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "test_file"
+            }
+        ]
+    }
+]

--- a/providers/tests/system/google/cloud/gcs/resources/openlineage/mysql_to_gcs.json
+++ b/providers/tests/system/google/cloud/gcs/resources/openlineage/mysql_to_gcs.json
@@ -1,0 +1,132 @@
+[
+    {
+        "eventType": "START",
+        "job": {
+            "name": "mysql_to_gcs.create_sql_table"
+        },
+        "run": {
+            "facets": {
+                "sql": {
+                    "query": "CREATE TABLE IF NOT EXISTS testdb.test_table (col_1 INT, col_2 VARCHAR(8))"
+                }
+            }
+        },
+        "inputs": [],
+        "outputs": [
+            {
+                "namespace": "{{ result.startswith('mysql://') }}",
+                "name": "testdb.test_table"
+            }
+        ]
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "mysql_to_gcs.create_sql_table"
+        },
+        "run": {
+            "facets": {
+                "sql": {
+                    "query": "CREATE TABLE IF NOT EXISTS testdb.test_table (col_1 INT, col_2 VARCHAR(8))"
+                }
+            }
+        },
+        "inputs": [],
+        "outputs": [
+            {
+                "namespace": "{{ result.startswith('mysql://') }}",
+                "name": "testdb.test_table"
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "mysql_to_gcs.insert_sql_data"
+        },
+        "run": {
+            "facets": {
+                "sql": {
+                    "query": "INSERT INTO testdb.test_table (col_1, col_2) VALUES (1, 'one'), (2, 'two')"
+                }
+            }
+        },
+        "inputs": [],
+        "outputs": [
+            {
+                "namespace": "{{ result.startswith('mysql://') }}",
+                "name": "testdb.test_table"
+            }
+        ]
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "mysql_to_gcs.insert_sql_data"
+        },
+        "run": {
+            "facets": {
+                "sql": {
+                    "query": "INSERT INTO testdb.test_table (col_1, col_2) VALUES (1, 'one'), (2, 'two')"
+                }
+            }
+        },
+        "inputs": [],
+        "outputs": [
+            {
+                "namespace": "{{ result.startswith('mysql://') }}",
+                "name": "testdb.test_table"
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "mysql_to_gcs.mysql_to_gcs"
+        },
+        "run": {
+            "facets": {
+                "sql": {
+                    "query": "SELECT * FROM testdb.test_table"
+                }
+            }
+        },
+        "inputs": [
+            {
+                "namespace": "{{ result.startswith('mysql://') }}",
+                "name": "testdb.test_table"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket_mysql_to_gcs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "result.json"
+            }
+        ]
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "mysql_to_gcs.mysql_to_gcs"
+        },
+        "run": {
+            "facets": {
+                "sql": {
+                    "query": "SELECT * FROM testdb.test_table"
+                }
+            }
+        },
+        "inputs": [
+            {
+                "namespace": "{{ result.startswith('mysql://') }}",
+                "name": "testdb.test_table"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket_mysql_to_gcs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "result.json"
+            }
+        ]
+    }
+]

--- a/providers/tests/system/google/cloud/gcs/resources/openlineage/s3_to_gcs.json
+++ b/providers/tests/system/google/cloud/gcs/resources/openlineage/s3_to_gcs.json
@@ -1,0 +1,74 @@
+[
+    {
+        "eventType": "START",
+        "job": {
+            "name": "example_s3_to_gcs.s3_to_gcs_task"
+        },
+        "inputs": [
+            {
+                "namespace": "s3://bucket-example-s3-to-gcs-{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "gcs"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket-example-s3-to-gcs-{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "/"
+            }
+        ]
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "example_s3_to_gcs.s3_to_gcs_task"
+        },
+        "inputs": [
+            {
+                "namespace": "s3://bucket-example-s3-to-gcs-{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "gcs"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket-example-s3-to-gcs-{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "/"
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "example_s3_to_gcs.s3_to_gcs_task_def"
+        },
+        "inputs": [
+            {
+                "namespace": "s3://bucket-example-s3-to-gcs-{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "gcs"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket-example-s3-to-gcs-{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "/"
+            }
+        ]
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "example_s3_to_gcs.s3_to_gcs_task_def"
+        },
+        "inputs": [
+            {
+                "namespace": "s3://bucket-example-s3-to-gcs-{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "gcs"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket-example-s3-to-gcs-{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "/"
+            }
+        ]
+    }
+]

--- a/providers/tests/system/google/cloud/gcs/resources/openlineage/sftp_to_gcs.json
+++ b/providers/tests/system/google/cloud/gcs/resources/openlineage/sftp_to_gcs.json
@@ -1,0 +1,146 @@
+[
+    {
+        "eventType": "START",
+        "job": {
+            "name": "example_sftp_to_gcs.file-copy-sftp-to-gcs"
+        },
+        "inputs": [
+            {
+                "namespace": "file://localhost:22",
+                "name": "{{ result.endswith('airflow/providers/tests/system/google/cloud/gcs/resources/tmp/tests_sftp_hook_dir/parent-1.bin') }}"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket-example_sftp_to_gcs-{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "parent-1.bin"
+            }
+        ]
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "example_sftp_to_gcs.file-copy-sftp-to-gcs"
+        },
+        "inputs": [
+            {
+                "namespace": "file://localhost:22",
+                "name": "{{ result.endswith('airflow/providers/tests/system/google/cloud/gcs/resources/tmp/tests_sftp_hook_dir/parent-1.bin') }}"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket-example_sftp_to_gcs-{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "parent-1.bin"
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "example_sftp_to_gcs.file-move-sftp-to-gcs-destination"
+        },
+        "inputs": [
+            {
+                "namespace": "file://localhost:22",
+                "name": "{{ result.endswith('airflow/providers/tests/system/google/cloud/gcs/resources/tmp/tests_sftp_hook_dir/parent-2.bin') }}"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket-example_sftp_to_gcs-{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "destination_dir/destination_filename.bin"
+            }
+        ]
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "example_sftp_to_gcs.file-move-sftp-to-gcs-destination"
+        },
+        "inputs": [
+            {
+                "namespace": "file://localhost:22",
+                "name": "{{ result.endswith('airflow/providers/tests/system/google/cloud/gcs/resources/tmp/tests_sftp_hook_dir/parent-2.bin') }}"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket-example_sftp_to_gcs-{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "destination_dir/destination_filename.bin"
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "example_sftp_to_gcs.dir-copy-sftp-to-gcs"
+        },
+        "inputs": [
+            {
+                "namespace": "file://localhost:22",
+                "name": "{{ result.endswith('airflow/providers/tests/system/google/cloud/gcs/resources/tmp/tests_sftp_hook_dir/subdir') }}"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket-example_sftp_to_gcs-{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "/"
+            }
+        ]
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "example_sftp_to_gcs.dir-copy-sftp-to-gcs"
+        },
+        "inputs": [
+            {
+                "namespace": "file://localhost:22",
+                "name": "{{ result.endswith('airflow/providers/tests/system/google/cloud/gcs/resources/tmp/tests_sftp_hook_dir/subdir') }}"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket-example_sftp_to_gcs-{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "/"
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "example_sftp_to_gcs.dir-move-specific-files-sftp-to-gcs"
+        },
+        "inputs": [
+            {
+                "namespace": "file://localhost:22",
+                "name": "{{ result.endswith('airflow/providers/tests/system/google/cloud/gcs/resources/tmp/tests_sftp_hook_dir/subdir') }}"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket-example_sftp_to_gcs-{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "specific_files"
+            }
+        ]
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "example_sftp_to_gcs.dir-move-specific-files-sftp-to-gcs"
+        },
+        "inputs": [
+            {
+                "namespace": "file://localhost:22",
+                "name": "{{ result.endswith('airflow/providers/tests/system/google/cloud/gcs/resources/tmp/tests_sftp_hook_dir/subdir') }}"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket-example_sftp_to_gcs-{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "specific_files"
+            }
+        ]
+    }
+]

--- a/providers/tests/system/google/cloud/gcs/resources/openlineage/trino_to_gcs.json
+++ b/providers/tests/system/google/cloud/gcs/resources/openlineage/trino_to_gcs.json
@@ -1,0 +1,102 @@
+[
+    {
+        "eventType": "START",
+        "job": {
+            "name": "example_trino_to_gcs.trino_to_gcs_basic"
+        },
+        "run": {
+            "facets": {
+                "sql": {
+                    "query": "select * from memory.information_schema.columns"
+                }
+            }
+        },
+        "inputs": [
+            {
+                "namespace": "{{ result.startswith('trino://') }}",
+                "name": "information_schema.columns"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket_example_trino_to_gcs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "/"
+            }
+        ]
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "example_trino_to_gcs.trino_to_gcs_basic"
+        },
+        "run": {
+            "facets": {
+                "sql": {
+                    "query": "select * from memory.information_schema.columns"
+                }
+            }
+        },
+        "inputs": [
+            {
+                "namespace": "{{ result.startswith('trino://') }}",
+                "name": "information_schema.columns"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket_example_trino_to_gcs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "/"
+            }
+        ]
+    },
+    {
+        "eventType": "START",
+        "job": {
+            "name": "example_trino_to_gcs.trino_to_gcs_many_chunks"
+        },
+        "run": {
+            "facets": {
+                "sql": {
+                    "query": "select * from tpch.sf1.customer"
+                }
+            }
+        },
+        "inputs": [
+            {
+                "namespace": "{{ result.startswith('trino://') }}",
+                "name": "tpch.sf1.customer"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket_example_trino_to_gcs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "/"
+            }
+        ]
+    },
+    {
+        "eventType": "COMPLETE",
+        "job": {
+            "name": "example_trino_to_gcs.trino_to_gcs_many_chunks"
+        },
+        "run": {
+            "facets": {
+                "sql": {
+                    "query": "select * from tpch.sf1.customer"
+                }
+            }
+        },
+        "inputs": [
+            {
+                "namespace": "{{ result.startswith('trino://') }}",
+                "name": "tpch.sf1.customer"
+            }
+        ],
+        "outputs": [
+            {
+                "namespace": "gs://bucket_example_trino_to_gcs_{{ env_var('SYSTEM_TESTS_ENV_ID', 'default') }}",
+                "name": "/"
+            }
+        ]
+    }
+]


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
This PR adds checking OpenLineage events produced by selected Google Provider operators when running system checks. This is an addition to unit tests already checking OpenLineage for specific operators.

Thanks to VariableTransport introduced in #43643, we can easily check if OpenLineage events produced by any operator match the expected values. The logic is simple, for each system tests: adding the OpenLineageTestOperator to the DAG and providing it with json file with what we expect to be in the events. Whenever a system test is run, we will verify OpenLineage events emitted.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
