### PR TITLE
Add autorefresh to dag page

### DIFF
--- a/airflow/ui/src/components/TaskTrySelect.tsx
+++ b/airflow/ui/src/components/TaskTrySelect.tsx
@@ -21,8 +21,7 @@ import { Button, createListCollection, HStack, VStack, Heading } from "@chakra-u
 import { useTaskInstanceServiceGetMappedTaskInstanceTries } from "openapi/queries";
 import type { TaskInstanceHistoryResponse, TaskInstanceResponse } from "openapi/requests/types.gen";
 import { StateBadge } from "src/components/StateBadge";
-import { useConfig } from "src/queries/useConfig";
-import { isStatePending } from "src/utils";
+import { isStatePending, useAutoRefresh } from "src/utils";
 
 import TaskInstanceTooltip from "./TaskInstanceTooltip";
 import { Select } from "./ui";
@@ -43,7 +42,7 @@ export const TaskTrySelect = ({ onSelectTryNumber, selectedTryNumber, taskInstan
     try_number: finalTryNumber,
   } = taskInstance;
 
-  const autoRefreshInterval = useConfig("auto_refresh_interval") as number;
+  const refetchInterval = useAutoRefresh({ dagId });
 
   const { data: tiHistory } = useTaskInstanceServiceGetMappedTaskInstanceTries(
     {
@@ -59,7 +58,7 @@ export const TaskTrySelect = ({ onSelectTryNumber, selectedTryNumber, taskInstan
         // We actually want to use || here
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         query.state.data?.task_instances.some((ti) => isStatePending(ti.state)) || isStatePending(state)
-          ? autoRefreshInterval * 1000
+          ? refetchInterval
           : false,
     },
   );

--- a/airflow/ui/src/components/TaskTrySelect.tsx
+++ b/airflow/ui/src/components/TaskTrySelect.tsx
@@ -22,7 +22,7 @@ import { useTaskInstanceServiceGetMappedTaskInstanceTries } from "openapi/querie
 import type { TaskInstanceHistoryResponse, TaskInstanceResponse } from "openapi/requests/types.gen";
 import { StateBadge } from "src/components/StateBadge";
 import { useConfig } from "src/queries/useConfig";
-import { isStatePending } from "src/utils/refresh";
+import { isStatePending } from "src/utils";
 
 import TaskInstanceTooltip from "./TaskInstanceTooltip";
 import { Select } from "./ui";

--- a/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -55,7 +55,7 @@ const TriggerDAGForm = ({ dagId, onClose, open }: TriggerDAGFormProps) => {
     error: errorTrigger,
     isPending,
     triggerDagRun,
-  } = useTrigger({ onSuccessConfirm: onClose });
+  } = useTrigger({ dagId, onSuccessConfirm: onClose });
   const { conf, setConf } = useParamStore();
 
   const { control, handleSubmit, reset, watch } = useForm<DagRunTriggerParams>({
@@ -85,7 +85,7 @@ const TriggerDAGForm = ({ dagId, onClose, open }: TriggerDAGFormProps) => {
   const dataIntervalEnd = watch("dataIntervalEnd");
 
   const onSubmit = (data: DagRunTriggerParams) => {
-    triggerDagRun(dagId, data);
+    triggerDagRun(data);
   };
 
   const validateAndPrettifyJson = (value: string) => {

--- a/airflow/ui/src/constants/sortParams.ts
+++ b/airflow/ui/src/constants/sortParams.ts
@@ -24,14 +24,14 @@ export const dagSortOptions = createListCollection({
     { label: "Sort by Display Name (Z-A)", value: "-dag_display_name" },
     { label: "Sort by Next DAG Run (Earliest-Latest)", value: "next_dagrun" },
     { label: "Sort by Next DAG Run (Latest-Earliest)", value: "-next_dagrun" },
-    { label: "Sort by Last Run State (A-Z)", value: "last_run_state" },
-    { label: "Sort by Last Run State (Z-A)", value: "-last_run_state" },
+    { label: "Sort by Latest Run State (A-Z)", value: "last_run_state" },
+    { label: "Sort by Latest Run State (Z-A)", value: "-last_run_state" },
     {
-      label: "Sort by Last Run Start Date (Earliest-Latest)",
+      label: "Sort by Latest Run Start Date (Earliest-Latest)",
       value: "last_run_start_date",
     },
     {
-      label: "Sort by Last Run Start Date (Latest-Earliest)",
+      label: "Sort by Latest Run Start Date (Latest-Earliest)",
       value: "-last_run_start_date",
     },
   ],

--- a/airflow/ui/src/pages/Dag/Dag.tsx
+++ b/airflow/ui/src/pages/Dag/Dag.tsx
@@ -68,7 +68,17 @@ export const Dag = () => {
     <DetailsLayout dag={dag} error={error ?? runsError} isLoading={isLoading || isLoadingRuns} tabs={tabs}>
       <Header
         dag={
-          dag ? ({ ...dag, ...dagWithRuns } as DAGDetailsResponse & DAGWithLatestDagRunsResponse) : undefined
+          dag
+            ? ({
+                ...dag,
+                // We only need to refresh latest runs and next run
+                latest_dag_runs: dagWithRuns?.latest_dag_runs,
+                next_dagrun: dagWithRuns?.next_dagrun,
+                next_dagrun_create_after: dagWithRuns?.next_dagrun_create_after,
+                next_dagrun_data_interval_end: dagWithRuns?.next_dagrun_data_interval_end,
+                next_dagrun_data_interval_start: dagWithRuns?.next_dagrun_data_interval_start,
+              } as DAGDetailsResponse & DAGWithLatestDagRunsResponse)
+            : undefined
         }
         dagId={dagId}
         isRefreshing={Boolean(

--- a/airflow/ui/src/pages/Dag/Dag.tsx
+++ b/airflow/ui/src/pages/Dag/Dag.tsx
@@ -21,8 +21,7 @@ import { useParams } from "react-router-dom";
 import { useDagServiceGetDagDetails, useDagsServiceRecentDagRuns } from "openapi/queries";
 import type { DAGDetailsResponse, DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
 import { DetailsLayout } from "src/layouts/Details/DetailsLayout";
-import { useConfig } from "src/queries/useConfig";
-import { isStatePending } from "src/utils";
+import { isStatePending, useAutoRefresh } from "src/utils";
 
 import { Header } from "./Header";
 
@@ -45,7 +44,7 @@ export const Dag = () => {
     dagId,
   });
 
-  const autoRefreshInterval = useConfig("auto_refresh_interval") as number;
+  const refetchInterval = useAutoRefresh({ dagId });
 
   // TODO: replace with with a list dag runs by dag id request
   const {
@@ -58,7 +57,7 @@ export const Dag = () => {
       query.state.data?.dags
         .find((recentDag) => recentDag.dag_id === dagId)
         ?.latest_dag_runs.some((run) => isStatePending(run.state))
-        ? autoRefreshInterval * 1000
+        ? refetchInterval
         : false,
   });
 
@@ -82,7 +81,7 @@ export const Dag = () => {
         }
         dagId={dagId}
         isRefreshing={Boolean(
-          dagWithRuns?.latest_dag_runs.some((dr) => isStatePending(dr.state)) && autoRefreshInterval,
+          dagWithRuns?.latest_dag_runs.some((dr) => isStatePending(dr.state)) && Boolean(refetchInterval),
         )}
       />
     </DetailsLayout>

--- a/airflow/ui/src/pages/Dag/Dag.tsx
+++ b/airflow/ui/src/pages/Dag/Dag.tsx
@@ -19,7 +19,6 @@
 import { useParams } from "react-router-dom";
 
 import { useDagServiceGetDagDetails, useDagsServiceRecentDagRuns } from "openapi/queries";
-import type { DAGDetailsResponse, DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
 import { DetailsLayout } from "src/layouts/Details/DetailsLayout";
 import { isStatePending, useAutoRefresh } from "src/utils";
 
@@ -66,20 +65,8 @@ export const Dag = () => {
   return (
     <DetailsLayout dag={dag} error={error ?? runsError} isLoading={isLoading || isLoadingRuns} tabs={tabs}>
       <Header
-        dag={
-          dag
-            ? ({
-                ...dag,
-                // We only need to refresh latest runs and next run
-                latest_dag_runs: dagWithRuns?.latest_dag_runs,
-                next_dagrun: dagWithRuns?.next_dagrun,
-                next_dagrun_create_after: dagWithRuns?.next_dagrun_create_after,
-                next_dagrun_data_interval_end: dagWithRuns?.next_dagrun_data_interval_end,
-                next_dagrun_data_interval_start: dagWithRuns?.next_dagrun_data_interval_start,
-              } as DAGDetailsResponse & DAGWithLatestDagRunsResponse)
-            : undefined
-        }
-        dagId={dagId}
+        dag={dag}
+        dagWithRuns={dagWithRuns}
         isRefreshing={Boolean(
           dagWithRuns?.latest_dag_runs.some((dr) => isStatePending(dr.state)) && Boolean(refetchInterval),
         )}

--- a/airflow/ui/src/pages/Dag/Header.tsx
+++ b/airflow/ui/src/pages/Dag/Header.tsx
@@ -16,10 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Flex, Heading, HStack, SimpleGrid, Text } from "@chakra-ui/react";
+import { Box, Flex, Heading, HStack, SimpleGrid, Spinner, Text } from "@chakra-ui/react";
 import { FiBookOpen, FiCalendar } from "react-icons/fi";
 
-import type { DAGDetailsResponse, DAGRunResponse } from "openapi/requests/types.gen";
+import type { DAGDetailsResponse, DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
 import { DagIcon } from "src/assets/DagIcon";
 import DagRunInfo from "src/components/DagRunInfo";
 import DisplayMarkdownButton from "src/components/DisplayMarkdownButton";
@@ -34,86 +34,95 @@ import { DagTags } from "../DagsList/DagTags";
 export const Header = ({
   dag,
   dagId,
-  latestRun,
+  isRefreshing,
 }: {
-  readonly dag?: DAGDetailsResponse;
+  readonly dag?: DAGDetailsResponse & DAGWithLatestDagRunsResponse;
   readonly dagId?: string;
-  readonly latestRun?: DAGRunResponse;
-}) => (
-  <Box borderColor="border" borderRadius={8} borderWidth={1} p={2}>
-    <Box p={2}>
-      <Flex alignItems="center" justifyContent="space-between">
-        <HStack alignItems="center" gap={2}>
-          <DagIcon height={8} width={8} />
-          <Heading size="lg">{dag?.dag_display_name ?? dagId}</Heading>
-          {dag !== undefined && (
-            <TogglePause dagDisplayName={dag.dag_display_name} dagId={dag.dag_id} isPaused={dag.is_paused} />
-          )}
-        </HStack>
-        <Flex>
-          {dag ? (
-            <HStack>
-              {dag.doc_md === null ? undefined : (
-                <DisplayMarkdownButton
-                  header="Dag Documentation"
-                  icon={<FiBookOpen />}
-                  mdContent={dag.doc_md}
-                  text="Dag Docs"
-                />
-              )}
-              <ParseDag dagId={dag.dag_id} fileToken={dag.file_token} />
-              <TriggerDAGButton dag={dag} />
-            </HStack>
-          ) : undefined}
+  readonly isRefreshing?: boolean;
+}) => {
+  const latestRun = dag?.latest_dag_runs ? dag.latest_dag_runs[0] : undefined;
+
+  return (
+    <Box borderColor="border" borderRadius={8} borderWidth={1} p={2}>
+      <Box p={2}>
+        <Flex alignItems="center" justifyContent="space-between">
+          <HStack alignItems="center" gap={2}>
+            <DagIcon height={8} width={8} />
+            <Heading size="lg">{dag?.dag_display_name ?? dagId}</Heading>
+            {dag !== undefined && (
+              <TogglePause
+                dagDisplayName={dag.dag_display_name}
+                dagId={dag.dag_id}
+                isPaused={dag.is_paused}
+              />
+            )}
+            {isRefreshing ? <Spinner /> : <div />}
+          </HStack>
+          <Flex>
+            {dag ? (
+              <HStack>
+                {dag.doc_md === null ? undefined : (
+                  <DisplayMarkdownButton
+                    header="Dag Documentation"
+                    icon={<FiBookOpen />}
+                    mdContent={dag.doc_md}
+                    text="Dag Docs"
+                  />
+                )}
+                <ParseDag dagId={dag.dag_id} fileToken={dag.file_token} />
+                <TriggerDAGButton dag={dag} />
+              </HStack>
+            ) : undefined}
+          </Flex>
         </Flex>
+        <SimpleGrid columns={4} gap={4} my={2}>
+          <Stat label="Schedule">
+            {Boolean(dag?.timetable_summary) ? (
+              <Tooltip content={dag?.timetable_description}>
+                <Text fontSize="sm">
+                  <FiCalendar style={{ display: "inline" }} /> {dag?.timetable_summary}
+                </Text>
+              </Tooltip>
+            ) : undefined}
+          </Stat>
+          <Stat label="Latest Run">
+            {Boolean(latestRun) && latestRun !== undefined ? (
+              <DagRunInfo
+                dataIntervalEnd={latestRun.data_interval_end}
+                dataIntervalStart={latestRun.data_interval_start}
+                endDate={latestRun.end_date}
+                startDate={latestRun.start_date}
+                state={latestRun.state}
+              />
+            ) : undefined}
+          </Stat>
+          <Stat label="Next Run">
+            {Boolean(dag?.next_dagrun) && dag !== undefined ? (
+              <DagRunInfo
+                dataIntervalEnd={dag.next_dagrun_data_interval_end}
+                dataIntervalStart={dag.next_dagrun_data_interval_start}
+                nextDagrunCreateAfter={dag.next_dagrun_create_after}
+              />
+            ) : undefined}
+          </Stat>
+          <div />
+          <div />
+        </SimpleGrid>
+      </Box>
+      <Flex
+        alignItems="center"
+        bg="bg.muted"
+        borderTopColor="border"
+        borderTopWidth={1}
+        color="fg.subtle"
+        fontSize="sm"
+        justifyContent="space-between"
+        px={2}
+        py={1}
+      >
+        <Text>Owner: {dag?.owners.join(", ")}</Text>
+        <DagTags tags={dag?.tags ?? []} />
       </Flex>
-      <SimpleGrid columns={4} gap={4} my={2}>
-        <Stat label="Schedule">
-          {Boolean(dag?.timetable_summary) ? (
-            <Tooltip content={dag?.timetable_description}>
-              <Text fontSize="sm">
-                <FiCalendar style={{ display: "inline" }} /> {dag?.timetable_summary}
-              </Text>
-            </Tooltip>
-          ) : undefined}
-        </Stat>
-        <Stat label="Last Run">
-          {Boolean(latestRun) && latestRun !== undefined ? (
-            <DagRunInfo
-              dataIntervalEnd={latestRun.data_interval_end}
-              dataIntervalStart={latestRun.data_interval_start}
-              endDate={latestRun.end_date}
-              startDate={latestRun.start_date}
-              state={latestRun.state}
-            />
-          ) : undefined}
-        </Stat>
-        <Stat label="Next Run">
-          {Boolean(dag?.next_dagrun) && dag !== undefined ? (
-            <DagRunInfo
-              dataIntervalEnd={dag.next_dagrun_data_interval_end}
-              dataIntervalStart={dag.next_dagrun_data_interval_start}
-              nextDagrunCreateAfter={dag.next_dagrun_create_after}
-            />
-          ) : undefined}
-        </Stat>
-        <div />
-        <div />
-      </SimpleGrid>
     </Box>
-    <Flex
-      alignItems="center"
-      bg="bg.muted"
-      borderTopColor="border"
-      borderTopWidth={1}
-      color="fg.subtle"
-      fontSize="sm"
-      justifyContent="space-between"
-      px={2}
-      py={1}
-    >
-      <Text>Owner: {dag?.owners.join(", ")}</Text>
-      <DagTags tags={dag?.tags ?? []} />
-    </Flex>
-  </Box>
-);
+  );
+};

--- a/airflow/ui/src/pages/Dag/Header.tsx
+++ b/airflow/ui/src/pages/Dag/Header.tsx
@@ -18,6 +18,7 @@
  */
 import { Box, Flex, Heading, HStack, SimpleGrid, Spinner, Text } from "@chakra-ui/react";
 import { FiBookOpen, FiCalendar } from "react-icons/fi";
+import { useParams } from "react-router-dom";
 
 import type { DAGDetailsResponse, DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
 import { DagIcon } from "src/assets/DagIcon";
@@ -33,14 +34,16 @@ import { DagTags } from "../DagsList/DagTags";
 
 export const Header = ({
   dag,
-  dagId,
+  dagWithRuns,
   isRefreshing,
 }: {
-  readonly dag?: DAGDetailsResponse & DAGWithLatestDagRunsResponse;
-  readonly dagId?: string;
+  readonly dag?: DAGDetailsResponse;
+  readonly dagWithRuns?: DAGWithLatestDagRunsResponse;
   readonly isRefreshing?: boolean;
 }) => {
-  const latestRun = dag?.latest_dag_runs ? dag.latest_dag_runs[0] : undefined;
+  // We would still like to show the dagId even if the dag object hasn't loaded yet
+  const { dagId } = useParams();
+  const latestRun = dagWithRuns?.latest_dag_runs ? dagWithRuns.latest_dag_runs[0] : undefined;
 
   return (
     <Box borderColor="border" borderRadius={8} borderWidth={1} p={2}>
@@ -97,11 +100,11 @@ export const Header = ({
             ) : undefined}
           </Stat>
           <Stat label="Next Run">
-            {Boolean(dag?.next_dagrun) && dag !== undefined ? (
+            {Boolean(dagWithRuns?.next_dagrun) ? (
               <DagRunInfo
-                dataIntervalEnd={dag.next_dagrun_data_interval_end}
-                dataIntervalStart={dag.next_dagrun_data_interval_start}
-                nextDagrunCreateAfter={dag.next_dagrun_create_after}
+                dataIntervalEnd={dagWithRuns?.next_dagrun_data_interval_end}
+                dataIntervalStart={dagWithRuns?.next_dagrun_data_interval_start}
+                nextDagrunCreateAfter={dagWithRuns?.next_dagrun_create_after}
               />
             ) : undefined}
           </Stat>

--- a/airflow/ui/src/pages/Dag/Runs/Runs.tsx
+++ b/airflow/ui/src/pages/Dag/Runs/Runs.tsx
@@ -40,9 +40,7 @@ import { RunTypeIcon } from "src/components/RunTypeIcon";
 import { StateBadge } from "src/components/StateBadge";
 import Time from "src/components/Time";
 import { Select } from "src/components/ui";
-import { useConfig } from "src/queries/useConfig";
-import { capitalize, getDuration } from "src/utils";
-import { isStatePending } from "src/utils";
+import { capitalize, getDuration, useAutoRefresh, isStatePending } from "src/utils";
 
 const columns: Array<ColumnDef<DAGRunResponse>> = [
   {
@@ -131,7 +129,7 @@ export const Runs = () => {
 
   const filteredState = searchParams.get(STATE_PARAM);
 
-  const autoRefreshInterval = useConfig("auto_refresh_interval") as number;
+  const refetchInterval = useAutoRefresh({ dagId });
 
   const { data, error, isLoading } = useDagRunServiceGetDagRuns(
     {
@@ -145,9 +143,7 @@ export const Runs = () => {
     {
       enabled: !isNaN(pagination.pageSize),
       refetchInterval: (query) =>
-        query.state.data?.dag_runs.some((run) => isStatePending(run.state))
-          ? autoRefreshInterval * 1000
-          : false,
+        query.state.data?.dag_runs.some((run) => isStatePending(run.state)) ? refetchInterval : false,
     },
   );
 

--- a/airflow/ui/src/pages/Dag/Runs/Runs.tsx
+++ b/airflow/ui/src/pages/Dag/Runs/Runs.tsx
@@ -40,7 +40,9 @@ import { RunTypeIcon } from "src/components/RunTypeIcon";
 import { StateBadge } from "src/components/StateBadge";
 import Time from "src/components/Time";
 import { Select } from "src/components/ui";
+import { useConfig } from "src/queries/useConfig";
 import { capitalize, getDuration } from "src/utils";
+import { isStatePending } from "src/utils";
 
 const columns: Array<ColumnDef<DAGRunResponse>> = [
   {
@@ -125,11 +127,13 @@ export const Runs = () => {
   const { setTableURLState, tableURLState } = useTableURLState();
   const { pagination, sorting } = tableURLState;
   const [sort] = sorting;
-  const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : "-start_date";
+  const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : "-logical_date";
 
   const filteredState = searchParams.get(STATE_PARAM);
 
-  const { data, error, isFetching, isLoading } = useDagRunServiceGetDagRuns(
+  const autoRefreshInterval = useConfig("auto_refresh_interval") as number;
+
+  const { data, error, isLoading } = useDagRunServiceGetDagRuns(
     {
       dagId: dagId ?? "~",
       limit: pagination.pageSize,
@@ -138,7 +142,13 @@ export const Runs = () => {
       state: filteredState === null ? undefined : [filteredState],
     },
     undefined,
-    { enabled: !isNaN(pagination.pageSize) },
+    {
+      enabled: !isNaN(pagination.pageSize),
+      refetchInterval: (query) =>
+        query.state.data?.dag_runs.some((run) => isStatePending(run.state))
+          ? autoRefreshInterval * 1000
+          : false,
+    },
   );
 
   const handleStateChange = useCallback(
@@ -197,7 +207,6 @@ export const Runs = () => {
         data={data?.dag_runs ?? []}
         errorMessage={<ErrorAlert error={error} />}
         initialState={tableURLState}
-        isFetching={isFetching}
         isLoading={isLoading}
         modelName="Dag Run"
         onStateChange={setTableURLState}

--- a/airflow/ui/src/pages/Dag/Tasks/TaskCard.tsx
+++ b/airflow/ui/src/pages/Dag/Tasks/TaskCard.tsx
@@ -31,12 +31,11 @@ import { getTaskInstanceLink } from "src/utils/links";
 import { TaskRecentRuns } from "./TaskRecentRuns.tsx";
 
 type Props = {
-  readonly areActiveRuns?: boolean;
   readonly dagId: string;
   readonly task: TaskResponse;
 };
 
-export const TaskCard = ({ areActiveRuns, dagId, task }: Props) => {
+export const TaskCard = ({ dagId, task }: Props) => {
   const autoRefreshInterval = useConfig("auto_refresh_interval") as number;
   const { data } = useTaskInstanceServiceGetTaskInstances(
     {
@@ -50,8 +49,7 @@ export const TaskCard = ({ areActiveRuns, dagId, task }: Props) => {
     {
       enabled: Boolean(dagId) && Boolean(task.task_id),
       refetchInterval: (query) =>
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        areActiveRuns || query.state.data?.task_instances.some((ti) => isStatePending(ti.state))
+        query.state.data?.task_instances.some((ti) => isStatePending(ti.state))
           ? autoRefreshInterval * 1000
           : false,
     },

--- a/airflow/ui/src/pages/Dag/Tasks/TaskCard.tsx
+++ b/airflow/ui/src/pages/Dag/Tasks/TaskCard.tsx
@@ -24,8 +24,7 @@ import type { TaskResponse } from "openapi/requests/types.gen";
 import { StateBadge } from "src/components/StateBadge";
 import TaskInstanceTooltip from "src/components/TaskInstanceTooltip";
 import Time from "src/components/Time";
-import { useConfig } from "src/queries/useConfig.tsx";
-import { isStatePending } from "src/utils";
+import { isStatePending, useAutoRefresh } from "src/utils";
 import { getTaskInstanceLink } from "src/utils/links";
 
 import { TaskRecentRuns } from "./TaskRecentRuns.tsx";
@@ -36,7 +35,8 @@ type Props = {
 };
 
 export const TaskCard = ({ dagId, task }: Props) => {
-  const autoRefreshInterval = useConfig("auto_refresh_interval") as number;
+  const refetchInterval = useAutoRefresh({ dagId });
+
   const { data } = useTaskInstanceServiceGetTaskInstances(
     {
       dagId,
@@ -49,9 +49,7 @@ export const TaskCard = ({ dagId, task }: Props) => {
     {
       enabled: Boolean(dagId) && Boolean(task.task_id),
       refetchInterval: (query) =>
-        query.state.data?.task_instances.some((ti) => isStatePending(ti.state))
-          ? autoRefreshInterval * 1000
-          : false,
+        query.state.data?.task_instances.some((ti) => isStatePending(ti.state)) ? refetchInterval : false,
     },
   );
 

--- a/airflow/ui/src/pages/Dag/Tasks/TaskCard.tsx
+++ b/airflow/ui/src/pages/Dag/Tasks/TaskCard.tsx
@@ -19,58 +19,83 @@
 import { Heading, VStack, Box, SimpleGrid, Text, Link } from "@chakra-ui/react";
 import { Link as RouterLink } from "react-router-dom";
 
-import type { TaskResponse, TaskInstanceResponse } from "openapi/requests/types.gen";
+import { useTaskInstanceServiceGetTaskInstances } from "openapi/queries/queries.ts";
+import type { TaskResponse } from "openapi/requests/types.gen";
 import { StateBadge } from "src/components/StateBadge";
 import TaskInstanceTooltip from "src/components/TaskInstanceTooltip";
 import Time from "src/components/Time";
-import { getTaskInstanceLink } from "src/utils/links.ts";
+import { useConfig } from "src/queries/useConfig.tsx";
+import { isStatePending } from "src/utils";
+import { getTaskInstanceLink } from "src/utils/links";
 
 import { TaskRecentRuns } from "./TaskRecentRuns.tsx";
 
 type Props = {
+  readonly areActiveRuns?: boolean;
   readonly dagId: string;
   readonly task: TaskResponse;
-  readonly taskInstances: Array<TaskInstanceResponse>;
 };
 
-export const TaskCard = ({ dagId, task, taskInstances }: Props) => (
-  <Box borderColor="border.emphasized" borderRadius={8} borderWidth={1} overflow="hidden" px={3} py={2}>
-    <Link asChild color="fg.info" fontWeight="bold">
-      <RouterLink to={`/dags/${dagId}/tasks/${task.task_id}`}>
-        {task.task_display_name ?? task.task_id}
-        {task.is_mapped ? "[]" : undefined}
-      </RouterLink>
-    </Link>
-    <SimpleGrid columns={4} gap={4} height={20}>
-      <VStack align="flex-start" gap={1}>
-        <Heading color="fg.muted" fontSize="xs">
-          Operator
-        </Heading>
-        <Text fontSize="sm">{task.operator_name}</Text>
-      </VStack>
-      <VStack align="flex-start" gap={1}>
-        <Heading color="fg.muted" fontSize="xs">
-          Trigger Rule
-        </Heading>
-        <Text fontSize="sm">{task.trigger_rule}</Text>
-      </VStack>
-      <VStack align="flex-start" gap={1}>
-        <Heading color="fg.muted" fontSize="xs">
-          Last Instance
-        </Heading>
-        {taskInstances[0] ? (
-          <TaskInstanceTooltip taskInstance={taskInstances[0]}>
-            <Link asChild color="fg.info" fontSize="sm">
-              <RouterLink to={getTaskInstanceLink(taskInstances[0])}>
-                <Time datetime={taskInstances[0].start_date} />
-                {taskInstances[0].state === null ? undefined : <StateBadge state={taskInstances[0].state} />}
-              </RouterLink>
-            </Link>
-          </TaskInstanceTooltip>
-        ) : undefined}
-      </VStack>
-      {/* TODO: Handled mapped tasks to not plot each map index as a task instance */}
-      {!task.is_mapped && <TaskRecentRuns taskInstances={taskInstances} />}
-    </SimpleGrid>
-  </Box>
-);
+export const TaskCard = ({ areActiveRuns, dagId, task }: Props) => {
+  const autoRefreshInterval = useConfig("auto_refresh_interval") as number;
+  const { data } = useTaskInstanceServiceGetTaskInstances(
+    {
+      dagId,
+      dagRunId: "~",
+      limit: 14,
+      orderBy: "-logical_date",
+      taskId: task.task_id ?? "",
+    },
+    undefined,
+    {
+      enabled: Boolean(dagId) && Boolean(task.task_id),
+      refetchInterval: (query) =>
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        areActiveRuns || query.state.data?.task_instances.some((ti) => isStatePending(ti.state))
+          ? autoRefreshInterval * 1000
+          : false,
+    },
+  );
+
+  return (
+    <Box borderColor="border.emphasized" borderRadius={8} borderWidth={1} overflow="hidden" px={3} py={2}>
+      <Link asChild color="fg.info" fontWeight="bold">
+        <RouterLink to={`/dags/${dagId}/tasks/${task.task_id}`}>
+          {task.task_display_name ?? task.task_id}
+          {task.is_mapped ? "[]" : undefined}
+        </RouterLink>
+      </Link>
+      <SimpleGrid columns={4} gap={4} height={20}>
+        <VStack align="flex-start" gap={1}>
+          <Heading color="fg.muted" fontSize="xs">
+            Operator
+          </Heading>
+          <Text fontSize="sm">{task.operator_name}</Text>
+        </VStack>
+        <VStack align="flex-start" gap={1}>
+          <Heading color="fg.muted" fontSize="xs">
+            Trigger Rule
+          </Heading>
+          <Text fontSize="sm">{task.trigger_rule}</Text>
+        </VStack>
+        <VStack align="flex-start" gap={1}>
+          <Heading color="fg.muted" fontSize="xs">
+            Last Instance
+          </Heading>
+          {data?.task_instances[0] ? (
+            <TaskInstanceTooltip taskInstance={data.task_instances[0]}>
+              <Link asChild color="fg.info" fontSize="sm">
+                <RouterLink to={getTaskInstanceLink(data.task_instances[0])}>
+                  <Time datetime={data.task_instances[0].start_date} />
+                  <StateBadge state={data.task_instances[0].state} />
+                </RouterLink>
+              </Link>
+            </TaskInstanceTooltip>
+          ) : undefined}
+        </VStack>
+        {/* TODO: Handled mapped tasks to not plot each map index as a task instance */}
+        {!task.is_mapped && <TaskRecentRuns taskInstances={data?.task_instances ?? []} />}
+      </SimpleGrid>
+    </Box>
+  );
+};

--- a/airflow/ui/src/pages/Dag/Tasks/TaskRecentRuns.tsx
+++ b/airflow/ui/src/pages/Dag/Tasks/TaskRecentRuns.tsx
@@ -51,23 +51,21 @@ export const TaskRecentRuns = ({
 
   return (
     <Flex alignItems="flex-end" flexDirection="row-reverse">
-      {taskInstancesWithDuration.map((taskInstance) =>
-        taskInstance.state === null ? undefined : (
-          <TaskInstanceTooltip key={taskInstance.dag_run_id} taskInstance={taskInstance}>
-            <Link to={getTaskInstanceLink(taskInstance)}>
-              <Box p={1}>
-                <Box
-                  bg={`${taskInstance.state}.solid`}
-                  borderRadius="4px"
-                  height={`${(taskInstance.duration / max) * BAR_HEIGHT}px`}
-                  minHeight={1}
-                  width="4px"
-                />
-              </Box>
-            </Link>
-          </TaskInstanceTooltip>
-        ),
-      )}
+      {taskInstancesWithDuration.map((taskInstance) => (
+        <TaskInstanceTooltip key={taskInstance.dag_run_id} taskInstance={taskInstance}>
+          <Link to={getTaskInstanceLink(taskInstance)}>
+            <Box p={1}>
+              <Box
+                bg={`${taskInstance.state ?? "none"}.solid`}
+                borderRadius="4px"
+                height={`${(taskInstance.duration / max) * BAR_HEIGHT}px`}
+                minHeight={1}
+                width="4px"
+              />
+            </Box>
+          </Link>
+        </TaskInstanceTooltip>
+      ))}
     </Flex>
   );
 };

--- a/airflow/ui/src/pages/Dag/Tasks/Tasks.tsx
+++ b/airflow/ui/src/pages/Dag/Tasks/Tasks.tsx
@@ -19,18 +19,17 @@
 import { Heading, Skeleton, Box } from "@chakra-ui/react";
 import { useParams } from "react-router-dom";
 
-import { useTaskServiceGetTasks, useDagRunServiceGetDagRuns } from "openapi/queries";
+import { useTaskServiceGetTasks } from "openapi/queries";
 import type { TaskResponse } from "openapi/requests/types.gen";
 import { DataTable } from "src/components/DataTable";
 import type { CardDef } from "src/components/DataTable/types";
 import { ErrorAlert } from "src/components/ErrorAlert";
-import { useConfig } from "src/queries/useConfig";
 import { pluralize } from "src/utils";
 
 import { TaskCard } from "./TaskCard";
 
-const cardDef = (dagId: string, areActiveRuns?: boolean): CardDef<TaskResponse> => ({
-  card: ({ row }) => <TaskCard areActiveRuns={areActiveRuns} dagId={dagId} task={row} />,
+const cardDef = (dagId: string): CardDef<TaskResponse> => ({
+  card: ({ row }) => <TaskCard dagId={dagId} task={row} />,
   meta: {
     customSkeleton: <Skeleton height="120px" width="100%" />,
   },
@@ -47,24 +46,6 @@ export const Tasks = () => {
     dagId,
   });
 
-  const autoRefreshInterval = useConfig("auto_refresh_interval") as number;
-
-  const { data: runsData } = useDagRunServiceGetDagRuns(
-    {
-      dagId,
-      limit: 14,
-      orderBy: "-logical_date",
-      state: ["queued", "running"],
-    },
-    undefined,
-    {
-      refetchInterval: (query) =>
-        Boolean(query.state.data?.dag_runs.length) ? autoRefreshInterval * 1000 : false,
-    },
-  );
-
-  const runs = runsData?.dag_runs ?? [];
-
   return (
     <Box>
       <ErrorAlert error={tasksError} />
@@ -72,7 +53,7 @@ export const Tasks = () => {
         {pluralize("Task", data ? data.total_entries : 0)}
       </Heading>
       <DataTable
-        cardDef={cardDef(dagId, runs.length > 0)}
+        cardDef={cardDef(dagId)}
         columns={[]}
         data={data ? data.tasks : []}
         displayMode="card"

--- a/airflow/ui/src/pages/Run/Run.tsx
+++ b/airflow/ui/src/pages/Run/Run.tsx
@@ -22,8 +22,7 @@ import { useParams, Link as RouterLink } from "react-router-dom";
 import { useDagRunServiceGetDagRun, useDagServiceGetDagDetails } from "openapi/queries";
 import { Breadcrumb } from "src/components/ui";
 import { DetailsLayout } from "src/layouts/Details/DetailsLayout";
-import { useConfig } from "src/queries/useConfig";
-import { isStatePending } from "src/utils";
+import { isStatePending, useAutoRefresh } from "src/utils";
 
 import { Header } from "./Header";
 
@@ -37,7 +36,15 @@ const tabs = [
 export const Run = () => {
   const { dagId = "", runId = "" } = useParams();
 
-  const autoRefreshInterval = useConfig("auto_refresh_interval") as number;
+  const refetchInterval = useAutoRefresh({ dagId });
+
+  const {
+    data: dag,
+    error: dagError,
+    isLoading: isLoadinDag,
+  } = useDagServiceGetDagDetails({
+    dagId,
+  });
 
   const {
     data: dagRun,
@@ -50,18 +57,9 @@ export const Run = () => {
     },
     undefined,
     {
-      refetchInterval: (query) =>
-        isStatePending(query.state.data?.state) ? autoRefreshInterval * 1000 : false,
+      refetchInterval: (query) => (isStatePending(query.state.data?.state) ? refetchInterval : false),
     },
   );
-
-  const {
-    data: dag,
-    error: dagError,
-    isLoading: isLoadinDag,
-  } = useDagServiceGetDagDetails({
-    dagId,
-  });
 
   return (
     <DetailsLayout dag={dag} error={error ?? dagError} isLoading={isLoading || isLoadinDag} tabs={tabs}>
@@ -75,7 +73,10 @@ export const Run = () => {
         <Breadcrumb.CurrentLink>{runId}</Breadcrumb.CurrentLink>
       </Breadcrumb.Root>
       {dagRun === undefined ? undefined : (
-        <Header dagRun={dagRun} isRefreshing={Boolean(isStatePending(dagRun.state) && autoRefreshInterval)} />
+        <Header
+          dagRun={dagRun}
+          isRefreshing={Boolean(isStatePending(dagRun.state) && Boolean(refetchInterval))}
+        />
       )}
     </DetailsLayout>
   );

--- a/airflow/ui/src/pages/Run/Run.tsx
+++ b/airflow/ui/src/pages/Run/Run.tsx
@@ -23,7 +23,7 @@ import { useDagRunServiceGetDagRun, useDagServiceGetDagDetails } from "openapi/q
 import { Breadcrumb } from "src/components/ui";
 import { DetailsLayout } from "src/layouts/Details/DetailsLayout";
 import { useConfig } from "src/queries/useConfig";
-import { isStatePending } from "src/utils/refresh";
+import { isStatePending } from "src/utils";
 
 import { Header } from "./Header";
 

--- a/airflow/ui/src/pages/Run/TaskInstances.tsx
+++ b/airflow/ui/src/pages/Run/TaskInstances.tsx
@@ -42,8 +42,8 @@ import { Select } from "src/components/ui";
 import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
 import { useConfig } from "src/queries/useConfig";
 import { capitalize, getDuration } from "src/utils";
+import { isStatePending } from "src/utils";
 import { getTaskInstanceLink } from "src/utils/links";
-import { isStatePending } from "src/utils/refresh";
 
 const columns: Array<ColumnDef<TaskInstanceResponse>> = [
   {
@@ -182,7 +182,7 @@ export const TaskInstances = () => {
 
   const autoRefreshInterval = useConfig("auto_refresh_interval") as number;
 
-  const { data, error, isFetching, isLoading } = useTaskInstanceServiceGetTaskInstances(
+  const { data, error, isLoading } = useTaskInstanceServiceGetTaskInstances(
     {
       dagId,
       dagRunId: runId,
@@ -258,7 +258,6 @@ export const TaskInstances = () => {
         data={data?.task_instances ?? []}
         errorMessage={<ErrorAlert error={error} />}
         initialState={tableURLState}
-        isFetching={isFetching}
         isLoading={isLoading}
         modelName="Task Instance"
         onStateChange={setTableURLState}

--- a/airflow/ui/src/pages/Run/TaskInstances.tsx
+++ b/airflow/ui/src/pages/Run/TaskInstances.tsx
@@ -40,9 +40,7 @@ import { StateBadge } from "src/components/StateBadge";
 import Time from "src/components/Time";
 import { Select } from "src/components/ui";
 import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
-import { useConfig } from "src/queries/useConfig";
-import { capitalize, getDuration } from "src/utils";
-import { isStatePending } from "src/utils";
+import { capitalize, getDuration, useAutoRefresh, isStatePending } from "src/utils";
 import { getTaskInstanceLink } from "src/utils/links";
 
 const columns: Array<ColumnDef<TaskInstanceResponse>> = [
@@ -180,7 +178,7 @@ export const TaskInstances = () => {
     setSearchParams(searchParams);
   };
 
-  const autoRefreshInterval = useConfig("auto_refresh_interval") as number;
+  const refetchInterval = useAutoRefresh({ dagId });
 
   const { data, error, isLoading } = useTaskInstanceServiceGetTaskInstances(
     {
@@ -196,9 +194,7 @@ export const TaskInstances = () => {
     {
       enabled: !isNaN(pagination.pageSize),
       refetchInterval: (query) =>
-        query.state.data?.task_instances.some((ti) => isStatePending(ti.state))
-          ? autoRefreshInterval * 1000
-          : false,
+        query.state.data?.task_instances.some((ti) => isStatePending(ti.state)) ? refetchInterval : false,
     },
   );
 

--- a/airflow/ui/src/pages/TaskInstance/Details.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Details.tsx
@@ -29,7 +29,7 @@ import Time from "src/components/Time";
 import { ClipboardRoot, ClipboardIconButton } from "src/components/ui";
 import { useConfig } from "src/queries/useConfig";
 import { getDuration } from "src/utils";
-import { isStatePending } from "src/utils/refresh";
+import { isStatePending } from "src/utils";
 
 export const Details = () => {
   const { dagId = "", runId = "", taskId = "" } = useParams();

--- a/airflow/ui/src/pages/TaskInstance/Details.tsx
+++ b/airflow/ui/src/pages/TaskInstance/Details.tsx
@@ -27,9 +27,7 @@ import { StateBadge } from "src/components/StateBadge";
 import { TaskTrySelect } from "src/components/TaskTrySelect";
 import Time from "src/components/Time";
 import { ClipboardRoot, ClipboardIconButton } from "src/components/ui";
-import { useConfig } from "src/queries/useConfig";
-import { getDuration } from "src/utils";
-import { isStatePending } from "src/utils";
+import { getDuration, useAutoRefresh, isStatePending } from "src/utils";
 
 export const Details = () => {
   const { dagId = "", runId = "", taskId = "" } = useParams();
@@ -38,8 +36,6 @@ export const Details = () => {
   const mapIndexParam = searchParams.get("map_index");
   const tryNumberParam = searchParams.get("try_number");
   const mapIndex = parseInt(mapIndexParam ?? "-1", 10);
-
-  const autoRefreshInterval = useConfig("auto_refresh_interval") as number;
 
   const { data: taskInstance } = useTaskInstanceServiceGetMappedTaskInstance({
     dagId,
@@ -59,6 +55,8 @@ export const Details = () => {
 
   const tryNumber = tryNumberParam === null ? taskInstance?.try_number : parseInt(tryNumberParam, 10);
 
+  const refetchInterval = useAutoRefresh({ dagId });
+
   const { data: tryInstance } = useTaskInstanceServiceGetTaskInstanceTryDetails(
     {
       dagId,
@@ -69,8 +67,7 @@ export const Details = () => {
     },
     undefined,
     {
-      refetchInterval: (query) =>
-        isStatePending(query.state.data?.state) ? autoRefreshInterval * 1000 : false,
+      refetchInterval: (query) => (isStatePending(query.state.data?.state) ? refetchInterval : false),
     },
   );
 

--- a/airflow/ui/src/pages/TaskInstance/TaskInstance.tsx
+++ b/airflow/ui/src/pages/TaskInstance/TaskInstance.tsx
@@ -22,8 +22,7 @@ import { useParams, Link as RouterLink, useSearchParams } from "react-router-dom
 import { useDagServiceGetDagDetails, useTaskInstanceServiceGetMappedTaskInstance } from "openapi/queries";
 import { Breadcrumb } from "src/components/ui";
 import { DetailsLayout } from "src/layouts/Details/DetailsLayout";
-import { useConfig } from "src/queries/useConfig";
-import { isStatePending } from "src/utils";
+import { isStatePending, useAutoRefresh } from "src/utils";
 
 import { Header } from "./Header";
 
@@ -42,7 +41,15 @@ export const TaskInstance = () => {
   const mapIndexParam = searchParams.get("map_index");
   const mapIndex = parseInt(mapIndexParam ?? "-1", 10);
 
-  const autoRefreshInterval = useConfig("auto_refresh_interval") as number;
+  const refetchInterval = useAutoRefresh({ dagId });
+
+  const {
+    data: dag,
+    error: dagError,
+    isLoading: isDagLoading,
+  } = useDagServiceGetDagDetails({
+    dagId,
+  });
 
   const {
     data: taskInstance,
@@ -57,18 +64,9 @@ export const TaskInstance = () => {
     },
     undefined,
     {
-      refetchInterval: (query) =>
-        isStatePending(query.state.data?.state) ? autoRefreshInterval * 1000 : false,
+      refetchInterval: (query) => (isStatePending(query.state.data?.state) ? refetchInterval : false),
     },
   );
-
-  const {
-    data: dag,
-    error: dagError,
-    isLoading: isDagLoading,
-  } = useDagServiceGetDagDetails({
-    dagId,
-  });
 
   const links = [
     { label: "Dags", value: "/dags" },
@@ -102,7 +100,7 @@ export const TaskInstance = () => {
       </Breadcrumb.Root>
       {taskInstance === undefined ? undefined : (
         <Header
-          isRefreshing={Boolean(isStatePending(taskInstance.state) && autoRefreshInterval)}
+          isRefreshing={Boolean(isStatePending(taskInstance.state) && Boolean(refetchInterval))}
           taskInstance={taskInstance}
         />
       )}

--- a/airflow/ui/src/pages/TaskInstance/TaskInstance.tsx
+++ b/airflow/ui/src/pages/TaskInstance/TaskInstance.tsx
@@ -23,7 +23,7 @@ import { useDagServiceGetDagDetails, useTaskInstanceServiceGetMappedTaskInstance
 import { Breadcrumb } from "src/components/ui";
 import { DetailsLayout } from "src/layouts/Details/DetailsLayout";
 import { useConfig } from "src/queries/useConfig";
-import { isStatePending } from "src/utils/refresh";
+import { isStatePending } from "src/utils";
 
 import { Header } from "./Header";
 

--- a/airflow/ui/src/queries/useLogs.tsx
+++ b/airflow/ui/src/queries/useLogs.tsx
@@ -20,7 +20,7 @@ import dayjs from "dayjs";
 
 import { useTaskInstanceServiceGetLog } from "openapi/queries";
 import type { TaskInstanceResponse } from "openapi/requests/types.gen";
-import { isStatePending } from "src/utils/refresh";
+import { isStatePending } from "src/utils";
 
 import { useConfig } from "./useConfig";
 

--- a/airflow/ui/src/queries/useLogs.tsx
+++ b/airflow/ui/src/queries/useLogs.tsx
@@ -20,9 +20,7 @@ import dayjs from "dayjs";
 
 import { useTaskInstanceServiceGetLog } from "openapi/queries";
 import type { TaskInstanceResponse } from "openapi/requests/types.gen";
-import { isStatePending } from "src/utils";
-
-import { useConfig } from "./useConfig";
+import { isStatePending, useAutoRefresh } from "src/utils";
 
 type Props = {
   dagId: string;
@@ -62,7 +60,8 @@ const parseLogs = ({ data }: ParseLogsProps) => {
 };
 
 export const useLogs = ({ dagId, taskInstance, tryNumber = 1 }: Props) => {
-  const autoRefreshInterval = useConfig("auto_refresh_interval") as number;
+  const refetchInterval = useAutoRefresh({ dagId });
+
   const { data, ...rest } = useTaskInstanceServiceGetLog(
     {
       dagId,
@@ -77,8 +76,8 @@ export const useLogs = ({ dagId, taskInstance, tryNumber = 1 }: Props) => {
       refetchInterval: (query) =>
         isStatePending(taskInstance?.state) ||
         dayjs(query.state.dataUpdatedAt).isBefore(taskInstance?.end_date)
-          ? autoRefreshInterval * 1000
-          : autoRefreshInterval * 10 * 1000,
+          ? refetchInterval
+          : false,
     },
   );
 

--- a/airflow/ui/src/queries/useTrigger.ts
+++ b/airflow/ui/src/queries/useTrigger.ts
@@ -28,7 +28,7 @@ import {
 } from "openapi/queries";
 import type { DagRunTriggerParams } from "src/components/TriggerDag/TriggerDAGForm";
 import { toaster } from "src/components/ui";
-import { doQueriesMatch, type PartialQueryKey } from "src/utils";
+import { doQueryKeysMatch, type PartialQueryKey } from "src/utils";
 
 export const useTrigger = ({ dagId, onSuccessConfirm }: { dagId: string; onSuccessConfirm: () => void }) => {
   const queryClient = useQueryClient();
@@ -44,7 +44,7 @@ export const useTrigger = ({ dagId, onSuccessConfirm }: { dagId: string; onSucce
       { baseKey: useTaskInstanceServiceGetTaskInstancesKey, options: { dagId, dagRunId: "~" } },
     ];
 
-    await queryClient.invalidateQueries({ predicate: (query) => doQueriesMatch(query, queryKeys) });
+    await queryClient.invalidateQueries({ predicate: (query) => doQueryKeysMatch(query, queryKeys) });
 
     toaster.create({
       description: "DAG run has been successfully triggered.",

--- a/airflow/ui/src/queries/useTrigger.ts
+++ b/airflow/ui/src/queries/useTrigger.ts
@@ -24,24 +24,28 @@ import {
   useDagRunServiceTriggerDagRun,
   useDagServiceGetDagsKey,
   useDagsServiceRecentDagRunsKey,
+  useTaskInstanceServiceGetTaskInstancesKey,
 } from "openapi/queries";
 import type { DagRunTriggerParams } from "src/components/TriggerDag/TriggerDAGForm";
 import { toaster } from "src/components/ui";
+import { doQueriesMatch, type PartialQueryKey } from "src/utils";
 
-export const useTrigger = ({ onSuccessConfirm }: { onSuccessConfirm: () => void }) => {
+export const useTrigger = ({ dagId, onSuccessConfirm }: { dagId: string; onSuccessConfirm: () => void }) => {
   const queryClient = useQueryClient();
   const [error, setError] = useState<unknown>(undefined);
 
   const [dateValidationError, setDateValidationError] = useState<unknown>(undefined);
 
   const onSuccess = async () => {
-    const queryKeys = [
-      useDagServiceGetDagsKey,
-      useDagsServiceRecentDagRunsKey,
-      useDagRunServiceGetDagRunsKey,
+    const queryKeys: Array<PartialQueryKey> = [
+      { baseKey: useDagServiceGetDagsKey },
+      { baseKey: useDagsServiceRecentDagRunsKey },
+      { baseKey: useDagRunServiceGetDagRunsKey, options: { dagIds: [dagId] } },
+      { baseKey: useTaskInstanceServiceGetTaskInstancesKey, options: { dagId, dagRunId: "~" } },
     ];
 
-    await Promise.all(queryKeys.map((key) => queryClient.invalidateQueries({ queryKey: [key] })));
+    await queryClient.invalidateQueries({ predicate: (query) => doQueriesMatch(query, queryKeys) });
+
     toaster.create({
       description: "DAG run has been successfully triggered.",
       title: "DAG Run Request Submitted",
@@ -59,7 +63,7 @@ export const useTrigger = ({ onSuccessConfirm }: { onSuccessConfirm: () => void 
     onSuccess,
   });
 
-  const triggerDagRun = (dagId: string, dagRunRequestBody: DagRunTriggerParams) => {
+  const triggerDagRun = (dagRunRequestBody: DagRunTriggerParams) => {
     const parsedConfig = JSON.parse(dagRunRequestBody.conf) as Record<string, unknown>;
 
     const DataIntervalStart = dagRunRequestBody.dataIntervalStart

--- a/airflow/ui/src/utils/index.ts
+++ b/airflow/ui/src/utils/index.ts
@@ -21,3 +21,4 @@ export { capitalize } from "./capitalize";
 export { pluralize } from "./pluralize";
 export { getDuration } from "./datetime_utils";
 export { getMetaKey } from "./getMetaKey";
+export * from "./query";

--- a/airflow/ui/src/utils/query.ts
+++ b/airflow/ui/src/utils/query.ts
@@ -34,10 +34,12 @@ export const isStatePending = (state?: TaskInstanceState | null) =>
 
 export type PartialQueryKey = { baseKey: string; options?: Record<string, unknown> };
 
-export const doQueriesMatch = (query: Query, queriesToMatch: Array<PartialQueryKey>) => {
+// This allows us to specify what query key values we actually care about and ignore the rest
+// ex: match everything with this dagId and dagRunId but ignore anything related to pagination
+export const doQueryKeysMatch = (query: Query, queryKeysToMatch: Array<PartialQueryKey>) => {
   const [baseKey, options] = query.queryKey;
 
-  const matchedKey = queriesToMatch.find((qk) => qk.baseKey === baseKey);
+  const matchedKey = queryKeysToMatch.find((qk) => qk.baseKey === baseKey);
 
   if (!matchedKey) {
     return false;

--- a/airflow/ui/src/utils/query.ts
+++ b/airflow/ui/src/utils/query.ts
@@ -16,6 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import type { Query } from "@tanstack/react-query";
+
 import type { TaskInstanceState } from "openapi/requests/types.gen";
 
 export const isStatePending = (state?: TaskInstanceState | null) =>
@@ -27,3 +29,21 @@ export const isStatePending = (state?: TaskInstanceState | null) =>
   state === "queued" ||
   state === "restarting" ||
   !Boolean(state);
+
+export type PartialQueryKey = { baseKey: string; options?: Record<string, unknown> };
+
+export const doQueriesMatch = (query: Query, queriesToMatch: Array<PartialQueryKey>) => {
+  const [baseKey, options] = query.queryKey;
+
+  const matchedKey = queriesToMatch.find((qk) => qk.baseKey === baseKey);
+
+  if (!matchedKey) {
+    return false;
+  }
+
+  return matchedKey.options
+    ? Object.entries(matchedKey.options).every(
+        ([key, value]) => typeof options === "object" && (options as Record<string, unknown>)[key] === value,
+      )
+    : true;
+};


### PR DESCRIPTION
Add autorefresh to Dag page for the header, runs list, and tasks list.

This required rebuilding how we get data for the tasks list cards and how we invalidate queries when triggering a dag run.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
