### PR TITLE
Revert "Mostly use relative fileloc in dag processor"

### DIFF
--- a/airflow/dag_processing/collection.py
+++ b/airflow/dag_processing/collection.py
@@ -210,7 +210,6 @@ def _serialize_dag_capturing_errors(
     except Exception:
         log.exception("Failed to write serialized DAG dag_id=%s fileloc=%s", dag.dag_id, dag.fileloc)
         dagbag_import_error_traceback_depth = conf.getint("core", "dagbag_import_error_traceback_depth")
-        # todo AIP-66: this needs to use bundle name / rel fileloc instead
         return [(dag.fileloc, traceback.format_exc(limit=-dagbag_import_error_traceback_depth))]
 
 

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -119,7 +119,7 @@ class DagBag(LoggingMixin):
 
     def __init__(
         self,
-        dag_folder: str | Path | None = None,  # todo AIP-66: rename this to path
+        dag_folder: str | Path | None = None,
         include_examples: bool | ArgNotSet = NOTSET,
         safe_mode: bool | ArgNotSet = NOTSET,
         read_dags_from_db: bool = False,

--- a/airflow/models/errors.py
+++ b/airflow/models/errors.py
@@ -29,6 +29,6 @@ class ParseImportError(Base):
     __tablename__ = "import_error"
     id = Column(Integer, primary_key=True)
     timestamp = Column(UtcDateTime)
-    filename = Column(String(1024))  # todo AIP-66: make this bundle and relative fileloc
+    filename = Column(String(1024))
     bundle_name = Column(StringID())
     stacktrace = Column(Text)

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -1081,16 +1081,18 @@ class TestDag:
         dag.clear()
         self._clean_up(dag_id)
 
-    def test_dag_is_deactivated_upon_dagfile_deletion(self, dag_maker):
+    def test_dag_is_deactivated_upon_dagfile_deletion(self):
         dag_id = "old_existing_dag"
-        with dag_maker(dag_id, schedule=None, is_paused_upon_creation=True) as dag:
-            ...
+        dag_fileloc = "/usr/local/airflow/dags/non_existing_path.py"
+        dag = DAG(dag_id, schedule=None, is_paused_upon_creation=True)
+        dag.fileloc = dag_fileloc
         session = settings.Session()
         dag.sync_to_db(session=session)
 
         orm_dag = session.query(DagModel).filter(DagModel.dag_id == dag_id).one()
 
         assert orm_dag.is_active
+        assert orm_dag.fileloc == dag_fileloc
 
         DagModel.deactivate_deleted_dags(list_py_file_paths(settings.DAGS_FOLDER))
 


### PR DESCRIPTION
Reverts apache/airflow#46290

Unfortunately this broke `prepare_file_path_queue` which only showed up in the Kube integration tests, not in this PR (due to selective tests, which 99.9% of the time is fine to not run for this sort of change)

The error we saw was:

```
2025-01-31T10:02:53.715990881Z stderr F   File "/home/airflow/.local/lib/python3.10/site-packages/airflow/dag_processing/manager.py", line 317, in _run_parsing_loop
2025-01-31T10:02:53.715993857Z stderr F     self.prepare_file_path_queue()
2025-01-31T10:02:53.715996832Z stderr F   File "/home/airflow/.local/lib/python3.10/site-packages/airflow/dag_processing/manager.py", line 899, in prepare_file_path_queue
2025-01-31T10:02:53.716003114Z stderr F     "\n\t".join(f.path for f in files_paths_to_queue),
2025-01-31T10:02:53.71600625Z stderr F   File "/home/airflow/.local/lib/python3.10/site-packages/airflow/dag_processing/manager.py", line 899, in <genexpr>
2025-01-31T10:02:53.716009275Z stderr F     "\n\t".join(f.path for f in files_paths_to_queue),
2025-01-31T10:02:53.716012241Z stderr F AttributeError: 'DagFileInfo' object has no attribute 'path'
```

And while that change was easy enough to fix, (`path` -> `relpath`) I wasn't happy "just" fixing that path without some kind of tests/checks, so I also added typing here:

https://github.com/apache/airflow/blob/9ef89acf85dffe69266b716fa0fa1cfa6246b1f3/airflow/dag_processing/manager.py#L831

```python
        file_paths: list[DagFileInfo] = []
```

I noticed this as I use basedpyright in my editor which type checks functions even when the signature has no typing.
Adding a `-> None:` on the function so mypy type checks it, and then suddenly we get all these errors:

```
airflow/dag_processing/manager.py:840: error: Invalid index type "DagFileInfo" for "dict[str, datetime]"; expected type "str"  [index]
                        files_with_mtime[file_path] = os.path.getmtime(file_path.absolute_path)
                                         ^~~~~~~~~
airflow/dag_processing/manager.py:840: error: Incompatible types in assignment (expression has type "float", target has type "datetime")  [assignment]
                        files_with_mtime[file_path] = os.path.getmtime(file_path.absolute_path)
                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
airflow/dag_processing/manager.py:846: error: Argument 1 to "fromtimestamp" of "datetime" has incompatible type "datetime"; expected "float"  [arg-type]
                    file_modified_time = datetime.fromtimestamp(files_with_mtime[file_path], tz=timezone.utc)
                                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~
airflow/dag_processing/manager.py:846: error: Invalid index type "DagFileInfo" for "dict[str, datetime]"; expected type "str"  [index]
                    file_modified_time = datetime.fromtimestamp(files_with_mtime[file_path], tz=timezone.utc)
                                                                                 ^~~~~~~~~
airflow/dag_processing/manager.py:866: error: Argument 1 to "sorted" has incompatible type "dict[str, datetime]"; expected "Iterable[DagFileInfo]"  [arg-type]
                file_paths = sorted(files_with_mtime, key=files_with_mtime.get, reverse=True)
                                    ^~~~~~~~~~~~~~~~
airflow/dag_processing/manager.py:866: error: Argument "key" to "sorted" has incompatible type overloaded function; expected "Callable[[DagFileInfo], SupportsDunderLT[Any] | SupportsDunderGT[Any]]"  [arg-type]
                file_paths = sorted(files_with_mtime, key=files_with_mtime.get, reverse=True)
                                                          ^~~~~~~~~~~~~~~~~~~~
airflow/dag_processing/manager.py:867: error: Name "files_paths" is not defined  [name-defined]
                reveal_type(files_paths)
                            ^
airflow/dag_processing/manager.py:904: error: "DagFileInfo" has no attribute "relpath"; maybe "rel_path"?  [attr-defined]
                    "\n\t".join(f.relpath for f in files_paths_to_queue),
                                ^~~~~~~~~
Found 8 errors in 1 file (checked 1 source file)
```

The mtime path is geborken, so reverting this for now as it's breaking main.

Sorry @dstandish 