### PR TITLE
Disable Flask-SQLAlchemy modification tracking in FAB provider

### DIFF
--- a/providers/src/airflow/providers/fab/www/app.py
+++ b/providers/src/airflow/providers/fab/www/app.py
@@ -46,6 +46,7 @@ def create_app(enable_plugins: bool):
     flask_app = Flask(__name__)
     flask_app.secret_key = conf.get("webserver", "SECRET_KEY")
     flask_app.config["SQLALCHEMY_DATABASE_URI"] = conf.get("database", "SQL_ALCHEMY_CONN")
+    flask_app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 
     url = make_url(flask_app.config["SQLALCHEMY_DATABASE_URI"])
     if url.drivername == "sqlite" and url.database and not isabs(url.database):


### PR DESCRIPTION
We disable modification tracking since we don't use it and it's expensive, but this was accidentally not carried over into the FAB provider when the app was moved there. This just brings it back and silences a warning about it:

  FSADeprecationWarning: SQLALCHEMY_TRACK_MODIFICATIONS adds significant
  overhead and will be disabled by default in the future.  Set it to
  True or False to suppress this warning.