### PR TITLE
Fix pre-commit to re-generate on dependency changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -349,6 +349,7 @@ repos:
           (?x)
           ^providers/[^\/]*/src/airflow/providers/[^\/]*/__init__.py$|
           ^providers/[^\/]*/[^\/]*/src/airflow/providers/[^\/]*/[^\/]*/__init__.py$|
+          ^providers/.*/pyproject\.toml$|
           ^providers/.*/provider.yaml$|
           ^airflow_breeze/templates/PROVIDER__INIT__PY_TEMPLATE.py.jinja2$
           ^airflow_breeze/templates/get_provider_info_TEMPLATE.py.jinja2$
@@ -467,6 +468,7 @@ repos:
         language: python
         files: |
           (?x)
+          ^providers/.*/pyproject\.toml$|
           ^providers/.*/provider\.yaml$|
           ^scripts/ci/pre_commit/update_providers_dependencies\.py$
         pass_filenames: false


### PR DESCRIPTION
After I raised #46216 and I realized that @potiuk added #46220 to fix behind... realized that my local pre-commti did not re-generate files.
This is due to providers move and the fact that provider dependencies are now in pyproject.toml and not in the YAML anymore. 

This PR adjusts the pre-commit pattern to ensure files are re-generated if dependencies change.