### PR TITLE
Only update docs inventory cache from a single docs build matrix job

### DIFF
--- a/.github/workflows/ci-image-checks.yml
+++ b/.github/workflows/ci-image-checks.yml
@@ -289,7 +289,9 @@ jobs:
           key: cache-docs-inventory-v1-${{ hashFiles('pyproject.toml') }}
           if-no-files-found: 'error'
           retention-days: '2'
-        if: steps.restore-docs-inventory-cache != 'true'
+        # If we upload from multiple matrix jobs we could end up with a race condition. so just pick one job
+        # to be responsible for updating it. https://github.com/actions/upload-artifact/issues/506
+        if: steps.restore-docs-inventory-cache != 'true' && matrix.flag == '--docs-only'
       - name: "Upload build docs"
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Since each job is producing the same content we want the key to be the same,
but we don't need to update it from both -- that is wasteful, and worse, prone
to race condotions and 409 HTTP errors.

Rather than ignore all errors by specifying `continue-on-error: true` in the
step, we choose to instead only upload from one matrix
