### PR TITLE
Remove log tests from  Livy

### DIFF
--- a/providers/tests/apache/livy/operators/test_livy.py
+++ b/providers/tests/apache/livy/operators/test_livy.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -147,32 +146,6 @@ class TestLivyOperator:
         task.kill()
 
         mock_delete.assert_called_once_with(BATCH_ID)
-
-    @patch(
-        "airflow.providers.apache.livy.operators.livy.LivyHook.get_batch_state",
-        return_value=BatchState.SUCCESS,
-    )
-    @patch("airflow.providers.apache.livy.operators.livy.LivyHook.get_batch_logs", return_value=LOG_RESPONSE)
-    @patch("airflow.providers.apache.livy.operators.livy.LivyHook.post_batch", return_value=BATCH_ID)
-    @patch("airflow.providers.apache.livy.operators.livy.LivyHook.get_batch", return_value=GET_BATCH)
-    def test_log_dump(self, mock_get_batch, mock_post, mock_get_logs, mock_get, caplog):
-        task = LivyOperator(
-            livy_conn_id="livyunittest",
-            file="sparkapp",
-            dag=self.dag,
-            task_id="livy_example",
-            polling_interval=1,
-        )
-        caplog.clear()
-        with caplog.at_level(level=logging.INFO, logger=task.hook.log.name):
-            task.execute(context=self.mock_context)
-
-        assert "first_line" in caplog.messages
-        assert "second_line" in caplog.messages
-        assert "third_line" in caplog.messages
-
-        mock_get.assert_called_once_with(BATCH_ID, retry_args=None)
-        mock_get_logs.assert_called_once_with(BATCH_ID, 0, 100)
 
     @patch(
         "airflow.providers.apache.livy.operators.livy.LivyHook.dump_batch_logs",
@@ -318,34 +291,6 @@ class TestLivyOperator:
         task.kill()
 
         mock_delete.assert_called_once_with(BATCH_ID)
-
-    @patch(
-        "airflow.providers.apache.livy.operators.livy.LivyHook.get_batch_state",
-        return_value=BatchState.SUCCESS,
-    )
-    @patch("airflow.providers.apache.livy.operators.livy.LivyHook.get_batch_logs", return_value=LOG_RESPONSE)
-    @patch("airflow.providers.apache.livy.operators.livy.LivyHook.post_batch", return_value=BATCH_ID)
-    @patch("airflow.providers.apache.livy.operators.livy.LivyHook.get_batch", return_value=GET_BATCH)
-    def test_log_dump_deferrable(self, mock_get_batch, mock_post, mock_get_logs, mock_get, caplog):
-        task = LivyOperator(
-            livy_conn_id="livyunittest",
-            file="sparkapp",
-            dag=self.dag,
-            task_id="livy_example",
-            polling_interval=1,
-            deferrable=True,
-        )
-        caplog.clear()
-
-        with caplog.at_level(level=logging.INFO, logger=task.hook.log.name):
-            task.execute(context=self.mock_context)
-
-            assert "first_line" in caplog.messages
-            assert "second_line" in caplog.messages
-            assert "third_line" in caplog.messages
-
-        mock_get.assert_called_once_with(BATCH_ID, retry_args=None)
-        mock_get_logs.assert_called_once_with(BATCH_ID, 0, 100)
 
     @patch("airflow.providers.apache.livy.operators.livy.LivyHook.get_batch", return_value={"appId": APP_ID})
     @patch("airflow.providers.apache.livy.operators.livy.LivyHook.post_batch", return_value=BATCH_ID)


### PR DESCRIPTION
Similarly to #46263 - there is no real value in keeping tests for logs in Livy - and caplog tests are known to be super vulnerable to side-effects from other tests. Since those tests add no value, we should just remove them without replacement.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
