### PR TITLE
Create TaskMap rows when pushing XCom values from the Task Exec Interface

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import collections.abc
 import contextlib
 import hashlib
 import itertools
@@ -163,7 +162,7 @@ if TYPE_CHECKING:
     from airflow.sdk.definitions._internal.abstractoperator import Operator
     from airflow.sdk.definitions.dag import DAG
     from airflow.sdk.types import RuntimeTaskInstanceProtocol
-    from airflow.typing_compat import Literal, TypeGuard
+    from airflow.typing_compat import Literal
     from airflow.utils.task_group import TaskGroup
 
 
@@ -666,20 +665,6 @@ def _xcom_pull(
         order_by=ordering,
         session=session,
     )
-
-
-def _is_mappable_value(value: Any) -> TypeGuard[Collection]:
-    """
-    Whether a value can be used for task mapping.
-
-    We only allow collections with guaranteed ordering, but exclude character
-    sequences since that's usually not what users would expect to be mappable.
-    """
-    if not isinstance(value, (collections.abc.Sequence, dict)):
-        return False
-    if isinstance(value, (bytearray, bytes, str)):
-        return False
-    return True
 
 
 def _creator_note(val):
@@ -1217,7 +1202,7 @@ def _record_task_map_for_downstreams(
 
     :meta private:
     """
-    from airflow.sdk.definitions.mappedoperator import MappedOperator
+    from airflow.sdk.definitions.mappedoperator import MappedOperator, is_mappable_value
 
     if next(task.iter_mapped_dependants(), None) is None:  # No mapped dependants, no need to validate.
         return
@@ -1229,7 +1214,7 @@ def _record_task_map_for_downstreams(
         return
     if value is None:
         raise XComForMappingNotPushed()
-    if not _is_mappable_value(value):
+    if not is_mappable_value(value):
         raise UnmappableXComTypePushed(value)
     task_map = TaskMap.from_task_instance_xcom(task_instance, value)
     max_map_length = conf.getint("core", "max_map_length", fallback=1024)

--- a/task_sdk/src/airflow/sdk/definitions/mappedoperator.py
+++ b/task_sdk/src/airflow/sdk/definitions/mappedoperator.py
@@ -78,6 +78,7 @@ if TYPE_CHECKING:
     from airflow.sdk.definitions.param import ParamsDict
     from airflow.sdk.types import Operator
     from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
+    from airflow.typing_compat import TypeGuard
     from airflow.utils.context import Context
     from airflow.utils.operator_resources import Resources
     from airflow.utils.task_group import TaskGroup
@@ -134,6 +135,22 @@ def ensure_xcomarg_return_value(arg: Any) -> None:
     elif isinstance(arg, Iterable):
         for v in arg:
             ensure_xcomarg_return_value(v)
+
+
+def is_mappable_value(value: Any) -> TypeGuard[Collection]:
+    """
+    Whether a value can be used for task mapping.
+
+    We only allow collections with guaranteed ordering, but exclude character
+    sequences since that's usually not what users would expect to be mappable.
+
+    :meta private:
+    """
+    if not isinstance(value, (Sequence, dict)):
+        return False
+    if isinstance(value, (bytearray, bytes, str)):
+        return False
+    return True
 
 
 @attrs.define(kw_only=True, repr=False)

--- a/task_sdk/src/airflow/sdk/exceptions.py
+++ b/task_sdk/src/airflow/sdk/exceptions.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 import enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from airflow.sdk.execution_time.comms import ErrorResponse
@@ -35,3 +35,23 @@ class ErrorType(enum.Enum):
     VARIABLE_NOT_FOUND = "VARIABLE_NOT_FOUND"
     XCOM_NOT_FOUND = "XCOM_NOT_FOUND"
     GENERIC_ERROR = "GENERIC_ERROR"
+
+
+class XComForMappingNotPushed(TypeError):
+    """Raise when a mapped downstream's dependency fails to push XCom for task mapping."""
+
+    def __str__(self) -> str:
+        return "did not push XCom for task mapping"
+
+
+class UnmappableXComTypePushed(TypeError):
+    """Raise when an unmappable type is pushed as a mapped downstream's dependency."""
+
+    def __init__(self, value: Any, *values: Any) -> None:
+        super().__init__(value, *values)
+
+    def __str__(self) -> str:
+        typename = type(self.args[0]).__qualname__
+        for arg in self.args[1:]:
+            typename = f"{typename}[{type(arg).__qualname__}]"
+        return f"unmappable return type {typename!r}"

--- a/task_sdk/src/airflow/sdk/execution_time/comms.py
+++ b/task_sdk/src/airflow/sdk/execution_time/comms.py
@@ -268,6 +268,7 @@ class SetXCom(BaseModel):
     run_id: str
     task_id: str
     map_index: int | None = None
+    mapped_length: int | None = None
     type: Literal["SetXCom"] = "SetXCom"
 
 

--- a/tests/api_fastapi/execution_api/routes/test_xcoms.py
+++ b/tests/api_fastapi/execution_api/routes/test_xcoms.py
@@ -17,12 +17,15 @@
 
 from __future__ import annotations
 
+import contextlib
 from unittest import mock
 
+import httpx
 import pytest
 
 from airflow.api_fastapi.execution_api.datamodels.xcom import XComResponse
 from airflow.models.dagrun import DagRun
+from airflow.models.taskmap import TaskMap
 from airflow.models.xcom import XCom
 from airflow.utils.session import create_session
 
@@ -114,12 +117,45 @@ class TestXComsSetEndpoint:
 
         xcom = session.query(XCom).filter_by(task_id=ti.task_id, dag_id=ti.dag_id, key="xcom_1").first()
         assert xcom.value == expected_value
+        task_map = session.query(TaskMap).filter_by(task_id=ti.task_id, dag_id=ti.dag_id).one_or_none()
+        assert task_map is None, "Should not be mapped"
 
     @pytest.mark.parametrize(
-        "value",
-        ["value1", {"key2": "value2"}, ["value1"]],
+        ("length", "err_context"),
+        [
+            pytest.param(
+                20,
+                contextlib.nullcontext(),
+                id="20-success",
+            ),
+            pytest.param(
+                2000,
+                pytest.raises(httpx.HTTPStatusError),
+                id="2000-too-long",
+            ),
+        ],
     )
-    def test_xcom_set_invalid_json(self, client, create_task_instance, value):
+    def test_xcom_set_downstream_of_mapped(self, client, create_task_instance, session, length, err_context):
+        """
+        Test that XCom value is set correctly. The value is passed as a JSON string in the request body.
+        XCom.set then uses json.dumps to serialize it and store the value in the database.
+        This is done so that Task SDK in multiple languages can use the same API to set XCom values.
+        """
+        ti = create_task_instance()
+        session.commit()
+
+        with err_context:
+            response = client.post(
+                f"/execution/xcoms/{ti.dag_id}/{ti.run_id}/{ti.task_id}/xcom_1",
+                json='"valid json"',
+                params={"mapped_length": length},
+            )
+            response.raise_for_status()
+
+            task_map = session.query(TaskMap).filter_by(task_id=ti.task_id, dag_id=ti.dag_id).one_or_none()
+            assert task_map.length == length
+
+    def test_xcom_set_invalid_json(self, client):
         response = client.post(
             "/execution/xcoms/dag/runid/task/xcom_1",
             json="invalid_json",


### PR DESCRIPTION
This is needed so that we can have the scheduler create the expand TIs for the downstream tasks.

Note, that we don't enforce that this is set when it needs to be on the server side, as the only way for us to know if we need to or not (and conversely, when it's set when it _doesn't_ need to, which is no effect other than creating a small DB row that nothing will ever read) as doing that would involve loading the serialized DAG to walk the structure which is a relatively expensive operation.

We could improve that by "pre-computing" some of the info on what tasks are actually mapped or not before serialization so we wouldn't have to walk the task groups to find out, but that wouldn't do anything about the need to load the serialized DAG which is the expensive part.

If this turns out to be a problem to not be enforcing this  is passed when required we can revisit the decision later.

Relates to #44360