### PR TITLE
Validate body to be defined when the server/network is not available.

### DIFF
--- a/airflow/ui/src/components/ErrorAlert.tsx
+++ b/airflow/ui/src/components/ErrorAlert.tsx
@@ -23,7 +23,7 @@ import type { HTTPExceptionResponse, HTTPValidationError } from "openapi-gen/req
 import { Alert } from "./ui";
 
 type ExpandedApiError = {
-  body: HTTPExceptionResponse | HTTPValidationError;
+  body: HTTPExceptionResponse | HTTPValidationError | undefined;
 } & ApiError;
 
 type Props = {
@@ -37,7 +37,7 @@ export const ErrorAlert = ({ error: err }: Props) => {
     return undefined;
   }
 
-  const details = error.body.detail;
+  const details = error.body?.detail;
   let detailMessage;
 
   if (details !== undefined) {


### PR DESCRIPTION
I noticed few times during development when the fastapi server is restarting or down with UI open where `error.body` is not defined resulting in below stacktrace and UI crashing.

To reproduce : 

1. Run fastapi in dev mode
2. Open home page
3. Stop fastapi server and navigate to another page in UI.

Before 

![image](https://github.com/user-attachments/assets/df30c348-20b6-4b19-83d1-9cc528afaa0c)

After PR

![image](https://github.com/user-attachments/assets/47902af6-e833-4f35-adc4-59fc4dcb3a0a)

