### PR TITLE
Remove log asserts from HDFS tests

### DIFF
--- a/providers/tests/apache/hdfs/sensors/test_web_hdfs.py
+++ b/providers/tests/apache/hdfs/sensors/test_web_hdfs.py
@@ -62,7 +62,7 @@ class TestWebHdfsSensor:
 
 class TestMultipleFilesWebHdfsSensor:
     @mock.patch("airflow.providers.apache.hdfs.hooks.webhdfs.WebHDFSHook")
-    def test_poke(self, mock_hook, caplog):
+    def test_poke(self, mock_hook):
         mock_hook.return_value.get_conn.return_value.list.return_value = TEST_HDFS_FILENAMES
 
         sensor = MultipleFilesWebHdfsSensor(
@@ -72,18 +72,16 @@ class TestMultipleFilesWebHdfsSensor:
             expected_filenames=TEST_HDFS_FILENAMES,
         )
 
-        with caplog.at_level("DEBUG", logger=sensor.log.name):
-            result = sensor.poke(dict())
+        result = sensor.poke(dict())
 
         assert result
-        assert "Files Found in directory: " in caplog.text
 
         mock_hook.return_value.get_conn.return_value.list.assert_called_once_with(TEST_HDFS_DIRECTORY)
         mock_hook.return_value.get_conn.assert_called_once()
         mock_hook.assert_called_once_with(TEST_HDFS_CONN)
 
     @mock.patch("airflow.providers.apache.hdfs.hooks.webhdfs.WebHDFSHook")
-    def test_poke_should_return_false_for_missing_file(self, mock_hook, caplog):
+    def test_poke_should_return_false_for_missing_file(self, mock_hook):
         mock_hook.return_value.get_conn.return_value.list.return_value = TEST_HDFS_FILENAMES[0]
 
         sensor = MultipleFilesWebHdfsSensor(
@@ -95,7 +93,6 @@ class TestMultipleFilesWebHdfsSensor:
         exists = sensor.poke(dict())
 
         assert not exists
-        assert "There are missing files: " in caplog.text
 
         mock_hook.return_value.get_conn.return_value.list.assert_called_once_with(TEST_HDFS_DIRECTORY)
         mock_hook.return_value.get_conn.assert_called_once()


### PR DESCRIPTION
I am not a fan of ... actually I dislike caplog to implement tests expecting logs. On one side it does not tell anything about the tested function, it needs to know internals of logging and... as today it often causes problems if log settigns side effects jjust break the test.

For the HDFS test, the check for caplog does not bring any benefit in my view, therefore removing caplog w/o replacement. This repairs parts of broken main in https://github.com/apache/airflow/actions/runs/13038931877/job/36376761299