### PR TITLE
Try and reduce flakiness of number of test call asserts

### DIFF
--- a/providers/tests/dbt/cloud/operators/test_dbt.py
+++ b/providers/tests/dbt/cloud/operators/test_dbt.py
@@ -285,9 +285,11 @@ class TestDbtCloudRunJobOperator:
             else:
                 # When the job run status is not in a terminal status or "Success", the operator will
                 # continue to call ``get_job_run()`` until a ``timeout`` number of seconds has passed
-                # (3 seconds for this test).  Therefore, there should be 4 calls of this function: one
-                # initially and 3 for each check done at a 1 second interval.
-                assert mock_get_job_run.call_count == 4
+                assert mock_get_job_run.call_count >= 1
+
+                # To make it more dynamic, try and calculate number of calls
+                max_number_of_calls = timeout // self.config["check_interval"] + 1
+                assert mock_get_job_run.call_count <= max_number_of_calls
 
     @patch.object(DbtCloudHook, "trigger_job_run")
     @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Saw such failures in CI:
```
TestDbtCloudRunJobOperator.test_execute_wait_for_termination[default_account-2-timeout] _
providers/tests/dbt/cloud/operators/test_dbt.py:290: in test_execute_wait_for_termination
    assert mock_get_job_run.call_count == 4
E   AssertionError: assert 2 == 4
E    +  where 2 = <MagicMock name='get_job_run' id='139851324412688'>.call_count
```

Example run https://github.com/apache/airflow/actions/runs/13044119066

We can just make it more dynamic by expecting the max calls and asserting that we have finished sooner.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
