### PR TITLE
feat: Add ProcessingEngineRunFacet to all OL events

### DIFF
--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/adapter.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/adapter.py
@@ -251,6 +251,7 @@ class OpenLineageAdapter(LoggingMixin):
         run_facets = run_facets or {}
         if task:
             run_facets = {**task.run_facets, **run_facets}
+        run_facets = {**run_facets, **get_processing_engine_facet()}  # type: ignore
         event = RunEvent(
             eventType=RunState.COMPLETE,
             eventTime=end_time,
@@ -296,6 +297,7 @@ class OpenLineageAdapter(LoggingMixin):
         run_facets = run_facets or {}
         if task:
             run_facets = {**task.run_facets, **run_facets}
+        run_facets = {**run_facets, **get_processing_engine_facet()}  # type: ignore
 
         if error:
             stack_trace = None
@@ -391,6 +393,7 @@ class OpenLineageAdapter(LoggingMixin):
                     facets={
                         **get_airflow_state_run_facet(dag_id, run_id, task_ids, dag_run_state),
                         **get_airflow_debug_facet(),
+                        **get_processing_engine_facet(),
                         **run_facets,
                     },
                 ),
@@ -434,6 +437,7 @@ class OpenLineageAdapter(LoggingMixin):
                         ),
                         **get_airflow_state_run_facet(dag_id, run_id, task_ids, dag_run_state),
                         **get_airflow_debug_facet(),
+                        **get_processing_engine_facet(),
                         **run_facets,
                     },
                 ),

--- a/providers/openlineage/tests/provider_tests/openlineage/plugins/test_adapter.py
+++ b/providers/openlineage/tests/provider_tests/openlineage/plugins/test_adapter.py
@@ -302,7 +302,14 @@ def test_emit_complete_event(mock_stats_incr, mock_stats_timer):
             RunEvent(
                 eventType=RunState.COMPLETE,
                 eventTime=event_time,
-                run=Run(runId=run_id, facets={}),
+                run=Run(
+                    runId=run_id,
+                    facets={
+                        "processing_engine": processing_engine_run.ProcessingEngineRunFacet(
+                            version=ANY, name="Airflow", openlineageAdapterVersion=ANY
+                        )
+                    },
+                ),
                 job=Job(
                     namespace=namespace(),
                     name="job",
@@ -366,6 +373,9 @@ def test_emit_complete_event_with_additional_information(mock_stats_incr, mock_s
                             run=parent_run.Run(runId=parent_run_id),
                             job=parent_run.Job(namespace=namespace(), name="parent_job_name"),
                         ),
+                        "processing_engine": processing_engine_run.ProcessingEngineRunFacet(
+                            version=ANY, name="Airflow", openlineageAdapterVersion=ANY
+                        ),
                         "externalQuery": external_query_run.ExternalQueryRunFacet(
                             externalQueryId="123", source="source"
                         ),
@@ -421,7 +431,14 @@ def test_emit_failed_event(mock_stats_incr, mock_stats_timer):
             RunEvent(
                 eventType=RunState.FAIL,
                 eventTime=event_time,
-                run=Run(runId=run_id, facets={}),
+                run=Run(
+                    runId=run_id,
+                    facets={
+                        "processing_engine": processing_engine_run.ProcessingEngineRunFacet(
+                            version=ANY, name="Airflow", openlineageAdapterVersion=ANY
+                        )
+                    },
+                ),
                 job=Job(
                     namespace=namespace(),
                     name="job",
@@ -484,6 +501,9 @@ def test_emit_failed_event_with_additional_information(mock_stats_incr, mock_sta
                     "parent": parent_run.ParentRunFacet(
                         run=parent_run.Run(runId=parent_run_id),
                         job=parent_run.Job(namespace=namespace(), name="parent_job_name"),
+                    ),
+                    "processing_engine": processing_engine_run.ProcessingEngineRunFacet(
+                        version=ANY, name="Airflow", openlineageAdapterVersion=ANY
                     ),
                     "errorMessage": error_message_run.ErrorMessageRunFacet(
                         message="Error message", programmingLanguage="python", stackTrace=None
@@ -731,6 +751,9 @@ def test_emit_dag_complete_event(
                             task_2.task_id: TaskInstanceState.FAILED,
                         },
                     ),
+                    "processing_engine": processing_engine_run.ProcessingEngineRunFacet(
+                        version=ANY, name="Airflow", openlineageAdapterVersion=ANY
+                    ),
                     "debug": AirflowDebugRunFacet(packages=ANY),
                     "airflowDagRun": AirflowDagRunFacet(dag={"description": "dag desc"}, dagRun=dag_run),
                 },
@@ -826,6 +849,9 @@ def test_emit_dag_failed_event(
                             task_1.task_id: TaskInstanceState.SKIPPED,
                             task_2.task_id: TaskInstanceState.FAILED,
                         },
+                    ),
+                    "processing_engine": processing_engine_run.ProcessingEngineRunFacet(
+                        version=ANY, name="Airflow", openlineageAdapterVersion=ANY
                     ),
                     "debug": AirflowDebugRunFacet(packages=ANY),
                     "airflowDagRun": AirflowDagRunFacet(dag={"description": "dag desc"}, dagRun=dag_run),


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
ProcessingEngineRunFacet was added in #43213 only for start events. As it is useful for debugging and lightweight, i think we can extend it to all OpenLineage events.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
