### PR TITLE
Importing correct MySqlContext in test_generic_transfer

### DIFF
--- a/providers/mysql/tests/provider_tests/mysql/hooks/test_mysql.py
+++ b/providers/mysql/tests/provider_tests/mysql/hooks/test_mysql.py
@@ -29,6 +29,8 @@ import sqlalchemy
 from airflow.models import Connection
 from airflow.models.dag import DAG
 
+from tests_common.test_utils.common_sql import MySqlContext
+
 try:
     import MySQLdb.cursors
 
@@ -410,19 +412,6 @@ DEFAULT_DATE = timezone.datetime(2015, 1, 1)
 DEFAULT_DATE_ISO = DEFAULT_DATE.isoformat()
 DEFAULT_DATE_DS = DEFAULT_DATE_ISO[:10]
 TEST_DAG_ID = "unit_test_dag"
-
-
-class MySqlContext:
-    def __init__(self, client):
-        self.client = client
-        self.connection = MySqlHook.get_connection(MySqlHook.default_conn_name)
-        self.init_client = self.connection.extra_dejson.get("client", "mysqlclient")
-
-    def __enter__(self):
-        self.connection.set_extra(f'{{"client": "{self.client}"}}')
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.connection.set_extra(f'{{"client": "{self.init_client}"}}')
 
 
 @pytest.mark.backend("mysql")

--- a/providers/standard/tests/provider_tests/standard/operators/test_generic_transfer.py
+++ b/providers/standard/tests/provider_tests/standard/operators/test_generic_transfer.py
@@ -65,7 +65,7 @@ class TestMySql:
         ],
     )
     def test_mysql_to_mysql(self, client):
-        from providers.tests.mysql.hooks.test_mysql import MySqlContext
+        from providers.mysql.tests.provider_tests.mysql.hooks.test_mysql import MySqlContext
 
         with MySqlContext(client):
             sql = "SELECT * FROM connection;"

--- a/providers/standard/tests/provider_tests/standard/operators/test_generic_transfer.py
+++ b/providers/standard/tests/provider_tests/standard/operators/test_generic_transfer.py
@@ -65,7 +65,7 @@ class TestMySql:
         ],
     )
     def test_mysql_to_mysql(self, client):
-        from providers.mysql.tests.provider_tests.mysql.hooks.test_mysql import MySqlContext
+        from tests_common.test_utils.common_sql import MySqlContext
 
         with MySqlContext(client):
             sql = "SELECT * FROM connection;"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


Saw this failure in CI:
```
  __________________ TestMySql.test_mysql_to_mysql[mysqlclient] __________________
  
  self = <provider_tests.standard.operators.test_generic_transfer.TestMySql object at 0x7f4af01daa30>
  client = 'mysqlclient'
  
      @pytest.mark.parametrize(
          "client",
          [
              "mysqlclient",
              "mysql-connector-python",
          ],
      )
      def test_mysql_to_mysql(self, client):
  >       from providers.tests.mysql.hooks.test_mysql import MySqlContext
  E       ModuleNotFoundError: No module named 'providers.tests.mysql'
  
  providers/standard/tests/provider_tests/standard/operators/test_generic_transfer.py:68: ModuleNotFoundError
  --------------------------- Captured stdout teardown ---------------------------
  [2025-01-29T15:34:23.806+0000] {base.py:65} INFO - Retrieving connection 'mysql_default'
  ---------------------------- Captured log teardown -----------------------------
  INFO     airflow.hooks.base:base.py:65 Retrieving connection 'mysql_default'
  ____________ TestMySql.test_mysql_to_mysql[mysql-connector-python] _____________
  
  self = <provider_tests.standard.operators.test_generic_transfer.TestMySql object at 0x7f4af01daaf0>
  client = 'mysql-connector-python'
  
      @pytest.mark.parametrize(
          "client",
          [
              "mysqlclient",
              "mysql-connector-python",
          ],
      )
      def test_mysql_to_mysql(self, client):
  >       from providers.tests.mysql.hooks.test_mysql import MySqlContext
  E       ModuleNotFoundError: No module named 'providers.tests.mysql'
  
  providers/standard/tests/provider_tests/standard/operators/test_generic_transfer.py:68: ModuleNotFoundError
```




<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
