### PR TITLE
Fix side effect of not tearing down mongo hook in tests

### DIFF
--- a/providers/mongo/src/airflow/providers/mongo/hooks/mongo.py
+++ b/providers/mongo/src/airflow/providers/mongo/hooks/mongo.py
@@ -193,6 +193,9 @@ class MongoHook(BaseHook):
         self.client = MongoClient(self.uri, **options)
         return self.client
 
+    def close(self):
+        self.client.close()
+
     def _create_uri(self) -> str:
         """
         Create URI string from the given credentials.

--- a/providers/mongo/tests/provider_tests/mongo/hooks/test_mongo.py
+++ b/providers/mongo/tests/provider_tests/mongo/hooks/test_mongo.py
@@ -97,6 +97,9 @@ class TestMongoHook:
         self.hook = MongoHookTest(mongo_conn_id="mongo_default")
         self.conn = self.hook.get_conn()
 
+    def teardown_method(self):
+        self.conn.close()
+
     def test_mongo_conn_id(self):
         # Use default "mongo_default"
         assert MongoHook().mongo_conn_id == "mongo_default"


### PR DESCRIPTION
The MongoClient apparently starts a separate thread that runs an active loop that performs sleep every 0.5 second. MongoClient is stored in the Hook and hooks/test_mongo.py stored the hook as object in the test class, which means that the thread has not been torn down and continued to run after mongo tests completed.

Subsequently any test that was mocking time.sleep (and skipping waiting) had been spammed by mongo client thread calling sleep() - potentially many times.

Earlier attempts to fix this had not succeeded - so they are reverted now as part of this PR, as the original patching of sleep was much nicer there.

Revert "Make  racy test test_start_pod_startup_interval_seconds less racy (#46282)"

This reverts commit 60f0abf4ced92c8c6fd6343092b53e802c41eb72.

Revert "Make azure test less flaky/racy (#46281)"

This reverts commit ae55e2224493ff812135ca7e8a64de2aeca8317d.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
