### PR TITLE
Make  racy test test_start_pod_startup_interval_seconds less racy

### DIFF
--- a/providers/tests/cncf/kubernetes/utils/test_pod_manager.py
+++ b/providers/tests/cncf/kubernetes/utils/test_pod_manager.py
@@ -404,8 +404,7 @@ class TestPodManager:
                 startup_timeout=0,
             )
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.time.sleep")
-    def test_start_pod_startup_interval_seconds(self, mock_time_sleep):
+    def test_start_pod_startup_interval_seconds(self):
         pod_info_pending = mock.MagicMock(**{"status.phase": PodPhase.PENDING})
         pod_info_succeeded = mock.MagicMock(**{"status.phase": PodPhase.SUCCEEDED})
 
@@ -415,15 +414,21 @@ class TestPodManager:
             while True:
                 yield pod_info_succeeded
 
-        self.mock_kube_client.read_namespaced_pod.side_effect = pod_state_gen()
-        startup_check_interval = 10  # Any value is fine, as time.sleep is mocked to do nothing
-        mock_pod = MagicMock()
-        self.pod_manager.await_pod_start(
-            pod=mock_pod,
-            startup_timeout=60,  # Never hit, any value is fine, as time.sleep is mocked to do nothing
-            startup_check_interval=startup_check_interval,
-        )
-        mock_time_sleep.assert_called_with(startup_check_interval)
+        import time
+
+        # Avoid race condition when we can run to a lot of sleeps when mock takes no time at all
+        original_time_sleep = time.sleep
+        with mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.time.sleep") as mock_time_sleep:
+            mock_time_sleep.side_effect = lambda _: original_time_sleep(0.2)
+            self.mock_kube_client.read_namespaced_pod.side_effect = pod_state_gen()
+            startup_check_interval = 10  # Any value is fine, as time.sleep is mocked to do almost nothing
+            mock_pod = MagicMock()
+            self.pod_manager.await_pod_start(
+                pod=mock_pod,
+                startup_timeout=60,  # Never hit, any value is fine, as time.sleep is mocked to do nothing
+                startup_check_interval=startup_check_interval,
+            )
+            mock_time_sleep.assert_called_with(startup_check_interval)
         assert mock_time_sleep.call_count == 2
 
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.container_is_running")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
