### PR TITLE
Fix branch used for constraints in k8s env creation

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/kubernetes_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/kubernetes_utils.py
@@ -33,7 +33,7 @@ from time import sleep
 from typing import Any, NamedTuple
 from urllib import request
 
-from airflow_breeze.branch_defaults import AIRFLOW_BRANCH
+from airflow_breeze.branch_defaults import DEFAULT_AIRFLOW_CONSTRAINTS_BRANCH
 from airflow_breeze.global_constants import (
     ALLOWED_ARCHITECTURES,
     ALLOWED_PYTHON_MAJOR_MINOR_VERSIONS,
@@ -336,7 +336,7 @@ def _install_packages_in_k8s_virtualenv():
             "--constraint",
             "https://raw.githubusercontent.com/"
             f"{APACHE_AIRFLOW_GITHUB_REPOSITORY}/"
-            f"constraints-{AIRFLOW_BRANCH}/constraints-{python_major_minor_version}.txt",
+            f"{DEFAULT_AIRFLOW_CONSTRAINTS_BRANCH}/constraints-{python_major_minor_version}.txt",
         ],
     )
     install_packages_result = run_command(


### PR DESCRIPTION
This was using `constraints-{AIRFLOW_BRANCH}`, which could be e.g. `constraints-v3-0-test` outside of main, where it should be `constraints-3-0`, which is already defined in
`DEFAULT_AIRFLOW_CONSTRAINTS_BRANCH`.