### PR TITLE
AIP-65 Fix version_number in grid endpoint

### DIFF
--- a/airflow/api_fastapi/core_api/datamodels/ui/grid.py
+++ b/airflow/api_fastapi/core_api/datamodels/ui/grid.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 from datetime import datetime
-from uuid import UUID
 
 from pydantic import BaseModel, Field
 
@@ -51,7 +50,7 @@ class GridDAGRunwithTIs(BaseModel):
     run_type: DagRunType
     data_interval_start: datetime | None
     data_interval_end: datetime | None
-    version_number: UUID | None
+    version_number: int | None
     note: str | None
     task_instances: list[GridTaskInstanceSummary]
 

--- a/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
+++ b/airflow/api_fastapi/core_api/openapi/v1-generated.yaml
@@ -8786,8 +8786,7 @@ components:
           title: Data Interval End
         version_number:
           anyOf:
-          - type: string
-            format: uuid
+          - type: integer
           - type: 'null'
           title: Version Number
         note:

--- a/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -3401,8 +3401,7 @@ export const $GridDAGRunwithTIs = {
     version_number: {
       anyOf: [
         {
-          type: "string",
-          format: "uuid",
+          type: "integer",
         },
         {
           type: "null",

--- a/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -889,7 +889,7 @@ export type GridDAGRunwithTIs = {
   run_type: DagRunType;
   data_interval_start: string | null;
   data_interval_end: string | null;
-  version_number: string | null;
+  version_number: number | null;
   note: string | null;
   task_instances: Array<GridTaskInstanceSummary>;
 };


### PR DESCRIPTION
`version_number` field was actually pointing to the `dag_version_id`.

Fixing this as we will use the `version_number` to identify the `dag_version` for a specific dag.