### PR TITLE
Limit Apache Beam's numpy used

### DIFF
--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -76,6 +76,7 @@
     "deps": [
       "apache-airflow>=2.9.0",
       "apache-beam>=2.53.0",
+      "numpy>=1.26.0",
       "pyarrow>=14.0.1"
     ],
     "devel-deps": [],

--- a/providers/apache/beam/README.rst
+++ b/providers/apache/beam/README.rst
@@ -57,6 +57,7 @@ PIP package         Version required
 ``apache-airflow``  ``>=2.9.0``
 ``apache-beam``     ``>=2.53.0``
 ``pyarrow``         ``>=14.0.1``
+``numpy``           ``>=1.26.0``
 ==================  ==================
 
 Cross provider package dependencies

--- a/providers/apache/beam/pyproject.toml
+++ b/providers/apache/beam/pyproject.toml
@@ -59,6 +59,7 @@ dependencies = [
     # Apache Beam > 2.53.0 and pyarrow > 14.0.1 fix https://nvd.nist.gov/vuln/detail/CVE-2023-47248.
     "apache-beam>=2.53.0",
     "pyarrow>=14.0.1",
+    "numpy>=1.26.0",
 ]
 
 # The optional dependencies should be modified in place in the generated file

--- a/providers/apache/beam/src/airflow/providers/apache/beam/get_provider_info.py
+++ b/providers/apache/beam/src/airflow/providers/apache/beam/get_provider_info.py
@@ -93,7 +93,7 @@ def get_provider_info():
                 "python-modules": ["airflow.providers.apache.beam.triggers.beam"],
             }
         ],
-        "dependencies": ["apache-airflow>=2.9.0", "apache-beam>=2.53.0", "pyarrow>=14.0.1"],
+        "dependencies": ["apache-airflow>=2.9.0", "apache-beam>=2.53.0", "pyarrow>=14.0.1", "numpy>=1.26.0"],
         "optional-dependencies": {
             "google": ["apache-beam[gcp]"],
             "common.compat": ["apache-airflow-providers-common-compat"],


### PR DESCRIPTION
Separating beam out reveald that the lower limit for numpy migh lead to installation problems on newer package managers and python versions (lack of distutils installed by default in Python 3.12 in causes older versions of numpy to not build and uv / pip trying to install it will fail.

This PR lower-binds numpy to mid-2023 version.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
