### PR TITLE
update some icons and add dag import error to dagslist

### DIFF
--- a/airflow/ui/src/components/ParseDag.tsx
+++ b/airflow/ui/src/components/ParseDag.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { LuFolderSync } from "react-icons/lu";
+import { AiOutlineFileSync } from "react-icons/ai";
 
 import { Button } from "src/components/ui";
 import { useDagParsing } from "src/queries/useDagParsing.ts";
@@ -31,7 +31,7 @@ const ParseDag = ({ dagId, fileToken }: Props) => {
 
   return (
     <Button loading={isPending} onClick={() => mutate({ fileToken })} variant="outline">
-      <LuFolderSync height={5} width={5} />
+      <AiOutlineFileSync height={5} width={5} />
       Reparse Dag
     </Button>
   );

--- a/airflow/ui/src/components/ParseDag.tsx
+++ b/airflow/ui/src/components/ParseDag.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { FiRefreshCw } from "react-icons/fi";
+import { LuFolderSync } from "react-icons/lu";
 
 import { Button } from "src/components/ui";
 import { useDagParsing } from "src/queries/useDagParsing.ts";
@@ -31,7 +31,7 @@ const ParseDag = ({ dagId, fileToken }: Props) => {
 
   return (
     <Button loading={isPending} onClick={() => mutate({ fileToken })} variant="outline">
-      <FiRefreshCw height={5} width={5} />
+      <LuFolderSync height={5} width={5} />
       Reparse Dag
     </Button>
   );

--- a/airflow/ui/src/components/StateIcon.tsx
+++ b/airflow/ui/src/components/StateIcon.tsx
@@ -19,17 +19,15 @@
 import type { IconBaseProps } from "react-icons";
 import {
   FiActivity,
-  FiAlertCircle,
   FiAlertOctagon,
   FiCalendar,
   FiCheckCircle,
-  FiCircle,
   FiRepeat,
   FiSkipForward,
   FiSlash,
   FiWatch,
 } from "react-icons/fi";
-import { LuCalendarSync, LuRedo2 } from "react-icons/lu";
+import { LuCalendarSync, LuCircleDashed, LuCircleFadingArrowUp, LuRedo2 } from "react-icons/lu";
 import { PiQueue } from "react-icons/pi";
 
 import type { TaskInstanceState } from "openapi/requests/types.gen";
@@ -63,8 +61,8 @@ export const StateIcon = ({ state, ...rest }: Props) => {
     case "up_for_retry":
       return <LuRedo2 {...rest} />;
     case "upstream_failed":
-      return <FiAlertCircle {...rest} />;
+      return <LuCircleFadingArrowUp {...rest} />;
     default:
-      return <FiCircle {...rest} />;
+      return <LuCircleDashed {...rest} />;
   }
 };

--- a/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -45,6 +45,7 @@ import { useConfig } from "src/queries/useConfig";
 import { useDags } from "src/queries/useDags";
 import { pluralize } from "src/utils";
 
+import { DAGImportErrors } from "../Dashboard/Stats/DAGImportErrors";
 import { DagCard } from "./DagCard";
 import { DagTags } from "./DagTags";
 import { DagsFilters } from "./DagsFilters";
@@ -223,9 +224,12 @@ export const DagsList = () => {
         />
         <DagsFilters />
         <HStack justifyContent="space-between">
-          <Heading py={3} size="md">
-            {pluralize("Dag", data.total_entries)}
-          </Heading>
+          <HStack>
+            <Heading py={3} size="md">
+              {pluralize("Dag", data.total_entries)}
+            </Heading>
+            <DAGImportErrors iconOnly />
+          </HStack>
           {display === "card" ? (
             <SortSelect handleSortChange={handleSortChange} orderBy={orderBy} />
           ) : undefined}

--- a/airflow/ui/src/pages/Dashboard/Stats/DAGImportErrors.tsx
+++ b/airflow/ui/src/pages/Dashboard/Stats/DAGImportErrors.tsx
@@ -16,18 +16,22 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Text, Button, useDisclosure, Skeleton, Badge } from "@chakra-ui/react";
+import { Box, Text, Button, useDisclosure, Skeleton } from "@chakra-ui/react";
 import { FiChevronRight } from "react-icons/fi";
+import { LuFileWarning } from "react-icons/lu";
 
 import { useImportErrorServiceGetImportErrors } from "openapi/queries";
 import { ErrorAlert } from "src/components/ErrorAlert";
+import { StateBadge } from "src/components/StateBadge";
+import { pluralize } from "src/utils";
 
 import { DAGImportErrorsModal } from "./DAGImportErrorsModal";
 
-export const DAGImportErrors = () => {
+export const DAGImportErrors = ({ iconOnly = false }: { readonly iconOnly?: boolean }) => {
   const { onClose, onOpen, open } = useDisclosure();
 
   const { data, error, isLoading } = useImportErrorServiceGetImportErrors();
+
   const importErrorsCount = data?.total_entries ?? 0;
   const importErrors = data?.import_errors ?? [];
 
@@ -36,25 +40,43 @@ export const DAGImportErrors = () => {
   }
 
   return (
-    <Box alignItems="center" display="flex" gap={2}>
+    <Box alignItems="center" display="flex" maxH="10px">
       <ErrorAlert error={error} />
       {importErrorsCount > 0 && (
-        <Button
-          alignItems="center"
-          borderRadius="md"
-          display="flex"
-          gap={2}
-          onClick={onOpen}
-          variant="outline"
-        >
-          <Badge colorPalette="failed">{importErrorsCount}</Badge>
-          <Box alignItems="center" display="flex" gap={1}>
-            <Text fontWeight="bold">Dag Import Errors</Text>
-            <FiChevronRight />
-          </Box>
-        </Button>
+        <>
+          {iconOnly ? (
+            <StateBadge
+              as={Button}
+              colorPalette="failed"
+              height={7}
+              onClick={onOpen}
+              title={pluralize("Dag Import Error", importErrorsCount)}
+            >
+              <LuFileWarning size="0.5rem" />
+              {importErrorsCount}
+            </StateBadge>
+          ) : (
+            <Button
+              alignItems="center"
+              borderRadius="md"
+              display="flex"
+              gap={2}
+              onClick={onOpen}
+              variant="outline"
+            >
+              <StateBadge colorPalette="failed">
+                <LuFileWarning />
+                {importErrorsCount}
+              </StateBadge>
+              <Box alignItems="center" display="flex" gap={1}>
+                <Text fontWeight="bold">Dag Import Errors</Text>
+                <FiChevronRight />
+              </Box>
+            </Button>
+          )}
+          <DAGImportErrorsModal importErrors={importErrors} onClose={onClose} open={open} />
+        </>
       )}
-      <DAGImportErrorsModal importErrors={importErrors} onClose={onClose} open={open} />
     </Box>
   );
 };

--- a/airflow/ui/src/pages/Dashboard/Stats/DAGImportErrorsModal.tsx
+++ b/airflow/ui/src/pages/Dashboard/Stats/DAGImportErrorsModal.tsx
@@ -18,6 +18,7 @@
  */
 import { Heading, Text, HStack, Input } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
+import { LuFileWarning } from "react-icons/lu";
 import { PiFilePy } from "react-icons/pi";
 
 import type { ImportErrorResponse } from "openapi/requests/types.gen";
@@ -60,7 +61,10 @@ export const DAGImportErrorsModal: React.FC<ImportDAGErrorModalProps> = ({ impor
     <Dialog.Root onOpenChange={onOpenChange} open={open} scrollBehavior="inside" size="xl">
       <Dialog.Content backdrop>
         <Dialog.Header>
-          <Heading size="xl">Dag Import Errors</Heading>
+          <HStack fontSize="xl">
+            <LuFileWarning />
+            <Heading>Dag Import Errors</Heading>
+          </HStack>
           <Input
             mt={4}
             onChange={(event) => setSearchQuery(event.target.value)}


### PR DESCRIPTION
Based on a [slack conversation](https://apache-airflow.slack.com/archives/C0809U4S1Q9/p1738167430328999?thread_ts=1738165298.917869&cid=C0809U4S1Q9)

Change upstream_failed and none state icons:
<img width="214" alt="Screenshot 2025-01-29 at 12 26 14 PM" src="https://github.com/user-attachments/assets/2fd31566-07d2-4401-8a10-844cde99093b" />

Change reparse dag icon:
<img width="700" alt="Screenshot 2025-01-29 at 12 24 31 PM" src="https://github.com/user-attachments/assets/e574531d-e3ca-45d9-a7bc-846f3dbfa169" />

Add icon to Dag Import Error and add a simple button for it in the dags list:
<img width="267" alt="Screenshot 2025-01-29 at 12 23 35 PM" src="https://github.com/user-attachments/assets/285ea5ba-85ea-4ce4-bdb8-60c764bcce5a" />
<img width="584" alt="Screenshot 2025-01-29 at 12 24 12 PM" src="https://github.com/user-attachments/assets/7557555d-2448-4f75-b702-44a1c34d4554" />


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
