### PR TITLE
Get bundle execution working again

### DIFF
--- a/task_sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task_sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -24,7 +24,6 @@ import sys
 from collections.abc import Iterable, Mapping
 from datetime import datetime, timezone
 from io import FileIO
-from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, Generic, TextIO, TypeVar
 
 import attrs
@@ -320,10 +319,11 @@ def parse(what: StartupDetails) -> RuntimeTaskInstance:
         name=bundle_info.name,
         version=bundle_info.version,
     )
+    bundle_instance.initialize()
 
-    dag_absolute_path = os.fspath(Path(bundle_instance.path, what.dag_rel_path))
+    # TODO AIP-66: switch to specific file once relative_fileloc work is done
     bag = DagBag(
-        dag_folder=dag_absolute_path,
+        dag_folder=bundle_instance.path,
         include_examples=False,
         safe_mode=False,
         load_op_links=False,


### PR DESCRIPTION
Temporarily switch back to parsing the whole bundle during execution, just until we have a reliable way to determine the relative filename.

We also need to call `initialize()` on the bundle!