### PR TITLE
Adding from_path.exists() check in a couple of conditions

### DIFF
--- a/dev/moving_providers/move_providers.py
+++ b/dev/moving_providers/move_providers.py
@@ -109,7 +109,11 @@ def _do_stuff(
                 console.print(Syntax(updated_str, syntax, theme="ansi_dark"))
         elif not from_content and not updated_content and from_path and to_path and delete_from:
             console.print(f"\n[yellow]Moving[/] {from_path} -> {to_path}\n")
-            if remove_empty_parent_dir and len([path for path in from_path.parent.iterdir()]) == 1:
+            if (
+                remove_empty_parent_dir
+                and from_path.exists()
+                and len([path for path in from_path.parent.iterdir()]) == 1
+            ):
                 console.print(f"\n[yellow]Removing also empty parent dir {from_path.parent}\n")
         elif not from_content and not updated_content and from_path and to_path and not delete_from:
             console.print(f"\n[yellow]Copying[/] {from_path} -> {to_path}\n")
@@ -127,7 +131,8 @@ def _do_stuff(
                 to_path.parent.mkdir(parents=True, exist_ok=True)
                 if from_path.is_dir() and to_path.exists():
                     shutil.rmtree(to_path)
-                shutil.move(from_path, to_path)
+                if from_path.exists():
+                    shutil.move(from_path, to_path)
                 console.print(f"\n[yellow]Moved {from_path} -> {to_path}\n")
                 if remove_empty_parent_dir and len([path for path in from_path.parent.iterdir()]) == 0:
                     console.print(f"\n[yellow]Removed also empty parent dir {from_path.parent}\n")


### PR DESCRIPTION
Seems like `dev/moving_providers/move_providers.py` ran into an edge case (stack trace below) when trying to move files from `docs/integration-logos` as this dir gets deleted in a previous step once it's empty. 

This fix is intended to handle that by checking if the source path i.e. `from_path` exists before trying to operate on it. Fixed the issue below when trying to move the `microsoft.azure` provider files. 

Error stack trace:
```
Moving /Users/a81045729/Documents/constant_variables/airflow/docs/integration-logos/azure/Data Lake Storage.svg -> 
/Users/a81045729/Documents/constant_variables/airflow/providers/microsoft/azure/docs/integration-logos/Data Lake Storage.svg


Removing also empty parent dir /Users/a81045729/Documents/constant_variables/airflow/docs/integration-logos/azure

Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.13/3.13.1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/shutil.py", line 856, in move
    os.rename(src, real_dst)
    ~~~~~~~~~^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/Users/a81045729/Documents/constant_variables/airflow/docs/integration-logos/azure/Data Lake Storage.svg' -> '/Users/a81045729/Documents/constant_variables/airflow/providers/microsoft/azure/docs/integration-logos/Data Lake Storage.svg'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/a81045729/Documents/constant_variables/airflow/dev/moving_providers/move_providers.py", line 736, in <module>
    move_providers()
    ~~~~~~~~~~~~~~^^
  File "/Users/a81045729/.cache/uv/archive-v0/-bNfI_UDWExwOMLuP_MGL/lib/python3.13/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/Users/a81045729/.cache/uv/archive-v0/-bNfI_UDWExwOMLuP_MGL/lib/python3.13/site-packages/rich_click/rich_command.py", line 152, in main
    rv = self.invoke(ctx)
  File "/Users/a81045729/.cache/uv/archive-v0/-bNfI_UDWExwOMLuP_MGL/lib/python3.13/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/a81045729/.cache/uv/archive-v0/-bNfI_UDWExwOMLuP_MGL/lib/python3.13/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "/Users/a81045729/Documents/constant_variables/airflow/dev/moving_providers/move_providers.py", line 212, in move_providers
    move_provider(provider_id)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/Users/a81045729/Documents/constant_variables/airflow/dev/moving_providers/move_providers.py", line 726, in move_provider
    dependencies, devel_dependencies, optional_dependencies = move_provider_yaml(provider_id)
                                                              ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/Users/a81045729/Documents/constant_variables/airflow/dev/moving_providers/move_providers.py", line 368, in move_provider_yaml
    _do_stuff(
    ~~~~~~~~~^
        syntax="none",
        ^^^^^^^^^^^^^^
    ...<3 lines>...
        remove_empty_parent_dir=True,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/a81045729/Documents/constant_variables/airflow/dev/moving_providers/move_providers.py", line 130, in _do_stuff
    shutil.move(from_path, to_path)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/shutil.py", line 876, in move
    copy_function(src, real_dst)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/shutil.py", line 468, in copy2
    copyfile(src, dst, follow_symlinks=follow_symlinks)
    ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/shutil.py", line 260, in copyfile
    with open(src, 'rb') as fsrc:
         ~~~~^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/Users/a81045729/Documents/constant_variables/airflow/docs/integration-logos/azure/Data Lake Storage.svg' 
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
